### PR TITLE
tests: Add ownership transfer tests for 09049 and 09052

### DIFF
--- a/tests/framework/barrier_queue_family.cpp
+++ b/tests/framework/barrier_queue_family.cpp
@@ -52,8 +52,9 @@ void BarrierQueueFamilyBase::Context::Reset() {
 void BarrierQueueFamilyTestHelper::Init(std::vector<uint32_t> *families, bool image_memory, bool buffer_memory) {
     vkt::Device *device_obj = context_->layer_test->DeviceObj();
 
-    auto image_ci = vkt::Image::ImageCreateInfo2D(32, 32, 1, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
-                                                  VK_IMAGE_TILING_OPTIMAL, families);
+    auto image_ci = vkt::Image::ImageCreateInfo2D(
+        32, 32, 1, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_OPTIMAL,
+        families ? vvl::make_span(families->data(), families->size()) : vvl::span<uint32_t>{});
     if (image_memory) {
         image_.init(*device_obj, image_ci, 0);
         image_.SetLayout(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);

--- a/tests/framework/binding.cpp
+++ b/tests/framework/binding.cpp
@@ -1248,7 +1248,7 @@ bool Image::IsCompatible(const Device &dev, const VkImageUsageFlags usages, cons
 
 VkImageCreateInfo Image::ImageCreateInfo2D(uint32_t const width, uint32_t const height, uint32_t const mip_levels,
                                            uint32_t const layers, VkFormat const format, VkFlags const usage,
-                                           VkImageTiling const requested_tiling, const std::vector<uint32_t> *queue_families) {
+                                           VkImageTiling const requested_tiling, const vvl::span<uint32_t> &queue_families) {
     VkImageCreateInfo imageCreateInfo = CreateInfo();
     imageCreateInfo.imageType = VK_IMAGE_TYPE_2D;
     imageCreateInfo.format = format;
@@ -1260,10 +1260,10 @@ VkImageCreateInfo Image::ImageCreateInfo2D(uint32_t const width, uint32_t const 
     imageCreateInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
     // Automatically set sharing mode etc. based on queue family information
-    if (queue_families && (queue_families->size() > 1)) {
+    if (queue_families.size() > 1) {
         imageCreateInfo.sharingMode = VK_SHARING_MODE_CONCURRENT;
-        imageCreateInfo.queueFamilyIndexCount = static_cast<uint32_t>(queue_families->size());
-        imageCreateInfo.pQueueFamilyIndices = queue_families->data();
+        imageCreateInfo.queueFamilyIndexCount = static_cast<uint32_t>(queue_families.size());
+        imageCreateInfo.pQueueFamilyIndices = queue_families.data();
     }
     imageCreateInfo.usage = usage;
     return imageCreateInfo;

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -737,7 +737,7 @@ class Image : public internal::NonDispHandle<VkImage> {
     static VkImageCreateInfo ImageCreateInfo2D(uint32_t const width, uint32_t const height, uint32_t const mip_levels,
                                                uint32_t const layers, VkFormat const format, VkFlags const usage,
                                                VkImageTiling const requested_tiling = VK_IMAGE_TILING_OPTIMAL,
-                                               const std::vector<uint32_t> *queue_families = nullptr);
+                                               const vvl::span<uint32_t> &queue_families = {});
 
     static bool IsCompatible(const Device &dev, VkImageUsageFlags usages, VkFormatFeatureFlags2 features);
 


### PR DESCRIPTION
There is validation but not the tests for:
VUID-VkBufferMemoryBarrier-None-09049
VUID-VkImageMemoryBarrier-None-09052