### PR TITLE
gpu: Add new VUID label of Index OOB

### DIFF
--- a/layers/gpu/error_message/gpuav_vuids.cpp
+++ b/layers/gpu/error_message/gpuav_vuids.cpp
@@ -26,6 +26,7 @@ struct GpuVuidsCmdDraw : GpuVuid {
         uniform_access_oob_08612 = "VUID-vkCmdDraw-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdDraw-None-08613";
         invalid_descriptor_08114 = "VUID-vkCmdDraw-None-08114";
+        descriptor_index_oob_10068 = "VUID-vkCmdDraw-None-10068";
     }
 };
 
@@ -36,6 +37,7 @@ struct GpuVuidsCmdDrawMultiEXT : GpuVuid {
         uniform_access_oob_08612 = "VUID-vkCmdDrawMultiEXT-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdDrawMultiEXT-None-08613";
         invalid_descriptor_08114 = "VUID-vkCmdDrawMultiEXT-None-08114";
+        descriptor_index_oob_10068 = "VUID-vkCmdDrawMultiEXT-None-10068";
     }
 };
 
@@ -46,6 +48,7 @@ struct GpuVuidsCmdDrawIndexed : GpuVuid {
         uniform_access_oob_08612 = "VUID-vkCmdDrawIndexed-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdDrawIndexed-None-08613";
         invalid_descriptor_08114 = "VUID-vkCmdDrawIndexed-None-08114";
+        descriptor_index_oob_10068 = "VUID-vkCmdDrawIndexed-None-10068";
     }
 };
 
@@ -56,6 +59,7 @@ struct GpuVuidsCmdDrawMultiIndexedEXT : GpuVuid {
         uniform_access_oob_08612 = "VUID-vkCmdDrawMultiIndexedEXT-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdDrawMultiIndexedEXT-None-08613";
         invalid_descriptor_08114 = "VUID-vkCmdDrawMultiIndexedEXT-None-08114";
+        descriptor_index_oob_10068 = "VUID-vkCmdDrawMultiIndexedEXT-None-10068";
     }
 };
 
@@ -67,6 +71,7 @@ struct GpuVuidsCmdDrawIndirect : GpuVuid {
         storage_access_oob_08613 = "VUID-vkCmdDrawIndirect-None-08613";
         invalid_descriptor_08114 = "VUID-vkCmdDrawIndirect-None-08114";
         first_instance_not_zero = "VUID-VkDrawIndirectCommand-firstInstance-00501";
+        descriptor_index_oob_10068 = "VUID-vkCmdDrawIndirect-None-10068";
     }
 };
 
@@ -78,6 +83,7 @@ struct GpuVuidsCmdDrawIndexedIndirect : GpuVuid {
         storage_access_oob_08613 = "VUID-vkCmdDrawIndexedIndirect-None-08613";
         invalid_descriptor_08114 = "VUID-vkCmdDrawIndexedIndirect-None-08114";
         first_instance_not_zero = "VUID-VkDrawIndexedIndirectCommand-firstInstance-00554";
+        descriptor_index_oob_10068 = "VUID-vkCmdDrawIndexedIndirect-None-10068";
     }
 };
 
@@ -88,6 +94,7 @@ struct GpuVuidsCmdDispatch : GpuVuid {
         uniform_access_oob_08612 = "VUID-vkCmdDispatch-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdDispatch-None-08613";
         invalid_descriptor_08114 = "VUID-vkCmdDispatch-None-08114";
+        descriptor_index_oob_10068 = "VUID-vkCmdDispatch-None-10068";
     }
 };
 
@@ -101,6 +108,7 @@ struct GpuVuidsCmdDispatchIndirect : GpuVuid {
         group_exceeds_device_limit_x = "VUID-VkDispatchIndirectCommand-x-00417";
         group_exceeds_device_limit_y = "VUID-VkDispatchIndirectCommand-y-00418";
         group_exceeds_device_limit_z = "VUID-VkDispatchIndirectCommand-z-00419";
+        descriptor_index_oob_10068 = "VUID-vkCmdDispatchIndirect-None-10068";
 
     }
 };
@@ -115,6 +123,7 @@ struct GpuVuidsCmdDrawIndirectCount : GpuVuid {
         count_exceeds_bufsize_1 = "VUID-vkCmdDrawIndirectCount-countBuffer-03121";
         count_exceeds_bufsize = "VUID-vkCmdDrawIndirectCount-countBuffer-03122";
         count_exceeds_device_limit = "VUID-vkCmdDrawIndirectCount-countBuffer-02717";
+        descriptor_index_oob_10068 = "VUID-vkCmdDrawIndirectCount-None-10068";
     }
 };
 
@@ -128,6 +137,7 @@ struct GpuVuidsCmdDrawIndexedIndirectCount : GpuVuid {
         count_exceeds_bufsize_1 = "VUID-vkCmdDrawIndexedIndirectCount-countBuffer-03153";
         count_exceeds_bufsize = "VUID-vkCmdDrawIndexedIndirectCount-countBuffer-03154";
         count_exceeds_device_limit = "VUID-vkCmdDrawIndexedIndirectCount-countBuffer-02717";
+        descriptor_index_oob_10068 = "VUID-vkCmdDrawIndexedIndirectCount-None-10068";
     }
 };
 
@@ -138,6 +148,7 @@ struct GpuVuidsCmdTraceRaysNV : GpuVuid {
         uniform_access_oob_08612 = "VUID-vkCmdTraceRaysNV-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdTraceRaysNV-None-08613";
         invalid_descriptor_08114 = "VUID-vkCmdTraceRaysNV-None-08114";
+        descriptor_index_oob_10068 = "VUID-vkCmdTraceRaysNV-None-10068";
     }
 };
 
@@ -148,6 +159,7 @@ struct GpuVuidsCmdTraceRaysKHR : GpuVuid {
         uniform_access_oob_08612 = "VUID-vkCmdTraceRaysKHR-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdTraceRaysKHR-None-08613";
         invalid_descriptor_08114 = "VUID-vkCmdTraceRaysKHR-None-08114";
+        descriptor_index_oob_10068 = "VUID-vkCmdTraceRaysKHR-None-10068";
     }
 };
 
@@ -158,6 +170,7 @@ struct GpuVuidsCmdTraceRaysIndirectKHR : GpuVuid {
         uniform_access_oob_08612 = "VUID-vkCmdTraceRaysIndirectKHR-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdTraceRaysIndirectKHR-None-08613";
         invalid_descriptor_08114 = "VUID-vkCmdTraceRaysIndirectKHR-None-08114";
+        descriptor_index_oob_10068 = "VUID-vkCmdTraceRaysIndirectKHR-None-10068";
         trace_rays_width_exceeds_device_limit = "VUID-VkTraceRaysIndirectCommandKHR-width-03638";
         trace_rays_height_exceeds_device_limit = "VUID-VkTraceRaysIndirectCommandKHR-height-03639";
         trace_rays_depth_exceeds_device_limit = "VUID-VkTraceRaysIndirectCommandKHR-depth-03640";
@@ -171,6 +184,7 @@ struct GpuVuidsCmdTraceRaysIndirect2KHR : GpuVuid {
         uniform_access_oob_08612 = "VUID-vkCmdTraceRaysIndirect2KHR-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdTraceRaysIndirect2KHR-None-08613";
         invalid_descriptor_08114 = "VUID-vkCmdTraceRaysIndirect2KHR-None-08114";
+        descriptor_index_oob_10068 = "VUID-vkCmdTraceRaysIndirect2KHR-None-10068";
     }
 };
 
@@ -181,6 +195,7 @@ struct GpuVuidsCmdDrawMeshTasksNV : GpuVuid {
         uniform_access_oob_08612 = "VUID-vkCmdDrawMeshTasksNV-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdDrawMeshTasksNV-None-08613";
         invalid_descriptor_08114 = "VUID-vkCmdDrawMeshTasksNV-None-08114";
+        descriptor_index_oob_10068 = "VUID-vkCmdDrawMeshTasksNV-None-10068";
     }
 };
 
@@ -191,6 +206,7 @@ struct GpuVuidsCmdDrawMeshTasksIndirectNV : GpuVuid {
         uniform_access_oob_08612 = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08613";
         invalid_descriptor_08114 = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08114";
+        descriptor_index_oob_10068 = "VUID-vkCmdDrawMeshTasksIndirectNV-None-10068";
         task_group_count_exceeds_max_x = "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07322";
         task_group_count_exceeds_max_y = "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07323";
         task_group_count_exceeds_max_z = "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07324";
@@ -209,6 +225,7 @@ struct GpuVuidsCmdDrawMeshTasksIndirectCountNV : GpuVuid {
         uniform_access_oob_08612 = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08613";
         invalid_descriptor_08114 = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08114";
+        descriptor_index_oob_10068 = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-10068";
         count_exceeds_bufsize_1 = "VUID-vkCmdDrawMeshTasksIndirectCountNV-countBuffer-02191";
         count_exceeds_bufsize = "VUID-vkCmdDrawMeshTasksIndirectCountNV-countBuffer-02192";
         count_exceeds_device_limit = "VUID-vkCmdDrawMeshTasksIndirectCountNV-countBuffer-02717";
@@ -230,6 +247,7 @@ struct GpuVuidsCmdDrawMeshTasksEXT : GpuVuid {
         uniform_access_oob_08612 = "VUID-vkCmdDrawMeshTasksEXT-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdDrawMeshTasksEXT-None-08613";
         invalid_descriptor_08114 = "VUID-vkCmdDrawMeshTasksEXT-None-08114";
+        descriptor_index_oob_10068 = "VUID-vkCmdDrawMeshTasksEXT-None-10068";
     }
 };
 
@@ -240,6 +258,7 @@ struct GpuVuidsCmdDrawMeshTasksIndirectEXT : GpuVuid {
         uniform_access_oob_08612 = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08613";
         invalid_descriptor_08114 = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08114";
+        descriptor_index_oob_10068 = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-10068";
         task_group_count_exceeds_max_x = "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07322";
         task_group_count_exceeds_max_y = "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07323";
         task_group_count_exceeds_max_z = "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07324";
@@ -258,6 +277,7 @@ struct GpuVuidsCmdDrawMeshTasksIndirectCountEXT : GpuVuid {
         uniform_access_oob_08612 = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08613";
         invalid_descriptor_08114 = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08114";
+        descriptor_index_oob_10068 = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-10068";
         count_exceeds_bufsize_1 = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-countBuffer-07098";
         count_exceeds_bufsize = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-countBuffer-07099";
         count_exceeds_device_limit = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-countBuffer-02717";
@@ -279,6 +299,7 @@ struct GpuVuidsCmdDrawIndirectByteCountEXT : GpuVuid {
         uniform_access_oob_08612 = "VUID-vkCmdDrawIndirectByteCountEXT-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdDrawIndirectByteCountEXT-None-08613";
         invalid_descriptor_08114 = "VUID-vkCmdDrawIndirectByteCountEXT-None-08114";
+        descriptor_index_oob_10068 = "VUID-vkCmdDrawIndirectByteCountEXT-None-10068";
     }
 };
 
@@ -289,6 +310,7 @@ struct GpuVuidsCmdDispatchBase : GpuVuid {
         uniform_access_oob_08612 = "VUID-vkCmdDispatchBase-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdDispatchBase-None-08613";
         invalid_descriptor_08114 = "VUID-vkCmdDispatchBase-None-08114";
+        descriptor_index_oob_10068 = "VUID-vkCmdDispatchBase-None-10068";
     }
 };
 
@@ -299,6 +321,7 @@ struct GpuVuidsCmdExecuteGeneratedCommandsEXT : GpuVuid {
         uniform_access_oob_08612 = "VUID-vkCmdExecuteGeneratedCommandsEXT-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdExecuteGeneratedCommandsEXT-None-08613";
         invalid_descriptor_08114 = "VUID-vkCmdExecuteGeneratedCommandsEXT-None-08114";
+        descriptor_index_oob_10068 = "VUID-vkCmdExecuteGeneratedCommandsEXT-None-10068";
     }
 };
 

--- a/layers/gpu/error_message/gpuav_vuids.cpp
+++ b/layers/gpu/error_message/gpuav_vuids.cpp
@@ -25,7 +25,7 @@ struct GpuVuidsCmdDraw : GpuVuid {
         storage_access_oob_06936 = "VUID-vkCmdDraw-storageBuffers-06936";
         uniform_access_oob_08612 = "VUID-vkCmdDraw-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdDraw-None-08613";
-        invalid_descriptor = "VUID-vkCmdDraw-None-08114";
+        invalid_descriptor_08114 = "VUID-vkCmdDraw-None-08114";
     }
 };
 
@@ -35,7 +35,7 @@ struct GpuVuidsCmdDrawMultiEXT : GpuVuid {
         storage_access_oob_06936 = "VUID-vkCmdDrawMultiEXT-storageBuffers-06936";
         uniform_access_oob_08612 = "VUID-vkCmdDrawMultiEXT-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdDrawMultiEXT-None-08613";
-        invalid_descriptor = "VUID-vkCmdDrawMultiEXT-None-08114";
+        invalid_descriptor_08114 = "VUID-vkCmdDrawMultiEXT-None-08114";
     }
 };
 
@@ -45,7 +45,7 @@ struct GpuVuidsCmdDrawIndexed : GpuVuid {
         storage_access_oob_06936 = "VUID-vkCmdDrawIndexed-storageBuffers-06936";
         uniform_access_oob_08612 = "VUID-vkCmdDrawIndexed-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdDrawIndexed-None-08613";
-        invalid_descriptor = "VUID-vkCmdDrawIndexed-None-08114";
+        invalid_descriptor_08114 = "VUID-vkCmdDrawIndexed-None-08114";
     }
 };
 
@@ -55,7 +55,7 @@ struct GpuVuidsCmdDrawMultiIndexedEXT : GpuVuid {
         storage_access_oob_06936 = "VUID-vkCmdDrawMultiIndexedEXT-storageBuffers-06936";
         uniform_access_oob_08612 = "VUID-vkCmdDrawMultiIndexedEXT-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdDrawMultiIndexedEXT-None-08613";
-        invalid_descriptor = "VUID-vkCmdDrawMultiIndexedEXT-None-08114";
+        invalid_descriptor_08114 = "VUID-vkCmdDrawMultiIndexedEXT-None-08114";
     }
 };
 
@@ -65,7 +65,7 @@ struct GpuVuidsCmdDrawIndirect : GpuVuid {
         storage_access_oob_06936 = "VUID-vkCmdDrawIndirect-storageBuffers-06936";
         uniform_access_oob_08612 = "VUID-vkCmdDrawIndirect-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdDrawIndirect-None-08613";
-        invalid_descriptor = "VUID-vkCmdDrawIndirect-None-08114";
+        invalid_descriptor_08114 = "VUID-vkCmdDrawIndirect-None-08114";
         first_instance_not_zero = "VUID-VkDrawIndirectCommand-firstInstance-00501";
     }
 };
@@ -76,7 +76,7 @@ struct GpuVuidsCmdDrawIndexedIndirect : GpuVuid {
         storage_access_oob_06936 = "VUID-vkCmdDrawIndexedIndirect-storageBuffers-06936";
         uniform_access_oob_08612 = "VUID-vkCmdDrawIndexedIndirect-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdDrawIndexedIndirect-None-08613";
-        invalid_descriptor = "VUID-vkCmdDrawIndexedIndirect-None-08114";
+        invalid_descriptor_08114 = "VUID-vkCmdDrawIndexedIndirect-None-08114";
         first_instance_not_zero = "VUID-VkDrawIndexedIndirectCommand-firstInstance-00554";
     }
 };
@@ -87,7 +87,7 @@ struct GpuVuidsCmdDispatch : GpuVuid {
         storage_access_oob_06936 = "VUID-vkCmdDispatch-storageBuffers-06936";
         uniform_access_oob_08612 = "VUID-vkCmdDispatch-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdDispatch-None-08613";
-        invalid_descriptor = "VUID-vkCmdDispatch-None-08114";
+        invalid_descriptor_08114 = "VUID-vkCmdDispatch-None-08114";
     }
 };
 
@@ -97,7 +97,7 @@ struct GpuVuidsCmdDispatchIndirect : GpuVuid {
         storage_access_oob_06936 = "VUID-vkCmdDispatchIndirect-storageBuffers-06936";
         uniform_access_oob_08612 = "VUID-vkCmdDispatchIndirect-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdDispatchIndirect-None-08613";
-        invalid_descriptor = "VUID-vkCmdDispatchIndirect-None-08114";
+        invalid_descriptor_08114 = "VUID-vkCmdDispatchIndirect-None-08114";
         group_exceeds_device_limit_x = "VUID-VkDispatchIndirectCommand-x-00417";
         group_exceeds_device_limit_y = "VUID-VkDispatchIndirectCommand-y-00418";
         group_exceeds_device_limit_z = "VUID-VkDispatchIndirectCommand-z-00419";
@@ -111,7 +111,7 @@ struct GpuVuidsCmdDrawIndirectCount : GpuVuid {
         storage_access_oob_06936 = "VUID-vkCmdDrawIndirectCount-storageBuffers-06936";
         uniform_access_oob_08612 = "VUID-vkCmdDrawIndirectCount-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdDrawIndirectCount-None-08613";
-        invalid_descriptor = "VUID-vkCmdDrawIndirectCount-None-08114";
+        invalid_descriptor_08114 = "VUID-vkCmdDrawIndirectCount-None-08114";
         count_exceeds_bufsize_1 = "VUID-vkCmdDrawIndirectCount-countBuffer-03121";
         count_exceeds_bufsize = "VUID-vkCmdDrawIndirectCount-countBuffer-03122";
         count_exceeds_device_limit = "VUID-vkCmdDrawIndirectCount-countBuffer-02717";
@@ -124,7 +124,7 @@ struct GpuVuidsCmdDrawIndexedIndirectCount : GpuVuid {
         storage_access_oob_06936 = "VUID-vkCmdDrawIndexedIndirectCount-storageBuffers-06936";
         uniform_access_oob_08612 = "VUID-vkCmdDrawIndexedIndirectCount-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdDrawIndexedIndirectCount-None-08613";
-        invalid_descriptor = "VUID-vkCmdDrawIndexedIndirectCount-None-08114";
+        invalid_descriptor_08114 = "VUID-vkCmdDrawIndexedIndirectCount-None-08114";
         count_exceeds_bufsize_1 = "VUID-vkCmdDrawIndexedIndirectCount-countBuffer-03153";
         count_exceeds_bufsize = "VUID-vkCmdDrawIndexedIndirectCount-countBuffer-03154";
         count_exceeds_device_limit = "VUID-vkCmdDrawIndexedIndirectCount-countBuffer-02717";
@@ -137,7 +137,7 @@ struct GpuVuidsCmdTraceRaysNV : GpuVuid {
         storage_access_oob_06936 = "VUID-vkCmdTraceRaysNV-storageBuffers-06936";
         uniform_access_oob_08612 = "VUID-vkCmdTraceRaysNV-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdTraceRaysNV-None-08613";
-        invalid_descriptor = "VUID-vkCmdTraceRaysNV-None-08114";
+        invalid_descriptor_08114 = "VUID-vkCmdTraceRaysNV-None-08114";
     }
 };
 
@@ -147,7 +147,7 @@ struct GpuVuidsCmdTraceRaysKHR : GpuVuid {
         storage_access_oob_06936 = "VUID-vkCmdTraceRaysKHR-storageBuffers-06936";
         uniform_access_oob_08612 = "VUID-vkCmdTraceRaysKHR-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdTraceRaysKHR-None-08613";
-        invalid_descriptor = "VUID-vkCmdTraceRaysKHR-None-08114";
+        invalid_descriptor_08114 = "VUID-vkCmdTraceRaysKHR-None-08114";
     }
 };
 
@@ -157,7 +157,7 @@ struct GpuVuidsCmdTraceRaysIndirectKHR : GpuVuid {
         storage_access_oob_06936 = "VUID-vkCmdTraceRaysIndirectKHR-storageBuffers-06936";
         uniform_access_oob_08612 = "VUID-vkCmdTraceRaysIndirectKHR-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdTraceRaysIndirectKHR-None-08613";
-        invalid_descriptor = "VUID-vkCmdTraceRaysIndirectKHR-None-08114";
+        invalid_descriptor_08114 = "VUID-vkCmdTraceRaysIndirectKHR-None-08114";
         trace_rays_width_exceeds_device_limit = "VUID-VkTraceRaysIndirectCommandKHR-width-03638";
         trace_rays_height_exceeds_device_limit = "VUID-VkTraceRaysIndirectCommandKHR-height-03639";
         trace_rays_depth_exceeds_device_limit = "VUID-VkTraceRaysIndirectCommandKHR-depth-03640";
@@ -170,7 +170,7 @@ struct GpuVuidsCmdTraceRaysIndirect2KHR : GpuVuid {
         storage_access_oob_06936 = "VUID-vkCmdTraceRaysIndirect2KHR-storageBuffers-06936";
         uniform_access_oob_08612 = "VUID-vkCmdTraceRaysIndirect2KHR-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdTraceRaysIndirect2KHR-None-08613";
-        invalid_descriptor = "VUID-vkCmdTraceRaysIndirect2KHR-None-08114";
+        invalid_descriptor_08114 = "VUID-vkCmdTraceRaysIndirect2KHR-None-08114";
     }
 };
 
@@ -180,7 +180,7 @@ struct GpuVuidsCmdDrawMeshTasksNV : GpuVuid {
         storage_access_oob_06936 = "VUID-vkCmdDrawMeshTasksNV-storageBuffers-06936";
         uniform_access_oob_08612 = "VUID-vkCmdDrawMeshTasksNV-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdDrawMeshTasksNV-None-08613";
-        invalid_descriptor = "VUID-vkCmdDrawMeshTasksNV-None-08114";
+        invalid_descriptor_08114 = "VUID-vkCmdDrawMeshTasksNV-None-08114";
     }
 };
 
@@ -190,7 +190,7 @@ struct GpuVuidsCmdDrawMeshTasksIndirectNV : GpuVuid {
         storage_access_oob_06936 = "VUID-vkCmdDrawMeshTasksIndirectNV-storageBuffers-06936";
         uniform_access_oob_08612 = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08613";
-        invalid_descriptor = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08114";
+        invalid_descriptor_08114 = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08114";
         task_group_count_exceeds_max_x = "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07322";
         task_group_count_exceeds_max_y = "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07323";
         task_group_count_exceeds_max_z = "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07324";
@@ -208,7 +208,7 @@ struct GpuVuidsCmdDrawMeshTasksIndirectCountNV : GpuVuid {
         storage_access_oob_06936 = "VUID-vkCmdDrawMeshTasksIndirectCountNV-storageBuffers-06936";
         uniform_access_oob_08612 = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08613";
-        invalid_descriptor = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08114";
+        invalid_descriptor_08114 = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08114";
         count_exceeds_bufsize_1 = "VUID-vkCmdDrawMeshTasksIndirectCountNV-countBuffer-02191";
         count_exceeds_bufsize = "VUID-vkCmdDrawMeshTasksIndirectCountNV-countBuffer-02192";
         count_exceeds_device_limit = "VUID-vkCmdDrawMeshTasksIndirectCountNV-countBuffer-02717";
@@ -229,7 +229,7 @@ struct GpuVuidsCmdDrawMeshTasksEXT : GpuVuid {
         storage_access_oob_06936 = "VUID-vkCmdDrawMeshTasksEXT-storageBuffers-06936";
         uniform_access_oob_08612 = "VUID-vkCmdDrawMeshTasksEXT-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdDrawMeshTasksEXT-None-08613";
-        invalid_descriptor = "VUID-vkCmdDrawMeshTasksEXT-None-08114";
+        invalid_descriptor_08114 = "VUID-vkCmdDrawMeshTasksEXT-None-08114";
     }
 };
 
@@ -239,7 +239,7 @@ struct GpuVuidsCmdDrawMeshTasksIndirectEXT : GpuVuid {
         storage_access_oob_06936 = "VUID-vkCmdDrawMeshTasksIndirectEXT-storageBuffers-06936";
         uniform_access_oob_08612 = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08613";
-        invalid_descriptor = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08114";
+        invalid_descriptor_08114 = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08114";
         task_group_count_exceeds_max_x = "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07322";
         task_group_count_exceeds_max_y = "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07323";
         task_group_count_exceeds_max_z = "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07324";
@@ -257,7 +257,7 @@ struct GpuVuidsCmdDrawMeshTasksIndirectCountEXT : GpuVuid {
         storage_access_oob_06936 = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-storageBuffers-06936";
         uniform_access_oob_08612 = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08613";
-        invalid_descriptor = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08114";
+        invalid_descriptor_08114 = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08114";
         count_exceeds_bufsize_1 = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-countBuffer-07098";
         count_exceeds_bufsize = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-countBuffer-07099";
         count_exceeds_device_limit = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-countBuffer-02717";
@@ -278,7 +278,7 @@ struct GpuVuidsCmdDrawIndirectByteCountEXT : GpuVuid {
         storage_access_oob_06936 = "VUID-vkCmdDrawIndirectByteCountEXT-storageBuffers-06936";
         uniform_access_oob_08612 = "VUID-vkCmdDrawIndirectByteCountEXT-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdDrawIndirectByteCountEXT-None-08613";
-        invalid_descriptor = "VUID-vkCmdDrawIndirectByteCountEXT-None-08114";
+        invalid_descriptor_08114 = "VUID-vkCmdDrawIndirectByteCountEXT-None-08114";
     }
 };
 
@@ -288,7 +288,7 @@ struct GpuVuidsCmdDispatchBase : GpuVuid {
         storage_access_oob_06936 = "VUID-vkCmdDispatchBase-storageBuffers-06936";
         uniform_access_oob_08612 = "VUID-vkCmdDispatchBase-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdDispatchBase-None-08613";
-        invalid_descriptor = "VUID-vkCmdDispatchBase-None-08114";
+        invalid_descriptor_08114 = "VUID-vkCmdDispatchBase-None-08114";
     }
 };
 
@@ -298,7 +298,7 @@ struct GpuVuidsCmdExecuteGeneratedCommandsEXT : GpuVuid {
         storage_access_oob_06936 = "VUID-vkCmdExecuteGeneratedCommandsEXT-storageBuffers-06936";
         uniform_access_oob_08612 = "VUID-vkCmdExecuteGeneratedCommandsEXT-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdExecuteGeneratedCommandsEXT-None-08613";
-        invalid_descriptor = "VUID-vkCmdExecuteGeneratedCommandsEXT-None-08114";
+        invalid_descriptor_08114 = "VUID-vkCmdExecuteGeneratedCommandsEXT-None-08114";
     }
 };
 

--- a/layers/gpu/error_message/gpuav_vuids.h
+++ b/layers/gpu/error_message/gpuav_vuids.h
@@ -26,7 +26,7 @@ struct GpuVuid {
     const char* storage_access_oob_06936 = kVUIDUndefined;
     const char* uniform_access_oob_08612 = kVUIDUndefined;
     const char* storage_access_oob_08613 = kVUIDUndefined;
-    const char* invalid_descriptor = kVUIDUndefined;
+    const char* invalid_descriptor_08114 = kVUIDUndefined;
     const char* count_exceeds_bufsize_1 = kVUIDUndefined;
     const char* count_exceeds_bufsize = kVUIDUndefined;
     const char* count_exceeds_device_limit = kVUIDUndefined;

--- a/layers/gpu/error_message/gpuav_vuids.h
+++ b/layers/gpu/error_message/gpuav_vuids.h
@@ -27,6 +27,7 @@ struct GpuVuid {
     const char* uniform_access_oob_08612 = kVUIDUndefined;
     const char* storage_access_oob_08613 = kVUIDUndefined;
     const char* invalid_descriptor_08114 = kVUIDUndefined;
+    const char* descriptor_index_oob_10068 = kVUIDUndefined;
     const char* count_exceeds_bufsize_1 = kVUIDUndefined;
     const char* count_exceeds_bufsize = kVUIDUndefined;
     const char* count_exceeds_device_limit = kVUIDUndefined;

--- a/layers/gpu/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpu/instrumentation/gpuav_instrumentation.cpp
@@ -470,7 +470,7 @@ bool LogMessageInstBindlessDescriptor(Validator &gpuav, const uint32_t *error_re
                  << ", binding = " << error_record[kInstBindlessBoundsDescBindingOffset] << ") Index of "
                  << error_record[kInstBindlessBoundsDescIndexOffset] << " used to index descriptor array of length "
                  << error_record[kInstBindlessCustomOffset_0] << ".";
-            out_vuid_msg = "UNASSIGNED-Descriptor index out of bounds";
+            out_vuid_msg = vuid.descriptor_index_oob_10068;
             error_found = true;
         } break;
         case kErrorSubCodeBindlessDescriptorUninit: {
@@ -571,7 +571,7 @@ bool LogMessageInstNonBindlessOOB(Validator &gpuav, const uint32_t *error_record
             const uint32_t desc_array_size = error_record[kInstNonBindlessOOBParamOffset0];
             strm << " access out of bounds. The descriptor buffer array is " << desc_array_size
                  << " large, but as accessed at index [" << desc_index << "]";
-            out_vuid_msg = "UNASSIGNED-Descriptor Buffer index out of bounds";
+            out_vuid_msg = vuid.descriptor_index_oob_10068;
         } break;
 
         case kErrorSubCodeNonBindlessOOBBufferBounds: {
@@ -598,7 +598,7 @@ bool LogMessageInstNonBindlessOOB(Validator &gpuav, const uint32_t *error_record
             const uint32_t desc_array_size = error_record[kInstNonBindlessOOBParamOffset0];
             strm << " access out of bounds. The descriptor texel buffer array is " << desc_array_size
                  << " large, but as accessed at index [" << desc_index << "]";
-            out_vuid_msg = "UNASSIGNED-Descriptor Texel Buffer index out of bounds";
+            out_vuid_msg = vuid.descriptor_index_oob_10068;
         } break;
 
         case kErrorSubCodeNonBindlessOOBTexelBufferBounds: {

--- a/layers/gpu/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpu/instrumentation/gpuav_instrumentation.cpp
@@ -477,7 +477,7 @@ bool LogMessageInstBindlessDescriptor(Validator &gpuav, const uint32_t *error_re
             strm << "(set = " << error_record[kInstBindlessUninitDescSetOffset]
                  << ", binding = " << error_record[kInstBindlessUninitBindingOffset] << ") Descriptor index "
                  << error_record[kInstBindlessUninitDescIndexOffset] << " is uninitialized.";
-            out_vuid_msg = vuid.invalid_descriptor;
+            out_vuid_msg = vuid.invalid_descriptor_08114;
             error_found = true;
         } break;
         case kErrorSubCodeBindlessDescriptorDestroyed: {
@@ -498,7 +498,7 @@ bool LogMessageInstBindlessDescriptor(Validator &gpuav, const uint32_t *error_re
             if (size == 0) {
                 strm << "(set = " << set_num << ", binding = " << binding_num << ") Descriptor index " << desc_index
                      << " is uninitialized.";
-                out_vuid_msg = vuid.invalid_descriptor;
+                out_vuid_msg = vuid.invalid_descriptor_08114;
                 error_found = true;
                 break;
             }

--- a/tests/unit/gpu_av_descriptor_indexing.cpp
+++ b/tests/unit/gpu_av_descriptor_indexing.cpp
@@ -124,7 +124,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, DISABLED_ArrayOOBBuffer) {
         buffer0.Memory().Unmap();
 
         SCOPED_TRACE("Out of Bounds");
-        m_errorMonitor->SetDesiredError("UNASSIGNED-Descriptor index out of bounds");
+        m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-10068");
         m_default_queue->Submit(m_command_buffer);
         m_default_queue->Wait();
         m_errorMonitor->VerifyFound();
@@ -244,7 +244,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBVertex) {
     data[0] = 25;
     buffer0.Memory().Unmap();
 
-    m_errorMonitor->SetDesiredError("UNASSIGNED-Descriptor index out of bounds", 2 * 3);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-10068", 2 * 3);
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -356,7 +356,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBFragment) {
     data[0] = 25;
     buffer0.Memory().Unmap();
 
-    m_errorMonitor->SetDesiredError("UNASSIGNED-Descriptor index out of bounds", gpuav::glsl::kMaxErrorsPerCmd);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-10068", gpuav::glsl::kMaxErrorsPerCmd);
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
     m_errorMonitor->VerifyFound();
@@ -486,7 +486,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBRuntime) {
     buffer0.Memory().Unmap();
 
     SCOPED_TRACE("Out of Bounds");
-    m_errorMonitor->SetDesiredError("UNASSIGNED-Descriptor index out of bounds", gpuav::glsl::kMaxErrorsPerCmd);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-10068", gpuav::glsl::kMaxErrorsPerCmd);
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -615,7 +615,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBVariableDescriptorCountAllocate)
     buffer0.Memory().Unmap();
 
     SCOPED_TRACE("Out of Bounds");
-    m_errorMonitor->SetDesiredError("UNASSIGNED-Descriptor index out of bounds", gpuav::glsl::kMaxErrorsPerCmd);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-10068", gpuav::glsl::kMaxErrorsPerCmd);
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -737,7 +737,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBTess) {
     buffer0.Memory().Unmap();
 
     SCOPED_TRACE("Out of Bounds");
-    m_errorMonitor->SetDesiredError("UNASSIGNED-Descriptor index out of bounds", 3);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-10068", 3);
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
     m_errorMonitor->VerifyFound();
@@ -857,7 +857,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBGeom) {
     buffer0.Memory().Unmap();
 
     SCOPED_TRACE("Out of Bounds");
-    m_errorMonitor->SetDesiredError("UNASSIGNED-Descriptor index out of bounds");
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-10068");
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
     m_errorMonitor->VerifyFound();
@@ -970,7 +970,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBCompute) {
         data[0] = 25;
         buffer0.Memory().Unmap();
         // Invalid read and invalid write
-        m_errorMonitor->SetDesiredError("UNASSIGNED-Descriptor index out of bounds", 2);
+        m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-None-10068", 2);
         m_default_queue->Submit(m_command_buffer);
         m_default_queue->Wait();
         m_errorMonitor->VerifyFound();
@@ -1766,7 +1766,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, BasicHLSL) {
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
     m_command_buffer.End();
 
-    m_errorMonitor->SetDesiredError("UNASSIGNED-Descriptor index out of bounds");
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-None-10068");
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
     m_errorMonitor->VerifyFound();
@@ -1947,7 +1947,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, PushConstant) {
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
     m_command_buffer.End();
 
-    m_errorMonitor->SetDesiredError("UNASSIGNED-Descriptor index out of bounds");
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-None-10068");
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
     m_errorMonitor->VerifyFound();

--- a/tests/unit/gpu_av_oob.cpp
+++ b/tests/unit/gpu_av_oob.cpp
@@ -1745,7 +1745,7 @@ TEST_F(NegativeGpuAVOOB, ConstantArrayOOBBuffer) {
     *data = 8;
     offset_buffer.Memory().Unmap();
 
-    m_errorMonitor->SetDesiredError("UNASSIGNED-Descriptor Buffer index out of bounds", 3);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-10068", 3);
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();


### PR DESCRIPTION
This was added back in 1.3.292 from https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/6793

Adds the `VUID-vkCmdDraw-None-10068` draw time VU for having a descriptor index out of bounds
