### PR TITLE
layers: Cleanup prior to extension release

### DIFF
--- a/layers/core_checks/cc_pipeline.cpp
+++ b/layers/core_checks/cc_pipeline.cpp
@@ -86,21 +86,6 @@ bool CoreChecks::ValidatePipelineProtectedAccessFlags(VkPipelineCreateFlags2KHR 
     return skip;
 }
 
-bool CoreChecks::PreCallValidateCreatePipelineCache(VkDevice device, const VkPipelineCacheCreateInfo *pCreateInfo,
-                                                    const VkAllocationCallbacks *pAllocator, VkPipelineCache *pPipelineCache,
-                                                    const ErrorObject &error_obj) const {
-    bool skip = false;
-    if (enabled_features.pipelineCreationCacheControl == VK_FALSE) {
-        if ((pCreateInfo->flags & VK_PIPELINE_CACHE_CREATE_EXTERNALLY_SYNCHRONIZED_BIT_EXT) != 0) {
-            skip |= LogError("VUID-VkPipelineCacheCreateInfo-pipelineCreationCacheControl-02892", device,
-                             error_obj.location.dot(Field::pCreateInfo).dot(Field::flags),
-                             "includes VK_PIPELINE_CACHE_CREATE_EXTERNALLY_SYNCHRONIZED_BIT_EXT, but pipelineCreationCacheControl "
-                             "feature was not enabled");
-        }
-    }
-    return skip;
-}
-
 // This can be chained in the vkCreate*Pipelines() function or the VkPipelineShaderStageCreateInfo
 bool CoreChecks::ValidatePipelineRobustnessCreateInfo(const vvl::Pipeline &pipeline,
                                                       const VkPipelineRobustnessCreateInfoEXT &pipeline_robustness_info,

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1214,9 +1214,6 @@ class CoreChecks : public ValidationStateTracker {
                                              const Location& loc) const;
     bool ValidateImageImportedHandleANDROID(VkExternalMemoryHandleTypeFlags handle_types, VkDeviceMemory memory, VkImage image,
                                             const Location& loc) const;
-    bool PreCallValidateCreatePipelineCache(VkDevice device, const VkPipelineCacheCreateInfo* pCreateInfo,
-                                            const VkAllocationCallbacks* pAllocator, VkPipelineCache* pPipelineCache,
-                                            const ErrorObject& error_obj) const override;
     bool PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                                 const VkGraphicsPipelineCreateInfo* pCreateInfos,
                                                 const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,

--- a/layers/stateless/sl_pipeline.cpp
+++ b/layers/stateless/sl_pipeline.cpp
@@ -1372,6 +1372,22 @@ bool StatelessValidation::ValidateDepthClampRange(const VkDepthClampRangeEXT &de
     return skip;
 }
 
+bool StatelessValidation::manual_PreCallValidateCreatePipelineCache(VkDevice device, const VkPipelineCacheCreateInfo *pCreateInfo,
+                                                                    const VkAllocationCallbacks *pAllocator,
+                                                                    VkPipelineCache *pPipelineCache,
+                                                                    const ErrorObject &error_obj) const {
+    bool skip = false;
+    const bool has_externally_sync = (pCreateInfo->flags & VK_PIPELINE_CACHE_CREATE_EXTERNALLY_SYNCHRONIZED_BIT_EXT) != 0;
+
+    if (!enabled_features.pipelineCreationCacheControl && has_externally_sync) {
+        skip |= LogError("VUID-VkPipelineCacheCreateInfo-pipelineCreationCacheControl-02892", device,
+                         error_obj.location.dot(Field::pCreateInfo).dot(Field::flags),
+                         "includes VK_PIPELINE_CACHE_CREATE_EXTERNALLY_SYNCHRONIZED_BIT_EXT, but pipelineCreationCacheControl "
+                         "feature was not enabled");
+    }
+    return skip;
+}
+
 bool StatelessValidation::manual_PreCallValidateMergePipelineCaches(VkDevice device, VkPipelineCache dstCache,
                                                                     uint32_t srcCacheCount, const VkPipelineCache *pSrcCaches,
                                                                     const ErrorObject &error_obj) const {

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -1087,6 +1087,9 @@ class StatelessValidation : public ValidationObject {
                                                 VkShaderStageFlags stageFlags, uint32_t offset, uint32_t size, const void *pValues,
                                                 const ErrorObject &error_obj) const;
 
+    bool manual_PreCallValidateCreatePipelineCache(VkDevice device, const VkPipelineCacheCreateInfo *pCreateInfo,
+                                                   const VkAllocationCallbacks *pAllocator, VkPipelineCache *pPipelineCache,
+                                                   const ErrorObject &error_obj) const;
     bool manual_PreCallValidateMergePipelineCaches(VkDevice device, VkPipelineCache dstCache, uint32_t srcCacheCount,
                                                    const VkPipelineCache *pSrcCaches, const ErrorObject &error_obj) const;
     bool manual_PreCallValidateGetPipelinePropertiesEXT(VkDevice device, const VkPipelineInfoEXT *pPipelineInfo,

--- a/layers/vulkan/generated/stateless_validation_helper.cpp
+++ b/layers/vulkan/generated/stateless_validation_helper.cpp
@@ -11331,6 +11331,7 @@ bool StatelessValidation::PreCallValidateCreatePipelineCache(VkDevice device, co
     }
     skip |= ValidateRequiredPointer(loc.dot(Field::pPipelineCache), pPipelineCache,
                                     "VUID-vkCreatePipelineCache-pPipelineCache-parameter");
+    if (!skip) skip |= manual_PreCallValidateCreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache, error_obj);
     return skip;
 }
 

--- a/scripts/generators/stateless_validation_helper_generator.py
+++ b/scripts/generators/stateless_validation_helper_generator.py
@@ -166,6 +166,7 @@ class StatelessValidationHelperOutputGenerator(BaseGenerator):
             'vkCmdSetVertexInputEXT',
             'vkCmdPushConstants',
             'vkCmdPushConstants2KHR',
+            'vkCreatePipelineCache',
             'vkMergePipelineCaches',
             'vkCmdClearColorImage',
             'vkCmdBeginRenderPass',


### PR DESCRIPTION
Pulling out the cleanup code from https://gitlab.khronos.org/vulkan/Vulkan-ValidationLayers/-/merge_requests/107 to have in now and make that PR cleaner in the future