### PR TITLE
layers: Change ownership of AcquireFenceSync object

### DIFF
--- a/layers/state_tracker/fence_state.cpp
+++ b/layers/state_tracker/fence_state.cpp
@@ -173,8 +173,3 @@ void vvl::Fence::SetAcquireFenceSync(const AcquireFenceSync &acquire_fence_sync)
 
     acquire_fence_sync_ = acquire_fence_sync;
 }
-
-bool vvl::Fence::IsAcquireFenceSyncSwapchainChanged(const std::shared_ptr<vvl::Swapchain> &current_swapchain) const {
-    auto guard = ReadLock();
-    return acquire_fence_sync_.swapchain != current_swapchain;
-}

--- a/layers/state_tracker/fence_state.h
+++ b/layers/state_tracker/fence_state.h
@@ -49,9 +49,6 @@ class Swapchain;
 struct AcquireFenceSync {
     // The queue submissions that will be notified when WaitForFences is called.
     small_vector<SubmissionReference, 2, uint32_t> submission_refs;
-
-    // The swapchain associated with this synchronization instance.
-    std::shared_ptr<vvl::Swapchain> swapchain;
 };
 
 class Fence : public RefcountedStateObject {
@@ -91,7 +88,6 @@ class Fence : public RefcountedStateObject {
     std::optional<VkExternalFenceHandleTypeFlagBits> ImportedHandleType() const;
 
     void SetAcquireFenceSync(const AcquireFenceSync &acquire_fence_sync);
-    bool IsAcquireFenceSyncSwapchainChanged(const std::shared_ptr<vvl::Swapchain> &current_swapchain) const;
 
     const VkFenceCreateFlags flags;
     const VkExternalFenceHandleTypeFlags export_handle_types;

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -22,6 +22,7 @@
 #include <variant>
 
 #include "state_tracker/device_memory_state.h"
+#include "state_tracker/fence_state.h"
 #include "state_tracker/image_layout_map.h"
 #include "utils/vk_layer_utils.h"
 
@@ -313,6 +314,11 @@ struct SwapchainImage {
     bool acquired = false;
     std::shared_ptr<vvl::Semaphore> acquire_semaphore;
     std::shared_ptr<vvl::Fence> acquire_fence;
+
+    // Each swapchain image keeps information about submissions associated with current present.
+    // When the image is re-acquired later this information can be used to synchronize with
+    // these submissions by using acquire fence.
+    AcquireFenceSync acquire_fence_sync;
 };
 
 // State for VkSwapchainKHR objects.
@@ -346,7 +352,7 @@ class Swapchain : public StateObject {
 
     VkSwapchainKHR VkHandle() const { return handle_.Cast<VkSwapchainKHR>(); }
 
-    void PresentImage(uint32_t image_index, uint64_t present_id);
+    void PresentImage(uint32_t image_index, uint64_t present_id, const AcquireFenceSync &acquire_fence_sync);
 
     void ReleaseImage(uint32_t image_index);
 


### PR DESCRIPTION
`AcquireNextImage` does not necessarily use the same fence with a specific
swapchain image. The previous implementation made this (incorrect) assumption,
and this allowed to use Fence object as the owner of `AcquireFenceSync`.

A better solution is that Present call stores `AcquireFenceSync` in a
swapchain image. When swapchain image is re-acquired, it assigns
`AcquireFenceSync` to a Fence object, if any.

This also removes the need to handle a special case that swapchain can
be re-created, and in that case we had to invalidate `AcquireFenceSync`
stored inside Fence. Now Fence object is automatically associated
with correct swapchain.

Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8880
