### PR TITLE
layers: 1.3.302 VU Churn

### DIFF
--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -1139,10 +1139,11 @@ bool CoreChecks::ValidateDrawDynamicState(const LastBound& last_bound_state, con
                     }
                 }
             }
-            if (!location_provided) {
+            if (!location_provided && !enabled_features.vertexAttributeRobustness) {
                 skip |= LogError(vuid.vertex_input_format_07939, vert_spirv_state->handle(), vuid.loc(),
                                  "Vertex shader uses input at location %" PRIu32
-                                 ", but it was not provided with vkCmdSetVertexInputEXT().",
+                                 ", but it was not provided with vkCmdSetVertexInputEXT(). (This can be valid if "
+                                 "vertexAttributeRobustness feature is enabled)",
                                  variable_ptr->decorations.location);
             }
         }

--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -1500,9 +1500,8 @@ bool CoreChecks::ValidateDrawDynamicStateShaderObject(const LastBound& last_boun
     if (tessev_shader_bound) {
         if (cb_state.IsDynamicStateSet(CB_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY) &&
             cb_state.dynamic_state_value.primitive_topology != VK_PRIMITIVE_TOPOLOGY_PATCH_LIST) {
-            // VUID - https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/6981
             skip |= LogError(
-                "UNASSIGNED-vkCmdDraw-None-topology", cb_state.Handle(), loc,
+                vuid.primitive_topology_patch_list_10286, cb_state.Handle(), loc,
                 "Tessellation shaders were bound, but the last call to vkCmdSetPrimitiveTopology set primitiveTopology to %s.",
                 string_VkPrimitiveTopology(cb_state.dynamic_state_value.primitive_topology));
         }

--- a/layers/core_checks/cc_device.cpp
+++ b/layers/core_checks/cc_device.cpp
@@ -807,10 +807,6 @@ bool CoreChecks::ValidateDeviceQueueSupport(const Location &loc) const {
             vuid = "VUID-vkCreateEvent-device-09672";
             flags = VK_QUEUE_VIDEO_ENCODE_BIT_KHR | VK_QUEUE_VIDEO_DECODE_BIT_KHR | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_GRAPHICS_BIT;
             break;
-        case Func::vkCreateShadersEXT:
-            vuid = "VUID-vkCreateShadersEXT-device-09669";
-            flags = VK_QUEUE_COMPUTE_BIT | VK_QUEUE_GRAPHICS_BIT;
-            break;
         case Func::vkCreateRenderPass:
             vuid = "VUID-vkCreateRenderPass-device-10000";
             flags = VK_QUEUE_GRAPHICS_BIT;

--- a/layers/core_checks/cc_shader_interface.cpp
+++ b/layers/core_checks/cc_shader_interface.cpp
@@ -108,10 +108,14 @@ bool CoreChecks::ValidateInterfaceVertexInput(const vvl::Pipeline &pipeline, con
             skip |= LogPerformanceWarning("WARNING-Shader-OutputNotConsumed", module_state.handle(), vi_loc,
                                           "Vertex attribute at location %" PRIu32 " not consumed by vertex shader.", location);
         } else if (!attribute_input && shader_input) {
-            skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-Input-07904", module_state.handle(),
-                             vi_loc.dot(Field::pVertexAttributeDescriptions),
-                             "does not have a Location %" PRIu32 " but vertex shader has an input variable at that Location.",
-                             location);
+            if (!enabled_features.vertexAttributeRobustness) {
+                skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-Input-07904", module_state.handle(),
+                                 vi_loc.dot(Field::pVertexAttributeDescriptions),
+                                 "does not have a Location %" PRIu32
+                                 " but vertex shader has an input variable at that Location. (This can be valid if "
+                                 "vertexAttributeRobustness feature is enabled)",
+                                 location);
+            }
         } else if (attribute_input && shader_input) {
             const VkFormat attribute_format = *attribute_input;
             const uint32_t attribute_type = spirv::GetFormatType(attribute_format);

--- a/layers/core_checks/cc_shader_object.cpp
+++ b/layers/core_checks/cc_shader_object.cpp
@@ -396,9 +396,9 @@ bool CoreChecks::PreCallValidateCreateShadersEXT(VkDevice device, uint32_t creat
                          string_SpvExecutionMode(tesc_linked_spacing), string_SpvExecutionMode(tese_linked_spacing));
     }
 
-    skip |= ValidateDeviceQueueSupport(error_obj.location);  // check if compute or graphics
     const VkQueueFlags queue_flag = has_compute ? VK_QUEUE_COMPUTE_BIT : VK_QUEUE_GRAPHICS_BIT;
     if ((physical_device_state->supported_queues & queue_flag) == 0) {
+        // Used instead of calling ValidateDeviceQueueSupport()
         const char* vuid = has_compute ? "VUID-vkCreateShadersEXT-stage-09670" : "VUID-vkCreateShadersEXT-stage-09671";
         skip |=
             LogError(vuid, device, error_obj.location, "device only supports (%s) but require %s.",

--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -1982,30 +1982,30 @@ bool CoreChecks::ValidateShaderInterfaceVariableShaderObject(const VkShaderCreat
     // VUIDs being added in https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/7020
 
     if (!binding) {
-        skip |= LogError("VUID-VkShaderCreateInfoEXT-pSetLayouts-stage", device, loc,
+        skip |= LogError("UNASSIGNED-VkShaderCreateInfoEXT-pSetLayouts-stage", device, loc,
                          "SPIR-V (%s) uses descriptor %s (type %s) but was not declared in pSetLayouts[%" PRIu32 "].",
                          string_VkShaderStageFlagBits(variable.stage), variable.DescribeDescriptor().c_str(),
                          string_DescriptorTypeSet(descriptor_type_set).c_str(), set);
     } else if (~binding->stageFlags & variable.stage) {
         skip |=
-            LogError("VUID-VkShaderCreateInfoEXT-pSetLayouts-stage", device, loc,
+            LogError("UNASSIGNED-VkShaderCreateInfoEXT-pSetLayouts-stage", device, loc,
                      "SPIR-V (%s) uses descriptor %s (type %s) but the VkDescriptorSetLayoutBinding::stageFlags was %s.",
                      string_VkShaderStageFlagBits(variable.stage), variable.DescribeDescriptor().c_str(),
                      string_DescriptorTypeSet(descriptor_type_set).c_str(), string_VkShaderStageFlags(binding->stageFlags).c_str());
     } else if ((binding->descriptorType != VK_DESCRIPTOR_TYPE_MUTABLE_EXT) &&
                (descriptor_type_set.find(binding->descriptorType) == descriptor_type_set.end())) {
-        skip |= LogError("VUID-VkShaderCreateInfoEXT-pSetLayouts-mutable", device, loc,
+        skip |= LogError("UNASSIGNED-VkShaderCreateInfoEXT-pSetLayouts-mutable", device, loc,
                          "SPIR-V (%s) uses descriptor %s of type %s but expected %s.", string_VkShaderStageFlagBits(variable.stage),
                          variable.DescribeDescriptor().c_str(), string_VkDescriptorType(binding->descriptorType),
                          string_DescriptorTypeSet(descriptor_type_set).c_str());
     } else if (binding->descriptorType == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK && variable.array_length) {
         skip |=
-            LogError("VUID-VkShaderCreateInfoEXT-pSetLayouts-inline", device, loc,
+            LogError("UNASSIGNED-VkShaderCreateInfoEXT-pSetLayouts-inline", device, loc,
                      "SPIR-V (%s) uses descriptor %s as VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK, but it is an array of descriptor.",
                      string_VkShaderStageFlagBits(variable.stage), variable.DescribeDescriptor().c_str());
 
     } else if (binding->descriptorCount < variable.array_length && variable.array_length != spirv::kRuntimeArray) {
-        skip |= LogError("VUID-VkShaderCreateInfoEXT-pSetLayouts-descriptorCount", device, loc,
+        skip |= LogError("UNASSIGNED-VkShaderCreateInfoEXT-pSetLayouts-descriptorCount", device, loc,
                          "SPIR-V (%s) uses descriptor %s with a VkDescriptorSetLayoutBinding::descriptorCount of %" PRIu32
                          ", but requires at least %" PRIu32 " in the SPIR-V.",
                          string_VkShaderStageFlagBits(variable.stage), variable.DescribeDescriptor().c_str(),

--- a/layers/drawdispatch/drawdispatch_vuids.cpp
+++ b/layers/drawdispatch/drawdispatch_vuids.cpp
@@ -43,6 +43,7 @@ struct DispatchVuidsCmdDraw : DrawDispatchVuid {
         scissor_count_03418                      = "VUID-vkCmdDraw-scissorCount-03418";
         viewport_scissor_count_03419             = "VUID-vkCmdDraw-viewportCount-03419";
         primitive_topology_class_07500           = "VUID-vkCmdDraw-dynamicPrimitiveTopologyUnrestricted-07500";
+        primitive_topology_patch_list_10286      = "VUID-vkCmdDraw-primitiveTopology-10286";
         corner_sampled_address_mode_02696        = "VUID-vkCmdDraw-flags-02696";
         imageview_atomic_02691                   = "VUID-vkCmdDraw-None-02691";
         bufferview_atomic_07888                  = "VUID-vkCmdDraw-None-07888";
@@ -310,6 +311,7 @@ struct DispatchVuidsCmdDrawMultiEXT : DrawDispatchVuid {
         scissor_count_03418                      = "VUID-vkCmdDrawMultiEXT-scissorCount-03418";
         viewport_scissor_count_03419             = "VUID-vkCmdDrawMultiEXT-viewportCount-03419";
         primitive_topology_class_07500           = "VUID-vkCmdDrawMultiEXT-dynamicPrimitiveTopologyUnrestricted-07500";
+        primitive_topology_patch_list_10286      = "VUID-vkCmdDrawMultiEXT-primitiveTopology-10286";
         corner_sampled_address_mode_02696        = "VUID-vkCmdDrawMultiEXT-flags-02696";
         imageview_atomic_02691                   = "VUID-vkCmdDrawMultiEXT-None-02691";
         bufferview_atomic_07888                  = "VUID-vkCmdDrawMultiEXT-None-07888";
@@ -578,6 +580,7 @@ struct DispatchVuidsCmdDrawIndexed : DrawDispatchVuid {
         scissor_count_03418                      = "VUID-vkCmdDrawIndexed-scissorCount-03418";
         viewport_scissor_count_03419             = "VUID-vkCmdDrawIndexed-viewportCount-03419";
         primitive_topology_class_07500           = "VUID-vkCmdDrawIndexed-dynamicPrimitiveTopologyUnrestricted-07500";
+        primitive_topology_patch_list_10286      = "VUID-vkCmdDrawIndexed-primitiveTopology-10286";
         corner_sampled_address_mode_02696        = "VUID-vkCmdDrawIndexed-flags-02696";
         imageview_atomic_02691                   = "VUID-vkCmdDrawIndexed-None-02691";
         bufferview_atomic_07888                  = "VUID-vkCmdDrawIndexed-None-07888";
@@ -846,6 +849,7 @@ struct DispatchVuidsCmdDrawMultiIndexedEXT : DrawDispatchVuid {
         scissor_count_03418                      = "VUID-vkCmdDrawMultiIndexedEXT-scissorCount-03418";
         viewport_scissor_count_03419             = "VUID-vkCmdDrawMultiIndexedEXT-viewportCount-03419";
         primitive_topology_class_07500           = "VUID-vkCmdDrawMultiIndexedEXT-dynamicPrimitiveTopologyUnrestricted-07500";
+        primitive_topology_patch_list_10286      = "VUID-vkCmdDrawMultiIndexedEXT-primitiveTopology-10286";
         corner_sampled_address_mode_02696        = "VUID-vkCmdDrawMultiIndexedEXT-flags-02696";
         imageview_atomic_02691                   = "VUID-vkCmdDrawMultiIndexedEXT-None-02691";
         bufferview_atomic_07888                  = "VUID-vkCmdDrawMultiIndexedEXT-None-07888";
@@ -1116,6 +1120,7 @@ struct DispatchVuidsCmdDrawIndirect : DrawDispatchVuid {
         scissor_count_03418                      = "VUID-vkCmdDrawIndirect-scissorCount-03418";
         viewport_scissor_count_03419             = "VUID-vkCmdDrawIndirect-viewportCount-03419";
         primitive_topology_class_07500           = "VUID-vkCmdDrawIndirect-dynamicPrimitiveTopologyUnrestricted-07500";
+        primitive_topology_patch_list_10286      = "VUID-vkCmdDrawIndirect-primitiveTopology-10286";
         corner_sampled_address_mode_02696        = "VUID-vkCmdDrawIndirect-flags-02696";
         imageview_atomic_02691                   = "VUID-vkCmdDrawIndirect-None-02691";
         bufferview_atomic_07888                  = "VUID-vkCmdDrawIndirect-None-07888";
@@ -1383,6 +1388,7 @@ struct DispatchVuidsCmdDrawIndexedIndirect : DrawDispatchVuid {
         scissor_count_03418                      = "VUID-vkCmdDrawIndexedIndirect-scissorCount-03418";
         viewport_scissor_count_03419             = "VUID-vkCmdDrawIndexedIndirect-viewportCount-03419";
         primitive_topology_class_07500           = "VUID-vkCmdDrawIndexedIndirect-dynamicPrimitiveTopologyUnrestricted-07500";
+        primitive_topology_patch_list_10286      = "VUID-vkCmdDrawIndexedIndirect-primitiveTopology-10286";
         corner_sampled_address_mode_02696        = "VUID-vkCmdDrawIndexedIndirect-flags-02696";
         imageview_atomic_02691                   = "VUID-vkCmdDrawIndexedIndirect-None-02691";
         bufferview_atomic_07888                  = "VUID-vkCmdDrawIndexedIndirect-None-07888";
@@ -1749,6 +1755,7 @@ struct DispatchVuidsCmdDrawIndirectCount : DrawDispatchVuid {
         scissor_count_03418                      = "VUID-vkCmdDrawIndirectCount-scissorCount-03418";
         viewport_scissor_count_03419             = "VUID-vkCmdDrawIndirectCount-viewportCount-03419";
         primitive_topology_class_07500           = "VUID-vkCmdDrawIndirectCount-dynamicPrimitiveTopologyUnrestricted-07500";
+        primitive_topology_patch_list_10286      = "VUID-vkCmdDrawIndirectCount-primitiveTopology-10286";
         corner_sampled_address_mode_02696        = "VUID-vkCmdDrawIndirectCount-flags-02696";
         imageview_atomic_02691                   = "VUID-vkCmdDrawIndirectCount-None-02691";
         bufferview_atomic_07888                  = "VUID-vkCmdDrawIndirectCount-None-07888";
@@ -2019,6 +2026,7 @@ struct DispatchVuidsCmdDrawIndexedIndirectCount : DrawDispatchVuid {
         scissor_count_03418                      = "VUID-vkCmdDrawIndexedIndirectCount-scissorCount-03418";
         viewport_scissor_count_03419             = "VUID-vkCmdDrawIndexedIndirectCount-viewportCount-03419";
         primitive_topology_class_07500           = "VUID-vkCmdDrawIndexedIndirectCount-dynamicPrimitiveTopologyUnrestricted-07500";
+        primitive_topology_patch_list_10286      = "VUID-vkCmdDrawIndexedIndirectCount-primitiveTopology-10286";
         corner_sampled_address_mode_02696        = "VUID-vkCmdDrawIndexedIndirectCount-flags-02696";
         imageview_atomic_02691                   = "VUID-vkCmdDrawIndexedIndirectCount-None-02691";
         bufferview_atomic_07888                  = "VUID-vkCmdDrawIndexedIndirectCount-None-07888";
@@ -3999,6 +4007,7 @@ struct DispatchVuidsCmdDrawIndirectByteCountEXT: DrawDispatchVuid {
         scissor_count_03418                      = "VUID-vkCmdDrawIndirectByteCountEXT-scissorCount-03418";
         viewport_scissor_count_03419             = "VUID-vkCmdDrawIndirectByteCountEXT-viewportCount-03419";
         primitive_topology_class_07500           = "VUID-vkCmdDrawIndirectByteCountEXT-dynamicPrimitiveTopologyUnrestricted-07500";
+        primitive_topology_patch_list_10286      = "VUID-vkCmdDrawIndirectByteCountEXT-primitiveTopology-10286";
         corner_sampled_address_mode_02696        = "VUID-vkCmdDrawIndirectByteCountEXT-flags-02696";
         imageview_atomic_02691                   = "VUID-vkCmdDrawIndirectByteCountEXT-None-02691";
         bufferview_atomic_07888                  = "VUID-vkCmdDrawIndirectByteCountEXT-None-07888";

--- a/layers/drawdispatch/drawdispatch_vuids.h
+++ b/layers/drawdispatch/drawdispatch_vuids.h
@@ -56,6 +56,7 @@ struct DrawDispatchVuid {
     const char* scissor_count_03418 = kVUIDUndefined;
     const char* viewport_scissor_count_03419 = kVUIDUndefined;
     const char* primitive_topology_class_07500 = kVUIDUndefined;
+    const char* primitive_topology_patch_list_10286 = kVUIDUndefined;
     const char* corner_sampled_address_mode_02696 = kVUIDUndefined;
     const char* imageview_atomic_02691 = kVUIDUndefined;
     const char* bufferview_atomic_07888 = kVUIDUndefined;

--- a/layers/stateless/sl_ray_tracing.cpp
+++ b/layers/stateless/sl_ray_tracing.cpp
@@ -1874,13 +1874,11 @@ bool StatelessValidation::manual_PreCallValidateDestroyMicromapEXT(
     const VkAllocationCallbacks*                pAllocator, const ErrorObject& error_obj) const {
     bool skip = false;
 
-    // XXX Spec doesn't actually require the feature right now (oversight)
-
-    //if (!enabled_features.micromap) {
-    //    skip |= LogError("VUID-vkCreateMicromapEXT-micromap-NNNN", device,
-    //        error_obj.location, "micromap feature was not enabled.");
-    //}
-
+    if (!enabled_features.micromapHostCommands) {
+        // Adding in https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/7023
+        skip |= LogError("UNASSIGNED-vkDestroyMicromapEXT-micromapHostCommands-feature", device, error_obj.location,
+                         "micromapHostCommands feature was not enabled.");
+    }
 
     return skip;
 }
@@ -1945,8 +1943,8 @@ bool StatelessValidation::manual_PreCallValidateCopyMicromapEXT(
     bool skip = false;
 
     if (!enabled_features.micromapHostCommands) {
-        skip |= LogError("VUID-vkBuildMicromapsEXT-micromapHostCommands-07560", device,
-            error_obj.location, "micromapHostCommands feature was not enabled.");
+        skip |= LogError("VUID-vkCopyMicromapEXT-micromapHostCommands-07560", device, error_obj.location,
+                         "micromapHostCommands feature was not enabled.");
     }
 
     const Location info_loc = error_obj.location.dot(Field::pInfo);
@@ -1966,8 +1964,8 @@ bool StatelessValidation::manual_PreCallValidateCopyMicromapToMemoryEXT(
     bool skip = false;
 
     if (!enabled_features.micromapHostCommands) {
-        skip |= LogError("VUID-vkBuildMicromapsEXT-micromapHostCommands-07571", device,
-            error_obj.location, "micromapHostCommands feature was not enabled.");
+        skip |= LogError("VUID-vkCopyMicromapToMemoryEXT-micromapHostCommands-07571", device, error_obj.location,
+                         "micromapHostCommands feature was not enabled.");
     }
 
     const Location info_loc = error_obj.location.dot(Field::pInfo);
@@ -1986,14 +1984,14 @@ bool StatelessValidation::manual_PreCallValidateCopyMemoryToMicromapEXT(
     bool skip = false;
 
     if (!enabled_features.micromapHostCommands) {
-        skip |= LogError("VUID-vkBuildMicromapsEXT-micromapHostCommands-07560", device,
-            error_obj.location, "micromapHostCommands feature was not enabled.");
+        skip |= LogError("VUID-vkCopyMemoryToMicromapEXT-micromapHostCommands-07566", device, error_obj.location,
+                         "micromapHostCommands feature was not enabled.");
     }
 
     const Location info_loc = error_obj.location.dot(Field::pInfo);
     if (pInfo->mode != VK_COPY_MICROMAP_MODE_DESERIALIZE_EXT) {
-        skip |= LogError("UID-VkCopyMemoryToMicromapInfoEXT-mode-07548", device, info_loc.dot(Field::mode), "is %s.",
-            string_VkCopyMicromapModeEXT(pInfo->mode));
+        skip |= LogError("VUID-VkCopyMemoryToMicromapInfoEXT-mode-07548", device, info_loc.dot(Field::mode), "is %s.",
+                         string_VkCopyMicromapModeEXT(pInfo->mode));
     }
 
     return skip;
@@ -2104,11 +2102,11 @@ bool StatelessValidation::manual_PreCallValidateGetMicromapBuildSizesEXT(
         skip |= LogError("VUID-vkGetMicromapBuildSizesEXT-micromap-07439", device,
             error_obj.location, "micromap feature was not enabled.");
     }
-    
+
     if (pBuildInfo->pUsageCounts && pBuildInfo->ppUsageCounts) {
         skip |= LogError("VUID-VkMicromapBuildInfoEXT-pUsageCounts-07516", device, error_obj.location,
             "both pUsageCounts and ppUsageCounts are not NULL.");
     }
-    
+
     return skip;
 }

--- a/scripts/generate_spec_error_message.py
+++ b/scripts/generate_spec_error_message.py
@@ -67,6 +67,7 @@ class ValidationJSON:
             '\u230b' : ')', # RIGHT FLOOR (⌋)
             '\u00d7' : 'x', # MULTIPLICATION SIGN (×)
             '\u2264' : '<=', # LESS-THAN OR EQUAL TO (≤)
+            '\u2208' : 'E', # ELEMENT OF (∈)
         }
 
     def sanitize(self, text, location):

--- a/tests/device_profiles/max_profile.json
+++ b/tests/device_profiles/max_profile.json
@@ -267,6 +267,9 @@
                     "vertexAttributeInstanceRateDivisor": true,
                     "vertexAttributeInstanceRateZeroDivisor": true
                 },
+                "VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT": {
+                    "vertexAttributeRobustness": true
+                },
                 "VkPhysicalDeviceASTCDecodeFeaturesEXT": {
                     "decodeModeSharedExponent": true
                 },
@@ -2064,6 +2067,7 @@
                 "VK_EXT_vertex_attribute_divisor": 1,
                 "VK_KHR_vertex_attribute_divisor": 1,
                 "VK_EXT_vertex_input_dynamic_state": 1,
+                "VK_EXT_vertex_attribute_robustness": 1,
                 "VK_EXT_video_encode_h264": 1,
                 "VK_EXT_video_encode_h265": 1,
                 "VK_EXT_ycbcr_2plane_444_formats": 1,

--- a/tests/unit/ray_tracing_positive.cpp
+++ b/tests/unit/ray_tracing_positive.cpp
@@ -1276,10 +1276,11 @@ TEST_F(PositiveRayTracing, BasicOpacityMicromapBuild) {
     AddRequiredFeature(vkt::Feature::synchronization2);
     AddRequiredFeature(vkt::Feature::rayTracingPipeline);
     AddRequiredFeature(vkt::Feature::micromap);
+    AddRequiredFeature(vkt::Feature::micromapHostCommands);
 
     RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
     RETURN_IF_SKIP(InitState());
-    
+
     if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
@@ -1410,7 +1411,7 @@ TEST_F(PositiveRayTracing, BasicOpacityMicromapBuild) {
     vkt::Buffer vertexBuffer(*m_device, sizeof(vertexData) + sizeof(indexData),
         VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT, vkt::device_address);
 
-    VkDeviceAddress vertexAddress = vertexBuffer.Address(); 
+    VkDeviceAddress vertexAddress = vertexBuffer.Address();
 
     // Upload data to the vertex buffer.
     {
@@ -1487,7 +1488,7 @@ TEST_F(PositiveRayTracing, BasicOpacityMicromapBuild) {
     vkt::Buffer instanceBuffer(*m_device, 2 * sizeof(VkAccelerationStructureInstanceKHR),
         VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT, vkt::device_address);
 
-    VkDeviceAddress instanceAddress = instanceBuffer.Address(); 
+    VkDeviceAddress instanceAddress = instanceBuffer.Address();
 
     {
         VkAccelerationStructureInstanceKHR* instance = (VkAccelerationStructureInstanceKHR*)instanceBuffer.Memory().Map();
@@ -1554,7 +1555,7 @@ TEST_F(PositiveRayTracing, BasicOpacityMicromapBuild) {
     asCreateInfo.createFlags = 0;
     asCreateInfo.buffer = topASBuffer;
     asCreateInfo.offset = 0;
-    asCreateInfo.size = topASBuildSizesInfo.accelerationStructureSize; 
+    asCreateInfo.size = topASBuildSizesInfo.accelerationStructureSize;
     asCreateInfo.type = VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR;
     asCreateInfo.deviceAddress = 0;
 

--- a/tests/unit/shader_object.cpp
+++ b/tests/unit/shader_object.cpp
@@ -7011,7 +7011,7 @@ TEST_F(NegativeShaderObject, SetPrimitiveTopologyNonPatch) {
                                    fragShader.handle()};
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 5u, stages, shaders);
     vk::CmdSetPrimitiveTopologyEXT(m_command_buffer.handle(), VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST);
-    m_errorMonitor->SetDesiredError("UNASSIGNED-vkCmdDraw-None-topology");
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-primitiveTopology-10286");
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_errorMonitor->VerifyFound();
 
@@ -7037,7 +7037,7 @@ TEST_F(NegativeShaderObject, DescriptorWrongStage) {
         }
     )glsl";
 
-    m_errorMonitor->SetDesiredError("VUID-VkShaderCreateInfoEXT-pSetLayouts-stage");
+    m_errorMonitor->SetDesiredError("UNASSIGNED-VkShaderCreateInfoEXT-pSetLayouts-stage");
     const vkt::Shader comp_shader(*m_device, VK_SHADER_STAGE_COMPUTE_BIT, GLSLToSPV(VK_SHADER_STAGE_COMPUTE_BIT, comp_src),
                                   &descriptor_set.layout_.handle());
     m_errorMonitor->VerifyFound();
@@ -7061,7 +7061,7 @@ TEST_F(NegativeShaderObject, DescriptorWrongStageMultipleBindings) {
         }
     )glsl";
 
-    m_errorMonitor->SetDesiredError("VUID-VkShaderCreateInfoEXT-pSetLayouts-stage");
+    m_errorMonitor->SetDesiredError("UNASSIGNED-VkShaderCreateInfoEXT-pSetLayouts-stage");
     const vkt::Shader comp_shader(*m_device, VK_SHADER_STAGE_COMPUTE_BIT, GLSLToSPV(VK_SHADER_STAGE_COMPUTE_BIT, comp_src),
                                   &descriptor_set.layout_.handle());
     m_errorMonitor->VerifyFound();
@@ -7090,7 +7090,7 @@ TEST_F(NegativeShaderObject, DescriptorWrongStageMultipleSets) {
     VkDescriptorSetLayout dsl[3] = {descriptor_set0.layout_.handle(), descriptor_set1.layout_.handle(),
                                     descriptor_set2.layout_.handle()};
     VkShaderCreateInfoEXT create_info = ShaderCreateInfo(comp_spv, VK_SHADER_STAGE_COMPUTE_BIT, 3, dsl);
-    m_errorMonitor->SetDesiredError("VUID-VkShaderCreateInfoEXT-pSetLayouts-stage");
+    m_errorMonitor->SetDesiredError("UNASSIGNED-VkShaderCreateInfoEXT-pSetLayouts-stage");
     const vkt::Shader comp_shader(*m_device, create_info);
     m_errorMonitor->VerifyFound();
 }
@@ -7106,7 +7106,7 @@ TEST_F(NegativeShaderObject, DescriptorNotProvided) {
         }
     )glsl";
 
-    m_errorMonitor->SetDesiredError("VUID-VkShaderCreateInfoEXT-pSetLayouts-stage");
+    m_errorMonitor->SetDesiredError("UNASSIGNED-VkShaderCreateInfoEXT-pSetLayouts-stage");
     const vkt::Shader comp_shader(*m_device, VK_SHADER_STAGE_COMPUTE_BIT, GLSLToSPV(VK_SHADER_STAGE_COMPUTE_BIT, comp_src));
     m_errorMonitor->VerifyFound();
 }
@@ -7123,7 +7123,7 @@ TEST_F(NegativeShaderObject, DescriptorTypeMismatch) {
     )glsl";
 
     OneOffDescriptorSet descriptor_set(m_device, {{0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr}});
-    m_errorMonitor->SetDesiredError("VUID-VkShaderCreateInfoEXT-pSetLayouts-mutable");
+    m_errorMonitor->SetDesiredError("UNASSIGNED-VkShaderCreateInfoEXT-pSetLayouts-mutable");
     const vkt::Shader comp_shader(*m_device, VK_SHADER_STAGE_COMPUTE_BIT, GLSLToSPV(VK_SHADER_STAGE_COMPUTE_BIT, comp_src),
                                   &descriptor_set.layout_.handle());
     m_errorMonitor->VerifyFound();
@@ -7141,7 +7141,7 @@ TEST_F(NegativeShaderObject, DescriptorCount) {
     )glsl";
 
     OneOffDescriptorSet descriptor_set(m_device, {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 2, VK_SHADER_STAGE_ALL, nullptr}});
-    m_errorMonitor->SetDesiredError("VUID-VkShaderCreateInfoEXT-pSetLayouts-descriptorCount");
+    m_errorMonitor->SetDesiredError("UNASSIGNED-VkShaderCreateInfoEXT-pSetLayouts-descriptorCount");
     const vkt::Shader comp_shader(*m_device, VK_SHADER_STAGE_COMPUTE_BIT, GLSLToSPV(VK_SHADER_STAGE_COMPUTE_BIT, comp_src),
                                   &descriptor_set.layout_.handle());
     m_errorMonitor->VerifyFound();
@@ -7171,7 +7171,7 @@ TEST_F(NegativeShaderObject, InlineUniformBlockArray) {
                                        },
                                        0, nullptr, 0, nullptr, &pool_inline_info);
 
-    m_errorMonitor->SetDesiredError("VUID-VkShaderCreateInfoEXT-pSetLayouts-inline");
+    m_errorMonitor->SetDesiredError("UNASSIGNED-VkShaderCreateInfoEXT-pSetLayouts-inline");
     const vkt::Shader comp_shader(*m_device, VK_SHADER_STAGE_COMPUTE_BIT, GLSLToSPV(VK_SHADER_STAGE_COMPUTE_BIT, comp_src),
                                   &descriptor_set.layout_.handle());
     m_errorMonitor->VerifyFound();


### PR DESCRIPTION
Fixes for
- VUID-vkCmdDraw-primitiveTopology-10286
- VUID-VkDeviceCreateInfo-robustBufferAccess-10247
- VUID-vkCreateShadersEXT-device-09669

also [VK_EXT_vertex_attribute_robustness](https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/6992)
- VUID-vkCmdDraw-Input-07939
- VUID-VkGraphicsPipelineCreateInfo-Input-07904
