### PR TITLE
gpu: Demote DrawCount capped by maxDrawCount to warning

### DIFF
--- a/layers/gpu/cmd_validation/gpuav_draw.cpp
+++ b/layers/gpu/cmd_validation/gpuav_draw.cpp
@@ -385,19 +385,16 @@ void InsertIndirectDrawValidation(Validator &gpuav, const Location &loc, Command
                                                                                  // think about also doing it in the error message
                 const uint32_t draw_size = (stride * (count - 1) + offset + sizeof(VkDrawIndexedIndirectCommand));
 
-                const char *vuid = nullptr;
-                if (count == 1) {
-                    vuid = vuids.count_exceeds_bufsize_1;
-                } else {
-                    vuid = vuids.count_exceeds_bufsize;
-                }
-                skip |= gpuav.LogError(vuid, objlist, loc,
-                                       "Indirect draw count of %" PRIu32 " would exceed buffer size %" PRIu64
-                                       " of buffer %s "
-                                       "stride = %" PRIu32 " offset = %" PRIu32
-                                       " (stride * (drawCount - 1) + offset + sizeof(VkDrawIndexedIndirectCommand)) = %" PRIu32 ".",
-                                       count, indirect_buffer_size, gpuav.FormatHandle(indirect_buffer).c_str(), stride, offset,
-                                       draw_size);
+                // Discussed that if drawCount is largeer than the buffer, it is still capped by the maxDrawCount on the CPU (which
+                // we would have checked is in the buffer range). We decided that we still want to give a warning, but the nothing
+                // is invalid here. https://gitlab.khronos.org/vulkan/vulkan/-/issues/3991
+                skip |= gpuav.LogWarning(
+                    "WARNING-GPU-AV-drawCount", objlist, loc,
+                    "Indirect draw count of %" PRIu32 " would exceed buffer size %" PRIu64
+                    " of buffer %s "
+                    "stride = %" PRIu32 " offset = %" PRIu32
+                    " (stride * (drawCount - 1) + offset + sizeof(VkDrawIndexedIndirectCommand)) = %" PRIu32 ".",
+                    count, indirect_buffer_size, gpuav.FormatHandle(indirect_buffer).c_str(), stride, offset, draw_size);
                 break;
             }
             case kErrorSubCodePreDrawCountLimit: {

--- a/layers/gpu/error_message/gpuav_vuids.cpp
+++ b/layers/gpu/error_message/gpuav_vuids.cpp
@@ -120,8 +120,6 @@ struct GpuVuidsCmdDrawIndirectCount : GpuVuid {
         uniform_access_oob_08612 = "VUID-vkCmdDrawIndirectCount-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdDrawIndirectCount-None-08613";
         invalid_descriptor_08114 = "VUID-vkCmdDrawIndirectCount-None-08114";
-        count_exceeds_bufsize_1 = "VUID-vkCmdDrawIndirectCount-countBuffer-03121";
-        count_exceeds_bufsize = "VUID-vkCmdDrawIndirectCount-countBuffer-03122";
         count_exceeds_device_limit = "VUID-vkCmdDrawIndirectCount-countBuffer-02717";
         descriptor_index_oob_10068 = "VUID-vkCmdDrawIndirectCount-None-10068";
     }
@@ -134,8 +132,6 @@ struct GpuVuidsCmdDrawIndexedIndirectCount : GpuVuid {
         uniform_access_oob_08612 = "VUID-vkCmdDrawIndexedIndirectCount-None-08612";
         storage_access_oob_08613 = "VUID-vkCmdDrawIndexedIndirectCount-None-08613";
         invalid_descriptor_08114 = "VUID-vkCmdDrawIndexedIndirectCount-None-08114";
-        count_exceeds_bufsize_1 = "VUID-vkCmdDrawIndexedIndirectCount-countBuffer-03153";
-        count_exceeds_bufsize = "VUID-vkCmdDrawIndexedIndirectCount-countBuffer-03154";
         count_exceeds_device_limit = "VUID-vkCmdDrawIndexedIndirectCount-countBuffer-02717";
         descriptor_index_oob_10068 = "VUID-vkCmdDrawIndexedIndirectCount-None-10068";
     }
@@ -226,8 +222,6 @@ struct GpuVuidsCmdDrawMeshTasksIndirectCountNV : GpuVuid {
         storage_access_oob_08613 = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08613";
         invalid_descriptor_08114 = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08114";
         descriptor_index_oob_10068 = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-10068";
-        count_exceeds_bufsize_1 = "VUID-vkCmdDrawMeshTasksIndirectCountNV-countBuffer-02191";
-        count_exceeds_bufsize = "VUID-vkCmdDrawMeshTasksIndirectCountNV-countBuffer-02192";
         count_exceeds_device_limit = "VUID-vkCmdDrawMeshTasksIndirectCountNV-countBuffer-02717";
         task_group_count_exceeds_max_x = "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07322";
         task_group_count_exceeds_max_y = "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07323";
@@ -278,8 +272,6 @@ struct GpuVuidsCmdDrawMeshTasksIndirectCountEXT : GpuVuid {
         storage_access_oob_08613 = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08613";
         invalid_descriptor_08114 = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08114";
         descriptor_index_oob_10068 = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-10068";
-        count_exceeds_bufsize_1 = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-countBuffer-07098";
-        count_exceeds_bufsize = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-countBuffer-07099";
         count_exceeds_device_limit = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-countBuffer-02717";
         task_group_count_exceeds_max_x = "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07322";
         task_group_count_exceeds_max_y = "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07323";

--- a/layers/gpu/error_message/gpuav_vuids.h
+++ b/layers/gpu/error_message/gpuav_vuids.h
@@ -28,8 +28,6 @@ struct GpuVuid {
     const char* storage_access_oob_08613 = kVUIDUndefined;
     const char* invalid_descriptor_08114 = kVUIDUndefined;
     const char* descriptor_index_oob_10068 = kVUIDUndefined;
-    const char* count_exceeds_bufsize_1 = kVUIDUndefined;
-    const char* count_exceeds_bufsize = kVUIDUndefined;
     const char* count_exceeds_device_limit = kVUIDUndefined;
     const char* first_instance_not_zero = kVUIDUndefined;
     const char* group_exceeds_device_limit_x = kVUIDUndefined;

--- a/tests/unit/gpu_av_indirect_buffer.cpp
+++ b/tests/unit/gpu_av_indirect_buffer.cpp
@@ -252,9 +252,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_errorMonitor->SetDesiredErrorRegex("VUID-vkCmdDrawIndirectCount-countBuffer-03122",
-                                         "Indirect draw count of 2 would exceed buffer size 16 of buffer .* stride = 16 offset = 0 "
-                                         ".* = 36");
+    m_errorMonitor->SetDesiredWarning("WARNING-GPU-AV-drawCount");
     uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
     *count_ptr = 2;
     count_buffer.Memory().Unmap();
@@ -274,7 +272,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
     *count_ptr = 1;
     count_buffer.Memory().Unmap();
 
-    m_errorMonitor->SetDesiredError("VUID-vkCmdDrawIndirectCount-countBuffer-03121");
+    m_errorMonitor->SetDesiredWarning("WARNING-GPU-AV-drawCount");
     m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -287,7 +285,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
     m_default_queue->Wait();
     m_errorMonitor->VerifyFound();
 
-    m_errorMonitor->SetDesiredError("VUID-vkCmdDrawIndexedIndirectCount-countBuffer-03154");
+    m_errorMonitor->SetDesiredWarning("WARNING-GPU-AV-drawCount");
     vkt::Buffer indexed_draw_buffer(*m_device, sizeof(VkDrawIndexedIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                     VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
     VkDrawIndexedIndirectCommand *indexed_draw_ptr = (VkDrawIndexedIndirectCommand *)indexed_draw_buffer.Memory().Map();
@@ -317,7 +315,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
     *count_ptr = 1;
     count_buffer.Memory().Unmap();
 
-    m_errorMonitor->SetDesiredError("VUID-vkCmdDrawIndexedIndirectCount-countBuffer-03153");
+    m_errorMonitor->SetDesiredWarning("WARNING-GPU-AV-drawCount");
     m_command_buffer.Begin(&begin_info);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -355,7 +353,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
         mesh_draw_ptr->groupCountY = 0;
         mesh_draw_ptr->groupCountZ = 0;
         mesh_draw_buffer.Memory().Unmap();
-        m_errorMonitor->SetDesiredError("VUID-vkCmdDrawMeshTasksIndirectCountEXT-countBuffer-07098");
+        m_errorMonitor->SetDesiredWarning("WARNING-GPU-AV-drawCount");
         count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
         *count_ptr = 1;
         count_buffer.Memory().Unmap();
@@ -370,7 +368,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
         m_default_queue->Wait();
         m_errorMonitor->VerifyFound();
 
-        m_errorMonitor->SetDesiredError("VUID-vkCmdDrawMeshTasksIndirectCountEXT-countBuffer-07099");
+        m_errorMonitor->SetDesiredWarning("WARNING-GPU-AV-drawCount");
         count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
         *count_ptr = 2;
         count_buffer.Memory().Unmap();


### PR DESCRIPTION
These VUID will be removed in the next header update (https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/6969)

Was discussed in https://gitlab.khronos.org/vulkan/vulkan/-/issues/3991 that these VUs were not possible to hit if your `maxDrawCount` is within range of the buffer.

We decided to keep this check, but demote it to a warning for now