### PR TITLE
gpu: Give error if using IES with GPU-AV

### DIFF
--- a/layers/gpu/instrumentation/gpuav_shader_instrumentor.h
+++ b/layers/gpu/instrumentation/gpuav_shader_instrumentor.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "containers/custom_containers.h"
+#include "error_message/error_location.h"
 #include "generated/chassis.h"
 #include "state_tracker/shader_instruction.h"
 #include "state_tracker/state_tracker.h"
@@ -178,7 +179,7 @@ class GpuShaderInstrumentor : public ValidationStateTracker {
                                          uint32_t operation_index) const;
 
   protected:
-    bool NeedPipelineCreationShaderInstrumentation(vvl::Pipeline &pipeline_state);
+    bool NeedPipelineCreationShaderInstrumentation(vvl::Pipeline &pipeline_state, const Location &loc);
     bool HasBindlessDescriptors(vvl::Pipeline &pipeline_state);
     bool HasBindlessDescriptors(VkShaderCreateInfoEXT &create_info);
 

--- a/tests/unit/debug_printf.cpp
+++ b/tests/unit/debug_printf.cpp
@@ -3777,9 +3777,7 @@ TEST_F(NegativeDebugPrintf, DeviceGeneratedCommandsCompute) {
         }
     )glsl";
 
-    VkPipelineCreateFlags2CreateInfoKHR pipe_flags2 = vku::InitStructHelper();
-    pipe_flags2.flags = VK_PIPELINE_CREATE_2_INDIRECT_BINDABLE_BIT_EXT;
-    CreateComputePipelineHelper pipe(*this, &pipe_flags2);
+    CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1);
     pipe.CreateComputePipeline();
 
@@ -3873,9 +3871,7 @@ TEST_F(NegativeDebugPrintf, DeviceGeneratedCommandsGraphics) {
     )glsl";
     VkShaderObj vs(this, vs_source, VK_SHADER_STAGE_VERTEX_BIT);
 
-    VkPipelineCreateFlags2CreateInfoKHR pipe_flags2 = vku::InitStructHelper();
-    pipe_flags2.flags = VK_PIPELINE_CREATE_2_INDIRECT_BINDABLE_BIT_EXT;
-    CreatePipelineHelper pipe(*this, &pipe_flags2);
+    CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {vs.GetStageCreateInfo()};
     pipe.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
     pipe.CreateGraphicsPipeline();
@@ -3935,7 +3931,9 @@ TEST_F(NegativeDebugPrintf, DeviceGeneratedCommandsGraphics) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeDebugPrintf, DeviceGeneratedCommandsIES) {
+// TODO - Currently can't use IES with GPU-AV due to us creating invalid Pipeline Layouts
+// https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/8806
+TEST_F(NegativeDebugPrintf, DISABLED_DeviceGeneratedCommandsIES) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_EXT_DEVICE_GENERATED_COMMANDS_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);

--- a/tests/unit/gpu_av_oob.cpp
+++ b/tests/unit/gpu_av_oob.cpp
@@ -1827,9 +1827,7 @@ TEST_F(NegativeGpuAVOOB, DeviceGeneratedCommandsCompute) {
         }
     )glsl";
 
-    VkPipelineCreateFlags2CreateInfoKHR pipe_flags2 = vku::InitStructHelper();
-    pipe_flags2.flags = VK_PIPELINE_CREATE_2_INDIRECT_BINDABLE_BIT_EXT;
-    CreateComputePipelineHelper pipe(*this, &pipe_flags2);
+    CreateComputePipelineHelper pipe(*this);
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};
     pipe.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1);
     pipe.CreateComputePipeline();

--- a/tests/unit/gpu_av_positive.cpp
+++ b/tests/unit/gpu_av_positive.cpp
@@ -1866,7 +1866,9 @@ TEST_F(PositiveGpuAV, DestroyedPipelineLayout2) {
     m_command_buffer.End();
 }
 
-TEST_F(PositiveGpuAV, DeviceGeneratedCommandsIES) {
+// TODO - Currently can't use IES with GPU-AV due to us creating invalid Pipeline Layouts
+// https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/8806
+TEST_F(PositiveGpuAV, DISABLED_DeviceGeneratedCommandsIES) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_EXT_DEVICE_GENERATED_COMMANDS_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);


### PR DESCRIPTION
See inline comments, we can't use `VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC` with `vkCreateIndirectExecutionSetEXT` but it "seems to work" for people (because we are not actually touching those descriptors in the `vkCmdExecuteGeneratedCommandsEXT` currently - https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8605)

so for now, report an error, but let run incase it might still work