### PR TITLE
layers: Cleanup ValidateHostCopyCurrentLayout

### DIFF
--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -2828,9 +2828,8 @@ bool CoreChecks::PreCallValidateTransitionImageLayout(VkDevice device, uint32_t 
             transition.image, phys_dev_props_core14.copyDstLayoutCount, phys_dev_props_core14.pCopyDstLayouts, transition.newLayout,
             transition_loc.dot(Field::newLayout), Field::pCopyDstLayouts, "VUID-VkHostImageLayoutTransitionInfo-newLayout-09057");
         if (transition.oldLayout != VK_IMAGE_LAYOUT_UNDEFINED) {
-            skip |= ValidateHostCopyCurrentLayout(transition.oldLayout, transition.subresourceRange, i, *image_state,
-                                                  transition_loc.dot(Field::oldLayout), "transition",
-                                                  "VUID-VkHostImageLayoutTransitionInfo-oldLayout-09229");
+            skip |= ValidateHostCopyCurrentLayout(transition.oldLayout, transition.subresourceRange, *image_state,
+                                                  transition_loc.dot(Field::oldLayout));
         }
     }
     return skip;

--- a/layers/core_checks/cc_vuid_maps.cpp
+++ b/layers/core_checks/cc_vuid_maps.cpp
@@ -583,6 +583,24 @@ const std::string &GetImageArrayLayerRangeVUID(const Location &loc) {
     return result;
 }
 
+const std::string &GetImageImageLayoutVUID(const Location &loc) {
+    static const std::array<Entry, 5> errors{{
+        {Key(Func::vkTransitionImageLayout), "VUID-VkHostImageLayoutTransitionInfo-oldLayout-09229"},
+        {Key(Func::vkCopyImageToMemory, Field::srcImageLayout), "VUID-VkCopyImageToMemoryInfo-srcImageLayout-09064"},
+        {Key(Func::vkCopyMemoryToImage, Field::dstImageLayout), "VUID-VkCopyMemoryToImageInfo-dstImageLayout-09059"},
+        {Key(Func::vkCopyImageToImage, Field::srcImageLayout), "VUID-VkCopyImageToImageInfo-srcImageLayout-09070"},
+        {Key(Func::vkCopyImageToImage, Field::dstImageLayout), "VUID-VkCopyImageToImageInfo-dstImageLayout-09071"},
+    }};
+
+    const auto &result = FindVUID(loc, errors);
+    assert(!result.empty());
+    if (result.empty()) {
+        static const std::string unhandled("UNASSIGNED-CoreChecks-unhandled-image-layout");
+        return unhandled;
+    }
+    return result;
+}
+
 const std::string &GetSubresourceRangeVUID(const Location &loc, SubresourceRangeError error) {
     static const std::map<SubresourceRangeError, std::array<Entry, 6>> errors{
         {SubresourceRangeError::BaseMip_01486,

--- a/layers/core_checks/cc_vuid_maps.h
+++ b/layers/core_checks/cc_vuid_maps.h
@@ -96,6 +96,7 @@ const std::string &GetCopyBufferImageVUID(const Location &loc, CopyError error);
 const std::string &GetCopyImageVUID(const Location &loc, CopyError error);
 const std::string &GetImageMipLevelVUID(const Location &loc);
 const std::string &GetImageArrayLayerRangeVUID(const Location &loc);
+const std::string &GetImageImageLayoutVUID(const Location &loc);
 
 enum class SubresourceRangeError {
     BaseMip_01486,

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -837,11 +837,9 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateMemcpyExtents(const VkImageCopy2& region, const vvl::Image& src_image_state, const vvl::Image& dst_image_state,
                                const Location& region_loc) const;
     bool ValidateHostCopyCurrentLayout(VkImageLayout expected_layout, const VkImageSubresourceLayers& subres_layers,
-                                       uint32_t region, const vvl::Image& image_state, const Location& loc, const char* image_label,
-                                       const char* vuid) const;
-    bool ValidateHostCopyCurrentLayout(VkImageLayout expected_layout, const VkImageSubresourceRange& subres_range, uint32_t region,
-                                       const vvl::Image& image_state, const Location& loc, const char* image_label,
-                                       const char* vuid) const;
+                                       const vvl::Image& image_state, const Location& loc) const;
+    bool ValidateHostCopyCurrentLayout(VkImageLayout expected_layout, const VkImageSubresourceRange& subres_range,
+                                       const vvl::Image& image_state, const Location& loc) const;
     bool ValidateHostCopyMultiplane(const VkImageCopy2& region, const vvl::Image& src_image_state,
                                     const vvl::Image& dst_image_state, const Location& region_loc) const;
     bool ValidateBufferViewRange(const vvl::Buffer& buffer_state, const VkBufferViewCreateInfo& create_info,
@@ -1037,7 +1035,7 @@ class CoreChecks : public ValidationStateTracker {
                                      const RecordObject& record_obj) override;
 
     bool ValidateCmdBufImageLayouts(const Location& loc, const vvl::CommandBuffer& cb_state,
-                                    GlobalImageLayoutMap& overlayLayoutMap) const;
+                                    GlobalImageLayoutMap& global_image_layout_map) const;
 
     void UpdateCmdBufImageLayouts(const vvl::CommandBuffer& cb_state);
 

--- a/layers/error_message/error_strings.h
+++ b/layers/error_message/error_strings.h
@@ -86,3 +86,10 @@
     ss << "[" << range.offset << ", " << (range.offset + range.size) << "]";
     return ss.str();
 }
+
+[[maybe_unused]] static std::string string_VkImageSubresource(VkImageSubresource subresource) {
+    std::stringstream ss;
+    ss << "aspectMask = " << subresource.aspectMask << ", mipLevel = " << subresource.mipLevel
+       << ", arrayLayer = " << subresource.arrayLayer;
+    return ss.str();
+}

--- a/tests/unit/host_image_copy.cpp
+++ b/tests/unit/host_image_copy.cpp
@@ -1910,10 +1910,18 @@ TEST_F(NegativeHostImageCopy, TransitionImageLayout) {
     m_errorMonitor->SetDesiredError("VUID-VkHostImageLayoutTransitionInfo-image-09241");
     vk::TransitionImageLayoutEXT(*m_device, 1, &transition_info);
     m_errorMonitor->VerifyFound();
-    transition_info.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+}
 
-    // Bad oldLayout
-    transition_info.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
+TEST_F(NegativeHostImageCopy, TransitionImageLayout2) {
+    RETURN_IF_SKIP(InitHostImageCopyTest());
+    vkt::Image image(*m_device, image_ci, vkt::set_layout);
+
+    VkHostImageLayoutTransitionInfo transition_info = vku::InitStructHelper();
+    transition_info.oldLayout = VK_IMAGE_LAYOUT_GENERAL;  // wrong
+    transition_info.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+    transition_info.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+    transition_info.image = image;
+
     m_errorMonitor->SetDesiredError("VUID-VkHostImageLayoutTransitionInfo-oldLayout-09229");
     vk::TransitionImageLayoutEXT(*m_device, 1, &transition_info);
     m_errorMonitor->VerifyFound();


### PR DESCRIPTION
Improves the `ValidateHostCopyCurrentLayout` code flow to match other functions