### PR TITLE
tests: Remove unused GetPhysicalDeviceFeatures

### DIFF
--- a/tests/device_profiles/max_profile.json
+++ b/tests/device_profiles/max_profile.json
@@ -1040,7 +1040,7 @@
                         "maxTessellationEvaluationOutputComponents": 128,
                         "maxTessellationGenerationLevel": 64,
                         "maxTessellationPatchSize": 32,
-                        "maxTexelBufferElements": 4294967000,
+                        "maxTexelBufferElements": 65536,
                         "maxTexelGatherOffset": 31,
                         "maxTexelOffset": 7,
                         "maxUniformBufferRange": 65536,

--- a/tests/device_profiles/max_profile.json
+++ b/tests/device_profiles/max_profile.json
@@ -1276,7 +1276,7 @@
                     "filterMinmaxImageComponentMapping": true
                 },
                 "VkPhysicalDeviceSampleLocationsPropertiesEXT": {
-                    "variableSampleLocations": false,
+                    "variableSampleLocations": true,
                     "sampleLocationSampleCounts": [
                         "VK_SAMPLE_COUNT_1_BIT",
                         "VK_SAMPLE_COUNT_2_BIT",
@@ -1462,7 +1462,7 @@
                         65535,
                         65535
                     ],
-                    "maxTaskWorkGroupInvocations": 32,
+                    "maxTaskWorkGroupInvocations": 128,
                     "maxTaskWorkGroupSize": [
                         128,
                         128,
@@ -4360,7 +4360,6 @@
                             "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
                             "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
                             "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
-                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
                             "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT",
                             "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
                             "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
@@ -4383,7 +4382,6 @@
                             "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
                             "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
                             "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
-                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
                             "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT",
                             "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
                             "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
@@ -4406,7 +4404,6 @@
                             "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
                             "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
                             "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
-                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
                             "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_CUBIC_BIT",
                             "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
                             "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT",
@@ -4795,7 +4792,6 @@
                             "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
                             "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
                             "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
-                            "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
                             "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
                             "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
                             "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
@@ -4818,7 +4814,6 @@
                             "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
                             "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
                             "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
-                            "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
                             "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
                             "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
                             "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
@@ -4841,7 +4836,6 @@
                             "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
                             "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
                             "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
-                            "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
                             "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
                             "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
                             "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
@@ -5307,7 +5301,6 @@
                             "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
                             "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
                             "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
-                            "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
                             "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
                             "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
                             "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
@@ -5330,7 +5323,6 @@
                             "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
                             "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
                             "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
-                            "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
                             "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
                             "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
                             "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
@@ -5353,7 +5345,6 @@
                             "VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_ATOMIC_BIT",
                             "VK_FORMAT_FEATURE_2_VERTEX_BUFFER_BIT",
                             "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BIT",
-                            "VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT",
                             "VK_FORMAT_FEATURE_2_BLIT_SRC_BIT",
                             "VK_FORMAT_FEATURE_2_BLIT_DST_BIT",
                             "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT",
@@ -6757,6 +6748,16 @@
                         ]
                     }
                 },
+                "VK_FORMAT_ASTC_10x10_UNORM_BLOCK": {
+                    "VkFormatProperties3": {
+                        "linearTilingFeatures": [],
+                        "optimalTilingFeatures": [
+                            "VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT",
+                            "VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT"
+                        ],
+                        "bufferFeatures": []
+                    }
+                },
                 "VK_FORMAT_ASTC_12x12_UNORM_BLOCK": {
                     "VkFormatProperties3": {
                         "linearTilingFeatures": [
@@ -7914,6 +7915,20 @@
                             "VK_VIDEO_CODEC_OPERATION_ENCODE_H264_BIT_KHR",
                             "VK_VIDEO_CODEC_OPERATION_ENCODE_H265_BIT_KHR"
                         ]
+                    }
+                },
+                {
+                    "VkQueueFamilyProperties": {
+                        "queueFlags": [
+                            "VK_QUEUE_COMPUTE_BIT"
+                        ],
+                        "queueCount": 2,
+                        "timestampValidBits": 16,
+                        "minImageTransferGranularity": {
+                            "width": 1,
+                            "height": 1,
+                            "depth": 1
+                        }
                     }
                 }
             ]

--- a/tests/unit/arm_best_practices.cpp
+++ b/tests/unit/arm_best_practices.cpp
@@ -587,8 +587,7 @@ TEST_F(VkArmBestPracticesLayerTest, PresentModeTest) {
     swapchain_create_info.oldSwapchain = 0;
     swapchain_create_info.compositeAlpha = m_surface_composite_alpha;
     if (m_surface_present_modes.size() <= 1) {
-        printf("TEST SKIPPED: Only %i presentation mode is available!", int(m_surface_present_modes.size()));
-        return;
+        GTEST_SKIP() << "Only 1 presentation mode is available";
     }
 
     for (size_t i = 0; i < m_surface_present_modes.size(); i++) {

--- a/tests/unit/atomics.cpp
+++ b/tests/unit/atomics.cpp
@@ -572,8 +572,6 @@ TEST_F(NegativeAtomic, Float) {
     AddRequiredFeature(vkt::Feature::shaderFloat64);
     // Create device without VK_EXT_shader_atomic_float extension or features enabled
     RETURN_IF_SKIP(Init());
-    VkPhysicalDeviceFeatures available_features = {};
-    GetPhysicalDeviceFeatures(&available_features);
 
     // clang-format off
     std::string cs_32_base = R"glsl(
@@ -764,12 +762,10 @@ TEST_F(NegativeAtomic, Float) {
         m_errorMonitor->VerifyFound();
     }
 
-    // shaderBufferFloat64Atomics
-    if (available_features.shaderFloat64) {
-        {
-            m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-None-06284");
-            VkShaderObj const cs(this, cs_buffer_float_64_load.c_str(), VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1);
-            m_errorMonitor->VerifyFound();
+    // shaderBufferFloat64Atomics (requires shaderFloat64)
+    {{m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-None-06284");
+    VkShaderObj const cs(this, cs_buffer_float_64_load.c_str(), VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1);
+    m_errorMonitor->VerifyFound();
         }
         {
             m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-None-06284");
@@ -816,8 +812,6 @@ TEST_F(NegativeAtomic, Float) {
             VkShaderObj const cs(this, cs_shared_float_64_add.c_str(), VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1);
             m_errorMonitor->VerifyFound();
         }
-    } else {
-        printf("Skipping 64-bit float tests\n");
     }
 
     // shaderImageFloat32Atomics

--- a/tests/unit/buffer_positive.cpp
+++ b/tests/unit/buffer_positive.cpp
@@ -76,9 +76,7 @@ TEST_F(PositiveBuffer, TexelBufferAlignmentIn13) {
 
     // to prevent VUID-VkBufferViewCreateInfo-buffer-02751
     const uint32_t block_size = 4;  // VK_FORMAT_R8G8B8A8_UNORM
-
-    const VkBufferCreateInfo buffer_info = vkt::Buffer::CreateInfo(1024, VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT);
-    vkt::Buffer buffer(*m_device, buffer_info, (VkMemoryPropertyFlags)VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    vkt::Buffer buffer(*m_device, 1024, VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT);
 
     VkBufferViewCreateInfo buff_view_ci = vku::InitStructHelper();
     buff_view_ci.format = VK_FORMAT_R8G8B8A8_UNORM;

--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -1913,13 +1913,7 @@ TEST_F(NegativeCommand, IndirectDraw) {
 
 TEST_F(NegativeCommand, MultiDrawIndirectFeature) {
     TEST_DESCRIPTION("use vkCmdDrawIndexedIndirect without MultiDrawIndirect");
-
-    RETURN_IF_SKIP(InitFramework());
-
-    VkPhysicalDeviceFeatures features;
-    vk::GetPhysicalDeviceFeatures(Gpu(), &features);
-    features.multiDrawIndirect = VK_FALSE;
-    RETURN_IF_SKIP(InitState(&features));
+    RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
     if (m_device->Physical().limits_.maxDrawIndirectCount < 2) {

--- a/tests/unit/copy_buffer_image.cpp
+++ b/tests/unit/copy_buffer_image.cpp
@@ -2515,8 +2515,8 @@ TEST_F(NegativeCopyBufferImage, DifferentFormatTexelBlockExtent) {
     SetTargetApiVersion(VK_API_VERSION_1_3);
     RETURN_IF_SKIP(Init());
 
-    VkFormat src_format = VK_FORMAT_BC7_UNORM_BLOCK;
-    VkFormat dst_format = VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK;
+    VkFormat src_format = VK_FORMAT_BC3_UNORM_BLOCK;
+    VkFormat dst_format = VK_FORMAT_ASTC_12x12_SRGB_BLOCK;
 
     VkFormatProperties format_properties;
     vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), src_format, &format_properties);

--- a/tests/unit/dynamic_state.cpp
+++ b/tests/unit/dynamic_state.cpp
@@ -12,6 +12,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#include <gtest/gtest.h>
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/render_pass_helper.h"
@@ -395,7 +396,6 @@ TEST_F(NegativeDynamicState, SetScissorParam) {
 
 TEST_F(NegativeDynamicState, SetScissorParamMultiviewport) {
     TEST_DESCRIPTION("Test parameters of vkCmdSetScissor with multiViewport feature enabled");
-
     AddRequiredFeature(vkt::Feature::multiViewport);
     RETURN_IF_SKIP(Init());
 
@@ -410,30 +410,36 @@ TEST_F(NegativeDynamicState, SetScissorParamMultiviewport) {
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetScissor-pScissors-parameter");
     vk::CmdSetScissor(m_command_buffer.handle(), 0, max_scissors, nullptr);
     m_errorMonitor->VerifyFound();
+}
 
+TEST_F(NegativeDynamicState, SetScissorParamMultiviewportLimit) {
+    AddRequiredFeature(vkt::Feature::multiViewport);
+    RETURN_IF_SKIP(Init());
+    const auto max_scissors = m_device->Physical().limits_.maxViewports;
     const uint32_t too_big_max_scissors = 65536 + 1;  // let's say this is too much to allocate
     if (max_scissors >= too_big_max_scissors) {
-        printf("VkPhysicalDeviceLimits::maxViewports is too large to practically test against -- skipping part of test.\n");
-    } else {
-        const VkRect2D scissor = {{0, 0}, {16, 16}};
-        const std::vector<VkRect2D> scissors(max_scissors + 1, scissor);
-
-        m_errorMonitor->SetDesiredError("VUID-vkCmdSetScissor-firstScissor-00592");
-        vk::CmdSetScissor(m_command_buffer.handle(), 0, max_scissors + 1, scissors.data());
-        m_errorMonitor->VerifyFound();
-
-        m_errorMonitor->SetDesiredError("VUID-vkCmdSetScissor-firstScissor-00592");
-        vk::CmdSetScissor(m_command_buffer.handle(), max_scissors, 1, scissors.data());
-        m_errorMonitor->VerifyFound();
-
-        m_errorMonitor->SetDesiredError("VUID-vkCmdSetScissor-firstScissor-00592");
-        vk::CmdSetScissor(m_command_buffer.handle(), 1, max_scissors, scissors.data());
-        m_errorMonitor->VerifyFound();
-
-        m_errorMonitor->SetDesiredError("VUID-vkCmdSetScissor-scissorCount-arraylength");
-        vk::CmdSetScissor(m_command_buffer.handle(), 1, 0, scissors.data());
-        m_errorMonitor->VerifyFound();
+        GTEST_SKIP() << "maxViewports is too large to practically test against";
     }
+
+    m_command_buffer.Begin();
+    const VkRect2D scissor = {{0, 0}, {16, 16}};
+    const std::vector<VkRect2D> scissors(max_scissors + 1, scissor);
+
+    m_errorMonitor->SetDesiredError("VUID-vkCmdSetScissor-firstScissor-00592");
+    vk::CmdSetScissor(m_command_buffer.handle(), 0, max_scissors + 1, scissors.data());
+    m_errorMonitor->VerifyFound();
+
+    m_errorMonitor->SetDesiredError("VUID-vkCmdSetScissor-firstScissor-00592");
+    vk::CmdSetScissor(m_command_buffer.handle(), max_scissors, 1, scissors.data());
+    m_errorMonitor->VerifyFound();
+
+    m_errorMonitor->SetDesiredError("VUID-vkCmdSetScissor-firstScissor-00592");
+    vk::CmdSetScissor(m_command_buffer.handle(), 1, max_scissors, scissors.data());
+    m_errorMonitor->VerifyFound();
+
+    m_errorMonitor->SetDesiredError("VUID-vkCmdSetScissor-scissorCount-arraylength");
+    vk::CmdSetScissor(m_command_buffer.handle(), 1, 0, scissors.data());
+    m_errorMonitor->VerifyFound();
 }
 
 template <typename ExtType, typename Parm>
@@ -3384,7 +3390,6 @@ TEST_F(NegativeDynamicState, SetViewportParamMaintenance1) {
 
 TEST_F(NegativeDynamicState, SetViewportParamMultiviewport) {
     TEST_DESCRIPTION("Test parameters of vkCmdSetViewport with multiViewport feature enabled");
-
     AddRequiredFeature(vkt::Feature::multiViewport);
     RETURN_IF_SKIP(Init());
 
@@ -3399,30 +3404,37 @@ TEST_F(NegativeDynamicState, SetViewportParamMultiviewport) {
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetViewport-pViewports-parameter");
     vk::CmdSetViewport(m_command_buffer.handle(), 0, max_viewports, nullptr);
     m_errorMonitor->VerifyFound();
+}
 
+TEST_F(NegativeDynamicState, SetViewportParamMultiviewportLimit) {
+    TEST_DESCRIPTION("Test parameters of vkCmdSetViewport with multiViewport feature enabled");
+    AddRequiredFeature(vkt::Feature::multiViewport);
+    RETURN_IF_SKIP(Init());
+    const auto max_viewports = m_device->Physical().limits_.maxViewports;
     const uint32_t too_big_max_viewports = 65536 + 1;  // let's say this is too much to allocate
     if (max_viewports >= too_big_max_viewports) {
-        printf("VkPhysicalDeviceLimits::maxViewports is too large to practically test against -- skipping part of test.\n");
-    } else {
-        const VkViewport vp = {0.0, 0.0, 64.0, 64.0, 0.0, 1.0};
-        const std::vector<VkViewport> viewports(max_viewports + 1, vp);
-
-        m_errorMonitor->SetDesiredError("VUID-vkCmdSetViewport-firstViewport-01223");
-        vk::CmdSetViewport(m_command_buffer.handle(), 0, max_viewports + 1, viewports.data());
-        m_errorMonitor->VerifyFound();
-
-        m_errorMonitor->SetDesiredError("VUID-vkCmdSetViewport-firstViewport-01223");
-        vk::CmdSetViewport(m_command_buffer.handle(), max_viewports, 1, viewports.data());
-        m_errorMonitor->VerifyFound();
-
-        m_errorMonitor->SetDesiredError("VUID-vkCmdSetViewport-firstViewport-01223");
-        vk::CmdSetViewport(m_command_buffer.handle(), 1, max_viewports, viewports.data());
-        m_errorMonitor->VerifyFound();
-
-        m_errorMonitor->SetDesiredError("VUID-vkCmdSetViewport-viewportCount-arraylength");
-        vk::CmdSetViewport(m_command_buffer.handle(), 1, 0, viewports.data());
-        m_errorMonitor->VerifyFound();
+        GTEST_SKIP() << "maxViewports is too large to practically test against";
     }
+
+    m_command_buffer.Begin();
+    const VkViewport vp = {0.0, 0.0, 64.0, 64.0, 0.0, 1.0};
+    const std::vector<VkViewport> viewports(max_viewports + 1, vp);
+
+    m_errorMonitor->SetDesiredError("VUID-vkCmdSetViewport-firstViewport-01223");
+    vk::CmdSetViewport(m_command_buffer.handle(), 0, max_viewports + 1, viewports.data());
+    m_errorMonitor->VerifyFound();
+
+    m_errorMonitor->SetDesiredError("VUID-vkCmdSetViewport-firstViewport-01223");
+    vk::CmdSetViewport(m_command_buffer.handle(), max_viewports, 1, viewports.data());
+    m_errorMonitor->VerifyFound();
+
+    m_errorMonitor->SetDesiredError("VUID-vkCmdSetViewport-firstViewport-01223");
+    vk::CmdSetViewport(m_command_buffer.handle(), 1, max_viewports, viewports.data());
+    m_errorMonitor->VerifyFound();
+
+    m_errorMonitor->SetDesiredError("VUID-vkCmdSetViewport-viewportCount-arraylength");
+    vk::CmdSetViewport(m_command_buffer.handle(), 1, 0, viewports.data());
+    m_errorMonitor->VerifyFound();
 }
 
 TEST_F(NegativeDynamicState, CmdSetDiscardRectangleEXTOffsets) {

--- a/tests/unit/geometry_tessellation.cpp
+++ b/tests/unit/geometry_tessellation.cpp
@@ -187,14 +187,8 @@ TEST_F(NegativeGeometryTessellation, PointSizeGeomShaderWrite) {
     TEST_DESCRIPTION(
         "Create a pipeline using TOPOLOGY_POINT_LIST, set PointSize vertex shader, but not in the final geometry stage.");
 
-    RETURN_IF_SKIP(InitFramework());
-    VkPhysicalDeviceFeatures features{};
-    vk::GetPhysicalDeviceFeatures(Gpu(), &features);
-    if (features.geometryShader == VK_FALSE) {
-        GTEST_SKIP() << "geometryShader not supported";
-    }
-    features.shaderTessellationAndGeometryPointSize = VK_FALSE;
-    RETURN_IF_SKIP(InitState(&features));
+    AddRequiredFeature(vkt::Feature::geometryShader);
+    RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
     // Compiled using the GLSL code below. GlslangValidator rearranges the members, but here they are kept in the order provided.
@@ -451,11 +445,6 @@ TEST_F(NegativeGeometryTessellation, MaxTessellationControlInputOutputComponents
     // overflow == 0: no overflow, 1: too many components, 2: location number too large
     for (uint32_t overflow = 0; overflow < 3; ++overflow) {
         m_errorMonitor->Reset();
-        VkPhysicalDeviceFeatures feat;
-        vk::GetPhysicalDeviceFeatures(Gpu(), &feat);
-        if (!feat.tessellationShader) {
-            GTEST_SKIP() << "tessellation shader stage(s) unsupported";
-        }
 
         // Tessellation control stage
         std::string tcsSourceStr =
@@ -555,11 +544,6 @@ TEST_F(NegativeGeometryTessellation, MaxTessellationEvaluationInputOutputCompone
     // overflow == 0: no overflow, 1: too many components, 2: location number too large
     for (uint32_t overflow = 0; overflow < 3; ++overflow) {
         m_errorMonitor->Reset();
-        VkPhysicalDeviceFeatures feat;
-        vk::GetPhysicalDeviceFeatures(Gpu(), &feat);
-        if (!feat.tessellationShader) {
-            GTEST_SKIP() << "tessellation shader stage(s) unsupported";
-        }
 
         // Tessellation evaluation stage
         std::string tesSourceStr =
@@ -660,11 +644,6 @@ TEST_F(NegativeGeometryTessellation, MaxGeometryInputOutputComponents) {
     // overflow == 0: no overflow, 1: too many components, 2: location number too large
     for (uint32_t overflow = 0; overflow < 3; ++overflow) {
         m_errorMonitor->Reset();
-        VkPhysicalDeviceFeatures feat;
-        vk::GetPhysicalDeviceFeatures(Gpu(), &feat);
-        if (!feat.geometryShader) {
-            GTEST_SKIP() << "geometry shader stage unsupported";
-        }
 
         std::string gsSourceStr =
             "#version 450\n"
@@ -766,11 +745,6 @@ TEST_F(NegativeGeometryTessellation, MaxGeometryInstanceVertexCount) {
 
     for (int overflow = 0; overflow < 2; ++overflow) {
         m_errorMonitor->Reset();
-        VkPhysicalDeviceFeatures feat;
-        vk::GetPhysicalDeviceFeatures(Gpu(), &feat);
-        if (!feat.geometryShader) {
-            GTEST_SKIP() << "geometry shader stage unsupported";
-        }
 
         std::string gsSourceStr = R"(
                OpCapability Geometry

--- a/tests/unit/gpu_av.cpp
+++ b/tests/unit/gpu_av.cpp
@@ -335,9 +335,6 @@ TEST_F(NegativeGpuAV, DISABLED_InvalidAtomicStorageOperation) {
     m_errorMonitor->SetUnexpectedError("VUID-VkBufferViewCreateInfo-format-08779");
     InitRenderTarget();
 
-    VkPhysicalDeviceFeatures device_features = {};
-    GetPhysicalDeviceFeatures(&device_features);
-
     vkt::Image image(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView image_view = image.CreateView();
 

--- a/tests/unit/pipeline.cpp
+++ b/tests/unit/pipeline.cpp
@@ -2482,8 +2482,7 @@ TEST_F(NegativePipeline, VariableSampleLocations) {
         multisample_prop.maxSampleLocationGridSize.width * multisample_prop.maxSampleLocationGridSize.height;
 
     if (valid_count == 0) {
-        printf("multisample properties are not supported.\n");
-        return;
+        GTEST_SKIP() << "multisample properties are not supported";
     }
 
     std::vector<VkSampleLocationEXT> sample_location(valid_count, {0.5, 0.5});

--- a/tests/unit/pipeline.cpp
+++ b/tests/unit/pipeline.cpp
@@ -2882,12 +2882,6 @@ TEST_F(NegativePipeline, IncompatibleScissorCountAndViewportCount) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    VkPhysicalDeviceFeatures features{};
-    vk::GetPhysicalDeviceFeatures(Gpu(), &features);
-    if (features.multiViewport == false) {
-        GTEST_SKIP() << "multiViewport feature not supported by device";
-    }
-
     VkViewport viewports[2] = {{0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 1.0f}, {0.0f, 0.0f, 1.0f, 1.0f, 0.0f, 1.0f}};
 
     auto set_viewport_state_createinfo = [&](CreatePipelineHelper &helper) {
@@ -3483,14 +3477,8 @@ TEST_F(NegativePipeline, GeometryShaderConservativeRasterization) {
     TEST_DESCRIPTION("Use geometry shader with invalid conservative rasterization mode");
 
     AddRequiredExtensions(VK_EXT_CONSERVATIVE_RASTERIZATION_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitFramework());
-    VkPhysicalDeviceFeatures features{};
-    vk::GetPhysicalDeviceFeatures(Gpu(), &features);
-    if (features.geometryShader == VK_FALSE) {
-        GTEST_SKIP() << "geometryShader not supported";
-    }
-    features.shaderTessellationAndGeometryPointSize = VK_FALSE;
-    RETURN_IF_SKIP(InitState(&features));
+    AddRequiredFeature(vkt::Feature::geometryShader);
+    RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
     static char const *gsSource = R"glsl(
@@ -3527,14 +3515,8 @@ TEST_F(NegativePipeline, VertexPointOutputConservativeRasterization) {
     TEST_DESCRIPTION("Use vertex shader with invalid conservative rasterization mode");
 
     AddRequiredExtensions(VK_EXT_CONSERVATIVE_RASTERIZATION_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitFramework());
-    VkPhysicalDeviceFeatures features{};
-    vk::GetPhysicalDeviceFeatures(Gpu(), &features);
-    if (features.geometryShader == VK_FALSE) {
-        GTEST_SKIP() << "geometryShader not supported";
-    }
-    features.shaderTessellationAndGeometryPointSize = VK_FALSE;
-    RETURN_IF_SKIP(InitState(&features));
+    AddRequiredFeature(vkt::Feature::geometryShader);
+    RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
     VkPhysicalDeviceConservativeRasterizationPropertiesEXT conservative_rasterization_props = vku::InitStructHelper();

--- a/tests/unit/pipeline_topology_positive.cpp
+++ b/tests/unit/pipeline_topology_positive.cpp
@@ -271,39 +271,39 @@ TEST_F(PositivePipelineTopology, PointSizeStructMemeberWritten) {
     )asm";
     auto vs = VkShaderObj::CreateFromASM(this, vs_src.c_str(), VK_SHADER_STAGE_VERTEX_BIT);
 
-    if (vs) {
-        // struct has {
-        //     mat4x4
-        //     float
-        //     vec4
-        // }
-        // but std140 padding so the vec4 is offset 80
-        VkPushConstantRange push_constant_ranges[1]{{VK_SHADER_STAGE_VERTEX_BIT, 0, 96}};
-
-        VkPipelineLayoutCreateInfo const pipeline_layout_info{
-            VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO, nullptr, 0, 0, nullptr, 1, push_constant_ranges};
-
-        VkVertexInputBindingDescription input_binding[2] = {
-            {0, 16, VK_VERTEX_INPUT_RATE_VERTEX},
-            {1, 16, VK_VERTEX_INPUT_RATE_VERTEX},
-        };
-        VkVertexInputAttributeDescription input_attribs[2] = {
-            {0, 0, VK_FORMAT_R32G32B32A32_SFLOAT, 0},
-            {1, 1, VK_FORMAT_R32G32B32A32_SFLOAT, 0},
-        };
-
-        CreatePipelineHelper pipe(*this);
-        pipe.shader_stages_ = {vs->GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
-        pipe.pipeline_layout_ci_ = pipeline_layout_info;
-        pipe.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
-        pipe.vi_ci_.pVertexBindingDescriptions = input_binding;
-        pipe.vi_ci_.vertexBindingDescriptionCount = 2;
-        pipe.vi_ci_.pVertexAttributeDescriptions = input_attribs;
-        pipe.vi_ci_.vertexAttributeDescriptionCount = 2;
-        pipe.CreateGraphicsPipeline();
-    } else {
-        printf("Error creating shader from assembly\n");
+    if (!vs) {
+        GTEST_SKIP() << "Error creating shader from assembly";
     }
+
+    // struct has {
+    //     mat4x4
+    //     float
+    //     vec4
+    // }
+    // but std140 padding so the vec4 is offset 80
+    VkPushConstantRange push_constant_ranges[1]{{VK_SHADER_STAGE_VERTEX_BIT, 0, 96}};
+
+    VkPipelineLayoutCreateInfo const pipeline_layout_info{
+        VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO, nullptr, 0, 0, nullptr, 1, push_constant_ranges};
+
+    VkVertexInputBindingDescription input_binding[2] = {
+        {0, 16, VK_VERTEX_INPUT_RATE_VERTEX},
+        {1, 16, VK_VERTEX_INPUT_RATE_VERTEX},
+    };
+    VkVertexInputAttributeDescription input_attribs[2] = {
+        {0, 0, VK_FORMAT_R32G32B32A32_SFLOAT, 0},
+        {1, 1, VK_FORMAT_R32G32B32A32_SFLOAT, 0},
+    };
+
+    CreatePipelineHelper pipe(*this);
+    pipe.shader_stages_ = {vs->GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
+    pipe.pipeline_layout_ci_ = pipeline_layout_info;
+    pipe.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
+    pipe.vi_ci_.pVertexBindingDescriptions = input_binding;
+    pipe.vi_ci_.vertexBindingDescriptionCount = 2;
+    pipe.vi_ci_.pVertexAttributeDescriptions = input_attribs;
+    pipe.vi_ci_.vertexAttributeDescriptionCount = 2;
+    pipe.CreateGraphicsPipeline();
 }
 
 TEST_F(PositivePipelineTopology, PolygonModeValid) {

--- a/tests/unit/ray_tracing_pipeline_positive.cpp
+++ b/tests/unit/ray_tracing_pipeline_positive.cpp
@@ -168,7 +168,6 @@ TEST_F(PositiveRayTracingPipeline, GetCaptureReplayShaderGroupHandlesKHR) {
     AddRequiredFeature(vkt::Feature::pipelineLibraryGroupHandles);
     AddRequiredFeature(vkt::Feature::rayTracingPipelineShaderGroupHandleCaptureReplay);
     RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
-
     RETURN_IF_SKIP(InitState());
 
     vkt::rt::Pipeline rt_pipe_lib(*this, m_device);

--- a/tests/unit/sampler.cpp
+++ b/tests/unit/sampler.cpp
@@ -57,11 +57,8 @@ TEST_F(NegativeSampler, AnisotropyFeatureDisabled) {
 
 TEST_F(NegativeSampler, AnisotropyFeatureEnabled) {
     TEST_DESCRIPTION("Validation must check several conditions that apply only when Anisotropy is enabled.");
-
-    AddOptionalExtensions(VK_IMG_FILTER_CUBIC_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::samplerAnisotropy);
     RETURN_IF_SKIP(Init());
-    const bool cubic_support = IsExtensionsEnabled(VK_IMG_FILTER_CUBIC_EXTENSION_NAME);
     VkSamplerCreateInfo sampler_info_ref = SafeSaneSamplerCreateInfo();
     sampler_info_ref.anisotropyEnable = VK_TRUE;
     VkSamplerCreateInfo sampler_info = sampler_info_ref;
@@ -83,19 +80,26 @@ TEST_F(NegativeSampler, AnisotropyFeatureEnabled) {
     sampler_info.maxLod = 0;
     CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01076");
     sampler_info.unnormalizedCoordinates = sampler_info_ref.unnormalizedCoordinates;
+}
 
-    // Both anisotropy and cubic filtering enabled
-    if (cubic_support) {
-        sampler_info.minFilter = VK_FILTER_CUBIC_IMG;
-        CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-magFilter-01081");
-        sampler_info.minFilter = sampler_info_ref.minFilter;
+TEST_F(NegativeSampler, AnisotropyFeatureEnabledCubic) {
+    TEST_DESCRIPTION("Validation must check several conditions that apply only when Anisotropy is enabled.");
+    AddRequiredExtensions(VK_IMG_FILTER_CUBIC_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::samplerAnisotropy);
+    RETURN_IF_SKIP(Init());
+    VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
+    sampler_info.anisotropyEnable = VK_TRUE;
+    // If unnormalizedCoordinates is VK_TRUE, minLod and maxLod must be zero
+    sampler_info.minLod = 0;
+    sampler_info.maxLod = 0;
 
-        sampler_info.magFilter = VK_FILTER_CUBIC_IMG;
-        CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-magFilter-01081");
-        sampler_info.magFilter = sampler_info_ref.magFilter;
-    } else {
-        printf("Test requires unsupported extension \"VK_IMG_filter_cubic\". Skipped.\n");
-    }
+    sampler_info.minFilter = VK_FILTER_CUBIC_IMG;
+    sampler_info.magFilter = VK_FILTER_NEAREST;
+    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-magFilter-01081");
+
+    sampler_info.minFilter = VK_FILTER_NEAREST;
+    sampler_info.magFilter = VK_FILTER_CUBIC_IMG;
+    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-magFilter-01081");
 }
 
 TEST_F(NegativeSampler, UnnormalizedCoordinatesEnabled) {

--- a/tests/unit/sampler_positive.cpp
+++ b/tests/unit/sampler_positive.cpp
@@ -11,6 +11,8 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#include <gtest/gtest.h>
+#include <vulkan/vulkan_core.h>
 #include "../framework/layer_validation_tests.h"
 
 class PositiveSampler : public VkLayerTest {};
@@ -49,17 +51,14 @@ TEST_F(PositiveSampler, SamplerMirrorClampToEdgeWithoutFeature12) {
 
 TEST_F(PositiveSampler, SamplerMirrorClampToEdgeWithFeature) {
     TEST_DESCRIPTION("Use VK_KHR_sampler_mirror_clamp_to_edge in 1.2 with feature bit enabled");
-
     SetTargetApiVersion(VK_API_VERSION_1_2);
-
     RETURN_IF_SKIP(InitFramework());
 
     VkPhysicalDeviceVulkan12Features features12 = vku::InitStructHelper();
     features12.samplerMirrorClampToEdge = VK_TRUE;
     auto features2 = GetPhysicalDeviceFeatures2(features12);
-    if (features12.samplerMirrorClampToEdge != VK_TRUE) {
-        printf("samplerMirrorClampToEdge not supported, skipping test\n");
-        return;
+    if (features12.samplerMirrorClampToEdge == VK_FALSE) {
+        GTEST_SKIP() << "samplerMirrorClampToEdge not supported";
     }
 
     RETURN_IF_SKIP(InitState(nullptr, &features2));

--- a/tests/unit/shader_object.cpp
+++ b/tests/unit/shader_object.cpp
@@ -3276,11 +3276,6 @@ TEST_F(NegativeShaderObject, MissingCmdSetPatchControlPointsEXT) {
 
     AddRequiredFeature(vkt::Feature::tessellationShader);
     RETURN_IF_SKIP(InitBasicShaderObject());
-    VkPhysicalDeviceFeatures features;
-    GetPhysicalDeviceFeatures(&features);
-    if (features.tessellationShader == VK_FALSE) {
-        GTEST_SKIP() << "tessellationShader not supported.";
-    }
     InitDynamicRenderTarget();
 
     const vkt::Shader vertShader(*m_device, VK_SHADER_STAGE_VERTEX_BIT, GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl));
@@ -3312,11 +3307,6 @@ TEST_F(NegativeShaderObject, MissingCmdSetTessellationDomainOriginEXT) {
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-07619");
     AddRequiredFeature(vkt::Feature::tessellationShader);
     RETURN_IF_SKIP(InitBasicShaderObject());
-    VkPhysicalDeviceFeatures features;
-    GetPhysicalDeviceFeatures(&features);
-    if (features.tessellationShader == VK_FALSE) {
-        GTEST_SKIP() << "tessellationShader not supported.";
-    }
     InitDynamicRenderTarget();
 
     const vkt::Shader vertShader(*m_device, VK_SHADER_STAGE_VERTEX_BIT, GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl));
@@ -3787,11 +3777,6 @@ TEST_F(NegativeShaderObject, MissingCmdSetDepthBoundsTestEnable) {
     AddRequiredFeature(vkt::Feature::depthBounds);
     RETURN_IF_SKIP(InitBasicShaderObject());
     InitDynamicRenderTarget();
-    VkPhysicalDeviceFeatures features;
-    GetPhysicalDeviceFeatures(&features);
-    if (features.depthBounds == VK_FALSE) {
-        GTEST_SKIP() << "depthBounds not supported.";
-    }
 
     const vkt::Shader vertShader(*m_device, VK_SHADER_STAGE_VERTEX_BIT, GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl));
 
@@ -3815,11 +3800,6 @@ TEST_F(NegativeShaderObject, MissingCmdSetStencilTestEnable) {
 
     RETURN_IF_SKIP(InitBasicShaderObject());
     InitDynamicRenderTarget();
-    VkPhysicalDeviceFeatures features;
-    GetPhysicalDeviceFeatures(&features);
-    if (features.depthBounds == VK_FALSE) {
-        GTEST_SKIP() << "depthBounds not supported.";
-    }
 
     const vkt::Shader vertShader(*m_device, VK_SHADER_STAGE_VERTEX_BIT, GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl));
 
@@ -3843,11 +3823,6 @@ TEST_F(NegativeShaderObject, MissingCmdSetStencilOp) {
 
     RETURN_IF_SKIP(InitBasicShaderObject());
     InitDynamicRenderTarget();
-    VkPhysicalDeviceFeatures features;
-    GetPhysicalDeviceFeatures(&features);
-    if (features.depthBounds == VK_FALSE) {
-        GTEST_SKIP() << "depthBounds not supported.";
-    }
 
     const vkt::Shader vertShader(*m_device, VK_SHADER_STAGE_VERTEX_BIT, GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl));
 
@@ -4673,13 +4648,8 @@ TEST_F(NegativeShaderObject, Atomics) {
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_SHADER_ATOMIC_INT64_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::shaderInt64);
     RETURN_IF_SKIP(InitBasicShaderObject());
-
-    VkPhysicalDeviceFeatures available_features = {};
-    GetPhysicalDeviceFeatures(&available_features);
-    if (!available_features.shaderInt64) {
-        GTEST_SKIP() << "shaderInt64 is not supported";
-    }
 
     std::string cs_src = R"glsl(
         #version 450
@@ -5132,11 +5102,6 @@ TEST_F(NegativeShaderObject, MissingLineWidthSet) {
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-08619");
     AddRequiredFeature(vkt::Feature::geometryShader);
     RETURN_IF_SKIP(InitBasicShaderObject());
-    VkPhysicalDeviceFeatures features;
-    GetPhysicalDeviceFeatures(&features);
-    if (features.geometryShader == VK_FALSE) {
-        GTEST_SKIP() << "geometryShader not supported.";
-    }
     InitDynamicRenderTarget();
 
     static char const geom_src[] = R"glsl(
@@ -5258,11 +5223,6 @@ TEST_F(NegativeShaderObject, MissingLineRasterizationMode) {
     AddRequiredExtensions(VK_EXT_LINE_RASTERIZATION_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::geometryShader);
     RETURN_IF_SKIP(InitBasicShaderObject());
-    VkPhysicalDeviceFeatures features;
-    GetPhysicalDeviceFeatures(&features);
-    if (features.geometryShader == VK_FALSE) {
-        GTEST_SKIP() << "geometryShader not supported.";
-    }
     InitDynamicRenderTarget();
 
     static char const geom_src[] = R"glsl(
@@ -5301,11 +5261,6 @@ TEST_F(NegativeShaderObject, MissingLineStippleEnable) {
     AddRequiredExtensions(VK_EXT_LINE_RASTERIZATION_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::geometryShader);
     RETURN_IF_SKIP(InitBasicShaderObject());
-    VkPhysicalDeviceFeatures features;
-    GetPhysicalDeviceFeatures(&features);
-    if (features.geometryShader == VK_FALSE) {
-        GTEST_SKIP() << "geometryShader not supported.";
-    }
     InitDynamicRenderTarget();
 
     static char const geom_src[] = R"glsl(
@@ -5719,12 +5674,6 @@ TEST_F(NegativeShaderObject, GeometryShaderMaxOutputVertices) {
     AddRequiredFeature(vkt::Feature::geometryShader);
     RETURN_IF_SKIP(InitBasicShaderObject());
 
-    VkPhysicalDeviceFeatures features;
-    GetPhysicalDeviceFeatures(&features);
-    if (features.geometryShader == VK_FALSE) {
-        GTEST_SKIP() << "geometryShader not supported.";
-    }
-
     std::string geom_src = R"(
                OpCapability Geometry
           %1 = OpExtInstImport "GLSL.std.450"
@@ -5794,12 +5743,6 @@ TEST_F(NegativeShaderObject, GeometryShaderMaxInvocations) {
     m_errorMonitor->SetDesiredError("VUID-VkShaderCreateInfoEXT-pCode-08455");
     AddRequiredFeature(vkt::Feature::geometryShader);
     RETURN_IF_SKIP(InitBasicShaderObject());
-
-    VkPhysicalDeviceFeatures features;
-    GetPhysicalDeviceFeatures(&features);
-    if (features.geometryShader == VK_FALSE) {
-        GTEST_SKIP() << "geometryShader not supported.";
-    }
 
     std::string geom_src = R"(
                OpCapability Geometry

--- a/tests/unit/shader_object.cpp
+++ b/tests/unit/shader_object.cpp
@@ -4667,7 +4667,6 @@ TEST_F(NegativeShaderObject, Atomics) {
     VkShaderCreateInfoEXT create_info = ShaderCreateInfo(spv, VK_SHADER_STAGE_COMPUTE_BIT);
     VkShaderEXT shader;
 
-    m_errorMonitor->SetDesiredError("VUID-VkShaderCreateInfoEXT-pCode-08740");
     m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-None-06278");
     m_errorMonitor->SetDesiredError("VUID-VkShaderCreateInfoEXT-pCode-08740");
     vk::CreateShadersEXT(m_device->handle(), 1u, &create_info, nullptr, &shader);

--- a/tests/unit/shader_spirv_positive.cpp
+++ b/tests/unit/shader_spirv_positive.cpp
@@ -11,6 +11,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#include <gtest/gtest.h>
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 
@@ -279,21 +280,16 @@ TEST_F(PositiveShaderSpirv, ShaderDrawParametersWithoutFeature11) {
 
 TEST_F(PositiveShaderSpirv, ShaderDrawParametersWithFeature) {
     TEST_DESCRIPTION("Use VK_KHR_shader_draw_parameters in 1.2 with feature bit enabled");
-
     // use 1.2 to get the feature bit in VkPhysicalDeviceVulkan11Features
     SetTargetApiVersion(VK_API_VERSION_1_2);
-
     RETURN_IF_SKIP(InitFramework());
 
     VkPhysicalDeviceVulkan11Features features11 = vku::InitStructHelper();
     features11.shaderDrawParameters = VK_TRUE;
     auto features2 = GetPhysicalDeviceFeatures2(features11);
-
     GetPhysicalDeviceFeatures2(features2);
-
-    if (features11.shaderDrawParameters != VK_TRUE) {
-        printf("shaderDrawParameters not supported, skipping test\n");
-        return;
+    if (features11.shaderDrawParameters == VK_FALSE) {
+        GTEST_SKIP() << "shaderDrawParameters not supported";
     }
 
     RETURN_IF_SKIP(InitState(nullptr, &features2));

--- a/tests/unit/shader_storage_image.cpp
+++ b/tests/unit/shader_storage_image.cpp
@@ -22,11 +22,7 @@ TEST_F(NegativeShaderStorageImage, MissingFormatRead) {
     TEST_DESCRIPTION("Create a shader reading a storage image without an image format");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
-    RETURN_IF_SKIP(InitFramework());
-    VkPhysicalDeviceFeatures features;
-    vk::GetPhysicalDeviceFeatures(Gpu(), &features);
-    features.shaderStorageImageReadWithoutFormat = VK_FALSE;
-    RETURN_IF_SKIP(InitState(&features));
+    RETURN_IF_SKIP(Init());
 
     // Checks based off shaderStorageImage(Read|Write)WithoutFormat are
     // disabled if VK_KHR_format_feature_flags2 is supported.
@@ -89,11 +85,7 @@ TEST_F(NegativeShaderStorageImage, MissingFormatWrite) {
     TEST_DESCRIPTION("Create a shader writing a storage image without an image format");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
-    RETURN_IF_SKIP(InitFramework());
-    VkPhysicalDeviceFeatures features;
-    vk::GetPhysicalDeviceFeatures(Gpu(), &features);
-    features.shaderStorageImageWriteWithoutFormat = VK_FALSE;
-    RETURN_IF_SKIP(InitState(&features));
+    RETURN_IF_SKIP(Init());
 
     // Checks based off shaderStorageImage(Read|Write)WithoutFormat are
     // disabled if VK_KHR_format_feature_flags2 is supported.
@@ -450,11 +442,7 @@ TEST_F(NegativeShaderStorageImage, MissingNonReadableDecorationFormatRead) {
     // rather than as a device feature. The code we test here only looks at
     // the shader.
     SetTargetApiVersion(VK_API_VERSION_1_2);
-    RETURN_IF_SKIP(InitFramework());
-    VkPhysicalDeviceFeatures features;
-    vk::GetPhysicalDeviceFeatures(Gpu(), &features);
-    features.shaderStorageImageReadWithoutFormat = VK_FALSE;
-    RETURN_IF_SKIP(InitState(&features));
+    RETURN_IF_SKIP(Init());
 
     if (DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_format_feature_flags2 is supported";
@@ -511,11 +499,7 @@ TEST_F(NegativeShaderStorageImage, MissingNonWritableDecorationFormatWrite) {
     // rather than as a device feature. The code we test here only looks at
     // the shader.
     SetTargetApiVersion(VK_API_VERSION_1_2);
-    RETURN_IF_SKIP(InitFramework());
-    VkPhysicalDeviceFeatures features;
-    vk::GetPhysicalDeviceFeatures(Gpu(), &features);
-    features.shaderStorageImageWriteWithoutFormat = VK_FALSE;
-    RETURN_IF_SKIP(InitState(&features));
+    RETURN_IF_SKIP(Init());
 
     if (DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_format_feature_flags2 is supported";

--- a/tests/unit/sparse_image.cpp
+++ b/tests/unit/sparse_image.cpp
@@ -1109,7 +1109,8 @@ TEST_F(NegativeSparseImage, ImageMemoryBindInvalidMemory) {
     VkMemoryAllocateInfo invalid_image_mem_alloc = vku::InitStructHelper();
     invalid_image_mem_alloc.allocationSize = invalid_image_mem_reqs.size;
     if (!m_device->Physical().SetMemoryType(invalid_image_mem_reqs.memoryTypeBits, &invalid_image_mem_alloc,
-                                            VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD)) {
+                                            VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+                                            VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD | VK_MEMORY_PROPERTY_PROTECTED_BIT)) {
         GTEST_SKIP() << "Could not find required memory type";
     }
 
@@ -1197,7 +1198,8 @@ TEST_F(NegativeSparseImage, ImageMemoryBindInvalidAlignment) {
     VkMemoryAllocateInfo invalid_image_mem_alloc = vku::InitStructHelper();
     invalid_image_mem_alloc.allocationSize = invalid_image_mem_reqs.size;
     if (!m_device->Physical().SetMemoryType(invalid_image_mem_reqs.memoryTypeBits, &invalid_image_mem_alloc,
-                                            VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD)) {
+                                            VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+                                            VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD | VK_MEMORY_PROPERTY_PROTECTED_BIT)) {
         GTEST_SKIP() << "Could not find required memory type";
     }
 

--- a/tests/unit/subgroups.cpp
+++ b/tests/unit/subgroups.cpp
@@ -23,17 +23,8 @@ TEST_F(NegativeSubgroup, Properties) {
         "supportedOperations, quadOperationsInAllStages.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    RETURN_IF_SKIP(InitFramework());
-
-    VkPhysicalDeviceFeatures features{};
-    vk::GetPhysicalDeviceFeatures(Gpu(), &features);
-    if (features.vertexPipelineStoresAndAtomics == VK_FALSE) {
-        GTEST_SKIP() << "vertexPipelineStoresAndAtomics not supported";
-    }
-
-    features = {};
-    features.vertexPipelineStoresAndAtomics = VK_TRUE;
-    RETURN_IF_SKIP(InitState(&features));
+    AddRequiredFeature(vkt::Feature::vertexPipelineStoresAndAtomics);
+    RETURN_IF_SKIP(Init());
 
     // Don't enable the extension on purpose
     const bool extension_support_partitioned =

--- a/tests/unit/subpass.cpp
+++ b/tests/unit/subpass.cpp
@@ -1111,11 +1111,7 @@ TEST_F(NegativeSubpass, SubpassInputWithoutFormat) {
     TEST_DESCRIPTION("Non-InputAttachment shader input with unknown image format");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
-    RETURN_IF_SKIP(InitFramework());
-    VkPhysicalDeviceFeatures features;
-    vk::GetPhysicalDeviceFeatures(Gpu(), &features);
-    features.shaderStorageImageReadWithoutFormat = VK_FALSE;
-    RETURN_IF_SKIP(InitState(&features));
+    RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
     if (DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME)) {

--- a/tests/unit/wsi.cpp
+++ b/tests/unit/wsi.cpp
@@ -1526,7 +1526,7 @@ TEST_F(NegativeWsi, SwapchainAcquireImageWithPendingSemaphoreWait) {
 
     // Add a wait, but don't let it finish.
     m_default_queue->Submit(vkt::no_cmd, vkt::Wait(semaphore, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT));
-    
+
     m_errorMonitor->SetDesiredError("VUID-vkAcquireNextImageKHR-semaphore-01779");
     m_swapchain.AcquireNextImage(semaphore, kWaitTimeout);
     m_errorMonitor->VerifyFound();
@@ -1768,7 +1768,7 @@ TEST_F(NegativeWsi, GetSwapchainImagesCountButNotImages) {
     m_swapchain.Init(*m_device, swapchain_info);
 
     // This test initiates image count query, but don't need resulting value
-    m_swapchain.GetImageCount(); 
+    m_swapchain.GetImageCount();
 
     m_errorMonitor->SetDesiredError("VUID-VkPresentInfoKHR-pImageIndices-01430");
     m_default_queue->Present(m_swapchain, 0, vkt::no_semaphore);


### PR DESCRIPTION
We have some `GetPhysicalDeviceFeatures` after we merged in https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/8687