### PR TITLE
layers: Revise VU 08358 to include equality

### DIFF
--- a/layers/core_checks/cc_video.cpp
+++ b/layers/core_checks/cc_video.cpp
@@ -206,10 +206,10 @@ bool CoreChecks::ValidateVideoEncodeRateControlInfo(const VkVideoEncodeRateContr
                              rc_info_loc.dot(Field::virtualBufferSizeInMs), "must not be zero if %s (%u) is not zero.",
                              rc_info_loc.dot(Field::layerCount).Fields().c_str(), rc_info.layerCount);
         }
-        if (rc_info.initialVirtualBufferSizeInMs >= rc_info.virtualBufferSizeInMs) {
+        if (rc_info.initialVirtualBufferSizeInMs > rc_info.virtualBufferSizeInMs) {
             skip |= LogError("VUID-VkVideoEncodeRateControlInfoKHR-layerCount-08358", cmdbuf,
                              rc_info_loc.dot(Field::initialVirtualBufferSizeInMs),
-                             "(%u) must be less than virtualBufferSizeInMs (%u) if %s (%u) is not zero.",
+                             "(%u) must be less than or equal to virtualBufferSizeInMs (%u) if %s (%u) is not zero.",
                              rc_info.initialVirtualBufferSizeInMs, rc_info.virtualBufferSizeInMs,
                              rc_info_loc.dot(Field::layerCount).Fields().c_str(), rc_info.layerCount);
         }

--- a/tests/unit/video.cpp
+++ b/tests/unit/video.cpp
@@ -4699,13 +4699,12 @@ TEST_F(NegativeVideo, EncodeRateControlVirtualBufferSize) {
     // virtualBufferSizeInMs must be greater than 0
     rc_info->virtualBufferSizeInMs = 0;
     m_errorMonitor->SetDesiredError("VUID-VkVideoEncodeRateControlInfoKHR-layerCount-08357");
-    m_errorMonitor->SetDesiredError("VUID-VkVideoEncodeRateControlInfoKHR-layerCount-08358");
     cb.ControlVideoCoding(context.Control().RateControl(rc_info));
     m_errorMonitor->VerifyFound();
 
-    // initialVirtualBufferSizeInMs must be less than virtualBufferSizeInMs
+    // initialVirtualBufferSizeInMs must be less than or equal to virtualBufferSizeInMs
     rc_info->virtualBufferSizeInMs = 1000;
-    rc_info->initialVirtualBufferSizeInMs = 1000;
+    rc_info->initialVirtualBufferSizeInMs = 1001;
     m_errorMonitor->SetDesiredError("VUID-VkVideoEncodeRateControlInfoKHR-layerCount-08358");
     cb.ControlVideoCoding(context.Control().RateControl(rc_info));
     m_errorMonitor->VerifyFound();


### PR DESCRIPTION
In Vulkan 1.3.299, VkVideoEncodeRateControlInfoKHR VU 08358 was updated to allow initialVirtualBufferSizeInMs to equal virtualBufferSizeInMs.

Also add a positive test case for this.