### PR TITLE
settings: Fix minor typos in VkLayer_khronos_validation.json.in

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -7,7 +7,7 @@
         "api_version": "1.3.301",
         "implementation_version": "1",
         "description": "Khronos Validation Layer",
-        "introduction": "The main, comprehensive Khronos validation layer.\n\nVulkan is an Explicit API, enabling direct control over how GPUs actually work. By design, minimal error checking is done inside a Vulkan driver. Applications have full control and responsibility for correct operation. Any errors in how Vulkan is used can result in a crash. \n\nThe Khronos Valiation Layer can be enabled to assist development by enabling developers to verify their applications correctly use the Vulkan API.",
+        "introduction": "The main, comprehensive Khronos validation layer.\n\nVulkan is an Explicit API, enabling direct control over how GPUs actually work. By design, minimal error checking is done inside a Vulkan driver. Applications have full control and responsibility for correct operation. Any errors in how Vulkan is used can result in a crash. \n\nThe Khronos Validation Layer can be enabled to assist development by enabling developers to verify their applications correctly use the Vulkan API.",
         "platforms": [
             "WINDOWS",
             "LINUX",
@@ -347,7 +347,7 @@
                         {
                             "key": "unique_handles",
                             "label": "Handle Wrapping",
-                            "description": "Handle wrapping checks. Disable this feature if you are exerience crashes when creating new extensions or developing new Vulkan objects/structures.",
+                            "description": "Handle wrapping checks. Disable this feature if you are experiencing crashes when creating new extensions or developing new Vulkan objects/structures.",
                             "type": "BOOL",
                             "default": true,
                             "status": "STABLE",
@@ -1070,7 +1070,7 @@
                 {
                     "key": "message_id_filter",
                     "label": "Mute Message VUIDs",
-                    "description": "List of VUIDs and VUID identifers which are to be IGNORED by the validation layer",
+                    "description": "List of VUIDs and VUID identifiers which are to be IGNORED by the validation layer",
                     "type": "LIST",
                     "env": "VK_LAYER_MESSAGE_ID_FILTER",
                     "default": []
@@ -1123,7 +1123,7 @@
                         {
                             "key": "VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT",
                             "label": "Handle Wrapping",
-                            "description": "Handle wrapping checks. Disable this feature if you are exerience crashes when creating new extensions or developing new Vulkan objects/structures."
+                            "description": "Handle wrapping checks. Disable this feature if you are experiencing crashes when creating new extensions or developing new Vulkan objects/structures."
                         },
                         {
                             "key": "VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT",


### PR DESCRIPTION
While browsing/modifying this JSON file I spotted a glaring typo in the main layer description, and ended up fixing a few more in the settings descriptions down below.