### PR TITLE
layers: Add string_view header

### DIFF
--- a/layers/utils/hash_util.h
+++ b/layers/utils/hash_util.h
@@ -22,6 +22,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <string_view>
 #include <type_traits>
 #include <vector>
 #include "containers/custom_containers.h"


### PR DESCRIPTION
replacement for https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/8914

needed for LLVM 20