### PR TITLE
layers: Don't validate external image layouts

### DIFF
--- a/layers/core_checks/cc_image_layout.cpp
+++ b/layers/core_checks/cc_image_layout.cpp
@@ -201,6 +201,12 @@ bool CoreChecks::ValidateCmdBufImageLayouts(const Location &loc, const vvl::Comm
         const auto image_state = Get<vvl::Image>(image);
         if (!image_state) continue;
 
+        // TODO - things like ANGLE might have external images which have their layouts transitioned implicitly
+        // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8940
+        if (image_state->external_memory_handle_types != 0) {
+            continue;
+        }
+
         const auto &layout_map = layout_map_entry.second.map->GetLayoutMap();
         // Validate the initial_uses for each subresource referenced
         if (layout_map.empty()) continue;

--- a/layers/gpu/descriptor_validation/gpuav_image_layout.cpp
+++ b/layers/gpu/descriptor_validation/gpuav_image_layout.cpp
@@ -161,6 +161,13 @@ static bool VerifyImageLayoutRange(const Validator &gpuav, const vvl::CommandBuf
     if (!subresource_map) {
         return skip;
     }
+
+    // TODO - things like ANGLE might have external images which have their layouts transitioned implicitly
+    // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8940
+    if (image_state.external_memory_handle_types != 0) {
+        return skip;
+    }
+
     const auto &layout_map = subresource_map->GetLayoutMap();
     const auto *global_range_map = image_state.layout_range_map.get();
     GlobalImageLayoutRangeMap empty_map(1);


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8940 (well fixes the false positives for now)