### PR TITLE
sync: Introduce key-value properties section

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -427,9 +427,9 @@
                                     "expanded": false,
                                     "settings": [
                                         {
-                                            "key": "syncval_message_include_debug_information",
-                                            "label": "Include debug information",
-                                            "description": "Includes debug information for additional diagnostics. This can be useful for reporting issues or for users familiar with the validation codebase.",
+                                            "key": "syncval_message_extra_properties",
+                                            "label": "Add extra key-value properties",
+                                            "description": "Appends a section of key-value properties to the error message. This structured information is useful for filtering error messages and may include optional or debug properties that are not found in the main error message.",
                                             "type": "BOOL",
                                             "default": false,
                                             "dependence": {

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -213,7 +213,7 @@ const char *VK_LAYER_GPUAV_DEBUG_PRINT_INSTRUMENTATION_INFO = "gpuav_debug_print
 // ---
 const char *VK_LAYER_SYNCVAL_SUBMIT_TIME_VALIDATION = "syncval_submit_time_validation";
 const char *VK_LAYER_SYNCVAL_SHADER_ACCESSES_HEURISTIC = "syncval_shader_accesses_heuristic";
-const char *VK_LAYER_SYNCVAL_MESSAGE_INCLUDE_DEBUG_INFORMATION = "syncval_message_include_debug_information";
+const char *VK_LAYER_SYNCVAL_MESSAGE_EXTRA_PROPERTIES = "syncval_message_extra_properties";
 
 // Message Formatting
 // ---
@@ -1000,9 +1000,9 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
                                 syncval_settings.shader_accesses_heuristic);
     }
 
-    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_SYNCVAL_MESSAGE_INCLUDE_DEBUG_INFORMATION)) {
-        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_SYNCVAL_MESSAGE_INCLUDE_DEBUG_INFORMATION,
-                                syncval_settings.message_include_debug_information);
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_SYNCVAL_MESSAGE_EXTRA_PROPERTIES)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_SYNCVAL_MESSAGE_EXTRA_PROPERTIES,
+                                syncval_settings.message_extra_properties);
     }
 
     const auto *validation_features_ext = vku::FindStructInPNextChain<VkValidationFeaturesEXT>(settings_data->create_info);

--- a/layers/sync/sync_commandbuffer.h
+++ b/layers/sync/sync_commandbuffer.h
@@ -19,6 +19,7 @@
 #include "sync/sync_renderpass.h"
 #include "state_tracker/cmd_buffer_state.h"
 
+struct ReportKeyValues;
 class SyncValidator;
 
 namespace syncval {
@@ -210,6 +211,7 @@ class CommandExecutionContext {
     virtual QueueId GetQueueId() const = 0;
     virtual VulkanTypedHandle Handle() const = 0;
     virtual std::string FormatUsage(ResourceUsageTagEx tag_ex) const = 0;
+    virtual void AddUsageRecordExtraProperties(ResourceUsageTag tag, ReportKeyValues &extra_properties) const = 0;
 
     std::string FormatHazard(const HazardResult &hazard) const;
     bool ValidForSyncOps() const;
@@ -261,6 +263,7 @@ class CommandBufferAccessContext : public CommandExecutionContext, DebugNameProv
     void Reset();
 
     std::string FormatUsage(ResourceUsageTagEx tag_ex) const override;
+    void AddUsageRecordExtraProperties(ResourceUsageTag tag, ReportKeyValues &extra_properties) const override;
     std::string FormatUsage(const char *usage_string,
                             const ResourceFirstAccess &access) const;  //  Only command buffers have "first usage"
     AccessContext *GetCurrentAccessContext() override { return current_context_; }

--- a/layers/sync/sync_error_messages.cpp
+++ b/layers/sync/sync_error_messages.cpp
@@ -18,6 +18,7 @@
 #include "sync/sync_error_messages.h"
 #include "sync/sync_commandbuffer.h"
 #include "sync/sync_image.h"
+#include "sync/sync_reporting.h"
 #include "state_tracker/buffer_state.h"
 #include "state_tracker/descriptor_sets.h"
 
@@ -103,62 +104,87 @@ static const char* string_SyncHazard(SyncHazard hazard) {
 
 namespace syncval {
 
+void ErrorMessages::AddCbContextExtraProperties(const CommandBufferAccessContext& cb_context, ResourceUsageTag tag,
+                                                std::string& message) const {
+    if (validator_.syncval_settings.message_extra_properties) {
+        ReportKeyValues key_values;
+        cb_context.AddUsageRecordExtraProperties(tag, key_values);
+        message += key_values.GetExtraPropertiesSection();
+    }
+}
+
 std::string ErrorMessages::Error(const HazardResult& hazard, const char* description,
                                  const CommandBufferAccessContext& cb_context) const {
-    const auto message = "Hazard %s for %s. Access info %s.";
-    return Format(message, string_SyncHazard(hazard.Hazard()), description, cb_context.FormatHazard(hazard).c_str());
+    const auto format = "Hazard %s for %s. Access info %s.";
+    std::string message = Format(format, string_SyncHazard(hazard.Hazard()), description, cb_context.FormatHazard(hazard).c_str());
+    AddCbContextExtraProperties(cb_context, hazard.Tag(), message);
+    return message;
 }
 
 std::string ErrorMessages::BufferError(const HazardResult& hazard, VkBuffer buffer, const char* buffer_description,
                                        const CommandBufferAccessContext& cb_context) const {
-    const auto message = "Hazard %s for %s %s. Access info %s.";
-    return Format(message, string_SyncHazard(hazard.Hazard()), buffer_description, validator_.FormatHandle(buffer).c_str(),
-                  cb_context.FormatHazard(hazard).c_str());
+    const auto format = "Hazard %s for %s %s. Access info %s.";
+    std::string message = Format(format, string_SyncHazard(hazard.Hazard()), buffer_description,
+                                 validator_.FormatHandle(buffer).c_str(), cb_context.FormatHazard(hazard).c_str());
+    AddCbContextExtraProperties(cb_context, hazard.Tag(), message);
+    return message;
 }
 
 std::string ErrorMessages::BufferRegionError(const HazardResult& hazard, VkBuffer buffer, bool is_src_buffer, uint32_t region_index,
                                              const CommandBufferAccessContext& cb_context) const {
-    const auto message = "Hazard %s for %s %s, region %" PRIu32 ". Access info %s.";
-    return Format(message, string_SyncHazard(hazard.Hazard()), is_src_buffer ? "srcBuffer" : "dstBuffer",
-                  validator_.FormatHandle(buffer).c_str(), region_index, cb_context.FormatHazard(hazard).c_str());
+    const auto format = "Hazard %s for %s %s, region %" PRIu32 ". Access info %s.";
+    std::string message = Format(format, string_SyncHazard(hazard.Hazard()), is_src_buffer ? "srcBuffer" : "dstBuffer",
+                                 validator_.FormatHandle(buffer).c_str(), region_index, cb_context.FormatHazard(hazard).c_str());
+    AddCbContextExtraProperties(cb_context, hazard.Tag(), message);
+    return message;
 }
 
 std::string ErrorMessages::ImageRegionError(const HazardResult& hazard, VkImage image, bool is_src_image, uint32_t region_index,
                                             const CommandBufferAccessContext& cb_context) const {
-    const auto message = "Hazard %s for %s %s, region %" PRIu32 ". Access info %s.";
-    return Format(message, string_SyncHazard(hazard.Hazard()), is_src_image ? "srcImage" : "dstImage",
-                  validator_.FormatHandle(image).c_str(), region_index, cb_context.FormatHazard(hazard).c_str());
+    const auto format = "Hazard %s for %s %s, region %" PRIu32 ". Access info %s.";
+    std::string message = Format(format, string_SyncHazard(hazard.Hazard()), is_src_image ? "srcImage" : "dstImage",
+                                 validator_.FormatHandle(image).c_str(), region_index, cb_context.FormatHazard(hazard).c_str());
+    AddCbContextExtraProperties(cb_context, hazard.Tag(), message);
+    return message;
 }
 
 std::string ErrorMessages::ImageSubresourceRangeError(const HazardResult& hazard, VkImage image, uint32_t subresource_range_index,
                                                       const CommandBufferAccessContext& cb_context) const {
-    const auto message = "Hazard %s for %s, range index %" PRIu32 ". Access info %s.";
-    return Format(message, string_SyncHazard(hazard.Hazard()), validator_.FormatHandle(image).c_str(), subresource_range_index,
-                  cb_context.FormatHazard(hazard).c_str());
+    const auto format = "Hazard %s for %s, range index %" PRIu32 ". Access info %s.";
+    std::string message = Format(format, string_SyncHazard(hazard.Hazard()), validator_.FormatHandle(image).c_str(),
+                                 subresource_range_index, cb_context.FormatHazard(hazard).c_str());
+    AddCbContextExtraProperties(cb_context, hazard.Tag(), message);
+    return message;
 }
 
 std::string ErrorMessages::BeginRenderingError(const HazardResult& hazard,
                                                const syncval_state::DynamicRenderingInfo::Attachment& attachment,
                                                const CommandBufferAccessContext& cb_context) const {
-    const auto message = "(%s), with loadOp %s. Access info %s.";
-    return Format(message, validator_.FormatHandle(attachment.view->Handle()).c_str(),
-                  string_VkAttachmentLoadOp(attachment.info.loadOp), cb_context.FormatHazard(hazard).c_str());
+    const auto format = "(%s), with loadOp %s. Access info %s.";
+    std::string message = Format(format, validator_.FormatHandle(attachment.view->Handle()).c_str(),
+                                 string_VkAttachmentLoadOp(attachment.info.loadOp), cb_context.FormatHazard(hazard).c_str());
+    AddCbContextExtraProperties(cb_context, hazard.Tag(), message);
+    return message;
 }
 
 std::string ErrorMessages::EndRenderingResolveError(const HazardResult& hazard, const VulkanTypedHandle& image_view_handle,
                                                     VkResolveModeFlagBits resolve_mode,
                                                     const CommandBufferAccessContext& cb_context) const {
-    const auto message = "(%s), during resolve with resolveMode %s. Access info %s.";
-    return Format(message, validator_.FormatHandle(image_view_handle).c_str(), string_VkResolveModeFlagBits(resolve_mode),
-                  cb_context.FormatHazard(hazard).c_str());
+    const auto format = "(%s), during resolve with resolveMode %s. Access info %s.";
+    std::string message = Format(format, validator_.FormatHandle(image_view_handle).c_str(),
+                                 string_VkResolveModeFlagBits(resolve_mode), cb_context.FormatHazard(hazard).c_str());
+    AddCbContextExtraProperties(cb_context, hazard.Tag(), message);
+    return message;
 }
 
 std::string ErrorMessages::EndRenderingStoreError(const HazardResult& hazard, const VulkanTypedHandle& image_view_handle,
                                                   VkAttachmentStoreOp store_op,
                                                   const CommandBufferAccessContext& cb_context) const {
-    const auto message = "(%s), during store with storeOp %s. Access info %s.";
-    return Format(message, validator_.FormatHandle(image_view_handle).c_str(), string_VkAttachmentStoreOp(store_op),
-                  cb_context.FormatHazard(hazard).c_str());
+    const auto format = "(%s), during store with storeOp %s. Access info %s.";
+    std::string message = Format(format, validator_.FormatHandle(image_view_handle).c_str(), string_VkAttachmentStoreOp(store_op),
+                                 cb_context.FormatHazard(hazard).c_str());
+    AddCbContextExtraProperties(cb_context, hazard.Tag(), message);
+    return message;
 }
 
 std::string ErrorMessages::DrawDispatchImageError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
@@ -166,167 +192,213 @@ std::string ErrorMessages::DrawDispatchImageError(const HazardResult& hazard, co
                                                   const vvl::DescriptorSet& descriptor_set, VkDescriptorType descriptor_type,
                                                   VkImageLayout image_layout, uint32_t descriptor_binding,
                                                   uint32_t binding_index) const {
-    const auto message =
+    const auto format =
         "Hazard %s for %s, in %s, and %s, %s, type: %s, imageLayout: %s, binding #%" PRIu32 ", index %" PRIu32 ". Access info %s.";
-    return Format(message, string_SyncHazard(hazard.Hazard()), validator_.FormatHandle(image_view.Handle()).c_str(),
-                  validator_.FormatHandle(cb_context.Handle()).c_str(), validator_.FormatHandle(pipeline.Handle()).c_str(),
-                  validator_.FormatHandle(descriptor_set.Handle()).c_str(), string_VkDescriptorType(descriptor_type),
-                  string_VkImageLayout(image_layout), descriptor_binding, binding_index, cb_context.FormatHazard(hazard).c_str());
+    std::string message =
+        Format(format, string_SyncHazard(hazard.Hazard()), validator_.FormatHandle(image_view.Handle()).c_str(),
+               validator_.FormatHandle(cb_context.Handle()).c_str(), validator_.FormatHandle(pipeline.Handle()).c_str(),
+               validator_.FormatHandle(descriptor_set.Handle()).c_str(), string_VkDescriptorType(descriptor_type),
+               string_VkImageLayout(image_layout), descriptor_binding, binding_index, cb_context.FormatHazard(hazard).c_str());
+    AddCbContextExtraProperties(cb_context, hazard.Tag(), message);
+    return message;
 }
 
 std::string ErrorMessages::DrawDispatchTexelBufferError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
                                                         const vvl::BufferView& buffer_view, const vvl::Pipeline& pipeline,
                                                         const vvl::DescriptorSet& descriptor_set, VkDescriptorType descriptor_type,
                                                         uint32_t descriptor_binding, uint32_t binding_index) const {
-    const auto message = "Hazard %s for %s in %s, %s, and %s, type: %s, binding #%" PRIu32 " index %" PRIu32 ". Access info %s.";
-    return Format(message, string_SyncHazard(hazard.Hazard()), validator_.FormatHandle(buffer_view.Handle()).c_str(),
-                  validator_.FormatHandle(cb_context.Handle()).c_str(), validator_.FormatHandle(pipeline.Handle()).c_str(),
-                  validator_.FormatHandle(descriptor_set.Handle()).c_str(), string_VkDescriptorType(descriptor_type),
-                  descriptor_binding, binding_index, cb_context.FormatHazard(hazard).c_str());
+    const auto format = "Hazard %s for %s in %s, %s, and %s, type: %s, binding #%" PRIu32 " index %" PRIu32 ". Access info %s.";
+    std::string message =
+        Format(format, string_SyncHazard(hazard.Hazard()), validator_.FormatHandle(buffer_view.Handle()).c_str(),
+               validator_.FormatHandle(cb_context.Handle()).c_str(), validator_.FormatHandle(pipeline.Handle()).c_str(),
+               validator_.FormatHandle(descriptor_set.Handle()).c_str(), string_VkDescriptorType(descriptor_type),
+               descriptor_binding, binding_index, cb_context.FormatHazard(hazard).c_str());
+    AddCbContextExtraProperties(cb_context, hazard.Tag(), message);
+    return message;
 }
 
 std::string ErrorMessages::DrawDispatchBufferError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
                                                    const vvl::Buffer& buffer, const vvl::Pipeline& pipeline,
                                                    const vvl::DescriptorSet& descriptor_set, VkDescriptorType descriptor_type,
                                                    uint32_t descriptor_binding, uint32_t binding_index) const {
-    const auto message = "Hazard %s for %s in %s, %s, and %s, type: %s, binding #%" PRIu32 " index %" PRIu32 ". Access info %s.";
-    return Format(message, string_SyncHazard(hazard.Hazard()), validator_.FormatHandle(buffer.Handle()).c_str(),
-                  validator_.FormatHandle(cb_context.Handle()).c_str(), validator_.FormatHandle(pipeline.Handle()).c_str(),
-                  validator_.FormatHandle(descriptor_set.Handle()).c_str(), string_VkDescriptorType(descriptor_type),
-                  descriptor_binding, binding_index, cb_context.FormatHazard(hazard).c_str());
+    const auto format = "Hazard %s for %s in %s, %s, and %s, type: %s, binding #%" PRIu32 " index %" PRIu32 ". Access info %s.";
+    std::string message =
+        Format(format, string_SyncHazard(hazard.Hazard()), validator_.FormatHandle(buffer.Handle()).c_str(),
+               validator_.FormatHandle(cb_context.Handle()).c_str(), validator_.FormatHandle(pipeline.Handle()).c_str(),
+               validator_.FormatHandle(descriptor_set.Handle()).c_str(), string_VkDescriptorType(descriptor_type),
+               descriptor_binding, binding_index, cb_context.FormatHazard(hazard).c_str());
+    AddCbContextExtraProperties(cb_context, hazard.Tag(), message);
+    return message;
 }
 
 std::string ErrorMessages::DrawVertexBufferError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
                                                  const vvl::Buffer& vertex_buffer) const {
-    const auto message = "Hazard %s for vertex %s in %s. Access info %s.";
-    return Format(message, string_SyncHazard(hazard.Hazard()), validator_.FormatHandle(vertex_buffer.Handle()).c_str(),
-                  validator_.FormatHandle(cb_context.Handle()).c_str(), cb_context.FormatHazard(hazard).c_str());
+    const auto format = "Hazard %s for vertex %s in %s. Access info %s.";
+    std::string message =
+        Format(format, string_SyncHazard(hazard.Hazard()), validator_.FormatHandle(vertex_buffer.Handle()).c_str(),
+               validator_.FormatHandle(cb_context.Handle()).c_str(), cb_context.FormatHazard(hazard).c_str());
+    AddCbContextExtraProperties(cb_context, hazard.Tag(), message);
+    return message;
 }
 
 std::string ErrorMessages::DrawIndexBufferError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
                                                 const vvl::Buffer& index_buffer) const {
-    const auto message = "Hazard %s for index %s in %s. Access info %s.";
-    return Format(message, string_SyncHazard(hazard.Hazard()), validator_.FormatHandle(index_buffer.Handle()).c_str(),
-                  validator_.FormatHandle(cb_context.Handle()).c_str(), cb_context.FormatHazard(hazard).c_str());
+    const auto format = "Hazard %s for index %s in %s. Access info %s.";
+    std::string message = Format(format, string_SyncHazard(hazard.Hazard()), validator_.FormatHandle(index_buffer.Handle()).c_str(),
+                                 validator_.FormatHandle(cb_context.Handle()).c_str(), cb_context.FormatHazard(hazard).c_str());
+    AddCbContextExtraProperties(cb_context, hazard.Tag(), message);
+    return message;
 }
 
 std::string ErrorMessages::DrawAttachmentError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
                                                const vvl::ImageView& attachment_view) const {
-    const auto message = "(%s). Access info %s.";
-    return Format(message, validator_.FormatHandle(attachment_view.Handle()).c_str(), cb_context.FormatHazard(hazard).c_str());
+    const auto format = "(%s). Access info %s.";
+    std::string message =
+        Format(format, validator_.FormatHandle(attachment_view.Handle()).c_str(), cb_context.FormatHazard(hazard).c_str());
+    AddCbContextExtraProperties(cb_context, hazard.Tag(), message);
+    return message;
 }
 
 std::string ErrorMessages::ClearColorAttachmentError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
                                                      const std::string& subpass_attachment_info) const {
-    const auto message = "Hazard %s while clearing color attachment%s. Access info %s.";
-    return Format(message, string_SyncHazard(hazard.Hazard()), subpass_attachment_info.c_str(),
-                  cb_context.FormatHazard(hazard).c_str());
+    const auto format = "Hazard %s while clearing color attachment%s. Access info %s.";
+    std::string message = Format(format, string_SyncHazard(hazard.Hazard()), subpass_attachment_info.c_str(),
+                                 cb_context.FormatHazard(hazard).c_str());
+    AddCbContextExtraProperties(cb_context, hazard.Tag(), message);
+    return message;
 }
 
 std::string ErrorMessages::ClearDepthStencilAttachmentError(const HazardResult& hazard,
                                                             const CommandBufferAccessContext& cb_context,
                                                             const std::string& subpass_attachment_info,
                                                             VkImageAspectFlagBits aspect) const {
-    const auto message = "Hazard %s when clearing %s aspect of depth-stencil attachment%s. Access info %s.";
-    return Format(message, string_SyncHazard(hazard.Hazard()), string_VkImageAspectFlagBits(aspect),
-                  subpass_attachment_info.c_str(), cb_context.FormatHazard(hazard).c_str());
+    const auto format = "Hazard %s when clearing %s aspect of depth-stencil attachment%s. Access info %s.";
+    std::string message = Format(format, string_SyncHazard(hazard.Hazard()), string_VkImageAspectFlagBits(aspect),
+                                 subpass_attachment_info.c_str(), cb_context.FormatHazard(hazard).c_str());
+    AddCbContextExtraProperties(cb_context, hazard.Tag(), message);
+    return message;
 }
 
 std::string ErrorMessages::PipelineBarrierError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
                                                 uint32_t image_barrier_index, const vvl::Image& image) const {
-    const auto message = "Hazard %s for image barrier %" PRIu32 " %s. Access info %s.";
-    return Format(message, string_SyncHazard(hazard.Hazard()), image_barrier_index, validator_.FormatHandle(image.Handle()).c_str(),
-                  cb_context.FormatHazard(hazard).c_str());
+    const auto format = "Hazard %s for image barrier %" PRIu32 " %s. Access info %s.";
+    std::string message = Format(format, string_SyncHazard(hazard.Hazard()), image_barrier_index,
+                                 validator_.FormatHandle(image.Handle()).c_str(), cb_context.FormatHazard(hazard).c_str());
+    AddCbContextExtraProperties(cb_context, hazard.Tag(), message);
+    return message;
 }
 
 std::string ErrorMessages::WaitEventsError(const HazardResult& hazard, const CommandExecutionContext& exec_context,
                                            uint32_t image_barrier_index, const vvl::Image& image) const {
-    const auto message = "Hazard %s for image barrier %" PRIu32 " %s. Access info %s.";
-    return Format(message, string_SyncHazard(hazard.Hazard()), image_barrier_index, validator_.FormatHandle(image.Handle()).c_str(),
-                  exec_context.FormatHazard(hazard).c_str());
+    const auto format = "Hazard %s for image barrier %" PRIu32 " %s. Access info %s.";
+    std::string message = Format(format, string_SyncHazard(hazard.Hazard()), image_barrier_index,
+                                 validator_.FormatHandle(image.Handle()).c_str(), exec_context.FormatHazard(hazard).c_str());
+    return message;
 }
 
 std::string ErrorMessages::FirstUseError(const HazardResult& hazard, const CommandExecutionContext& exec_context,
                                          const CommandBufferAccessContext& recorded_context, uint32_t command_buffer_index,
                                          VkCommandBuffer recorded_handle) const {
-    const auto message = "Hazard %s for entry %" PRIu32 ", %s, %s access info %s. Access info %s.";
-    return Format(message, string_SyncHazard(hazard.Hazard()), command_buffer_index,
-                  validator_.FormatHandle(recorded_handle).c_str(), exec_context.ExecutionTypeString(),
-                  recorded_context.FormatUsage(exec_context.ExecutionUsageString(), *hazard.RecordedAccess()).c_str(),
-                  exec_context.FormatHazard(hazard).c_str());
+    const auto format = "Hazard %s for entry %" PRIu32 ", %s, %s access info %s. Access info %s.";
+    std::string message =
+        Format(format, string_SyncHazard(hazard.Hazard()), command_buffer_index, validator_.FormatHandle(recorded_handle).c_str(),
+               exec_context.ExecutionTypeString(),
+               recorded_context.FormatUsage(exec_context.ExecutionUsageString(), *hazard.RecordedAccess()).c_str(),
+               exec_context.FormatHazard(hazard).c_str());
+    if (validator_.syncval_settings.message_extra_properties) {
+        ReportKeyValues key_values;
+        exec_context.AddUsageRecordExtraProperties(hazard.Tag(), key_values);
+        message += key_values.GetExtraPropertiesSection();
+    }
+    return message;
 }
 
 std::string ErrorMessages::RenderPassResolveError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
                                                   uint32_t subpass, const char* aspect_name, const char* attachment_name,
                                                   uint32_t src_attachment, uint32_t dst_attachment) const {
-    const auto message = "Hazard %s in subpass %" PRIu32 "during %s %s, from attachment %" PRIu32 " to resolve attachment %" PRIu32
-                         ". Access info %s.";
-    return Format(message, string_SyncHazard(hazard.Hazard()), subpass, aspect_name, attachment_name, src_attachment,
-                  dst_attachment, cb_context.FormatHazard(hazard).c_str());
+    const auto format = "Hazard %s in subpass %" PRIu32 "during %s %s, from attachment %" PRIu32 " to resolve attachment %" PRIu32
+                        ". Access info %s.";
+    std::string message = Format(format, string_SyncHazard(hazard.Hazard()), subpass, aspect_name, attachment_name, src_attachment,
+                                 dst_attachment, cb_context.FormatHazard(hazard).c_str());
+    AddCbContextExtraProperties(cb_context, hazard.Tag(), message);
+    return message;
 }
 
 std::string ErrorMessages::RenderPassLayoutTransitionVsStoreResolveError(const HazardResult& hazard, uint32_t subpass,
                                                                          uint32_t attachment, VkImageLayout old_layout,
                                                                          VkImageLayout new_layout,
                                                                          uint32_t store_resolve_subpass) const {
-    const auto message =
+    const auto format =
         "Hazard %s in subpass %" PRIu32 " for attachment %" PRIu32
         " image layout transition (old_layout: %s, new_layout: %s) after store/resolve operation in subpass %" PRIu32;
-    return Format(message, string_SyncHazard(hazard.Hazard()), subpass, attachment, string_VkImageLayout(old_layout),
-                  string_VkImageLayout(new_layout), store_resolve_subpass);
+    std::string message = Format(format, string_SyncHazard(hazard.Hazard()), subpass, attachment, string_VkImageLayout(old_layout),
+                                 string_VkImageLayout(new_layout), store_resolve_subpass);
+    return message;
 }
 
 std::string ErrorMessages::RenderPassLayoutTransitionError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
                                                            uint32_t subpass, uint32_t attachment, VkImageLayout old_layout,
                                                            VkImageLayout new_layout) const {
-    const auto message = "Hazard %s in subpass %" PRIu32 " for attachment %" PRIu32
-                         " image layout transition (old_layout: %s, new_layout: %s). Access info %s.";
-    return Format(message, string_SyncHazard(hazard.Hazard()), subpass, attachment, string_VkImageLayout(old_layout),
-                  string_VkImageLayout(new_layout), cb_context.FormatHazard(hazard).c_str());
+    const auto format = "Hazard %s in subpass %" PRIu32 " for attachment %" PRIu32
+                        " image layout transition (old_layout: %s, new_layout: %s). Access info %s.";
+    std::string message = Format(format, string_SyncHazard(hazard.Hazard()), subpass, attachment, string_VkImageLayout(old_layout),
+                                 string_VkImageLayout(new_layout), cb_context.FormatHazard(hazard).c_str());
+    AddCbContextExtraProperties(cb_context, hazard.Tag(), message);
+    return message;
 }
 
 std::string ErrorMessages::RenderPassLoadOpVsLayoutTransitionError(const HazardResult& hazard, uint32_t subpass,
                                                                    uint32_t attachment, const char* aspect_name,
                                                                    const char* load_op_name) const {
-    const auto message =
+    const auto format =
         "Hazard %s vs. layout transition in subpass %" PRIu32 " for attachment %" PRIu32 " aspect %s during load with loadOp %s.";
-    return Format(message, string_SyncHazard(hazard.Hazard()), subpass, attachment, aspect_name, load_op_name);
+    std::string message = Format(format, string_SyncHazard(hazard.Hazard()), subpass, attachment, aspect_name, load_op_name);
+    return message;
 }
 
 std::string ErrorMessages::RenderPassLoadOpError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
                                                  uint32_t subpass, uint32_t attachment, const char* aspect_name,
                                                  const char* load_op_name) const {
-    const auto message =
+    const auto format =
         "Hazard %s in subpass %" PRIu32 " for attachment %" PRIu32 " aspect %s during load with loadOp %s. Access info %s.";
-    return Format(message, string_SyncHazard(hazard.Hazard()), subpass, attachment, aspect_name, load_op_name,
-                  cb_context.FormatHazard(hazard).c_str());
+    std::string message = Format(format, string_SyncHazard(hazard.Hazard()), subpass, attachment, aspect_name, load_op_name,
+                                 cb_context.FormatHazard(hazard).c_str());
+    AddCbContextExtraProperties(cb_context, hazard.Tag(), message);
+    return message;
 }
 
 std::string ErrorMessages::RenderPassStoreOpError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
                                                   uint32_t subpass, uint32_t attachment, const char* aspect_name,
                                                   const char* store_op_type_name, const char* store_op_name) const {
-    const auto message =
+    const auto format =
         "Hazard %s in subpass %" PRIu32 " for attachment %" PRIu32 " %s aspect during store with %s %s. Access info %s";
-    return Format(message, string_SyncHazard(hazard.Hazard()), subpass, attachment, aspect_name, store_op_type_name, store_op_name,
-                  cb_context.FormatHazard(hazard).c_str());
+    std::string message = Format(format, string_SyncHazard(hazard.Hazard()), subpass, attachment, aspect_name, store_op_type_name,
+                                 store_op_name, cb_context.FormatHazard(hazard).c_str());
+    AddCbContextExtraProperties(cb_context, hazard.Tag(), message);
+    return message;
 }
 
 std::string ErrorMessages::RenderPassColorAttachmentError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
                                                           const vvl::ImageView& view, uint32_t attachment) const {
-    const auto message = "Hazard %s for %s in %s, Subpass #%d, and pColorAttachments #%d. Access info %s.";
-    return Format(message, string_SyncHazard(hazard.Hazard()), validator_.FormatHandle(view.Handle()).c_str(),
-                  validator_.FormatHandle(cb_context.GetCBState().Handle()).c_str(), cb_context.GetCBState().GetActiveSubpass(),
-                  attachment, cb_context.FormatHazard(hazard).c_str());
+    const auto format = "Hazard %s for %s in %s, Subpass #%d, and pColorAttachments #%d. Access info %s.";
+    std::string message = Format(format, string_SyncHazard(hazard.Hazard()), validator_.FormatHandle(view.Handle()).c_str(),
+                                 validator_.FormatHandle(cb_context.GetCBState().Handle()).c_str(),
+                                 cb_context.GetCBState().GetActiveSubpass(), attachment, cb_context.FormatHazard(hazard).c_str());
+    AddCbContextExtraProperties(cb_context, hazard.Tag(), message);
+    return message;
 }
 
 std::string ErrorMessages::RenderPassDepthStencilAttachmentError(const HazardResult& hazard,
                                                                  const CommandBufferAccessContext& cb_context,
                                                                  const vvl::ImageView& view, bool is_depth) const {
-    const auto message = "Hazard %s for %s in %s, Subpass #%d, and %s part of pDepthStencilAttachment. Access info %s.";
+    const auto format = "Hazard %s for %s in %s, Subpass #%d, and %s part of pDepthStencilAttachment. Access info %s.";
 
-    return Format(message, string_SyncHazard(hazard.Hazard()), validator_.FormatHandle(view.Handle()).c_str(),
-                  validator_.FormatHandle(cb_context.GetCBState().Handle()).c_str(), cb_context.GetCBState().GetActiveSubpass(),
-                  is_depth ? "depth" : "stencil", cb_context.FormatHazard(hazard).c_str());
+    std::string message =
+        Format(format, string_SyncHazard(hazard.Hazard()), validator_.FormatHandle(view.Handle()).c_str(),
+               validator_.FormatHandle(cb_context.GetCBState().Handle()).c_str(), cb_context.GetCBState().GetActiveSubpass(),
+               is_depth ? "depth" : "stencil", cb_context.FormatHazard(hazard).c_str());
+    AddCbContextExtraProperties(cb_context, hazard.Tag(), message);
+    return message;
 }
 
 std::string ErrorMessages::RenderPassFinalLayoutTransitionVsStoreResolveError(const HazardResult& hazard,
@@ -334,35 +406,44 @@ std::string ErrorMessages::RenderPassFinalLayoutTransitionVsStoreResolveError(co
                                                                               uint32_t subpass, uint32_t attachment,
                                                                               VkImageLayout old_layout,
                                                                               VkImageLayout new_layout) const {
-    const auto message = "Hazard %s vs. store/resolve operations in subpass %" PRIu32 " for attachment %" PRIu32
-                         " final image layout transition (old_layout: %s, new_layout: %s).";
-    return Format(message, string_SyncHazard(hazard.Hazard()), subpass, attachment, string_VkImageLayout(old_layout),
-                  string_VkImageLayout(new_layout));
+    const auto format = "Hazard %s vs. store/resolve operations in subpass %" PRIu32 " for attachment %" PRIu32
+                        " final image layout transition (old_layout: %s, new_layout: %s).";
+    std::string message = Format(format, string_SyncHazard(hazard.Hazard()), subpass, attachment, string_VkImageLayout(old_layout),
+                                 string_VkImageLayout(new_layout));
+    AddCbContextExtraProperties(cb_context, hazard.Tag(), message);
+    return message;
 }
 
 std::string ErrorMessages::RenderPassFinalLayoutTransitionError(const HazardResult& hazard,
                                                                 const CommandBufferAccessContext& cb_context, uint32_t subpass,
                                                                 uint32_t attachment, VkImageLayout old_layout,
                                                                 VkImageLayout new_layout) const {
-    const auto message = "Hazard %s with last use subpass %" PRIu32 " for attachment %" PRIu32
-                         " final image layout transition (old_layout: %s, new_layout: %s). Access info %s.";
-    return Format(message, string_SyncHazard(hazard.Hazard()), subpass, attachment, string_VkImageLayout(old_layout),
-                  string_VkImageLayout(new_layout), cb_context.FormatHazard(hazard).c_str());
+    const auto format = "Hazard %s with last use subpass %" PRIu32 " for attachment %" PRIu32
+                        " final image layout transition (old_layout: %s, new_layout: %s). Access info %s.";
+    std::string message = Format(format, string_SyncHazard(hazard.Hazard()), subpass, attachment, string_VkImageLayout(old_layout),
+                                 string_VkImageLayout(new_layout), cb_context.FormatHazard(hazard).c_str());
+    AddCbContextExtraProperties(cb_context, hazard.Tag(), message);
+    return message;
 }
 
 std::string ErrorMessages::PresentError(const HazardResult& hazard, const QueueBatchContext& batch_context, uint32_t present_index,
                                         const VulkanTypedHandle& swapchain_handle, uint32_t image_index,
                                         const VulkanTypedHandle& image_handle) const {
-    const auto message =
+    const auto format =
         "Hazard %s for present pSwapchains[%" PRIu32 "] , swapchain %s, image index %" PRIu32 " %s, Access info %s.";
-    return Format(message, string_SyncHazard(hazard.Hazard()), present_index, validator_.FormatHandle(swapchain_handle).c_str(),
-                  image_index, validator_.FormatHandle(image_handle).c_str(), batch_context.FormatHazard(hazard).c_str());
+    std::string message =
+        Format(format, string_SyncHazard(hazard.Hazard()), present_index, validator_.FormatHandle(swapchain_handle).c_str(),
+               image_index, validator_.FormatHandle(image_handle).c_str(), batch_context.FormatHazard(hazard).c_str());
+    return message;
 }
 
 std::string ErrorMessages::VideoReferencePictureError(const HazardResult& hazard, uint32_t reference_picture_index,
                                                       const CommandBufferAccessContext& cb_context) const {
-    const auto message = "Hazard %s for reference picture #%u. Access info %s.";
-    return Format(message, string_SyncHazard(hazard.Hazard()), reference_picture_index, cb_context.FormatHazard(hazard).c_str());
+    const auto format = "Hazard %s for reference picture #%u. Access info %s.";
+    std::string message =
+        Format(format, string_SyncHazard(hazard.Hazard()), reference_picture_index, cb_context.FormatHazard(hazard).c_str());
+    AddCbContextExtraProperties(cb_context, hazard.Tag(), message);
+    return message;
 }
 
 }  // namespace syncval

--- a/layers/sync/sync_error_messages.h
+++ b/layers/sync/sync_error_messages.h
@@ -24,6 +24,7 @@
 
 class CommandBufferAccessContext;
 class HazardResult;
+struct ReportKeyValues;
 class QueueBatchContext;
 class ValidationObject;
 
@@ -144,6 +145,10 @@ class ErrorMessages {
 
     std::string VideoReferencePictureError(const HazardResult& hazard, uint32_t reference_picture_index,
                                            const CommandBufferAccessContext& cb_context) const;
+
+  private:
+    void AddCbContextExtraProperties(const CommandBufferAccessContext& cb_context, ResourceUsageTag tag,
+                                     std::string& message) const;
 
   private:
     ValidationObject& validator_;

--- a/layers/sync/sync_reporting.h
+++ b/layers/sync/sync_reporting.h
@@ -30,3 +30,20 @@ struct SyncNodeFormatter {
     SyncNodeFormatter(const SyncValidator &sync_state, const vvl::StateObject *state_object, const char *label_ = nullptr);
 };
 std::string FormatStateObject(const SyncNodeFormatter &formatter);
+
+struct ReportKeyValues {
+    struct KeyValue {
+        std::string key;
+        std::string value;
+    };
+    std::vector<KeyValue> key_values;
+
+    void Add(std::string_view key, std::string_view value);
+
+    template <typename ValueType>
+    void Add(std::string_view key, const ValueType &value) {
+        key_values.emplace_back(KeyValue{std::string(key), std::to_string(value)});
+    }
+
+    std::string GetExtraPropertiesSection() const;
+};

--- a/layers/sync/sync_settings.h
+++ b/layers/sync/sync_settings.h
@@ -20,5 +20,5 @@
 struct SyncValSettings {
     bool submit_time_validation = true;
     bool shader_accesses_heuristic = false;
-    bool message_include_debug_information = false;
+    bool message_extra_properties = false;
 };

--- a/layers/sync/sync_submit.h
+++ b/layers/sync/sync_submit.h
@@ -294,6 +294,7 @@ class QueueBatchContext : public CommandExecutionContext, public std::enable_sha
     void Trim();
 
     std::string FormatUsage(ResourceUsageTagEx tag_ex) const override;
+    void AddUsageRecordExtraProperties(ResourceUsageTag tag, ReportKeyValues &extra_properties) const override;
     AccessContext *GetCurrentAccessContext() override { return current_access_context_; }
     const AccessContext *GetCurrentAccessContext() const override { return current_access_context_; }
     SyncEventsContext *GetCurrentEventsContext() override { return &events_context_; }

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -39,7 +39,6 @@ void VkSyncValTest::InitSyncValFramework(const SyncValSettings *p_sync_settings)
         SyncValSettings settings;
         settings.submit_time_validation = true;
         settings.shader_accesses_heuristic = true;
-        settings.message_include_debug_information = true;
         return settings;
     }();
     const SyncValSettings &sync_settings = p_sync_settings ? *p_sync_settings : test_default_sync_settings;
@@ -51,10 +50,6 @@ void VkSyncValTest::InitSyncValFramework(const SyncValSettings *p_sync_settings)
     const auto shader_accesses_heuristic = static_cast<VkBool32>(sync_settings.shader_accesses_heuristic);
     settings.emplace_back(VkLayerSettingEXT{OBJECT_LAYER_NAME, "syncval_shader_accesses_heuristic",
                                             VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &shader_accesses_heuristic});
-
-    const auto message_include_debug_information = static_cast<VkBool32>(sync_settings.message_include_debug_information);
-    settings.emplace_back(VkLayerSettingEXT{OBJECT_LAYER_NAME, "syncval_message_include_debug_information",
-                                            VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &message_include_debug_information});
 
     VkLayerSettingsCreateInfoEXT settings_create_info = vku::InitStructHelper();
     settings_create_info.settingCount = size32(settings);


### PR DESCRIPTION
This section is optional and is disabled by default. If enabled it is appended to the main error messages. The purpose of the key-values section is to allow filtering of the error messages based on selected properties. It can also contain debug/optional information.

This aims to solve a problem when the applications extract parts of the main error message for filtering purposes (false positives or the errors not fixed by the application yet). Even minor changes to the main error message can break these filters. This makes it harder to modify and improve error messages. The key-values section is more structured and more stable which makes it more suitable for filtering purposes.

The key-values section is not used to improve the main error message. The latter should contain all the necessary information to understand the error and present it in the most comprehensible way possible.