### PR TITLE
sync: Add setting to report debug information

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -419,6 +419,28 @@
                                             { "key": "validate_sync", "value": true }
                                         ]
                                     }
+                                },
+                                {
+                                    "key": "syncval_reporting",
+                                    "label": "Error messages",
+                                    "description": "Options to configure synchronization validation error reporting",
+                                    "type": "GROUP",
+                                    "expanded": false,
+                                    "settings": [
+                                        {
+                                            "key": "syncval_message_include_debug_information",
+                                            "label": "Include debug information",
+                                            "description": "Includes debug information for additional diagnostics. This can be useful for reporting issues or for users familiar with the validation codebase.",
+                                            "type": "BOOL",
+                                            "default": false,
+                                            "dependence": {
+                                                "mode": "ALL",
+                                                "settings": [
+                                                    { "key": "validate_sync", "value": true }
+                                                ]
+                                            }
+                                        }
+                                    ]
                                 }
                             ]
                         },

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -213,6 +213,7 @@ const char *VK_LAYER_GPUAV_DEBUG_PRINT_INSTRUMENTATION_INFO = "gpuav_debug_print
 // ---
 const char *VK_LAYER_SYNCVAL_SUBMIT_TIME_VALIDATION = "syncval_submit_time_validation";
 const char *VK_LAYER_SYNCVAL_SHADER_ACCESSES_HEURISTIC = "syncval_shader_accesses_heuristic";
+const char *VK_LAYER_SYNCVAL_MESSAGE_INCLUDE_DEBUG_INFORMATION = "syncval_message_include_debug_information";
 
 // Message Formatting
 // ---
@@ -1008,6 +1009,11 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
     if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_SYNCVAL_SHADER_ACCESSES_HEURISTIC)) {
         vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_SYNCVAL_SHADER_ACCESSES_HEURISTIC,
                                 syncval_settings.shader_accesses_heuristic);
+    }
+
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_SYNCVAL_MESSAGE_INCLUDE_DEBUG_INFORMATION)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_SYNCVAL_MESSAGE_INCLUDE_DEBUG_INFORMATION,
+                                syncval_settings.message_include_debug_information);
     }
 
     const auto *validation_features_ext = vku::FindStructInPNextChain<VkValidationFeaturesEXT>(settings_data->create_info);

--- a/layers/sync/sync_reporting.cpp
+++ b/layers/sync/sync_reporting.cpp
@@ -84,11 +84,13 @@ std::ostream &operator<<(std::ostream &out, const ResourceUsageRecord::Formatter
         if (!formatter.ex_cb_state || (formatter.ex_cb_state != record.cb_state)) {
             out << ", " << SyncNodeFormatter(formatter.sync_state, record.cb_state);
         }
-        out << ", seq_no: " << record.seq_num;
-        if (record.sub_command != 0) {
-            out << ", subcmd: " << record.sub_command;
+        if (formatter.sync_state.syncval_settings.message_include_debug_information) {
+            out << ", seq_no: " << record.seq_num;
+            if (record.sub_command != 0) {
+                out << ", subcmd: " << record.sub_command;
+            }
+            out << ", reset_no: " << std::to_string(record.reset_count);
         }
-        out << ", reset_no: " << std::to_string(record.reset_count);
 
         // Associated resource
         if (formatter.handle_index != vvl::kNoIndex32) {

--- a/layers/sync/sync_settings.h
+++ b/layers/sync/sync_settings.h
@@ -20,4 +20,5 @@
 struct SyncValSettings {
     bool submit_time_validation = true;
     bool shader_accesses_heuristic = false;
+    bool message_include_debug_information = false;
 };

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -539,7 +539,9 @@ std::string QueueBatchContext::FormatUsage(ResourceUsageTagEx tag_ex) const {
             out << SyncNodeFormatter(*sync_state_, batch.queue->GetQueueState());
             out << ", submit: " << batch.submit_index << ", batch: " << batch.batch_index;
         }
-        out << ", batch_tag: " << batch.base_tag;
+        if (sync_state_->syncval_settings.message_include_debug_information) {
+            out << ", batch_tag: " << batch.base_tag;
+        }
 
         // Commandbuffer Usages Information
         out << ", " << record.Formatter(*sync_state_, nullptr, access.debug_name_provider, tag_ex.handle_index);

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -39,6 +39,7 @@ void VkSyncValTest::InitSyncValFramework(const SyncValSettings *p_sync_settings)
         SyncValSettings settings;
         settings.submit_time_validation = true;
         settings.shader_accesses_heuristic = true;
+        settings.message_include_debug_information = true;
         return settings;
     }();
     const SyncValSettings &sync_settings = p_sync_settings ? *p_sync_settings : test_default_sync_settings;
@@ -50,6 +51,10 @@ void VkSyncValTest::InitSyncValFramework(const SyncValSettings *p_sync_settings)
     const auto shader_accesses_heuristic = static_cast<VkBool32>(sync_settings.shader_accesses_heuristic);
     settings.emplace_back(VkLayerSettingEXT{OBJECT_LAYER_NAME, "syncval_shader_accesses_heuristic",
                                             VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &shader_accesses_heuristic});
+
+    const auto message_include_debug_information = static_cast<VkBool32>(sync_settings.message_include_debug_information);
+    settings.emplace_back(VkLayerSettingEXT{OBJECT_LAYER_NAME, "syncval_message_include_debug_information",
+                                            VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &message_include_debug_information});
 
     VkLayerSettingsCreateInfoEXT settings_create_info = vku::InitStructHelper();
     settings_create_info.settingCount = size32(settings);


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7491

Debug/internal information is not reported by default now.
There might be more tweaks before the next SDK what should be put into this category.