### PR TITLE
layers: Renaming related to debug label regions

### DIFF
--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -107,9 +107,9 @@ private:
             // The assumption that after label mismatch the label stack is corrupted and can't be reasoned about.
             return skip;
         }
-        for (const auto &command : cb_state.GetLabelCommands()) {
-            if (command.begin) {
-                cmdbuf_label_stack.emplace_back(command.label_name);
+        for (const auto &label_region : cb_state.GetDebugLabelRegions()) {
+            if (label_region.begin) {
+                cmdbuf_label_stack.emplace_back(label_region.label_name);
             } else {
                 if (cmdbuf_label_stack.empty()) {
                     found_unbalanced_cmdbuf_label = true;

--- a/layers/error_message/logging.cpp
+++ b/layers/error_message/logging.cpp
@@ -159,15 +159,13 @@ bool DebugReport::DebugLogMsg(VkFlags msg_flags, const LogObjectList &objects, c
         if (VK_OBJECT_TYPE_QUEUE == object_name_info.objectType) {
             auto label_iter = debug_utils_queue_labels.find(reinterpret_cast<VkQueue>(object_name_info.objectHandle));
             if (label_iter != debug_utils_queue_labels.end()) {
-                auto found_queue_labels = label_iter->second->Export();
-                queue_labels.insert(queue_labels.end(), found_queue_labels.begin(), found_queue_labels.end());
+                label_iter->second->Export(queue_labels);
             }
             // If this is a command buffer, add any command buffer labels to the callback data.
         } else if (VK_OBJECT_TYPE_COMMAND_BUFFER == object_name_info.objectType) {
             auto label_iter = debug_utils_cmd_buffer_labels.find(reinterpret_cast<VkCommandBuffer>(object_name_info.objectHandle));
             if (label_iter != debug_utils_cmd_buffer_labels.end()) {
-                auto found_cmd_buf_labels = label_iter->second->Export();
-                cmd_buf_labels.insert(cmd_buf_labels.end(), found_cmd_buf_labels.begin(), found_cmd_buf_labels.end());
+                label_iter->second->Export(cmd_buf_labels);
             }
         }
 

--- a/layers/error_message/logging.h
+++ b/layers/error_message/logging.h
@@ -105,10 +105,12 @@ static inline uint64_t HandleToUint64(HANDLE_T h) {
 
 static inline uint64_t HandleToUint64(uint64_t h) { return h; }
 
+// #ARNO_TODO Move LabelCommand/DebugUtilsLabel here
+
 // Data we store per label for logging
 struct LoggingLabel {
-    std::string name;
-    std::array<float, 4> color;
+    std::string name{};
+    std::array<float, 4> color{};
 
     void Reset() { *this = LoggingLabel(); }
     bool Empty() const { return name.empty(); }
@@ -125,8 +127,6 @@ struct LoggingLabel {
         if (label_info && label_info->pLabelName) {
             name = label_info->pLabelName;
             std::copy_n(std::begin(label_info->color), 4, color.begin());
-        } else {
-            Reset();
         }
     }
 
@@ -144,20 +144,13 @@ struct LoggingLabelState {
     LoggingLabel insert_label;
 
     // Export the labels, but in reverse order since we want the most recent at the top.
-    std::vector<VkDebugUtilsLabelEXT> Export() const {
-        size_t count = labels.size() + (insert_label.Empty() ? 0 : 1);
-        std::vector<VkDebugUtilsLabelEXT> out(count);
-
-        if (!count) return out;
-
-        size_t index = count - 1;
+    void Export(std::vector<VkDebugUtilsLabelEXT> &exported_labels) const {
         if (!insert_label.Empty()) {
-            out[index--] = insert_label.Export();
+            exported_labels.emplace_back(insert_label.Export());
         }
-        for (const auto &label : labels) {
-            out[index--] = label.Export();
-        }
-        return out;
+        exported_labels.reserve(exported_labels.size() + labels.size());
+        std::for_each(labels.rbegin(), labels.rend(),
+                      [&exported_labels](const LoggingLabel &label) { exported_labels.emplace_back(label.Export()); });
     }
 };
 

--- a/layers/gpu/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpu/instrumentation/gpuav_instrumentation.cpp
@@ -395,12 +395,12 @@ void PreCallSetupShaderInstrumentationResources(Validator &gpuav, CommandBuffer 
     const bool uses_robustness = (gpuav.enabled_features.robustBufferAccess || gpuav.enabled_features.robustBufferAccess2 ||
                                   (last_bound.pipeline_state && last_bound.pipeline_state->uses_pipeline_robustness));
 
-    std::optional<vvl::LabelCommand> deepest_opened_label_region = std::nullopt;
+    std::optional<vvl::DebugUtilsLabel> deepest_opened_label_region = std::nullopt;
     {
         int32_t ended_label_regions_count = 0;
         if (auto deepest_opened_label_region_rit =
-                std::find_if(cb_state.GetLabelCommands().rbegin(), cb_state.GetLabelCommands().rend(),
-                             [&ended_label_regions_count](const vvl::LabelCommand &label_cmd) {
+                std::find_if(cb_state.GetDebugLabelRegions().rbegin(), cb_state.GetDebugLabelRegions().rend(),
+                             [&ended_label_regions_count](const vvl::DebugUtilsLabel &label_cmd) {
                                  if (label_cmd.begin) {
                                      if (ended_label_regions_count == 0) {
                                          return true;
@@ -413,7 +413,7 @@ void PreCallSetupShaderInstrumentationResources(Validator &gpuav, CommandBuffer 
                                      return false;
                                  }
                              });
-            deepest_opened_label_region_rit != cb_state.GetLabelCommands().rend()) {
+            deepest_opened_label_region_rit != cb_state.GetDebugLabelRegions().rend()) {
             deepest_opened_label_region = *deepest_opened_label_region_rit;
         }
     }
@@ -720,7 +720,7 @@ bool LogMessageInstRayQuery(const uint32_t *error_record, std::string &out_error
 // keeps a copy, but it can be destroyed after the pipeline is created and before it is submitted.)
 //
 bool LogInstrumentationError(Validator &gpuav, VkCommandBuffer cmd_buffer, const LogObjectList &objlist,
-                             const std::optional<vvl::LabelCommand> &label_cmd, uint32_t operation_index,
+                             const std::optional<vvl::DebugUtilsLabel> &label_cmd, uint32_t operation_index,
                              const uint32_t *error_record, const std::vector<DescriptorCommandBountSet> &descriptor_sets,
                              VkPipelineBindPoint pipeline_bind_point, bool uses_shader_object, bool uses_robustness,
                              const Location &loc) {

--- a/layers/gpu/instrumentation/gpuav_instrumentation.h
+++ b/layers/gpu/instrumentation/gpuav_instrumentation.h
@@ -26,7 +26,7 @@ struct Location;
 struct LogObjectList;
 
 namespace vvl {
-struct LabelCommand;
+struct DebugUtilsLabel;
 }
 
 namespace gpuav {
@@ -46,7 +46,7 @@ void PostCallSetupShaderInstrumentationResources(Validator& gpuav, CommandBuffer
 
 // Return true iff an error has been found
 bool LogInstrumentationError(Validator& gpuav, VkCommandBuffer cmd_buffer, const LogObjectList& objlist,
-                             const std::optional<vvl::LabelCommand>& label_cmd, uint32_t operation_index,
+                             const std::optional<vvl::DebugUtilsLabel>& label_cmd, uint32_t operation_index,
                              const uint32_t* error_record, const std::vector<DescriptorCommandBountSet>& descriptor_sets,
                              VkPipelineBindPoint pipeline_bind_point, bool uses_shader_object, bool uses_robustness,
                              const Location& loc);

--- a/layers/gpu/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpu/instrumentation/gpuav_shader_instrumentor.cpp
@@ -1450,10 +1450,10 @@ static std::string FindShaderSource(std::ostringstream &ss, const std::vector<In
 
 // Where we build up the error message with all the useful debug information about where the error occured
 std::string GpuShaderInstrumentor::GenerateDebugInfoMessage(
-    VkCommandBuffer commandBuffer, const std::optional<vvl::LabelCommand> &label_cmd, const std::vector<Instruction> &instructions,
-    uint32_t stage_id, uint32_t stage_info_0, uint32_t stage_info_1, uint32_t stage_info_2, uint32_t instruction_position,
-    const InstrumentedShader *instrumented_shader, uint32_t shader_id, VkPipelineBindPoint pipeline_bind_point,
-    uint32_t operation_index) const {
+    VkCommandBuffer commandBuffer, const std::optional<vvl::DebugUtilsLabel> &label_cmd,
+    const std::vector<Instruction> &instructions, uint32_t stage_id, uint32_t stage_info_0, uint32_t stage_info_1,
+    uint32_t stage_info_2, uint32_t instruction_position, const InstrumentedShader *instrumented_shader, uint32_t shader_id,
+    VkPipelineBindPoint pipeline_bind_point, uint32_t operation_index) const {
     std::ostringstream ss;
     if (instructions.empty() || !instrumented_shader) {
         ss << "[Internal Error] - Can't get instructions from shader_map\n";

--- a/layers/gpu/instrumentation/gpuav_shader_instrumentor.h
+++ b/layers/gpu/instrumentation/gpuav_shader_instrumentor.h
@@ -32,7 +32,7 @@
 using Instruction = ::spirv::Instruction;
 
 namespace vvl {
-struct LabelCommand;
+struct DebugUtilsLabel;
 }
 
 namespace chassis {
@@ -167,7 +167,7 @@ class GpuShaderInstrumentor : public ValidationStateTracker {
 
     bool IsSelectiveInstrumentationEnabled(const void *pNext);
 
-    std::string GenerateDebugInfoMessage(VkCommandBuffer commandBuffer, const std::optional<vvl::LabelCommand> &label_cmd,
+    std::string GenerateDebugInfoMessage(VkCommandBuffer commandBuffer, const std::optional<vvl::DebugUtilsLabel> &label_cmd,
                                          const std::vector<Instruction> &instructions, uint32_t stage_id, uint32_t stage_info_0,
                                          uint32_t stage_info_1, uint32_t stage_info_2, uint32_t instruction_position,
                                          const InstrumentedShader *instrumented_shader, uint32_t shader_id,

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -1243,9 +1243,9 @@ void ValidationStateTracker::PreCallRecordQueueSubmit(VkQueue queue, uint32_t su
 
 static void UpdateCmdBufLabelStack(const vvl::CommandBuffer &cb_state, vvl::Queue &queue_state) {
     if (queue_state.found_unbalanced_cmdbuf_label) return;
-    for (const auto &command : cb_state.GetLabelCommands()) {
-        if (command.begin) {
-            queue_state.cmdbuf_label_stack.push_back(command.label_name);
+    for (const auto &label_region : cb_state.GetDebugLabelRegions()) {
+        if (label_region.begin) {
+            queue_state.cmdbuf_label_stack.push_back(label_region.label_name);
         } else {
             if (queue_state.cmdbuf_label_stack.empty()) {
                 queue_state.found_unbalanced_cmdbuf_label = true;
@@ -4305,13 +4305,13 @@ void ValidationStateTracker::PostCallRecordCmdBeginDebugUtilsLabelEXT(VkCommandB
                                                                       const VkDebugUtilsLabelEXT *pLabelInfo,
                                                                       const RecordObject &record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
-    cb_state->BeginLabel((pLabelInfo && pLabelInfo->pLabelName) ? pLabelInfo->pLabelName : "");
+    cb_state->BeginDebugUtilsLabel((pLabelInfo && pLabelInfo->pLabelName) ? pLabelInfo->pLabelName : "");
 }
 
 void ValidationStateTracker::PostCallRecordCmdEndDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const RecordObject &record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     cb_state->RecordCmd(record_obj.location.function);
-    cb_state->EndLabel();
+    cb_state->EndDebugUtilsLabel();
     debug_report->EndCmdDebugUtilsLabel(commandBuffer);
 }
 

--- a/layers/sync/sync_commandbuffer.h
+++ b/layers/sync/sync_commandbuffer.h
@@ -131,7 +131,7 @@ struct ResourceCmdUsageRecord {
     uint32_t first_handle_index = vvl::kNoIndex32;
     uint32_t handle_count = 0;
 
-    uint32_t label_command_index = vvl::kNoIndex32;
+    uint32_t label_region_i = vvl::kNoIndex32;
 };
 
 struct DebugNameProvider;
@@ -171,7 +171,7 @@ struct ResourceUsageRecord : public ResourceCmdUsageRecord {
 // Provides debug region name for the specified access log command.
 // If empty name is returned it means the command is not inside debug region.
 struct DebugNameProvider {
-    virtual std::string GetDebugRegionName(const ResourceUsageRecord &record) const = 0;
+    virtual std::string GetStackedDebugLabelRegionName(const ResourceUsageRecord &record) const = 0;
 };
 
 // Command execution context is the base class for command buffer and queue contexts
@@ -338,9 +338,9 @@ class CommandBufferAccessContext : public CommandExecutionContext, DebugNameProv
     const std::vector<SyncOpEntry> &GetSyncOps() const { return sync_ops_; };
 
     // DebugNameProvider
-    std::string GetDebugRegionName(const ResourceUsageRecord &record) const override;
+    std::string GetStackedDebugLabelRegionName(const ResourceUsageRecord &record) const override;
 
-    std::vector<vvl::LabelCommand> &GetProxyLabelCommands() { return proxy_label_commands_; }
+    std::vector<vvl::DebugUtilsLabel> &GetProxyLabelCommands() { return proxy_label_regions_; }
 
   private:
     CommandBufferAccessContext(const SyncValidator &sync_validator, VkQueueFlags queue_flags);
@@ -389,7 +389,7 @@ class CommandBufferAccessContext : public CommandExecutionContext, DebugNameProv
     // Secondary buffer validation uses proxy context and does local update (imitates Record).
     // Because in this case PreRecord is not called, the label state is not updated. We make
     // a copy of label state to update it locally together with proxy context.
-    std::vector<vvl::LabelCommand> proxy_label_commands_;
+    std::vector<vvl::DebugUtilsLabel> proxy_label_regions_;
 };
 
 namespace syncval_state {

--- a/layers/sync/sync_reporting.cpp
+++ b/layers/sync/sync_reporting.cpp
@@ -110,7 +110,7 @@ std::string FormatResourceUsageRecord(const ResourceUsageRecord::FormatterState 
         }
         // Report debug region name. Empty name means that we are not inside any debug region.
         if (formatter.debug_name_provider) {
-            const std::string debug_region_name = formatter.debug_name_provider->GetDebugRegionName(record);
+            const std::string debug_region_name = formatter.debug_name_provider->GetStackedDebugLabelRegionName(record);
             if (!debug_region_name.empty()) {
                 out << ", debug_region: " << debug_region_name;
             }
@@ -252,7 +252,7 @@ std::string CommandBufferAccessContext::FormatUsage(ResourceUsageTagEx tag_ex) c
     std::stringstream out;
     assert(tag_ex.tag < access_log_->size());
     const auto &record = (*access_log_)[tag_ex.tag];
-    const auto debug_name_provider = (record.label_command_index == vvl::kU32Max) ? nullptr : this;
+    const auto debug_name_provider = (record.label_region_i == vvl::kU32Max) ? nullptr : this;
     out << FormatResourceUsageRecord(record.Formatter(sync_state_, cb_state_, debug_name_provider, tag_ex.handle_index));
     return out.str();
 }

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -630,8 +630,8 @@ bool QueueBatchContext::ValidateSubmit(const std::vector<CommandBufferConstPtr>&
             ResolveSubmittedCommandBuffer(*access_context.GetCurrentAccessContext(), batch.base_tag);
             batch.base_tag += access_context.GetTagCount();
         }
-        // Apply debug label commands
-        vvl::CommandBuffer::ReplayLabelCommands(cb->GetLabelCommands(), current_label_stack);
+
+        vvl::CommandBuffer::ReplayDebugLabelRegions(cb->GetDebugLabelRegions(), current_label_stack);
         batch.cb_index++;
     }
     return skip;
@@ -835,9 +835,9 @@ BatchAccessLog::AccessRecord BatchAccessLog::GetAccessRecord(ResourceUsageTag ta
     return AccessRecord();
 }
 
-std::string BatchAccessLog::CBSubmitLog::GetDebugRegionName(const ResourceUsageRecord& record) const {
-    const auto& label_commands = (*cbs_)[0]->GetLabelCommands();
-    return vvl::CommandBuffer::GetDebugRegionName(label_commands, record.label_command_index, initial_label_stack_);
+std::string BatchAccessLog::CBSubmitLog::GetStackedDebugLabelRegionName(const ResourceUsageRecord& record) const {
+    const auto& label_regions = (*cbs_)[0]->GetDebugLabelRegions();
+    return vvl::CommandBuffer::GetStackedDebugLabelRegionName(label_regions, record.label_region_i, initial_label_stack_);
 }
 
 BatchAccessLog::AccessRecord BatchAccessLog::CBSubmitLog::GetAccessRecord(ResourceUsageTag tag) const {
@@ -846,7 +846,7 @@ BatchAccessLog::AccessRecord BatchAccessLog::CBSubmitLog::GetAccessRecord(Resour
     assert(log_);
     assert(index < log_->size());
     const ResourceUsageRecord* record = &(*log_)[index];
-    const auto debug_name_provider = (record->label_command_index == vvl::kU32Max) ? nullptr : this;
+    const auto debug_name_provider = (record->label_region_i == vvl::kU32Max) ? nullptr : this;
     return AccessRecord{&batch_, record, debug_name_provider};
 }
 

--- a/layers/sync/sync_submit.h
+++ b/layers/sync/sync_submit.h
@@ -198,7 +198,7 @@ class BatchAccessLog {
         AccessRecord GetAccessRecord(ResourceUsageTag tag) const;
 
         // DebugNameProvider
-        std::string GetDebugRegionName(const ResourceUsageRecord &record) const override;
+        std::string GetStackedDebugLabelRegionName(const ResourceUsageRecord &record) const override;
 
       private:
         BatchRecord batch_;

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -2883,8 +2883,8 @@ bool SyncValidator::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuf
     // Heavyweight, but we need a proxy copy of the active command buffer access context
     CommandBufferAccessContext proxy_cb_context(*cb_context, CommandBufferAccessContext::AsProxyContext());
 
-    auto &proxy_label_commands = proxy_cb_context.GetProxyLabelCommands();
-    proxy_label_commands = cb_state->GetLabelCommands();
+    auto &proxy_label_regions = proxy_cb_context.GetProxyLabelCommands();
+    proxy_label_regions = cb_state->GetDebugLabelRegions();
 
     // Make working copies of the access and events contexts
     for (uint32_t cb_index = 0; cb_index < commandBufferCount; ++cb_index) {
@@ -2903,14 +2903,14 @@ bool SyncValidator::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuf
         skip |= ReplayState(proxy_cb_context, *recorded_cb_context, error_obj, cb_index, base_tag).ValidateFirstUse();
 
         // Update proxy label commands so they can be used by ImportRecordedAccessLog
-        const auto &recorded_label_commands = recorded_cb->GetLabelCommands();
-        proxy_label_commands.insert(proxy_label_commands.end(), recorded_label_commands.begin(), recorded_label_commands.end());
+        const auto &recorded_label_regions = recorded_cb->GetDebugLabelRegions();
+        proxy_label_regions.insert(proxy_label_regions.end(), recorded_label_regions.begin(), recorded_label_regions.end());
 
         // The barriers have already been applied in ValidatFirstUse
         proxy_cb_context.ImportRecordedAccessLog(*recorded_cb_context);
         proxy_cb_context.ResolveExecutedCommandBuffer(*recorded_cb_context->GetCurrentAccessContext(), base_tag);
     }
-    proxy_label_commands.clear();
+    proxy_label_regions.clear();
 
     return skip;
 }

--- a/tests/unit/sync_val_reporting.cpp
+++ b/tests/unit/sync_val_reporting.cpp
@@ -63,7 +63,7 @@ TEST_F(NegativeSyncValReporting, DebugRegion2) {
 
     // Command buffer can start with end label command. It can close debug region
     // started in the previous command buffer (that's why primary command buffer labels
-    // are validated at sumbit time). Start command buffer with EndLabel command to
+    // are validated at sumbit time). Start command buffer with EndDebugUtilsLabel command to
     // check it is handled properly.
     //
     // NOTE: the following command crashes CI Linux-Mesa-6800 driver but works


### PR DESCRIPTION
Multiple renaming relate to debug label regions.

I was working on adding support for debug label regions in GPU-AV, and looking for what we already had was hard. Few of the old names related to Vulkan functions/structs mentioned in the specification, making looking for things needlessly cumbersome. 
`LabelCommand` for instance appears nowhere in the spec, and this struct essentially is a wrapper for `VkDebugUtilsLabelEXT`, so I just renamed it to `DebugUtilsLabel` for easy lookup. I tried to base all renaming I did from Vulkan spec excerpts: things like "debug label region", "label region". 
Following the [Google style guide](https://google.github.io/styleguide/cppguide.html#General_Naming_Rules), I also tried to use `label_region` instead of the full blown `debug_label_region` for local variables, I think the small scope allows to use the shorter version.

Doing this allowed me to find that Artem has done some great work in that area  that GPU-AV could use. So it was a shame that I could not find it easily!