### PR TITLE
layers: Ensure QueuePresent has access to per-swapchain results

### DIFF
--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -3840,8 +3840,8 @@ void ValidationStateTracker::PostCallRecordQueuePresentKHR(VkQueue queue, const 
 
     const auto *present_id_info = vku::FindStructInPNextChain<VkPresentIdKHR>(pPresentInfo->pNext);
     for (uint32_t i = 0; i < pPresentInfo->swapchainCount; ++i) {
-        // Note: this is imperfect, in that we can get confused about what did or didn't succeed-- but if the app does that, it's
-        // confused itself just as much.
+        // For multi-swapchain present pResults are always available (chassis adds pResults if necessary)
+        assert(pPresentInfo->swapchainCount < 2 || pPresentInfo->pResults);
         auto local_result = pPresentInfo->pResults ? pPresentInfo->pResults[i] : record_obj.result;
         if (local_result != VK_SUCCESS && local_result != VK_SUBOPTIMAL_KHR) continue;  // this present didn't actually happen.
         // Mark the image as having been released to the WSI

--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -1257,6 +1257,61 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateBuffer(VkDevice device, const VkBufferCreat
     return result;
 }
 
+// This API needs to ensure that per-swapchain VkResult results are available
+VKAPI_ATTR VkResult VKAPI_CALL QueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo) {
+    VVL_ZoneScoped;
+
+    auto layer_data = GetLayerDataPtr(GetDispatchKey(queue), layer_data_map);
+    bool skip = false;
+    ErrorObject error_obj(vvl::Func::vkQueuePresentKHR, VulkanTypedHandle(queue, kVulkanObjectTypeQueue));
+    {
+        VVL_ZoneScopedN("PreCallValidate");
+        for (const ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPreCallValidateQueuePresentKHR]) {
+            auto lock = intercept->ReadLock();
+            skip |= intercept->PreCallValidateQueuePresentKHR(queue, pPresentInfo, error_obj);
+            if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
+        }
+    }
+    RecordObject record_obj(vvl::Func::vkQueuePresentKHR);
+    {
+        VVL_ZoneScopedN("PreCallRecord");
+        for (ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPreCallRecordQueuePresentKHR]) {
+            auto lock = intercept->WriteLock();
+            intercept->PreCallRecordQueuePresentKHR(queue, pPresentInfo, record_obj);
+        }
+    }
+
+    // Track per-swapchain results when there is more than one swapchain and VkPresentInfoKHR::pResults is null
+    small_vector<VkResult, 2> present_results;
+    VkPresentInfoKHR modified_present_info;
+    if (pPresentInfo && pPresentInfo->swapchainCount > 1 && pPresentInfo->pResults == nullptr) {
+        present_results.resize(pPresentInfo->swapchainCount);
+        modified_present_info = *pPresentInfo;
+        modified_present_info.pResults = present_results.data();
+        pPresentInfo = &modified_present_info;
+    }
+
+    VkResult result;
+    {
+        VVL_ZoneScopedN("Dispatch");
+        result = DispatchQueuePresentKHR(queue, pPresentInfo);
+    }
+    VVL_TracyCFrameMark;
+    record_obj.result = result;
+    {
+        VVL_ZoneScopedN("PostCallRecord");
+        for (ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPostCallRecordQueuePresentKHR]) {
+            auto lock = intercept->WriteLock();
+
+            if (result == VK_ERROR_DEVICE_LOST) {
+                intercept->is_device_lost = true;
+            }
+            intercept->PostCallRecordQueuePresentKHR(queue, pPresentInfo, record_obj);
+        }
+    }
+    return result;
+}
+
 VKAPI_ATTR VkResult VKAPI_CALL BeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo* pBeginInfo) {
     VVL_ZoneScoped;
 
@@ -9262,49 +9317,6 @@ VKAPI_ATTR VkResult VKAPI_CALL AcquireNextImageKHR(VkDevice device, VkSwapchainK
                 intercept->is_device_lost = true;
             }
             intercept->PostCallRecordAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex, record_obj);
-        }
-    }
-    return result;
-}
-
-VKAPI_ATTR VkResult VKAPI_CALL QueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo) {
-    VVL_ZoneScoped;
-
-    auto layer_data = GetLayerDataPtr(GetDispatchKey(queue), layer_data_map);
-    bool skip = false;
-    ErrorObject error_obj(vvl::Func::vkQueuePresentKHR, VulkanTypedHandle(queue, kVulkanObjectTypeQueue));
-    {
-        VVL_ZoneScopedN("PreCallValidate");
-        for (const ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPreCallValidateQueuePresentKHR]) {
-            auto lock = intercept->ReadLock();
-            skip |= intercept->PreCallValidateQueuePresentKHR(queue, pPresentInfo, error_obj);
-            if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
-        }
-    }
-    RecordObject record_obj(vvl::Func::vkQueuePresentKHR);
-    {
-        VVL_ZoneScopedN("PreCallRecord");
-        for (ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPreCallRecordQueuePresentKHR]) {
-            auto lock = intercept->WriteLock();
-            intercept->PreCallRecordQueuePresentKHR(queue, pPresentInfo, record_obj);
-        }
-    }
-    VkResult result;
-    {
-        VVL_ZoneScopedN("Dispatch");
-        result = DispatchQueuePresentKHR(queue, pPresentInfo);
-    }
-    VVL_TracyCFrameMark;
-    record_obj.result = result;
-    {
-        VVL_ZoneScopedN("PostCallRecord");
-        for (ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPostCallRecordQueuePresentKHR]) {
-            auto lock = intercept->WriteLock();
-
-            if (result == VK_ERROR_DEVICE_LOST) {
-                intercept->is_device_lost = true;
-            }
-            intercept->PostCallRecordQueuePresentKHR(queue, pPresentInfo, record_obj);
         }
     }
     return result;

--- a/tests/framework/binding.cpp
+++ b/tests/framework/binding.cpp
@@ -874,7 +874,13 @@ Fence &Fence::operator=(Fence &&rhs) noexcept {
     return *this;
 }
 
-void Fence::init(const Device &dev, const VkFenceCreateInfo &info) { NON_DISPATCHABLE_HANDLE_INIT(vk::CreateFence, dev, &info); }
+void Fence::Init(const Device &dev, const VkFenceCreateInfo &info) { NON_DISPATCHABLE_HANDLE_INIT(vk::CreateFence, dev, &info); }
+
+void Fence::Init(const Device &dev, const VkFenceCreateFlags flags) {
+    VkFenceCreateInfo fence_ci = vku::InitStructHelper();
+    fence_ci.flags = flags;
+    Init(dev, fence_ci);
+}
 
 VkResult Fence::Wait(uint64_t timeout) const { return vk::WaitForFences(device(), 1, &handle(), VK_TRUE, timeout); }
 

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -371,15 +371,16 @@ class DeviceMemory : public internal::NonDispHandle<VkDeviceMemory> {
 class Fence : public internal::NonDispHandle<VkFence> {
   public:
     Fence() = default;
-    Fence(const Device &dev) { init(dev, CreateInfo()); }
-    Fence(const Device &dev, const VkFenceCreateInfo &info) { init(dev, info); }
+    Fence(const Device &dev, const VkFenceCreateFlags flags = 0) { Init(dev, flags); }
+    Fence(const Device &dev, const VkFenceCreateInfo &info) { Init(dev, info); }
     Fence(Fence &&rhs) noexcept : NonDispHandle(std::move(rhs)) {}
     Fence &operator=(Fence &&) noexcept;
     ~Fence() noexcept;
     void destroy() noexcept;
 
     // vkCreateFence()
-    void init(const Device &dev, const VkFenceCreateInfo &info);
+    void Init(const Device &dev, const VkFenceCreateInfo &info);
+    void Init(const Device &dev, const VkFenceCreateFlags flags = 0);
     void SetName(const char *name) { NonDispHandle<VkFence>::SetName(VK_OBJECT_TYPE_FENCE, name); }
 
     // vkGetFenceStatus()
@@ -394,9 +395,6 @@ class Fence : public internal::NonDispHandle<VkFence> {
 #endif
     VkResult ExportHandle(int &fd_handle, VkExternalFenceHandleTypeFlagBits handle_type);
     VkResult ImportHandle(int fd_handle, VkExternalFenceHandleTypeFlagBits handle_type, VkFenceImportFlags flags = 0);
-
-    static VkFenceCreateInfo CreateInfo(VkFenceCreateFlags flags);
-    static VkFenceCreateInfo CreateInfo();
 };
 
 inline const Fence no_fence;
@@ -1274,17 +1272,6 @@ inline VkBufferCreateInfo Buffer::CreateInfo(VkDeviceSize size, VkFlags usage, c
         info.pQueueFamilyIndices = queue_families.data();
     }
 
-    return info;
-}
-
-inline VkFenceCreateInfo Fence::CreateInfo(VkFenceCreateFlags flags) {
-    VkFenceCreateInfo info = vku::InitStructHelper();
-    info.flags = flags;
-    return info;
-}
-
-inline VkFenceCreateInfo Fence::CreateInfo() {
-    VkFenceCreateInfo info = vku::InitStructHelper();
     return info;
 }
 

--- a/tests/framework/render.cpp
+++ b/tests/framework/render.cpp
@@ -697,6 +697,10 @@ void VkRenderFramework::InitSurface() {
 LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
     return DefWindowProc(hwnd, uMsg, wParam, lParam);
 }
+
+void SurfaceContext::Resize(uint32_t width, uint32_t height) {
+    ::SetWindowPos(m_win32Window, NULL, 0, 0, (int)width, (int)height, SWP_NOMOVE);
+}
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 
 VkResult VkRenderFramework::CreateSurface(SurfaceContext &surface_context, VkSurfaceKHR &surface, VkInstance custom_instance) {
@@ -711,7 +715,8 @@ VkResult VkRenderFramework::CreateSurface(SurfaceContext &surface_context, VkSur
         wc.hInstance = window_instance;
         wc.lpszClassName = class_name;
         RegisterClass(&wc);
-        HWND window = CreateWindowEx(0, class_name, 0, 0, 0, 0, (int)m_width, (int)m_height, NULL, NULL, window_instance, NULL);
+        HWND window = CreateWindowEx(0, class_name, nullptr, 0, 0, 0, (int)m_width, (int)m_height, NULL, NULL, window_instance, NULL);
+        surface_context.m_win32Window = window;
         ShowWindow(window, SW_HIDE);
 
         VkWin32SurfaceCreateInfoKHR surface_create_info = vku::InitStructHelper();
@@ -919,6 +924,18 @@ void VkRenderFramework::DestroySwapchain() {
         if (m_swapchain.initialized()) {
             m_swapchain.destroy();
         }
+    }
+}
+
+void VkRenderFramework::SupportMultiSwapchain() {
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+    GTEST_SKIP() << "Android currently doesn't support multiple swapchain on all devices";
+#endif  // VK_USE_PLATFORM_ANDROID_KHR
+}
+
+void VkRenderFramework::SupportSurfaceResize() {
+    if (!SurfaceContext::CanResize()) {
+        GTEST_SKIP() << "VVL test framework does not support surface resizing on the current platform";
     }
 }
 

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -50,9 +50,16 @@ struct SurfaceContext {
 #if defined(VK_USE_PLATFORM_XCB_KHR)
     xcb_connection_t *m_surface_xcb_conn{};
 #endif
-
 #if defined(VK_USE_PLATFORM_METAL_EXT)
     void *caMetalLayer;
+#endif
+
+#if defined(VK_USE_PLATFORM_WIN32_KHR)
+    static bool CanResize() { return true; }
+    void Resize(uint32_t width, uint32_t height);
+#else
+    static bool CanResize() { return false; }
+    void Resize(uint32_t width, uint32_t height) {}
 #endif
 };
 
@@ -104,6 +111,10 @@ class VkRenderFramework : public VkTestFramework {
     SurfaceInformation GetSwapchainInfo(const VkSurfaceKHR surface);
     vkt::Swapchain CreateSwapchain(VkSurfaceKHR &surface, VkImageUsageFlags imageUsage, VkSurfaceTransformFlagBitsKHR preTransform,
                                    VkSwapchainKHR oldSwapchain = VK_NULL_HANDLE);
+
+    // Swapchain capabilities declaration to be used with RETURN_IF_SKIP
+    void SupportMultiSwapchain();
+    void SupportSurfaceResize();
 
     void InitRenderTarget();
     void InitRenderTarget(uint32_t targets);

--- a/tests/unit/amd_best_practices.cpp
+++ b/tests/unit/amd_best_practices.cpp
@@ -637,13 +637,12 @@ TEST_F(VkAmdBestPracticesLayerTest, NumSyncPrimitives) {
     InitRenderTarget();
 
     constexpr int fence_warn_limit = 5;
-    const auto fence_ci = vkt::Fence::CreateInfo();
-    std::vector<vkt::Fence> test_fences(fence_warn_limit);
+    std::vector<vkt::Fence> test_fences;
     for (int i = 0; i < fence_warn_limit - 1; ++i) {
-        test_fences[i].init(*m_device, fence_ci);
+        test_fences.emplace_back(*m_device);
     }
     m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-SyncObjects-HighNumberOfFences");
-    test_fences[fence_warn_limit - 1].init(*m_device, fence_ci);
+    test_fences.emplace_back(*m_device);
     m_errorMonitor->VerifyFound();
 
     constexpr int semaphore_warn_limit = 12;

--- a/tests/unit/sync_object_positive.cpp
+++ b/tests/unit/sync_object_positive.cpp
@@ -271,7 +271,7 @@ TEST_F(PositiveSyncObject, TwoFencesThreeFrames) {
 
     for (uint32_t i = 0; i < NUM_OBJECTS; ++i) {
         cmd_buffers[i].Init(*m_device, m_command_pool);
-        fences[i].init(*m_device, vku::InitStruct<VkFenceCreateInfo>());
+        fences[i].Init(*m_device);
     }
     for (uint32_t frame = 0; frame < NUM_FRAMES; ++frame) {
         for (uint32_t obj = 0; obj < NUM_OBJECTS; ++obj) {
@@ -977,8 +977,8 @@ TEST_F(PositiveSyncObject, ExternalFenceSyncFdLoop) {
     fci.pNext = nullptr;
     fci.flags = VK_FENCE_CREATE_SIGNALED_BIT;
     std::array<vkt::Fence, 2> fences;
-    fences[0].init(*m_device, fci);
-    fences[1].init(*m_device, fci);
+    fences[0].Init(*m_device, fci);
+    fences[1].Init(*m_device, fci);
 
     for (uint32_t i = 0; i < 1000; i++) {
         auto submitter = i & 1;

--- a/tests/unit/wsi.cpp
+++ b/tests/unit/wsi.cpp
@@ -595,7 +595,7 @@ TEST_F(NegativeWsi, SwapchainAcquireTooManyImages) {
     const uint32_t acquirable_count = image_count - caps.minImageCount + 1;
     std::vector<vkt::Fence> fences(acquirable_count);
     for (uint32_t i = 0; i < acquirable_count; ++i) {
-        fences[i].init(*m_device, vkt::Fence::CreateInfo());
+        fences[i].Init(*m_device);
         VkResult res{};
         m_swapchain.AcquireNextImage(fences[i], kWaitTimeout, &res);
         ASSERT_TRUE(res == VK_SUCCESS || res == VK_SUBOPTIMAL_KHR);
@@ -719,7 +719,7 @@ TEST_F(NegativeWsi, SwapchainAcquireTooManyImages2KHR) {
     const uint32_t acquirable_count = image_count - caps.minImageCount + 1;
     std::vector<vkt::Fence> fences(acquirable_count);
     for (uint32_t i = 0; i < acquirable_count; ++i) {
-        fences[i].init(*m_device, vkt::Fence::CreateInfo());
+        fences[i].Init(*m_device);
         VkResult res{};
         m_swapchain.AcquireNextImage(fences[i], kWaitTimeout, &res);
         ASSERT_TRUE(res == VK_SUCCESS || res == VK_SUBOPTIMAL_KHR);


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8753

The issue was caused by presenting multiple swapchains with a single `QueuePresent` command. If one presentation failed, state tracking was disabled for all swapchains, even those without presentation errors. This led to false positives for "good" swapchains that had no presentation issues. This problem occurred when the optional `VkPresentInfoKHR::pResults` was not specified.