### PR TITLE
layers: Cleanup Buffer::ComputeSize

### DIFF
--- a/layers/gpu/cmd_validation/gpuav_draw.cpp
+++ b/layers/gpu/cmd_validation/gpuav_draw.cpp
@@ -811,7 +811,8 @@ static std::optional<SmallestVertexBufferBinding> SmallestVertexAttributesCount(
             const VkDeviceSize stride =
                 vbb.stride != 0 ? vbb.stride : attribute_size;  // Tracked stride should already handle all possible value origin
 
-            VkDeviceSize vertex_buffer_remaining_size = vbb.size > attrib.desc.offset ? vbb.size - attrib.desc.offset : 0;
+            VkDeviceSize vertex_buffer_remaining_size =
+                vbb.effective_size > attrib.desc.offset ? vbb.effective_size - attrib.desc.offset : 0;
 
             VkDeviceSize vertex_attributes_count = vertex_buffer_remaining_size / stride;
             if (vertex_buffer_remaining_size > vertex_attributes_count * stride) {
@@ -1030,7 +1031,7 @@ void DrawIndexed(Validator &gpuav, CommandBuffer &cb_state, const Location &loc,
 
                         // Vertex buffer binding info
                         gpuav.FormatHandle(smallest_vertex_buffer_binding.binding_info.buffer).c_str(),
-                        smallest_vertex_buffer_binding.binding, smallest_vertex_buffer_binding.binding_info.size,
+                        smallest_vertex_buffer_binding.binding, smallest_vertex_buffer_binding.binding_info.effective_size,
                         smallest_vertex_buffer_binding.binding_info.offset, smallest_vertex_buffer_binding.binding_info.stride,
                         smallest_vertex_buffer_binding.smallest_vertex_attributes_count,
 
@@ -1493,7 +1494,7 @@ void DrawIndexedIndirectVertexBuffer(Validator &gpuav, CommandBuffer &cb_state, 
 
                         // Vertex buffer binding info
                         gpuav.FormatHandle(smallest_vertex_buffer_binding.binding_info.buffer).c_str(),
-                        smallest_vertex_buffer_binding.binding, smallest_vertex_buffer_binding.binding_info.size,
+                        smallest_vertex_buffer_binding.binding, smallest_vertex_buffer_binding.binding_info.effective_size,
                         smallest_vertex_buffer_binding.binding_info.offset, smallest_vertex_buffer_binding.binding_info.stride,
                         smallest_vertex_buffer_binding.smallest_vertex_attributes_count,
 

--- a/layers/state_tracker/vertex_index_buffer_state.h
+++ b/layers/state_tracker/vertex_index_buffer_state.h
@@ -26,11 +26,13 @@ class Buffer;
 
 struct VertexBufferBinding {
     VkBuffer buffer;  // VK_NULL_HANDLE is valid if using nullDescriptor
-    VkDeviceSize size;
+    // Binding valid size: 0 if buffer is not tracked, actual size if VK_WHOLE_SIZE was specified,
+    // clamped up to 0 if specified size is greater than the size actually left in the buffer
+    VkDeviceSize effective_size;
     VkDeviceSize offset;
     VkDeviceSize stride;
 
-    VertexBufferBinding() : buffer(VK_NULL_HANDLE), size(0), offset(0), stride(0) {}
+    VertexBufferBinding() : buffer(VK_NULL_HANDLE), effective_size(0), offset(0), stride(0) {}
 
     void reset() { *this = VertexBufferBinding(); }
 };

--- a/layers/sync/sync_common.cpp
+++ b/layers/sync/sync_common.cpp
@@ -52,7 +52,7 @@ SyncAccessFlags SyncStageAccess::AccessScope(VkPipelineStageFlags2 stages, VkAcc
 ResourceAccessRange MakeRange(VkDeviceSize start, VkDeviceSize size) { return ResourceAccessRange(start, (start + size)); }
 
 ResourceAccessRange MakeRange(const vvl::Buffer& buffer, VkDeviceSize offset, VkDeviceSize size) {
-    return MakeRange(offset, buffer.ComputeSize(offset, size));
+    return MakeRange(offset, buffer.GetRegionSize(offset, size));
 }
 
 ResourceAccessRange MakeRange(const vvl::BufferView& buf_view_state) {

--- a/layers/sync/sync_common.h
+++ b/layers/sync/sync_common.h
@@ -60,7 +60,7 @@ struct ResourceUsageTagEx {
 
 template <typename T>
 ResourceAccessRange MakeRange(const T &has_offset_and_size) {
-    return ResourceAccessRange(has_offset_and_size.offset, (has_offset_and_size.offset + has_offset_and_size.size));
+    return ResourceAccessRange(has_offset_and_size.offset, (has_offset_and_size.offset + has_offset_and_size.effective_size));
 }
 ResourceAccessRange MakeRange(VkDeviceSize start, VkDeviceSize size);
 ResourceAccessRange MakeRange(const vvl::Buffer &buffer, VkDeviceSize offset, VkDeviceSize size);

--- a/layers/utils/vk_layer_utils.h
+++ b/layers/utils/vk_layer_utils.h
@@ -404,18 +404,6 @@ static inline VkDeviceSize SafeDivision(VkDeviceSize dividend, VkDeviceSize divi
     return result;
 }
 
-inline std::optional<VkDeviceSize> ComputeValidSize(VkDeviceSize offset, VkDeviceSize size, VkDeviceSize whole_size) {
-    std::optional<VkDeviceSize> valid_size;
-    if (offset < whole_size) {
-        if (size == VK_WHOLE_SIZE) {
-            valid_size.emplace(whole_size - offset);
-        } else if ((offset + size) <= whole_size) {
-            valid_size.emplace(size);
-        }
-    }
-    return valid_size;
-}
-
 // Only 32 bit fields should need a bit count
 static inline uint32_t GetBitSetCount(uint32_t field) {
     std::bitset<32> view_bits(field);


### PR DESCRIPTION
It always has been `ComputeValidSize` under the hood, so remove needless abstractions