### PR TITLE
layers: Add assert for external semaphore code path

### DIFF
--- a/layers/state_tracker/semaphore_state.cpp
+++ b/layers/state_tracker/semaphore_state.cpp
@@ -116,7 +116,7 @@ void vvl::Semaphore::EnqueueWait(const SubmissionReference &wait_submit, uint64_
         // Timeline can be empty for the binary wait operation if the semaphore was imported.
         // Otherwise timeline should contain a binary signal.
         if (timeline_.empty()) {
-            assert(payload == 0);
+            assert(scope_ != vvl::Semaphore::kInternal);
             completed_ = SemOp(kWait, wait_submit, 0);
             return;
         }


### PR DESCRIPTION
Related to https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8989

The above issue has similar symptoms as infamous `PositiveSyncObject.KhronosTimelineSemaphoreExample` test. In both cases code can take "impossible" branch (like in the case when memory corruption changes object state). The added assert will help to detect such cases (`scope_` gets corrupted and has different value than `kInternal` for regular non-external semaphore) .

The original `assert(payload == 0);` assert was not correct. When binary and timeline semaphores are mixed, the semaphore value entries for binary semaphores should be ignored because they can contain arbitrary values.