### PR TITLE
ci: Skip Video tests for ThreadSanitizer

### DIFF
--- a/.github/workflows/vvl.yml
+++ b/.github/workflows/vvl.yml
@@ -112,7 +112,15 @@ jobs:
           CMAKE_C_COMPILER_LAUNCHER: ccache
           CMAKE_CXX_COMPILER_LAUNCHER: ccache
       - name: Test Max Profile
+        if: ${{ matrix.sanitize != 'thread' }}
         run: python scripts/tests.py --test
+        env:
+          VK_KHRONOS_PROFILES_PROFILE_FILE: ${{ github.workspace }}/tests/device_profiles/max_profile.json
+      - name: Test Max Profile - Skip Video
+        # Currently Thread Sanitizer causes each video framework tests to slowly increase the time each test runs
+        # This then persists for the following tests as well, really slowing down runs by factor of an hour or more
+        if: ${{ matrix.sanitize == 'thread' }}
+        run: python scripts/tests.py --test --skipVideo
         env:
           VK_KHRONOS_PROFILES_PROFILE_FILE: ${{ github.workspace }}/tests/device_profiles/max_profile.json
       - name: Test Max Core

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -219,6 +219,9 @@ def RunVVLTests(args):
         # a manual vkCreateDevice call and need to investigate more why
         common_ci.RunShellCmd(lvt_cmd + " --gtest_filter=*AndroidHardwareBuffer.*:*AndroidExternalResolve.*", env=lvt_env)
         return
+    if args.skipVideo:
+        common_ci.RunShellCmd(lvt_cmd + " --gtest_filter=-*Video.*", env=lvt_env)
+        return
 
     common_ci.RunShellCmd(lvt_cmd, env=lvt_env)
 
@@ -266,6 +269,9 @@ if __name__ == '__main__':
     parser.add_argument(
         '--mockAndroid', dest='mockAndroid',
         action='store_true', help='Use Mock Android')
+    parser.add_argument(
+        '--skipVideo', dest='skipVideo',
+        action='store_true', help='Filter out video tests')
 
     args = parser.parse_args()
 


### PR DESCRIPTION
The introduction of https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/8911 showed that we are running about an hour longer for the Thread Sanitizer tests because there is something causing each Video tests to slowly increase the time the test takes to run.

This is intended to be a quick fix until we have time to investigate more. This should reduce the test time from 2.5 hours back to under 1.5 hours

edit - the 2.5+ hour run now only takes 30 minutes!