### PR TITLE
gpu: Cleanup DescriptorClass usage

### DIFF
--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -807,7 +807,7 @@ bool CoreChecks::ValidateDrawState(const DescriptorSet &descriptor_set, uint32_t
     bool result = false;
     VkFramebuffer framebuffer = cb_state.activeFramebuffer ? cb_state.activeFramebuffer->VkHandle() : VK_NULL_HANDLE;
     // NOTE: GPU-AV needs non-const state objects to do lazy updates of descriptor state of only the dynamically used
-    // descriptors, via the non-const version of ValidateBinding(), this code uses the const path only even it gives up
+    // descriptors, via the non-const version of ValidateBindingDynamic(), this code uses the const path only even it gives up
     // non-const versions of its state objects here.
     const vvl::DescriptorValidator desc_val(const_cast<CoreChecks &>(*this), const_cast<vvl::CommandBuffer &>(cb_state),
                                             const_cast<DescriptorSet &>(descriptor_set), set_index, framebuffer, loc);
@@ -828,7 +828,7 @@ bool CoreChecks::ValidateDrawState(const DescriptorSet &descriptor_set, uint32_t
         binding_info.first = binding_pair.first;
         binding_info.second.emplace_back(binding_pair.second);
 
-        result |= desc_val.ValidateBinding(binding_info, *binding);
+        result |= desc_val.ValidateBindingStatic(binding_info, *binding);
     }
     return result;
 }

--- a/layers/drawdispatch/descriptor_validator.h
+++ b/layers/drawdispatch/descriptor_validator.h
@@ -51,44 +51,46 @@ class DescriptorValidator {
        return dev_state.FormatHandle(std::forward<T>(handle));
    }
 
-    bool ValidateBinding(const DescriptorBindingInfo& binding_info, const vvl::DescriptorBinding& binding) const;
-    bool ValidateBinding(const DescriptorBindingInfo& binding_info, const std::vector<uint32_t> &indices);
+   // Used with normal validation where we know which descriptors are accessed.
+   bool ValidateBindingStatic(const DescriptorBindingInfo& binding_info, const vvl::DescriptorBinding& binding) const;
+   // Used with GPU-AV when we need to run the GPU to know which descriptors are accessed.
+   // The main reason we can't combine is one function needs to be const and the other is non-const.
+   bool ValidateBindingDynamic(const DescriptorBindingInfo& binding_info, const std::vector<uint32_t>& indices);
 
  private:
-    template <typename T>
-    bool ValidateDescriptors(const DescriptorBindingInfo& binding_info, const T& binding) const;
+   template <typename T>
+   bool ValidateDescriptorsStatic(const DescriptorBindingInfo& binding_info, const T& binding) const;
 
-    template <typename T>
-    bool ValidateDescriptors(const DescriptorBindingInfo& binding_info, const T& binding, const std::vector<uint32_t>& indices);
+   template <typename T>
+   bool ValidateDescriptorsDynamic(const DescriptorBindingInfo& binding_info, const T& binding,
+                                   const std::vector<uint32_t>& indices);
 
+   bool ValidateDescriptor(const DescriptorBindingInfo& binding_info, uint32_t index, VkDescriptorType descriptor_type,
+                           const vvl::BufferDescriptor& descriptor) const;
+   bool ValidateDescriptor(const DescriptorBindingInfo& binding_info, uint32_t index, VkDescriptorType descriptor_type,
+                           const vvl::ImageDescriptor& descriptor) const;
+   bool ValidateDescriptor(const DescriptorBindingInfo& binding_info, uint32_t index, VkDescriptorType descriptor_type,
+                           const vvl::ImageSamplerDescriptor& descriptor) const;
+   bool ValidateDescriptor(const DescriptorBindingInfo& binding_info, uint32_t index, VkDescriptorType descriptor_type,
+                           const vvl::TexelDescriptor& descriptor) const;
+   bool ValidateDescriptor(const DescriptorBindingInfo& binding_info, uint32_t index, VkDescriptorType descriptor_type,
+                           const vvl::AccelerationStructureDescriptor& descriptor) const;
+   bool ValidateDescriptor(const DescriptorBindingInfo& binding_info, uint32_t index, VkDescriptorType descriptor_type,
+                           const vvl::SamplerDescriptor& descriptor) const;
 
-    bool ValidateDescriptor(const DescriptorBindingInfo& binding_info, uint32_t index,
-                            VkDescriptorType descriptor_type, const vvl::BufferDescriptor& descriptor) const;
-    bool ValidateDescriptor(const DescriptorBindingInfo& binding_info, uint32_t index,
-                            VkDescriptorType descriptor_type, const vvl::ImageDescriptor& descriptor) const;
-    bool ValidateDescriptor(const DescriptorBindingInfo& binding_info, uint32_t index,
-                            VkDescriptorType descriptor_type, const vvl::ImageSamplerDescriptor& descriptor) const;
-    bool ValidateDescriptor(const DescriptorBindingInfo& binding_info, uint32_t index,
-                            VkDescriptorType descriptor_type, const vvl::TexelDescriptor& descriptor) const;
-    bool ValidateDescriptor(const DescriptorBindingInfo& binding_info, uint32_t index,
-                            VkDescriptorType descriptor_type,
-                            const vvl::AccelerationStructureDescriptor& descriptor) const;
-    bool ValidateDescriptor(const DescriptorBindingInfo& binding_info, uint32_t index,
-                            VkDescriptorType descriptor_type, const vvl::SamplerDescriptor& descriptor) const;
+   // helper for the common parts of ImageSamplerDescriptor and SamplerDescriptor validation
+   bool ValidateSamplerDescriptor(const DescriptorBindingInfo& binding_info, uint32_t index, VkSampler sampler, bool is_immutable,
+                                  const vvl::Sampler* sampler_state) const;
 
-    // helper for the common parts of ImageSamplerDescriptor and SamplerDescriptor validation
-    bool ValidateSamplerDescriptor(const DescriptorBindingInfo& binding_info, uint32_t index, VkSampler sampler, bool is_immutable,
-                                   const vvl::Sampler* sampler_state) const;
+   std::string DescribeDescriptor(const DescriptorBindingInfo& binding_info, uint32_t index) const;
 
-    std::string DescribeDescriptor(const DescriptorBindingInfo& binding_info, uint32_t index) const;
-
-    ValidationStateTracker& dev_state;
-    vvl::CommandBuffer& cb_state;
-    vvl::DescriptorSet& descriptor_set;
-    const uint32_t set_index;
-    const VkFramebuffer framebuffer;
-    const Location& loc;
-    const DrawDispatchVuid& vuids;
+   ValidationStateTracker& dev_state;
+   vvl::CommandBuffer& cb_state;
+   vvl::DescriptorSet& descriptor_set;
+   const uint32_t set_index;
+   const VkFramebuffer framebuffer;
+   const Location& loc;
+   const DrawDispatchVuid& vuids;
 
 };
 }  // namespace vvl

--- a/layers/gpu/descriptor_validation/gpuav_descriptor_set.cpp
+++ b/layers/gpu/descriptor_validation/gpuav_descriptor_set.cpp
@@ -21,6 +21,7 @@
 #include "gpu/resources/gpuav_subclasses.h"
 #include "gpu/resources/gpuav_shader_resources.h"
 #include "gpu/shaders/gpuav_shaders_constants.h"
+#include "state_tracker/descriptor_sets.h"
 
 using vvl::DescriptorClass;
 
@@ -155,7 +156,9 @@ static glsl::DescriptorState GetInData(const vvl::MutableDescriptor &desc) {
             }
             return glsl::DescriptorState(desc_class, id);
         }
-        default:
+        case DescriptorClass::InlineUniform:
+        case DescriptorClass::Mutable:
+        case DescriptorClass::Invalid:
             assert(false);
             break;
     }
@@ -240,8 +243,8 @@ VkDeviceAddress DescriptorSet::GetTypeAddress(Validator &gpuav, const Location &
             case DescriptorClass::AccelerationStructure:
                 FillBindingInData(static_cast<const vvl::AccelerationStructureBinding &>(binding), data, index);
                 break;
-            case DescriptorClass::NoDescriptorClass:
-                gpuav.InternalError(gpuav.device, loc, "NoDescriptorClass not supported.");
+            case DescriptorClass::Invalid:
+                gpuav.InternalError(gpuav.device, loc, "Unknown DescriptorClass");
         }
     }
 

--- a/layers/gpu/descriptor_validation/gpuav_descriptor_validation.cpp
+++ b/layers/gpu/descriptor_validation/gpuav_descriptor_validation.cpp
@@ -192,7 +192,7 @@ void UpdateBoundDescriptors(Validator &gpuav, CommandBuffer &cb_state, VkPipelin
                     binding_info.second.emplace_back(iter->second);
                     ++iter;
                 }
-                context.ValidateBinding(binding_info, u.second);
+                context.ValidateBindingDynamic(binding_info, u.second);
             }
         }
     }

--- a/layers/gpu/resources/gpuav_shader_resources.h
+++ b/layers/gpu/resources/gpuav_shader_resources.h
@@ -102,8 +102,10 @@ struct DescriptorState {
                 return (kInlineUniformDesc << kDescBitShift);
             case vvl::DescriptorClass::AccelerationStructure:
                 return (kAccelDesc << kDescBitShift);
-            default:
+            case vvl::DescriptorClass::Mutable:
+            case vvl::DescriptorClass::Invalid:
                 assert(false);
+                break;
         }
         return 0;
     }

--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -358,30 +358,26 @@ class DescriptorSetLayout : public StateObject {
     std::unique_ptr<VkDeviceSize> layout_size_in_bytes;
 };
 
-/*
- * Descriptor classes
- *  Descriptor is an abstract base class from which 5 separate descriptor types are derived.
- *   This allows the WriteUpdate() and CopyUpdate() operations to be specialized per
- *   descriptor type, but all descriptors in a set can be accessed via the common Descriptor*.
- */
-
 // Slightly broader than type, each c++ "class" will has a corresponding "DescriptorClass"
 enum class DescriptorClass {
-    PlainSampler,
-    ImageSampler,
-    Image,
-    TexelBuffer,
-    GeneralBuffer,
-    InlineUniform,
-    AccelerationStructure,
-    Mutable,
-    NoDescriptorClass
+    PlainSampler,           // SAMPLER
+    ImageSampler,           // COMBINED_IMAGE_SAMPLER
+    Image,                  // SAMPLED_IMAGE/STORAGE_IMAGE/INPUT_ATTACHMENT
+    TexelBuffer,            // UNIFORM_TEXEL_BUFFER/VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER
+    GeneralBuffer,          // UNIFORM_BUFFER/VK_DESCRIPTOR_TYPE_STORAGE_BUFFER (and dynamic version)
+    InlineUniform,          // INLINE_UNIFORM_BLOCK
+    AccelerationStructure,  // ACCELERATION_STRUCTURE
+    Mutable,                // MUTABLE
+    Invalid
 };
 
 DescriptorClass DescriptorTypeToClass(VkDescriptorType type);
 
 class DescriptorSet;
 
+// Descriptor is an abstract base class from which many separate descriptor types are derived.
+// This allows the WriteUpdate() and CopyUpdate() operations to be specialized per descriptor type, but all descriptors in a set can
+// be accessed via the common Descriptor.
 class Descriptor {
   public:
     static bool SupportsNotifyInvalidate() { return false; }


### PR DESCRIPTION
Two small commits to improve the usage of `DescriptorClass`

Main thing is removing the `default` in the switch cases so it is easier to see which descriptors are covered or not in various spots