### PR TITLE
layers: Add ShaderObject Interface Variable checks

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -764,6 +764,9 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateShaderInterfaceVariablePipeline(const spirv::Module& module_state, const vvl::Pipeline& pipeline,
                                                  const spirv::ResourceInterfaceVariable& variable,
                                                  vvl::unordered_set<uint32_t>& descriptor_type_set, const Location& loc) const;
+    bool ValidateShaderInterfaceVariableShaderObject(const VkShaderCreateInfoEXT& create_info,
+                                                     const spirv::ResourceInterfaceVariable& variable,
+                                                     vvl::unordered_set<uint32_t>& descriptor_type_set, const Location& loc) const;
     bool ValidateShaderInterfaceVariable(const spirv::Module& module_state, const spirv::ResourceInterfaceVariable& variable,
                                          vvl::unordered_set<uint32_t>& descriptor_type_set, const Location& loc) const;
     bool ValidateTransformFeedbackPipeline(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,


### PR DESCRIPTION
Found when adding VUs to https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/7020

Adds the ShaderObject version of 

- VUID-VkGraphicsPipelineCreateInfo-layout-07988
- VUID-VkGraphicsPipelineCreateInfo-layout-07990
- VUID-VkGraphicsPipelineCreateInfo-layout-07991
- UNASSIGNED-VkGraphicsPipelineCreateInfo-layout-inline