### PR TITLE
tests: Cleanup copy image buffer tests

### DIFF
--- a/tests/unit/best_practices.cpp
+++ b/tests/unit/best_practices.cpp
@@ -294,9 +294,7 @@ TEST_F(VkBestPracticesLayerTest, CmdResolveImageTypeMismatch) {
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_B8G8R8A8_UNORM;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 1;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 1, 1};
     image_create_info.mipLevels = 1;
     image_create_info.arrayLayers = 1;
     image_create_info.samples = VK_SAMPLE_COUNT_4_BIT;  // guarantee support from sampledImageColorSampleCounts

--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -1042,9 +1042,7 @@ TEST_F(NegativeCommand, ResolveImageHighSampleCount) {
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_B8G8R8A8_UNORM;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 1;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 32, 1};
     image_create_info.mipLevels = 1;
     image_create_info.arrayLayers = 1;
     image_create_info.samples = VK_SAMPLE_COUNT_4_BIT;
@@ -1088,9 +1086,7 @@ TEST_F(NegativeCommand, ResolveImageFormatMismatch) {
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_B8G8R8A8_UNORM;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 1;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 1, 1};
     image_create_info.mipLevels = 1;
     image_create_info.arrayLayers = 1;
     image_create_info.samples = VK_SAMPLE_COUNT_4_BIT;  // guarantee support from sampledImageColorSampleCounts
@@ -1137,9 +1133,7 @@ TEST_F(NegativeCommand, ResolveImageLayoutMismatch) {
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_B8G8R8A8_UNORM;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 32;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 32, 1};
     image_create_info.mipLevels = 1;
     image_create_info.arrayLayers = 1;
     image_create_info.samples = VK_SAMPLE_COUNT_4_BIT;  // guarantee support from sampledImageColorSampleCounts
@@ -1201,9 +1195,7 @@ TEST_F(NegativeCommand, ResolveInvalidSubresource) {
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_B8G8R8A8_UNORM;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 32;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 32, 1};
     image_create_info.mipLevels = 1;
     image_create_info.arrayLayers = 1;
     image_create_info.samples = VK_SAMPLE_COUNT_4_BIT;  // guarantee support from sampledImageColorSampleCounts
@@ -1374,9 +1366,7 @@ TEST_F(NegativeCommand, ResolveImageImageType) {
 
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 1;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 1, 1};
     image_create_info.mipLevels = 1;
     image_create_info.arrayLayers = 4;  // more than 1 to not trip other validation
     image_create_info.samples = VK_SAMPLE_COUNT_4_BIT;  // guarantee support from sampledImageColorSampleCounts
@@ -1452,9 +1442,7 @@ TEST_F(NegativeCommand, ResolveImageSizeExceeded) {
 
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 32;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 32, 1};
     image_create_info.mipLevels = 1;
     image_create_info.arrayLayers = 1;
     image_create_info.samples = VK_SAMPLE_COUNT_4_BIT;
@@ -2893,9 +2881,7 @@ TEST_F(NegativeCommand, ResolveUsage) {
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_B8G8R8A8_UNORM;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 1;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 1, 1};
     image_create_info.mipLevels = 1;
     image_create_info.arrayLayers = 1;
     image_create_info.samples = VK_SAMPLE_COUNT_2_BIT;

--- a/tests/unit/command_positive.cpp
+++ b/tests/unit/command_positive.cpp
@@ -228,9 +228,7 @@ TEST_F(PositiveCommand, DISABLED_ClearRectWith2DArray) {
         image_ci.flags = VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT;
         image_ci.imageType = VK_IMAGE_TYPE_3D;
         image_ci.format = VK_FORMAT_B8G8R8A8_UNORM;
-        image_ci.extent.width = 32;
-        image_ci.extent.height = 32;
-        image_ci.extent.depth = 4;
+        image_ci.extent = {32, 32, 4};
         image_ci.mipLevels = 1;
         image_ci.arrayLayers = 1;
         image_ci.samples = VK_SAMPLE_COUNT_1_BIT;

--- a/tests/unit/descriptors.cpp
+++ b/tests/unit/descriptors.cpp
@@ -4735,9 +4735,7 @@ TEST_F(NegativeDescriptors, InvalidImageInfoDescriptorType) {
     image_ci.flags = VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT | VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT;
     image_ci.imageType = VK_IMAGE_TYPE_3D;
     image_ci.format = format;
-    image_ci.extent.width = 32;
-    image_ci.extent.height = 32;
-    image_ci.extent.depth = 2;
+    image_ci.extent = {32, 32, 2};
     image_ci.mipLevels = 1u;
     image_ci.arrayLayers = 1u;
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;

--- a/tests/unit/external_memory_sync.cpp
+++ b/tests/unit/external_memory_sync.cpp
@@ -73,9 +73,7 @@ TEST_F(NegativeExternalMemorySync, CreateImageIncompatibleHandleTypes) {
     VkImageCreateInfo image_create_info = vku::InitStructHelper(&external_memory_info);
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 32;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 32, 1};
     image_create_info.mipLevels = 1;
     image_create_info.arrayLayers = 1;
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
@@ -127,9 +125,7 @@ TEST_F(NegativeExternalMemorySync, CreateImageIncompatibleHandleTypesNV) {
     VkImageCreateInfo image_create_info = vku::InitStructHelper(&external_memory_info);
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 32;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 32, 1};
     image_create_info.mipLevels = 1;
     image_create_info.arrayLayers = 1;
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;

--- a/tests/unit/fragment_shading_rate.cpp
+++ b/tests/unit/fragment_shading_rate.cpp
@@ -730,9 +730,7 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapReferenceAttachment) {
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_R8G8_UNORM;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 32;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 32, 1};
     image_create_info.mipLevels = 1;
     image_create_info.arrayLayers = 4;
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;

--- a/tests/unit/gpu_av_positive.cpp
+++ b/tests/unit/gpu_av_positive.cpp
@@ -1167,8 +1167,7 @@ TEST_F(PositiveGpuAV, CopyBufferToImageTwoSubmit) {
     VkBufferImageCopy region = {};
     region.bufferRowLength = 0;
     region.bufferImageHeight = 0;
-    region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    region.imageSubresource.layerCount = 1;
+    region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
     region.imageOffset = {0, 0, 0};
     region.imageExtent = {32, 32, 1};
     region.bufferOffset = 0;

--- a/tests/unit/host_image_copy.cpp
+++ b/tests/unit/host_image_copy.cpp
@@ -30,11 +30,8 @@ TEST_F(NegativeHostImageCopy, ImageLayout) {
 
     VkMemoryToImageCopyEXT region_to_image = vku::InitStructHelper();
     region_to_image.pHostPointer = pixels.data();
-    region_to_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    region_to_image.imageSubresource.layerCount = 1;
-    region_to_image.imageExtent.width = width;
-    region_to_image.imageExtent.height = height;
-    region_to_image.imageExtent.depth = 1;
+    region_to_image.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region_to_image.imageExtent = {width, height, 1};
 
     VkCopyMemoryToImageInfoEXT copy_to_image = vku::InitStructHelper();
     copy_to_image.dstImage = image;
@@ -44,11 +41,8 @@ TEST_F(NegativeHostImageCopy, ImageLayout) {
 
     VkImageToMemoryCopyEXT region_from_image = vku::InitStructHelper();
     region_from_image.pHostPointer = pixels.data();
-    region_from_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    region_from_image.imageSubresource.layerCount = 1;
-    region_from_image.imageExtent.width = width;
-    region_from_image.imageExtent.height = height;
-    region_from_image.imageExtent.depth = 1;
+    region_from_image.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region_from_image.imageExtent = {width, height, 1};
 
     VkCopyImageToMemoryInfoEXT copy_from_image = vku::InitStructHelper();
     copy_from_image.srcImage = image;
@@ -80,11 +74,8 @@ TEST_F(NegativeHostImageCopy, ImageOffset) {
 
     VkMemoryToImageCopyEXT region_to_image = vku::InitStructHelper();
     region_to_image.pHostPointer = pixels.data();
-    region_to_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    region_to_image.imageSubresource.layerCount = 1;
-    region_to_image.imageExtent.width = width;
-    region_to_image.imageExtent.height = height;
-    region_to_image.imageExtent.depth = 1;
+    region_to_image.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region_to_image.imageExtent = {width, height, 1};
 
     VkCopyMemoryToImageInfoEXT copy_to_image = vku::InitStructHelper();
     copy_to_image.dstImage = image;
@@ -94,11 +85,8 @@ TEST_F(NegativeHostImageCopy, ImageOffset) {
 
     VkImageToMemoryCopyEXT region_from_image = vku::InitStructHelper();
     region_from_image.pHostPointer = pixels.data();
-    region_from_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    region_from_image.imageSubresource.layerCount = 1;
-    region_from_image.imageExtent.width = width;
-    region_from_image.imageExtent.height = height;
-    region_from_image.imageExtent.depth = 1;
+    region_from_image.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region_from_image.imageExtent = {width, height, 1};
 
     VkCopyImageToMemoryInfoEXT copy_from_image = vku::InitStructHelper();
     copy_from_image.srcImage = image;
@@ -158,11 +146,8 @@ TEST_F(NegativeHostImageCopy, AspectMask) {
 
     VkMemoryToImageCopyEXT region_to_image = vku::InitStructHelper();
     region_to_image.pHostPointer = pixels.data();
-    region_to_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    region_to_image.imageSubresource.layerCount = 1;
-    region_to_image.imageExtent.width = width;
-    region_to_image.imageExtent.height = height;
-    region_to_image.imageExtent.depth = 1;
+    region_to_image.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region_to_image.imageExtent = {width, height, 1};
 
     VkCopyMemoryToImageInfoEXT copy_to_image = vku::InitStructHelper();
     copy_to_image.dstImage = image;
@@ -172,11 +157,8 @@ TEST_F(NegativeHostImageCopy, AspectMask) {
 
     VkImageToMemoryCopyEXT region_from_image = vku::InitStructHelper();
     region_from_image.pHostPointer = pixels.data();
-    region_from_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    region_from_image.imageSubresource.layerCount = 1;
-    region_from_image.imageExtent.width = width;
-    region_from_image.imageExtent.height = height;
-    region_from_image.imageExtent.depth = 1;
+    region_from_image.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region_from_image.imageExtent = {width, height, 1};
 
     VkCopyImageToMemoryInfoEXT copy_from_image = vku::InitStructHelper();
     copy_from_image.srcImage = image;
@@ -209,11 +191,8 @@ TEST_F(NegativeHostImageCopy, CopyImageToFromMemoryNoMemory) {
 
     VkMemoryToImageCopyEXT region_to_image = vku::InitStructHelper();
     region_to_image.pHostPointer = pixels.data();
-    region_to_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    region_to_image.imageSubresource.layerCount = 1;
-    region_to_image.imageExtent.width = width;
-    region_to_image.imageExtent.height = height;
-    region_to_image.imageExtent.depth = 1;
+    region_to_image.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region_to_image.imageExtent = {width, height, 1};
 
     VkCopyMemoryToImageInfoEXT copy_to_image = vku::InitStructHelper();
     copy_to_image.dstImage = image;
@@ -223,11 +202,8 @@ TEST_F(NegativeHostImageCopy, CopyImageToFromMemoryNoMemory) {
 
     VkImageToMemoryCopyEXT region_from_image = vku::InitStructHelper();
     region_from_image.pHostPointer = pixels.data();
-    region_from_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    region_from_image.imageSubresource.layerCount = 1;
-    region_from_image.imageExtent.width = width;
-    region_from_image.imageExtent.height = height;
-    region_from_image.imageExtent.depth = 1;
+    region_from_image.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region_from_image.imageExtent = {width, height, 1};
 
     VkCopyImageToMemoryInfoEXT copy_from_image = vku::InitStructHelper();
     copy_from_image.srcImage = image;
@@ -261,11 +237,8 @@ TEST_F(NegativeHostImageCopy, ImageSubresource) {
 
     VkMemoryToImageCopyEXT region_to_image = vku::InitStructHelper();
     region_to_image.pHostPointer = pixels.data();
-    region_to_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    region_to_image.imageSubresource.layerCount = 1;
-    region_to_image.imageExtent.width = width;
-    region_to_image.imageExtent.height = height;
-    region_to_image.imageExtent.depth = 1;
+    region_to_image.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region_to_image.imageExtent = {width, height, 1};
 
     VkCopyMemoryToImageInfoEXT copy_to_image = vku::InitStructHelper();
     copy_to_image.dstImage = image;
@@ -275,11 +248,8 @@ TEST_F(NegativeHostImageCopy, ImageSubresource) {
 
     VkImageToMemoryCopyEXT region_from_image = vku::InitStructHelper();
     region_from_image.pHostPointer = pixels.data();
-    region_from_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    region_from_image.imageSubresource.layerCount = 1;
-    region_from_image.imageExtent.width = width;
-    region_from_image.imageExtent.height = height;
-    region_from_image.imageExtent.depth = 1;
+    region_from_image.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region_from_image.imageExtent = {width, height, 1};
 
     VkCopyImageToMemoryInfoEXT copy_from_image = vku::InitStructHelper();
     copy_from_image.srcImage = image;
@@ -365,11 +335,8 @@ TEST_F(NegativeHostImageCopy, ImageExtent) {
 
     VkMemoryToImageCopyEXT region_to_image = vku::InitStructHelper();
     region_to_image.pHostPointer = pixels.data();
-    region_to_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    region_to_image.imageSubresource.layerCount = 1;
-    region_to_image.imageExtent.width = width;
-    region_to_image.imageExtent.height = height;
-    region_to_image.imageExtent.depth = 1;
+    region_to_image.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region_to_image.imageExtent = {width, height, 1};
 
     VkCopyMemoryToImageInfoEXT copy_to_image = vku::InitStructHelper();
     copy_to_image.dstImage = image;
@@ -379,11 +346,8 @@ TEST_F(NegativeHostImageCopy, ImageExtent) {
 
     VkImageToMemoryCopyEXT region_from_image = vku::InitStructHelper();
     region_from_image.pHostPointer = pixels.data();
-    region_from_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    region_from_image.imageSubresource.layerCount = 1;
-    region_from_image.imageExtent.width = width;
-    region_from_image.imageExtent.height = height;
-    region_from_image.imageExtent.depth = 1;
+    region_from_image.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region_from_image.imageExtent = {width, height, 1};
 
     VkCopyImageToMemoryInfoEXT copy_from_image = vku::InitStructHelper();
     copy_from_image.srcImage = image;
@@ -452,11 +416,8 @@ TEST_F(NegativeHostImageCopy, Image1D) {
 
     VkMemoryToImageCopyEXT region_to_image = vku::InitStructHelper();
     region_to_image.pHostPointer = pixels.data();
-    region_to_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    region_to_image.imageSubresource.layerCount = 1;
-    region_to_image.imageExtent.width = width;
-    region_to_image.imageExtent.height = height;
-    region_to_image.imageExtent.depth = 1;
+    region_to_image.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region_to_image.imageExtent = {width, height, 1};
 
     VkCopyMemoryToImageInfoEXT copy_to_image = vku::InitStructHelper();
     copy_to_image.dstImage = image;
@@ -466,11 +427,8 @@ TEST_F(NegativeHostImageCopy, Image1D) {
 
     VkImageToMemoryCopyEXT region_from_image = vku::InitStructHelper();
     region_from_image.pHostPointer = pixels.data();
-    region_from_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    region_from_image.imageSubresource.layerCount = 1;
-    region_from_image.imageExtent.width = width;
-    region_from_image.imageExtent.height = height;
-    region_from_image.imageExtent.depth = 1;
+    region_from_image.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region_from_image.imageExtent = {width, height, 1};
 
     VkCopyImageToMemoryInfoEXT copy_from_image = vku::InitStructHelper();
     copy_from_image.srcImage = image;
@@ -568,11 +526,8 @@ TEST_F(NegativeHostImageCopy, CompressedFormat) {
 
     VkMemoryToImageCopyEXT region_to_image = vku::InitStructHelper();
     region_to_image.pHostPointer = pixels.data();
-    region_to_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    region_to_image.imageSubresource.layerCount = 1;
-    region_to_image.imageExtent.width = width;
-    region_to_image.imageExtent.height = height;
-    region_to_image.imageExtent.depth = 1;
+    region_to_image.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region_to_image.imageExtent = {width, height, 1};
 
     VkCopyMemoryToImageInfoEXT copy_to_image = vku::InitStructHelper();
     copy_to_image.dstImage = image;
@@ -582,11 +537,8 @@ TEST_F(NegativeHostImageCopy, CompressedFormat) {
 
     VkImageToMemoryCopyEXT region_from_image = vku::InitStructHelper();
     region_from_image.pHostPointer = pixels.data();
-    region_from_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    region_from_image.imageSubresource.layerCount = 1;
-    region_from_image.imageExtent.width = width;
-    region_from_image.imageExtent.height = height;
-    region_from_image.imageExtent.depth = 1;
+    region_from_image.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region_from_image.imageExtent = {width, height, 1};
 
     VkCopyImageToMemoryInfoEXT copy_from_image = vku::InitStructHelper();
     copy_from_image.srcImage = image;
@@ -706,11 +658,8 @@ TEST_F(NegativeHostImageCopy, DepthStencil) {
 
     VkMemoryToImageCopyEXT region_to_image = vku::InitStructHelper();
     region_to_image.pHostPointer = pixels.data();
-    region_to_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    region_to_image.imageSubresource.layerCount = 1;
-    region_to_image.imageExtent.width = width;
-    region_to_image.imageExtent.height = height;
-    region_to_image.imageExtent.depth = 1;
+    region_to_image.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region_to_image.imageExtent = {width, height, 1};
 
     VkCopyMemoryToImageInfoEXT copy_to_image = vku::InitStructHelper();
     copy_to_image.dstImage = image;
@@ -720,11 +669,8 @@ TEST_F(NegativeHostImageCopy, DepthStencil) {
 
     VkImageToMemoryCopyEXT region_from_image = vku::InitStructHelper();
     region_from_image.pHostPointer = pixels.data();
-    region_from_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    region_from_image.imageSubresource.layerCount = 1;
-    region_from_image.imageExtent.width = width;
-    region_from_image.imageExtent.height = height;
-    region_from_image.imageExtent.depth = 1;
+    region_from_image.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region_from_image.imageExtent = {width, height, 1};
 
     VkCopyImageToMemoryInfoEXT copy_from_image = vku::InitStructHelper();
     copy_from_image.srcImage = image;
@@ -810,11 +756,8 @@ TEST_F(NegativeHostImageCopy, MultiPlanar) {
 
     VkMemoryToImageCopyEXT region_to_image = vku::InitStructHelper();
     region_to_image.pHostPointer = pixels.data();
-    region_to_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    region_to_image.imageSubresource.layerCount = 1;
-    region_to_image.imageExtent.width = width;
-    region_to_image.imageExtent.height = height;
-    region_to_image.imageExtent.depth = 1;
+    region_to_image.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region_to_image.imageExtent = {width, height, 1};
 
     VkCopyMemoryToImageInfoEXT copy_to_image = vku::InitStructHelper();
     copy_to_image.dstImage = image;
@@ -824,11 +767,8 @@ TEST_F(NegativeHostImageCopy, MultiPlanar) {
 
     VkImageToMemoryCopyEXT region_from_image = vku::InitStructHelper();
     region_from_image.pHostPointer = pixels.data();
-    region_from_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    region_from_image.imageSubresource.layerCount = 1;
-    region_from_image.imageExtent.width = width;
-    region_from_image.imageExtent.height = height;
-    region_from_image.imageExtent.depth = 1;
+    region_from_image.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region_from_image.imageExtent = {width, height, 1};
 
     VkCopyImageToMemoryInfoEXT copy_from_image = vku::InitStructHelper();
     copy_from_image.srcImage = image;
@@ -897,11 +837,8 @@ TEST_F(NegativeHostImageCopy, NonSupportedLayout) {
 
     VkMemoryToImageCopyEXT region_to_image = vku::InitStructHelper();
     region_to_image.pHostPointer = pixels.data();
-    region_to_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    region_to_image.imageSubresource.layerCount = 1;
-    region_to_image.imageExtent.width = width;
-    region_to_image.imageExtent.height = height;
-    region_to_image.imageExtent.depth = 1;
+    region_to_image.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region_to_image.imageExtent = {width, height, 1};
 
     VkCopyMemoryToImageInfoEXT copy_to_image = vku::InitStructHelper();
     copy_to_image.dstImage = image;
@@ -911,11 +848,8 @@ TEST_F(NegativeHostImageCopy, NonSupportedLayout) {
 
     VkImageToMemoryCopyEXT region_from_image = vku::InitStructHelper();
     region_from_image.pHostPointer = pixels.data();
-    region_from_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    region_from_image.imageSubresource.layerCount = 1;
-    region_from_image.imageExtent.width = width;
-    region_from_image.imageExtent.height = height;
-    region_from_image.imageExtent.depth = 1;
+    region_from_image.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region_from_image.imageExtent = {width, height, 1};
 
     VkCopyImageToMemoryInfoEXT copy_from_image = vku::InitStructHelper();
     copy_from_image.srcImage = image;
@@ -952,11 +886,8 @@ TEST_F(NegativeHostImageCopy, ImageExtent2) {
 
     VkMemoryToImageCopyEXT region_to_image = vku::InitStructHelper();
     region_to_image.pHostPointer = pixels.data();
-    region_to_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    region_to_image.imageSubresource.layerCount = 1;
-    region_to_image.imageExtent.width = width;
-    region_to_image.imageExtent.height = height;
-    region_to_image.imageExtent.depth = 1;
+    region_to_image.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region_to_image.imageExtent = {width, height, 1};
 
     VkCopyMemoryToImageInfoEXT copy_to_image = vku::InitStructHelper();
     copy_to_image.dstImage = image;
@@ -966,11 +897,8 @@ TEST_F(NegativeHostImageCopy, ImageExtent2) {
 
     VkImageToMemoryCopyEXT region_from_image = vku::InitStructHelper();
     region_from_image.pHostPointer = pixels.data();
-    region_from_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    region_from_image.imageSubresource.layerCount = 1;
-    region_from_image.imageExtent.width = width;
-    region_from_image.imageExtent.height = height;
-    region_from_image.imageExtent.depth = 1;
+    region_from_image.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region_from_image.imageExtent = {width, height, 1};
 
     VkCopyImageToMemoryInfoEXT copy_from_image = vku::InitStructHelper();
     copy_from_image.srcImage = image;
@@ -1538,11 +1466,8 @@ TEST_F(NegativeHostImageCopy, CopyImageToFromMemorySubsampled) {
 
     VkMemoryToImageCopyEXT region_to_image = vku::InitStructHelper();
     region_to_image.pHostPointer = pixels.data();
-    region_to_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    region_to_image.imageSubresource.layerCount = 1;
-    region_to_image.imageExtent.width = width;
-    region_to_image.imageExtent.height = height;
-    region_to_image.imageExtent.depth = 1;
+    region_to_image.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region_to_image.imageExtent = {width, height, 1};
 
     VkCopyMemoryToImageInfoEXT copy_to_image = vku::InitStructHelper();
     copy_to_image.dstImage = image;
@@ -1552,11 +1477,8 @@ TEST_F(NegativeHostImageCopy, CopyImageToFromMemorySubsampled) {
 
     VkImageToMemoryCopyEXT region_from_image = vku::InitStructHelper();
     region_from_image.pHostPointer = pixels.data();
-    region_from_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    region_from_image.imageSubresource.layerCount = 1;
-    region_from_image.imageExtent.width = width;
-    region_from_image.imageExtent.height = height;
-    region_from_image.imageExtent.depth = 1;
+    region_from_image.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region_from_image.imageExtent = {width, height, 1};
 
     VkCopyImageToMemoryInfoEXT copy_from_image = vku::InitStructHelper();
     copy_from_image.srcImage = image;
@@ -1913,15 +1835,11 @@ TEST_F(NegativeHostImageCopy, ImageMemoryOverlap) {
 
     VkDeviceAddress *data = (VkDeviceAddress *)image.Memory().Map();
 
-    VkImageSubresourceLayers imageSubresource = {};
-    imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    imageSubresource.layerCount = 1;
-
     VkImageToMemoryCopyEXT region = vku::InitStructHelper();
     region.pHostPointer = data;
     region.memoryRowLength = 0;
     region.memoryImageHeight = 0;
-    region.imageSubresource = imageSubresource;
+    region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
     region.imageOffset = {0, 0, 0};
     region.imageExtent = {32, 32, 1};
     const uint32_t copy_size = (32 * 32 * 4) / 8;  // 64 bit pointer
@@ -1954,7 +1872,7 @@ TEST_F(NegativeHostImageCopy, ImageMemoryOverlap) {
     region2.pHostPointer = data;
     region2.memoryRowLength = 0;
     region2.memoryImageHeight = 0;
-    region2.imageSubresource = imageSubresource;
+    region2.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
     region2.imageOffset = {0, 0, 0};
     region2.imageExtent = {32, 32, 1};
 
@@ -1988,15 +1906,11 @@ TEST_F(NegativeHostImageCopy, ImageMemorySparseUnbound) {
     const uint32_t bufferSize = width * height * 4;
     std::vector<uint8_t> data(bufferSize);
 
-    VkImageSubresourceLayers imageSubresource = {};
-    imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    imageSubresource.layerCount = 1;
-
     VkImageToMemoryCopyEXT region = vku::InitStructHelper();
     region.pHostPointer = data.data();
     region.memoryRowLength = 0;
     region.memoryImageHeight = 0;
-    region.imageSubresource = imageSubresource;
+    region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
     region.imageOffset = {0, 0, 0};
     region.imageExtent = {width, height, 1};
 
@@ -2016,7 +1930,7 @@ TEST_F(NegativeHostImageCopy, ImageMemorySparseUnbound) {
     region2.pHostPointer = data.data();
     region2.memoryRowLength = 0;
     region2.memoryImageHeight = 0;
-    region2.imageSubresource = imageSubresource;
+    region2.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
     region2.imageOffset = {0, 0, 0};
     region2.imageExtent = {width, height, 1};
 

--- a/tests/unit/host_image_copy_positive.cpp
+++ b/tests/unit/host_image_copy_positive.cpp
@@ -86,11 +86,8 @@ TEST_F(PositiveHostImageCopy, BasicUsage) {
 
     VkMemoryToImageCopyEXT region_to_image = vku::InitStructHelper();
     region_to_image.pHostPointer = pixels.data();
-    region_to_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    region_to_image.imageSubresource.layerCount = 1;
-    region_to_image.imageExtent.width = width;
-    region_to_image.imageExtent.height = height;
-    region_to_image.imageExtent.depth = 1;
+    region_to_image.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region_to_image.imageExtent = {width, height, 1};
 
     VkCopyMemoryToImageInfoEXT copy_to_image = vku::InitStructHelper();
     copy_to_image.dstImage = image;
@@ -106,11 +103,8 @@ TEST_F(PositiveHostImageCopy, BasicUsage) {
 
     VkImageToMemoryCopyEXT region_from_image = vku::InitStructHelper();
     region_from_image.pHostPointer = welcome_back.data();
-    region_from_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    region_from_image.imageSubresource.layerCount = 1;
-    region_from_image.imageExtent.width = width;
-    region_from_image.imageExtent.height = height;
-    region_from_image.imageExtent.depth = 1;
+    region_from_image.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region_from_image.imageExtent = {width, height, 1};
 
     VkCopyImageToMemoryInfoEXT copy_from_image = vku::InitStructHelper();
     copy_from_image.srcImage = image;

--- a/tests/unit/image.cpp
+++ b/tests/unit/image.cpp
@@ -51,11 +51,8 @@ TEST_F(NegativeImage, UsageBits) {
     VkBufferImageCopy region = {};
     region.bufferRowLength = 128;
     region.bufferImageHeight = 128;
-    region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
-    region.imageSubresource.layerCount = 1;
-    region.imageExtent.height = 16;
-    region.imageExtent.width = 16;
-    region.imageExtent.depth = 1;
+    region.imageSubresource = {VK_IMAGE_ASPECT_DEPTH_BIT, 0, 0, 1};
+    region.imageExtent = {16, 16, 1};
 
     // Buffer usage not set to TRANSFER_SRC and image usage not set to TRANSFER_DST
     m_command_buffer.Begin();
@@ -174,11 +171,8 @@ TEST_F(NegativeImage, SampleCounts) {
     VkBufferImageCopy copy_region = {};
     copy_region.bufferRowLength = 128;
     copy_region.bufferImageHeight = 128;
-    copy_region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    copy_region.imageSubresource.layerCount = 1;
-    copy_region.imageExtent.height = 64;
-    copy_region.imageExtent.width = 64;
-    copy_region.imageExtent.depth = 1;
+    copy_region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    copy_region.imageExtent = {64, 64, 1};
 
     // Create src buffer and dst image with sampleCount = 4 and attempt to copy
     // buffer to image
@@ -2070,9 +2064,7 @@ TEST_F(NegativeImage, UndefinedFormat) {
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_UNDEFINED;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 32;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 32, 1};
     image_create_info.mipLevels = 1;
     image_create_info.arrayLayers = 1;
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
@@ -3744,9 +3736,7 @@ TEST_F(NegativeImage, BlockTexelViewLevelOrLayerCount) {
     image_create_info.flags = VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT | VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_BC1_RGBA_UNORM_BLOCK;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 32;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 32, 1};
     image_create_info.mipLevels = 4;
     image_create_info.arrayLayers = 2;
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
@@ -3798,9 +3788,7 @@ TEST_F(NegativeImage, BlockTexelViewCompatibleMultipleLayers) {
     image_create_info.flags = VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT | VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_BC1_RGBA_UNORM_BLOCK;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 32;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 32, 1};
     image_create_info.mipLevels = 4;
     image_create_info.arrayLayers = 2;
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
@@ -3924,9 +3912,7 @@ TEST_F(NegativeImage, BlockTexelViewType) {
     image_create_info.flags = VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT | VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
     image_create_info.imageType = VK_IMAGE_TYPE_3D;
     image_create_info.format = VK_FORMAT_BC1_RGBA_SRGB_BLOCK;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 32;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 32, 1};
     image_create_info.mipLevels = 1;
     image_create_info.arrayLayers = 1;
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
@@ -3963,9 +3949,7 @@ TEST_F(NegativeImage, BlockTexelViewFormat) {
     image_create_info.flags = VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT | VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_BC1_RGBA_SRGB_BLOCK;  // 64-bit block size
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 32;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 32, 1};
     image_create_info.mipLevels = 1;
     image_create_info.arrayLayers = 1;
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
@@ -4014,9 +3998,7 @@ TEST_F(NegativeImage, ImageSubresourceRangeAspectMask) {
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = mp_format;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 32;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 32, 1};
     image_create_info.mipLevels = 1;
     image_create_info.arrayLayers = 1;
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
@@ -4125,9 +4107,7 @@ TEST_F(NegativeImage, MultiSampleImageView) {
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 1;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 1, 1};
     image_create_info.mipLevels = 1;
     image_create_info.arrayLayers = 1;
     image_create_info.samples = VK_SAMPLE_COUNT_2_BIT;
@@ -5619,9 +5599,7 @@ TEST_F(NegativeImage, RemainingMipLevels2DViewOf3D) {
     image_ci.flags = VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT | VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT;
     image_ci.imageType = VK_IMAGE_TYPE_3D;
     image_ci.format = VK_FORMAT_R8G8B8A8_UNORM;
-    image_ci.extent.width = 32;
-    image_ci.extent.height = 32;
-    image_ci.extent.depth = 2;
+    image_ci.extent = {32, 32, 2};
     image_ci.mipLevels = 2;
     image_ci.arrayLayers = 1;
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;

--- a/tests/unit/image_positive.cpp
+++ b/tests/unit/image_positive.cpp
@@ -247,9 +247,7 @@ TEST_F(PositiveImage, FormatCompatibility) {
     VkImageCreateInfo image_create_info = vku::InitStructHelper(&format_list);
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 32;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 32, 1};
     image_create_info.mipLevels = 1;
     image_create_info.arrayLayers = 1;
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
@@ -280,9 +278,7 @@ TEST_F(PositiveImage, MultpilePNext) {
     VkImageCreateInfo image_create_info = vku::InitStructHelper(&image_compression);
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 32;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 32, 1};
     image_create_info.mipLevels = 1;
     image_create_info.arrayLayers = 1;
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
@@ -304,9 +300,7 @@ TEST_F(PositiveImage, FramebufferFrom3DImage) {
     image_ci.flags = VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT;
     image_ci.imageType = VK_IMAGE_TYPE_3D;
     image_ci.format = VK_FORMAT_B8G8R8A8_UNORM;
-    image_ci.extent.width = 32;
-    image_ci.extent.height = 32;
-    image_ci.extent.depth = 4;
+    image_ci.extent = {32, 32, 4};
     image_ci.mipLevels = 1;
     image_ci.arrayLayers = 1;
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
@@ -1089,9 +1083,7 @@ TEST_F(PositiveImage, BlockTexelViewCompatibleMultipleLayers) {
     image_create_info.flags = VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT | VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_BC1_RGBA_UNORM_BLOCK;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 32;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 32, 1};
     image_create_info.mipLevels = 4;
     image_create_info.arrayLayers = 2;
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
@@ -1158,9 +1150,7 @@ TEST_F(PositiveImage, RemainingMipLevels2DViewOf3D) {
     image_ci.flags = VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT | VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT;
     image_ci.imageType = VK_IMAGE_TYPE_3D;
     image_ci.format = VK_FORMAT_R8G8B8A8_UNORM;
-    image_ci.extent.width = 32;
-    image_ci.extent.height = 32;
-    image_ci.extent.depth = 2;
+    image_ci.extent = {32, 32, 2};
     image_ci.mipLevels = 1;
     image_ci.arrayLayers = 1;
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
@@ -1179,9 +1169,7 @@ TEST_F(PositiveImage, RemainingMipLevelsBlockTexelView) {
     image_create_info.flags = VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT | VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_BC1_RGBA_UNORM_BLOCK;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 32;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 32, 1};
     image_create_info.mipLevels = 1;
     image_create_info.arrayLayers = 2;
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;

--- a/tests/unit/imageless_framebuffer_positive.cpp
+++ b/tests/unit/imageless_framebuffer_positive.cpp
@@ -82,9 +82,7 @@ TEST_F(PositiveImagelessFramebuffer, Image3D) {
     image_ci.flags = VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT;
     image_ci.imageType = VK_IMAGE_TYPE_3D;
     image_ci.format = format;
-    image_ci.extent.width = 32;
-    image_ci.extent.height = 32;
-    image_ci.extent.depth = 4;
+    image_ci.extent = {32, 32, 4};
     image_ci.mipLevels = 1;
     image_ci.arrayLayers = 1;
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;

--- a/tests/unit/memory.cpp
+++ b/tests/unit/memory.cpp
@@ -1347,12 +1347,8 @@ TEST_F(NegativeMemory, BufferMemoryNotBound) {
     VkBufferImageCopy region = {};
     region.bufferRowLength = 16;
     region.bufferImageHeight = 16;
-    region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-
-    region.imageSubresource.layerCount = 1;
-    region.imageExtent.height = 4;
-    region.imageExtent.width = 4;
-    region.imageExtent.depth = 1;
+    region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region.imageExtent = {4, 4, 1};
     m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyBufferToImage-srcBuffer-00176");
     vk::CmdCopyBufferToImage(m_command_buffer.handle(), buffer, image.handle(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);

--- a/tests/unit/memory_positive.cpp
+++ b/tests/unit/memory_positive.cpp
@@ -411,9 +411,7 @@ TEST_F(PositiveMemory, BindImageMemoryMultiThreaded) {
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_B8G8R8A8_UNORM;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 32;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 32, 1};
     image_create_info.mipLevels = 1;
     image_create_info.arrayLayers = 1;
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;

--- a/tests/unit/multiview.cpp
+++ b/tests/unit/multiview.cpp
@@ -70,9 +70,7 @@ TEST_F(NegativeMultiview, ClearColorAttachments) {
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 32;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 32, 1};
     image_create_info.mipLevels = 1;
     image_create_info.arrayLayers = 4;
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
@@ -586,9 +584,7 @@ TEST_F(NegativeMultiview, BeginTransformFeedback) {
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 32;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 32, 1};
     image_create_info.mipLevels = 1;
     image_create_info.arrayLayers = 4;
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;

--- a/tests/unit/object_lifetime.cpp
+++ b/tests/unit/object_lifetime.cpp
@@ -504,9 +504,7 @@ TEST_F(NegativeObjectLifetime, CmdBufferImageDestroyed) {
         VkImageCreateInfo image_create_info = vku::InitStructHelper();
         image_create_info.imageType = VK_IMAGE_TYPE_2D;
         image_create_info.format = tex_format;
-        image_create_info.extent.width = 32;
-        image_create_info.extent.height = 32;
-        image_create_info.extent.depth = 1;
+        image_create_info.extent = {32, 32, 1};
         image_create_info.mipLevels = 1;
         image_create_info.arrayLayers = 1;
         image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
@@ -554,9 +552,7 @@ TEST_F(NegativeObjectLifetime, CmdBufferFramebufferImageDestroyed) {
         VkImageCreateInfo image_ci = vku::InitStructHelper();
         image_ci.imageType = VK_IMAGE_TYPE_2D;
         image_ci.format = VK_FORMAT_B8G8R8A8_UNORM;
-        image_ci.extent.width = 32;
-        image_ci.extent.height = 32;
-        image_ci.extent.depth = 1;
+        image_ci.extent = {32, 32, 1};
         image_ci.mipLevels = 1;
         image_ci.arrayLayers = 1;
         image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
@@ -618,9 +614,7 @@ TEST_F(NegativeObjectLifetime, FramebufferAttachmentMemoryFreed) {
     VkImageCreateInfo image_ci = vku::InitStructHelper();
     image_ci.imageType = VK_IMAGE_TYPE_2D;
     image_ci.format = VK_FORMAT_B8G8R8A8_UNORM;
-    image_ci.extent.width = 32;
-    image_ci.extent.height = 32;
-    image_ci.extent.depth = 1;
+    image_ci.extent = {32, 32, 1};
     image_ci.mipLevels = 1;
     image_ci.arrayLayers = 1;
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;

--- a/tests/unit/render_pass.cpp
+++ b/tests/unit/render_pass.cpp
@@ -2385,9 +2385,7 @@ TEST_F(NegativeRenderPass, SamplingFromReadOnlyDepthStencilAttachment) {
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = format;
-    image_create_info.extent.width = width;
-    image_create_info.extent.height = height;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {width, height, 1};
     image_create_info.mipLevels = 1;
     image_create_info.arrayLayers = 1;
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;

--- a/tests/unit/render_pass_positive.cpp
+++ b/tests/unit/render_pass_positive.cpp
@@ -719,9 +719,7 @@ TEST_F(PositiveRenderPass, QueriesInMultiview) {
 
     VkImageCreateInfo image_ci = vku::InitStructHelper();
     image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-    image_ci.extent.width = 32;
-    image_ci.extent.height = 32;
-    image_ci.extent.depth = 1;
+    image_ci.extent = {32, 32, 1};
     image_ci.arrayLayers = 3;
     image_ci.mipLevels = 2;
     image_ci.imageType = VK_IMAGE_TYPE_2D;

--- a/tests/unit/sparse_image.cpp
+++ b/tests/unit/sparse_image.cpp
@@ -199,9 +199,7 @@ TEST_F(NegativeSparseImage, ImageUsageBits) {
     image_create_info.flags = VK_IMAGE_CREATE_SPARSE_BINDING_BIT;
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 32;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 32, 1};
     image_create_info.mipLevels = 1;
     image_create_info.arrayLayers = 1;
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;

--- a/tests/unit/sync_object_positive.cpp
+++ b/tests/unit/sync_object_positive.cpp
@@ -1127,9 +1127,7 @@ TEST_F(PositiveSyncObject, DoubleLayoutTransition) {
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_B8G8R8A8_UNORM;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 1;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 1, 1};
     image_create_info.mipLevels = 1;
     image_create_info.arrayLayers = 1;
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -4100,9 +4100,7 @@ TEST_F(NegativeSyncVal, TestInvalidExternalSubpassDependency) {
     VkImageCreateInfo image_ci = vku::InitStructHelper();
     image_ci.imageType = VK_IMAGE_TYPE_2D;
     image_ci.format = VK_FORMAT_D32_SFLOAT;
-    image_ci.extent.width = 32;
-    image_ci.extent.height = 32;
-    image_ci.extent.depth = 1;
+    image_ci.extent = {32, 32, 1};
     image_ci.mipLevels = 1;
     image_ci.arrayLayers = 1;
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -206,11 +206,8 @@ TEST_F(PositiveSyncVal, WriteToImageAfterTransition) {
     barrier.subresourceRange.layerCount = 1;
 
     VkBufferImageCopy region = {};
-    region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    region.imageSubresource.layerCount = 1;
-    region.imageExtent.width = width;
-    region.imageExtent.height = height;
-    region.imageExtent.depth = 1;
+    region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region.imageExtent = {width, height, 1};
 
     m_command_buffer.Begin();
     vk::CmdPipelineBarrier(m_command_buffer, VK_PIPELINE_STAGE_HOST_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr,
@@ -470,11 +467,8 @@ TEST_F(PositiveSyncVal, LayoutTransitionWithAlreadyAvailableImage) {
 
     // Copy data from buffer to image
     VkBufferImageCopy region = {};
-    region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    region.imageSubresource.layerCount = 1;
-    region.imageExtent.width = 64;
-    region.imageExtent.height = 64;
-    region.imageExtent.depth = 1;
+    region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    region.imageExtent = {64, 64, 1};
     vk::CmdCopyBufferToImage(m_command_buffer, buffer, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
 
     // Make writes available

--- a/tests/unit/sync_val_wsi_positive.cpp
+++ b/tests/unit/sync_val_wsi_positive.cpp
@@ -426,11 +426,8 @@ TEST_F(PositiveSyncValWsi, RecreateImage) {
         dst_image = vkt::Image(*m_device, width, height, 1, format, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
 
         VkBufferImageCopy region = {};
-        region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-        region.imageSubresource.layerCount = 1;
-        region.imageExtent.width = width;
-        region.imageExtent.height = height;
-        region.imageExtent.depth = 1;
+        region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+        region.imageExtent = {width, height, 1};
 
         VkImageMemoryBarrier2 layout_transition = vku::InitStructHelper();
         layout_transition.srcStageMask = VK_PIPELINE_STAGE_2_NONE;

--- a/tests/unit/ycbcr.cpp
+++ b/tests/unit/ycbcr.cpp
@@ -305,9 +305,7 @@ TEST_F(NegativeYcbcr, Formats) {
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = mp_format;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 32;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 32, 1};
     image_create_info.mipLevels = 1;
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
@@ -386,9 +384,7 @@ TEST_F(NegativeYcbcr, FormatsLimits) {
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = mp_format;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 32;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 32, 1};
     image_create_info.mipLevels = 1;
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
@@ -659,9 +655,7 @@ TEST_F(NegativeYcbcr, ClearColorImageFormat) {
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = mp_format;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 32;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 32, 1};
     image_create_info.mipLevels = 1;
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
@@ -1968,9 +1962,7 @@ TEST_F(NegativeYcbcr, FormatCompatibilitySamePlane) {
     image_create_info.format = VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM;
     image_create_info.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 32;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 32, 1};
     image_create_info.mipLevels = 1;
     image_create_info.arrayLayers = 1;
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
@@ -2000,9 +1992,7 @@ TEST_F(NegativeYcbcr, FormatCompatibilityDifferentPlane) {
     image_create_info.format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;
     image_create_info.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 32;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 32, 1};
     image_create_info.mipLevels = 1;
     image_create_info.arrayLayers = 1;
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
@@ -2033,9 +2023,7 @@ TEST_F(NegativeYcbcr, DISABLED_FormatCompatibilityNonMutable) {
     image_create_info.format = VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM;
     image_create_info.flags = 0;
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 32;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 32, 1};
     image_create_info.mipLevels = 1;
     image_create_info.arrayLayers = 1;
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;

--- a/tests/unit/ycbcr_positive.cpp
+++ b/tests/unit/ycbcr_positive.cpp
@@ -106,9 +106,7 @@ TEST_F(PositiveYcbcr, MultiplaneImageCopyBufferToImage) {
 
     VkBufferImageCopy copy = {};
     copy.imageSubresource.layerCount = 1;
-    copy.imageExtent.depth = 1;
-    copy.imageExtent.height = 16;
-    copy.imageExtent.width = 16;
+    copy.imageExtent = {16, 16, 1};
 
     for (size_t i = 0; i < aspects.size(); ++i) {
         buffers[i].init(*m_device, 16 * 16 * 1, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
@@ -296,11 +294,8 @@ TEST_F(PositiveYcbcr, ImageLayout) {
     VkBufferImageCopy copy_region = {};
     copy_region.bufferRowLength = 128;
     copy_region.bufferImageHeight = 128;
-    copy_region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_PLANE_1_BIT;
-    copy_region.imageSubresource.layerCount = 1;
-    copy_region.imageExtent.height = 64;
-    copy_region.imageExtent.width = 64;
-    copy_region.imageExtent.depth = 1;
+    copy_region.imageSubresource = {VK_IMAGE_ASPECT_PLANE_1_BIT, 0, 0, 1};
+    copy_region.imageExtent = {64, 64, 1};
 
     vk::ResetCommandBuffer(m_command_buffer.handle(), 0);
     m_command_buffer.Begin();
@@ -522,9 +517,7 @@ TEST_F(PositiveYcbcr, FormatCompatibilitySamePlane) {
     image_create_info.format = VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM;
     image_create_info.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 32;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 32, 1};
     image_create_info.mipLevels = 1;
     image_create_info.arrayLayers = 1;
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
@@ -552,9 +545,7 @@ TEST_F(PositiveYcbcr, FormatCompatibilityDifferentPlane) {
     image_create_info.format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;
     image_create_info.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
-    image_create_info.extent.width = 32;
-    image_create_info.extent.height = 32;
-    image_create_info.extent.depth = 1;
+    image_create_info.extent = {32, 32, 1};
     image_create_info.mipLevels = 1;
     image_create_info.arrayLayers = 1;
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;


### PR DESCRIPTION
Started as a way to clean up some tests in `copy_buffer_image.cpp` but figured I would just squash things from being copied and pasted in the future