### PR TITLE
Add a missing #include <string_view>

### DIFF
--- a/layers/utils/hash_util.h
+++ b/layers/utils/hash_util.h
@@ -22,6 +22,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <string_view>
 #include <type_traits>
 #include <vector>
 #include "containers/custom_containers.h"


### PR DESCRIPTION
This PR adds a missing #include <string_view> to allow compiling
with LLVM 20 + libc++

#include <string_view> is necessary to use std::string_view.
Previously it would be provided transitively by another header,
but starting with LLVM 20 the code will break.