### PR TITLE
sync: Devirtualize renderpass replay

### DIFF
--- a/layers/sync/sync_commandbuffer.h
+++ b/layers/sync/sync_commandbuffer.h
@@ -208,21 +208,6 @@ class CommandExecutionContext {
     virtual VulkanTypedHandle Handle() const = 0;
     virtual std::string FormatUsage(ResourceUsageTagEx tag_ex) const = 0;
 
-    virtual void BeginRenderPassReplaySetup(ReplayState &replay, const SyncOpBeginRenderPass &begin_op) {
-        // Must override if use by derived type is valid
-        assert(false);
-    }
-
-    virtual void NextSubpassReplaySetup(ReplayState &replay) {
-        // Must override if use by derived type is valid
-        assert(false);
-    }
-
-    virtual void EndRenderPassReplayCleanup(ReplayState &replay) {
-        // Must override if use by derived type is valid
-        assert(false);
-    }
-
     std::string FormatHazard(const HazardResult &hazard) const;
     bool ValidForSyncOps() const;
     const SyncValidator &GetSyncState() const { return sync_state_; }

--- a/layers/sync/sync_op.h
+++ b/layers/sync/sync_op.h
@@ -435,10 +435,6 @@ class ReplayState {
     CommandExecutionContext &GetExecutionContext() const { return exec_context_; }
     ResourceUsageTag GetBaseTag() const { return base_tag_; }
 
-    void BeginRenderPassReplaySetup(const SyncOpBeginRenderPass &begin_op);
-    void NextSubpassReplaySetup();
-    void EndRenderPassReplayCleanup();
-
     AccessContext *ReplayStateRenderPassBegin(VkQueueFlags queue_flags, const SyncOpBeginRenderPass &begin_op,
                                               const AccessContext &external_context);
     AccessContext *ReplayStateRenderPassNext();

--- a/layers/sync/sync_submit.h
+++ b/layers/sync/sync_submit.h
@@ -334,9 +334,9 @@ class QueueBatchContext : public CommandExecutionContext, public std::enable_sha
     void ApplyTaggedWait(QueueId queue_id, ResourceUsageTag tag);
     void ApplyAcquireWait(const AcquiredImage &acquired);
 
-    void BeginRenderPassReplaySetup(ReplayState &replay, const SyncOpBeginRenderPass &begin_op) override;
-    void NextSubpassReplaySetup(ReplayState &replay) override;
-    void EndRenderPassReplayCleanup(ReplayState &replay) override;
+    void BeginRenderPassReplaySetup(ReplayState &replay, const SyncOpBeginRenderPass &begin_op);
+    void NextSubpassReplaySetup(ReplayState &replay);
+    void EndRenderPassReplayCleanup(ReplayState &replay);
 
     [[nodiscard]] std::vector<ConstPtr> RegisterAsyncContexts(const std::vector<ConstPtr> &batches_resolved);
     void ResolveLastBatch(const QueueBatchContext::ConstPtr &last_batch);

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -804,6 +804,9 @@ void SyncValidator::RecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, cons
                                              const VkSubpassBeginInfo *pSubpassBeginInfo, Func command) {
     auto cb_state = Get<syncval_state::CommandBuffer>(commandBuffer);
     if (cb_state) {
+        if (!cb_state->IsPrimary()) {
+            return;  // [core validation check]: only primary command buffer can begin render pass
+        }
         cb_state->access_context.RecordSyncOp<SyncOpBeginRenderPass>(command, *this, pRenderPassBegin, pSubpassBeginInfo);
     }
 }
@@ -871,6 +874,9 @@ void SyncValidator::RecordCmdNextSubpass(VkCommandBuffer commandBuffer, const Vk
     if (!cb_state) return;
     auto *cb_context = &cb_state->access_context;
 
+    if (!cb_state->IsPrimary()) {
+        return;  // [core validation check]: only primary command buffer can start next subpass
+    }
     cb_context->RecordSyncOp<SyncOpNextSubpass>(command, *this, pSubpassBeginInfo, pSubpassEndInfo);
 }
 
@@ -932,6 +938,9 @@ void SyncValidator::RecordCmdEndRenderPass(VkCommandBuffer commandBuffer, const 
     if (!cb_state) return;
     auto *cb_context = &cb_state->access_context;
 
+    if (!cb_state->IsPrimary()) {
+        return;  // [core validation check]: only primary command buffer can end render pass
+    }
     cb_context->RecordSyncOp<SyncOpEndRenderPass>(command, *this, pSubpassEndInfo);
 }
 


### PR DESCRIPTION
Only primary command buffers can begin/end render pass.

This simplifies design by removing dynamic dispatch and shows explicitly that operations are applicable only to `QueueBatchContext`.