### PR TITLE
Remove including state tracker in header 

### DIFF
--- a/layers/drawdispatch/descriptor_validator.cpp
+++ b/layers/drawdispatch/descriptor_validator.cpp
@@ -53,8 +53,8 @@ static const char *GetActionType(Func command) {
 
 std::string DescriptorValidator::DescribeDescriptor(const DescriptorBindingInfo &binding_info, uint32_t index) const {
     std::stringstream ss;
-    ss << FormatHandle(descriptor_set.Handle()) << " [Set " << set_index << ", Binding " << binding_info.first << ", Index "
-       << index;
+    ss << dev_state.FormatHandle(descriptor_set.Handle()) << " [Set " << set_index << ", Binding " << binding_info.first
+       << ", Index " << index;
 
     // If multiple variables tied to a binding, don't attempt to detect which one
     if (binding_info.second.size() == 1) {
@@ -202,7 +202,7 @@ bool DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &bindin
         auto set = descriptor_set.Handle();
         return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
                                   "the descriptor %s is using buffer %s that is invalid or has been destroyed.",
-                                  DescribeDescriptor(binding_info, index).c_str(), FormatHandle(buffer).c_str());
+                                  DescribeDescriptor(binding_info, index).c_str(), dev_state.FormatHandle(buffer).c_str());
     }
 
     if (buffer == VK_NULL_HANDLE) {
@@ -213,8 +213,8 @@ bool DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &bindin
             auto set = descriptor_set.Handle();
             return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
                                       "the descriptor %s is using buffer %s that references invalid memory %s.",
-                                      DescribeDescriptor(binding_info, index).c_str(), FormatHandle(buffer).c_str(),
-                                      FormatHandle(binding->Handle()).c_str());
+                                      DescribeDescriptor(binding_info, index).c_str(), dev_state.FormatHandle(buffer).c_str(),
+                                      dev_state.FormatHandle(binding->Handle()).c_str());
         }
     }
     if (dev_state.enabled_features.protectedMemory == VK_TRUE) {
@@ -328,7 +328,7 @@ bool DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &bindin
         auto set = descriptor_set.Handle();
         return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
                                   "the descriptor %s is using imageView %s that is invalid or has been destroyed.",
-                                  DescribeDescriptor(binding_info, index).c_str(), FormatHandle(image_view).c_str());
+                                  DescribeDescriptor(binding_info, index).c_str(), dev_state.FormatHandle(image_view).c_str());
     }
 
     if (image_view == VK_NULL_HANDLE) {
@@ -448,7 +448,7 @@ bool DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &bindin
             auto set = descriptor_set.Handle();
             std::stringstream msg;
             if (!descriptor_set.IsPushDescriptor()) {
-                msg << "Descriptor set " << FormatHandle(set)
+                msg << "Descriptor set " << dev_state.FormatHandle(set)
                     << " Image layout specified by vkCmdBindDescriptorSets doesn't match actual image layout at time "
                        "descriptor is used";
             } else {
@@ -502,7 +502,7 @@ bool DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &bindin
             vuids.imageview_atomic_02691, objlist, loc,
             "the descriptor %s has %s with format of %s which is missing VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT.\n"
             "(supported features: %s).",
-            DescribeDescriptor(binding_info, index).c_str(), FormatHandle(image_view).c_str(),
+            DescribeDescriptor(binding_info, index).c_str(), dev_state.FormatHandle(image_view).c_str(),
             string_VkFormat(image_view_ci.format), string_VkFormatFeatureFlags2(image_view_state->format_features).c_str());
     }
 
@@ -521,8 +521,8 @@ bool DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &bindin
                                           "the descriptor %s has %s with format of %s which doesn't support "
                                           "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT.\n"
                                           "(supported features: %s).",
-                                          DescribeDescriptor(binding_info, index).c_str(), FormatHandle(image_view).c_str(),
-                                          string_VkFormat(image_view_ci.format),
+                                          DescribeDescriptor(binding_info, index).c_str(),
+                                          dev_state.FormatHandle(image_view).c_str(), string_VkFormat(image_view_ci.format),
                                           string_VkFormatFeatureFlags2(format_features).c_str());
             }
 
@@ -534,8 +534,8 @@ bool DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &bindin
                                           "the descriptor %s has %s with format of %s which doesn't support "
                                           "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT.\n"
                                           "(supported features: %s).",
-                                          DescribeDescriptor(binding_info, index).c_str(), FormatHandle(image_view).c_str(),
-                                          string_VkFormat(image_view_ci.format),
+                                          DescribeDescriptor(binding_info, index).c_str(),
+                                          dev_state.FormatHandle(image_view).c_str(), string_VkFormat(image_view_ci.format),
                                           string_VkFormatFeatureFlags2(format_features).c_str());
             }
         }
@@ -547,7 +547,7 @@ bool DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &bindin
                                       "the descriptor %s has %s with format of %s which doesn't support "
                                       "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT.\n"
                                       "(supported features: %s).",
-                                      DescribeDescriptor(binding_info, index).c_str(), FormatHandle(image_view).c_str(),
+                                      DescribeDescriptor(binding_info, index).c_str(), dev_state.FormatHandle(image_view).c_str(),
                                       string_VkFormat(image_view_ci.format), string_VkFormatFeatureFlags2(format_features).c_str());
         }
     }
@@ -587,16 +587,18 @@ bool DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &bindin
                     const LogObjectList objlist(set, image_view, framebuffer);
                     return dev_state.LogError(vuids.image_subresources_subpass_write_06539, objlist, loc,
                                               "the descriptor %s has %s which will be read from as %s attachment %" PRIu32 ".",
-                                              DescribeDescriptor(binding_info, index).c_str(), FormatHandle(image_view).c_str(),
-                                              FormatHandle(framebuffer).c_str(), att_index);
+                                              DescribeDescriptor(binding_info, index).c_str(),
+                                              dev_state.FormatHandle(image_view).c_str(),
+                                              dev_state.FormatHandle(framebuffer).c_str(), att_index);
                 } else if (overlapping_view) {
                     auto set = descriptor_set.Handle();
                     const LogObjectList objlist(set, image_view, framebuffer, view_state->Handle());
                     return dev_state.LogError(
                         vuids.image_subresources_subpass_write_06539, objlist, loc,
                         "the descriptor %s has %s which will be overlap read from as %s in %s attachment %" PRIu32 " overlap.",
-                        DescribeDescriptor(binding_info, index).c_str(), FormatHandle(image_view).c_str(),
-                        FormatHandle(view_state->Handle()).c_str(), FormatHandle(framebuffer).c_str(), att_index);
+                        DescribeDescriptor(binding_info, index).c_str(), dev_state.FormatHandle(image_view).c_str(),
+                        dev_state.FormatHandle(view_state->Handle()).c_str(), dev_state.FormatHandle(framebuffer).c_str(),
+                        att_index);
                 }
             }
 
@@ -606,16 +608,18 @@ bool DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &bindin
                     const LogObjectList objlist(set, image_view, framebuffer);
                     return dev_state.LogError(vuids.image_subresources_render_pass_write_06537, objlist, loc,
                                               "the descriptor %s has %s which is written to but is also %s attachment %" PRIu32 ".",
-                                              DescribeDescriptor(binding_info, index).c_str(), FormatHandle(image_view).c_str(),
-                                              FormatHandle(framebuffer).c_str(), att_index);
+                                              DescribeDescriptor(binding_info, index).c_str(),
+                                              dev_state.FormatHandle(image_view).c_str(),
+                                              dev_state.FormatHandle(framebuffer).c_str(), att_index);
                 } else if (overlapping_view) {
                     auto set = descriptor_set.Handle();
                     const LogObjectList objlist(set, image_view, framebuffer, view_state->Handle());
                     return dev_state.LogError(
                         vuids.image_subresources_render_pass_write_06537, objlist, loc,
                         "the descriptor %s has %s which overlaps writes to %s but is also %s attachment %" PRIu32 ".",
-                        DescribeDescriptor(binding_info, index).c_str(), FormatHandle(image_view).c_str(),
-                        FormatHandle(view_state->Handle()).c_str(), FormatHandle(framebuffer).c_str(), att_index);
+                        DescribeDescriptor(binding_info, index).c_str(), dev_state.FormatHandle(image_view).c_str(),
+                        dev_state.FormatHandle(view_state->Handle()).c_str(), dev_state.FormatHandle(framebuffer).c_str(),
+                        att_index);
                 }
             }
         }
@@ -647,13 +651,13 @@ bool DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &bindin
                 image_view_format == VK_FORMAT_B5G5R5A1_UNORM_PACK16 || image_view_format == VK_FORMAT_A1B5G5R5_UNORM_PACK16_KHR) {
                 auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, sampler_state->Handle(), image_view_state->Handle());
-                return dev_state.LogError("VUID-VkSamplerCustomBorderColorCreateInfoEXT-format-04015", objlist, loc,
-                                          "the descriptor %s has %s which has a custom border color with format = "
-                                          "VK_FORMAT_UNDEFINED and is used to sample an image "
-                                          "view %s with format %s",
-                                          DescribeDescriptor(binding_info, index).c_str(),
-                                          FormatHandle(sampler_state->Handle()).c_str(),
-                                          FormatHandle(image_view_state->Handle()).c_str(), string_VkFormat(image_view_format));
+                return dev_state.LogError(
+                    "VUID-VkSamplerCustomBorderColorCreateInfoEXT-format-04015", objlist, loc,
+                    "the descriptor %s has %s which has a custom border color with format = "
+                    "VK_FORMAT_UNDEFINED and is used to sample an image "
+                    "view %s with format %s",
+                    DescribeDescriptor(binding_info, index).c_str(), dev_state.FormatHandle(sampler_state->Handle()).c_str(),
+                    dev_state.FormatHandle(image_view_state->Handle()).c_str(), string_VkFormat(image_view_format));
             }
         }
         const VkFilter sampler_mag_filter = sampler_state->create_info.magFilter;
@@ -670,24 +674,24 @@ bool DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &bindin
             if (sampler_mag_filter == VK_FILTER_LINEAR || sampler_min_filter == VK_FILTER_LINEAR) {
                 auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, sampler_state->Handle(), image_view_state->Handle());
-                return dev_state.LogError(vuids.linear_filter_sampler_04553, objlist, loc,
-                                          "the descriptor %s has %s which is set to use VK_FILTER_LINEAR with compareEnable is set "
-                                          "to VK_FALSE, but image view's (%s) format (%s) does not contain "
-                                          "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT in its format features.",
-                                          DescribeDescriptor(binding_info, index).c_str(),
-                                          FormatHandle(sampler_state->Handle()).c_str(),
-                                          FormatHandle(image_view_state->Handle()).c_str(), string_VkFormat(image_view_format));
+                return dev_state.LogError(
+                    vuids.linear_filter_sampler_04553, objlist, loc,
+                    "the descriptor %s has %s which is set to use VK_FILTER_LINEAR with compareEnable is set "
+                    "to VK_FALSE, but image view's (%s) format (%s) does not contain "
+                    "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT in its format features.",
+                    DescribeDescriptor(binding_info, index).c_str(), dev_state.FormatHandle(sampler_state->Handle()).c_str(),
+                    dev_state.FormatHandle(image_view_state->Handle()).c_str(), string_VkFormat(image_view_format));
             }
             if (sampler_state->create_info.mipmapMode == VK_SAMPLER_MIPMAP_MODE_LINEAR) {
                 auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, sampler_state->Handle(), image_view_state->Handle());
-                return dev_state.LogError(vuids.linear_mipmap_sampler_04770, objlist, loc,
-                                          "the descriptor %s has %s which is set to use VK_SAMPLER_MIPMAP_MODE_LINEAR with "
-                                          "compareEnable is set to VK_FALSE, but image view's (%s) format (%s) does not contain "
-                                          "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT in its format features.",
-                                          DescribeDescriptor(binding_info, index).c_str(),
-                                          FormatHandle(sampler_state->Handle()).c_str(),
-                                          FormatHandle(image_view_state->Handle()).c_str(), string_VkFormat(image_view_format));
+                return dev_state.LogError(
+                    vuids.linear_mipmap_sampler_04770, objlist, loc,
+                    "the descriptor %s has %s which is set to use VK_SAMPLER_MIPMAP_MODE_LINEAR with "
+                    "compareEnable is set to VK_FALSE, but image view's (%s) format (%s) does not contain "
+                    "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT in its format features.",
+                    DescribeDescriptor(binding_info, index).c_str(), dev_state.FormatHandle(sampler_state->Handle()).c_str(),
+                    dev_state.FormatHandle(image_view_state->Handle()).c_str(), string_VkFormat(image_view_format));
             }
         }
 
@@ -697,26 +701,26 @@ bool DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &bindin
             if (sampler_mag_filter == VK_FILTER_LINEAR || sampler_min_filter == VK_FILTER_LINEAR) {
                 auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, sampler_state->Handle(), image_view_state->Handle());
-                return dev_state.LogError(vuids.linear_filter_sampler_09598, objlist, loc,
-                                          "the descriptor %s has %s which is set to use VK_FILTER_LINEAR with reductionMode is set "
-                                          "to %s, but image view's (%s) format (%s) does not contain "
-                                          "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT in its format features.",
-                                          DescribeDescriptor(binding_info, index).c_str(),
-                                          FormatHandle(sampler_state->Handle()).c_str(),
-                                          string_VkSamplerReductionMode(sampler_reduction->reductionMode),
-                                          FormatHandle(image_view_state->Handle()).c_str(), string_VkFormat(image_view_format));
+                return dev_state.LogError(
+                    vuids.linear_filter_sampler_09598, objlist, loc,
+                    "the descriptor %s has %s which is set to use VK_FILTER_LINEAR with reductionMode is set "
+                    "to %s, but image view's (%s) format (%s) does not contain "
+                    "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT in its format features.",
+                    DescribeDescriptor(binding_info, index).c_str(), dev_state.FormatHandle(sampler_state->Handle()).c_str(),
+                    string_VkSamplerReductionMode(sampler_reduction->reductionMode),
+                    dev_state.FormatHandle(image_view_state->Handle()).c_str(), string_VkFormat(image_view_format));
             }
             if (sampler_state->create_info.mipmapMode == VK_SAMPLER_MIPMAP_MODE_LINEAR) {
                 auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, sampler_state->Handle(), image_view_state->Handle());
-                return dev_state.LogError(vuids.linear_mipmap_sampler_09599, objlist, loc,
-                                          "the descriptor %s has %s which is set to use VK_SAMPLER_MIPMAP_MODE_LINEAR with "
-                                          "reductionMode is set to %s, but image view's (%s) format (%s) does not contain "
-                                          "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT in its format features.",
-                                          DescribeDescriptor(binding_info, index).c_str(),
-                                          FormatHandle(sampler_state->Handle()).c_str(),
-                                          string_VkSamplerReductionMode(sampler_reduction->reductionMode),
-                                          FormatHandle(image_view_state->Handle()).c_str(), string_VkFormat(image_view_format));
+                return dev_state.LogError(
+                    vuids.linear_mipmap_sampler_09599, objlist, loc,
+                    "the descriptor %s has %s which is set to use VK_SAMPLER_MIPMAP_MODE_LINEAR with "
+                    "reductionMode is set to %s, but image view's (%s) format (%s) does not contain "
+                    "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT in its format features.",
+                    DescribeDescriptor(binding_info, index).c_str(), dev_state.FormatHandle(sampler_state->Handle()).c_str(),
+                    string_VkSamplerReductionMode(sampler_reduction->reductionMode),
+                    dev_state.FormatHandle(image_view_state->Handle()).c_str(), string_VkFormat(image_view_format));
             }
         }
 
@@ -728,8 +732,9 @@ bool DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &bindin
                     vuids.cubic_sampler_02692, objlist, loc,
                     "the descriptor %s has %s which is set to use VK_FILTER_CUBIC_EXT, then image view's (%s) format (%s) "
                     "MUST contain VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT in its format features.",
-                    DescribeDescriptor(binding_info, index).c_str(), FormatHandle(sampler_state->Handle()).c_str(),
-                    FormatHandle(image_view_state->Handle()).c_str(), string_VkFormat(image_view_state->create_info.format));
+                    DescribeDescriptor(binding_info, index).c_str(), dev_state.FormatHandle(sampler_state->Handle()).c_str(),
+                    dev_state.FormatHandle(image_view_state->Handle()).c_str(),
+                    string_VkFormat(image_view_state->create_info.format));
             }
 
             if (IsExtEnabled(dev_state.device_extensions.vk_ext_filter_cubic)) {
@@ -745,9 +750,9 @@ bool DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &bindin
                         vuids.filter_cubic_min_max_02695, objlist, loc,
                         "the descriptor %s has %s which is set to use VK_FILTER_CUBIC_EXT & %s, but image view "
                         "(%s) doesn't support filterCubicMinmax.",
-                        DescribeDescriptor(binding_info, index).c_str(), FormatHandle(sampler_state->Handle()).c_str(),
+                        DescribeDescriptor(binding_info, index).c_str(), dev_state.FormatHandle(sampler_state->Handle()).c_str(),
                         string_VkSamplerReductionMode(reduction_mode_info->reductionMode),
-                        FormatHandle(image_view_state->Handle()).c_str());
+                        dev_state.FormatHandle(image_view_state->Handle()).c_str());
                 }
 
                 if (!image_view_state->filter_cubic_props.filterCubic) {
@@ -757,8 +762,8 @@ bool DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &bindin
                         vuids.filter_cubic_02694, objlist, loc,
                         "the descriptor %s has %s which is set to use VK_FILTER_CUBIC_EXT, but image view (%s) "
                         "doesn't support filterCubic.",
-                        DescribeDescriptor(binding_info, index).c_str(), FormatHandle(sampler_state->Handle()).c_str(),
-                        FormatHandle(image_view_state->Handle()).c_str());
+                        DescribeDescriptor(binding_info, index).c_str(), dev_state.FormatHandle(sampler_state->Handle()).c_str(),
+                        dev_state.FormatHandle(image_view_state->Handle()).c_str());
                 }
             }
 
@@ -772,8 +777,8 @@ bool DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &bindin
                         vuids.img_filter_cubic_02693, objlist, loc,
                         "the descriptor %s has %s which is set to use VK_FILTER_CUBIC_EXT while the VK_IMG_filter_cubic "
                         "extension is enabled, but image view (%s) has an invalid imageViewType (%s).",
-                        DescribeDescriptor(binding_info, index).c_str(), FormatHandle(sampler_state->Handle()).c_str(),
-                        FormatHandle(image_view_state->Handle()).c_str(),
+                        DescribeDescriptor(binding_info, index).c_str(), dev_state.FormatHandle(sampler_state->Handle()).c_str(),
+                        dev_state.FormatHandle(image_view_state->Handle()).c_str(),
                         string_VkImageViewType(image_view_state->create_info.viewType));
                 }
             }
@@ -795,15 +800,15 @@ bool DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &bindin
                                                     : sampler_state->create_info.addressModeW;
             auto set = descriptor_set.Handle();
             const LogObjectList objlist(set, sampler_state->Handle(), image_state->Handle(), image_view_state->Handle());
-            return dev_state.LogError(vuids.corner_sampled_address_mode_02696, objlist, loc,
-                                      "the descriptor %s image (%s) in image view (%s) is created with flag "
-                                      "VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV and can only be sampled using "
-                                      "VK_SAMPLER_ADDRESS_MODE_CLAMP_EDGE, but sampler (%s) has "
-                                      "pCreateInfo->addressMode%s set to %s.",
-                                      DescribeDescriptor(binding_info, index).c_str(), FormatHandle(image_state->Handle()).c_str(),
-                                      FormatHandle(image_view_state->Handle()).c_str(),
-                                      FormatHandle(sampler_state->Handle()).c_str(), address_mode_letter.c_str(),
-                                      string_VkSamplerAddressMode(address_mode));
+            return dev_state.LogError(
+                vuids.corner_sampled_address_mode_02696, objlist, loc,
+                "the descriptor %s image (%s) in image view (%s) is created with flag "
+                "VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV and can only be sampled using "
+                "VK_SAMPLER_ADDRESS_MODE_CLAMP_EDGE, but sampler (%s) has "
+                "pCreateInfo->addressMode%s set to %s.",
+                DescribeDescriptor(binding_info, index).c_str(), dev_state.FormatHandle(image_state->Handle()).c_str(),
+                dev_state.FormatHandle(image_view_state->Handle()).c_str(), dev_state.FormatHandle(sampler_state->Handle()).c_str(),
+                address_mode_letter.c_str(), string_VkSamplerAddressMode(address_mode));
         }
 
         // UnnormalizedCoordinates sampler validations
@@ -817,8 +822,8 @@ bool DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &bindin
                 const LogObjectList objlist(set, image_view, sampler_state->Handle());
                 return dev_state.LogError(
                     vuids.sampler_imageview_type_08609, objlist, loc, "the descriptor %s Image View %s, type %s, is used by %s.",
-                    DescribeDescriptor(binding_info, index).c_str(), FormatHandle(image_view).c_str(),
-                    string_VkImageViewType(image_view_ci.viewType), FormatHandle(sampler_state->Handle()).c_str());
+                    DescribeDescriptor(binding_info, index).c_str(), dev_state.FormatHandle(image_view).c_str(),
+                    string_VkImageViewType(image_view_ci.viewType), dev_state.FormatHandle(sampler_state->Handle()).c_str());
             }
 
             const auto &subresource_range = image_view_state->normalized_subresource_range;
@@ -829,9 +834,9 @@ bool DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &bindin
                     vuids.unnormalized_coordinates_09635, objlist, loc,
                     "the descriptor %s Image View %s was created with levelCount of %s, but the sampler (%s) was created with "
                     "unnormalizedCoordinates.",
-                    DescribeDescriptor(binding_info, index).c_str(), FormatHandle(image_view).c_str(),
+                    DescribeDescriptor(binding_info, index).c_str(), dev_state.FormatHandle(image_view).c_str(),
                     string_LevelCount(image_view_state->image_state->create_info, image_view_ci.subresourceRange).c_str(),
-                    FormatHandle(sampler_state->Handle()).c_str());
+                    dev_state.FormatHandle(sampler_state->Handle()).c_str());
             }
 
             if (subresource_range.layerCount != 1) {
@@ -841,9 +846,9 @@ bool DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &bindin
                     vuids.unnormalized_coordinates_09635, objlist, loc,
                     "the descriptor %s Image View %s was created with layerCount of %s, but the sampler (%s) was created with "
                     "unnormalizedCoordinates.",
-                    DescribeDescriptor(binding_info, index).c_str(), FormatHandle(image_view).c_str(),
+                    DescribeDescriptor(binding_info, index).c_str(), dev_state.FormatHandle(image_view).c_str(),
                     string_LayerCount(image_view_state->image_state->create_info, image_view_ci.subresourceRange).c_str(),
-                    FormatHandle(sampler_state->Handle()).c_str());
+                    dev_state.FormatHandle(sampler_state->Handle()).c_str());
             }
 
             // sampler must not be used with any of the SPIR-V OpImageSample* or OpImageSparseSample*
@@ -853,8 +858,9 @@ bool DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &bindin
                 const LogObjectList objlist(set, image_view, sampler_state->Handle());
                 return dev_state.LogError(vuids.sampler_implicitLod_dref_proj_08610, objlist, loc,
                                           "the descriptor %s Image View %s is used by %s that uses invalid operator.",
-                                          DescribeDescriptor(binding_info, index).c_str(), FormatHandle(image_view).c_str(),
-                                          FormatHandle(sampler_state->Handle()).c_str());
+                                          DescribeDescriptor(binding_info, index).c_str(),
+                                          dev_state.FormatHandle(image_view).c_str(),
+                                          dev_state.FormatHandle(sampler_state->Handle()).c_str());
             }
 
             // sampler must not be used with any of the SPIR-V OpImageSample* or OpImageSparseSample*
@@ -865,8 +871,8 @@ bool DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &bindin
                 return dev_state.LogError(
                     vuids.sampler_bias_offset_08611, objlist, loc,
                     "the descriptor %s Image View %s is used by %s that uses invalid bias or offset operator.",
-                    DescribeDescriptor(binding_info, index).c_str(), FormatHandle(image_view).c_str(),
-                    FormatHandle(sampler_state->Handle()).c_str());
+                    DescribeDescriptor(binding_info, index).c_str(), dev_state.FormatHandle(image_view).c_str(),
+                    dev_state.FormatHandle(sampler_state->Handle()).c_str());
             }
         }
 
@@ -954,7 +960,7 @@ bool DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &bindin
         auto set = descriptor_set.Handle();
         return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
                                   "the descriptor %s is using bufferView %s that is invalid or has been destroyed.",
-                                  DescribeDescriptor(binding_info, index).c_str(), FormatHandle(buffer_view).c_str());
+                                  DescribeDescriptor(binding_info, index).c_str(), dev_state.FormatHandle(buffer_view).c_str());
     }
 
     if (buffer_view == VK_NULL_HANDLE) {
@@ -969,7 +975,7 @@ bool DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &bindin
         auto set = descriptor_set.Handle();
         return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
                                   "the descriptor %s is using buffer %s that has been destroyed.",
-                                  DescribeDescriptor(binding_info, index).c_str(), FormatHandle(buffer).c_str());
+                                  DescribeDescriptor(binding_info, index).c_str(), dev_state.FormatHandle(buffer).c_str());
     }
     const VkFormat buffer_view_format = buffer_view_state->create_info.format;
     const uint32_t format_bits = spirv::GetFormatType(buffer_view_format);
@@ -1019,8 +1025,8 @@ bool DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &bindin
             vuids.bufferview_atomic_07888, objlist, loc,
             "the descriptor %s has %s with format of %s which is missing VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT.\n"
             "(supported features: %s).",
-            DescribeDescriptor(binding_info, index).c_str(), FormatHandle(buffer_view).c_str(), string_VkFormat(buffer_view_format),
-            string_VkFormatFeatureFlags2(buffer_format_features).c_str());
+            DescribeDescriptor(binding_info, index).c_str(), dev_state.FormatHandle(buffer_view).c_str(),
+            string_VkFormat(buffer_view_format), string_VkFormatFeatureFlags2(buffer_format_features).c_str());
     }
 
     // When KHR_format_feature_flags2 is supported, the read/write without
@@ -1036,8 +1042,8 @@ bool DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &bindin
                                           "the descriptor %s has %s with format of %s which is missing "
                                           "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR.\n"
                                           "(supported features: %s).",
-                                          DescribeDescriptor(binding_info, index).c_str(), FormatHandle(buffer_view).c_str(),
-                                          string_VkFormat(buffer_view_format),
+                                          DescribeDescriptor(binding_info, index).c_str(),
+                                          dev_state.FormatHandle(buffer_view).c_str(), string_VkFormat(buffer_view_format),
                                           string_VkFormatFeatureFlags2(buffer_format_features).c_str());
             }
 
@@ -1049,8 +1055,8 @@ bool DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &bindin
                                           "the descriptor %s has %s with format of %s which is missing "
                                           "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR.\n"
                                           "(supported features: %s).",
-                                          DescribeDescriptor(binding_info, index).c_str(), FormatHandle(buffer_view).c_str(),
-                                          string_VkFormat(buffer_view_format),
+                                          DescribeDescriptor(binding_info, index).c_str(),
+                                          dev_state.FormatHandle(buffer_view).c_str(), string_VkFormat(buffer_view_format),
                                           string_VkFormatFeatureFlags2(buffer_format_features).c_str());
             }
         }
@@ -1088,7 +1094,7 @@ bool DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &bindin
                                              VkDescriptorType descriptor_type,
                                              const AccelerationStructureDescriptor &descriptor) const {
     // Verify that acceleration structures are valid
-    if (descriptor.is_khr()) {
+    if (descriptor.IsKHR()) {
         auto acc = descriptor.GetAccelerationStructure();
         auto acc_node = descriptor.GetAccelerationStructureStateKHR();
         if (!acc_node || acc_node->Destroyed()) {
@@ -1097,15 +1103,15 @@ bool DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &bindin
                 return dev_state.LogError(
                     vuids.descriptor_buffer_bit_set_08114, set, loc,
                     "the descriptor %s is using acceleration structure %s that is invalid or has been destroyed.",
-                    DescribeDescriptor(binding_info, index).c_str(), FormatHandle(acc).c_str());
+                    DescribeDescriptor(binding_info, index).c_str(), dev_state.FormatHandle(acc).c_str());
             }
         } else if (acc_node->buffer_state) {
             for (const auto &mem_binding : acc_node->buffer_state->GetInvalidMemory()) {
                 auto set = descriptor_set.Handle();
                 return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
                                           "the descriptor %s is using acceleration structure %s that references invalid memory %s.",
-                                          DescribeDescriptor(binding_info, index).c_str(), FormatHandle(acc).c_str(),
-                                          FormatHandle(mem_binding->Handle()).c_str());
+                                          DescribeDescriptor(binding_info, index).c_str(), dev_state.FormatHandle(acc).c_str(),
+                                          dev_state.FormatHandle(mem_binding->Handle()).c_str());
             }
         }
     } else {
@@ -1117,15 +1123,15 @@ bool DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &bindin
                 return dev_state.LogError(
                     vuids.descriptor_buffer_bit_set_08114, set, loc,
                     "the descriptor %s is using acceleration structure %s that is invalid or has been destroyed.",
-                    DescribeDescriptor(binding_info, index).c_str(), FormatHandle(acc).c_str());
+                    DescribeDescriptor(binding_info, index).c_str(), dev_state.FormatHandle(acc).c_str());
             }
         } else {
             for (const auto &mem_binding : acc_node->GetInvalidMemory()) {
                 auto set = descriptor_set.Handle();
                 return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
                                           "the descriptor %s is using acceleration structure %s that references invalid memory %s.",
-                                          DescribeDescriptor(binding_info, index).c_str(), FormatHandle(acc).c_str(),
-                                          FormatHandle(mem_binding->Handle()).c_str());
+                                          DescribeDescriptor(binding_info, index).c_str(), dev_state.FormatHandle(acc).c_str(),
+                                          dev_state.FormatHandle(mem_binding->Handle()).c_str());
             }
         }
     }
@@ -1142,15 +1148,15 @@ bool DescriptorValidator::ValidateSamplerDescriptor(const DescriptorBindingInfo 
         auto set = descriptor_set.Handle();
         return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
                                   "the descriptor %s is using sampler %s that is invalid or has been destroyed.",
-                                  DescribeDescriptor(binding_info, index).c_str(), FormatHandle(sampler).c_str());
+                                  DescribeDescriptor(binding_info, index).c_str(), dev_state.FormatHandle(sampler).c_str());
     } else {
         if (sampler_state->samplerConversion && !is_immutable) {
             auto set = descriptor_set.Handle();
             return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
                                       "the descriptor %s sampler (%s) contains a YCBCR conversion (%s), but the sampler is not an "
                                       "immutable sampler.",
-                                      DescribeDescriptor(binding_info, index).c_str(), FormatHandle(sampler).c_str(),
-                                      FormatHandle(sampler_state->samplerConversion).c_str());
+                                      DescribeDescriptor(binding_info, index).c_str(), dev_state.FormatHandle(sampler).c_str(),
+                                      dev_state.FormatHandle(sampler_state->samplerConversion).c_str());
         }
     }
     return false;

--- a/layers/drawdispatch/descriptor_validator.h
+++ b/layers/drawdispatch/descriptor_validator.h
@@ -16,9 +16,8 @@
  */
 
 #pragma once
-// TODO - Should only need generated/chassis.h
-// Because of FormatHandle, we need to include all of state_tracker.h
-#include "state_tracker/state_tracker.h"
+#include <vulkan/vulkan.h>
+#include "error_message/error_location.h"
 
 class ValidationStateTracker;
 struct DescriptorRequirement;
@@ -45,11 +44,6 @@ class DescriptorValidator {
  public:
    DescriptorValidator(ValidationStateTracker& dev, vvl::CommandBuffer& cb_state, vvl::DescriptorSet& descriptor_set,
                        uint32_t set_index, VkFramebuffer framebuffer, const Location& loc);
-
-   template <typename T>
-   std::string FormatHandle(T&& handle) const {
-       return dev_state.FormatHandle(std::forward<T>(handle));
-   }
 
    // Used with normal validation where we know which descriptors are accessed.
    bool ValidateBindingStatic(const DescriptorBindingInfo& binding_info, const vvl::DescriptorBinding& binding) const;

--- a/layers/gpu/descriptor_validation/gpuav_descriptor_set.cpp
+++ b/layers/gpu/descriptor_validation/gpuav_descriptor_set.cpp
@@ -101,7 +101,7 @@ static glsl::DescriptorState GetInData(const vvl::ImageSamplerDescriptor &desc) 
 
 static glsl::DescriptorState GetInData(const vvl::AccelerationStructureDescriptor &ac) {
     uint32_t id;
-    if (ac.is_khr()) {
+    if (ac.IsKHR()) {
         auto ac_state = static_cast<const AccelerationStructureKHR *>(ac.GetAccelerationStructureStateKHR());
         id = ac_state ? ac_state->id : glsl::kDebugInputBindlessSkipId;
     } else {

--- a/layers/gpu/descriptor_validation/gpuav_descriptor_set.h
+++ b/layers/gpu/descriptor_validation/gpuav_descriptor_set.h
@@ -52,7 +52,8 @@ class DescriptorSet : public vvl::DescriptorSet {
     DeviceMemoryBlock post_process_block_;
 
     std::vector<gpuav::spirv::BindingLayout> binding_layouts_;
-    // TODO - We probably should just use GetTotalDescriptorCount() but need to confirm will still work with Inline UBO
+    // Can't use GetTotalDescriptorCount() because it handles Inline Uniforms as more than one count
+    // (since it is used to check if two layouts are the same or not)
     uint32_t total_descriptor_count_;
 
     // Since we will re-bind the same descriptor set many times, keeping a version allows us to know if things have changed and

--- a/layers/state_tracker/descriptor_sets.cpp
+++ b/layers/state_tracker/descriptor_sets.cpp
@@ -1234,7 +1234,7 @@ void vvl::MutableDescriptor::CopyUpdate(DescriptorSet &set_state, const Validati
                     ReplaceStatePtr(set_state, buffer_view_state_, mutable_src.GetSharedBufferViewState(), is_bindless);
                 } break;
                 case DescriptorClass::AccelerationStructure: {
-                    if (mutable_src.is_khr()) {
+                    if (mutable_src.IsKHR()) {
                         acc_ = mutable_src.GetAccelerationStructureKHR();
                         ReplaceStatePtr(set_state, acc_state_, dev_data.GetConstCastShared<vvl::AccelerationStructureKHR>(acc_),
                                         is_bindless);

--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -20,7 +20,6 @@
 
 #include "state_tracker/state_object.h"
 #include "utils/hash_util.h"
-#include "utils/vk_layer_utils.h"
 #include "state_tracker/shader_stage_state.h"
 #include "generated/vk_object_types.h"
 #include "generated/error_location_helper.h"
@@ -563,7 +562,7 @@ class AccelerationStructureDescriptor : public Descriptor {
     vvl::AccelerationStructureNV *GetAccelerationStructureStateNV() { return acc_state_nv_.get(); }
     void CopyUpdate(DescriptorSet &set_state, const ValidationStateTracker &dev_data, const Descriptor &, bool is_bindless,
                     VkDescriptorType type) override;
-    bool is_khr() const { return is_khr_; }
+    bool IsKHR() const { return is_khr_; }
 
     bool AddParent(StateObject *state_object) override;
     void RemoveParent(StateObject *state_object) override;
@@ -617,7 +616,7 @@ class MutableDescriptor : public Descriptor {
     bool AddParent(StateObject *state_object) override;
     void RemoveParent(StateObject *state_object) override;
 
-    bool is_khr() const { return is_khr_; }
+    bool IsKHR() const { return is_khr_; }
     bool Invalid() const override;
 
     VkDescriptorType ActiveType() const { return active_descriptor_type_; }
@@ -846,6 +845,7 @@ class DescriptorSet : public StateObject {
     uint32_t GetVariableDescriptorCount() const { return variable_count_; }
     vvl::DescriptorPool *GetPoolState() const { return pool_state_; }
 
+    // These are overriding STL so need lower case names
     ConstBindingIterator begin() const { return bindings_.begin(); }
     ConstBindingIterator end() const { return bindings_.end(); }
     ConstBindingIterator FindBinding(uint32_t binding) const {


### PR DESCRIPTION
Broken into commits, main goal was 

Remove the `#include <state_tracker.h>` from the `descriptor_validator.h` header
