### PR TITLE
gpuav: Fix handling of PIPELINE_COMPILE_REQUIRED

### DIFF
--- a/layers/gpu/instrumentation/gpuav_shader_instrumentor.h
+++ b/layers/gpu/instrumentation/gpuav_shader_instrumentor.h
@@ -200,8 +200,8 @@ class GpuShaderInstrumentor : public ValidationStateTracker {
                                       InstrumentationDescriptorSetLayouts &out_instrumentation_dsl);
 
     template <typename SafeCreateInfo>
-    void PreCallRecordPipelineCreationShaderInstrumentation(
-        const VkAllocationCallbacks *pAllocator, vvl::Pipeline &pipeline_state, SafeCreateInfo &new_pipeline_ci,
+    [[nodiscard]] bool PreCallRecordPipelineCreationShaderInstrumentation(
+        const VkAllocationCallbacks *pAllocator, vvl::Pipeline &pipeline_state, SafeCreateInfo &modified_pipeline_ci,
         const Location &loc, std::vector<chassis::ShaderInstrumentationMetadata> &shader_instrumentation_metadata);
     void PostCallRecordPipelineCreationShaderInstrumentation(
         vvl::Pipeline &pipeline_state, std::vector<chassis::ShaderInstrumentationMetadata> &shader_instrumentation_metadata);

--- a/layers/gpu/instrumentation/gpuav_shader_instrumentor.h
+++ b/layers/gpu/instrumentation/gpuav_shader_instrumentor.h
@@ -207,9 +207,9 @@ class GpuShaderInstrumentor : public ValidationStateTracker {
         vvl::Pipeline &pipeline_state, std::vector<chassis::ShaderInstrumentationMetadata> &shader_instrumentation_metadata);
 
     // We have GPL variations for graphics as they defer instrumentation until linking
-    void PreCallRecordPipelineCreationShaderInstrumentationGPL(
+    [[nodiscard]] bool PreCallRecordPipelineCreationShaderInstrumentationGPL(
         const VkAllocationCallbacks *pAllocator, vvl::Pipeline &pipeline_state,
-        vku::safe_VkGraphicsPipelineCreateInfo &new_pipeline_ci, const Location &loc,
+        vku::safe_VkGraphicsPipelineCreateInfo &modified_pipeline_ci, const Location &loc,
         std::vector<chassis::ShaderInstrumentationMetadata> &shader_instrumentation_metadata);
     void PostCallRecordPipelineCreationShaderInstrumentationGPL(
         vvl::Pipeline &pipeline_state, const VkAllocationCallbacks *pAllocator,


### PR DESCRIPTION
- Remove VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT from instrumented pipeline libray
GPU-AV needs to succeed in creating them no matter driver cache state

- Renaming for clarification