### PR TITLE
tests: Test binary-timeline dependency with sparse ops

### DIFF
--- a/tests/framework/render.cpp
+++ b/tests/framework/render.cpp
@@ -665,6 +665,7 @@ void VkRenderFramework::InitState(VkPhysicalDeviceFeatures *features, void *crea
         }
     }
     m_default_queue = queues[0];
+    m_default_queue_caps = m_device->Physical().queue_properties_[m_default_queue->family_index].queueFlags;
     if (queues.size() > 1) {
         m_second_queue = queues[1];
         m_second_queue_caps = m_device->Physical().queue_properties_[m_second_queue->family_index].queueFlags;

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -242,6 +242,7 @@ class VkRenderFramework : public VkTestFramework {
     vkt::Image *m_depthStencil;
     // first graphics queue, used must often, don't overwrite, use Device class
     vkt::Queue *m_default_queue = nullptr;
+    VkQueueFlags m_default_queue_caps = 0;
 
     // A queue different from the default one (can be null).
     // The queue with the most capabilities is selected (graphics > compute > transfer).


### PR DESCRIPTION
Added missing sparse bindings tests as a follow-up to https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/8764.

With regard to https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8900, one theory (suggested by @HansKristian-Work) is that it happens due to missing timeline support for sparse operations, but so far it looks like we  handle them properly. Likely the issue is in the general algorithm (or in another part of sparse functionality!).