### PR TITLE
layers: Validate binary sync depenency on timeline wait

### DIFF
--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -111,8 +111,7 @@ bool SemaphoreSubmitState::ValidateBinaryWait(const Location &loc, VkQueue queue
     bool skip = false;
     auto semaphore = semaphore_state.VkHandle();
     if ((semaphore_state.Scope() == vvl::Semaphore::kInternal || internal_semaphores.count(semaphore))) {
-        VkQueue other_queue = AnotherQueueWaits(semaphore_state);
-        if (other_queue) {
+        if (VkQueue other_queue = AnotherQueueWaits(semaphore_state)) {
             const auto &vuid = GetQueueSubmitVUID(loc, SubmitError::kOtherQueueWaiting);
             const LogObjectList objlist(semaphore, queue, other_queue);
             skip |= core.LogError(vuid, objlist, loc, "queue (%s) is already waiting on semaphore (%s).",

--- a/layers/state_tracker/queue_state.h
+++ b/layers/state_tracker/queue_state.h
@@ -115,6 +115,11 @@ class Queue : public StateObject {
     // Helper that combines Notify and Wait
     void NotifyAndWait(const Location &loc, uint64_t until_seq = kU64Max);
 
+    // Check if there is a timeline wait before or at until_seq submission that
+    // does not have a resolving timeline signal submitted yet. If such wait exists
+    // then the function returns not empty object with semaphore wait information.
+    std::optional<vvl::QueueSubmission::SemaphoreInfo> HasTimelineWaitWithoutResolvingSignal(uint64_t until_seq) const;
+
   public:
     // Queue family index. As queueFamilyIndex parameter in vkGetDeviceQueue.
     const uint32_t queue_family_index;
@@ -142,6 +147,9 @@ class Queue : public StateObject {
     virtual void PostSubmit(QueueSubmission &submission) {}
     // called when the worker thread decides a submissions has finished executing
     virtual void Retire(QueueSubmission &submission);
+
+  private:
+    uint32_t timeline_wait_count_ = 0;
 
   private:
     using LockGuard = std::unique_lock<std::mutex>;

--- a/layers/state_tracker/semaphore_state.h
+++ b/layers/state_tracker/semaphore_state.h
@@ -112,6 +112,7 @@ class Semaphore : public RefcountedStateObject {
 
     bool CanBinaryBeSignaled() const;
     bool CanBinaryBeWaited() const;
+    bool HasResolvingTimelineSignal(uint64_t wait_payload) const;
 
     void Import(VkExternalSemaphoreHandleTypeFlagBits handle_type, VkSemaphoreImportFlags flags);
     void Export(VkExternalSemaphoreHandleTypeFlagBits handle_type);

--- a/tests/framework/binding.cpp
+++ b/tests/framework/binding.cpp
@@ -743,6 +743,56 @@ VkResult Queue::Submit2(const CommandBuffer &cmd, const TimelineWait &wait, cons
     return result;
 }
 
+VkResult Queue::Submit2(const CommandBuffer &cmd, const vkt::Wait &wait, const TimelineSignal &signal, const Fence &fence) {
+    VkCommandBufferSubmitInfo cb_info = vku::InitStructHelper();
+    cb_info.commandBuffer = cmd.handle();
+
+    VkSemaphoreSubmitInfo wait_info = vku::InitStructHelper();
+    wait_info.semaphore = wait.semaphore.handle();
+    wait_info.stageMask = wait.stage_mask;
+
+    VkSemaphoreSubmitInfo signal_info = vku::InitStructHelper();
+    signal_info.semaphore = signal.semaphore.handle();
+    signal_info.value = signal.value;
+    signal_info.stageMask = signal.stage_mask;
+
+    VkSubmitInfo2 submit = vku::InitStructHelper();
+    submit.waitSemaphoreInfoCount = 1;
+    submit.pWaitSemaphoreInfos = &wait_info;
+    submit.commandBufferInfoCount = cmd.initialized() ? 1 : 0;
+    submit.pCommandBufferInfos = &cb_info;
+    submit.signalSemaphoreInfoCount = 1;
+    submit.pSignalSemaphoreInfos = &signal_info;
+
+    VkResult result = vk::QueueSubmit2(handle(), 1, &submit, fence.handle());
+    return result;
+}
+
+VkResult Queue::Submit2(const CommandBuffer &cmd, const TimelineWait &wait, const Signal &signal, const Fence &fence) {
+    VkCommandBufferSubmitInfo cb_info = vku::InitStructHelper();
+    cb_info.commandBuffer = cmd.handle();
+
+    VkSemaphoreSubmitInfo wait_info = vku::InitStructHelper();
+    wait_info.semaphore = wait.semaphore.handle();
+    wait_info.value = wait.value;
+    wait_info.stageMask = wait.stage_mask;
+
+    VkSemaphoreSubmitInfo signal_info = vku::InitStructHelper();
+    signal_info.semaphore = signal.semaphore.handle();
+    signal_info.stageMask = signal.stage_mask;
+
+    VkSubmitInfo2 submit = vku::InitStructHelper();
+    submit.waitSemaphoreInfoCount = 1;
+    submit.pWaitSemaphoreInfos = &wait_info;
+    submit.commandBufferInfoCount = cmd.initialized() ? 1 : 0;
+    submit.pCommandBufferInfos = &cb_info;
+    submit.signalSemaphoreInfoCount = 1;
+    submit.pSignalSemaphoreInfos = &signal_info;
+
+    VkResult result = vk::QueueSubmit2(handle(), 1, &submit, fence.handle());
+    return result;
+}
+
 VkResult Queue::Present(const Swapchain &swapchain, uint32_t image_index, const Semaphore &wait_semaphore,
                         void *present_info_pnext) {
     VkPresentInfoKHR present = vku::InitStructHelper(present_info_pnext);

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -526,6 +526,9 @@ class Queue : public internal::Handle<VkQueue> {
     VkResult Submit2(const CommandBuffer &cmd, const TimelineWait &wait, const TimelineSignal &signal,
                      const Fence &fence = no_fence, bool use_khr = false);
 
+    VkResult Submit2(const CommandBuffer &cmd, const Wait &wait, const TimelineSignal &signal, const Fence &fence = no_fence);
+    VkResult Submit2(const CommandBuffer &cmd, const TimelineWait &wait, const Signal &signal, const Fence &fence = no_fence);
+
     // vkQueuePresentKHR()
     VkResult Present(const Swapchain &swapchain, uint32_t image_index, const Semaphore &wait_semaphore,
                      void *present_info_pnext = nullptr);


### PR DESCRIPTION
~This partially~ addresses https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8707

What's left for other PRs:
* Provide different messages depending on which condition triggered VUs like `VUID-vkQueueSubmit-pWaitSemaphores-03238`: either missing binary signal or binary signal exists but depends on timeline wait.
* ~Try to analyze entire synchronization chain, not only direct parent.~ - actually this works, added one more test to show this `NegativeSyncObject.BinarySyncDependsOnTimelineWait3`.