### PR TITLE
sync: Mics cleanup of reporting code

### DIFF
--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -142,17 +142,6 @@ void CommandBufferAccessContext::Reset() {
     dynamic_rendering_info_.reset();
 }
 
-std::string CommandBufferAccessContext::FormatUsage(ResourceUsageTagEx tag_ex) const {
-    if (tag_ex.tag >= access_log_->size()) return std::string();
-
-    std::stringstream out;
-    assert(tag_ex.tag < access_log_->size());
-    const auto &record = (*access_log_)[tag_ex.tag];
-    const auto debug_name_provider = (record.label_command_index == vvl::kU32Max) ? nullptr : this;
-    out << FormatResourceUsageRecord(record.Formatter(*sync_state_, cb_state_, debug_name_provider, tag_ex.handle_index));
-    return out.str();
-}
-
 std::string CommandBufferAccessContext::FormatUsage(const char *usage_string, const ResourceFirstAccess &access) const {
     std::stringstream out;
     assert(access.usage_info);

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -149,7 +149,7 @@ std::string CommandBufferAccessContext::FormatUsage(ResourceUsageTagEx tag_ex) c
     assert(tag_ex.tag < access_log_->size());
     const auto &record = (*access_log_)[tag_ex.tag];
     const auto debug_name_provider = (record.label_command_index == vvl::kU32Max) ? nullptr : this;
-    out << record.Formatter(*sync_state_, cb_state_, debug_name_provider, tag_ex.handle_index);
+    out << FormatResourceUsageRecord(record.Formatter(*sync_state_, cb_state_, debug_name_provider, tag_ex.handle_index));
     return out.str();
 }
 

--- a/layers/sync/sync_commandbuffer.h
+++ b/layers/sync/sync_commandbuffer.h
@@ -179,7 +179,7 @@ class CommandExecutionContext {
   public:
     using AccessLog = std::vector<ResourceUsageRecord>;
     using CommandBufferSet = std::vector<std::shared_ptr<const vvl::CommandBuffer>>;
-    CommandExecutionContext(const SyncValidator *sync_validator, VkQueueFlags queue_flags)
+    CommandExecutionContext(const SyncValidator& sync_validator, VkQueueFlags queue_flags)
         : sync_state_(sync_validator), queue_flags_(queue_flags) {}
     virtual ~CommandExecutionContext() = default;
 
@@ -208,8 +208,6 @@ class CommandExecutionContext {
     virtual VulkanTypedHandle Handle() const = 0;
     virtual std::string FormatUsage(ResourceUsageTagEx tag_ex) const = 0;
 
-    std::string FormatHazard(const HazardResult &hazard) const;
-
     virtual void BeginRenderPassReplaySetup(ReplayState &replay, const SyncOpBeginRenderPass &begin_op) {
         // Must override if use by derived type is valid
         assert(false);
@@ -225,15 +223,12 @@ class CommandExecutionContext {
         assert(false);
     }
 
+    std::string FormatHazard(const HazardResult &hazard) const;
     bool ValidForSyncOps() const;
-
-    const SyncValidator &GetSyncState() const {
-        assert(sync_state_);
-        return *sync_state_;
-    }
+    const SyncValidator &GetSyncState() const { return sync_state_; }
 
   protected:
-    const SyncValidator *sync_state_;
+    const SyncValidator &sync_state_;
     const VkQueueFlags queue_flags_;
 };
 

--- a/layers/sync/sync_common.h
+++ b/layers/sync/sync_common.h
@@ -73,22 +73,6 @@ constexpr VkImageAspectFlags kColorAspects =
     VK_IMAGE_ASPECT_COLOR_BIT | VK_IMAGE_ASPECT_PLANE_0_BIT | VK_IMAGE_ASPECT_PLANE_1_BIT | VK_IMAGE_ASPECT_PLANE_2_BIT;
 constexpr VkImageAspectFlags kDepthStencilAspects = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
 
-class SyncValidationInfo {
-  public:
-    SyncValidationInfo(const SyncValidator* sync_validator, VkQueueFlags queue_flags) : sync_state_(sync_validator), queue_flags_(queue_flags) {}
-    const SyncValidator& GetSyncState() const {
-        assert(sync_state_);
-        return *sync_state_;
-    }
-    std::string FormatHazard(const HazardResult& hazard) const;
-    virtual std::string FormatUsage(ResourceUsageTagEx tag_ex) const = 0;
-
-  protected:
-    const SyncValidator* sync_state_;
-    const VkQueueFlags queue_flags_;
-};
-
-
 // Useful Utilites for manipulating StageAccess parameters, suitable as base class to save typing
 struct SyncStageAccess {
     static inline const SyncStageAccessInfoType &UsageInfo(SyncStageAccessIndex stage_access_index) {

--- a/layers/sync/sync_renderpass.h
+++ b/layers/sync/sync_renderpass.h
@@ -108,16 +108,16 @@ class RenderPassAccessContext {
                             const std::vector<const syncval_state::ImageViewState *> &attachment_views,
                             const AccessContext *external_context);
 
-    static bool ValidateLayoutTransitions(const SyncValidationInfo &val_info, const AccessContext &access_context,
+    static bool ValidateLayoutTransitions(const CommandBufferAccessContext &cb_context, const AccessContext &access_context,
                                           const vvl::RenderPass &rp_state, const VkRect2D &render_area, uint32_t subpass,
                                           const AttachmentViewGenVector &attachment_views, vvl::Func command);
 
-    static bool ValidateLoadOperation(const SyncValidationInfo &val_info, const AccessContext &access_context,
+    static bool ValidateLoadOperation(const CommandBufferAccessContext &cb_context, const AccessContext &access_context,
                                       const vvl::RenderPass &rp_state, const VkRect2D &render_area, uint32_t subpass,
                                       const AttachmentViewGenVector &attachment_views, vvl::Func command);
 
-    bool ValidateStoreOperation(const SyncValidationInfo &val_info, vvl::Func command) const;
-    bool ValidateResolveOperations(const SyncValidationInfo &val_info, vvl::Func command) const;
+    bool ValidateStoreOperation(const CommandBufferAccessContext &cb_context, vvl::Func command) const;
+    bool ValidateResolveOperations(const CommandBufferAccessContext &cb_context, vvl::Func command) const;
 
     static void UpdateAttachmentResolveAccess(const vvl::RenderPass &rp_state, const AttachmentViewGenVector &attachment_views,
                                               uint32_t subpass, const ResourceUsageTag tag, AccessContext access_context);
@@ -129,16 +129,16 @@ class RenderPassAccessContext {
                                         const AttachmentViewGenVector &attachment_views, const ResourceUsageTag tag,
                                         AccessContext &access_context);
 
-    bool ValidateDrawSubpassAttachment(const CommandExecutionContext &ex_context, const vvl::CommandBuffer &cmd_buffer,
+    bool ValidateDrawSubpassAttachment(const CommandBufferAccessContext &cb_context, const vvl::CommandBuffer &cmd_buffer,
                                        vvl::Func command) const;
     void RecordDrawSubpassAttachment(const vvl::CommandBuffer &cmd_buffer, ResourceUsageTag tag);
 
     uint32_t GetAttachmentIndex(const VkClearAttachment &clear_attachment) const;
     ClearAttachmentInfo GetClearAttachmentInfo(const VkClearAttachment &clear_attachment, const VkClearRect &rect) const;
 
-    bool ValidateNextSubpass(const CommandExecutionContext &ex_context, vvl::Func command) const;
-    bool ValidateEndRenderPass(const CommandExecutionContext &ex_context, vvl::Func command) const;
-    bool ValidateFinalSubpassLayoutTransitions(const CommandExecutionContext &ex_context, vvl::Func command) const;
+    bool ValidateNextSubpass(const CommandBufferAccessContext &cb_context, vvl::Func command) const;
+    bool ValidateEndRenderPass(const CommandBufferAccessContext &cb_context, vvl::Func command) const;
+    bool ValidateFinalSubpassLayoutTransitions(const CommandBufferAccessContext &cb_context, vvl::Func command) const;
 
     void RecordLayoutTransitions(ResourceUsageTag tag);
     void RecordLoadOperations(ResourceUsageTag tag);

--- a/layers/sync/sync_reporting.cpp
+++ b/layers/sync/sync_reporting.cpp
@@ -31,7 +31,8 @@ SyncNodeFormatter::SyncNodeFormatter(const SyncValidator &sync_state, const vvl:
 SyncNodeFormatter::SyncNodeFormatter(const SyncValidator &sync_state, const vvl::StateObject *state_object, const char *label_)
     : debug_report(sync_state.debug_report), node(state_object), label(label_) {}
 
-std::ostream &operator<<(std::ostream &out, const SyncNodeFormatter &formatter) {
+std::string FormatStateObject(const SyncNodeFormatter &formatter) {
+    std::stringstream out;
     if (formatter.label) {
         out << formatter.label << ": ";
     }
@@ -43,10 +44,11 @@ std::ostream &operator<<(std::ostream &out, const SyncNodeFormatter &formatter) 
     } else {
         out << "null handle";
     }
-    return out;
+    return out.str();
 }
 
-std::ostream &operator<<(std::ostream &out, const HandleRecord::FormatterState &formatter) {
+static std::string FormatHandleRecord(const HandleRecord::FormatterState &formatter) {
+    std::stringstream out;
     const HandleRecord &handle = formatter.that;
     bool labeled = false;
 
@@ -71,10 +73,11 @@ std::ostream &operator<<(std::ostream &out, const HandleRecord::FormatterState &
         out << ": ";
     }
     out << formatter.state.FormatHandle(handle.TypedHandle());
-    return out;
+    return out.str();
 }
 
-std::ostream &operator<<(std::ostream &out, const ResourceUsageRecord::FormatterState &formatter) {
+std::string FormatResourceUsageRecord(const ResourceUsageRecord::FormatterState &formatter) {
+    std::stringstream out;
     const ResourceUsageRecord &record = formatter.record;
     if (record.alt_usage) {
         out << record.alt_usage.Formatter(formatter.sync_state);
@@ -82,7 +85,7 @@ std::ostream &operator<<(std::ostream &out, const ResourceUsageRecord::Formatter
         out << "command: " << vvl::String(record.command);
         // Note: ex_cb_state set to null forces output of record.cb_state
         if (!formatter.ex_cb_state || (formatter.ex_cb_state != record.cb_state)) {
-            out << ", " << SyncNodeFormatter(formatter.sync_state, record.cb_state);
+            out << ", " << FormatStateObject(SyncNodeFormatter(formatter.sync_state, record.cb_state));
         }
         if (formatter.sync_state.syncval_settings.message_include_debug_information) {
             out << ", seq_no: " << record.seq_num;
@@ -102,7 +105,7 @@ std::ostream &operator<<(std::ostream &out, const ResourceUsageRecord::Formatter
             const bool valid_handle_index = formatter.handle_index < handle_records.size();
 
             if (valid_handle_index) {
-                out << ", resource: " << handle_records[formatter.handle_index].Formatter(formatter.sync_state);
+                out << ", resource: " << FormatHandleRecord(handle_records[formatter.handle_index].Formatter(formatter.sync_state));
             }
         }
         // Report debug region name. Empty name means that we are not inside any debug region.
@@ -113,7 +116,7 @@ std::ostream &operator<<(std::ostream &out, const ResourceUsageRecord::Formatter
             }
         }
     }
-    return out;
+    return out.str();
 }
 
 static const SyncStageAccessInfoType *SyncStageAccessInfoFromMask(SyncStageAccessFlags flags) {

--- a/layers/sync/sync_reporting.cpp
+++ b/layers/sync/sync_reporting.cpp
@@ -253,7 +253,7 @@ std::string CommandBufferAccessContext::FormatUsage(ResourceUsageTagEx tag_ex) c
     assert(tag_ex.tag < access_log_->size());
     const auto &record = (*access_log_)[tag_ex.tag];
     const auto debug_name_provider = (record.label_command_index == vvl::kU32Max) ? nullptr : this;
-    out << FormatResourceUsageRecord(record.Formatter(*sync_state_, cb_state_, debug_name_provider, tag_ex.handle_index));
+    out << FormatResourceUsageRecord(record.Formatter(sync_state_, cb_state_, debug_name_provider, tag_ex.handle_index));
     return out.str();
 }
 
@@ -265,16 +265,16 @@ std::string QueueBatchContext::FormatUsage(ResourceUsageTagEx tag_ex) const {
         const ResourceUsageRecord &record = *access.record;
         if (batch.queue) {
             // Queue and Batch information (for enqueued operations)
-            out << FormatStateObject(SyncNodeFormatter(*sync_state_, batch.queue->GetQueueState()));
+            out << FormatStateObject(SyncNodeFormatter(sync_state_, batch.queue->GetQueueState()));
             out << ", submit: " << batch.submit_index << ", batch: " << batch.batch_index;
         }
-        if (sync_state_->syncval_settings.message_include_debug_information) {
+        if (sync_state_.syncval_settings.message_include_debug_information) {
             out << ", batch_tag: " << batch.base_tag;
         }
 
         // Commandbuffer Usages Information
         out << ", "
-            << FormatResourceUsageRecord(record.Formatter(*sync_state_, nullptr, access.debug_name_provider, tag_ex.handle_index));
+            << FormatResourceUsageRecord(record.Formatter(sync_state_, nullptr, access.debug_name_provider, tag_ex.handle_index));
     }
     return out.str();
 }

--- a/layers/sync/sync_reporting.h
+++ b/layers/sync/sync_reporting.h
@@ -19,7 +19,6 @@
 
 #include "sync/sync_commandbuffer.h"
 
-// Message Creation Helpers
 struct SyncNodeFormatter {
     const DebugReport *debug_report;
     const vvl::StateObject *node;
@@ -30,7 +29,6 @@ struct SyncNodeFormatter {
     SyncNodeFormatter(const SyncValidator &sync_state, const vvl::Queue *q_state);
     SyncNodeFormatter(const SyncValidator &sync_state, const vvl::StateObject *state_object, const char *label_ = nullptr);
 };
+std::string FormatStateObject(const SyncNodeFormatter &formatter);
 
-std::ostream &operator<<(std::ostream &out, const SyncNodeFormatter &formatter);
-std::ostream &operator<<(std::ostream &out, const HandleRecord::FormatterState &formatter);
-std::ostream &operator<<(std::ostream &out, const ResourceUsageRecord::FormatterState &formatter);
+std::string FormatResourceUsageRecord(const ResourceUsageRecord::FormatterState &formatter);

--- a/layers/sync/sync_reporting.h
+++ b/layers/sync/sync_reporting.h
@@ -30,5 +30,3 @@ struct SyncNodeFormatter {
     SyncNodeFormatter(const SyncValidator &sync_state, const vvl::StateObject *state_object, const char *label_ = nullptr);
 };
 std::string FormatStateObject(const SyncNodeFormatter &formatter);
-
-std::string FormatResourceUsageRecord(const ResourceUsageRecord::FormatterState &formatter);

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -527,29 +527,6 @@ std::vector<QueueBatchContext::ConstPtr> QueueBatchContext::RegisterAsyncContext
     return async_batches;
 }
 
-// Look up the usage informaiton from the local or global logger
-std::string QueueBatchContext::FormatUsage(ResourceUsageTagEx tag_ex) const {
-    std::stringstream out;
-    BatchAccessLog::AccessRecord access = batch_log_.GetAccessRecord(tag_ex.tag);
-    if (access.IsValid()) {
-        const BatchAccessLog::BatchRecord& batch = *access.batch;
-        const ResourceUsageRecord& record = *access.record;
-        if (batch.queue) {
-            // Queue and Batch information (for enqueued operations)
-            out << FormatStateObject(SyncNodeFormatter(*sync_state_, batch.queue->GetQueueState()));
-            out << ", submit: " << batch.submit_index << ", batch: " << batch.batch_index;
-        }
-        if (sync_state_->syncval_settings.message_include_debug_information) {
-            out << ", batch_tag: " << batch.base_tag;
-        }
-
-        // Commandbuffer Usages Information
-        out << ", "
-            << FormatResourceUsageRecord(record.Formatter(*sync_state_, nullptr, access.debug_name_provider, tag_ex.handle_index));
-    }
-    return out.str();
-}
-
 QueueId QueueBatchContext::GetQueueId() const {
     QueueId id = queue_state_ ? queue_state_->GetQueueId() : kQueueIdInvalid;
     return id;

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -536,7 +536,7 @@ std::string QueueBatchContext::FormatUsage(ResourceUsageTagEx tag_ex) const {
         const ResourceUsageRecord& record = *access.record;
         if (batch.queue) {
             // Queue and Batch information (for enqueued operations)
-            out << SyncNodeFormatter(*sync_state_, batch.queue->GetQueueState());
+            out << FormatStateObject(SyncNodeFormatter(*sync_state_, batch.queue->GetQueueState()));
             out << ", submit: " << batch.submit_index << ", batch: " << batch.batch_index;
         }
         if (sync_state_->syncval_settings.message_include_debug_information) {
@@ -544,7 +544,8 @@ std::string QueueBatchContext::FormatUsage(ResourceUsageTagEx tag_ex) const {
         }
 
         // Commandbuffer Usages Information
-        out << ", " << record.Formatter(*sync_state_, nullptr, access.debug_name_provider, tag_ex.handle_index);
+        out << ", "
+            << FormatResourceUsageRecord(record.Formatter(*sync_state_, nullptr, access.debug_name_provider, tag_ex.handle_index));
     }
     return out.str();
 }
@@ -666,9 +667,9 @@ std::ostream& QueueBatchContext::PresentResourceRecord::Format(std::ostream& out
     out << "vkQueuePresentKHR ";
     out << "present_tag:" << presented_.tag;
     out << ", pSwapchains[" << presented_.present_index << "]";
-    out << ": " << SyncNodeFormatter(sync_state, presented_.swapchain_state.lock().get());
+    out << ": " << FormatStateObject(SyncNodeFormatter(sync_state, presented_.swapchain_state.lock().get()));
     out << ", image_index: " << presented_.image_index;
-    out << SyncNodeFormatter(sync_state, presented_.image.get());
+    out << FormatStateObject(SyncNodeFormatter(sync_state, presented_.image.get()));
 
     return out;
 }
@@ -680,9 +681,9 @@ QueueBatchContext::AcquireResourceRecord::Base_::Record QueueBatchContext::Acqui
 std::ostream& QueueBatchContext::AcquireResourceRecord::Format(std::ostream& out, const SyncValidator& sync_state) const {
     out << vvl::String(command_) << " ";
     out << "aquire_tag:" << acquire_tag_;
-    out << ": " << SyncNodeFormatter(sync_state, presented_.swapchain_state.lock().get());
+    out << ": " << FormatStateObject(SyncNodeFormatter(sync_state, presented_.swapchain_state.lock().get()));
     out << ", image_index: " << presented_.image_index;
-    out << SyncNodeFormatter(sync_state, presented_.image.get());
+    out << FormatStateObject(SyncNodeFormatter(sync_state, presented_.image.get()));
 
     return out;
 }


### PR DESCRIPTION
* Use formatting functions instead of operators. It was hard to search the code with operators.
* Move more code to `sync_reporting`
* Remove `SyncValidationInfo` type. Did not bring much value, currently use `CommandExecutionContext` instead (which might also be modified to show responsibilities better).
* Use `CommandBufferAccessContext` directly instead of base `CommandExecutionContext ` when type is statically known.
* Use reference instead of pointer for `CommandExecutionContext::sync_state_`.
