### PR TITLE
sync: Report image resources during submit time validation

### DIFF
--- a/layers/sync/sync_access_context.cpp
+++ b/layers/sync/sync_access_context.cpp
@@ -199,10 +199,10 @@ void AccessContext::UpdateAccessState(const ImageState &image, SyncStageAccessIn
 }
 void AccessContext::UpdateAccessState(const ImageState &image, SyncStageAccessIndex current_usage, SyncOrdering ordering_rule,
                                       const VkImageSubresourceRange &subresource_range, const VkOffset3D &offset,
-                                      const VkExtent3D &extent, const ResourceUsageTag tag) {
+                                      const VkExtent3D &extent, const ResourceUsageTagEx tag_ex) {
     // range_gen is non-temporary to avoid an additional copy
     ImageRangeGen range_gen = image.MakeImageRangeGen(subresource_range, offset, extent, false);
-    UpdateAccessState(range_gen, current_usage, ordering_rule, tag);
+    UpdateAccessState(range_gen, current_usage, ordering_rule, tag_ex);
 }
 
 void AccessContext::UpdateAccessState(const ImageViewState &image_view, SyncStageAccessIndex current_usage,
@@ -238,11 +238,11 @@ void AccessContext::UpdateAccessState(const vvl::VideoSession &vs_state, const v
 }
 
 void AccessContext::UpdateAccessState(ImageRangeGen &range_gen, SyncStageAccessIndex current_usage, SyncOrdering ordering_rule,
-                                      ResourceUsageTag tag) {
+                                      ResourceUsageTagEx tag_ex) {
     if (current_usage == SYNC_ACCESS_INDEX_NONE) {
         return;
     }
-    UpdateMemoryAccessStateFunctor action(*this, current_usage, ordering_rule, ResourceUsageTagEx{tag});
+    UpdateMemoryAccessStateFunctor action(*this, current_usage, ordering_rule, tag_ex);
     UpdateMemoryAccessState(action, range_gen);
 }
 
@@ -250,7 +250,7 @@ void AccessContext::UpdateAccessState(const ImageRangeGen &range_gen, SyncStageA
                                       SyncOrdering ordering_rule, ResourceUsageTag tag) {
     // range_gen is non-temporary to avoid infinite call recursion
     ImageRangeGen mutable_range_gen(range_gen);
-    UpdateAccessState(mutable_range_gen, current_usage, ordering_rule, tag);
+    UpdateAccessState(mutable_range_gen, current_usage, ordering_rule, ResourceUsageTagEx{tag});
 }
 
 void AccessContext::ResolveChildContexts(const std::vector<AccessContext> &contexts) {

--- a/layers/sync/sync_access_context.cpp
+++ b/layers/sync/sync_access_context.cpp
@@ -195,7 +195,7 @@ void AccessContext::UpdateAccessState(const ImageState &image, SyncStageAccessIn
                                       const VkImageSubresourceRange &subresource_range, const ResourceUsageTag &tag) {
     // range_gen is non-temporary to avoid an additional copy
     ImageRangeGen range_gen = image.MakeImageRangeGen(subresource_range, false);
-    UpdateAccessState(range_gen, current_usage, ordering_rule, tag);
+    UpdateAccessState(range_gen, current_usage, ordering_rule, ResourceUsageTagEx{tag});
 }
 void AccessContext::UpdateAccessState(const ImageState &image, SyncStageAccessIndex current_usage, SyncOrdering ordering_rule,
                                       const VkImageSubresourceRange &subresource_range, const VkOffset3D &offset,
@@ -207,16 +207,16 @@ void AccessContext::UpdateAccessState(const ImageState &image, SyncStageAccessIn
 
 void AccessContext::UpdateAccessState(const ImageViewState &image_view, SyncStageAccessIndex current_usage,
                                       SyncOrdering ordering_rule, const VkOffset3D &offset, const VkExtent3D &extent,
-                                      const ResourceUsageTag tag) {
+                                      const ResourceUsageTagEx tag_ex) {
     // range_gen is non-temporary to avoid an additional copy
     ImageRangeGen range_gen(image_view.MakeImageRangeGen(offset, extent));
-    UpdateAccessState(range_gen, current_usage, ordering_rule, tag);
+    UpdateAccessState(range_gen, current_usage, ordering_rule, tag_ex);
 }
 
 void AccessContext::UpdateAccessState(const ImageViewState &image_view, SyncStageAccessIndex current_usage,
-                                      SyncOrdering ordering_rule, ResourceUsageTag tag) {
+                                      SyncOrdering ordering_rule, ResourceUsageTagEx tag_ex) {
     // Get is const, and will be copied in callee
-    UpdateAccessState(image_view.GetFullViewImageRangeGen(), current_usage, ordering_rule, tag);
+    UpdateAccessState(image_view.GetFullViewImageRangeGen(), current_usage, ordering_rule, tag_ex);
 }
 
 void AccessContext::UpdateAccessState(const AttachmentViewGen &view_gen, AttachmentViewGen::Gen gen_type,
@@ -224,7 +224,7 @@ void AccessContext::UpdateAccessState(const AttachmentViewGen &view_gen, Attachm
     const std::optional<ImageRangeGen> &attachment_gen = view_gen.GetRangeGen(gen_type);
     if (attachment_gen) {
         // Value of const optional is const, and will be copied in callee
-        UpdateAccessState(*attachment_gen, current_usage, ordering_rule, tag);
+        UpdateAccessState(*attachment_gen, current_usage, ordering_rule, ResourceUsageTagEx{tag});
     }
 }
 
@@ -234,7 +234,7 @@ void AccessContext::UpdateAccessState(const vvl::VideoSession &vs_state, const v
     const auto offset = resource.GetEffectiveImageOffset(vs_state);
     const auto extent = resource.GetEffectiveImageExtent(vs_state);
     ImageRangeGen range_gen(image->MakeImageRangeGen(resource.range, offset, extent, false));
-    UpdateAccessState(range_gen, current_usage, SyncOrdering::kNonAttachment, tag);
+    UpdateAccessState(range_gen, current_usage, SyncOrdering::kNonAttachment, ResourceUsageTagEx{tag});
 }
 
 void AccessContext::UpdateAccessState(ImageRangeGen &range_gen, SyncStageAccessIndex current_usage, SyncOrdering ordering_rule,
@@ -247,10 +247,10 @@ void AccessContext::UpdateAccessState(ImageRangeGen &range_gen, SyncStageAccessI
 }
 
 void AccessContext::UpdateAccessState(const ImageRangeGen &range_gen, SyncStageAccessIndex current_usage,
-                                      SyncOrdering ordering_rule, ResourceUsageTag tag) {
+                                      SyncOrdering ordering_rule, ResourceUsageTagEx tag_ex) {
     // range_gen is non-temporary to avoid infinite call recursion
     ImageRangeGen mutable_range_gen(range_gen);
-    UpdateAccessState(mutable_range_gen, current_usage, ordering_rule, ResourceUsageTagEx{tag});
+    UpdateAccessState(mutable_range_gen, current_usage, ordering_rule, tag_ex);
 }
 
 void AccessContext::ResolveChildContexts(const std::vector<AccessContext> &contexts) {

--- a/layers/sync/sync_access_context.h
+++ b/layers/sync/sync_access_context.h
@@ -314,7 +314,7 @@ class AccessContext {
                            const VkImageSubresourceRange &subresource_range, const ResourceUsageTag &tag);
     void UpdateAccessState(const ImageState &image, SyncStageAccessIndex current_usage, SyncOrdering ordering_rule,
                            const VkImageSubresourceRange &subresource_range, const VkOffset3D &offset, const VkExtent3D &extent,
-                           ResourceUsageTag tag);
+                           ResourceUsageTagEx tag_ex);
     void UpdateAccessState(const AttachmentViewGen &view_gen, AttachmentViewGen::Gen gen_type, SyncStageAccessIndex current_usage,
                            SyncOrdering ordering_rule, ResourceUsageTag tag);
     void UpdateAccessState(const ImageViewState &image_view, SyncStageAccessIndex current_usage, SyncOrdering ordering_rule,
@@ -324,7 +324,7 @@ class AccessContext {
     void UpdateAccessState(const ImageRangeGen &range_gen, SyncStageAccessIndex current_usage, SyncOrdering ordering_rule,
                            ResourceUsageTag tag);
     void UpdateAccessState(ImageRangeGen &range_gen, SyncStageAccessIndex current_usage, SyncOrdering ordering_rule,
-                           ResourceUsageTag tag);
+                           ResourceUsageTagEx tag_ex);
     void UpdateAccessState(const vvl::VideoSession &vs_state, const vvl::VideoPictureResource &resource,
                            SyncStageAccessIndex current_usage, ResourceUsageTag tag);
     void ResolveChildContexts(const std::vector<AccessContext> &contexts);

--- a/layers/sync/sync_access_context.h
+++ b/layers/sync/sync_access_context.h
@@ -318,11 +318,11 @@ class AccessContext {
     void UpdateAccessState(const AttachmentViewGen &view_gen, AttachmentViewGen::Gen gen_type, SyncStageAccessIndex current_usage,
                            SyncOrdering ordering_rule, ResourceUsageTag tag);
     void UpdateAccessState(const ImageViewState &image_view, SyncStageAccessIndex current_usage, SyncOrdering ordering_rule,
-                           const VkOffset3D &offset, const VkExtent3D &extent, ResourceUsageTag tag);
+                           const VkOffset3D &offset, const VkExtent3D &extent, ResourceUsageTagEx tag_ex);
     void UpdateAccessState(const ImageViewState &image_view, SyncStageAccessIndex current_usage, SyncOrdering ordering_rule,
-                           ResourceUsageTag tag);
+                           ResourceUsageTagEx tag_ex);
     void UpdateAccessState(const ImageRangeGen &range_gen, SyncStageAccessIndex current_usage, SyncOrdering ordering_rule,
-                           ResourceUsageTag tag);
+                           ResourceUsageTagEx tag_ex);
     void UpdateAccessState(ImageRangeGen &range_gen, SyncStageAccessIndex current_usage, SyncOrdering ordering_rule,
                            ResourceUsageTagEx tag_ex);
     void UpdateAccessState(const vvl::VideoSession &vs_state, const vvl::VideoPictureResource &resource,

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -205,7 +205,8 @@ void CommandBufferAccessContext::RecordBeginRendering(syncval_state::BeginRender
             const SyncStageAccessIndex load_index = attachment.GetLoadUsage();
             if (load_index == SYNC_ACCESS_INDEX_NONE) continue;
 
-            GetCurrentAccessContext()->UpdateAccessState(attachment.view_gen, load_index, attachment.GetOrdering(), tag);
+            GetCurrentAccessContext()->UpdateAccessState(attachment.view_gen, load_index, attachment.GetOrdering(),
+                                                         ResourceUsageTagEx{tag});
         }
     }
 
@@ -283,13 +284,14 @@ void CommandBufferAccessContext::RecordEndRendering(const RecordObject &record_o
             if (attachment.resolve_gen) {
                 const bool is_color = attachment.type == syncval_state::AttachmentType::kColor;
                 const SyncOrdering kResolveOrder = is_color ? kColorResolveOrder : kDepthStencilResolveOrder;
-                access_context->UpdateAccessState(attachment.view_gen, kResolveRead, kResolveOrder, store_tag);
-                access_context->UpdateAccessState(*attachment.resolve_gen, kResolveWrite, kResolveOrder, store_tag);
+                access_context->UpdateAccessState(attachment.view_gen, kResolveRead, kResolveOrder, ResourceUsageTagEx{store_tag});
+                access_context->UpdateAccessState(*attachment.resolve_gen, kResolveWrite, kResolveOrder,
+                                                  ResourceUsageTagEx{store_tag});
             }
 
             const SyncStageAccessIndex store_index = attachment.GetStoreUsage();
             if (store_index == SYNC_ACCESS_INDEX_NONE) continue;
-            access_context->UpdateAccessState(attachment.view_gen, store_index, kStoreOrder, store_tag);
+            access_context->UpdateAccessState(attachment.view_gen, store_index, kStoreOrder, ResourceUsageTagEx{store_tag});
         }
     }
 
@@ -772,7 +774,7 @@ void CommandBufferAccessContext::RecordDrawDynamicRenderingAttachment(ResourceUs
         if (!attachment.IsWriteable(last_bound_state)) continue;
 
         access_context.UpdateAccessState(attachment.view_gen, SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE,
-                                         SyncOrdering::kColorAttachment, tag);
+                                         SyncOrdering::kColorAttachment, ResourceUsageTagEx{tag});
     }
 
     // TODO -- fixup this and Subpass attachment to correct map the various depth stencil enables/reads vs. writes
@@ -787,7 +789,7 @@ void CommandBufferAccessContext::RecordDrawDynamicRenderingAttachment(ResourceUs
 
         if (writeable) {
             access_context.UpdateAccessState(attachment.view_gen, SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE,
-                                             SyncOrdering::kDepthStencilAttachment, tag);
+                                             SyncOrdering::kDepthStencilAttachment, ResourceUsageTagEx{tag});
         }
     }
 }

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -516,15 +516,15 @@ void CommandBufferAccessContext::RecordDispatchDrawDescriptorSet(VkPipelineBindP
                             // See: VUID 00343
                             continue;
                         }
+                        const ResourceUsageTagEx tag_ex = AddCommandHandle(tag, img_view_state->GetImageState()->Handle());
                         if (sync_index == SYNC_FRAGMENT_SHADER_INPUT_ATTACHMENT_READ) {
                             const VkExtent3D extent = CastTo3D(cb_state_->active_render_pass_begin_info.renderArea.extent);
                             const VkOffset3D offset = CastTo3D(cb_state_->active_render_pass_begin_info.renderArea.offset);
                             current_context_->UpdateAccessState(*img_view_state, sync_index, SyncOrdering::kRaster, offset, extent,
-                                                                tag);
+                                                                tag_ex);
                         } else {
-                            current_context_->UpdateAccessState(*img_view_state, sync_index, SyncOrdering::kNonAttachment, tag);
+                            current_context_->UpdateAccessState(*img_view_state, sync_index, SyncOrdering::kNonAttachment, tag_ex);
                         }
-                        AddCommandHandle(tag, img_view_state->Handle());
                         break;
                     }
                     case DescriptorClass::TexelBuffer: {

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -1060,12 +1060,13 @@ void CommandBufferAccessContext::RecordClearAttachment(ResourceUsageTag tag, con
         assert((clear_info.aspects_to_clear & kDepthStencilAspects) == 0);
         access_context->UpdateAccessState(*clear_info.view->GetImageState(), SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE,
                                           SyncOrdering::kColorAttachment, subresource_range, clear_info.offset, clear_info.extent,
-                                          tag);
+                                          ResourceUsageTagEx{tag});
     } else {
         assert((clear_info.aspects_to_clear & kColorAspects) == 0);
-        access_context->UpdateAccessState(
-            *clear_info.view->GetImageState(), SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE,
-            SyncOrdering::kDepthStencilAttachment, subresource_range, clear_info.offset, clear_info.extent, tag);
+        access_context->UpdateAccessState(*clear_info.view->GetImageState(),
+                                          SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE,
+                                          SyncOrdering::kDepthStencilAttachment, subresource_range, clear_info.offset,
+                                          clear_info.extent, ResourceUsageTagEx{tag});
     }
 }
 

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -918,5 +918,5 @@ void PresentedImage::SetImage(uint32_t at_index) {
 
 void PresentedImage::UpdateMemoryAccess(SyncStageAccessIndex usage, ResourceUsageTag tag, AccessContext& access_context) const {
     // Intentional copy. The range_gen argument is not copied by the Update... call below
-    access_context.UpdateAccessState(range_gen, usage, SyncOrdering::kNonAttachment, tag);
+    access_context.UpdateAccessState(range_gen, usage, SyncOrdering::kNonAttachment, ResourceUsageTagEx{tag});
 }


### PR DESCRIPTION
Similar to https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/8222 but for images.

Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8139

> [ SYNC-HAZARD-WRITE-AFTER-READ ] Object 0: handle = 0x213dbe93750, type = VK_OBJECT_TYPE_QUEUE; | MessageID = 0x376bc9df | vkQueueSubmit():  Hazard WRITE_AFTER_READ for entry 0, VkCommandBuffer 0x213e8443680[], Submitted access info (submitted_usage: SYNC_COPY_TRANSFER_WRITE, command: vkCmdCopyBufferToImage, seq_no: 1, reset_no: 1, resource: VkImage 0xf443490000000006[ImageB]). Access info (prior_usage: SYNC_COPY_TRANSFER_READ, read_barriers: VkPipelineStageFlags2(0), queue: VkQueue 0x213dbe93750[], submit: 2, batch: 0, batch_tag: 5, command: vkCmdCopyImage, command_buffer: VkCommandBuffer 0x213e8435de0[], seq_no: 1, reset_no: 1, **resource: VkImage 0xf443490000000006[ImageB]**).