### PR TITLE
sync: Remove access entries of destroyed resources

### DIFF
--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -314,6 +314,12 @@ void QueueBatchContext::ApplyAcquireWait(const AcquiredImage& acquired) {
     ApplyPredicatedWait(predicate);
 }
 
+void QueueBatchContext::OnResourceDestroyed(const ResourceAccessRange& resource_range) {
+    // Remove all accesses associated with the resource being destroyed
+    access_context_.EraseIf(
+        [&resource_range](ResourceAccessRangeMap::value_type& access) { return resource_range.includes(access.first); });
+}
+
 void QueueBatchContext::BeginRenderPassReplaySetup(ReplayState& replay, const SyncOpBeginRenderPass& begin_op) {
     current_access_context_ = replay.ReplayStateRenderPassBegin(queue_state_->GetQueueFlags(), begin_op, access_context_);
 }

--- a/layers/sync/sync_submit.h
+++ b/layers/sync/sync_submit.h
@@ -333,6 +333,7 @@ class QueueBatchContext : public CommandExecutionContext, public std::enable_sha
     void ApplyPredicatedWait(Predicate &predicate);
     void ApplyTaggedWait(QueueId queue_id, ResourceUsageTag tag);
     void ApplyAcquireWait(const AcquiredImage &acquired);
+    void OnResourceDestroyed(const ResourceAccessRange &resource_range);
 
     void BeginRenderPassReplaySetup(ReplayState &replay, const SyncOpBeginRenderPass &begin_op);
     void NextSubpassReplaySetup(ReplayState &replay);

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -134,6 +134,10 @@ class SyncValidator : public ValidationStateTracker, public SyncStageAccess {
                                                          const VkImageViewCreateInfo *create_info,
                                                          VkFormatFeatureFlags2 format_features,
                                                          const VkFilterCubicImageViewImageFormatPropertiesEXT &cubic_props) final;
+    void PreCallRecordDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAllocationCallbacks *pAllocator,
+                                    const RecordObject &record_obj) override;
+    void PreCallRecordDestroyImage(VkDevice device, VkImage image, const VkAllocationCallbacks *pAllocator,
+                                   const RecordObject &record_obj) override;
 
     void RecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
                                   const VkSubpassBeginInfo *pSubpassBeginInfo, Func command);

--- a/tests/framework/binding.cpp
+++ b/tests/framework/binding.cpp
@@ -1075,6 +1075,23 @@ VkResult QueryPool::Results(uint32_t first, uint32_t count, size_t size, void *d
 
 NON_DISPATCHABLE_HANDLE_DTOR(Buffer, vk::DestroyBuffer)
 
+Buffer::Buffer(Buffer &&rhs) noexcept : NonDispHandle(std::move(rhs)) {
+    create_info_ = std::move(rhs.create_info_);
+    internal_mem_ = std::move(rhs.internal_mem_);
+}
+
+Buffer &Buffer::operator=(Buffer &&rhs) noexcept {
+    if (&rhs == this) {
+        return *this;
+    }
+    destroy();
+    internal_mem_.destroy();
+    NonDispHandle::operator=(std::move(rhs));
+    create_info_ = std::move(rhs.create_info_);
+    internal_mem_ = std::move(rhs.internal_mem_);
+    return *this;
+}
+
 void Buffer::init(const Device &dev, const VkBufferCreateInfo &info, VkMemoryPropertyFlags mem_props, void *alloc_info_pnext) {
     InitNoMemory(dev, info);
 
@@ -1181,6 +1198,40 @@ Image::Image(const Device &dev, const VkImageCreateInfo &info, SetLayoutT) : dev
 
     VkImageAspectFlags image_aspect = AspectMask(info.format);
     SetLayout(image_aspect, newLayout);
+}
+
+Image::Image(Image &&rhs) noexcept : NonDispHandle(std::move(rhs)) {
+    device_ = std::move(rhs.device_);
+    rhs.device_ = nullptr;
+
+    create_info_ = std::move(rhs.create_info_);
+    rhs.create_info_ = vku::InitStructHelper();
+
+    internal_mem_ = std::move(rhs.internal_mem_);
+
+    image_layout_ = std::move(rhs.image_layout_);
+    rhs.image_layout_ = VK_IMAGE_LAYOUT_UNDEFINED;
+}
+
+Image &Image::operator=(Image &&rhs) noexcept {
+    if (&rhs == this) {
+        return *this;
+    }
+    destroy();
+    internal_mem_.destroy();
+    NonDispHandle::operator=(std::move(rhs));
+
+    device_ = std::move(rhs.device_);
+    rhs.device_ = nullptr;
+
+    create_info_ = std::move(rhs.create_info_);
+    rhs.create_info_ = vku::InitStructHelper();
+
+    internal_mem_ = std::move(rhs.internal_mem_);
+
+    image_layout_ = std::move(rhs.image_layout_);
+    rhs.image_layout_ = VK_IMAGE_LAYOUT_UNDEFINED;
+    return *this;
 }
 
 void Image::init(const Device &dev, const VkImageCreateInfo &info, VkMemoryPropertyFlags mem_props, void *alloc_info_pnext) {

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -613,21 +613,8 @@ class Buffer : public internal::NonDispHandle<VkBuffer> {
         InitHostVisibleWithData(dev, usage, data, data_size, queue_families);
     }
 
-    Buffer(Buffer &&rhs) noexcept : NonDispHandle(std::move(rhs)) {
-        create_info_ = std::move(rhs.create_info_);
-        internal_mem_ = std::move(rhs.internal_mem_);
-    }
-    Buffer &operator=(Buffer &&rhs) noexcept {
-        if (&rhs == this) {
-            return *this;
-        }
-        destroy();
-        internal_mem_.destroy();
-        NonDispHandle::operator=(std::move(rhs));
-        create_info_ = std::move(rhs.create_info_);
-        internal_mem_ = std::move(rhs.internal_mem_);
-        return *this;
-    }
+    Buffer(Buffer &&rhs) noexcept;
+    Buffer &operator=(Buffer &&rhs) noexcept;
     ~Buffer() noexcept;
     void destroy() noexcept;
 
@@ -745,6 +732,8 @@ class Image : public internal::NonDispHandle<VkImage> {
 
     explicit Image(const Device &dev, const VkImageCreateInfo &info, NoMemT);
     explicit Image(const Device &dev, const VkImageCreateInfo &info, SetLayoutT);
+    Image(Image &&rhs) noexcept;
+    Image &operator=(Image &&rhs) noexcept;
 
     ~Image() noexcept;
     void destroy() noexcept;


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8934

Syncval cleanups old access entries during host side synchronization
operations. For example, when frame synchronization uses `vkWaitForFences`
to wait for the QueueSubmit's fence, this guarantees that device memory
accesses are completed and it is safe to remove corresponding tracking
state.

There are synchronization mechanisms that are not associated directly
with a queue (acquire fence sync) and do not guarantee completion
of memory accesses (provide only execution dependency). In this case
we need to cleanup access entries when resource is destroyed, because
there is no guarantee they will be removed later.