### PR TITLE
layers: Add UNUSED_WHILE_PENDING to threading exception

### DIFF
--- a/tests/unit/threading_positive.cpp
+++ b/tests/unit/threading_positive.cpp
@@ -117,6 +117,57 @@ TEST_F(PositiveThreading, UpdateDescriptorUpdateAfterBindNoCollision) {
     m_errorMonitor->SetBailout(NULL);
 }
 
+TEST_F(PositiveThreading, UpdateDescriptorUnusedWhilePendingNoCollision) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8975");
+    AddRequiredExtensions(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_3_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::descriptorBindingUpdateUnusedWhilePending);
+    RETURN_IF_SKIP(Init());
+    InitRenderTarget();
+
+    std::array<VkDescriptorBindingFlagsEXT, 2> flags = {
+        {VK_DESCRIPTOR_BINDING_UPDATE_UNUSED_WHILE_PENDING_BIT, VK_DESCRIPTOR_BINDING_UPDATE_UNUSED_WHILE_PENDING_BIT}};
+    VkDescriptorSetLayoutBindingFlagsCreateInfo flags_create_info = vku::InitStructHelper();
+    flags_create_info.bindingCount = (uint32_t)flags.size();
+    flags_create_info.pBindingFlags = flags.data();
+
+    OneOffDescriptorSet normal_descriptor_set(m_device,
+                                              {
+                                                  {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+                                                  {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+                                              },
+                                              VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT, &flags_create_info,
+                                              VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT);
+
+    vkt::Buffer buffer(*m_device, 256, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
+
+    ThreadTestData data;
+    data.device = device();
+    data.descriptorSet = normal_descriptor_set.set_;
+    data.binding = 0;
+    data.buffer = buffer.handle();
+    std::atomic<bool> bailout{false};
+    data.bailout = &bailout;
+    m_errorMonitor->SetBailout(data.bailout);
+
+    // Update descriptors from another thread.
+    std::thread thread(UpdateDescriptor, &data);
+    // Update descriptors from this thread at the same time.
+
+    ThreadTestData data2;
+    data2.device = device();
+    data2.descriptorSet = normal_descriptor_set.set_;
+    data2.binding = 1;
+    data2.buffer = buffer.handle();
+    data2.bailout = &bailout;
+
+    UpdateDescriptor(&data2);
+
+    thread.join();
+
+    m_errorMonitor->SetBailout(NULL);
+}
+
 TEST_F(PositiveThreading, NullFenceCollision) {
     RETURN_IF_SKIP(Init());
 


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8975

simply seems we did mark `UNUSED_WHILE_PENDING` the same way we did for `UPDATE_AFTER_BIND`