### PR TITLE
scripts: Fix UTF8 with ASCII values

### DIFF
--- a/scripts/generate_spec_error_message.py
+++ b/scripts/generate_spec_error_message.py
@@ -61,12 +61,12 @@ class ValidationJSON:
             '\u2026' : '...',# HORIZONTAL ELLIPSIS
             '\u2032' : "'",  # PRIME
             '\u2192' : '->', # RIGHTWARDS ARROW
-            '\u2308' : '⌈', # LEFT CEILING
-            '\u2309' : '⌉', # RIGHT CEILING
-            '\u230a' : '⌊', # LEFT FLOOR
-            '\u230b' : '⌋', # RIGHT FLOOR
-            '\u00d7' : '×', # MULTIPLICATION SIGN
-            '\u2264' : '≤', # LESS-THAN OR EQUAL TO
+            '\u2308' : 'ceil(', # LEFT CEILING (⌈)
+            '\u2309' : ')', # RIGHT CEILING (⌉)
+            '\u230a' : 'floor(', # LEFT FLOOR (⌊)
+            '\u230b' : ')', # RIGHT FLOOR (⌋)
+            '\u00d7' : 'x', # MULTIPLICATION SIGN (×)
+            '\u2264' : '<=', # LESS-THAN OR EQUAL TO (≤)
         }
 
     def sanitize(self, text, location):


### PR DESCRIPTION
Fixes messages like
![image](https://github.com/user-attachments/assets/9b3cb6ec-7277-4d40-8f92-5e5a55dcc6aa)
