### PR TITLE
layers: Rename LastBound::PER_SET

### DIFF
--- a/layers/best_practices/bp_drawdispatch.cpp
+++ b/layers/best_practices/bp_drawdispatch.cpp
@@ -594,9 +594,9 @@ void BestPractices::ValidateBoundDescriptorSets(bp_state::CommandBuffer& cb_stat
     auto lvl_bind_point = ConvertToLvlBindPoint(bind_point);
     auto& last_bound = cb_state.lastBound[lvl_bind_point];
 
-    for (const auto& descriptor_set : last_bound.per_set) {
-        if (!descriptor_set.bound_descriptor_set) continue;
-        for (const auto& binding : *descriptor_set.bound_descriptor_set) {
+    for (const auto& ds_slot : last_bound.ds_slots) {
+        if (!ds_slot.ds_state) continue;
+        for (const auto& binding : *ds_slot.ds_state) {
             // For bindless scenarios, we should not attempt to track descriptor set state.
             // It is highly uncertain which resources are actually bound.
             // Resources which are written to such a descriptor should be marked as indeterminate w.r.t. state.

--- a/layers/gpu/cmd_validation/gpuav_cmd_validation_common.cpp
+++ b/layers/gpu/cmd_validation/gpuav_cmd_validation_common.cpp
@@ -63,15 +63,15 @@ void RestorablePipelineState::Create(vvl::CommandBuffer &cb_state, VkPipelineBin
 
     push_constants_data_ = cb_state.push_constant_data_chunks;
 
-    descriptor_sets_.reserve(last_bound.per_set.size());
-    for (std::size_t set_i = 0; set_i < last_bound.per_set.size(); set_i++) {
-        const auto &bound_descriptor_set = last_bound.per_set[set_i].bound_descriptor_set;
+    descriptor_sets_.reserve(last_bound.ds_slots.size());
+    for (std::size_t set_i = 0; set_i < last_bound.ds_slots.size(); set_i++) {
+        const auto &bound_descriptor_set = last_bound.ds_slots[set_i].ds_state;
         if (bound_descriptor_set) {
             descriptor_sets_.emplace_back(bound_descriptor_set->VkHandle(), static_cast<uint32_t>(set_i));
             if (bound_descriptor_set->IsPushDescriptor()) {
                 push_descriptor_set_index_ = static_cast<uint32_t>(set_i);
             }
-            dynamic_offsets_.push_back(last_bound.per_set[set_i].dynamicOffsets);
+            dynamic_offsets_.push_back(last_bound.ds_slots[set_i].dynamic_offsets);
         }
     }
 

--- a/layers/gpu/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpu/instrumentation/gpuav_instrumentation.cpp
@@ -487,13 +487,13 @@ void PostCallSetupShaderInstrumentationResources(Validator &gpuav, CommandBuffer
 
                 for (uint32_t set_i = 0; set_i < disturbed_bindings_count; ++set_i) {
                     const uint32_t last_bound_set_i = set_i + first_disturbed_set;
-                    const auto &last_bound_set_state = last_bound.per_set[last_bound_set_i].bound_descriptor_set;
-                    // last_bound.per_set is a LUT, and descriptor sets before the last one could be unbound.
+                    const auto &last_bound_set_state = last_bound.ds_slots[last_bound_set_i].ds_state;
+                    // last_bound.ds_slot is a LUT, and descriptor sets before the last one could be unbound.
                     if (!last_bound_set_state) {
                         continue;
                     }
                     VkDescriptorSet last_bound_set = last_bound_set_state->VkHandle();
-                    const std::vector<uint32_t> &dynamic_offset = last_bound.per_set[last_bound_set_i].dynamicOffsets;
+                    const std::vector<uint32_t> &dynamic_offset = last_bound.ds_slots[last_bound_set_i].dynamic_offsets;
                     const uint32_t dynamic_offset_count = static_cast<uint32_t>(dynamic_offset.size());
                     DispatchCmdBindDescriptorSets(cb_state.VkHandle(), bind_point,
                                                   last_bound_desc_set_pipe_layout_state->VkHandle(), last_bound_set_i, 1,

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1217,12 +1217,12 @@ void CommandBuffer::UpdatePipelineState(Func command, const VkPipelineBindPoint 
     if (last_bound.desc_set_pipeline_layout != VK_NULL_HANDLE) {
         for (const auto &set_binding_pair : pipe->active_slots) {
             uint32_t set_index = set_binding_pair.first;
-            if (set_index >= last_bound.per_set.size()) {
+            if (set_index >= last_bound.ds_slots.size()) {
                 continue;
             }
-            auto &set_info = last_bound.per_set[set_index];
+            auto &ds_slot = last_bound.ds_slots[set_index];
             // Pull the set node
-            auto &descriptor_set = set_info.bound_descriptor_set;
+            auto &descriptor_set = ds_slot.ds_state;
             if (!descriptor_set) {
                 continue;
             }
@@ -1232,10 +1232,10 @@ void CommandBuffer::UpdatePipelineState(Func command, const VkPipelineBindPoint 
             // We can skip updating the state if "nothing" has changed since the last validation.
             // See CoreChecks::ValidateActionState for more details.
             const bool need_update =  // Update if descriptor set (or contents) has changed
-                set_info.validated_set != descriptor_set.get() ||
-                set_info.validated_set_change_count != descriptor_set->GetChangeCount() ||
+                ds_slot.validated_set != descriptor_set.get() ||
+                ds_slot.validated_set_change_count != descriptor_set->GetChangeCount() ||
                 (!dev_data.disabled[image_layout_validation] &&
-                 set_info.validated_set_image_layout_change_count != image_layout_change_count);
+                 ds_slot.validated_set_image_layout_change_count != image_layout_change_count);
             if (need_update) {
                 if (!dev_data.disabled[command_buffer_state] && !descriptor_set->IsPushDescriptor()) {
                     AddChild(descriptor_set);
@@ -1244,9 +1244,9 @@ void CommandBuffer::UpdatePipelineState(Func command, const VkPipelineBindPoint 
                 // Bind this set and its active descriptor resources to the command buffer
                 descriptor_set->UpdateDrawState(&dev_data, this, command, pipe, set_binding_pair.second);
 
-                set_info.validated_set = descriptor_set.get();
-                set_info.validated_set_change_count = descriptor_set->GetChangeCount();
-                set_info.validated_set_image_layout_change_count = image_layout_change_count;
+                ds_slot.validated_set = descriptor_set.get();
+                ds_slot.validated_set_change_count = descriptor_set->GetChangeCount();
+                ds_slot.validated_set_image_layout_change_count = image_layout_change_count;
             }
         }
     }
@@ -1254,12 +1254,12 @@ void CommandBuffer::UpdatePipelineState(Func command, const VkPipelineBindPoint 
 
 // Helper for descriptor set (and buffer) updates.
 static bool PushDescriptorCleanup(LastBound &last_bound, uint32_t set_idx) {
-    // All uses are from loops over per_set, but just in case..
-    assert(set_idx < last_bound.per_set.size());
+    // All uses are from loops over ds_slots, but just in case..
+    assert(set_idx < last_bound.ds_slots.size());
 
-    auto ds = last_bound.per_set[set_idx].bound_descriptor_set.get();
-    if (ds && ds->IsPushDescriptor()) {
-        assert(ds == last_bound.push_descriptor_set.get());
+    auto descriptor_set = last_bound.ds_slots[set_idx].ds_state.get();
+    if (descriptor_set && descriptor_set->IsPushDescriptor()) {
+        assert(descriptor_set == last_bound.push_descriptor_set.get());
         last_bound.push_descriptor_set = nullptr;
         return true;
     }
@@ -1287,14 +1287,14 @@ void CommandBuffer::UpdateLastBoundDescriptorSets(VkPipelineBindPoint pipeline_b
     last_bound.desc_set_bound_command = bound_command;
     auto &pipe_compat_ids = pipeline_layout.set_compat_ids;
     // Resize binding arrays
-    if (last_binding_index >= last_bound.per_set.size()) {
-        last_bound.per_set.resize(required_size);
+    if (last_binding_index >= last_bound.ds_slots.size()) {
+        last_bound.ds_slots.resize(required_size);
     }
-    const uint32_t current_size = static_cast<uint32_t>(last_bound.per_set.size());
+    const uint32_t current_size = static_cast<uint32_t>(last_bound.ds_slots.size());
 
     // Clean up the "disturbed" before and after the range to be set
     if (required_size < current_size) {
-        if (last_bound.per_set[last_binding_index].compat_id_for_set != pipe_compat_ids[last_binding_index]) {
+        if (last_bound.ds_slots[last_binding_index].compat_id_for_set != pipe_compat_ids[last_binding_index]) {
             // We're disturbing those after last, we'll shrink below, but first need to check for and cleanup the push_descriptor
             for (auto set_idx = required_size; set_idx < current_size; ++set_idx) {
                 if (PushDescriptorCleanup(last_bound, set_idx)) {
@@ -1309,16 +1309,16 @@ void CommandBuffer::UpdateLastBoundDescriptorSets(VkPipelineBindPoint pipeline_b
 
     // We resize if we need more set entries or if those past "last" are disturbed
     if (required_size != current_size) {
-        last_bound.per_set.resize(required_size);
+        last_bound.ds_slots.resize(required_size);
     }
 
     // For any previously bound sets, need to set them to "invalid" if they were disturbed by this update
     for (uint32_t set_idx = 0; set_idx < first_set; ++set_idx) {
-        auto &set_info = last_bound.per_set[set_idx];
-        if (set_info.compat_id_for_set != pipe_compat_ids[set_idx]) {
+        auto &ds_slot = last_bound.ds_slots[set_idx];
+        if (ds_slot.compat_id_for_set != pipe_compat_ids[set_idx]) {
             PushDescriptorCleanup(last_bound, set_idx);
-            set_info.Reset();
-            set_info.compat_id_for_set = pipe_compat_ids[set_idx];
+            ds_slot.Reset();
+            ds_slot.compat_id_for_set = pipe_compat_ids[set_idx];
         }
     }
 
@@ -1326,29 +1326,29 @@ void CommandBuffer::UpdateLastBoundDescriptorSets(VkPipelineBindPoint pipeline_b
     const uint32_t *input_dynamic_offsets = p_dynamic_offsets;  // "read" pointer for dynamic offset data
     for (uint32_t input_idx = 0; input_idx < set_count; input_idx++) {
         auto set_idx = input_idx + first_set;  // set_idx is index within layout, input_idx is index within input descriptor sets
-        auto &set_info = last_bound.per_set[set_idx];
+        auto &ds_slot = last_bound.ds_slots[set_idx];
         auto descriptor_set =
             push_descriptor_set ? push_descriptor_set : dev_data.Get<vvl::DescriptorSet>(pDescriptorSets[input_idx]);
 
-        set_info.Reset();
+        ds_slot.Reset();
         // Record binding (or push)
         if (descriptor_set != last_bound.push_descriptor_set) {
             // Only cleanup the push descriptors if they aren't the currently used set.
             PushDescriptorCleanup(last_bound, set_idx);
         }
-        set_info.bound_descriptor_set = descriptor_set;
-        set_info.compat_id_for_set = pipe_compat_ids[set_idx];  // compat ids are canonical *per* set index
+        ds_slot.ds_state = descriptor_set;
+        ds_slot.compat_id_for_set = pipe_compat_ids[set_idx];  // compat ids are canonical *per* set index
 
         if (descriptor_set) {
             auto set_dynamic_descriptor_count = descriptor_set->GetDynamicDescriptorCount();
             // TODO: Add logic for tracking push_descriptor offsets (here or in caller)
             if (set_dynamic_descriptor_count && input_dynamic_offsets) {
                 const uint32_t *end_offset = input_dynamic_offsets + set_dynamic_descriptor_count;
-                set_info.dynamicOffsets = std::vector<uint32_t>(input_dynamic_offsets, end_offset);
+                ds_slot.dynamic_offsets = std::vector<uint32_t>(input_dynamic_offsets, end_offset);
                 input_dynamic_offsets = end_offset;
                 assert(input_dynamic_offsets <= (p_dynamic_offsets + dynamic_offset_count));
             } else {
-                set_info.dynamicOffsets.clear();
+                ds_slot.dynamic_offsets.clear();
             }
         }
     }
@@ -1368,14 +1368,14 @@ void CommandBuffer::UpdateLastBoundDescriptorBuffers(VkPipelineBindPoint pipelin
     last_bound.desc_set_pipeline_layout = pipeline_layout.VkHandle();
     auto &pipe_compat_ids = pipeline_layout.set_compat_ids;
     // Resize binding arrays
-    if (last_binding_index >= last_bound.per_set.size()) {
-        last_bound.per_set.resize(required_size);
+    if (last_binding_index >= last_bound.ds_slots.size()) {
+        last_bound.ds_slots.resize(required_size);
     }
-    const uint32_t current_size = static_cast<uint32_t>(last_bound.per_set.size());
+    const uint32_t current_size = static_cast<uint32_t>(last_bound.ds_slots.size());
 
     // Clean up the "disturbed" before and after the range to be set
     if (required_size < current_size) {
-        if (last_bound.per_set[last_binding_index].compat_id_for_set != pipe_compat_ids[last_binding_index]) {
+        if (last_bound.ds_slots[last_binding_index].compat_id_for_set != pipe_compat_ids[last_binding_index]) {
             // We're disturbing those after last, we'll shrink below, but first need to check for and cleanup the push_descriptor
             for (auto set_idx = required_size; set_idx < current_size; ++set_idx) {
                 if (PushDescriptorCleanup(last_bound, set_idx)) {
@@ -1390,24 +1390,24 @@ void CommandBuffer::UpdateLastBoundDescriptorBuffers(VkPipelineBindPoint pipelin
 
     // We resize if we need more set entries or if those past "last" are disturbed
     if (required_size != current_size) {
-        last_bound.per_set.resize(required_size);
+        last_bound.ds_slots.resize(required_size);
     }
 
     // For any previously bound sets, need to set them to "invalid" if they were disturbed by this update
     for (uint32_t set_idx = 0; set_idx < first_set; ++set_idx) {
         PushDescriptorCleanup(last_bound, set_idx);
-        last_bound.per_set[set_idx].Reset();
+        last_bound.ds_slots[set_idx].Reset();
     }
 
     // Now update the bound sets with the input sets
     for (uint32_t input_idx = 0; input_idx < set_count; input_idx++) {
         auto set_idx = input_idx + first_set;  // set_idx is index within layout, input_idx is index within input descriptor sets
-        auto &set_info = last_bound.per_set[set_idx];
-        set_info.Reset();
+        auto &ds_slot = last_bound.ds_slots[set_idx];
+        ds_slot.Reset();
 
         // Record binding
-        set_info.bound_descriptor_buffer = {buffer_indicies[input_idx], buffer_offsets[input_idx]};
-        set_info.compat_id_for_set = pipe_compat_ids[set_idx];  // compat ids are canonical *per* set index
+        ds_slot.descriptor_buffer_binding = {buffer_indicies[input_idx], buffer_offsets[input_idx]};
+        ds_slot.compat_id_for_set = pipe_compat_ids[set_idx];  // compat ids are canonical *per* set index
     }
 }
 
@@ -1802,12 +1802,12 @@ vvl::Pipeline *CommandBuffer::GetCurrentPipeline(VkPipelineBindPoint pipelineBin
 }
 
 void CommandBuffer::GetCurrentPipelineAndDesriptorSets(VkPipelineBindPoint pipelineBindPoint, const vvl::Pipeline **rtn_pipe,
-                                                       const std::vector<LastBound::PER_SET> **rtn_sets) const {
+                                                       const std::vector<LastBound::DescriptorSetSlot> **rtn_sets) const {
     const auto lv_bind_point = ConvertToLvlBindPoint(pipelineBindPoint);
     const auto &last_bound = lastBound[lv_bind_point];
     if (!last_bound.pipeline_state) return;
     *rtn_pipe = last_bound.pipeline_state;
-    *rtn_sets = &(last_bound.per_set);
+    *rtn_sets = &(last_bound.ds_slots);
 }
 
 void CommandBuffer::BeginLabel(const char *label_name) {

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -596,7 +596,7 @@ class CommandBuffer : public RefcountedStateObject {
 
     vvl::Pipeline *GetCurrentPipeline(VkPipelineBindPoint pipelineBindPoint) const;
     void GetCurrentPipelineAndDesriptorSets(VkPipelineBindPoint pipelineBindPoint, const vvl::Pipeline **rtn_pipe,
-                                            const std::vector<LastBound::PER_SET> **rtn_sets) const;
+                                            const std::vector<LastBound::DescriptorSetSlot> **rtn_sets) const;
 
     VkQueueFlags GetQueueFlags() const { return command_pool->queue_flags; }
 

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -678,13 +678,14 @@ struct LastBound {
         uint32_t index = 0;
         VkDeviceSize offset = 0;
     };
-    // Ordered bound set tracking where index is set# that given set is bound to
-    struct PER_SET {
-        std::shared_ptr<vvl::DescriptorSet> bound_descriptor_set;
-        std::optional<DescriptorBufferBinding> bound_descriptor_buffer;
+
+    // Each command buffer has a "slot" to hold a descriptor set binding. This "slot" also might be empty
+    struct DescriptorSetSlot {
+        std::shared_ptr<vvl::DescriptorSet> ds_state;
+        std::optional<DescriptorBufferBinding> descriptor_buffer_binding;
 
         // one dynamic offset per dynamic descriptor bound to this CB
-        std::vector<uint32_t> dynamicOffsets;
+        std::vector<uint32_t> dynamic_offsets;
         PipelineLayoutCompatId compat_id_for_set{0};
 
         // Cache most recently validated descriptor state for ValidateActionState/UpdateDrawState
@@ -693,13 +694,14 @@ struct LastBound {
         uint64_t validated_set_image_layout_change_count{~0ULL};
 
         void Reset() {
-            bound_descriptor_set.reset();
-            bound_descriptor_buffer.reset();
-            dynamicOffsets.clear();
+            ds_state.reset();
+            descriptor_buffer_binding.reset();
+            dynamic_offsets.clear();
         }
     };
 
-    std::vector<PER_SET> per_set;
+    // Ordered bound set tracking where index is set# that given set is bound to
+    std::vector<DescriptorSetSlot> ds_slots;
 
     void Reset();
 


### PR DESCRIPTION
`LastBound::PER_SET` is not helpful name, changed to `DescriptorSetSlot`

also instead of going `last_bound.ds_slots[index].bound_descriptor_set` it is just `last_bound.ds_slots[index].ds_state` to try and reduce the `bound` being littered everything it doesn't need to be (since you are already actively grabbing `LastBound`)