### PR TITLE
layers: Renames and cleanup of ownership transfer code

### DIFF
--- a/layers/containers/qfo_transfer.h
+++ b/layers/containers/qfo_transfer.h
@@ -23,8 +23,7 @@
 
 // Types to store queue family ownership (QFO) Transfers
 
-template <typename Barrier>
-inline bool IsTransferOp(const Barrier &barrier) {
+static inline bool IsOwnershipTransfer(const sync_utils::OwnershipTransferBarrier &barrier) {
     return barrier.srcQueueFamilyIndex != barrier.dstQueueFamilyIndex;
 }
 

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -48,7 +48,7 @@ class CoreChecks : public ValidationStateTracker {
     using Struct = vvl::Struct;
     using Field = vvl::Field;
     using MemoryBarrier = sync_utils::MemoryBarrier;
-    using QueueFamilyBarrier = sync_utils::QueueFamilyBarrier;
+    using OwnershipTransferBarrier = sync_utils::OwnershipTransferBarrier;
     using BufferBarrier = sync_utils::BufferBarrier;
     using ImageBarrier = sync_utils::ImageBarrier;
     using OwnershipTransferOp = sync_utils::OwnershipTransferOp;
@@ -217,7 +217,7 @@ class CoreChecks : public ValidationStateTracker {
                                 const VkDependencyInfoKHR& dep_info) const;
 
     bool ValidateBarrierQueueFamilies(const LogObjectList& objects, const Location& barrier_loc, const Location& field_loc,
-                                      const QueueFamilyBarrier& barrier, const VulkanTypedHandle& handle,
+                                      const OwnershipTransferBarrier& barrier, const VulkanTypedHandle& handle,
                                       VkSharingMode sharing_mode) const;
     bool ValidateSwapchainImageExtent(const VkSwapchainCreateInfoKHR& create_info, const VkSurfaceCapabilitiesKHR& surface_caps,
                                       const Location& create_info_loc, const vvl::Surface* surface_state) const;
@@ -492,9 +492,11 @@ class CoreChecks : public ValidationStateTracker {
     template <typename Barrier, typename Scoreboard>
     bool ValidateAndUpdateQFOScoreboard(const vvl::CommandBuffer& cb_state, const char* operation, const Barrier& barrier,
                                         Scoreboard* scoreboard, const Location& loc) const;
-    template <typename Barrier, typename TransferBarrier>
-    void RecordBarrierValidationInfo(const Location& loc, vvl::CommandBuffer& cb_state, const Barrier& barrier,
-                                     QFOTransferBarrierSets<TransferBarrier>& barrier_sets);
+
+    void RecordBarrierValidationInfo(const Location& loc, vvl::CommandBuffer& cb_state, const BufferBarrier& barrier,
+                                     QFOTransferBarrierSets<QFOBufferTransferBarrier>& barrier_sets);
+    void RecordBarrierValidationInfo(const Location& loc, vvl::CommandBuffer& cb_state, const ImageBarrier& barrier,
+                                     QFOTransferBarrierSets<QFOImageTransferBarrier>& barrier_sets);
 
     template <typename Barrier, typename TransferBarrier>
     bool ValidateQFOTransferBarrierUniqueness(const Location& barrier_loc, const vvl::CommandBuffer& cb_state,

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -595,13 +595,11 @@ class CommandBuffer : public RefcountedStateObject {
 
     VkQueueFlags GetQueueFlags() const { return command_pool->queue_flags; }
 
-    template <typename Barrier>
-    inline bool IsReleaseOp(const Barrier &barrier) const {
-        return (IsTransferOp(barrier)) && (command_pool->queueFamilyIndex == barrier.srcQueueFamilyIndex);
+    bool IsReleaseOp(const sync_utils::OwnershipTransferBarrier &barrier) const {
+        return (IsOwnershipTransfer(barrier)) && (command_pool->queueFamilyIndex == barrier.srcQueueFamilyIndex);
     }
-    template <typename Barrier>
-    inline bool IsAcquireOp(const Barrier &barrier) const {
-        return (IsTransferOp(barrier)) && (command_pool->queueFamilyIndex == barrier.dstQueueFamilyIndex);
+    bool IsAcquireOp(const sync_utils::OwnershipTransferBarrier &barrier) const {
+        return (IsOwnershipTransfer(barrier)) && (command_pool->queueFamilyIndex == barrier.dstQueueFamilyIndex);
     }
 
     void Begin(const VkCommandBufferBeginInfo *pBeginInfo);
@@ -733,31 +731,5 @@ class CommandBuffer : public RefcountedStateObject {
     void EnqueueUpdateVideoInlineQueries(const VkVideoInlineQueryInfoKHR &query_info);
     void UnbindResources();
 };
-
-// specializations for barriers that cannot do queue family ownership transfers
-template <>
-inline bool CommandBuffer::IsReleaseOp(const sync_utils::MemoryBarrier &barrier) const {
-    return false;
-}
-template <>
-inline bool CommandBuffer::IsReleaseOp(const VkMemoryBarrier &barrier) const {
-    return false;
-}
-template <>
-inline bool CommandBuffer::IsReleaseOp(const VkMemoryBarrier2KHR &barrier) const {
-    return false;
-}
-template <>
-inline bool CommandBuffer::IsAcquireOp(const sync_utils::MemoryBarrier &barrier) const {
-    return false;
-}
-template <>
-inline bool CommandBuffer::IsAcquireOp(const VkMemoryBarrier &barrier) const {
-    return false;
-}
-template <>
-inline bool CommandBuffer::IsAcquireOp(const VkMemoryBarrier2KHR &barrier) const {
-    return false;
-}
 
 }  // namespace vvl

--- a/layers/sync/sync_utils.cpp
+++ b/layers/sync/sync_utils.cpp
@@ -296,12 +296,4 @@ ShaderStageAccesses GetShaderStageAccesses(VkShaderStageFlagBits shader_stage) {
     return it->second;
 }
 
-const std::shared_ptr<const vvl::Buffer> BufferBarrier::GetResourceState(const ValidationStateTracker &state_tracker) const {
-    return state_tracker.Get<vvl::Buffer>(buffer);
-}
-
-const std::shared_ptr<const vvl::Image> ImageBarrier::GetResourceState(const ValidationStateTracker &state_tracker) const {
-    return state_tracker.Get<vvl::Image>(image);
-}
-
 }  // namespace sync_utils


### PR DESCRIPTION
@spencer-lunarg This is some renames (it took me probably a year to realize that `OwnershipTransferBarrier` is better a match than  `QueueFamilyBarrier`) and some untemplation and simplification. But none of the potential changes we discussed earlier today. Thinking to do that after I fix the issue this PR is preparing for. Also found we don't have tests for some VUIDs, that's also in the plans.
