### PR TITLE
tests: Add test for GPL and legacy dithering

### DIFF
--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -3695,7 +3695,9 @@ bool CoreChecks::ValidateDrawPipelineDynamicRenderpassLegacyDithering(const Last
     if (!enabled_features.legacyDithering) return skip;
 
     const vvl::CommandBuffer &cb_state = last_bound_state.cb_state;
-    const bool has_legacy_dithering_pipeline = (pipeline.create_flags & VK_PIPELINE_CREATE_2_ENABLE_LEGACY_DITHERING_BIT_EXT) != 0;
+    const bool has_legacy_dithering_pipeline =
+        ((pipeline.create_flags & VK_PIPELINE_CREATE_2_ENABLE_LEGACY_DITHERING_BIT_EXT) != 0) ||
+        pipeline.fragment_output_state->legacy_dithering_enabled;
     const bool has_legacy_dithering_rendering = (rendering_info.flags & VK_RENDERING_ENABLE_LEGACY_DITHERING_BIT_EXT) != 0;
     if (has_legacy_dithering_pipeline && !has_legacy_dithering_rendering) {
         const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());

--- a/layers/state_tracker/pipeline_sub_state.h
+++ b/layers/state_tracker/pipeline_sub_state.h
@@ -223,6 +223,11 @@ struct FragmentOutputState : public PipelineSubState {
             sample_location_enabled = IsSampleLocationEnabled(create_info);
         }
 
+        const auto flags2 = vku::FindStructInPNextChain<VkPipelineCreateFlags2CreateInfoKHR>(create_info.pNext);
+        if (flags2) {
+            legacy_dithering_enabled = (flags2->flags & VK_PIPELINE_CREATE_2_ENABLE_LEGACY_DITHERING_BIT_EXT) != 0;
+        }
+
         // TODO
         // auto format_ci = vku::FindStructInPNextChain<VkPipelineRenderingFormatCreateInfoKHR>(gpci->pNext);
     }
@@ -237,6 +242,7 @@ struct FragmentOutputState : public PipelineSubState {
 
     AttachmentStateVector attachment_states;
 
+    bool legacy_dithering_enabled = false;
     bool blend_constants_enabled = false;  // Blend constants enabled for any attachments
     bool sample_location_enabled = false;
 };


### PR DESCRIPTION
The VK_PIPELINE_CREATE_2_ENABLE_LEGACY_DITHERING_BIT_EXT flag is part of the fragment output state, but is not tracked by the fragment output state of the validation layer. This can cause incorrect validation layer errors when the flag is included when creating a pipeline library, while not including it in the final pipeline. This PR fixes this by adding the flag to the fragment output state, and adds a test to the positive graphics pipeline library test class.

Addresses issue: #8988