### PR TITLE
layers: Add error message for binary signal dependency

### DIFF
--- a/layers/state_tracker/queue_state.cpp
+++ b/layers/state_tracker/queue_state.cpp
@@ -135,14 +135,13 @@ void vvl::Queue::NotifyAndWait(const Location &loc, uint64_t until_seq) {
     Wait(loc, until_seq);
 }
 
-std::optional<vvl::QueueSubmission::SemaphoreInfo> vvl::Queue::HasTimelineWaitWithoutResolvingSignal(uint64_t until_seq) const {
-    auto guard = Lock();
-
+std::optional<vvl::SemaphoreInfo> vvl::Queue::FindTimelineWaitWithoutResolvingSignal(uint64_t until_seq) const {
     // A simple optimization for a long sequence of submits without host waits.
     // Stop iteration over submits if there are no timeline waits left. If only
     // binary semaphores are used this will return immediately.
     uint32_t processed_waits = 0;
 
+    auto guard = Lock();
     for (auto it = submissions_.rbegin(); it != submissions_.rend() && processed_waits < timeline_wait_count_; ++it) {
         const vvl::QueueSubmission &submission = *it;
         if (submission.seq > until_seq) {

--- a/layers/state_tracker/queue_state.h
+++ b/layers/state_tracker/queue_state.h
@@ -35,11 +35,6 @@ class CommandBuffer;
 class Queue;
 
 struct QueueSubmission {
-    struct SemaphoreInfo {
-        SemaphoreInfo(std::shared_ptr<Semaphore> &&sem, uint64_t pl) : semaphore(std::move(sem)), payload(pl) {}
-        std::shared_ptr<Semaphore> semaphore;
-        uint64_t payload{0};
-    };
     QueueSubmission(const Location &loc_) : loc(loc_), completed(), waiter(completed.get_future()) {}
 
     bool end_batch{false};
@@ -115,10 +110,9 @@ class Queue : public StateObject {
     // Helper that combines Notify and Wait
     void NotifyAndWait(const Location &loc, uint64_t until_seq = kU64Max);
 
-    // Check if there is a timeline wait before or at until_seq submission that
-    // does not have a resolving timeline signal submitted yet. If such wait exists
-    // then the function returns not empty object with semaphore wait information.
-    std::optional<vvl::QueueSubmission::SemaphoreInfo> HasTimelineWaitWithoutResolvingSignal(uint64_t until_seq) const;
+    // Find a timeline wait that does not have a resolving signal submitted yet.
+    // Check submissions up to and including until_seq.
+    std::optional<SemaphoreInfo> FindTimelineWaitWithoutResolvingSignal(uint64_t until_seq) const;
 
   public:
     // Queue family index. As queueFamilyIndex parameter in vkGetDeviceQueue.

--- a/layers/state_tracker/semaphore_state.h
+++ b/layers/state_tracker/semaphore_state.h
@@ -30,6 +30,13 @@ class ValidationStateTracker;
 namespace vvl {
 
 class Queue;
+class Semaphore;
+
+struct SemaphoreInfo {
+    SemaphoreInfo(std::shared_ptr<Semaphore> &&sem, uint64_t pl) : semaphore(std::move(sem)), payload(pl) {}
+    std::shared_ptr<Semaphore> semaphore;
+    uint64_t payload{0};
+};
 
 class Semaphore : public RefcountedStateObject {
   public:
@@ -104,6 +111,12 @@ class Semaphore : public RefcountedStateObject {
 
     // Returns pending queue submission that waits on this binary semaphore.
     std::optional<SubmissionReference> GetPendingBinaryWaitSubmission() const;
+
+    // If a pending binary signal depends on an unresolved timeline wait, this function
+    // returns information about the timeline wait; otherwise, it returns an empty result.
+    // This is used to validate VUs (such as VUID-vkQueueSubmit-pWaitSemaphores-03238) that have this statement:
+    // "and any semaphore signal operations on which it depends must have also been submitted for execution"
+    std::optional<SemaphoreInfo> GetPendingBinarySignalTimelineDependency() const;  
 
     // Current payload value.
     // If a queue submission command is pending execution, then the returned value may immediately be out of date


### PR DESCRIPTION
Follow-up to https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/8739

VUs like `VUID-vkQueueSubmit2-semaphore-03873` validate binary wait by checking two conditions:
  * there is a signal
  * signal does not depend on not submitted signal

Existing message covers the first condition. This PR provides a separate message for the second condition.

Also provided additional test for external semaphore `VUID-VkSemaphoreGetFdInfoKHR-handleType-03254`, other VUs are tested by https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/8739

> Validation Error: [ VUID-VkSemaphoreGetFdInfoKHR-handleType-03254 ] Object 0: handle = 0xf56c9b0000000004, type = VK_OBJECT_TYPE_SEMAPHORE; Object 1: handle = 0xe7f79a0000000005, type = VK_OBJECT_TYPE_SEMAPHORE; | MessageID = 0x6b4a4728 | vkGetSemaphoreFdKHR(): **pGetFdInfo->semaphore (VkSemaphore 0xf56c9b0000000004[]) has an associated signal but it depends on timeline semaphore wait (VkSemaphore 0xe7f79a0000000005[], wait value = 1) that does not have resolving signal submitted yet**.
The Vulkan spec states: If handleType refers to a handle type with copy payload transference semantics, semaphore must have an associated semaphore signal operation that has been submitted for execution and any semaphore signal operations on which it depends must have also been submitted for execution (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-VkSemaphoreGetFdInfoKHR-handleType-03254)