### PR TITLE
tests: Cleanup MultiPlane and YCbCr tests

### DIFF
--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -390,11 +390,6 @@ class WsiTest : public VkLayerTest {
 #endif
 };
 
-class YcbcrTest : public VkLayerTest {
-  public:
-    void InitBasicYcbcr(void *pNextFeatures = nullptr);
-};
-
 class CooperativeMatrixTest : public VkLayerTest {
   public:
     void InitCooperativeMatrixKHR();

--- a/tests/unit/copy_buffer_image.cpp
+++ b/tests/unit/copy_buffer_image.cpp
@@ -2049,7 +2049,6 @@ TEST_F(NegativeCopyBufferImage, ImageAspectMismatch) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_EXTENSION_NAME);
-    AddOptionalExtensions(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     auto ds_format = FindSupportedDepthStencilFormat(Gpu());
 

--- a/tests/unit/memory.cpp
+++ b/tests/unit/memory.cpp
@@ -873,350 +873,344 @@ TEST_F(NegativeMemory, BindMemoryUnsupported) {
     }
 }
 
-TEST_F(NegativeMemory, BindMemoryNoCheck) {
+TEST_F(NegativeMemory, BindMemoryNoCheckBuffer) {
     TEST_DESCRIPTION("Tests case were no call to memory requirements was made prior to binding");
-
-    // Enable KHR YCbCr req'd extensions for Disjoint Bit
-    AddRequiredExtensions(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
-    AddOptionalExtensions(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
-    const bool mp_extensions = IsExtensionsEnabled(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);
 
-    // first test buffer
-    {
-        VkBufferCreateInfo buffer_create_info = vku::InitStructHelper();
-        buffer_create_info.size = 1024;
-        buffer_create_info.usage = VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
+    VkBufferCreateInfo buffer_create_info = vku::InitStructHelper();
+    buffer_create_info.size = 1024;
+    buffer_create_info.usage = VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
 
-        // Create 2 buffers, one that is checked and one that isn't by GetBufferMemoryRequirements
-        vkt::Buffer buffer(*m_device, buffer_create_info, vkt::no_mem);
-        vkt::Buffer unchecked_buffer(*m_device, buffer_create_info, vkt::no_mem);
+    // Create 2 buffers, one that is checked and one that isn't by GetBufferMemoryRequirements
+    vkt::Buffer buffer(*m_device, buffer_create_info, vkt::no_mem);
+    vkt::Buffer unchecked_buffer(*m_device, buffer_create_info, vkt::no_mem);
 
-        VkMemoryRequirements buffer_mem_reqs = {};
-        vk::GetBufferMemoryRequirements(device(), buffer, &buffer_mem_reqs);
-        VkMemoryAllocateInfo buffer_alloc_info = vku::InitStructHelper();
-        // Leave some extra space for alignment wiggle room
-        buffer_alloc_info.allocationSize = buffer_mem_reqs.size + buffer_mem_reqs.alignment;
-        ASSERT_TRUE(m_device->Physical().SetMemoryType(buffer_mem_reqs.memoryTypeBits, &buffer_alloc_info, 0));
-        vkt::DeviceMemory buffer_mem(*m_device, buffer_alloc_info);
-        vkt::DeviceMemory unchecked_buffer_mem(*m_device, buffer_alloc_info);
+    VkMemoryRequirements buffer_mem_reqs = {};
+    vk::GetBufferMemoryRequirements(device(), buffer, &buffer_mem_reqs);
+    VkMemoryAllocateInfo buffer_alloc_info = vku::InitStructHelper();
+    // Leave some extra space for alignment wiggle room
+    buffer_alloc_info.allocationSize = buffer_mem_reqs.size + buffer_mem_reqs.alignment;
+    ASSERT_TRUE(m_device->Physical().SetMemoryType(buffer_mem_reqs.memoryTypeBits, &buffer_alloc_info, 0));
+    vkt::DeviceMemory buffer_mem(*m_device, buffer_alloc_info);
+    vkt::DeviceMemory unchecked_buffer_mem(*m_device, buffer_alloc_info);
 
-        if (buffer_mem_reqs.alignment > 1) {
-            VkDeviceSize buffer_offset = 1;
+    if (buffer_mem_reqs.alignment > 1) {
+        VkDeviceSize buffer_offset = 1;
 
-            m_errorMonitor->SetDesiredError("VUID-vkBindBufferMemory-memoryOffset-01036");
-            vk::BindBufferMemory(device(), buffer, buffer_mem, buffer_offset);
-            m_errorMonitor->VerifyFound();
+        m_errorMonitor->SetDesiredError("VUID-vkBindBufferMemory-memoryOffset-01036");
+        vk::BindBufferMemory(device(), buffer, buffer_mem, buffer_offset);
+        m_errorMonitor->VerifyFound();
 
-            // Should trigger same VUID even when image was never checked
-            // this makes an assumption that the driver will return the same image requirements for same createImageInfo where even
-            // being close to running out of heap space
-            m_errorMonitor->SetDesiredError("VUID-vkBindBufferMemory-memoryOffset-01036");
-            vk::BindBufferMemory(device(), unchecked_buffer, unchecked_buffer_mem, buffer_offset);
-            m_errorMonitor->VerifyFound();
-        }
-    }
-
-    // Next test is a single-plane image
-    {
-        VkImageCreateInfo image_create_info =
-            vkt::Image::ImageCreateInfo2D(256, 256, 1, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
-
-        // Create 2 images, one that is checked and one that isn't by GetImageMemoryRequirements
-        vkt::Image image(*m_device, image_create_info, vkt::no_mem);
-        vkt::Image unchecked_image(*m_device, image_create_info, vkt::no_mem);
-
-        VkMemoryRequirements image_mem_reqs = {};
-        vk::GetImageMemoryRequirements(device(), image, &image_mem_reqs);
-        VkMemoryAllocateInfo image_alloc_info = vku::InitStructHelper();
-        // Leave some extra space for alignment wiggle room
-        image_alloc_info.allocationSize = image_mem_reqs.size + image_mem_reqs.alignment;
-        ASSERT_TRUE(m_device->Physical().SetMemoryType(image_mem_reqs.memoryTypeBits, &image_alloc_info, 0));
-        vkt::DeviceMemory image_mem(*m_device, image_alloc_info);
-        vkt::DeviceMemory unchecked_image_mem(*m_device, image_alloc_info);
-
-        // single-plane image
-        if (image_mem_reqs.alignment > 1) {
-            VkDeviceSize image_offset = 1;
-
-            m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory-memoryOffset-01048");
-            vk::BindImageMemory(device(), image, image_mem, image_offset);
-            m_errorMonitor->VerifyFound();
-
-            // Should trigger same VUID even when image was never checked
-            // this makes an assumption that the driver will return the same image requirements for same createImageInfo where even
-            // being close to running out of heap space
-            m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory-memoryOffset-01048");
-            vk::BindImageMemory(device(), unchecked_image, unchecked_image_mem, image_offset);
-            m_errorMonitor->VerifyFound();
-        }
-    }
-
-    // Same style test but with a multi-planar disjoint image
-    // Test doesn't check either of the planes for the unchecked image
-    if (mp_extensions == false) {
-        GTEST_SKIP() << "Rest of test rely on YCbCr Multi-planar support";
-    } else {
-        // Check for support of format used by all multi-planar tests
-        const VkFormat mp_format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;
-        VkFormatProperties mp_format_properties;
-        vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), mp_format, &mp_format_properties);
-        if (!((mp_format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_DISJOINT_BIT) &&
-              (mp_format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT))) {
-            GTEST_SKIP() << "test rely on a supported disjoint format";
-        }
-
-        VkImageCreateInfo mp_image_create_info =
-            vkt::Image::ImageCreateInfo2D(256, 256, 1, 1, mp_format, VK_IMAGE_USAGE_SAMPLED_BIT);
-        mp_image_create_info.flags = VK_IMAGE_CREATE_DISJOINT_BIT;
-
-        // Array represent planes for disjoint images
-        VkDeviceMemory mp_image_mem[2] = {VK_NULL_HANDLE, VK_NULL_HANDLE};
-        VkDeviceMemory mp_unchecked_image_mem[2] = {VK_NULL_HANDLE, VK_NULL_HANDLE};
-        VkMemoryRequirements2 mp_image_mem_reqs2[2];
-        VkMemoryAllocateInfo mp_image_alloc_info[2];
-
-        vkt::Image mp_image(*m_device, mp_image_create_info, vkt::no_mem);
-        vkt::Image mp_unchecked_image(*m_device, mp_image_create_info, vkt::no_mem);
-
-        VkImagePlaneMemoryRequirementsInfo image_plane_req = vku::InitStructHelper();
-        image_plane_req.planeAspect = VK_IMAGE_ASPECT_PLANE_0_BIT;
-
-        VkImageMemoryRequirementsInfo2 mem_req_info2 = vku::InitStructHelper(&image_plane_req);
-        mem_req_info2.image = mp_image;
-        mp_image_mem_reqs2[0] = vku::InitStructHelper();
-        vk::GetImageMemoryRequirements2KHR(device(), &mem_req_info2, &mp_image_mem_reqs2[0]);
-
-        image_plane_req.planeAspect = VK_IMAGE_ASPECT_PLANE_1_BIT;
-        mp_image_mem_reqs2[1] = vku::InitStructHelper();
-        vk::GetImageMemoryRequirements2KHR(device(), &mem_req_info2, &mp_image_mem_reqs2[1]);
-
-        mp_image_alloc_info[0] = vku::InitStructHelper();
-        mp_image_alloc_info[1] = vku::InitStructHelper();
-
-        mp_image_alloc_info[0].allocationSize = mp_image_mem_reqs2[0].memoryRequirements.size;
-        ASSERT_TRUE(m_device->Physical().SetMemoryType(mp_image_mem_reqs2[0].memoryRequirements.memoryTypeBits,
-                                                       &mp_image_alloc_info[0], 0));
-        // Leave some extra space for alignment wiggle room
-        mp_image_alloc_info[1].allocationSize =
-            mp_image_mem_reqs2[1].memoryRequirements.size + mp_image_mem_reqs2[1].memoryRequirements.alignment;
-        ASSERT_TRUE(m_device->Physical().SetMemoryType(mp_image_mem_reqs2[1].memoryRequirements.memoryTypeBits,
-                                                       &mp_image_alloc_info[1], 0));
-
-        ASSERT_EQ(VK_SUCCESS, vk::AllocateMemory(device(), &mp_image_alloc_info[0], NULL, &mp_image_mem[0]));
-        ASSERT_EQ(VK_SUCCESS, vk::AllocateMemory(device(), &mp_image_alloc_info[1], NULL, &mp_image_mem[1]));
-        ASSERT_EQ(VK_SUCCESS, vk::AllocateMemory(device(), &mp_image_alloc_info[0], NULL, &mp_unchecked_image_mem[0]));
-        ASSERT_EQ(VK_SUCCESS, vk::AllocateMemory(device(), &mp_image_alloc_info[1], NULL, &mp_unchecked_image_mem[1]));
-
-        // Sets an invalid offset to plane 1
-        if (mp_image_mem_reqs2[1].memoryRequirements.alignment > 1) {
-            VkBindImagePlaneMemoryInfo plane_memory_info[2];
-            plane_memory_info[0] = vku::InitStructHelper();
-            plane_memory_info[0].planeAspect = VK_IMAGE_ASPECT_PLANE_0_BIT;
-            plane_memory_info[1] = vku::InitStructHelper();
-            plane_memory_info[1].planeAspect = VK_IMAGE_ASPECT_PLANE_1_BIT;
-
-            VkBindImageMemoryInfo bind_image_info[2];
-            bind_image_info[0] = vku::InitStructHelper(&plane_memory_info[0]);
-            bind_image_info[0].image = mp_image;
-            bind_image_info[0].memory = mp_image_mem[0];
-            bind_image_info[0].memoryOffset = 0;
-            bind_image_info[1] = vku::InitStructHelper(&plane_memory_info[1]);
-            bind_image_info[1].image = mp_image;
-            bind_image_info[1].memory = mp_image_mem[1];
-            bind_image_info[1].memoryOffset = 1;  // off alignment
-
-            m_errorMonitor->SetDesiredError("VUID-VkBindImageMemoryInfo-pNext-01620");
-            vk::BindImageMemory2KHR(device(), 2, bind_image_info);
-            m_errorMonitor->VerifyFound();
-
-            // Should trigger same VUID even when image was never checked
-            // this makes an assumption that the driver will return the same image requirements for same createImageInfo where even
-            // being close to running out of heap space
-            bind_image_info[0].image = mp_unchecked_image;
-            bind_image_info[0].memory = mp_unchecked_image_mem[0];
-            bind_image_info[1].image = mp_unchecked_image;
-            bind_image_info[1].memory = mp_unchecked_image_mem[1];
-            m_errorMonitor->SetDesiredError("VUID-VkBindImageMemoryInfo-pNext-01620");
-            vk::BindImageMemory2KHR(device(), 2, bind_image_info);
-            m_errorMonitor->VerifyFound();
-        }
-
-        vk::FreeMemory(device(), mp_image_mem[0], NULL);
-        vk::FreeMemory(device(), mp_image_mem[1], NULL);
-        vk::FreeMemory(device(), mp_unchecked_image_mem[0], NULL);
-        vk::FreeMemory(device(), mp_unchecked_image_mem[1], NULL);
+        // Should trigger same VUID even when image was never checked
+        // this makes an assumption that the driver will return the same image requirements for same createImageInfo where even
+        // being close to running out of heap space
+        m_errorMonitor->SetDesiredError("VUID-vkBindBufferMemory-memoryOffset-01036");
+        vk::BindBufferMemory(device(), unchecked_buffer, unchecked_buffer_mem, buffer_offset);
+        m_errorMonitor->VerifyFound();
     }
 }
 
-TEST_F(NegativeMemory, BindMemory2BindInfos) {
-    TEST_DESCRIPTION("These tests deal with VK_KHR_bind_memory_2 and invalid VkBindImageMemoryInfo* pBindInfos");
-
-    // Enable KHR YCbCr req'd extensions for Disjoint Bit
-    AddRequiredExtensions(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
-    AddRequiredExtensions(VK_KHR_BIND_MEMORY_2_EXTENSION_NAME);
-    AddOptionalExtensions(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);
+TEST_F(NegativeMemory, BindMemoryNoCheckImage) {
+    TEST_DESCRIPTION("Tests case were no call to memory requirements was made prior to binding");
     RETURN_IF_SKIP(Init());
-    const bool mp_extensions = IsExtensionsEnabled(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);
 
     VkImageCreateInfo image_create_info =
         vkt::Image::ImageCreateInfo2D(256, 256, 1, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
 
-    {
-        // Create 2 image with 2 memory objects
-        vkt::Image image_a(*m_device, image_create_info, vkt::no_mem);
-        vkt::Image image_b(*m_device, image_create_info, vkt::no_mem);
+    // Create 2 images, one that is checked and one that isn't by GetImageMemoryRequirements
+    vkt::Image image(*m_device, image_create_info, vkt::no_mem);
+    vkt::Image unchecked_image(*m_device, image_create_info, vkt::no_mem);
 
-        VkMemoryRequirements image_mem_reqs = {};
-        vk::GetImageMemoryRequirements(device(), image_a, &image_mem_reqs);
-        VkMemoryAllocateInfo image_alloc_info = vku::InitStructHelper();
-        image_alloc_info.allocationSize = image_mem_reqs.size;
-        ASSERT_TRUE(m_device->Physical().SetMemoryType(image_mem_reqs.memoryTypeBits, &image_alloc_info, 0));
-        vkt::DeviceMemory image_a_mem(*m_device, image_alloc_info);
+    VkMemoryRequirements image_mem_reqs = {};
+    vk::GetImageMemoryRequirements(device(), image, &image_mem_reqs);
+    VkMemoryAllocateInfo image_alloc_info = vku::InitStructHelper();
+    // Leave some extra space for alignment wiggle room
+    image_alloc_info.allocationSize = image_mem_reqs.size + image_mem_reqs.alignment;
+    ASSERT_TRUE(m_device->Physical().SetMemoryType(image_mem_reqs.memoryTypeBits, &image_alloc_info, 0));
+    vkt::DeviceMemory image_mem(*m_device, image_alloc_info);
+    vkt::DeviceMemory unchecked_image_mem(*m_device, image_alloc_info);
 
-        vk::GetImageMemoryRequirements(device(), image_b, &image_mem_reqs);
-        image_alloc_info.allocationSize = image_mem_reqs.size;
-        ASSERT_TRUE(m_device->Physical().SetMemoryType(image_mem_reqs.memoryTypeBits, &image_alloc_info, 0));
-        vkt::DeviceMemory image_b_mem(*m_device, image_alloc_info);
+    // single-plane image
+    if (image_mem_reqs.alignment > 1) {
+        VkDeviceSize image_offset = 1;
 
-        // Try binding same image twice in array
-        VkBindImageMemoryInfo bind_image_info[3];
-        bind_image_info[0] = vku::InitStructHelper();
-        bind_image_info[0].image = image_a;
-        bind_image_info[0].memory = image_a_mem;
-        bind_image_info[0].memoryOffset = 0;
-        bind_image_info[1] = vku::InitStructHelper();
-        bind_image_info[1].image = image_b;
-        bind_image_info[1].memory = image_b_mem;
-        bind_image_info[1].memoryOffset = 0;
-        bind_image_info[2] = bind_image_info[0];  // duplicate bind
-
-        m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory2-pBindInfos-04006");
-        vk::BindImageMemory2KHR(device(), 3, bind_image_info);
+        m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory-memoryOffset-01048");
+        vk::BindImageMemory(device(), image, image_mem, image_offset);
         m_errorMonitor->VerifyFound();
 
-        // Bind same image to 2 different memory in same array
-        bind_image_info[1].image = image_a;
-        m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory2-pBindInfos-04006");
-        vk::BindImageMemory2KHR(device(), 2, bind_image_info);
+        // Should trigger same VUID even when image was never checked
+        // this makes an assumption that the driver will return the same image requirements for same createImageInfo where even
+        // being close to running out of heap space
+        m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory-memoryOffset-01048");
+        vk::BindImageMemory(device(), unchecked_image, unchecked_image_mem, image_offset);
         m_errorMonitor->VerifyFound();
     }
+}
 
-    if (mp_extensions) {
-        const VkFormat mp_format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;
+TEST_F(NegativeMemory, BindMemoryNoCheckMultiPlane) {
+    TEST_DESCRIPTION("Tests case were no call to memory requirements was made prior to binding");
+    AddRequiredExtensions(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
 
-        // Check for support of format used by all multi-planar tests
-        VkFormatProperties mp_format_properties;
-        vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), mp_format, &mp_format_properties);
-        if (!((mp_format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_DISJOINT_BIT) &&
-              (mp_format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT))) {
-            GTEST_SKIP() << "test rely on a supported disjoint format";
-        }
+    // Check for support of format used by all multi-planar tests
+    const VkFormat mp_format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;
+    VkFormatProperties mp_format_properties;
+    vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), mp_format, &mp_format_properties);
+    if (!((mp_format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_DISJOINT_BIT) &&
+          (mp_format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT))) {
+        GTEST_SKIP() << "test rely on a supported disjoint format";
+    }
 
-        // Creat 1 normal, not disjoint image
-        vkt::Image normal_image(*m_device, image_create_info, vkt::no_mem);
-        VkMemoryRequirements image_mem_reqs = {};
-        vk::GetImageMemoryRequirements(device(), normal_image, &image_mem_reqs);
-        VkMemoryAllocateInfo image_alloc_info = vku::InitStructHelper();
-        image_alloc_info.allocationSize = image_mem_reqs.size;
-        ASSERT_TRUE(m_device->Physical().SetMemoryType(image_mem_reqs.memoryTypeBits, &image_alloc_info, 0));
-        vkt::DeviceMemory normal_image_mem(*m_device, image_alloc_info);
+    VkImageCreateInfo mp_image_create_info = vkt::Image::ImageCreateInfo2D(256, 256, 1, 1, mp_format, VK_IMAGE_USAGE_SAMPLED_BIT);
+    mp_image_create_info.flags = VK_IMAGE_CREATE_DISJOINT_BIT;
 
-        // Create 2 disjoint images with memory backing each plane
-        VkImageCreateInfo mp_image_create_info = image_create_info;
-        mp_image_create_info.format = mp_format;
-        mp_image_create_info.flags = VK_IMAGE_CREATE_DISJOINT_BIT;
+    // Array represent planes for disjoint images
+    VkDeviceMemory mp_image_mem[2] = {VK_NULL_HANDLE, VK_NULL_HANDLE};
+    VkDeviceMemory mp_unchecked_image_mem[2] = {VK_NULL_HANDLE, VK_NULL_HANDLE};
+    VkMemoryRequirements2 mp_image_mem_reqs2[2];
+    VkMemoryAllocateInfo mp_image_alloc_info[2];
 
-        VkDeviceMemory mp_image_a_mem[2] = {VK_NULL_HANDLE, VK_NULL_HANDLE};
-        VkDeviceMemory mp_image_b_mem[2] = {VK_NULL_HANDLE, VK_NULL_HANDLE};
-        vkt::Image mp_image_a(*m_device, mp_image_create_info, vkt::no_mem);
-        vkt::Image mp_image_b(*m_device, mp_image_create_info, vkt::no_mem);
+    vkt::Image mp_image(*m_device, mp_image_create_info, vkt::no_mem);
+    vkt::Image mp_unchecked_image(*m_device, mp_image_create_info, vkt::no_mem);
 
-        auto allocate = [this](VkImage mp_image, VkDeviceMemory *mp_image_mem, VkImageAspectFlagBits plane) {
-            VkImagePlaneMemoryRequirementsInfo image_plane_req = vku::InitStructHelper();
-            image_plane_req.planeAspect = plane;
+    VkImagePlaneMemoryRequirementsInfo image_plane_req = vku::InitStructHelper();
+    image_plane_req.planeAspect = VK_IMAGE_ASPECT_PLANE_0_BIT;
 
-            VkImageMemoryRequirementsInfo2 mem_req_info2 = vku::InitStructHelper(&image_plane_req);
-            mem_req_info2.image = mp_image;
+    VkImageMemoryRequirementsInfo2 mem_req_info2 = vku::InitStructHelper(&image_plane_req);
+    mem_req_info2.image = mp_image;
+    mp_image_mem_reqs2[0] = vku::InitStructHelper();
+    vk::GetImageMemoryRequirements2KHR(device(), &mem_req_info2, &mp_image_mem_reqs2[0]);
 
-            VkMemoryRequirements2 mp_image_mem_reqs2 = vku::InitStructHelper();
+    image_plane_req.planeAspect = VK_IMAGE_ASPECT_PLANE_1_BIT;
+    mp_image_mem_reqs2[1] = vku::InitStructHelper();
+    vk::GetImageMemoryRequirements2KHR(device(), &mem_req_info2, &mp_image_mem_reqs2[1]);
 
-            vk::GetImageMemoryRequirements2KHR(device(), &mem_req_info2, &mp_image_mem_reqs2);
+    mp_image_alloc_info[0] = vku::InitStructHelper();
+    mp_image_alloc_info[1] = vku::InitStructHelper();
 
-            VkMemoryAllocateInfo mp_image_alloc_info = vku::InitStructHelper();
-            mp_image_alloc_info.allocationSize = mp_image_mem_reqs2.memoryRequirements.size;
-            ASSERT_TRUE(
-                m_device->Physical().SetMemoryType(mp_image_mem_reqs2.memoryRequirements.memoryTypeBits, &mp_image_alloc_info, 0));
-            vk::AllocateMemory(device(), &mp_image_alloc_info, NULL, mp_image_mem);
-        };
+    mp_image_alloc_info[0].allocationSize = mp_image_mem_reqs2[0].memoryRequirements.size;
+    ASSERT_TRUE(
+        m_device->Physical().SetMemoryType(mp_image_mem_reqs2[0].memoryRequirements.memoryTypeBits, &mp_image_alloc_info[0], 0));
+    // Leave some extra space for alignment wiggle room
+    mp_image_alloc_info[1].allocationSize =
+        mp_image_mem_reqs2[1].memoryRequirements.size + mp_image_mem_reqs2[1].memoryRequirements.alignment;
+    ASSERT_TRUE(
+        m_device->Physical().SetMemoryType(mp_image_mem_reqs2[1].memoryRequirements.memoryTypeBits, &mp_image_alloc_info[1], 0));
 
-        allocate(mp_image_a, &mp_image_a_mem[0], VK_IMAGE_ASPECT_PLANE_0_BIT);
-        allocate(mp_image_a, &mp_image_a_mem[1], VK_IMAGE_ASPECT_PLANE_1_BIT);
-        allocate(mp_image_b, &mp_image_b_mem[0], VK_IMAGE_ASPECT_PLANE_0_BIT);
-        allocate(mp_image_b, &mp_image_b_mem[1], VK_IMAGE_ASPECT_PLANE_1_BIT);
+    ASSERT_EQ(VK_SUCCESS, vk::AllocateMemory(device(), &mp_image_alloc_info[0], NULL, &mp_image_mem[0]));
+    ASSERT_EQ(VK_SUCCESS, vk::AllocateMemory(device(), &mp_image_alloc_info[1], NULL, &mp_image_mem[1]));
+    ASSERT_EQ(VK_SUCCESS, vk::AllocateMemory(device(), &mp_image_alloc_info[0], NULL, &mp_unchecked_image_mem[0]));
+    ASSERT_EQ(VK_SUCCESS, vk::AllocateMemory(device(), &mp_image_alloc_info[1], NULL, &mp_unchecked_image_mem[1]));
 
+    // Sets an invalid offset to plane 1
+    if (mp_image_mem_reqs2[1].memoryRequirements.alignment > 1) {
         VkBindImagePlaneMemoryInfo plane_memory_info[2];
         plane_memory_info[0] = vku::InitStructHelper();
         plane_memory_info[0].planeAspect = VK_IMAGE_ASPECT_PLANE_0_BIT;
         plane_memory_info[1] = vku::InitStructHelper();
         plane_memory_info[1].planeAspect = VK_IMAGE_ASPECT_PLANE_1_BIT;
 
-        // set all sType and memoryOffset as they are the same
-        VkBindImageMemoryInfo bind_image_info[6];
-        for (int i = 0; i < 6; i++) {
-            bind_image_info[i] = vku::InitStructHelper();
-            bind_image_info[i].memoryOffset = 0;
-        }
+        VkBindImageMemoryInfo bind_image_info[2];
+        bind_image_info[0] = vku::InitStructHelper(&plane_memory_info[0]);
+        bind_image_info[0].image = mp_image;
+        bind_image_info[0].memory = mp_image_mem[0];
+        bind_image_info[0].memoryOffset = 0;
+        bind_image_info[1] = vku::InitStructHelper(&plane_memory_info[1]);
+        bind_image_info[1].image = mp_image;
+        bind_image_info[1].memory = mp_image_mem[1];
+        bind_image_info[1].memoryOffset = 1;  // off alignment
 
-        // Try only binding part of image_b
-        bind_image_info[0].pNext = (void *)&plane_memory_info[0];
-        bind_image_info[0].image = mp_image_a;
-        bind_image_info[0].memory = mp_image_a_mem[0];
-        bind_image_info[1].pNext = (void *)&plane_memory_info[1];
-        bind_image_info[1].image = mp_image_a;
-        bind_image_info[1].memory = mp_image_a_mem[1];
-        bind_image_info[2].pNext = (void *)&plane_memory_info[0];
-        bind_image_info[2].image = mp_image_b;
-        bind_image_info[2].memory = mp_image_b_mem[0];
-        m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory2-pBindInfos-02858");
-        vk::BindImageMemory2KHR(device(), 3, bind_image_info);
+        m_errorMonitor->SetDesiredError("VUID-VkBindImageMemoryInfo-pNext-01620");
+        vk::BindImageMemory2KHR(device(), 2, bind_image_info);
         m_errorMonitor->VerifyFound();
 
-        // Same thing, but mix in a non-disjoint image
-        bind_image_info[3].pNext = nullptr;
-        bind_image_info[3].image = normal_image;
-        bind_image_info[3].memory = normal_image_mem;
-        m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory2-pBindInfos-02858");
-        vk::BindImageMemory2KHR(device(), 4, bind_image_info);
+        // Should trigger same VUID even when image was never checked
+        // this makes an assumption that the driver will return the same image requirements for same createImageInfo where even
+        // being close to running out of heap space
+        bind_image_info[0].image = mp_unchecked_image;
+        bind_image_info[0].memory = mp_unchecked_image_mem[0];
+        bind_image_info[1].image = mp_unchecked_image;
+        bind_image_info[1].memory = mp_unchecked_image_mem[1];
+        m_errorMonitor->SetDesiredError("VUID-VkBindImageMemoryInfo-pNext-01620");
+        vk::BindImageMemory2KHR(device(), 2, bind_image_info);
         m_errorMonitor->VerifyFound();
-
-        // Try binding image_b plane 1 twice
-        // Valid case where binding disjoint and non-disjoint
-        bind_image_info[4].pNext = (void *)&plane_memory_info[1];
-        bind_image_info[4].image = mp_image_b;
-        bind_image_info[4].memory = mp_image_b_mem[1];
-        bind_image_info[5].pNext = (void *)&plane_memory_info[1];
-        bind_image_info[5].image = mp_image_b;
-        bind_image_info[5].memory = mp_image_b_mem[1];
-        m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory2-pBindInfos-04006");
-        vk::BindImageMemory2KHR(device(), 6, bind_image_info);
-        m_errorMonitor->VerifyFound();
-
-        // Try binding image_a with no plane specified
-        bind_image_info[0].pNext = nullptr;
-        m_errorMonitor->SetDesiredError("VUID-VkBindImageMemoryInfo-image-07736");
-        vk::BindImageMemory2KHR(device(), 1, bind_image_info);
-        m_errorMonitor->VerifyFound();
-        bind_image_info[0].pNext = (void *)&plane_memory_info[0];
-
-        // Valid case of binding 2 disjoint image and normal image by removing duplicate
-        vk::BindImageMemory2KHR(device(), 5, bind_image_info);
-
-        vk::FreeMemory(device(), mp_image_a_mem[0], nullptr);
-        vk::FreeMemory(device(), mp_image_a_mem[1], nullptr);
-        vk::FreeMemory(device(), mp_image_b_mem[0], nullptr);
-        vk::FreeMemory(device(), mp_image_b_mem[1], nullptr);
     }
+
+    vk::FreeMemory(device(), mp_image_mem[0], NULL);
+    vk::FreeMemory(device(), mp_image_mem[1], NULL);
+    vk::FreeMemory(device(), mp_unchecked_image_mem[0], NULL);
+    vk::FreeMemory(device(), mp_unchecked_image_mem[1], NULL);
+}
+
+TEST_F(NegativeMemory, BindMemory2BindInfos) {
+    TEST_DESCRIPTION("These tests deal with VK_KHR_bind_memory_2 and invalid VkBindImageMemoryInfo* pBindInfos");
+    AddRequiredExtensions(VK_KHR_BIND_MEMORY_2_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+
+    VkImageCreateInfo image_create_info =
+        vkt::Image::ImageCreateInfo2D(256, 256, 1, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+
+    // Create 2 image with 2 memory objects
+    vkt::Image image_a(*m_device, image_create_info, vkt::no_mem);
+    vkt::Image image_b(*m_device, image_create_info, vkt::no_mem);
+
+    VkMemoryRequirements image_mem_reqs = {};
+    vk::GetImageMemoryRequirements(device(), image_a, &image_mem_reqs);
+    VkMemoryAllocateInfo image_alloc_info = vku::InitStructHelper();
+    image_alloc_info.allocationSize = image_mem_reqs.size;
+    ASSERT_TRUE(m_device->Physical().SetMemoryType(image_mem_reqs.memoryTypeBits, &image_alloc_info, 0));
+    vkt::DeviceMemory image_a_mem(*m_device, image_alloc_info);
+
+    vk::GetImageMemoryRequirements(device(), image_b, &image_mem_reqs);
+    image_alloc_info.allocationSize = image_mem_reqs.size;
+    ASSERT_TRUE(m_device->Physical().SetMemoryType(image_mem_reqs.memoryTypeBits, &image_alloc_info, 0));
+    vkt::DeviceMemory image_b_mem(*m_device, image_alloc_info);
+
+    // Try binding same image twice in array
+    VkBindImageMemoryInfo bind_image_info[3];
+    bind_image_info[0] = vku::InitStructHelper();
+    bind_image_info[0].image = image_a;
+    bind_image_info[0].memory = image_a_mem;
+    bind_image_info[0].memoryOffset = 0;
+    bind_image_info[1] = vku::InitStructHelper();
+    bind_image_info[1].image = image_b;
+    bind_image_info[1].memory = image_b_mem;
+    bind_image_info[1].memoryOffset = 0;
+    bind_image_info[2] = bind_image_info[0];  // duplicate bind
+
+    m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory2-pBindInfos-04006");
+    vk::BindImageMemory2KHR(device(), 3, bind_image_info);
+    m_errorMonitor->VerifyFound();
+
+    // Bind same image to 2 different memory in same array
+    bind_image_info[1].image = image_a;
+    m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory2-pBindInfos-04006");
+    vk::BindImageMemory2KHR(device(), 2, bind_image_info);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeMemory, BindMemory2BindInfosMultiPlane) {
+    TEST_DESCRIPTION("These tests deal with VK_KHR_bind_memory_2 and invalid VkBindImageMemoryInfo* pBindInfos");
+    AddRequiredExtensions(VK_KHR_BIND_MEMORY_2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+
+    VkImageCreateInfo image_create_info =
+        vkt::Image::ImageCreateInfo2D(256, 256, 1, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+
+    const VkFormat mp_format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;
+
+    // Check for support of format used by all multi-planar tests
+    VkFormatProperties mp_format_properties;
+    vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), mp_format, &mp_format_properties);
+    if (!((mp_format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_DISJOINT_BIT) &&
+          (mp_format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT))) {
+        GTEST_SKIP() << "test rely on a supported disjoint format";
+    }
+
+    // Creat 1 normal, not disjoint image
+    vkt::Image normal_image(*m_device, image_create_info, vkt::no_mem);
+    VkMemoryRequirements image_mem_reqs = {};
+    vk::GetImageMemoryRequirements(device(), normal_image, &image_mem_reqs);
+    VkMemoryAllocateInfo image_alloc_info = vku::InitStructHelper();
+    image_alloc_info.allocationSize = image_mem_reqs.size;
+    ASSERT_TRUE(m_device->Physical().SetMemoryType(image_mem_reqs.memoryTypeBits, &image_alloc_info, 0));
+    vkt::DeviceMemory normal_image_mem(*m_device, image_alloc_info);
+
+    // Create 2 disjoint images with memory backing each plane
+    VkImageCreateInfo mp_image_create_info = image_create_info;
+    mp_image_create_info.format = mp_format;
+    mp_image_create_info.flags = VK_IMAGE_CREATE_DISJOINT_BIT;
+
+    VkDeviceMemory mp_image_a_mem[2] = {VK_NULL_HANDLE, VK_NULL_HANDLE};
+    VkDeviceMemory mp_image_b_mem[2] = {VK_NULL_HANDLE, VK_NULL_HANDLE};
+    vkt::Image mp_image_a(*m_device, mp_image_create_info, vkt::no_mem);
+    vkt::Image mp_image_b(*m_device, mp_image_create_info, vkt::no_mem);
+
+    auto allocate = [this](VkImage mp_image, VkDeviceMemory *mp_image_mem, VkImageAspectFlagBits plane) {
+        VkImagePlaneMemoryRequirementsInfo image_plane_req = vku::InitStructHelper();
+        image_plane_req.planeAspect = plane;
+
+        VkImageMemoryRequirementsInfo2 mem_req_info2 = vku::InitStructHelper(&image_plane_req);
+        mem_req_info2.image = mp_image;
+
+        VkMemoryRequirements2 mp_image_mem_reqs2 = vku::InitStructHelper();
+
+        vk::GetImageMemoryRequirements2KHR(device(), &mem_req_info2, &mp_image_mem_reqs2);
+
+        VkMemoryAllocateInfo mp_image_alloc_info = vku::InitStructHelper();
+        mp_image_alloc_info.allocationSize = mp_image_mem_reqs2.memoryRequirements.size;
+        ASSERT_TRUE(
+            m_device->Physical().SetMemoryType(mp_image_mem_reqs2.memoryRequirements.memoryTypeBits, &mp_image_alloc_info, 0));
+        vk::AllocateMemory(device(), &mp_image_alloc_info, NULL, mp_image_mem);
+    };
+
+    allocate(mp_image_a, &mp_image_a_mem[0], VK_IMAGE_ASPECT_PLANE_0_BIT);
+    allocate(mp_image_a, &mp_image_a_mem[1], VK_IMAGE_ASPECT_PLANE_1_BIT);
+    allocate(mp_image_b, &mp_image_b_mem[0], VK_IMAGE_ASPECT_PLANE_0_BIT);
+    allocate(mp_image_b, &mp_image_b_mem[1], VK_IMAGE_ASPECT_PLANE_1_BIT);
+
+    VkBindImagePlaneMemoryInfo plane_memory_info[2];
+    plane_memory_info[0] = vku::InitStructHelper();
+    plane_memory_info[0].planeAspect = VK_IMAGE_ASPECT_PLANE_0_BIT;
+    plane_memory_info[1] = vku::InitStructHelper();
+    plane_memory_info[1].planeAspect = VK_IMAGE_ASPECT_PLANE_1_BIT;
+
+    // set all sType and memoryOffset as they are the same
+    VkBindImageMemoryInfo bind_image_info[6];
+    for (int i = 0; i < 6; i++) {
+        bind_image_info[i] = vku::InitStructHelper();
+        bind_image_info[i].memoryOffset = 0;
+    }
+
+    // Try only binding part of image_b
+    bind_image_info[0].pNext = (void *)&plane_memory_info[0];
+    bind_image_info[0].image = mp_image_a;
+    bind_image_info[0].memory = mp_image_a_mem[0];
+    bind_image_info[1].pNext = (void *)&plane_memory_info[1];
+    bind_image_info[1].image = mp_image_a;
+    bind_image_info[1].memory = mp_image_a_mem[1];
+    bind_image_info[2].pNext = (void *)&plane_memory_info[0];
+    bind_image_info[2].image = mp_image_b;
+    bind_image_info[2].memory = mp_image_b_mem[0];
+    m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory2-pBindInfos-02858");
+    vk::BindImageMemory2KHR(device(), 3, bind_image_info);
+    m_errorMonitor->VerifyFound();
+
+    // Same thing, but mix in a non-disjoint image
+    bind_image_info[3].pNext = nullptr;
+    bind_image_info[3].image = normal_image;
+    bind_image_info[3].memory = normal_image_mem;
+    m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory2-pBindInfos-02858");
+    vk::BindImageMemory2KHR(device(), 4, bind_image_info);
+    m_errorMonitor->VerifyFound();
+
+    // Try binding image_b plane 1 twice
+    // Valid case where binding disjoint and non-disjoint
+    bind_image_info[4].pNext = (void *)&plane_memory_info[1];
+    bind_image_info[4].image = mp_image_b;
+    bind_image_info[4].memory = mp_image_b_mem[1];
+    bind_image_info[5].pNext = (void *)&plane_memory_info[1];
+    bind_image_info[5].image = mp_image_b;
+    bind_image_info[5].memory = mp_image_b_mem[1];
+    m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory2-pBindInfos-04006");
+    vk::BindImageMemory2KHR(device(), 6, bind_image_info);
+    m_errorMonitor->VerifyFound();
+
+    // Try binding image_a with no plane specified
+    bind_image_info[0].pNext = nullptr;
+    m_errorMonitor->SetDesiredError("VUID-VkBindImageMemoryInfo-image-07736");
+    vk::BindImageMemory2KHR(device(), 1, bind_image_info);
+    m_errorMonitor->VerifyFound();
+    bind_image_info[0].pNext = (void *)&plane_memory_info[0];
+
+    // Valid case of binding 2 disjoint image and normal image by removing duplicate
+    vk::BindImageMemory2KHR(device(), 5, bind_image_info);
+
+    vk::FreeMemory(device(), mp_image_a_mem[0], nullptr);
+    vk::FreeMemory(device(), mp_image_a_mem[1], nullptr);
+    vk::FreeMemory(device(), mp_image_b_mem[0], nullptr);
+    vk::FreeMemory(device(), mp_image_b_mem[1], nullptr);
 }
 
 TEST_F(NegativeMemory, BindMemoryToDestroyedObject) {
@@ -1908,11 +1902,7 @@ TEST_F(NegativeMemory, DedicatedAllocation) {
 
 TEST_F(NegativeMemory, MemoryRequirements) {
     TEST_DESCRIPTION("Create invalid requests to image and buffer memory requirments.");
-
-    // Enable KHR YCbCr req'd extensions for Disjoint Bit
-    AddRequiredExtensions(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);
-    AddOptionalExtensions(VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
     // Need to make sure disjoint is supported for format
@@ -1922,91 +1912,90 @@ TEST_F(NegativeMemory, MemoryRequirements) {
     if (!((format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_DISJOINT_BIT) &&
           (format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT))) {
         GTEST_SKIP() << "test requires disjoint/sampled feature bit on format";
-    } else {
-        VkImageCreateInfo image_create_info = vku::InitStructHelper();
-        image_create_info.imageType = VK_IMAGE_TYPE_2D;
-        image_create_info.format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;
-        image_create_info.extent.width = 64;
-        image_create_info.extent.height = 64;
-        image_create_info.extent.depth = 1;
-        image_create_info.mipLevels = 1;
-        image_create_info.arrayLayers = 1;
-        image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
-        image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
-        image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-        image_create_info.flags = VK_IMAGE_CREATE_DISJOINT_BIT;
-
-        VkImage image;
-        VkResult err = vk::CreateImage(device(), &image_create_info, NULL, &image);
-        ASSERT_EQ(VK_SUCCESS, err);
-
-        m_errorMonitor->SetDesiredError("VUID-vkGetImageMemoryRequirements-image-01588");
-        VkMemoryRequirements memory_requirements;
-        vk::GetImageMemoryRequirements(device(), image, &memory_requirements);
-        m_errorMonitor->VerifyFound();
-
-        VkImageMemoryRequirementsInfo2 mem_req_info2 = vku::InitStructHelper();
-        mem_req_info2.image = image;
-        VkMemoryRequirements2 mem_req2 = vku::InitStructHelper();
-
-        m_errorMonitor->SetDesiredError("VUID-VkImageMemoryRequirementsInfo2-image-01589");
-        vk::GetImageMemoryRequirements2KHR(device(), &mem_req_info2, &mem_req2);
-        m_errorMonitor->VerifyFound();
-
-        // Point to a 3rd plane for a 2-plane format
-        VkImagePlaneMemoryRequirementsInfo image_plane_req = vku::InitStructHelper();
-        image_plane_req.planeAspect = VK_IMAGE_ASPECT_PLANE_2_BIT;
-        mem_req_info2.pNext = &image_plane_req;
-        mem_req_info2.image = image;
-
-        m_errorMonitor->SetDesiredError("VUID-VkImagePlaneMemoryRequirementsInfo-planeAspect-02281");
-        vk::GetImageMemoryRequirements2KHR(device(), &mem_req_info2, &mem_req2);
-        m_errorMonitor->VerifyFound();
-
-        // Test with a non planar image aspect also
-        image_plane_req.planeAspect = VK_IMAGE_ASPECT_COLOR_BIT;
-        mem_req_info2.pNext = &image_plane_req;
-        mem_req_info2.image = image;
-
-        m_errorMonitor->SetDesiredError("VUID-VkImagePlaneMemoryRequirementsInfo-planeAspect-02281");
-        vk::GetImageMemoryRequirements2KHR(device(), &mem_req_info2, &mem_req2);
-        m_errorMonitor->VerifyFound();
-
-        vk::DestroyImage(device(), image, nullptr);
-
-        // Recreate image without Disjoint bit
-        image_create_info.flags = 0;
-        err = vk::CreateImage(device(), &image_create_info, NULL, &image);
-        ASSERT_EQ(VK_SUCCESS, err);
-
-        image_plane_req.planeAspect = VK_IMAGE_ASPECT_PLANE_0_BIT;
-        mem_req_info2.pNext = &image_plane_req;
-        mem_req_info2.image = image;
-
-        m_errorMonitor->SetDesiredError("VUID-VkImageMemoryRequirementsInfo2-image-01590");
-        vk::GetImageMemoryRequirements2KHR(device(), &mem_req_info2, &mem_req2);
-        m_errorMonitor->VerifyFound();
-
-        vk::DestroyImage(device(), image, nullptr);
-
-        // Recreate image with single plane format and with Disjoint bit
-        image_create_info.flags = 0;
-        image_create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
-        err = vk::CreateImage(device(), &image_create_info, NULL, &image);
-        ASSERT_EQ(VK_SUCCESS, err);
-
-        image_plane_req.planeAspect = VK_IMAGE_ASPECT_PLANE_0_BIT;
-        mem_req_info2.pNext = &image_plane_req;
-        mem_req_info2.image = image;
-
-        // Disjoint bit isn't set as likely not even supported by non-planar format
-        m_errorMonitor->SetUnexpectedError("VUID-VkImageMemoryRequirementsInfo2-image-01590");
-        m_errorMonitor->SetDesiredError("VUID-VkImageMemoryRequirementsInfo2-image-02280");
-        vk::GetImageMemoryRequirements2KHR(device(), &mem_req_info2, &mem_req2);
-        m_errorMonitor->VerifyFound();
-
-        vk::DestroyImage(device(), image, nullptr);
     }
+    VkImageCreateInfo image_create_info = vku::InitStructHelper();
+    image_create_info.imageType = VK_IMAGE_TYPE_2D;
+    image_create_info.format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;
+    image_create_info.extent.width = 64;
+    image_create_info.extent.height = 64;
+    image_create_info.extent.depth = 1;
+    image_create_info.mipLevels = 1;
+    image_create_info.arrayLayers = 1;
+    image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
+    image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
+    image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
+    image_create_info.flags = VK_IMAGE_CREATE_DISJOINT_BIT;
+
+    VkImage image;
+    VkResult err = vk::CreateImage(device(), &image_create_info, NULL, &image);
+    ASSERT_EQ(VK_SUCCESS, err);
+
+    m_errorMonitor->SetDesiredError("VUID-vkGetImageMemoryRequirements-image-01588");
+    VkMemoryRequirements memory_requirements;
+    vk::GetImageMemoryRequirements(device(), image, &memory_requirements);
+    m_errorMonitor->VerifyFound();
+
+    VkImageMemoryRequirementsInfo2 mem_req_info2 = vku::InitStructHelper();
+    mem_req_info2.image = image;
+    VkMemoryRequirements2 mem_req2 = vku::InitStructHelper();
+
+    m_errorMonitor->SetDesiredError("VUID-VkImageMemoryRequirementsInfo2-image-01589");
+    vk::GetImageMemoryRequirements2KHR(device(), &mem_req_info2, &mem_req2);
+    m_errorMonitor->VerifyFound();
+
+    // Point to a 3rd plane for a 2-plane format
+    VkImagePlaneMemoryRequirementsInfo image_plane_req = vku::InitStructHelper();
+    image_plane_req.planeAspect = VK_IMAGE_ASPECT_PLANE_2_BIT;
+    mem_req_info2.pNext = &image_plane_req;
+    mem_req_info2.image = image;
+
+    m_errorMonitor->SetDesiredError("VUID-VkImagePlaneMemoryRequirementsInfo-planeAspect-02281");
+    vk::GetImageMemoryRequirements2KHR(device(), &mem_req_info2, &mem_req2);
+    m_errorMonitor->VerifyFound();
+
+    // Test with a non planar image aspect also
+    image_plane_req.planeAspect = VK_IMAGE_ASPECT_COLOR_BIT;
+    mem_req_info2.pNext = &image_plane_req;
+    mem_req_info2.image = image;
+
+    m_errorMonitor->SetDesiredError("VUID-VkImagePlaneMemoryRequirementsInfo-planeAspect-02281");
+    vk::GetImageMemoryRequirements2KHR(device(), &mem_req_info2, &mem_req2);
+    m_errorMonitor->VerifyFound();
+
+    vk::DestroyImage(device(), image, nullptr);
+
+    // Recreate image without Disjoint bit
+    image_create_info.flags = 0;
+    err = vk::CreateImage(device(), &image_create_info, NULL, &image);
+    ASSERT_EQ(VK_SUCCESS, err);
+
+    image_plane_req.planeAspect = VK_IMAGE_ASPECT_PLANE_0_BIT;
+    mem_req_info2.pNext = &image_plane_req;
+    mem_req_info2.image = image;
+
+    m_errorMonitor->SetDesiredError("VUID-VkImageMemoryRequirementsInfo2-image-01590");
+    vk::GetImageMemoryRequirements2KHR(device(), &mem_req_info2, &mem_req2);
+    m_errorMonitor->VerifyFound();
+
+    vk::DestroyImage(device(), image, nullptr);
+
+    // Recreate image with single plane format and with Disjoint bit
+    image_create_info.flags = 0;
+    image_create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
+    err = vk::CreateImage(device(), &image_create_info, NULL, &image);
+    ASSERT_EQ(VK_SUCCESS, err);
+
+    image_plane_req.planeAspect = VK_IMAGE_ASPECT_PLANE_0_BIT;
+    mem_req_info2.pNext = &image_plane_req;
+    mem_req_info2.image = image;
+
+    // Disjoint bit isn't set as likely not even supported by non-planar format
+    m_errorMonitor->SetUnexpectedError("VUID-VkImageMemoryRequirementsInfo2-image-01590");
+    m_errorMonitor->SetDesiredError("VUID-VkImageMemoryRequirementsInfo2-image-02280");
+    vk::GetImageMemoryRequirements2KHR(device(), &mem_req_info2, &mem_req2);
+    m_errorMonitor->VerifyFound();
+
+    vk::DestroyImage(device(), image, nullptr);
 }
 
 TEST_F(NegativeMemory, MemoryAllocatepNextChain) {

--- a/tests/unit/sampler.cpp
+++ b/tests/unit/sampler.cpp
@@ -734,8 +734,6 @@ TEST_F(NegativeSampler, ImageSamplerConversionNullImageView) {
 
 TEST_F(NegativeSampler, FilterMinmax) {
     TEST_DESCRIPTION("Invalid uses of VK_EXT_sampler_filter_minmax.");
-
-    // Enable KHR multiplane req'd extensions
     AddRequiredExtensions(VK_EXT_SAMPLER_FILTER_MINMAX_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -916,12 +916,12 @@ TEST_F(NegativeSyncVal, CopyOptimalMultiPlanarHazards) {
     vkt::Image image_b(*m_device, image_ci);
     vkt::Image image_c(*m_device, image_ci);
 
-    VkImageSubresourceLayers layer_all_plane0{VK_IMAGE_ASPECT_PLANE_0_BIT_KHR, 0, 0, 2};
-    VkImageSubresourceLayers layer0_plane0{VK_IMAGE_ASPECT_PLANE_0_BIT_KHR, 0, 0, 1};
-    VkImageSubresourceLayers layer0_plane1{VK_IMAGE_ASPECT_PLANE_1_BIT_KHR, 0, 0, 1};
-    VkImageSubresourceLayers layer1_plane1{VK_IMAGE_ASPECT_PLANE_1_BIT_KHR, 0, 1, 1};
+    VkImageSubresourceLayers layer_all_plane0{VK_IMAGE_ASPECT_PLANE_0_BIT, 0, 0, 2};
+    VkImageSubresourceLayers layer0_plane0{VK_IMAGE_ASPECT_PLANE_0_BIT, 0, 0, 1};
+    VkImageSubresourceLayers layer0_plane1{VK_IMAGE_ASPECT_PLANE_1_BIT, 0, 0, 1};
+    VkImageSubresourceLayers layer1_plane1{VK_IMAGE_ASPECT_PLANE_1_BIT, 0, 1, 1};
     VkImageSubresourceRange full_subresource_range{
-        VK_IMAGE_ASPECT_PLANE_0_BIT_KHR | VK_IMAGE_ASPECT_PLANE_1_BIT_KHR | VK_IMAGE_ASPECT_PLANE_2_BIT_KHR, 0, 1, 0, 2};
+        VK_IMAGE_ASPECT_PLANE_0_BIT | VK_IMAGE_ASPECT_PLANE_1_BIT | VK_IMAGE_ASPECT_PLANE_2_BIT, 0, 1, 0, 2};
     VkOffset3D zero_offset{0, 0, 0};
     VkOffset3D one_four_offset{32, 32, 0};
     VkExtent3D full_extent{128, 128, 1};    // <-- image type is 2D
@@ -1100,10 +1100,10 @@ TEST_F(NegativeSyncVal, CopyLinearMultiPlanarHazards) {
     vkt::Image image_b(*m_device, image_ci);
     vkt::Image image_c(*m_device, image_ci);
 
-    VkImageSubresourceLayers layer_all_plane0{VK_IMAGE_ASPECT_PLANE_0_BIT_KHR, 0, 0, 1};
-    VkImageSubresourceLayers layer_all_plane1{VK_IMAGE_ASPECT_PLANE_1_BIT_KHR, 0, 0, 1};
+    VkImageSubresourceLayers layer_all_plane0{VK_IMAGE_ASPECT_PLANE_0_BIT, 0, 0, 1};
+    VkImageSubresourceLayers layer_all_plane1{VK_IMAGE_ASPECT_PLANE_1_BIT, 0, 0, 1};
     VkImageSubresourceRange full_subresource_range{
-        VK_IMAGE_ASPECT_PLANE_0_BIT_KHR | VK_IMAGE_ASPECT_PLANE_1_BIT_KHR | VK_IMAGE_ASPECT_PLANE_2_BIT_KHR, 0, 1, 0, 1};
+        VK_IMAGE_ASPECT_PLANE_0_BIT | VK_IMAGE_ASPECT_PLANE_1_BIT | VK_IMAGE_ASPECT_PLANE_2_BIT, 0, 1, 0, 1};
     VkOffset3D zero_offset{0, 0, 0};
     VkOffset3D one_four_offset{32, 32, 0};
     VkExtent3D full_extent{128, 128, 1};    // <-- image type is 2D


### PR DESCRIPTION
- Removes `AddOptionalExtensions(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);` in favor for a Multi-Plane version of tests
- Remove `InitBasicYcbcr` to use new enable feature/extensions (this extension loooooog ago was the worst because it had so many requirements and didn't have codegen yet)
- remove `_KHR` suffix where not needed