### PR TITLE
sync: Access state cleanup

### DIFF
--- a/layers/sync/sync_access_context.cpp
+++ b/layers/sync/sync_access_context.cpp
@@ -533,16 +533,16 @@ void AccessContext::UpdateMemoryAccessStateFunctor::operator()(const ResourceAcc
 // hazards will be detected
 HazardResult AccessContext::DetectFirstUseHazard(QueueId queue_id, const ResourceUsageRange &tag_range,
                                                  const AccessContext &access_context) const {
-    HazardResult hazard;
     for (const auto &recorded_access : access_state_map_) {
         // Cull any entries not in the current tag range
         if (!recorded_access.second.FirstAccessInTagRange(tag_range)) continue;
         HazardDetectFirstUse detector(recorded_access.second, queue_id, tag_range);
-        hazard = access_context.DetectHazardRange(detector, recorded_access.first, DetectOptions::kDetectAll);
-        if (hazard.IsHazard()) break;
+        HazardResult hazard = access_context.DetectHazardRange(detector, recorded_access.first, DetectOptions::kDetectAll);
+        if (hazard.IsHazard()) {
+            return hazard;
+        }
     }
-
-    return hazard;
+    return {};
 }
 
 // For RenderPass time validation this is "start tag", for QueueSubmit, this is the earliest

--- a/layers/sync/sync_access_context.h
+++ b/layers/sync/sync_access_context.h
@@ -686,11 +686,13 @@ HazardResult AccessContext::DetectPreviousHazard(Detector &detector, const Resou
     ResourceAccessRangeMap descent_map;
     ResolvePreviousAccess(range, &descent_map, nullptr);
 
-    HazardResult hazard;
-    for (auto prev = descent_map.begin(); prev != descent_map.end() && !hazard.IsHazard(); ++prev) {
-        hazard = detector.Detect(prev);
+    for (auto prev = descent_map.begin(); prev != descent_map.end(); ++prev) {
+        HazardResult hazard = detector.Detect(prev);
+        if (hazard.IsHazard()) {
+            return hazard;
+        }
     }
-    return hazard;
+    return {};
 }
 
 template <typename Predicate>

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -161,8 +161,6 @@ bool CommandBufferAccessContext::ValidateBeginRendering(const ErrorObject &error
     // Load operations do not happen when resuming
     if (info.info.flags & VK_RENDERING_RESUMING_BIT) return skip;
 
-    HazardResult hazard;
-
     // Need to hazard detect load operations vs. the attachment views
     const uint32_t attachment_count = static_cast<uint32_t>(info.attachments.size());
     for (uint32_t i = 0; i < attachment_count; i++) {
@@ -170,7 +168,8 @@ bool CommandBufferAccessContext::ValidateBeginRendering(const ErrorObject &error
         const SyncAccessIndex load_index = attachment.GetLoadUsage();
         if (load_index == SYNC_ACCESS_INDEX_NONE) continue;
 
-        hazard = GetCurrentAccessContext()->DetectHazard(attachment.view_gen, load_index, attachment.GetOrdering());
+        const HazardResult hazard =
+            GetCurrentAccessContext()->DetectHazard(attachment.view_gen, load_index, attachment.GetOrdering());
         if (hazard.IsHazard()) {
             LogObjectList objlist(cb_state_->Handle(), attachment.view->Handle());
             Location loc = attachment.GetLocation(error_obj.location, i);

--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -1220,11 +1220,10 @@ const AccessContext *ReplayState::GetRecordedAccessContext() const {
 bool ReplayState::DetectFirstUseHazard(const ResourceUsageRange &first_use_range) const {
     bool skip = false;
     if (first_use_range.non_empty()) {
-        HazardResult hazard;
         // We're allowing for the Replay(Validate|Record) to modify the exec_context (e.g. for Renderpass operations), so
         // we need to fetch the current access context each time
-        hazard = GetRecordedAccessContext()->DetectFirstUseHazard(exec_context_.GetQueueId(), first_use_range,
-                                                                  *exec_context_.GetCurrentAccessContext());
+        const HazardResult hazard = GetRecordedAccessContext()->DetectFirstUseHazard(exec_context_.GetQueueId(), first_use_range,
+                                                                                     *exec_context_.GetCurrentAccessContext());
 
         if (hazard.IsHazard()) {
             const SyncValidator &sync_state = exec_context_.GetSyncState();

--- a/layers/sync/sync_renderpass.cpp
+++ b/layers/sync/sync_renderpass.cpp
@@ -36,8 +36,7 @@ class ValidateResolveAction {
     void operator()(const char *aspect_name, const char *attachment_name, uint32_t src_at, uint32_t dst_at,
                     const AttachmentViewGen &view_gen, AttachmentViewGen::Gen gen_type, SyncAccessIndex current_usage,
                     SyncOrdering ordering_rule) {
-        HazardResult hazard;
-        hazard = context_.DetectHazard(view_gen, gen_type, current_usage, ordering_rule);
+        const HazardResult hazard = context_.DetectHazard(view_gen, gen_type, current_usage, ordering_rule);
         if (hazard.IsHazard()) {
             const Location loc(command_);
             const auto error = cb_context_.GetSyncState().error_messages_.RenderPassResolveError(


### PR DESCRIPTION
* Rename `ResourceAccessWriteState` to have symmetrical names: `WriteState` and `ReadState`
* Use named calls (instead of constructor) to construct `HazardResult` objects for better searchability: `HazardVsPriorWrite`, `HazardVsPriorRead`