### PR TITLE
layers: Better surface caps caching

### DIFF
--- a/layers/core_checks/cc_wsi.cpp
+++ b/layers/core_checks/cc_wsi.cpp
@@ -368,7 +368,7 @@ bool CoreChecks::ValidateCreateSwapchain(const VkSwapchainCreateInfoKHR &create_
     }
 #endif
     VkSurfacePresentModeEXT present_mode_info = vku::InitStructHelper();
-    if (IsExtEnabled(device_extensions.vk_ext_surface_maintenance1)) {
+    if (surface_state->IsLastCapabilityQueryUsedPresentMode(physical_device_state->VkHandle())) {
         present_mode_info.presentMode = create_info.presentMode;
         present_mode_info.pNext = surface_info_pnext;
         surface_info_pnext = &present_mode_info;

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -423,6 +423,7 @@ class Surface : public StateObject {
     void UpdateCapabilitiesCache(VkPhysicalDevice phys_dev, const VkSurfaceCapabilities2KHR &surface_caps,
                                  VkPresentModeKHR present_mode);
 
+    bool IsLastCapabilityQueryUsedPresentMode(VkPhysicalDevice phys_dev) const;
     VkSurfaceCapabilitiesKHR GetSurfaceCapabilities(VkPhysicalDevice phys_dev, const void *surface_info_pnext) const;
     VkSurfaceCapabilitiesKHR GetPresentModeSurfaceCapabilities(VkPhysicalDevice phys_dev, VkPresentModeKHR present_mode) const;
     VkSurfacePresentScalingCapabilitiesEXT GetPresentModeScalingCapabilities(VkPhysicalDevice phys_dev,
@@ -455,6 +456,7 @@ class Surface : public StateObject {
         std::optional<std::vector<VkPresentModeKHR>> present_modes;
         std::optional<VkSurfaceCapabilitiesKHR> capabilities;
         std::vector<PresentModeInfo> present_mode_infos;
+        bool last_capability_query_used_present_mode = false;
 
         const PresentModeInfo *GetPresentModeInfo(VkPresentModeKHR present_mode) const;
     };


### PR DESCRIPTION
Replaces yesterday's fix (https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/8789) with a different one (so the same tests).
Why better:
- Simpler then yesterday's fix (no need to sync between two groups)
- Potentially fixes most blacklisted Android WSI tests. Big if true. (according to my experiments  https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/8792 there's a chance, but need to test with current changes).
- Potentially solves a problem raised by Ralph or at least handles additional cases (failures of our Android WSI is likely one of the manifestation of the problem): https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/8321