### PR TITLE
layers: Misc cleanup of Copy Buffer Image code

### DIFF
--- a/layers/core_checks/cc_copy_blit_resolve.cpp
+++ b/layers/core_checks/cc_copy_blit_resolve.cpp
@@ -794,31 +794,39 @@ bool CoreChecks::ValidateCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer s
 
     const bool is_2 = loc.function == Func::vkCmdCopyBuffer2 || loc.function == Func::vkCmdCopyBuffer2KHR;
     const char *vuid;
-    const Location src_buffer_loc = loc.dot(Field::srcBuffer);
-    const Location dst_buffer_loc = loc.dot(Field::dstBuffer);
-
-    vuid = is_2 ? "VUID-VkCopyBufferInfo2-srcBuffer-00119" : "VUID-vkCmdCopyBuffer-srcBuffer-00119";
-    skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *src_buffer_state, src_buffer_loc, vuid);
-    vuid = is_2 ? "VUID-VkCopyBufferInfo2-dstBuffer-00121" : "VUID-vkCmdCopyBuffer-dstBuffer-00121";
-    skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *dst_buffer_state, dst_buffer_loc, vuid);
-
-    // Validate that SRC & DST buffers have correct usage flags set
-    vuid = is_2 ? "VUID-VkCopyBufferInfo2-srcBuffer-00118" : "VUID-vkCmdCopyBuffer-srcBuffer-00118";
-    skip |= ValidateBufferUsageFlags(LogObjectList(commandBuffer, srcBuffer), *src_buffer_state, VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
-                                     true, vuid, src_buffer_loc);
-    vuid = is_2 ? "VUID-VkCopyBufferInfo2-dstBuffer-00120" : "VUID-vkCmdCopyBuffer-dstBuffer-00120";
-    skip |= ValidateBufferUsageFlags(LogObjectList(commandBuffer, dstBuffer), *dst_buffer_state, VK_BUFFER_USAGE_TRANSFER_DST_BIT,
-                                     true, vuid, dst_buffer_loc);
 
     skip |= ValidateCmd(cb_state, loc);
     skip |= ValidateCmdCopyBufferBounds(commandBuffer, *src_buffer_state, *dst_buffer_state, regionCount, pRegions, loc);
 
-    vuid = is_2 ? "VUID-vkCmdCopyBuffer2-commandBuffer-01822" : "VUID-vkCmdCopyBuffer-commandBuffer-01822";
-    skip |= ValidateProtectedBuffer(cb_state, *src_buffer_state, src_buffer_loc, vuid);
-    vuid = is_2 ? "VUID-vkCmdCopyBuffer2-commandBuffer-01823" : "VUID-vkCmdCopyBuffer-commandBuffer-01823";
-    skip |= ValidateProtectedBuffer(cb_state, *dst_buffer_state, dst_buffer_loc, vuid);
-    vuid = is_2 ? "VUID-vkCmdCopyBuffer2-commandBuffer-01824" : "VUID-vkCmdCopyBuffer-commandBuffer-01824";
-    skip |= ValidateUnprotectedBuffer(cb_state, *dst_buffer_state, dst_buffer_loc, vuid);
+    // src buffer
+    {
+        const Location src_buffer_loc = loc.dot(Field::srcBuffer);
+        vuid = is_2 ? "VUID-VkCopyBufferInfo2-srcBuffer-00119" : "VUID-vkCmdCopyBuffer-srcBuffer-00119";
+        skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *src_buffer_state, src_buffer_loc, vuid);
+
+        vuid = is_2 ? "VUID-VkCopyBufferInfo2-srcBuffer-00118" : "VUID-vkCmdCopyBuffer-srcBuffer-00118";
+        skip |= ValidateBufferUsageFlags(LogObjectList(commandBuffer, srcBuffer), *src_buffer_state,
+                                         VK_BUFFER_USAGE_TRANSFER_SRC_BIT, true, vuid, src_buffer_loc);
+
+        vuid = is_2 ? "VUID-vkCmdCopyBuffer2-commandBuffer-01822" : "VUID-vkCmdCopyBuffer-commandBuffer-01822";
+        skip |= ValidateProtectedBuffer(cb_state, *src_buffer_state, src_buffer_loc, vuid);
+    }
+
+    // dst buffer
+    {
+        const Location dst_buffer_loc = loc.dot(Field::dstBuffer);
+        vuid = is_2 ? "VUID-VkCopyBufferInfo2-dstBuffer-00121" : "VUID-vkCmdCopyBuffer-dstBuffer-00121";
+        skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *dst_buffer_state, dst_buffer_loc, vuid);
+
+        vuid = is_2 ? "VUID-VkCopyBufferInfo2-dstBuffer-00120" : "VUID-vkCmdCopyBuffer-dstBuffer-00120";
+        skip |= ValidateBufferUsageFlags(LogObjectList(commandBuffer, dstBuffer), *dst_buffer_state,
+                                         VK_BUFFER_USAGE_TRANSFER_DST_BIT, true, vuid, dst_buffer_loc);
+
+        vuid = is_2 ? "VUID-vkCmdCopyBuffer2-commandBuffer-01823" : "VUID-vkCmdCopyBuffer-commandBuffer-01823";
+        skip |= ValidateProtectedBuffer(cb_state, *dst_buffer_state, dst_buffer_loc, vuid);
+        vuid = is_2 ? "VUID-vkCmdCopyBuffer2-commandBuffer-01824" : "VUID-vkCmdCopyBuffer-commandBuffer-01824";
+        skip |= ValidateUnprotectedBuffer(cb_state, *dst_buffer_state, dst_buffer_loc, vuid);
+    }
 
     return skip;
 }

--- a/layers/core_checks/cc_vuid_maps.cpp
+++ b/layers/core_checks/cc_vuid_maps.cpp
@@ -40,7 +40,7 @@ const std::string &GetCopyBufferImageDeviceVUID(const Location &loc, CopyError e
          }}},
         {CopyError::TransferGranularity_07747,
          {{
-             {Key(Func::vkCmdCopyBufferToImage), "VUID-vkCmdCopyBufferToImage-imageOffset-07737"},
+             {Key(Func::vkCmdCopyBufferToImage), "VUID-vkCmdCopyBufferToImage-imageOffset-07738"},
              {Key(Func::vkCmdCopyImageToBuffer), "VUID-vkCmdCopyImageToBuffer-imageOffset-07747"},
              {Key(Func::vkCmdCopyBufferToImage2), "VUID-vkCmdCopyBufferToImage2-imageOffset-07738"},
              {Key(Func::vkCmdCopyImageToBuffer2), "VUID-vkCmdCopyImageToBuffer2-imageOffset-07747"},

--- a/layers/core_checks/cc_vuid_maps.cpp
+++ b/layers/core_checks/cc_vuid_maps.cpp
@@ -38,6 +38,13 @@ const std::string &GetCopyBufferImageDeviceVUID(const Location &loc, CopyError e
              {Key(Struct::VkCopyBufferToImageInfo2), "VUID-VkCopyBufferToImageInfo2-dstImage-07976"},
              {Key(Struct::VkCopyImageToBufferInfo2), "VUID-VkCopyImageToBufferInfo2-srcImage-07976"},
          }}},
+        {CopyError::TransferGranularity_07747,
+         {{
+             {Key(Func::vkCmdCopyBufferToImage), "VUID-vkCmdCopyBufferToImage-imageOffset-07737"},
+             {Key(Func::vkCmdCopyImageToBuffer), "VUID-vkCmdCopyImageToBuffer-imageOffset-07747"},
+             {Key(Func::vkCmdCopyBufferToImage2), "VUID-vkCmdCopyBufferToImage2-imageOffset-07738"},
+             {Key(Func::vkCmdCopyImageToBuffer2), "VUID-vkCmdCopyImageToBuffer2-imageOffset-07747"},
+         }}},
         {CopyError::BufferOffset_07737,
          {{
              // was split up in 1.3.236 spec (internal MR 5371)
@@ -101,6 +108,13 @@ const std::string &GetCopyBufferImageDeviceVUID(const Location &loc, CopyError e
              {Key(Struct::VkBufferImageCopy2), "VUID-VkBufferImageCopy2-aspectMask-09103"},
              {Key(Struct::VkMemoryToImageCopy), "VUID-VkMemoryToImageCopy-aspectMask-09103"},
              {Key(Struct::VkImageToMemoryCopy), "VUID-VkImageToMemoryCopy-aspectMask-09103"},
+         }}},
+        {CopyError::ExceedBufferBounds_00171,
+         {{
+             {Key(Func::vkCmdCopyBufferToImage), "VUID-vkCmdCopyBufferToImage-pRegions-00171"},
+             {Key(Func::vkCmdCopyImageToBuffer), "VUID-vkCmdCopyImageToBuffer-pRegions-00183"},
+             {Key(Struct::VkCopyBufferToImageInfo2), "VUID-VkCopyBufferToImageInfo2-pRegions-00171"},
+             {Key(Struct::VkCopyImageToBufferInfo2), "VUID-VkCopyImageToBufferInfo2-pRegions-00183"},
          }}},
     };
 

--- a/layers/core_checks/cc_vuid_maps.h
+++ b/layers/core_checks/cc_vuid_maps.h
@@ -25,6 +25,7 @@ class Pipeline;
 enum class CopyError {
     TexelBlockSize_07975,
     MultiPlaneCompatible_07976,
+    TransferGranularity_07747,
     BufferOffset_07737,
     BufferOffset_07978,
     MemoryOverlap_00173,
@@ -33,8 +34,9 @@ enum class CopyError {
     ImageExtentDepthZero_06661,
     ImageExtentRowLength_09101,
     ImageExtentImageHeight_09102,
-
     AspectMaskSingleBit_09103,
+    ExceedBufferBounds_00171,
+
     ImageOffest_07971,
     ImageOffest_07972,
     Image1D_07979,
@@ -87,7 +89,9 @@ enum class CopyError {
     DstImage3D_04444,
 };
 
+// Does not contain Host Image Copy
 const std::string &GetCopyBufferImageDeviceVUID(const Location &loc, CopyError error);
+// contains Host Image Copy
 const std::string &GetCopyBufferImageVUID(const Location &loc, CopyError error);
 const std::string &GetCopyImageVUID(const Location &loc, CopyError error);
 const std::string &GetImageMipLevelVUID(const Location &loc);

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -803,7 +803,7 @@ class CoreChecks : public ValidationStateTracker {
 
     template <typename RegionType>
     bool ValidateCopyImageTransferGranularityRequirements(const vvl::CommandBuffer& cb_state, const vvl::Image& src_image_state,
-                                                          const vvl::Image& dst_image_state, const RegionType* region,
+                                                          const vvl::Image& dst_image_state, const RegionType& region,
                                                           const Location& region_loc) const;
     bool ValidateImageSubresourceRange(const uint32_t image_mip_count, const uint32_t image_layer_count,
                                        const VkImageSubresourceRange& subresourceRange, vvl::Field image_layer_count_var,

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1108,12 +1108,11 @@ class CoreChecks : public ValidationStateTracker {
 
     template <typename RegionType>
     bool ValidateBufferBounds(VkCommandBuffer cb, const vvl::Image& image_state, const vvl::Buffer& buffer_state,
-                              const RegionType& region, const Location& region_loc, const char* vuid) const;
+                              const RegionType& region, const Location& region_loc) const;
 
     template <typename RegionType>
     bool ValidateCopyBufferImageTransferGranularityRequirements(const vvl::CommandBuffer& cb_state, const vvl::Image& image_state,
-                                                                const RegionType* region, const Location& region_loc,
-                                                                const char* vuid) const;
+                                                                const RegionType& region, const Location& region_loc) const;
 
     template <typename HandleT>
     bool ValidateImageMipLevel(const HandleT handle, const vvl::Image& image_state, uint32_t mip_level,

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -824,8 +824,8 @@ class CoreChecks : public ValidationStateTracker {
     template <typename HandleT, typename RegionType>
     bool ValidateHeterogeneousCopyData(const HandleT handle, const RegionType& region, const vvl::Image& image_state,
                                        const Location& region_loc) const;
-    bool UsageHostTransferCheck(const vvl::Image& image_state, bool has_stencil, bool has_non_stencil, const char* vuid_09111,
-                                const char* vuid_09112, const char* vuid_09113, const Location& loc) const;
+    bool UsageHostTransferCheck(const vvl::Image& image_state, const VkImageAspectFlags aspect_mask, const char* vuid_09111,
+                                const char* vuid_09112, const char* vuid_09113, const Location& subresource_loc) const;
     template <typename InfoPointer>
     bool ValidateMemoryImageCopyCommon(InfoPointer iPointer, const Location& loc) const;
     template <typename RegionType>

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -834,7 +834,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateHostCopyImageLayout(const VkImage image, const uint32_t layout_count, const VkImageLayout* supported_image_layouts,
                                      const VkImageLayout image_layout, const Location& loc, vvl::Field supported_name,
                                      const char* vuid) const;
-    bool ValidateMemcpyExtents(const VkImageCopy2 region, const vvl::Image& image_state, bool is_src,
+    bool ValidateMemcpyExtents(const VkImageCopy2& region, const vvl::Image& src_image_state, const vvl::Image& dst_image_state,
                                const Location& region_loc) const;
     bool ValidateHostCopyCurrentLayout(VkImageLayout expected_layout, const VkImageSubresourceLayers& subres_layers,
                                        uint32_t region, const vvl::Image& image_state, const Location& loc, const char* image_label,
@@ -842,8 +842,8 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateHostCopyCurrentLayout(VkImageLayout expected_layout, const VkImageSubresourceRange& subres_range, uint32_t region,
                                        const vvl::Image& image_state, const Location& loc, const char* image_label,
                                        const char* vuid) const;
-    bool ValidateHostCopyMultiplane(VkImageCopy2 region, const vvl::Image& image_state, bool is_src,
-                                    const Location& region_loc) const;
+    bool ValidateHostCopyMultiplane(const VkImageCopy2& region, const vvl::Image& src_image_state,
+                                    const vvl::Image& dst_image_state, const Location& region_loc) const;
     bool ValidateBufferViewRange(const vvl::Buffer& buffer_state, const VkBufferViewCreateInfo& create_info,
                                  const Location& loc) const;
     bool ValidateBufferViewBuffer(const vvl::Buffer& buffer_state, const VkBufferViewCreateInfo& create_info,
@@ -896,12 +896,12 @@ class CoreChecks : public ValidationStateTracker {
                            VkImageLayout explicit_layout, const Location& image_loc, const char* mismatch_layout_vuid,
                            bool* error) const;
 
-    bool CheckItgExtent(const LogObjectList& objlist, const VkExtent3D& extent, const VkOffset3D& offset,
-                        const VkExtent3D& granularity, const VkExtent3D& subresource_extent, const VkImageType image_type,
-                        const Location& extent_loc, const char* vuid) const;
+    bool ValidateTransferGranularityExtent(const LogObjectList& objlist, const VkExtent3D& extent, const VkOffset3D& offset,
+                                           const VkExtent3D& granularity, const VkExtent3D& subresource_extent,
+                                           const VkImageType image_type, const Location& extent_loc, const char* vuid) const;
 
-    bool CheckItgOffset(const LogObjectList& objlist, const VkOffset3D& offset, const VkExtent3D& granularity,
-                        const Location& offset_loc, const char* vuid) const;
+    bool ValidateTransferGranularityOffset(const LogObjectList& objlist, const VkOffset3D& offset, const VkExtent3D& granularity,
+                                           const Location& offset_loc, const char* vuid) const;
     VkExtent3D GetScaledItg(const vvl::CommandBuffer& cb_state, const vvl::Image& image_state) const;
 
     bool PreCallValidateCmdClearColorImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
@@ -1057,7 +1057,7 @@ class CoreChecks : public ValidationStateTracker {
                                          const Location& image_loc, const char* vuid) const;
 
     template <typename HandleT>
-    bool ValidateImageSubresourceLayers(HandleT handle, const VkImageSubresourceLayers* subresource_layers,
+    bool ValidateImageSubresourceLayers(HandleT handle, const VkImageSubresourceLayers& subresource_layers,
                                         const Location& subresource_loc) const;
 
     bool ValidateBufferUsageFlags(const LogObjectList& objlist, const vvl::Buffer& buffer_state, VkFlags desired, bool strict,
@@ -1228,7 +1228,7 @@ class CoreChecks : public ValidationStateTracker {
                                           const ErrorObject& error_obj) const override;
     bool PreCallValidateCopyImageToMemoryEXT(VkDevice device, const VkCopyImageToMemoryInfoEXT* pCopyImageToMemoryInfo,
                                              const ErrorObject& error_obj) const override;
-    bool PreCallValidateCopyImageToImage(VkDevice device, const VkCopyImageToImageInfoEXT* pCopyImageToImageInfo,
+    bool PreCallValidateCopyImageToImage(VkDevice device, const VkCopyImageToImageInfo* pCopyImageToImageInfo,
                                          const ErrorObject& error_obj) const override;
     bool PreCallValidateCopyImageToImageEXT(VkDevice device, const VkCopyImageToImageInfoEXT* pCopyImageToImageInfo,
                                             const ErrorObject& error_obj) const override;
@@ -2495,20 +2495,20 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateGetImageSubresourceLayout(const vvl::Image& image_state, const VkImageSubresource& subresource,
                                            const Location& subresource_loc) const;
     bool PreCallValidateTransitionImageLayout(VkDevice device, uint32_t transitionCount,
-                                              const VkHostImageLayoutTransitionInfoEXT* pTransitions,
+                                              const VkHostImageLayoutTransitionInfo* pTransitions,
                                               const ErrorObject& error_obj) const override;
     bool PreCallValidateTransitionImageLayoutEXT(VkDevice device, uint32_t transitionCount,
                                                  const VkHostImageLayoutTransitionInfoEXT* pTransitions,
                                                  const ErrorObject& error_obj) const override;
     void PostCallRecordTransitionImageLayout(VkDevice device, uint32_t transitionCount,
-                                             const VkHostImageLayoutTransitionInfoEXT* pTransitions,
+                                             const VkHostImageLayoutTransitionInfo* pTransitions,
                                              const RecordObject& record_obj) override;
     void PostCallRecordTransitionImageLayoutEXT(VkDevice device, uint32_t transitionCount,
                                                 const VkHostImageLayoutTransitionInfoEXT* pTransitions,
                                                 const RecordObject& record_obj) override;
     bool PreCallValidateGetImageSubresourceLayout(VkDevice device, VkImage image, const VkImageSubresource* pSubresource,
                                                   VkSubresourceLayout* pLayout, const ErrorObject& error_obj) const override;
-    bool PreCallValidateGetImageSubresourceLayout2(VkDevice device, VkImage image, const VkImageSubresource2KHR* pSubresource,
+    bool PreCallValidateGetImageSubresourceLayout2(VkDevice device, VkImage image, const VkImageSubresource2* pSubresource,
                                                    VkSubresourceLayout2KHR* pLayout, const ErrorObject& error_obj) const override;
     bool PreCallValidateGetImageSubresourceLayout2KHR(VkDevice device, VkImage image, const VkImageSubresource2KHR* pSubresource,
                                                       VkSubresourceLayout2KHR* pLayout,
@@ -2569,7 +2569,7 @@ class CoreChecks : public ValidationStateTracker {
                                                    const VkCalibratedTimestampInfoEXT* pTimestampInfos, uint64_t* pTimestamps,
                                                    uint64_t* pMaxDeviation, const ErrorObject& error_obj) const override;
     bool PreCallValidateGetCalibratedTimestampsKHR(VkDevice device, uint32_t timestampCount,
-                                                   const VkCalibratedTimestampInfoEXT* pTimestampInfos, uint64_t* pTimestamps,
+                                                   const VkCalibratedTimestampInfoKHR* pTimestampInfos, uint64_t* pTimestamps,
                                                    uint64_t* pMaxDeviation, const ErrorObject& error_obj) const override;
 
     bool PreCallValidateCreateIndirectCommandsLayoutEXT(VkDevice device, const VkIndirectCommandsLayoutCreateInfoEXT* pCreateInfo,

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -963,8 +963,12 @@ class CoreChecks : public ValidationStateTracker {
     void TransitionFinalSubpassLayouts(vvl::CommandBuffer& cb_state);
 
     template <typename HandleT, typename RegionType>
+    bool ValidateCopyImageRegionCommon(HandleT handle, const vvl::Image& src_image_state, const vvl::Image& dst_image_state,
+                                       const RegionType& region, const Location& region_loc) const;
+
+    template <typename HandleT>
     bool ValidateCopyImageCommon(HandleT handle, const vvl::Image& src_image_state, const vvl::Image& dst_image_state,
-                                 uint32_t regionCount, const RegionType* pRegions, const Location& loc) const;
+                                 const Location& loc) const;
 
     template <typename RegionType>
     bool ValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout, VkImage dstImage,

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -129,24 +129,6 @@ struct TraitsBase {
     struct Traits<state_type> : public TraitsBase<handle_type, state_type, base_type> {}; \
     }
 
-// For image copies between compressed/uncompressed formats, the extent is provided in source image texels
-// Destination image texel extents must be adjusted by block size for the dest validation checks
-static inline VkExtent3D GetAdjustedDestImageExtent(VkFormat src_format, VkFormat dst_format, VkExtent3D extent) {
-    VkExtent3D adjusted_extent = extent;
-    if (vkuFormatIsBlockedImage(src_format) && !vkuFormatIsBlockedImage(dst_format)) {
-        const VkExtent3D block_extent = vkuFormatTexelBlockExtent(src_format);
-        adjusted_extent.width /= block_extent.width;
-        adjusted_extent.height /= block_extent.height;
-        adjusted_extent.depth /= block_extent.depth;
-    } else if (!vkuFormatIsBlockedImage(src_format) && vkuFormatIsBlockedImage(dst_format)) {
-        const VkExtent3D block_extent = vkuFormatTexelBlockExtent(dst_format);
-        adjusted_extent.width *= block_extent.width;
-        adjusted_extent.height *= block_extent.height;
-        adjusted_extent.depth *= block_extent.depth;
-    }
-    return adjusted_extent;
-}
-
 // Get buffer size from VkBufferImageCopy / VkBufferImageCopy2KHR structure, for a given format
 template <typename RegionType>
 static inline VkDeviceSize GetBufferSizeFromCopyImage(const RegionType& region, VkFormat image_format,


### PR DESCRIPTION
This does a lot of things around the Copy Buffer/Image code

1. Reduce places we loop the `pRegion`
2. Keep src and dst together (prevents cache trashing going between)
3. Make more use of VUID maps to not need to pass `const char*` everywhere possible
