### PR TITLE
layers: Add pNext check for vkCreateShaderModule

### DIFF
--- a/layers/stateless/sl_pipeline.cpp
+++ b/layers/stateless/sl_pipeline.cpp
@@ -21,6 +21,23 @@
 #include "generated/layer_chassis_dispatch.h"
 #include "stateless/sl_vuid_maps.h"
 
+bool StatelessValidation::manual_PreCallValidateCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo *pCreateInfo,
+                                                                   const VkAllocationCallbacks *pAllocator,
+                                                                   VkShaderModule *pShaderModule,
+                                                                   const ErrorObject &error_obj) const {
+    bool skip = false;
+    if (pCreateInfo) {
+        constexpr std::array allowed_structs = {VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT,
+                                                VK_STRUCTURE_TYPE_SHADER_MODULE_VALIDATION_CACHE_CREATE_INFO_EXT};
+
+        skip |=
+            ValidateStructPnext(error_obj.location.dot(Field::pCreateInfo), pCreateInfo->pNext, allowed_structs.size(),
+                                allowed_structs.data(), GeneratedVulkanHeaderVersion, "VUID-vkCreateShaderModule-pCreateInfo-06904",
+                                "VUID-vkCreateShaderModule-pCreateInfo-06904", VK_NULL_HANDLE, true);
+    }
+    return skip;
+}
+
 bool StatelessValidation::manual_PreCallValidateCreatePipelineLayout(VkDevice device, const VkPipelineLayoutCreateInfo *pCreateInfo,
                                                                      const VkAllocationCallbacks *pAllocator,
                                                                      VkPipelineLayout *pPipelineLayout,

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -597,6 +597,9 @@ class StatelessValidation : public ValidationObject {
 
     bool ValidateViewport(const VkViewport &viewport, VkCommandBuffer object, const Location &loc) const;
 
+    bool manual_PreCallValidateCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo *pCreateInfo,
+                                                  const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule,
+                                                  const ErrorObject &error_obj) const;
     bool manual_PreCallValidateCreatePipelineLayout(VkDevice device, const VkPipelineLayoutCreateInfo *pCreateInfo,
                                                     const VkAllocationCallbacks *pAllocator, VkPipelineLayout *pPipelineLayout,
                                                     const ErrorObject &error_obj) const;

--- a/layers/vulkan/generated/stateless_validation_helper.cpp
+++ b/layers/vulkan/generated/stateless_validation_helper.cpp
@@ -11323,6 +11323,7 @@ bool StatelessValidation::PreCallValidateCreateShaderModule(VkDevice device, con
     }
     skip |=
         ValidateRequiredPointer(loc.dot(Field::pShaderModule), pShaderModule, "VUID-vkCreateShaderModule-pShaderModule-parameter");
+    if (!skip) skip |= manual_PreCallValidateCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule, error_obj);
     return skip;
 }
 

--- a/scripts/generators/stateless_validation_helper_generator.py
+++ b/scripts/generators/stateless_validation_helper_generator.py
@@ -63,6 +63,7 @@ class StatelessValidationHelperOutputGenerator(BaseGenerator):
             'vkCreateRenderPass2',
             'vkCreateBuffer',
             'vkCreateImage',
+            'vkCreateShaderModule',
             'vkCreatePipelineLayout',
             'vkCreateGraphicsPipelines',
             'vkCreateComputePipelines',

--- a/tests/unit/shader_spirv.cpp
+++ b/tests/unit/shader_spirv.cpp
@@ -2530,3 +2530,14 @@ TEST_F(NegativeShaderSpirv, ScalarBlockLayoutShaderCache) {
     VkShaderObj cs(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
     m_errorMonitor->VerifyFound();
 }
+
+TEST_F(NegativeShaderSpirv, VkShaderModuleCreateInfoPNext) {
+    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+    VkPhysicalDeviceFeatures2 pd_features2 = vku::InitStructHelper();
+
+    m_errorMonitor->SetDesiredError("VUID-vkCreateShaderModule-pCreateInfo-06904");
+    VkShaderObj vs(this, kMinimalShaderGlsl, VK_SHADER_STAGE_VERTEX_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_GLSL, nullptr, "main",
+                   &pd_features2);
+    m_errorMonitor->VerifyFound();
+}


### PR DESCRIPTION
seems `VUID-vkCreateShaderModule-pCreateInfo-06904` was missing

It is, yet-another, except around pNext checking so need to do it explicitly 