### PR TITLE
sync: Remove debug labels todo

### DIFF
--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1837,8 +1837,11 @@ void CommandBuffer::ReplayLabelCommands(const vvl::span<const LabelCommand> &lab
 
 std::string CommandBuffer::GetDebugRegionName(const std::vector<LabelCommand> &label_commands, uint32_t label_command_index,
                                               const std::vector<std::string> &initial_label_stack) {
-    assert(label_command_index < label_commands.size());
-
+    if (label_command_index >= label_commands.size()) {
+        // Can happen due to core validation error when in-use command buffer was re-recorded.
+        // It's a bug if this happens in a valid vulkan program.
+        return {};
+    }
     auto commands_to_replay = vvl::make_span(label_commands.data(), label_command_index + 1);
     auto label_stack = initial_label_stack;
     vvl::CommandBuffer::ReplayLabelCommands(commands_to_replay, label_stack);

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -855,8 +855,7 @@ BatchAccessLog::AccessRecord BatchAccessLog::GetAccessRecord(ResourceUsageTag ta
 }
 
 std::string BatchAccessLog::CBSubmitLog::GetDebugRegionName(const ResourceUsageRecord& record) const {
-    // const auto& label_commands = (*cbs_)[0]->GetLabelCommands();
-    const auto& label_commands = label_commands_;  // TODO: use the above line when timelines are supported
+    const auto& label_commands = (*cbs_)[0]->GetLabelCommands();
     return vvl::CommandBuffer::GetDebugRegionName(label_commands, record.label_command_index, initial_label_stack_);
 }
 
@@ -877,9 +876,7 @@ BatchAccessLog::CBSubmitLog::CBSubmitLog(const BatchRecord& batch,
 
 BatchAccessLog::CBSubmitLog::CBSubmitLog(const BatchRecord& batch, const CommandBufferAccessContext& cb,
                                          const std::vector<std::string>& initial_label_stack)
-    : batch_(batch), cbs_(cb.GetCBReferencesShared()), log_(cb.GetAccessLogShared()), initial_label_stack_(initial_label_stack) {
-    label_commands_ = (*cbs_)[0]->GetLabelCommands();  // TODO: when timelines are supported use cbs directly
-}
+    : batch_(batch), cbs_(cb.GetCBReferencesShared()), log_(cb.GetAccessLogShared()), initial_label_stack_(initial_label_stack) {}
 
 PresentedImage::PresentedImage(const SyncValidator& sync_state, QueueBatchContext::Ptr batch_, VkSwapchainKHR swapchain,
                                uint32_t image_index_, uint32_t present_index_, ResourceUsageTag tag_)

--- a/layers/sync/sync_submit.h
+++ b/layers/sync/sync_submit.h
@@ -206,16 +206,6 @@ class BatchAccessLog {
         std::shared_ptr<const CommandExecutionContext::AccessLog> log_;
         // label stack at the point when command buffer is submitted to the queue
         std::vector<std::string> initial_label_stack_;
-
-        // TODO: remove this field and use (*cbs_)[0]->GetLabelCommands() directly
-        // when timeline semaphore support is implemented.
-        //
-        // Until then, there is no guarantee command buffers stored in cbs_ are what
-        // they are supposed to be when timeline semaphores are used (they can be reused
-        // after wait on timeline semaphore). When this happens, validation might report
-        // false positives (which is okay for unsupported feeature), but label code can crash.
-        // Make a copy of label commands as a temporary protection measure.
-        std::vector<vvl::CommandBuffer::LabelCommand> label_commands_;
     };
 
     void Import(const BatchRecord &batch, const CommandBufferAccessContext &cb_access,


### PR DESCRIPTION
Don't need this after timelines support was added.

Removes temporary solution https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/7504