### PR TITLE
layers: Fix and cleanup ownership transfer code

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -167,10 +167,6 @@ class CoreChecks : public ValidationStateTracker {
                                         const ImageBarrier& img_barrier,
                                         const vvl::CommandBuffer* primary_cb_state = nullptr) const;
 
-    static bool ValidateConcurrentBarrierAtSubmit(const Location& loc, const ValidationStateTracker& state_data,
-                                                  const vvl::Queue& queue_data, const vvl::CommandBuffer& cb_state,
-                                                  const VulkanTypedHandle& typed_handle, uint32_t src_queue_family,
-                                                  uint32_t dst_queue_family);
     bool ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
                                     VkSubpassContents contents, const ErrorObject& error_obj) const;
     bool ValidateBufferBarrier(const LogObjectList& objlist, const Location& barrier_loc, const vvl::CommandBuffer& cb_state,
@@ -215,6 +211,13 @@ class CoreChecks : public ValidationStateTracker {
 
     bool ValidateDependencyInfo(const LogObjectList& objlist, const Location& dep_info_loc, const vvl::CommandBuffer& cb_state,
                                 const VkDependencyInfoKHR& dep_info) const;
+
+    bool ValidateHostStage(const LogObjectList& objlist, const Location& barrier_loc,
+                           const OwnershipTransferBarrier& barrier) const;
+
+    bool ValidateOwnershipTransferQueueSubmit(const Location& barrier_loc, const vvl::Queue& queue_state,
+                                              const VulkanTypedHandle& resource_typed_handle, uint32_t src_family,
+                                              uint32_t dst_family) const;
 
     bool ValidateBarrierQueueFamilies(const LogObjectList& objects, const Location& barrier_loc, const Location& field_loc,
                                       const OwnershipTransferBarrier& barrier, const VulkanTypedHandle& handle,

--- a/layers/sync/sync_vuid_maps.cpp
+++ b/layers/sync/sync_vuid_maps.cpp
@@ -977,6 +977,13 @@ static const vvl::unordered_map<QueueError, std::vector<Entry>> &GetBarrierQueue
              {Key(Struct::VkBufferMemoryBarrier), "VUID-vkCmdPipelineBarrier-srcStageMask-09634"},
              {Key(Struct::VkImageMemoryBarrier), "VUID-vkCmdPipelineBarrier-srcStageMask-09633"},
          }},
+        {QueueError::kSubmitQueueMustMatchSrcOrDst,
+         {
+             {Key(Struct::VkBufferMemoryBarrier2), "UNASSIGNED-VkBufferMemoryBarrier2-SharingModeExclusive-MatchingQueueFamilies"},
+             {Key(Struct::VkBufferMemoryBarrier), "UNASSIGNED-VkBufferMemoryBarrier-SharingModeExclusive-MatchingQueueFamilies"},
+             {Key(Struct::VkImageMemoryBarrier2), "UNASSIGNED-VkImageMemoryBarrier2-SharingModeExclusive-MatchingQueueFamilies"},
+             {Key(Struct::VkImageMemoryBarrier), "UNASSIGNED-VkImageMemoryBarrier-SharingModeExclusive-MatchingQueueFamilies"},
+         }},
     };
     return kBarrierQueueErrors;
 }
@@ -987,7 +994,6 @@ const vvl::unordered_map<QueueError, std::string> &GetQueueErrorSummaryMap() {
         {QueueError::kDstNoExternalExt, "Destination queue family must not be VK_QUEUE_FAMILY_EXTERNAL."},
         {QueueError::kSrcNoForeignExt, "Source queue family must not be VK_QUEUE_FAMILY_FOREIGN_EXT."},
         {QueueError::kDstNoForeignExt, "Destination queue family must not be VK_QUEUE_FAMILY_FOREIGN_EXT."},
-        {QueueError::kSync1ConcurrentNoIgnored, "Source or destination queue family must be VK_QUEUE_FAMILY_IGNORED."},
         {QueueError::kSync1ConcurrentSrc, "Source queue family must be VK_QUEUE_FAMILY_IGNORED or VK_QUEUE_FAMILY_EXTERNAL."},
         {QueueError::kSync1ConcurrentDst, "Destination queue family must be VK_QUEUE_FAMILY_IGNORED or VK_QUEUE_FAMILY_EXTERNAL."},
         {QueueError::kExclusiveSrc, "Source queue family must be valid when using VK_SHARING_MODE_EXCLUSIVE."},

--- a/layers/sync/sync_vuid_maps.h
+++ b/layers/sync/sync_vuid_maps.h
@@ -46,6 +46,7 @@ enum class QueueError {
     kExclusiveSrc,
     kExclusiveDst,
     kHostStage,
+    kSubmitQueueMustMatchSrcOrDst,
 };
 
 const vvl::unordered_map<QueueError, std::string> &GetQueueErrorSummaryMap();


### PR DESCRIPTION
This removes `ValidatorState` ownership transfer helper. It was mostly additional abstraction layer that copied local variables and the result was stored as another local variable.

Also replaced `VUID-vkQueueSubmit-pSubmits-04626` with unassigned VUID when resource is EXCLUSIVE. 04626 is only about checking CONCURRENT resource properties. It also checks resource itself but not a barrier properties which is needed in unassigned VUID.

Unassigned VUID is about this requirement from `7.7.4. Queue Family Ownership Transfer`:
> The srcQueueFamilyIndex parameter of the barrier must be the source queue family index, and the dstQueueFamilyIndex parameter to the destination queue family index.

Opened gitlab issue: https://gitlab.khronos.org/vulkan/vulkan/-/issues/4092. Will open a MR too.