### PR TITLE
layers: Remove unused ifdef

### DIFF
--- a/layers/containers/subresource_adapter.h
+++ b/layers/containers/subresource_adapter.h
@@ -23,11 +23,7 @@
 #include <vector>
 #include "range_vector.h"
 #include "custom_containers.h"
-#ifndef SPARSE_CONTAINER_UNIT_TEST
 #include "vulkan/vulkan.h"
-#else
-#include "vk_snippets.h"
-#endif
 
 namespace vvl {
 class Image;

--- a/layers/state_tracker/image_layout_map.cpp
+++ b/layers/state_tracker/image_layout_map.cpp
@@ -19,10 +19,8 @@
  *
  */
 #include "state_tracker/image_layout_map.h"
-#ifndef SPARSE_CONTAINER_UNIT_TEST
 #include "state_tracker/image_state.h"
 #include "state_tracker/cmd_buffer_state.h"
-#endif
 
 namespace image_layout_map {
 using InitialLayoutStates = ImageSubresourceLayoutMap::InitialLayoutStates;

--- a/layers/state_tracker/image_layout_map.h
+++ b/layers/state_tracker/image_layout_map.h
@@ -25,7 +25,6 @@
 #include "containers/range_vector.h"
 #include "containers/subresource_adapter.h"
 #include "utils/vk_layer_utils.h"
-#ifndef SPARSE_CONTAINER_UNIT_TEST
 #include "vulkan/vulkan.h"
 #include "error_message/logging.h"
 
@@ -34,7 +33,6 @@ class Image;
 class ImageView;
 class CommandBuffer;
 }  // namespace vvl
-#endif
 
 namespace image_layout_map {
 const static VkImageLayout kInvalidLayout = VK_IMAGE_LAYOUT_MAX_ENUM;


### PR DESCRIPTION
There is no `SPARSE_CONTAINER_UNIT_TEST` or `vk_snippets.h` and I think this is just been left over from years of code churn