### PR TITLE
layers: Add PushConstantRange check for ShaderObjects

### DIFF
--- a/layers/stateless/sl_shader_object.cpp
+++ b/layers/stateless/sl_shader_object.cpp
@@ -1,5 +1,5 @@
-/* Copyright (c) 2023 Nintendo
- * Copyright (c) 2023 LunarG, Inc.
+/* Copyright (c) 2023-2024 Nintendo
+ * Copyright (c) 2023-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -143,6 +143,8 @@ bool StatelessValidation::manual_PreCallValidateCreateShadersEXT(VkDevice device
                              "is %s, but stage is %s.", string_VkShaderCreateFlagsEXT(createInfo.flags).c_str(),
                              string_VkShaderStageFlagBits(createInfo.stage));
         }
+
+        skip |= ValidatePushConstantRange(createInfo.pushConstantRangeCount, createInfo.pPushConstantRanges, create_info_loc);
     }
 
     return skip;

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -452,6 +452,8 @@ class StatelessValidation : public ValidationObject {
     bool manual_PreCallValidateCreatePipelineLayout(VkDevice device, const VkPipelineLayoutCreateInfo *pCreateInfo,
                                                     const VkAllocationCallbacks *pAllocator, VkPipelineLayout *pPipelineLayout,
                                                     const ErrorObject &error_obj) const;
+    bool ValidatePushConstantRange(uint32_t push_constant_range_count, const VkPushConstantRange *push_constant_ranges,
+                                   const Location &loc) const;
 
     bool ValidatePipelineShaderStageCreateInfoCommon(const VkPipelineShaderStageCreateInfo &create_info, const Location &loc) const;
     bool ValidatePipelineBinaryInfo(const void *next, VkPipelineCreateFlags flags, VkPipelineCache pipelineCache,

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -907,6 +907,7 @@ class ShaderModule : public internal::NonDispHandle<VkShaderModule> {
 
 class Shader : public internal::NonDispHandle<VkShaderEXT> {
   public:
+    Shader() = default;
     Shader(const Device &dev, const VkShaderCreateInfoEXT &info) { init(dev, info); }
     Shader(const Device &dev, const VkShaderStageFlagBits stage, const std::vector<uint32_t> &spv,
            const VkDescriptorSetLayout *descriptorSetLayout = nullptr, const VkPushConstantRange *pushConstRange = nullptr);


### PR DESCRIPTION
Part of https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8737

We were not validating `VkPushConstantRange` for Shader Objects before