### PR TITLE
gpu: Remove Alias support to suppress false positives

### DIFF
--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -834,7 +834,7 @@ bool CoreChecks::ValidateDrawState(const DescriptorSet &descriptor_set, uint32_t
             return result;
         }
 
-        if (descriptor_set.SkipBinding(*binding, binding_pair.second.variable->is_dynamic_accessed)) {
+        if (descriptor_set.ValidateBindingOnGPU(*binding, binding_pair.second.variable->is_dynamic_accessed)) {
             continue;
         }
         vvl::DescriptorBindingInfo binding_info;

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -837,11 +837,8 @@ bool CoreChecks::ValidateDrawState(const DescriptorSet &descriptor_set, uint32_t
         if (descriptor_set.ValidateBindingOnGPU(*binding, binding_pair.second.variable->is_dynamic_accessed)) {
             continue;
         }
-        vvl::DescriptorBindingInfo binding_info;
-        binding_info.first = binding_pair.first;
-        binding_info.second.emplace_back(binding_pair.second);
 
-        result |= desc_val.ValidateBindingStatic(binding_info, *binding);
+        result |= desc_val.ValidateBindingStatic(binding_pair, *binding);
     }
     return result;
 }

--- a/layers/drawdispatch/descriptor_validator.h
+++ b/layers/drawdispatch/descriptor_validator.h
@@ -34,11 +34,13 @@ class CommandBuffer;
 class Sampler;
 class DescriptorSet;
 
-// The reason there is a vector is because we can have a shader that looks like
+// TODO - https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8875
+// We are allowed to have a binding alias like the following
 //   layout(set = 0, binding = 2) uniform sampler3D tex3d[];
 //   layout(set = 0, binding = 2) uniform sampler2D tex[];
-// And we need a DescriptorRequirement for each OpVariable
-using DescriptorBindingInfo = std::pair<uint32_t, std::vector<DescriptorRequirement>>;
+// This will require more tracking in the Post Processing of GPU-AV to determine which OpVariable actually accessed it
+// We used to have vector<DescriptorRequirement> but it was giving false positives
+using DescriptorBindingInfo = std::pair<uint32_t, DescriptorRequirement>;
 
 class DescriptorValidator {
  public:

--- a/layers/gpu/descriptor_validation/gpuav_descriptor_set.h
+++ b/layers/gpu/descriptor_validation/gpuav_descriptor_set.h
@@ -42,9 +42,6 @@ class DescriptorSet : public vvl::DescriptorSet {
 
     std::map<uint32_t, std::vector<uint32_t>> UsedDescriptors(const Location &loc, uint32_t shader_set) const;
 
-  protected:
-    bool SkipBinding(const vvl::DescriptorBinding &binding, bool is_dynamic_accessed) const override { return true; }
-
   private:
     void BuildBindingLayouts();
     std::lock_guard<std::mutex> Lock() const { return std::lock_guard<std::mutex>(state_lock_); }

--- a/layers/gpu/descriptor_validation/gpuav_descriptor_validation.cpp
+++ b/layers/gpu/descriptor_validation/gpuav_descriptor_validation.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "gpu/descriptor_validation/gpuav_descriptor_validation.h"
+#include <cstdint>
 
 #include "drawdispatch/descriptor_validator.h"
 #include "gpu/core/gpuav.h"
@@ -188,11 +189,17 @@ void UpdateBoundDescriptors(Validator &gpuav, CommandBuffer &cb_state, VkPipelin
                 auto iter = bound_descriptor_set.binding_req_map.find(binding);
                 vvl::DescriptorBindingInfo binding_info;
                 binding_info.first = binding;
+                uint32_t descriptor_req_found = 0;
                 while (iter != bound_descriptor_set.binding_req_map.end() && iter->first == binding) {
-                    binding_info.second.emplace_back(iter->second);
+                    descriptor_req_found++;
+                    binding_info.second = iter->second;
                     ++iter;
                 }
-                context.ValidateBindingDynamic(binding_info, u.second);
+                // TODO - https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8875
+                // Currently if we find multiple variables (aka aliased bindings) we will skip validating
+                if (descriptor_req_found == 1) {
+                    context.ValidateBindingDynamic(binding_info, u.second);
+                }
             }
         }
     }

--- a/layers/state_tracker/descriptor_sets.cpp
+++ b/layers/state_tracker/descriptor_sets.cpp
@@ -701,7 +701,7 @@ void vvl::DescriptorSet::UpdateDrawState(ValidationStateTracker *device_data, vv
         ASSERT_AND_CONTINUE(binding);
 
         // core validation doesn't handle descriptor indexing, that is only done by GPU-AV
-        if (SkipBinding(*binding, binding_req_pair.second.variable->is_dynamic_accessed)) {
+        if (ValidateBindingOnGPU(*binding, binding_req_pair.second.variable->is_dynamic_accessed)) {
             continue;
         }
         switch (binding->descriptor_class) {

--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -983,7 +983,7 @@ class DescriptorSet : public StateObject {
         return DescriptorIterator<ConstBindingIterator>(*this, binding, index);
     }
 
-    virtual bool SkipBinding(const DescriptorBinding &binding, bool is_dynamic_accessed) const {
+    inline bool ValidateBindingOnGPU(const DescriptorBinding &binding, bool is_dynamic_accessed) const {
         // core validation case: We check if all parts of the descriptor are statically known, from here spirv-val should have
         // caught any OOB values.
         return IsBindless(binding.binding_flags) || is_dynamic_accessed;

--- a/tests/unit/gpu_av_positive.cpp
+++ b/tests/unit/gpu_av_positive.cpp
@@ -1377,6 +1377,92 @@ TEST_F(PositiveGpuAV, AliasImageMultisample) {
 
 TEST_F(PositiveGpuAV, AliasImageMultisampleDescriptorSets) {
     TEST_DESCRIPTION("Same binding used for Multisampling and non-Multisampling across two descriptor sets");
+    RETURN_IF_SKIP(InitGpuAvFramework());
+    RETURN_IF_SKIP(InitState());
+
+    char const *cs_source = R"glsl(
+        #version 460
+        #extension GL_EXT_samplerless_texture_functions : require
+
+        layout(set = 0, binding = 0) uniform texture2D BaseTexture;
+        layout(set = 0, binding = 1) uniform sampler BaseTextureSampler;
+        layout(set = 0, binding = 2) buffer SSBO { vec4 dummy; };
+
+        void main() {
+            dummy = texture(sampler2D(BaseTexture, BaseTextureSampler), vec2(0));
+        }
+    )glsl";
+
+    char const *cs_source_ms = R"glsl(
+        #version 460
+        #extension GL_EXT_samplerless_texture_functions : require
+
+        layout(set = 0, binding = 0) uniform texture2DMS BaseTextureMS;
+        layout(set = 0, binding = 2) buffer SSBO { vec4 dummy; };
+
+        void main() {
+            dummy = texelFetch(BaseTextureMS, ivec2(0), 0);
+        }
+    )glsl";
+
+    vkt::Buffer buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
+    vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
+    auto image_ci = vkt::Image::ImageCreateInfo2D(64, 64, 1, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    vkt::Image image(*m_device, image_ci, vkt::set_layout);
+    vkt::ImageView image_view = image.CreateView();
+    image_ci.samples = VK_SAMPLE_COUNT_4_BIT;
+    vkt::Image ms_image(*m_device, image_ci, vkt::set_layout);
+    vkt::ImageView ms_image_view = ms_image.CreateView();
+
+    OneOffDescriptorSet descriptor_set0(m_device, {
+                                                      {0, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr},
+                                                      {1, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_ALL, nullptr},
+                                                      {2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
+                                                  });
+    const vkt::PipelineLayout pipeline_layout0(*m_device, {&descriptor_set0.layout_});
+    descriptor_set0.WriteDescriptorImageInfo(0, image_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
+    descriptor_set0.WriteDescriptorImageInfo(1, VK_NULL_HANDLE, sampler, VK_DESCRIPTOR_TYPE_SAMPLER);
+    descriptor_set0.WriteDescriptorBufferInfo(2, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    descriptor_set0.UpdateDescriptorSets();
+
+    OneOffDescriptorSet descriptor_set1(m_device, {
+                                                      {0, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr},
+                                                      {2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
+                                                  });
+    const vkt::PipelineLayout pipeline_layout1(*m_device, {&descriptor_set1.layout_});
+    descriptor_set1.WriteDescriptorImageInfo(0, ms_image_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
+    descriptor_set1.WriteDescriptorBufferInfo(2, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    descriptor_set1.UpdateDescriptorSets();
+
+    CreateComputePipelineHelper pipe(*this);
+    pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT);
+    pipe.cp_ci_.layout = pipeline_layout0.handle();
+    pipe.CreateComputePipeline();
+
+    CreateComputePipelineHelper pipe_ms(*this);
+    pipe_ms.cs_ = std::make_unique<VkShaderObj>(this, cs_source_ms, VK_SHADER_STAGE_COMPUTE_BIT);
+    pipe_ms.cp_ci_.layout = pipeline_layout1.handle();
+    pipe_ms.CreateComputePipeline();
+
+    m_command_buffer.Begin();
+    vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
+    vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout0.handle(), 0, 1,
+                              &descriptor_set0.set_, 0, nullptr);
+    vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
+
+    vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe_ms.Handle());
+    vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout1.handle(), 0, 1,
+                              &descriptor_set1.set_, 0, nullptr);
+    vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
+
+    m_command_buffer.End();
+    m_default_queue->Submit(m_command_buffer);
+    m_default_queue->Wait();
+}
+
+// TODO - This fails because the vkCmdBindPipeline is updating the previous vkCmdBindDescriptorSets call
+TEST_F(PositiveGpuAV, DISABLED_AliasImageMultisampleDescriptorSetsPartiallyBound) {
+    TEST_DESCRIPTION("Same binding used for Multisampling and non-Multisampling across two descriptor sets");
     AddRequiredExtensions(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::descriptorBindingPartiallyBound);
     RETURN_IF_SKIP(InitGpuAvFramework());
@@ -1428,43 +1514,48 @@ TEST_F(PositiveGpuAV, AliasImageMultisampleDescriptorSets) {
                                             {2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
                                         },
                                         0, &ds_layout_binding_flags);
+    const vkt::PipelineLayout pipeline_layout0(*m_device, {&descriptor_set0.layout_});
     descriptor_set0.WriteDescriptorImageInfo(0, image_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
     descriptor_set0.WriteDescriptorImageInfo(1, VK_NULL_HANDLE, sampler, VK_DESCRIPTOR_TYPE_SAMPLER);
     descriptor_set0.WriteDescriptorBufferInfo(2, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set0.UpdateDescriptorSets();
 
+    ds_layout_binding_flags.bindingCount = 2;
     OneOffDescriptorSet descriptor_set1(m_device,
                                         {
                                             {0, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr},
-                                            {1, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_ALL, nullptr},
                                             {2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
                                         },
                                         0, &ds_layout_binding_flags);
+    const vkt::PipelineLayout pipeline_layout1(*m_device, {&descriptor_set1.layout_});
     descriptor_set1.WriteDescriptorImageInfo(0, ms_image_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
-    descriptor_set1.WriteDescriptorImageInfo(1, VK_NULL_HANDLE, sampler, VK_DESCRIPTOR_TYPE_SAMPLER);
     descriptor_set1.WriteDescriptorBufferInfo(2, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set1.UpdateDescriptorSets();
 
-    const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set0.layout_});
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT);
-    pipe.cp_ci_.layout = pipeline_layout.handle();
+    pipe.cp_ci_.layout = pipeline_layout0.handle();
     pipe.CreateComputePipeline();
 
     CreateComputePipelineHelper pipe_ms(*this);
     pipe_ms.cs_ = std::make_unique<VkShaderObj>(this, cs_source_ms, VK_SHADER_STAGE_COMPUTE_BIT);
-    pipe_ms.cp_ci_.layout = pipeline_layout.handle();
+    pipe_ms.cp_ci_.layout = pipeline_layout1.handle();
     pipe_ms.CreateComputePipeline();
 
     m_command_buffer.Begin();
-    vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 1,
-                              &descriptor_set0.set_, 0, nullptr);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
+    vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout0.handle(), 0, 1,
+                              &descriptor_set0.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
 
-    vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 1,
-                              &descriptor_set1.set_, 0, nullptr);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe_ms.Handle());
+    vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout1.handle(), 0, 1,
+                              &descriptor_set1.set_, 0, nullptr);
+    vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
+
+    vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
+    vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout0.handle(), 0, 1,
+                              &descriptor_set0.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
     m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);


### PR DESCRIPTION
We added a quick hack for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8875 in https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/8876, but this takes it a step further and just removes alias binding checks all together. This will allow us to more easily get other things correct, and then can return and try to apply them back in