### PR TITLE
layers: Add Extension Checks for Layer Extensions

### DIFF
--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2025 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/best_practices.cpp
+++ b/tests/unit/best_practices.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (c) 2015-2024 Google, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2025 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -103,8 +103,9 @@ TEST_F(VkBestPracticesLayerTest, UseDeprecatedInstanceExtensions) {
         // Extra error if VK_EXT_debug_report is used on Android still
         m_errorMonitor->SetDesiredWarning("BestPractices-deprecated-extension");
     }
-    m_errorMonitor->SetDesiredWarning("BestPractices-deprecated-extension");
-    m_errorMonitor->SetDesiredWarning("BestPractices-specialuse-extension");
+
+    m_errorMonitor->SetDesiredWarning("BestPractices-deprecated-extension");  // VK_KHR_get_physical_device_properties2,
+    m_errorMonitor->SetDesiredWarning("BestPractices-specialuse-extension");  // VK_EXT_debug_utils
     VkInstance dummy;
     auto features = features_;
     auto ici = GetInstanceCreateInfo();

--- a/tests/unit/portability_subset.cpp
+++ b/tests/unit/portability_subset.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2020-2024 The Khronos Group Inc.
- * Copyright (c) 2020-2024 Valve Corporation
- * Copyright (c) 2020-2024 LunarG, Inc.
+ * Copyright (c) 2020-2025 The Khronos Group Inc.
+ * Copyright (c) 2020-2025 Valve Corporation
+ * Copyright (c) 2020-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -608,10 +608,17 @@ TEST_F(VkPortabilitySubsetTest, PortabilitySubsetColorBlendFactor) {
 
 TEST_F(VkPortabilitySubsetTest, InstanceCreateEnumerate) {
     TEST_DESCRIPTION("Validate creating instances with VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR.");
+    std::vector<const char *> enabled_extensions = {VK_EXT_DEBUG_UTILS_EXTENSION_NAME,
+                                                    VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME};
+
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+    GTEST_SKIP() << "Android doesn't support Debug Utils";
+#endif
 
     auto ici = GetInstanceCreateInfo();
     ici.flags = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
     ici.enabledExtensionCount = 1;
+    ici.ppEnabledExtensionNames = enabled_extensions.data();
 
     VkInstance local_instance;
 
@@ -620,11 +627,7 @@ TEST_F(VkPortabilitySubsetTest, InstanceCreateEnumerate) {
     m_errorMonitor->VerifyFound();
 
     if (InstanceExtensionSupported(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME)) {
-        std::vector<const char *> enabled_extensions = {VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME,
-                                                        VK_EXT_DEBUG_UTILS_EXTENSION_NAME};
-        ici.enabledExtensionCount = static_cast<uint32_t>(enabled_extensions.size());
-        ici.ppEnabledExtensionNames = enabled_extensions.data();
-
+        ici.enabledExtensionCount = 2;
         ASSERT_EQ(VK_SUCCESS, vk::CreateInstance(&ici, nullptr, &local_instance));
         vk::DestroyInstance(local_instance, nullptr);
     }


### PR DESCRIPTION
From https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8760#issuecomment-2442023146 and matches spec change in https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/6979 

This makes sure if you are using an extension like `VK_EXT_layer_settings` you need the `VkInstanceCreateInfo::ppEnabledExtensionNames` like any other extension

cc @charles-lunarg to make sure I am not overlooking anything obvious