### PR TITLE
layers: Replace unassigned VUIDs for ownership transfer

### DIFF
--- a/layers/containers/qfo_transfer.h
+++ b/layers/containers/qfo_transfer.h
@@ -88,8 +88,6 @@ struct QFOImageTransferBarrier : public QFOTransferBarrierBase<VkImage> {
     static const char *DuplicateQFOInSubmit() { return "WARNING-VkImageMemoryBarrier-image-00002"; }
     // QFO transfer image barrier must not duplicate QFO submitted previously
     static const char *DuplicateQFOSubmitted() { return "WARNING-VkImageMemoryBarrier-image-00003"; }
-    // QFO acquire image barrier must have matching QFO release submitted previously
-    static const char *MissingQFOReleaseInSubmit() { return "UNASSIGNED-VkImageMemoryBarrier-image-00004"; }
 };
 
 // Buffer barrier specific implementation
@@ -118,8 +116,6 @@ struct QFOBufferTransferBarrier : public QFOTransferBarrierBase<VkBuffer> {
     static const char *DuplicateQFOInSubmit() { return "WARNING-VkBufferMemoryBarrier-buffer-00002"; }
     // QFO transfer buffer barrier must not duplicate QFO submitted previously
     static const char *DuplicateQFOSubmitted() { return "WARNING-VkBufferMemoryBarrier-buffer-00003"; }
-    // QFO acquire buffer barrier must have matching QFO release submitted previously
-    static const char *MissingQFOReleaseInSubmit() { return "UNASSIGNED-VkBufferMemoryBarrier-buffer-00004"; }
 };
 
 template <typename TransferBarrier>

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -2109,7 +2109,9 @@ bool CoreChecks::ValidateQueuedQFOTransferBarriers(const vvl::CommandBuffer &cb_
             matching_release_found = set_for_handle.find(acquire) != set_for_handle.cend();
         }
         if (!matching_release_found) {
-            skip |= LogError(TransferBarrier::MissingQFOReleaseInSubmit(), cb_state.Handle(), loc,
+            const char *vuid = (loc.function == vvl::Func::vkQueueSubmit) ? "VUID-vkQueueSubmit-pSubmits-02207"
+                                                                          : "VUID-vkQueueSubmit2-commandBuffer-03879";
+            skip |= LogError(vuid, cb_state.Handle(), loc,
                              "in submitted command buffer %s acquiring ownership of %s (%s), from srcQueueFamilyIndex %" PRIu32
                              " to dstQueueFamilyIndex %" PRIu32 " has no matching release barrier queued for execution.",
                              barrier_name, handle_name, FormatHandle(acquire.handle).c_str(), acquire.srcQueueFamilyIndex,

--- a/tests/unit/sync_object.cpp
+++ b/tests/unit/sync_object.cpp
@@ -1324,8 +1324,7 @@ TEST_F(NegativeSyncObject, BarrierQueueFamily2) {
     excl_test("WARNING-VkImageMemoryBarrier-image-00001", "WARNING-VkBufferMemoryBarrier-buffer-00001", submit_family, other_family,
               other_family, BarrierQueueFamilyTestHelper::DOUBLE_RECORD);
     // No pending release
-    excl_test("UNASSIGNED-VkImageMemoryBarrier-image-00004", "UNASSIGNED-VkBufferMemoryBarrier-buffer-00004", submit_family,
-              other_family, other_family);
+    excl_test("VUID-vkQueueSubmit-pSubmits-02207", "VUID-vkQueueSubmit-pSubmits-02207", submit_family, other_family, other_family);
     // Duplicate release in two CB
     excl_test("WARNING-VkImageMemoryBarrier-image-00002", "WARNING-VkBufferMemoryBarrier-buffer-00002", submit_family, other_family,
               submit_family, BarrierQueueFamilyTestHelper::DOUBLE_COMMAND_BUFFER);


### PR DESCRIPTION
This specifies proper VUIDs. I did not check if there are any issues with how corresponding validation is implemented (regarding CTS hitting this).

Initiated by https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8902
