### PR TITLE
scripts: Start to refactor ValidationObject

### DIFF
--- a/layers/core_checks/cc_wsi.cpp
+++ b/layers/core_checks/cc_wsi.cpp
@@ -1449,8 +1449,7 @@ bool CoreChecks::PreCallValidateGetDeviceGroupSurfacePresentModes2EXT(VkDevice d
     bool skip = false;
 
     if (physical_device_count == 1) {
-        ValidationObject *device_object = GetLayerDataPtr(GetDispatchKey(device), layer_data_map);
-        skip |= ValidatePhysicalDeviceSurfaceSupport(device_object->physical_device, pSurfaceInfo->surface,
+        skip |= ValidatePhysicalDeviceSurfaceSupport(physical_device, pSurfaceInfo->surface,
                                                      "VUID-vkGetDeviceGroupSurfacePresentModes2EXT-pSurfaceInfo-06213",
                                                      error_obj.location);
     } else {
@@ -1486,10 +1485,8 @@ bool CoreChecks::PreCallValidateGetDeviceGroupSurfacePresentModesKHR(VkDevice de
     bool skip = false;
 
     if (physical_device_count == 1) {
-        ValidationObject *device_object = GetLayerDataPtr(GetDispatchKey(device), layer_data_map);
-        skip |=
-            ValidatePhysicalDeviceSurfaceSupport(device_object->physical_device, surface,
-                                                 "VUID-vkGetDeviceGroupSurfacePresentModesKHR-surface-06212", error_obj.location);
+        skip |= ValidatePhysicalDeviceSurfaceSupport(
+            physical_device, surface, "VUID-vkGetDeviceGroupSurfacePresentModesKHR-surface-06212", error_obj.location);
     } else {
         for (uint32_t i = 0; i < physical_device_count; ++i) {
             skip |= ValidatePhysicalDeviceSurfaceSupport(device_group_create_info.pPhysicalDevices[i], surface,

--- a/layers/gpu/core/gpuav_setup.cpp
+++ b/layers/gpu/core/gpuav_setup.cpp
@@ -595,7 +595,7 @@ void Validator::InternalVmaError(LogObjectList objlist, const Location &loc, con
     // Once we encounter an internal issue disconnect everything.
     // This prevents need to check "if (aborted)" (which is awful when we easily forget to check somewhere and the user gets spammed
     // with errors making it hard to see the first error with the real source of the problem).
-    ReleaseDeviceDispatchObject(LayerObjectTypeGpuAssisted);
+    dispatch_->ReleaseDeviceValidationObject(LayerObjectTypeGpuAssisted);
 }
 
 VkDeviceAddress Validator::GetBufferDeviceAddressHelper(VkBuffer buffer) const {

--- a/layers/gpu/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpu/instrumentation/gpuav_shader_instrumentor.cpp
@@ -1286,7 +1286,7 @@ void GpuShaderInstrumentor::InternalError(LogObjectList objlist, const Location 
     // Once we encounter an internal issue disconnect everything.
     // This prevents need to check "if (aborted)" (which is awful when we easily forget to check somewhere and the user gets spammed
     // with errors making it hard to see the first error with the real source of the problem).
-    ReleaseDeviceDispatchObject(LayerObjectTypeGpuAssisted);
+    dispatch_->ReleaseDeviceValidationObject(LayerObjectTypeGpuAssisted);
 }
 
 void GpuShaderInstrumentor::InternalWarning(LogObjectList objlist, const Location &loc, const char *const specific_message) const {

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -692,7 +692,7 @@ void ValidationStateTracker::PostCallRecordCreateDevice(VkPhysicalDevice gpu, co
     if (VK_SUCCESS != record_obj.result) return;
 
     // The current object represents the VkInstance, look up / create the object for the device.
-    ValidationObject *device_object = GetLayerDataPtr(GetDispatchKey(*pDevice), layer_data_map);
+    DispatchObject *device_object = GetLayerDataPtr(GetDispatchKey(*pDevice), layer_data_map);
     ValidationObject *validation_data = device_object->GetValidationObject(this->container_type);
     ValidationStateTracker *device_state = static_cast<ValidationStateTracker *>(validation_data);
 
@@ -3952,32 +3952,12 @@ std::shared_ptr<vvl::PhysicalDevice> ValidationStateTracker::CreatePhysicalDevic
     return std::make_shared<vvl::PhysicalDevice>(handle);
 }
 
-// This is here as some applications will call exit() which results in all our static allocations (like std::map) having their
-// destructor called and destroyed from under us. It is not possible to detect as sometimes (when using things like robin hood) the
-// size()/empty() will give false positive that memory is there there. We add this global hook that will go through and remove all
-// the function calls such that things can safely run in the case the applicaiton still wants to make Vulkan calls in their atexit()
-// handler
-void ApplicationAtExit() {
-    // On a "normal" application, this function is called after vkDestroyInstance and layer_data_map is empty
-    //
-    // If there are multiple devices we still want to delete them all as exit() is a global scope call
-    for (auto object : layer_data_map) {
-        // Should only be a instance and device object, but being safe.
-        // Need to clean up both the instance and device function hooks
-        if (object.second->container_type == LayerObjectTypeInstance || object.second->container_type == LayerObjectTypeDevice) {
-            object.second->ReleaseAllDispatchObjects();
-        }
-    }
-}
-
 void ValidationStateTracker::PostCallRecordCreateInstance(const VkInstanceCreateInfo *pCreateInfo,
                                                           const VkAllocationCallbacks *pAllocator, VkInstance *pInstance,
                                                           const RecordObject &record_obj) {
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
-
-    atexit(ApplicationAtExit);
 
     instance_state = this;
     uint32_t count = 0;

--- a/layers/thread_tracker/thread_safety_validation.h
+++ b/layers/thread_tracker/thread_safety_validation.h
@@ -280,6 +280,11 @@ class ThreadSafety : public ValidationObject {
     vvl::concurrent_unordered_map<VkDescriptorSetLayout, bool, 4> dsl_read_only_map;
     vvl::concurrent_unordered_map<VkDescriptorSet, bool, 6> ds_read_only_map;
     bool DsReadOnly(VkDescriptorSet) const;
+    // Map of wrapped swapchain handles to arrays of wrapped swapchain image IDs
+    // Each swapchain has an immutable list of wrapped swapchain image IDs -- always return these IDs if they exist
+    vvl::unordered_map<VkSwapchainKHR, std::vector<VkImage>> swapchain_wrapped_image_handle_map;
+    // Map of wrapped descriptor pools to set of wrapped descriptor sets allocated from each pool
+    vvl::unordered_map<VkDescriptorPool, vvl::unordered_set<VkDescriptorSet>> pool_descriptor_sets_map;
 
     counter<VkCommandBuffer> c_VkCommandBuffer;
     counter<VkDevice> c_VkDevice;

--- a/layers/vulkan/generated/chassis_dispatch_helper.h
+++ b/layers/vulkan/generated/chassis_dispatch_helper.h
@@ -1758,7 +1758,7 @@ typedef enum InterceptId {
 } InterceptId;
 
 // clang-format off
-void ValidationObject::InitObjectDispatchVectors() {
+void DispatchObject::InitObjectDispatchVectors() {
 
 #define BUILD_DISPATCH_VECTOR(name) \
     init_object_dispatch_vector(InterceptId ## name, \
@@ -1803,9 +1803,6 @@ void ValidationObject::InitObjectDispatchVectors() {
                 break;
             case LayerObjectTypeSyncValidation:
                 if (tsv_typeid != vo_typeid) intercept_vector->push_back(item);
-                break;
-            case LayerObjectTypeInstance:
-            case LayerObjectTypeDevice:
                 break;
             default:
                 /* Chassis codegen needs to be updated for unknown validation object type */

--- a/layers/vulkan/generated/layer_chassis_dispatch.cpp
+++ b/layers/vulkan/generated/layer_chassis_dispatch.cpp
@@ -32,7 +32,7 @@
 #define DISPATCH_MAX_STACK_ALLOCATIONS 32
 
 // Unique Objects pNext extension handling function
-void UnwrapPnextChainHandles(ValidationObject* layer_data, const void* pNext) {
+void UnwrapPnextChainHandles(DispatchObject* layer_data, const void* pNext) {
     void* cur_pnext = const_cast<void*>(pNext);
     while (cur_pnext != nullptr) {
         VkBaseOutStructure* header = reinterpret_cast<VkBaseOutStructure*>(cur_pnext);

--- a/layers/vulkan/generated/layer_chassis_dispatch.h
+++ b/layers/vulkan/generated/layer_chassis_dispatch.h
@@ -27,8 +27,8 @@
 
 extern bool wrap_handles;
 
-class ValidationObject;
-void UnwrapPnextChainHandles(ValidationObject* layer_data, const void* pNext);
+class DispatchObject;
+void UnwrapPnextChainHandles(DispatchObject* layer_data, const void* pNext);
 
 VkResult DispatchCreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                 VkInstance* pInstance);

--- a/scripts/generators/layer_chassis_dispatch_generator.py
+++ b/scripts/generators/layer_chassis_dispatch_generator.py
@@ -176,8 +176,8 @@ class LayerChassisDispatchOutputGenerator(BaseGenerator):
 
             extern bool wrap_handles;
 
-            class ValidationObject;
-            void UnwrapPnextChainHandles(ValidationObject *layer_data, const void *pNext);
+            class DispatchObject;
+            void UnwrapPnextChainHandles(DispatchObject *layer_data, const void *pNext);
 
             ''')
         guard_helper = PlatformGuardHelper()
@@ -213,7 +213,7 @@ class LayerChassisDispatchOutputGenerator(BaseGenerator):
             #define DISPATCH_MAX_STACK_ALLOCATIONS 32
 
             // Unique Objects pNext extension handling function
-            void UnwrapPnextChainHandles(ValidationObject *layer_data, const void *pNext) {
+            void UnwrapPnextChainHandles(DispatchObject *layer_data, const void *pNext) {
                 void *cur_pnext = const_cast<void *>(pNext);
                 while (cur_pnext != nullptr) {
                     VkBaseOutStructure *header = reinterpret_cast<VkBaseOutStructure *>(cur_pnext);


### PR DESCRIPTION
Previously, there were top level ValidationObjects stored in layer_data_map. These didn't do validation but contained more ValidationObjects in the object_dispatch vector (and a few others).

This caused much confusion, since some members were only used at the top level and others only at the lower level.  When uses got mixed up, this could only be detected at runtime since the members were always available even though they might not be set up correctly.

Start to split this up by moving top level functionality to a new DispatchObject class. This does handle wrapping and coordination of validation by the child ValidationObjects. There are still many members related to settings, extension status, logging  and dispatch tables that are duplicated at both levels. Fixing this is a big change that needs to be done separately.

Also note that DispatchObject and ValidationObject are still used to represent both VkDevice and VkInstance. This will require much more work to undo.