### PR TITLE
layers: Add ShaderObject Tess Topology draw VU

### DIFF
--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -1496,6 +1496,18 @@ bool CoreChecks::ValidateDrawDynamicStateShaderObject(const LastBound& last_boun
         skip |= ValidateDynamicStateIsSet(cb_state.dynamic_state_status.cb, CB_DYNAMIC_STATE_LINE_WIDTH, cb_state, objlist, loc,
                                           vuid.set_line_width_08619);
     }
+
+    if (tessev_shader_bound) {
+        if (cb_state.IsDynamicStateSet(CB_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY) &&
+            cb_state.dynamic_state_value.primitive_topology != VK_PRIMITIVE_TOPOLOGY_PATCH_LIST) {
+            // VUID - https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/6981
+            skip |= LogError(
+                "UNASSIGNED-vkCmdDraw-None-topology", cb_state.Handle(), loc,
+                "Tessellation shaders were bound, but the last call to vkCmdSetPrimitiveTopology set primitiveTopology to %s.",
+                string_VkPrimitiveTopology(cb_state.dynamic_state_value.primitive_topology));
+        }
+    }
+
     if (fragment_shader_bound) {
         if (!cb_state.dynamic_state_value.rasterizer_discard_enable) {
             const uint32_t attachment_count = cb_state.activeRenderPass->GetDynamicRenderingColorAttachmentCount();

--- a/tests/unit/shader_object_positive.cpp
+++ b/tests/unit/shader_object_positive.cpp
@@ -450,7 +450,7 @@ TEST_F(PositiveShaderObject, DrawWithAllGraphicsShaderStagesUsed) {
     }
     vk::CmdBeginRenderingKHR(m_command_buffer.handle(), &begin_rendering_info);
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 5u, shaderStages, shaders);
-    SetDefaultDynamicStatesExclude();
+    SetDefaultDynamicStatesExclude({}, true);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     vk::CmdEndRenderingKHR(m_command_buffer.handle());
 
@@ -1151,7 +1151,7 @@ TEST_F(PositiveShaderObject, IndirectDraw) {
     m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
 
-    SetDefaultDynamicStatesExclude();
+    SetDefaultDynamicStatesExclude({}, true);
 
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT,
                                             VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT, VK_SHADER_STAGE_GEOMETRY_BIT,
@@ -1366,7 +1366,7 @@ TEST_F(PositiveShaderObject, DrawRebindingShaders) {
     m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
 
-    SetDefaultDynamicStatesExclude();
+    SetDefaultDynamicStatesExclude({}, true);
 
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 1u, &vertStage, &vertShader.handle());
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 1u, &tescStage, &nullShader);
@@ -1441,7 +1441,7 @@ TEST_F(PositiveShaderObject, DrawWithBinaryShaders) {
 
     m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
-    SetDefaultDynamicStatesExclude();
+    SetDefaultDynamicStatesExclude({}, true);
 
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 5u, shaderStages, binaryShaders);
 
@@ -1514,7 +1514,7 @@ TEST_F(PositiveShaderObject, CreateAndDrawLinkedAndUnlinkedShaders) {
 
     m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
-    SetDefaultDynamicStatesExclude();
+    SetDefaultDynamicStatesExclude({}, true);
 
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 5u, stages, shaders);
 
@@ -1548,8 +1548,6 @@ TEST_F(PositiveShaderObject, IgnoredColorAttachmentCount) {
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
     m_command_buffer.End();
-
-    m_errorMonitor->VerifyFound();
 }
 
 TEST_F(PositiveShaderObject, DisabledColorBlend) {
@@ -1697,6 +1695,4 @@ TEST_F(PositiveShaderObject, SetPatchControlPointsEXT) {
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
     m_command_buffer.end();
-
-    m_errorMonitor->VerifyFound();
 }


### PR DESCRIPTION
For future header fix in https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/6981

prevents you to draw with shader object with tessellation without setting `VK_PRIMITIVE_TOPOLOGY_PATCH_LIST`

cc @ziga-lunarg who caught this