### PR TITLE
layers: Fix in-use message for fence and semaphore

### DIFF
--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -638,7 +638,7 @@ bool CoreChecks::PreCallValidateDestroyFence(VkDevice device, VkFence fence, con
     bool skip = false;
     auto fence_state = Get<vvl::Fence>(fence);
     if (fence_state && fence_state->Scope() == vvl::Fence::kInternal && fence_state->State() == vvl::Fence::kInflight) {
-        skip |= ValidateObjectNotInUse(fence_state.get(), error_obj.location.dot(Field::fence), "VUID-vkDestroyFence-fence-01120");
+        skip |= ValidateObjectNotInUse(fence_state.get(), error_obj.location, "VUID-vkDestroyFence-fence-01120");
     }
     return skip;
 }
@@ -661,8 +661,7 @@ bool CoreChecks::PreCallValidateDestroySemaphore(VkDevice device, VkSemaphore se
                                                  const ErrorObject &error_obj) const {
     bool skip = false;
     if (auto sema_node = Get<vvl::Semaphore>(semaphore)) {
-        skip |= ValidateObjectNotInUse(sema_node.get(), error_obj.location.dot(Field::semaphore),
-                                       "VUID-vkDestroySemaphore-semaphore-05149");
+        skip |= ValidateObjectNotInUse(sema_node.get(), error_obj.location, "VUID-vkDestroySemaphore-semaphore-05149");
     }
     return skip;
 }

--- a/layers/state_tracker/fence_state.h
+++ b/layers/state_tracker/fence_state.h
@@ -65,6 +65,7 @@ class Fence : public RefcountedStateObject {
 
     Fence(ValidationStateTracker &dev, VkFence handle, const VkFenceCreateInfo *pCreateInfo);
 
+    const VulkanTypedHandle *InUse() const override;
     VkFence VkHandle() const { return handle_.Cast<VkFence>(); }
     // TODO: apply ReadLock as Semaphore does, or consider reading enums without lock.
     // Consider if more high-level operation should be exposed, because
@@ -107,7 +108,10 @@ class Fence : public RefcountedStateObject {
     mutable std::shared_mutex lock_;
     std::promise<void> completed_;
     std::shared_future<void> waiter_;
+
+    // Special frame synchronization based on acquire fence (check AcquireFenceSync documentation)
     AcquireFenceSync acquire_fence_sync_;
+
     ValidationStateTracker &dev_data_;
 };
 

--- a/layers/state_tracker/semaphore_state.h
+++ b/layers/state_tracker/semaphore_state.h
@@ -83,6 +83,7 @@ class Semaphore : public RefcountedStateObject {
     std::shared_ptr<const Semaphore> shared_from_this() const { return SharedFromThisImpl(this); }
     std::shared_ptr<Semaphore> shared_from_this() { return SharedFromThisImpl(this); }
 
+    const VulkanTypedHandle *InUse() const override;
     VkSemaphore VkHandle() const { return handle_.Cast<VkSemaphore>(); }
     enum Scope Scope() const;
 


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8745

before: fence can't be called on VkFence that is in use by VkFence 🥹
> Validation Error: [ VUID-vkDestroyFence-fence-01120 ] | MessageID = 0x5d296248 | vkDestroyFence(): fence can't be called on VkFence 0xf56c9b0000000004[] that is currently in use by VkFence 0xf56c9b0000000004[].
The Vulkan spec states: All queue submission commands that refer to fence must have completed execution (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-vkDestroyFence-fence-01120)

after fix:
> Validation Error: [ VUID-vkDestroyFence-fence-01120 ] | MessageID = 0x5d296248 | vkDestroyFence():  can't be called on VkFence 0xf56c9b0000000004[] that is currently in use by VkQueue 0x25822fafa70[].
The Vulkan spec states: All queue submission commands that refer to fence must have completed execution (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-vkDestroyFence-fence-01120)

