### PR TITLE
Collapse the image layout map value

### DIFF
--- a/docs/fine_grained_locking.md
+++ b/docs/fine_grained_locking.md
@@ -632,10 +632,10 @@ Each `vvl::CommandBuffer` maintains its own copy of the image layout state, in a
 
 ```
    typedef vvl::unordered_map<const vvl::Image *,
-                                    std::shared_ptr<ImageSubresourceLayoutInfo>>  CommandBufferImageLayoutMap;
+                                    std::shared_ptr<ImageLayoutRegistry>>  CommandBufferImageLayoutMap;
    CommandBufferImageLayoutMap image_layout_map;
    typedef vvl::unordered_map<const GlobalImageLayoutRangeMap *,
-                                     std::shared_ptr<ImageSubresourceLayoutInfo>>
+                                     std::shared_ptr<ImageLayoutRegistry>>
                                                                                CommandBufferAliasedLayoutMap;
    CommandBufferAliasedLayoutMap aliased_image_layout_map;  // storage for potentially aliased images
 

--- a/docs/fine_grained_locking.md
+++ b/docs/fine_grained_locking.md
@@ -632,10 +632,10 @@ Each `vvl::CommandBuffer` maintains its own copy of the image layout state, in a
 
 ```
    typedef vvl::unordered_map<const vvl::Image *,
-                                    std::shared_ptr<ImageSubresourceLayoutMap>>  CommandBufferImageLayoutMap;
+                                    std::shared_ptr<ImageSubresourceLayoutInfo>>  CommandBufferImageLayoutMap;
    CommandBufferImageLayoutMap image_layout_map;
    typedef vvl::unordered_map<const GlobalImageLayoutRangeMap *,
-                                     std::shared_ptr<ImageSubresourceLayoutMap>>
+                                     std::shared_ptr<ImageSubresourceLayoutInfo>>
                                                                                CommandBufferAliasedLayoutMap;
    CommandBufferAliasedLayoutMap aliased_image_layout_map;  // storage for potentially aliased images
 

--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -1383,8 +1383,9 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
             const auto cb_subresource_layout_info = cb_state.GetImageSubresourceLayoutInfo(image);
             // Const getter can be null in which case we have nothing to check against for this image...
             if (!cb_subresource_layout_info) continue;
+            if (!sub_layout_map_entry.second) continue;
 
-            const auto &sub_layout_map = sub_layout_map_entry.second.info->GetLayoutMap();
+            const auto &sub_layout_map = sub_layout_map_entry.second->GetLayoutMap();
             const auto &cb_layout_map = cb_subresource_layout_info->GetLayoutMap();
             for (sparse_container::parallel_iterator<const ImageSubresourceLayoutInfo::LayoutMap> iter(sub_layout_map,
                                                                                                        cb_layout_map, 0);

--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -1378,16 +1378,16 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
         // Novel Valid usage: "UNASSIGNED-vkCmdExecuteCommands-commandBuffer-00001"
         // initial layout usage of secondary command buffers resources must match parent command buffer
         for (const auto &sub_layout_map_entry : sub_cb_state.image_layout_map) {
-            const auto image = sub_layout_map_entry.first;
+            const VkImage image = sub_layout_map_entry.first;
 
-            const auto cb_subres_map = cb_state.GetImageSubresourceLayoutMap(image);
+            const auto cb_subresource_layout_info = cb_state.GetImageSubresourceLayoutInfo(image);
             // Const getter can be null in which case we have nothing to check against for this image...
-            if (!cb_subres_map) continue;
+            if (!cb_subresource_layout_info) continue;
 
-            const auto &sub_layout_map = sub_layout_map_entry.second.map->GetLayoutMap();
-            const auto &cb_layout_map = cb_subres_map->GetLayoutMap();
-            for (sparse_container::parallel_iterator<const ImageSubresourceLayoutMap::LayoutMap> iter(sub_layout_map, cb_layout_map,
-                                                                                                      0);
+            const auto &sub_layout_map = sub_layout_map_entry.second.info->GetLayoutMap();
+            const auto &cb_layout_map = cb_subresource_layout_info->GetLayoutMap();
+            for (sparse_container::parallel_iterator<const ImageSubresourceLayoutInfo::LayoutMap> iter(sub_layout_map,
+                                                                                                       cb_layout_map, 0);
                  !iter->range.empty(); ++iter) {
                 VkImageLayout cb_layout = kInvalidLayout, sub_layout = kInvalidLayout;
                 const char *layout_type;

--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -1380,15 +1380,14 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
         for (const auto &sub_layout_map_entry : sub_cb_state.image_layout_map) {
             const VkImage image = sub_layout_map_entry.first;
 
-            const auto cb_subresource_layout_info = cb_state.GetImageSubresourceLayoutInfo(image);
+            const auto cb_image_layout_registry = cb_state.GetImageLayoutRegistry(image);
             // Const getter can be null in which case we have nothing to check against for this image...
-            if (!cb_subresource_layout_info) continue;
+            if (!cb_image_layout_registry) continue;
             if (!sub_layout_map_entry.second) continue;
 
             const auto &sub_layout_map = sub_layout_map_entry.second->GetLayoutMap();
-            const auto &cb_layout_map = cb_subresource_layout_info->GetLayoutMap();
-            for (sparse_container::parallel_iterator<const ImageSubresourceLayoutInfo::LayoutMap> iter(sub_layout_map,
-                                                                                                       cb_layout_map, 0);
+            const auto &cb_layout_map = cb_image_layout_registry->GetLayoutMap();
+            for (sparse_container::parallel_iterator<const ImageLayoutRegistry::LayoutMap> iter(sub_layout_map, cb_layout_map, 0);
                  !iter->range.empty(); ++iter) {
                 VkImageLayout cb_layout = kInvalidLayout, sub_layout = kInvalidLayout;
                 const char *layout_type;

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -1666,7 +1666,7 @@ bool CoreChecks::ValidateBarriersToImages(const Location &barrier_loc, const vvl
     using sync_vuid_maps::GetImageBarrierVUID;
     using sync_vuid_maps::ImageError;
 
-    const auto &current_map = cb_state.GetImageSubresourceLayoutMap();
+    const auto &current_map = cb_state.GetImageLayoutMap();
 
     {
         auto image_state = Get<vvl::Image>(img_barrier.image);

--- a/layers/gpu/descriptor_validation/gpuav_image_layout.cpp
+++ b/layers/gpu/descriptor_validation/gpuav_image_layout.cpp
@@ -256,14 +256,10 @@ static void RecordCmdWaitEvents2(Validator &gpuav, VkCommandBuffer commandBuffer
 }
 
 void UpdateCmdBufImageLayouts(Validator &gpuav, const vvl::CommandBuffer &cb_state) {
-    for (const auto &layout_map_entry : cb_state.image_layout_map) {
-        const auto image = layout_map_entry.first;
-        const auto subresource_layout_info = layout_map_entry.second.info;
-        if (!subresource_layout_info) {
-            continue;
-        }
+    for (const auto &[image, subresource_layout_info] : cb_state.image_layout_map) {
+        if (!subresource_layout_info) continue;
         auto image_state = gpuav.Get<vvl::Image>(image);
-        if (image_state && image_state->GetId() == layout_map_entry.second.id) {
+        if (image_state && image_state->GetId() == subresource_layout_info->GetImageId()) {
             auto guard = image_state->layout_range_map->WriteLock();
             sparse_container::splice(*image_state->layout_range_map, subresource_layout_info->GetLayoutMap(),
                                      GlobalLayoutUpdater());

--- a/layers/gpu/descriptor_validation/gpuav_image_layout.cpp
+++ b/layers/gpu/descriptor_validation/gpuav_image_layout.cpp
@@ -26,8 +26,8 @@
 
 #include "state_tracker/render_pass_state.h"
 
-using LayoutRange = image_layout_map::ImageSubresourceLayoutInfo::RangeType;
-using LayoutEntry = image_layout_map::ImageSubresourceLayoutInfo::LayoutEntry;
+using LayoutRange = image_layout_map::ImageLayoutRegistry::RangeType;
+using LayoutEntry = image_layout_map::ImageLayoutRegistry::LayoutEntry;
 
 // Utility type for checking Image layouts
 struct LayoutUseCheckAndMessage {
@@ -64,7 +64,7 @@ struct LayoutUseCheckAndMessage {
 
 // Helper to update the Global or Overlay layout map
 struct GlobalLayoutUpdater {
-    bool update(VkImageLayout &dst, const image_layout_map::ImageSubresourceLayoutInfo::LayoutEntry &src) const {
+    bool update(VkImageLayout &dst, const image_layout_map::ImageLayoutRegistry::LayoutEntry &src) const {
         if (src.current_layout != image_layout_map::kInvalidLayout && dst != src.current_layout) {
             dst = src.current_layout;
             return true;
@@ -72,7 +72,7 @@ struct GlobalLayoutUpdater {
         return false;
     }
 
-    std::optional<VkImageLayout> insert(const image_layout_map::ImageSubresourceLayoutInfo::LayoutEntry &src) const {
+    std::optional<VkImageLayout> insert(const image_layout_map::ImageLayoutRegistry::LayoutEntry &src) const {
         std::optional<VkImageLayout> result;
         if (src.current_layout != image_layout_map::kInvalidLayout) {
             result.emplace(src.current_layout);
@@ -157,8 +157,8 @@ static bool VerifyImageLayoutRange(const Validator &gpuav, const vvl::CommandBuf
                                    VkImageAspectFlags aspect_mask, VkImageLayout explicit_layout, const RangeFactory &range_factory,
                                    const Location &loc, const char *mismatch_layout_vuid, bool *error) {
     bool skip = false;
-    const auto subresource_layout_info = cb_state.GetImageSubresourceLayoutInfo(image_state.VkHandle());
-    if (!subresource_layout_info) {
+    const auto image_layout_registry = cb_state.GetImageLayoutRegistry(image_state.VkHandle());
+    if (!image_layout_registry) {
         return skip;
     }
 
@@ -168,7 +168,7 @@ static bool VerifyImageLayoutRange(const Validator &gpuav, const vvl::CommandBuf
         return skip;
     }
 
-    const auto &layout_map = subresource_layout_info->GetLayoutMap();
+    const auto &layout_map = image_layout_registry->GetLayoutMap();
     const auto *global_range_map = image_state.layout_range_map.get();
     GlobalImageLayoutRangeMap empty_map(1);
     assert(global_range_map);
@@ -256,13 +256,12 @@ static void RecordCmdWaitEvents2(Validator &gpuav, VkCommandBuffer commandBuffer
 }
 
 void UpdateCmdBufImageLayouts(Validator &gpuav, const vvl::CommandBuffer &cb_state) {
-    for (const auto &[image, subresource_layout_info] : cb_state.image_layout_map) {
-        if (!subresource_layout_info) continue;
+    for (const auto &[image, image_layout_registry] : cb_state.image_layout_map) {
+        if (!image_layout_registry) continue;
         auto image_state = gpuav.Get<vvl::Image>(image);
-        if (image_state && image_state->GetId() == subresource_layout_info->GetImageId()) {
+        if (image_state && image_state->GetId() == image_layout_registry->GetImageId()) {
             auto guard = image_state->layout_range_map->WriteLock();
-            sparse_container::splice(*image_state->layout_range_map, subresource_layout_info->GetLayoutMap(),
-                                     GlobalLayoutUpdater());
+            sparse_container::splice(*image_state->layout_range_map, image_layout_registry->GetLayoutMap(), GlobalLayoutUpdater());
         }
     }
 }
@@ -337,7 +336,7 @@ bool Validator::VerifyImageLayout(const vvl::CommandBuffer &cb_state, const vvl:
     if (disabled[image_layout_validation]) return false;
     // Possible the image state was destroyed and we didn't see it waiting for the queue submit callback
     if (!image_view_state.image_state) return false;
-    auto range_factory = [&image_view_state](const ImageSubresourceLayoutInfo &info) {
+    auto range_factory = [&image_view_state](const ImageLayoutRegistry &registry) {
         return image_layout_map::RangeGenerator(image_view_state.range_generator);
     };
 

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -405,28 +405,28 @@ void CommandBuffer::NotifyInvalidate(const StateObject::NodeList &invalid_nodes,
     StateObject::NotifyInvalidate(invalid_nodes, unlink);
 }
 
-const CommandBuffer::ImageLayoutMap &CommandBuffer::GetImageSubresourceLayoutMap() const { return image_layout_map; }
+const CommandBuffer::ImageLayoutMap &CommandBuffer::GetImageLayoutMap() const { return image_layout_map; }
 
 // The const variant only need the image as it is the key for the map
-std::shared_ptr<const ImageSubresourceLayoutMap> CommandBuffer::GetImageSubresourceLayoutMap(VkImage image) const {
+std::shared_ptr<const ImageSubresourceLayoutInfo> CommandBuffer::GetImageSubresourceLayoutInfo(VkImage image) const {
     auto it = image_layout_map.find(image);
     if (it == image_layout_map.cend()) {
         return nullptr;
     }
-    return it->second.map;
+    return it->second.info;
 }
 
 // The non-const variant only needs the image state, as the factory requires it to construct a new entry
-std::shared_ptr<ImageSubresourceLayoutMap> CommandBuffer::GetImageSubresourceLayoutMap(const vvl::Image &image_state) {
+std::shared_ptr<ImageSubresourceLayoutInfo> CommandBuffer::GetOrCreateImageSubresourceLayoutInfo(const vvl::Image &image_state) {
     // Make sure we don't create a nullptr keyed entry for a zombie Image
     if (image_state.Destroyed() || !image_state.layout_range_map) {
         return nullptr;
     }
     auto iter = image_layout_map.find(image_state.VkHandle());
     if (iter != image_layout_map.end() && image_state.GetId() == iter->second.id) {
-        return iter->second.map;
+        return iter->second.info;
     }
-    std::shared_ptr<ImageSubresourceLayoutMap> layout_map;
+    std::shared_ptr<ImageSubresourceLayoutInfo> subresource_layout_info;
     if (image_state.CanAlias()) {
         // Aliasing images need to share the same local layout map.
         // Since they use the same global layout state, use it as a key
@@ -435,27 +435,28 @@ std::shared_ptr<ImageSubresourceLayoutMap> CommandBuffer::GetImageSubresourceLay
         const auto *global_layout_map = image_state.layout_range_map.get();
         auto alias_iter = aliased_image_layout_map.find(global_layout_map);
         if (alias_iter != aliased_image_layout_map.end()) {
-            layout_map = alias_iter->second;
+            subresource_layout_info = alias_iter->second;
         } else {
-            layout_map = std::make_shared<ImageSubresourceLayoutMap>(image_state);
+            subresource_layout_info = std::make_shared<ImageSubresourceLayoutInfo>(image_state);
             // Save the local layout map for the next aliased image.
             // The global layout map pointer is only used as a key into the local lookup
             // table so it doesn't need to be locked.
-            aliased_image_layout_map.emplace(global_layout_map, layout_map);
+            aliased_image_layout_map.emplace(global_layout_map, subresource_layout_info);
         }
 
     } else {
-        layout_map = std::make_shared<ImageSubresourceLayoutMap>(image_state);
+        subresource_layout_info = std::make_shared<ImageSubresourceLayoutInfo>(image_state);
     }
     if (iter != image_layout_map.end()) {
         // overwrite the stale entry
         iter->second.id = image_state.GetId();
-        iter->second.map = layout_map;
+        iter->second.info = subresource_layout_info;
     } else {
         // add a new entry
-        image_layout_map.insert({image_state.VkHandle(), vvl::CommandBuffer::LayoutState{image_state.GetId(), layout_map}});
+        image_layout_map.insert(
+            {image_state.VkHandle(), vvl::CommandBuffer::LayoutState{image_state.GetId(), subresource_layout_info}});
     }
-    return layout_map;
+    return subresource_layout_info;
 }
 
 static bool SetQueryState(const QueryObject &object, QueryState value, QueryMap *localQueryToStateMap) {
@@ -1083,9 +1084,9 @@ void CommandBuffer::ExecuteCommands(vvl::span<const VkCommandBuffer> secondary_c
             if (!image_state || image_state->Destroyed() || image_state->GetId() != sub_layout_map_entry.second.id) {
                 continue;
             }
-            auto cb_subres_map = GetImageSubresourceLayoutMap(*image_state);
-            if (cb_subres_map) {
-                cb_subres_map->UpdateFrom(*sub_layout_map_entry.second.map);
+            auto cb_subresource_layout_info = GetOrCreateImageSubresourceLayoutInfo(*image_state);
+            if (cb_subresource_layout_info) {
+                cb_subresource_layout_info->UpdateFrom(*sub_layout_map_entry.second.info);
             }
         }
 
@@ -1414,7 +1415,7 @@ void CommandBuffer::UpdateLastBoundDescriptorBuffers(VkPipelineBindPoint pipelin
 // Set image layout for given VkImageSubresourceRange struct
 void CommandBuffer::SetImageLayout(const vvl::Image &image_state, const VkImageSubresourceRange &image_subresource_range,
                                    VkImageLayout layout, VkImageLayout expected_layout) {
-    auto subresource_map = GetImageSubresourceLayoutMap(image_state);
+    auto subresource_map = GetOrCreateImageSubresourceLayoutInfo(image_state);
     if (subresource_map && subresource_map->SetSubresourceRangeLayout(*this, image_subresource_range, layout, expected_layout)) {
         image_layout_change_count++;  // Change the version of this data to force revalidation
     }
@@ -1426,7 +1427,8 @@ void CommandBuffer::SetImageViewInitialLayout(const vvl::ImageView &view_state, 
         return;
     }
     vvl::Image *image_state = view_state.image_state.get();
-    auto subresource_map = (image_state && !image_state->Destroyed()) ? GetImageSubresourceLayoutMap(*image_state) : nullptr;
+    auto subresource_map =
+        (image_state && !image_state->Destroyed()) ? GetOrCreateImageSubresourceLayoutInfo(*image_state) : nullptr;
     if (subresource_map) {
         subresource_map->SetSubresourceRangeInitialLayout(*this, layout, view_state);
     }
@@ -1435,7 +1437,7 @@ void CommandBuffer::SetImageViewInitialLayout(const vvl::ImageView &view_state, 
 // Set the initial image layout for a passed non-normalized subresource range
 void CommandBuffer::SetImageInitialLayout(const vvl::Image &image_state, const VkImageSubresourceRange &range,
                                           VkImageLayout layout) {
-    auto subresource_map = GetImageSubresourceLayoutMap(image_state);
+    auto subresource_map = GetOrCreateImageSubresourceLayoutInfo(image_state);
     if (subresource_map) {
         subresource_map->SetSubresourceRangeInitialLayout(*this, image_state.NormalizeSubresourceRange(range), layout);
     }

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -41,7 +41,7 @@ class VideoSessionParameters;
 
 // Only CoreChecks uses this, but the state tracker stores it.
 constexpr static auto kInvalidLayout = image_layout_map::kInvalidLayout;
-using ImageSubresourceLayoutMap = image_layout_map::ImageSubresourceLayoutMap;
+using ImageSubresourceLayoutInfo = image_layout_map::ImageSubresourceLayoutInfo;
 
 struct EventInfo {
     VkPipelineStageFlags2 src_stage_mask = VK_PIPELINE_STAGE_2_NONE;
@@ -161,10 +161,10 @@ class CommandBuffer : public RefcountedStateObject {
   public:
     struct LayoutState {
         StateObject::IdType id;
-        std::shared_ptr<ImageSubresourceLayoutMap> map;
+        std::shared_ptr<ImageSubresourceLayoutInfo> info;
     };
     using ImageLayoutMap = vvl::unordered_map<VkImage, LayoutState>;
-    using AliasedLayoutMap = vvl::unordered_map<const GlobalImageLayoutRangeMap *, std::shared_ptr<ImageSubresourceLayoutMap>>;
+    using AliasedLayoutMap = vvl::unordered_map<const GlobalImageLayoutRangeMap *, std::shared_ptr<ImageSubresourceLayoutInfo>>;
 
     VkCommandBufferAllocateInfo allocate_info;
     VkCommandBufferBeginInfo beginInfo;
@@ -579,9 +579,9 @@ class CommandBuffer : public RefcountedStateObject {
 
     void ResetPushConstantRangesLayoutIfIncompatible(const vvl::PipelineLayout &pipeline_layout_state);
 
-    std::shared_ptr<const ImageSubresourceLayoutMap> GetImageSubresourceLayoutMap(VkImage image) const;
-    std::shared_ptr<ImageSubresourceLayoutMap> GetImageSubresourceLayoutMap(const vvl::Image &image_state);
-    const ImageLayoutMap &GetImageSubresourceLayoutMap() const;
+    std::shared_ptr<const ImageSubresourceLayoutInfo> GetImageSubresourceLayoutInfo(VkImage image) const;
+    std::shared_ptr<ImageSubresourceLayoutInfo> GetOrCreateImageSubresourceLayoutInfo(const vvl::Image &image_state);
+    const ImageLayoutMap &GetImageLayoutMap() const;
 
     const QFOTransferBarrierSets<QFOImageTransferBarrier> &GetQFOBarrierSets(const QFOImageTransferBarrier &type_tag) const {
         return qfo_transfer_image_barriers;

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -159,11 +159,7 @@ struct LabelCommand {
 class CommandBuffer : public RefcountedStateObject {
     using Func = vvl::Func;
   public:
-    struct LayoutState {
-        StateObject::IdType id;
-        std::shared_ptr<ImageSubresourceLayoutInfo> info;
-    };
-    using ImageLayoutMap = vvl::unordered_map<VkImage, LayoutState>;
+    using ImageLayoutMap = vvl::unordered_map<VkImage, std::shared_ptr<ImageSubresourceLayoutInfo>>;
     using AliasedLayoutMap = vvl::unordered_map<const GlobalImageLayoutRangeMap *, std::shared_ptr<ImageSubresourceLayoutInfo>>;
 
     VkCommandBufferAllocateInfo allocate_info;

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -41,7 +41,7 @@ class VideoSessionParameters;
 
 // Only CoreChecks uses this, but the state tracker stores it.
 constexpr static auto kInvalidLayout = image_layout_map::kInvalidLayout;
-using ImageSubresourceLayoutInfo = image_layout_map::ImageSubresourceLayoutInfo;
+using ImageLayoutRegistry = image_layout_map::ImageLayoutRegistry;
 
 struct EventInfo {
     VkPipelineStageFlags2 src_stage_mask = VK_PIPELINE_STAGE_2_NONE;
@@ -159,8 +159,8 @@ struct LabelCommand {
 class CommandBuffer : public RefcountedStateObject {
     using Func = vvl::Func;
   public:
-    using ImageLayoutMap = vvl::unordered_map<VkImage, std::shared_ptr<ImageSubresourceLayoutInfo>>;
-    using AliasedLayoutMap = vvl::unordered_map<const GlobalImageLayoutRangeMap *, std::shared_ptr<ImageSubresourceLayoutInfo>>;
+    using ImageLayoutMap = vvl::unordered_map<VkImage, std::shared_ptr<ImageLayoutRegistry>>;
+    using AliasedLayoutMap = vvl::unordered_map<const GlobalImageLayoutRangeMap *, std::shared_ptr<ImageLayoutRegistry>>;
 
     VkCommandBufferAllocateInfo allocate_info;
     VkCommandBufferBeginInfo beginInfo;
@@ -575,8 +575,8 @@ class CommandBuffer : public RefcountedStateObject {
 
     void ResetPushConstantRangesLayoutIfIncompatible(const vvl::PipelineLayout &pipeline_layout_state);
 
-    std::shared_ptr<const ImageSubresourceLayoutInfo> GetImageSubresourceLayoutInfo(VkImage image) const;
-    std::shared_ptr<ImageSubresourceLayoutInfo> GetOrCreateImageSubresourceLayoutInfo(const vvl::Image &image_state);
+    std::shared_ptr<const ImageLayoutRegistry> GetImageLayoutRegistry(VkImage image) const;
+    std::shared_ptr<ImageLayoutRegistry> GetOrCreateImageLayoutRegistry(const vvl::Image &image_state);
     const ImageLayoutMap &GetImageLayoutMap() const;
 
     const QFOTransferBarrierSets<QFOImageTransferBarrier> &GetQFOBarrierSets(const QFOImageTransferBarrier &type_tag) const {

--- a/layers/state_tracker/image_layout_map.cpp
+++ b/layers/state_tracker/image_layout_map.cpp
@@ -168,6 +168,8 @@ uintptr_t ImageSubresourceLayoutInfo::CompatibilityKey() const {
     return (reinterpret_cast<uintptr_t>(&image_state_) ^ encoder_.AspectMask());
 }
 
+uint32_t ImageSubresourceLayoutInfo::GetImageId() const { return image_state_.GetId(); }
+
 bool ImageSubresourceLayoutInfo::UpdateFrom(const ImageSubresourceLayoutInfo& other) {
     // Must be from matching images for the reinterpret cast to be valid
     assert(CompatibilityKey() == other.CompatibilityKey());

--- a/layers/state_tracker/image_layout_map.h
+++ b/layers/state_tracker/image_layout_map.h
@@ -52,7 +52,7 @@ struct InitialLayoutState {
 };
 
 // Contains all info around an image, its subresources and layout map
-class ImageSubresourceLayoutInfo {
+class ImageLayoutRegistry {
   public:
     typedef std::function<bool(const VkImageSubresource&, VkImageLayout, VkImageLayout)> Callback;
 
@@ -117,11 +117,11 @@ class ImageSubresourceLayoutInfo {
                                           VkImageLayout layout);
     void SetSubresourceRangeInitialLayout(const vvl::CommandBuffer& cb_state, VkImageLayout layout,
                                           const vvl::ImageView& view_state);
-    bool UpdateFrom(const ImageSubresourceLayoutInfo& from);
+    bool UpdateFrom(const ImageLayoutRegistry& from);
     uintptr_t CompatibilityKey() const;
     const LayoutMap& GetLayoutMap() const { return layout_map_; }
-    ImageSubresourceLayoutInfo(const vvl::Image& image_state);
-    ~ImageSubresourceLayoutInfo() {}
+    ImageLayoutRegistry(const vvl::Image& image_state);
+    ~ImageLayoutRegistry() {}
     uint32_t GetImageId() const;
 
     // This looks a bit ponderous but kAspectCount is a compile time constant

--- a/layers/state_tracker/image_layout_map.h
+++ b/layers/state_tracker/image_layout_map.h
@@ -122,6 +122,7 @@ class ImageSubresourceLayoutInfo {
     const LayoutMap& GetLayoutMap() const { return layout_map_; }
     ImageSubresourceLayoutInfo(const vvl::Image& image_state);
     ~ImageSubresourceLayoutInfo() {}
+    uint32_t GetImageId() const;
 
     // This looks a bit ponderous but kAspectCount is a compile time constant
     VkImageSubresource Decode(IndexType index) const {

--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -254,7 +254,7 @@ Image::Image(const ValidationStateTracker &dev_data, VkImage img, const VkImageC
 
 void Image::Destroy() {
     // NOTE: due to corner cases in aliased images, the layout_range_map MUST not be cleaned up here.
-    // If it is, bad local entries could be created by vvl::CommandBuffer::GetOrCreateImageSubresourceLayoutInfo()
+    // If it is, bad local entries could be created by vvl::CommandBuffer::GetOrCreateImageLayoutRegistry()
     // If an aliasing image was being destroyed (and layout_range_map was reset()), a nullptr keyed
     // entry could get put into vvl::CommandBuffer::aliased_image_layout_map.
     //

--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -254,7 +254,7 @@ Image::Image(const ValidationStateTracker &dev_data, VkImage img, const VkImageC
 
 void Image::Destroy() {
     // NOTE: due to corner cases in aliased images, the layout_range_map MUST not be cleaned up here.
-    // If it is, bad local entries could be created by vvl::CommandBuffer::GetImageSubresourceLayoutMap()
+    // If it is, bad local entries could be created by vvl::CommandBuffer::GetOrCreateImageSubresourceLayoutInfo()
     // If an aliasing image was being destroyed (and layout_range_map was reset()), a nullptr keyed
     // entry could get put into vvl::CommandBuffer::aliased_image_layout_map.
     //

--- a/layers/state_tracker/state_object.h
+++ b/layers/state_tracker/state_object.h
@@ -49,7 +49,6 @@ class StateObject: public std::enable_shared_from_this<StateObject>, public Type
     // parent types without locking every weak_ptr.
     using NodeMap = unordered_map<VulkanTypedHandle, std::weak_ptr<StateObject>>;
     using NodeList = small_vector<std::shared_ptr<StateObject>, 4, uint32_t>;
-    using IdType = uint32_t;
 
     template <typename Handle>
     StateObject(Handle h, VulkanObjectType t) : TypedHandleWrapper(h, t), destroyed_(false), id_(0) {}
@@ -72,8 +71,8 @@ class StateObject: public std::enable_shared_from_this<StateObject>, public Type
     // Some drivers may reuse vulkan handles, which can confuse some parts of validation that cache state.
     // Add a unique id to help detect this condition. SetId() should only be called by the state tracker during
     // object creation.
-    void SetId(IdType id) { id_ = id; }
-    IdType GetId() const { return id_; }
+    void SetId(uint32_t id) { id_ = id; }
+    uint32_t GetId() const { return id_; }
 
     // returns true if this vulkan object or any it uses have been destroyed
     virtual bool Invalid() const { return Destroyed(); }
@@ -116,7 +115,8 @@ class StateObject: public std::enable_shared_from_this<StateObject>, public Type
     // Set to true when the API-level object is destroyed, but this object may
     // hang around until its shared_ptr refcount goes to zero.
     std::atomic<bool> destroyed_;
-    IdType id_;
+    uint32_t id_;
+
   private:
     ReadLockGuard ReadLockTree() const { return ReadLockGuard(tree_lock_); }
     WriteLockGuard WriteLockTree() { return WriteLockGuard(tree_lock_); }

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -1956,7 +1956,7 @@ class ValidationStateTracker : public ValidationObject {
     VALSTATETRACK_MAP_AND_TRAITS_INSTANCE_SCOPE(VkDisplayModeKHR, vvl::DisplayMode, display_mode_map_)
     VALSTATETRACK_MAP_AND_TRAITS_INSTANCE_SCOPE(VkPhysicalDevice, vvl::PhysicalDevice, physical_device_map_)
 
-    std::atomic<vvl::StateObject::IdType> object_id_{1}; // 0 is an invalid id
+    std::atomic<uint32_t> object_id_{1};  // 0 is an invalid id
 
     // Simple base address allocator allow allow VkDeviceMemory allocations to appear to exist in a common address space.
     // At 256GB allocated/sec  ( > 8GB at 30Hz), will overflow in just over 2 years

--- a/tests/unit/image_layout.cpp
+++ b/tests/unit/image_layout.cpp
@@ -243,8 +243,9 @@ TEST_F(NegativeImageLayout, Compute11) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeImageLayout, TrackingCommand) {
-    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5846");
+// inspired by https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5846
+TEST_F(NegativeImageLayout, MultipleCommandDispatches) {
+    TEST_DESCRIPTION("Make sure we can detect the exact dispatch command that caused the error later");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(Init());
 


### PR DESCRIPTION
1. `ImageSubresourceLayoutMap` is not a map, it contains the `LayoutMap` and it is confusing, renamed to reflect that
2. Moved the `uint32_t` (`IdType`) inside `ImageSubresourceLayoutInfo` so that the other `image_layout_map` is simpler to use
