### PR TITLE
layers: Fix VerifySetLayoutCompatibility for Samplers

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -563,6 +563,8 @@ class CoreChecks : public ValidationStateTracker {
                            const std::vector<uint32_t>& dynamic_offsets, const vvl::CommandBuffer& cb_state, const Location& loc,
                            const vvl::DrawDispatchVuid& vuid) const;
 
+    bool ImmutableSamplersAreEqual(const VkDescriptorSetLayoutBinding& b1, const VkDescriptorSetLayoutBinding& b2,
+                                   bool& out_exception) const;
     bool VerifySetLayoutCompatibility(const vvl::DescriptorSetLayout& layout_dsl,
                                       const vvl::DescriptorSetLayout& bound_dsl, std::string& error_msg) const;
 

--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -275,6 +275,9 @@ static inline bool operator==(const DescriptorSetLayoutDef &lhs, const Descripto
         if (l.pImmutableSamplers) {
             for (uint32_t s = 0; s < l.descriptorCount; s++) {
                 if (l.pImmutableSamplers[s] != r.pImmutableSamplers[s]) {
+                    // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8497
+                    // This just checks pointers, but two different VkSampler handles could be created with same createInfo.
+                    // Since this is rare enough, mark as "not the same" and check later when checking for compatibility.
                     return false;
                 }
             }

--- a/layers/utils/vk_struct_compare.cpp
+++ b/layers/utils/vk_struct_compare.cpp
@@ -83,3 +83,74 @@ bool ComparePipelineFragmentShadingRateStateCreateInfo(const VkPipelineFragmentS
     return (a.fragmentSize.width == b.fragmentSize.width) && (a.fragmentSize.height == b.fragmentSize.height) &&
            (a.combinerOps[0] == b.combinerOps[0]) && (a.combinerOps[1] == b.combinerOps[1]);
 }
+
+static inline bool CompareSamplerYcbcrConversionInfo(const VkSamplerYcbcrConversionInfo &a, const VkSamplerYcbcrConversionInfo &b) {
+    return a.conversion == b.conversion;
+}
+static inline bool CompareSamplerReductionModeCreateInfo(const VkSamplerReductionModeCreateInfo &a,
+                                                         const VkSamplerReductionModeCreateInfo &b) {
+    return a.reductionMode == b.reductionMode;
+}
+
+static inline bool CompareSamplerBorderColorComponentMappingCreateInfo(const VkSamplerBorderColorComponentMappingCreateInfoEXT &a,
+                                                                       const VkSamplerBorderColorComponentMappingCreateInfoEXT &b) {
+    return (a.components.r == b.components.r) && (a.components.g == b.components.g) && (a.components.b == b.components.b) &&
+           (a.components.a == b.components.a) && (a.srgb == b.srgb);
+}
+
+static inline bool CompareSamplerCustomBorderColorCreateInfo(const VkSamplerCustomBorderColorCreateInfoEXT &a,
+                                                             const VkSamplerCustomBorderColorCreateInfoEXT &b) {
+    return (a.format == b.format);
+}
+
+bool CompareSamplerCreateInfo(const VkSamplerCreateInfo &a, const VkSamplerCreateInfo &b) {
+    if (a.pNext && b.pNext) {
+        auto *a_ycbcr_conversion = vku::FindStructInPNextChain<VkSamplerYcbcrConversionInfo>(a.pNext);
+        auto *b_ycbcr_conversion = vku::FindStructInPNextChain<VkSamplerYcbcrConversionInfo>(b.pNext);
+        if (a_ycbcr_conversion && b_ycbcr_conversion) {
+            if (!CompareSamplerYcbcrConversionInfo(*a_ycbcr_conversion, *b_ycbcr_conversion)) {
+                return false;
+            }
+        } else if (a_ycbcr_conversion != b_ycbcr_conversion) {
+            return false;  // both are not null
+        }
+
+        auto *a_reduction_mode = vku::FindStructInPNextChain<VkSamplerReductionModeCreateInfo>(a.pNext);
+        auto *b_reduction_mode = vku::FindStructInPNextChain<VkSamplerReductionModeCreateInfo>(b.pNext);
+        if (a_reduction_mode && b_reduction_mode) {
+            if (!CompareSamplerReductionModeCreateInfo(*a_reduction_mode, *b_reduction_mode)) {
+                return false;
+            }
+        } else if (a_reduction_mode != b_reduction_mode) {
+            return false;  // both are not null
+        }
+
+        auto *a_component_mapping = vku::FindStructInPNextChain<VkSamplerBorderColorComponentMappingCreateInfoEXT>(a.pNext);
+        auto *b_component_mapping = vku::FindStructInPNextChain<VkSamplerBorderColorComponentMappingCreateInfoEXT>(b.pNext);
+        if (a_component_mapping && b_component_mapping) {
+            if (!CompareSamplerBorderColorComponentMappingCreateInfo(*a_component_mapping, *b_component_mapping)) {
+                return false;
+            }
+        } else if (a_component_mapping != b_component_mapping) {
+            return false;  // both are not null
+        }
+
+        auto *a_border_color = vku::FindStructInPNextChain<VkSamplerCustomBorderColorCreateInfoEXT>(a.pNext);
+        auto *b_border_color = vku::FindStructInPNextChain<VkSamplerCustomBorderColorCreateInfoEXT>(b.pNext);
+        if (a_border_color && b_border_color) {
+            if (!CompareSamplerCustomBorderColorCreateInfo(*a_border_color, *b_border_color)) {
+                return false;
+            }
+        } else if (a_border_color != b_border_color) {
+            return false;  // both are not null
+        }
+    } else if (a.pNext != b.pNext) {
+        return false;  // both are not null
+    }
+
+    return (a.flags == b.flags) && (a.magFilter == b.magFilter) && (a.minFilter == b.minFilter) && (a.mipmapMode == b.mipmapMode) &&
+           (a.addressModeU == b.addressModeU) && (a.addressModeV == b.addressModeV) && (a.addressModeW == b.addressModeW) &&
+           (a.mipLodBias == b.mipLodBias) && (a.anisotropyEnable == b.anisotropyEnable) && (a.maxAnisotropy == b.maxAnisotropy) &&
+           (a.compareEnable == b.compareEnable) && (a.compareOp == b.compareOp) && (a.minLod == b.minLod) &&
+           (a.maxLod == b.maxLod) && (a.borderColor == b.borderColor) && (a.unnormalizedCoordinates == b.unnormalizedCoordinates);
+}

--- a/layers/utils/vk_struct_compare.h
+++ b/layers/utils/vk_struct_compare.h
@@ -35,3 +35,5 @@ bool ComparePipelineColorBlendAttachmentState(const VkPipelineColorBlendAttachme
 
 bool ComparePipelineFragmentShadingRateStateCreateInfo(const VkPipelineFragmentShadingRateStateCreateInfoKHR &a,
                                                        const VkPipelineFragmentShadingRateStateCreateInfoKHR &b);
+
+bool CompareSamplerCreateInfo(const VkSamplerCreateInfo &a, const VkSamplerCreateInfo &b);

--- a/tests/unit/descriptors.cpp
+++ b/tests/unit/descriptors.cpp
@@ -5160,3 +5160,47 @@ TEST_F(NegativeDescriptors, EmptyDescriptorSetLayout) {
     vk::UpdateDescriptorSets(device(), 1, &descriptor_write, 0, nullptr);
     m_errorMonitor->VerifyFound();
 }
+
+TEST_F(NegativeDescriptors, DuplicateLayoutDifferentSampler) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8497");
+    RETURN_IF_SKIP(Init());
+    auto sampler_ci = SafeSaneSamplerCreateInfo();
+    vkt::Sampler sampler_0(*m_device, sampler_ci);
+    sampler_ci.maxLod = 8.0;
+    vkt::Sampler sampler_1(*m_device, sampler_ci);
+
+    OneOffDescriptorSet ds_0(m_device,
+                             {{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_COMPUTE_BIT, &sampler_0.handle()}});
+    const vkt::PipelineLayout pipeline_layout_0(*m_device, {&ds_0.layout_});
+
+    OneOffDescriptorSet ds_1(m_device,
+                             {{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_COMPUTE_BIT, &sampler_1.handle()}});
+
+    m_command_buffer.Begin();
+    vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout_0.handle(), 0, 1,
+                              &ds_1.set_, 0, nullptr);
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeDescriptors, DuplicateLayoutDifferentSamplerArray) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8497");
+    RETURN_IF_SKIP(Init());
+    auto sampler_ci = SafeSaneSamplerCreateInfo();
+    vkt::Sampler sampler_0(*m_device, sampler_ci);
+    sampler_ci.maxLod = 8.0;
+    vkt::Sampler sampler_1(*m_device, sampler_ci);
+    VkSampler sampler_array_0[3] = {sampler_0.handle(), sampler_0.handle(), sampler_0.handle()};
+    VkSampler sampler_array_1[3] = {sampler_0.handle(), sampler_1.handle(), sampler_0.handle()};
+
+    OneOffDescriptorSet ds_0(m_device,
+                             {{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 3, VK_SHADER_STAGE_COMPUTE_BIT, sampler_array_0}});
+    const vkt::PipelineLayout pipeline_layout_0(*m_device, {&ds_0.layout_});
+
+    OneOffDescriptorSet ds_1(m_device,
+                             {{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 3, VK_SHADER_STAGE_COMPUTE_BIT, sampler_array_1}});
+
+    m_command_buffer.Begin();
+    vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout_0.handle(), 0, 1,
+                              &ds_1.set_, 0, nullptr);
+    m_command_buffer.End();
+}

--- a/tests/unit/descriptors_positive.cpp
+++ b/tests/unit/descriptors_positive.cpp
@@ -1189,3 +1189,80 @@ TEST_F(PositiveDescriptors, ImageSubresourceOverlapBetweenRenderPassAndDescripto
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
 }
+
+TEST_F(PositiveDescriptors, DuplicateLayoutSameSampler) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8497");
+    RETURN_IF_SKIP(Init());
+    vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
+
+    OneOffDescriptorSet ds_0(m_device,
+                             {{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_COMPUTE_BIT, &sampler.handle()}});
+    const vkt::PipelineLayout pipeline_layout_0(*m_device, {&ds_0.layout_});
+
+    OneOffDescriptorSet ds_1(m_device,
+                             {{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_COMPUTE_BIT, &sampler.handle()}});
+
+    m_command_buffer.Begin();
+    vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout_0.handle(), 0, 1,
+                              &ds_1.set_, 0, nullptr);
+    m_command_buffer.End();
+}
+
+TEST_F(PositiveDescriptors, DuplicateLayoutDuplicateSampler) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8497");
+    RETURN_IF_SKIP(Init());
+    vkt::Sampler sampler_0(*m_device, SafeSaneSamplerCreateInfo());
+    vkt::Sampler sampler_1(*m_device, SafeSaneSamplerCreateInfo());
+
+    OneOffDescriptorSet ds_0(m_device,
+                             {{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_COMPUTE_BIT, &sampler_0.handle()}});
+    const vkt::PipelineLayout pipeline_layout_0(*m_device, {&ds_0.layout_});
+
+    OneOffDescriptorSet ds_1(m_device,
+                             {{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_COMPUTE_BIT, &sampler_1.handle()}});
+
+    m_command_buffer.Begin();
+    vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout_0.handle(), 0, 1,
+                              &ds_1.set_, 0, nullptr);
+    m_command_buffer.End();
+}
+
+TEST_F(PositiveDescriptors, DuplicateLayoutSameSamplerArray) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8497");
+    RETURN_IF_SKIP(Init());
+    vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
+    VkSampler sampler_array[3] = {sampler.handle(), sampler.handle(), sampler.handle()};
+
+    OneOffDescriptorSet ds_0(m_device,
+                             {{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 3, VK_SHADER_STAGE_COMPUTE_BIT, sampler_array}});
+    const vkt::PipelineLayout pipeline_layout_0(*m_device, {&ds_0.layout_});
+
+    OneOffDescriptorSet ds_1(m_device,
+                             {{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 3, VK_SHADER_STAGE_COMPUTE_BIT, sampler_array}});
+
+    m_command_buffer.Begin();
+    vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout_0.handle(), 0, 1,
+                              &ds_1.set_, 0, nullptr);
+    m_command_buffer.End();
+}
+
+TEST_F(PositiveDescriptors, DuplicateLayoutDuplicateSamplerArray) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8497");
+    RETURN_IF_SKIP(Init());
+    vkt::Sampler sampler_0(*m_device, SafeSaneSamplerCreateInfo());
+    vkt::Sampler sampler_1(*m_device, SafeSaneSamplerCreateInfo());
+    VkSampler sampler_array_0[3] = {sampler_0.handle(), sampler_0.handle(), sampler_0.handle()};
+    VkSampler sampler_array_1[3] = {sampler_1.handle(), sampler_1.handle(), sampler_1.handle()};
+
+    OneOffDescriptorSet ds_0(m_device,
+                             {{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 3, VK_SHADER_STAGE_COMPUTE_BIT, sampler_array_0}});
+    const vkt::PipelineLayout pipeline_layout_0(*m_device, {&ds_0.layout_});
+
+    OneOffDescriptorSet ds_1(m_device,
+                             {{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 3, VK_SHADER_STAGE_COMPUTE_BIT, sampler_array_1}});
+
+    m_command_buffer.Begin();
+    vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout_0.handle(), 0, 1,
+                              &ds_1.set_, 0, nullptr);
+    m_command_buffer.End();
+}


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8497

Add exception to check the `VkSamplerCreateInfo` of 2 `pImmutableSamplers` to see if they are the same for Descriptor Set Layout Compatibility