### PR TITLE
gpu: Support Slang global BDA style pointers

### DIFF
--- a/layers/gpu/spirv/buffer_device_address_pass.cpp
+++ b/layers/gpu/spirv/buffer_device_address_pass.cpp
@@ -86,7 +86,7 @@ bool BufferDeviceAddressPass::RequiresInstrumentation(const Function& function, 
     // TODO - Should have loop to walk Load/Store to the Pointer,
     // this case will not cover things such as OpCopyObject or double OpAccessChains
     const Instruction* pointer_inst = function.FindInstruction(inst.Operand(0));
-    if (!pointer_inst || pointer_inst->Opcode() != spv::OpAccessChain) {
+    if (!pointer_inst || !pointer_inst->IsAccessChain()) {
         return false;
     }
 

--- a/layers/gpu/spirv/buffer_device_address_pass.h
+++ b/layers/gpu/spirv/buffer_device_address_pass.h
@@ -37,6 +37,7 @@ class BufferDeviceAddressPass : public InjectConditionalFunctionPass {
     uint32_t link_function_id = 0;
     uint32_t GetLinkFunctionId();
 
+    uint32_t alignment_literal_ = 0;
     uint32_t type_length_ = 0;
 };
 

--- a/layers/gpu/spirv/instruction.cpp
+++ b/layers/gpu/spirv/instruction.cpp
@@ -126,6 +126,17 @@ void Instruction::ReplaceOperandId(uint32_t old_word, uint32_t new_word) {
     }
 }
 
+bool Instruction::IsArray() const {
+    const uint32_t opcode = Opcode();
+    return opcode == spv::OpTypeArray || opcode == spv::OpTypeRuntimeArray;
+}
+
+bool Instruction::IsAccessChain() const {
+    const uint32_t opcode = Opcode();
+    return opcode == spv::OpAccessChain || opcode == spv::OpPtrAccessChain || opcode == spv::OpInBoundsAccessChain ||
+           opcode == spv::OpInBoundsPtrAccessChain;
+}
+
 // The main challenge with linking to functions from 2 modules is the IDs overlap.
 // TODO - Use the new generated operand to find the IDs.
 void Instruction::ReplaceLinkedId(vvl::unordered_map<uint32_t, uint32_t>& id_swap_map) {

--- a/layers/gpu/spirv/instruction.h
+++ b/layers/gpu/spirv/instruction.h
@@ -64,7 +64,8 @@ struct Instruction {
     void ReplaceOperandId(uint32_t old_word, uint32_t new_word);
     void ReplaceLinkedId(vvl::unordered_map<uint32_t, uint32_t>& id_swap_map);
 
-    bool IsArray() const { return (Opcode() == spv::OpTypeArray || Opcode() == spv::OpTypeRuntimeArray); }
+    bool IsArray() const;
+    bool IsAccessChain() const;
 
     // SPIR-V spec: "A string is interpreted as a nul-terminated stream of characters"
     char const* GetAsString(uint32_t index) const {

--- a/tests/unit/gpu_av_buffer_device_address_positive.cpp
+++ b/tests/unit/gpu_av_buffer_device_address_positive.cpp
@@ -1186,3 +1186,77 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, ProxyStructLoad) {
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }
+
+TEST_F(PositiveGpuAVBufferDeviceAddress, NonStructPointer) {
+    TEST_DESCRIPTION("Slang allows BDA pointers to be with POD instead of a struct");
+    RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
+
+    // Slang code
+    // uniform uint* data_ptr;
+    // [numthreads(1,1,1)]
+    // void computeMain() {
+    //    data_ptr[2] = 999;
+    // }
+    char const *shader_source = R"(
+               OpCapability PhysicalStorageBufferAddresses
+               OpCapability Shader
+               OpExtension "SPV_KHR_physical_storage_buffer"
+               OpMemoryModel PhysicalStorageBuffer64 GLSL450
+               OpEntryPoint GLCompute %computeMain "main" %globalParams
+               OpExecutionMode %computeMain LocalSize 1 1 1
+               OpDecorate %_ptr_PhysicalStorageBuffer_uint ArrayStride 4
+               OpDecorate %GlobalParams_std140 Block
+               OpMemberDecorate %GlobalParams_std140 0 Offset 0
+               OpDecorate %globalParams Binding 0
+               OpDecorate %globalParams DescriptorSet 0
+       %void = OpTypeVoid
+       %uint = OpTypeInt 32 0
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+      %int_2 = OpConstant %int 2
+   %uint_999 = OpConstant %uint 999
+         %12 = OpTypeFunction %void
+%_ptr_PhysicalStorageBuffer_uint = OpTypePointer PhysicalStorageBuffer %uint
+%GlobalParams_std140 = OpTypeStruct %_ptr_PhysicalStorageBuffer_uint
+%_ptr_Uniform_GlobalParams_std140 = OpTypePointer Uniform %GlobalParams_std140
+%_ptr_Uniform__ptr_PhysicalStorageBuffer_uint = OpTypePointer Uniform %_ptr_PhysicalStorageBuffer_uint
+%globalParams = OpVariable %_ptr_Uniform_GlobalParams_std140 Uniform
+%computeMain = OpFunction %void None %12
+         %13 = OpLabel
+         %35 = OpAccessChain %_ptr_Uniform__ptr_PhysicalStorageBuffer_uint %globalParams %int_0
+         %36 = OpLoad %_ptr_PhysicalStorageBuffer_uint %35
+         %37 = OpPtrAccessChain %_ptr_PhysicalStorageBuffer_uint %36 %int_2
+               OpStore %37 %uint_999 Aligned 4
+               OpReturn
+               OpFunctionEnd
+    )";
+
+    CreateComputePipelineHelper pipe(*this);
+    pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};
+    pipe.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
+    pipe.CreateComputePipeline();
+
+    vkt::Buffer block_buffer(*m_device, 256, 0, vkt::device_address);
+    vkt::Buffer in_buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
+
+    auto in_buffer_ptr = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    in_buffer_ptr[0] = block_buffer.Address();
+    in_buffer.Memory().Unmap();
+
+    pipe.descriptor_set_->WriteDescriptorBufferInfo(0, in_buffer.handle(), 0, VK_WHOLE_SIZE);
+    pipe.descriptor_set_->UpdateDescriptorSets();
+
+    m_command_buffer.Begin();
+    vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
+    vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
+                              &pipe.descriptor_set_->set_, 0, nullptr);
+    vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
+    m_command_buffer.End();
+
+    m_default_queue->Submit(m_command_buffer);
+    m_default_queue->Wait();
+
+    auto block_buffer_ptr = static_cast<uint32_t *>(block_buffer.Memory().Map());
+    ASSERT_TRUE(block_buffer_ptr[2] == 999);
+    block_buffer.Memory().Unmap();
+}


### PR DESCRIPTION
Found out with Slang you can have a BDA reference not tied to a struct (https://godbolt.org/z/1eKesYaPW)

Currently we were not validating it, this adds logic to detect it as well as tests