### PR TITLE
tests: Fix enabling extensions in multi draw test

### DIFF
--- a/tests/unit/debug_printf.cpp
+++ b/tests/unit/debug_printf.cpp
@@ -1823,7 +1823,7 @@ TEST_F(NegativeDebugPrintf, ShaderObjectsInt64) {
 TEST_F(NegativeDebugPrintf, ShaderObjectsMultiDraw) {
     AddRequiredExtensions(VK_EXT_SHADER_OBJECT_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
-    AddOptionalExtensions(VK_EXT_MULTI_DRAW_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_MULTI_DRAW_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::shaderObject);
     AddRequiredFeature(vkt::Feature::dynamicRendering);
     AddRequiredFeature(vkt::Feature::multiDraw);


### PR DESCRIPTION
This test would fail if the implementation does not support VK_EXT_multi_draw