### PR TITLE
gpuav: Update debug label regions management

### DIFF
--- a/layers/gpu/cmd_validation/gpuav_copy_buffer_to_image.cpp
+++ b/layers/gpu/cmd_validation/gpuav_copy_buffer_to_image.cpp
@@ -311,8 +311,8 @@ void InsertCopyBufferToImageValidation(Validator &gpuav, const Location &loc, Co
     DispatchCmdDispatch(cb_state.VkHandle(), group_count_x, 1, 1);
 
     CommandBuffer::ErrorLoggerFunc error_logger = [loc, src_buffer = copy_buffer_to_img_info->srcBuffer](
-                                                      Validator &gpuav, const uint32_t *error_record,
-                                                      const LogObjectList &objlist) {
+                                                      Validator &gpuav, const CommandBuffer &, const uint32_t *error_record,
+                                                      const LogObjectList &objlist, const std::vector<std::string> &) {
         bool skip = false;
 
         using namespace glsl;

--- a/layers/gpu/cmd_validation/gpuav_dispatch.cpp
+++ b/layers/gpu/cmd_validation/gpuav_dispatch.cpp
@@ -212,7 +212,8 @@ void InsertIndirectDispatchValidation(Validator &gpuav, const Location &loc, Com
     DispatchCmdDispatch(cb_state.VkHandle(), 1, 1, 1);
 
     CommandBuffer::ErrorLoggerFunc error_logger =
-        [loc](Validator &gpuav, const uint32_t *error_record, const LogObjectList &objlist) {
+        [loc](Validator &gpuav, const CommandBuffer &, const uint32_t *error_record, const LogObjectList &objlist,
+              const std::vector<std::string> &) {
             bool skip = false;
             using namespace glsl;
 

--- a/layers/gpu/cmd_validation/gpuav_draw.cpp
+++ b/layers/gpu/cmd_validation/gpuav_draw.cpp
@@ -364,8 +364,9 @@ void InsertIndirectDrawValidation(Validator &gpuav, const Location &loc, Command
     DispatchCmdDraw(cb_state.VkHandle(), 3, 1, 0, 0);  // TODO: this 3 assumes triangles I think, probably could be 1?
 
     CommandBuffer::ErrorLoggerFunc error_logger = [loc, indirect_buffer, indirect_offset, stride, indirect_buffer_size,
-                                                   emit_task_error](Validator &gpuav, const uint32_t *error_record,
-                                                                    const LogObjectList &objlist) {
+                                                   emit_task_error](Validator &gpuav, const CommandBuffer &,
+                                                                    const uint32_t *error_record, const LogObjectList &objlist,
+                                                                    const std::vector<std::string> &) {
         bool skip = false;
 
         using namespace glsl;

--- a/layers/gpu/cmd_validation/gpuav_trace_rays.cpp
+++ b/layers/gpu/cmd_validation/gpuav_trace_rays.cpp
@@ -248,8 +248,8 @@ void InsertIndirectTraceRaysValidation(Validator &gpuav, const Location &loc, Co
     VkStridedDeviceAddressRegionKHR empty_sbt{};
     DispatchCmdTraceRaysKHR(cb_state.VkHandle(), &ray_gen_sbt, &empty_sbt, &empty_sbt, &empty_sbt, 1, 1, 1);
 
-    CommandBuffer::ErrorLoggerFunc error_logger = [loc](Validator &gpuav, const uint32_t *error_record,
-                                                        const LogObjectList &objlist) {
+    CommandBuffer::ErrorLoggerFunc error_logger = [loc](Validator &gpuav, const CommandBuffer &, const uint32_t *error_record,
+                                                        const LogObjectList &objlist, const std::vector<std::string> &) {
         bool skip = false;
 
         using namespace glsl;

--- a/layers/gpu/debug_printf/debug_printf.cpp
+++ b/layers/gpu/debug_printf/debug_printf.cpp
@@ -335,7 +335,7 @@ void AnalyzeAndGenerateMessage(Validator &gpuav, VkCommandBuffer command_buffer,
         const bool use_stdout = gpuav.gpuav_settings.debug_printf_to_stdout;
         if (gpuav.gpuav_settings.debug_printf_verbose) {
             std::string debug_info_message = gpuav.GenerateDebugInfoMessage(
-                command_buffer, std::nullopt, instructions, debug_record->stage_id, debug_record->stage_info_0,
+                command_buffer, std::string{}, instructions, debug_record->stage_id, debug_record->stage_info_0,
                 debug_record->stage_info_1, debug_record->stage_info_2, debug_record->instruction_position, instrumented_shader,
                 debug_record->shader_id, buffer_info.pipeline_bind_point, buffer_info.action_command_index);
             if (use_stdout) {

--- a/layers/gpu/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpu/instrumentation/gpuav_instrumentation.cpp
@@ -411,44 +411,26 @@ void PreCallSetupShaderInstrumentationResources(Validator &gpuav, CommandBuffer 
     const bool uses_robustness = (gpuav.enabled_features.robustBufferAccess || gpuav.enabled_features.robustBufferAccess2 ||
                                   (last_bound.pipeline_state && last_bound.pipeline_state->uses_pipeline_robustness));
 
-    std::optional<vvl::LabelCommand> deepest_opened_label_region = std::nullopt;
-    {
-        int32_t ended_label_regions_count = 0;
-        if (auto deepest_opened_label_region_rit =
-                std::find_if(cb_state.GetLabelCommands().rbegin(), cb_state.GetLabelCommands().rend(),
-                             [&ended_label_regions_count](const vvl::LabelCommand &label_cmd) {
-                                 if (label_cmd.begin) {
-                                     if (ended_label_regions_count == 0) {
-                                         return true;
-                                     } else {
-                                         --ended_label_regions_count;
-                                         return false;
-                                     }
-                                 } else {
-                                     ++ended_label_regions_count;
-                                     return false;
-                                 }
-                             });
-            deepest_opened_label_region_rit != cb_state.GetLabelCommands().rend()) {
-            deepest_opened_label_region = *deepest_opened_label_region_rit;
-        }
-    }
+    const uint32_t last_label_command_i =
+        !cb_state.GetLabelCommands().empty() ? uint32_t(cb_state.GetLabelCommands().size() - 1) : vvl::kU32Max;
 
-    CommandBuffer::ErrorLoggerFunc error_logger =
-        [loc, descriptor_binding_index, descriptor_binding_list = &cb_state.descriptor_command_bindings,
-         cb_state_handle = cb_state.VkHandle(), bind_point, deepest_opened_label_region, operation_index, uses_shader_object,
-         uses_robustness](Validator &gpuav, const uint32_t *error_record, const LogObjectList &objlist) {
-            bool skip = false;
+    CommandBuffer::ErrorLoggerFunc error_logger = [loc, descriptor_binding_index,
+                                                   descriptor_binding_list = &cb_state.descriptor_command_bindings, bind_point,
+                                                   last_label_command_i, operation_index, uses_shader_object,
+                                                   uses_robustness](Validator &gpuav, const CommandBuffer &cb_state,
+                                                                    const uint32_t *error_record, const LogObjectList &objlist,
+                                                                    const std::vector<std::string> &initial_label_stack) {
+        bool skip = false;
 
-            const DescriptorCommandBinding *descriptor_command_binding =
-                descriptor_binding_index != vvl::kU32Max ? &(*descriptor_binding_list)[descriptor_binding_index] : nullptr;
-            skip |=
-                LogInstrumentationError(gpuav, cb_state_handle, objlist, deepest_opened_label_region, operation_index, error_record,
+        const DescriptorCommandBinding *descriptor_command_binding =
+            descriptor_binding_index != vvl::kU32Max ? &(*descriptor_binding_list)[descriptor_binding_index] : nullptr;
+        skip |= LogInstrumentationError(gpuav, cb_state, objlist, initial_label_stack, last_label_command_i, operation_index,
+                                        error_record,
                                         descriptor_command_binding ? descriptor_command_binding->bound_descriptor_sets
                                                                    : std::vector<std::shared_ptr<DescriptorSet>>(),
                                         bind_point, uses_shader_object, uses_robustness, loc);
-            return skip;
-        };
+        return skip;
+    };
 
     cb_state.per_command_error_loggers.emplace_back(error_logger);
 }
@@ -736,9 +718,10 @@ bool LogMessageInstRayQuery(const uint32_t *error_record, std::string &out_error
 // sure it is available when the pipeline is submitted.  (The ShaderModule tracking object also
 // keeps a copy, but it can be destroyed after the pipeline is created and before it is submitted.)
 //
-bool LogInstrumentationError(Validator &gpuav, VkCommandBuffer cmd_buffer, const LogObjectList &objlist,
-                             const std::optional<vvl::LabelCommand> &label_cmd, uint32_t operation_index,
-                             const uint32_t *error_record, const std::vector<std::shared_ptr<DescriptorSet>> &descriptor_sets,
+bool LogInstrumentationError(Validator &gpuav, const CommandBuffer &cb_state, const LogObjectList &objlist,
+                             const std::vector<std::string> &initial_label_stack, uint32_t label_command_i,
+                             uint32_t operation_index, const uint32_t *error_record,
+                             const std::vector<std::shared_ptr<DescriptorSet>> &descriptor_sets,
                              VkPipelineBindPoint pipeline_bind_point, bool uses_shader_object, bool uses_robustness,
                              const Location &loc) {
     // The second word in the debug output buffer is the number of words that would have
@@ -789,9 +772,23 @@ bool LogInstrumentationError(Validator &gpuav, VkCommandBuffer cmd_buffer, const
         if (instrumented_shader && !instrumented_shader->instrumented_spirv.empty()) {
             ::spirv::GenerateInstructions(instrumented_shader->instrumented_spirv, instructions);
         }
-
+        std::string debug_region_name;
+        if (label_command_i != vvl::kU32Max) {
+            debug_region_name = cb_state.GetDebugRegionName(cb_state.GetLabelCommands(), label_command_i, initial_label_stack);
+        } else {
+            // label_command_i == vvl::kU32Max => when the instrumented command was recorded,
+            // no debug label region was yet opened in the corresponding command buffer,
+            // but still a region might have been started in another previously submitted
+            // command buffer. So just compute region name from initial_label_stack.
+            for (const std::string &label_name : initial_label_stack) {
+                if (!debug_region_name.empty()) {
+                    debug_region_name += "::";
+                }
+                debug_region_name += label_name;
+            }
+        }
         std::string debug_info_message = gpuav.GenerateDebugInfoMessage(
-            cmd_buffer, label_cmd, instructions, error_record[gpuav::glsl::kHeaderStageIdOffset],
+            cb_state.VkHandle(), debug_region_name, instructions, error_record[gpuav::glsl::kHeaderStageIdOffset],
             error_record[gpuav::glsl::kHeaderStageInfoOffset_0], error_record[gpuav::glsl::kHeaderStageInfoOffset_1],
             error_record[gpuav::glsl::kHeaderStageInfoOffset_2], error_record[gpuav::glsl::kHeaderInstructionIdOffset],
             instrumented_shader, shader_id, pipeline_bind_point, operation_index);

--- a/layers/gpu/instrumentation/gpuav_instrumentation.h
+++ b/layers/gpu/instrumentation/gpuav_instrumentation.h
@@ -32,10 +32,10 @@ struct LabelCommand;
 
 namespace gpuav {
 
-struct DescriptorCommandBountSet;
 class DescriptorSet;
 class Validator;
 class CommandBuffer;
+class Queue;
 
 void UpdateInstrumentationDescSet(Validator& gpuav, CommandBuffer& cb_state, VkDescriptorSet instrumentation_desc_set,
                                   const Location& loc);
@@ -47,9 +47,10 @@ void PostCallSetupShaderInstrumentationResources(Validator& gpuav, CommandBuffer
                                                  const Location& loc);
 
 // Return true iff an error has been found
-bool LogInstrumentationError(Validator& gpuav, VkCommandBuffer cmd_buffer, const LogObjectList& objlist,
-                             const std::optional<vvl::LabelCommand>& label_cmd, uint32_t operation_index,
-                             const uint32_t* error_record, const std::vector<std::shared_ptr<DescriptorSet>>& descriptor_sets,
+bool LogInstrumentationError(Validator& gpuav, const CommandBuffer& cb_state, const LogObjectList& objlist,
+                             const std::vector<std::string>& initial_label_stack, uint32_t label_command_i,
+                             uint32_t operation_index, const uint32_t* error_record,
+                             const std::vector<std::shared_ptr<DescriptorSet>>& descriptor_sets,
                              VkPipelineBindPoint pipeline_bind_point, bool uses_shader_object, bool uses_robustness,
                              const Location& loc);
 

--- a/layers/gpu/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpu/instrumentation/gpuav_shader_instrumentor.cpp
@@ -1450,11 +1450,13 @@ static std::string FindShaderSource(std::ostringstream &ss, const std::vector<In
 }
 
 // Where we build up the error message with all the useful debug information about where the error occured
-std::string GpuShaderInstrumentor::GenerateDebugInfoMessage(
-    VkCommandBuffer commandBuffer, const std::optional<vvl::LabelCommand> &label_cmd, const std::vector<Instruction> &instructions,
-    uint32_t stage_id, uint32_t stage_info_0, uint32_t stage_info_1, uint32_t stage_info_2, uint32_t instruction_position,
-    const InstrumentedShader *instrumented_shader, uint32_t shader_id, VkPipelineBindPoint pipeline_bind_point,
-    uint32_t operation_index) const {
+std::string GpuShaderInstrumentor::GenerateDebugInfoMessage(VkCommandBuffer commandBuffer, const std::string &debug_region_name,
+                                                            const std::vector<Instruction> &instructions, uint32_t stage_id,
+                                                            uint32_t stage_info_0, uint32_t stage_info_1, uint32_t stage_info_2,
+                                                            uint32_t instruction_position,
+                                                            const InstrumentedShader *instrumented_shader, uint32_t shader_id,
+                                                            VkPipelineBindPoint pipeline_bind_point,
+                                                            uint32_t operation_index) const {
     std::ostringstream ss;
     if (instructions.empty() || !instrumented_shader) {
         ss << "[Internal Error] - Can't get instructions from shader_map\n";
@@ -1474,8 +1476,8 @@ std::string GpuShaderInstrumentor::GenerateDebugInfoMessage(
         std::unique_lock<std::mutex> lock(debug_report->debug_output_mutex);
         ss << "Command buffer " << LookupDebugUtilsNameNoLock(debug_report, HandleToUint64(commandBuffer)) << "("
            << HandleToUint64(commandBuffer) << ")";
-        if (label_cmd.has_value()) {
-            ss << " - [ Debug label region: " << label_cmd->label_name << " ]";
+        if (!debug_region_name.empty()) {
+            ss << " - [ Debug label region: " << debug_region_name << " ]";
         }
 
         ss << '\n';

--- a/layers/gpu/instrumentation/gpuav_shader_instrumentor.h
+++ b/layers/gpu/instrumentation/gpuav_shader_instrumentor.h
@@ -166,7 +166,7 @@ class GpuShaderInstrumentor : public ValidationStateTracker {
 
     bool IsSelectiveInstrumentationEnabled(const void *pNext);
 
-    std::string GenerateDebugInfoMessage(VkCommandBuffer commandBuffer, const std::optional<vvl::LabelCommand> &label_cmd,
+    std::string GenerateDebugInfoMessage(VkCommandBuffer commandBuffer, const std::string &debug_region_name,
                                          const std::vector<Instruction> &instructions, uint32_t stage_id, uint32_t stage_info_0,
                                          uint32_t stage_info_1, uint32_t stage_info_2, uint32_t instruction_position,
                                          const InstrumentedShader *instrumented_shader, uint32_t shader_id,

--- a/layers/gpu/resources/gpuav_state_trackers.h
+++ b/layers/gpu/resources/gpuav_state_trackers.h
@@ -77,7 +77,7 @@ class CommandBuffer : public vvl::CommandBuffer {
     ~CommandBuffer();
 
     bool PreProcess(const Location &loc);
-    void PostProcess(VkQueue queue, const Location &loc);
+    void PostProcess(VkQueue queue, const std::vector<std::string> &initial_label_stack, const Location &loc);
     [[nodiscard]] bool ValidateBindlessDescriptorSets(const Location &loc);
 
     const VkDescriptorSetLayout &GetInstrumentationDescriptorSetLayout() const {
@@ -121,7 +121,9 @@ class CommandBuffer : public vvl::CommandBuffer {
     vko::GpuResourcesManager gpu_resources_manager;
     // Using stdext::inplace_function over std::function to allocate memory in place
     using ErrorLoggerFunc =
-        stdext::inplace_function<bool(Validator &gpuav, const uint32_t *error_record, const LogObjectList &objlist), 128>;
+        stdext::inplace_function<bool(Validator &gpuav, const CommandBuffer &cb_state, const uint32_t *error_record,
+                                      const LogObjectList &objlist, const std::vector<std::string> &initial_label_stack),
+                                 128>;
     std::vector<ErrorLoggerFunc> per_command_error_loggers;
 
     std::vector<DebugPrintfBufferInfo> debug_printf_buffer_infos;
@@ -168,7 +170,7 @@ class Queue : public vvl::Queue {
     VkCommandPool barrier_command_pool_{VK_NULL_HANDLE};
     VkCommandBuffer barrier_command_buffer_{VK_NULL_HANDLE};
     VkSemaphore barrier_sem_{VK_NULL_HANDLE};
-    std::deque<std::vector<std::shared_ptr<vvl::CommandBuffer>>> retiring_;
+    std::deque<std::vector<vvl::CommandBufferSubmission>> retiring_;
     const bool timeline_khr_;
 };
 

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1842,10 +1842,11 @@ std::string CommandBuffer::GetDebugRegionName(const std::vector<LabelCommand> &l
         // It's a bug if this happens in a valid vulkan program.
         return {};
     }
-    auto commands_to_replay = vvl::make_span(label_commands.data(), label_command_index + 1);
+    auto label_commands_to_replay = vvl::make_span(label_commands.data(), label_command_index + 1);
     auto label_stack = initial_label_stack;
-    vvl::CommandBuffer::ReplayLabelCommands(commands_to_replay, label_stack);
+    vvl::CommandBuffer::ReplayLabelCommands(label_commands_to_replay, label_stack);
 
+    // Build up complete debug region name from all enclosing regions
     std::string debug_region;
     for (const std::string &label_name : label_stack) {
         if (!debug_region.empty()) {

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -150,6 +150,7 @@ class CommandPool : public StateObject {
     void Destroy() override;
 };
 
+// This struct is not used to store label inserted with vkCmdInsertDebugUtilsLabelEXT
 struct LabelCommand {
     bool begin = false;      // vkCmdBeginDebugUtilsLabelEXT or vkCmdEndDebugUtilsLabelEXT
     std::string label_name;  // used when begin == true
@@ -698,6 +699,7 @@ class CommandBuffer : public RefcountedStateObject {
 
     bool IsPrimary() const { return allocate_info.level == VK_COMMAND_BUFFER_LEVEL_PRIMARY; }
     bool IsSecondary() const { return allocate_info.level == VK_COMMAND_BUFFER_LEVEL_SECONDARY; }
+
     void BeginLabel(const char *label_name);
     void EndLabel();
     int32_t GetLabelStackDepth() const { return label_stack_depth_; }


### PR DESCRIPTION
Took some of what Artem did for syncval
Add debug label regions for debug printf
Still need to add support for secondary command buffers, not so easy

EDIT: Updated PR to add support for debug label regions starting in one (primary) command buffer and ending in another following one. To do that I drew inspiration from sync val, but had to come up with my own (little) system, for GPU-AV has different constraints. I described the problem in a comment above this new `vvl::CommandBuffer` method: https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/19390298820aceb3881e9865f05eabdd27cecf41/layers/state_tracker/cmd_buffer_state.h#L710

EDIT 2: Reworked again to account for Artem's comments. Removed debug label region tracking from the `CommandBuffer` class, now it is tracked on a "per command buffer submission" basis, in the `CommandBufferSubmission` struct. Added new test `StageInfoWithDebugLabel7` that was not working without this enhancement. 
Realized that support for debug printf was broken (https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8924) so removed it