### PR TITLE
sync: Add compact output for ALL reads

### DIFF
--- a/layers/sync/sync_commandbuffer.h
+++ b/layers/sync/sync_commandbuffer.h
@@ -182,8 +182,8 @@ class CommandExecutionContext : public SyncValidationInfo {
   public:
     using AccessLog = std::vector<ResourceUsageRecord>;
     using CommandBufferSet = std::vector<std::shared_ptr<const vvl::CommandBuffer>>;
-    CommandExecutionContext() : SyncValidationInfo(nullptr) {}
-    CommandExecutionContext(const SyncValidator *sync_validator) : SyncValidationInfo(sync_validator) {}
+    CommandExecutionContext(const SyncValidator *sync_validator, VkQueueFlags queue_flags)
+        : SyncValidationInfo(sync_validator, queue_flags) {}
     virtual ~CommandExecutionContext() = default;
 
     // Are imported command buffers Submitted (QueueBatchContext), or Executed (CommandBufferAccessContext)
@@ -259,8 +259,6 @@ class CommandBufferAccessContext : public CommandExecutionContext, DebugNameProv
     // NOTE: because this class is encapsulated in syncval_state::CommandBuffer, it isn't safe
     // to use shared_from_this from the constructor.
     void SetSelfReference() { cbs_referenced_->push_back(cb_state_->shared_from_this()); }
-
-    const CommandExecutionContext &GetExecutionContext() const { return *this; }
 
     void Destroy() {
         // the cb self reference must be cleared or the command buffer reference count will never go to 0
@@ -357,7 +355,7 @@ class CommandBufferAccessContext : public CommandExecutionContext, DebugNameProv
     std::vector<vvl::CommandBuffer::LabelCommand> &GetProxyLabelCommands() { return proxy_label_commands_; }
 
   private:
-    CommandBufferAccessContext(const SyncValidator &sync_validator);
+    CommandBufferAccessContext(const SyncValidator &sync_validator, VkQueueFlags queue_flags);
 
     uint32_t AddHandle(const VulkanTypedHandle &typed_handle, uint32_t index);
 

--- a/layers/sync/sync_common.h
+++ b/layers/sync/sync_common.h
@@ -75,7 +75,7 @@ constexpr VkImageAspectFlags kDepthStencilAspects = VK_IMAGE_ASPECT_DEPTH_BIT | 
 
 class SyncValidationInfo {
   public:
-    SyncValidationInfo(const SyncValidator* sync_validator) : sync_state_(sync_validator) {}
+    SyncValidationInfo(const SyncValidator* sync_validator, VkQueueFlags queue_flags) : sync_state_(sync_validator), queue_flags_(queue_flags) {}
     const SyncValidator& GetSyncState() const {
         assert(sync_state_);
         return *sync_state_;
@@ -85,6 +85,7 @@ class SyncValidationInfo {
 
   protected:
     const SyncValidator* sync_state_;
+    const VkQueueFlags queue_flags_;
 };
 
 

--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -1135,7 +1135,7 @@ bool SyncOpNextSubpass::Validate(const CommandBufferAccessContext &cb_context) c
     const auto *renderpass_context = cb_context.GetCurrentRenderPassContext();
     if (!renderpass_context) return skip;
 
-    skip |= renderpass_context->ValidateNextSubpass(cb_context.GetExecutionContext(), command_);
+    skip |= renderpass_context->ValidateNextSubpass(cb_context, command_);
     return skip;
 }
 
@@ -1168,7 +1168,7 @@ bool SyncOpEndRenderPass::Validate(const CommandBufferAccessContext &cb_context)
     const auto *renderpass_context = cb_context.GetCurrentRenderPassContext();
 
     if (!renderpass_context) return skip;
-    skip |= renderpass_context->ValidateEndRenderPass(cb_context.GetExecutionContext(), command_);
+    skip |= renderpass_context->ValidateEndRenderPass(cb_context, command_);
     return skip;
 }
 

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -239,7 +239,7 @@ class ApplyAcquireNextSemaphoreAction {
 };
 
 QueueBatchContext::QueueBatchContext(const SyncValidator& sync_state, const QueueSyncState& queue_state)
-    : CommandExecutionContext(&sync_state),
+    : CommandExecutionContext(&sync_state, queue_state.GetQueueFlags()),
       queue_state_(&queue_state),
       tag_range_(0, 0),
       current_access_context_(&access_context_),
@@ -249,7 +249,7 @@ QueueBatchContext::QueueBatchContext(const SyncValidator& sync_state, const Queu
 }
 
 QueueBatchContext::QueueBatchContext(const SyncValidator& sync_state)
-    : CommandExecutionContext(&sync_state),
+    : CommandExecutionContext(&sync_state, 0),
       queue_state_(),
       tag_range_(0, 0),
       current_access_context_(&access_context_),


### PR DESCRIPTION
Outputs this:
> Validation Error: [ SYNC-HAZARD-WRITE-AFTER-WRITE ] Object 0: handle = 0x1582da52030, type = VK_OBJECT_TYPE_COMMAND_BUFFER; Object 1: handle = 0xf443490000000006, type = VK_OBJECT_TYPE_BUFFER; | MessageID = 0x5c0ec5d6 | vkCmdCopyBuffer():  Hazard WRITE_AFTER_WRITE for dstBuffer VkBuffer 0xf443490000000006[], region 0. Access info (usage: SYNC_COPY_TRANSFER_WRITE, prior_usage: SYNC_COPY_TRANSFER_WRITE, write_barriers: **SYNC_ALL_COMMANDS_SHADER_READ**, command: vkCmdCopyBuffer, seq_no: 1, reset_no: 1, resource: VkBuffer 0xf443490000000006[]).

Instead of this:
> Validation Error: [ SYNC-HAZARD-WRITE-AFTER-WRITE ] Object 0: handle = 0x15232b73f60, type = VK_OBJECT_TYPE_COMMAND_BUFFER; Object 1: handle = 0xf443490000000006, type = VK_OBJECT_TYPE_BUFFER; | MessageID = 0x5c0ec5d6 | vkCmdCopyBuffer():  Hazard WRITE_AFTER_WRITE for dstBuffer VkBuffer 0xf443490000000006[], region 0. Access info (usage: SYNC_COPY_TRANSFER_WRITE, prior_usage: SYNC_COPY_TRANSFER_WRITE, write_barriers: **SYNC_VERTEX_SHADER_SHADER_BINDING_TABLE_READ|SYNC_VERTEX_SHADER_SHADER_SAMPLED_READ|SYNC_VERTEX_SHADER_SHADER_STORAGE_READ|SYNC_TESSELLATION_CONTROL_SHADER_SHADER_BINDING_TABLE_READ|SYNC_TESSELLATION_CONTROL_SHADER_SHADER_SAMPLED_READ|SYNC_TESSELLATION_CONTROL_SHADER_SHADER_STORAGE_READ|SYNC_TESSELLATION_EVALUATION_SHADER_SHADER_BINDING_TABLE_READ|SYNC_TESSELLATION_EVALUATION_SHADER_SHADER_SAMPLED_READ|SYNC_TESSELLATION_EVALUATION_SHADER_SHADER_STORAGE_READ|SYNC_GEOMETRY_SHADER_SHADER_BINDING_TABLE_READ|SYNC_GEOMETRY_SHADER_SHADER_SAMPLED_READ|SYNC_GEOMETRY_SHADER_SHADER_STORAGE_READ|SYNC_FRAGMENT_SHADER_SHADER_BINDING_TABLE_READ|SYNC_FRAGMENT_SHADER_SHADER_SAMPLED_READ|SYNC_FRAGMENT_SHADER_SHADER_STORAGE_READ|SYNC_COMPUTE_SHADER_SHADER_BINDING_TABLE_READ|SYNC_COMPUTE_SHADER_SHADER_SAMPLED_READ|SYNC_COMPUTE_SHADER_SHADER_STORAGE_READ|SYNC_TASK_SHADER_EXT_SHADER_BINDING_TABLE_READ|SYNC_TASK_SHADER_EXT_SHADER_SAMPLED_READ|SYNC_TASK_SHADER_EXT_SHADER_STORAGE_READ|SYNC_MESH_SHADER_EXT_SHADER_BINDING_TABLE_READ|SYNC_MESH_SHADER_EXT_SHADER_SAMPLED_READ|SYNC_MESH_SHADER_EXT_SHADER_STORAGE_READ|SYNC_RAY_TRACING_SHADER_SHADER_BINDING_TABLE_READ|SYNC_RAY_TRACING_SHADER_SHADER_SAMPLED_READ|SYNC_RAY_TRACING_SHADER_SHADER_STORAGE_READ|SYNC_ACCELERATION_STRUCTURE_BUILD_SHADER_STORAGE_READ|SYNC_MICROMAP_BUILD_EXT_SHADER_STORAGE_READ|SYNC_SUBPASS_SHADER_HUAWEI_SHADER_BINDING_TABLE_READ|SYNC_SUBPASS_SHADER_HUAWEI_SHADER_SAMPLED_READ|SYNC_SUBPASS_SHADER_HUAWEI_SHADER_STORAGE_READ|SYNC_CLUSTER_CULLING_SHADER_HUAWEI_SHADER_BINDING_TABLE_READ|SYNC_CLUSTER_CULLING_SHADER_HUAWEI_SHADER_SAMPLED_READ|SYNC_CLUSTER_CULLING_SHADER_HUAWEI_SHADER_STORAGE_READ**, command: vkCmdCopyBuffer, seq_no: 1, reset_no: 1, resource: VkBuffer 0xf443490000000006[]).