### PR TITLE
Fix GN build

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -192,6 +192,7 @@ vvl_sources = [
   "layers/gpu/resources/gpuav_shader_resources.h",
   "layers/gpu/resources/gpuav_state_trackers.cpp",
   "layers/gpu/resources/gpuav_state_trackers.h",
+  "layers/gpu/shaders/cmd_validation/draw_push_data.h",
   "layers/gpu/shaders/gpuav_error_codes.h",
   "layers/gpu/shaders/gpuav_error_header.h",
   "layers/gpu/shaders/gpuav_shaders_constants.h",


### PR DESCRIPTION
Log to failure output:

https://logs.chromium.org/logs/angle/buildbucket/cr-buildbucket/8728843360838685857/+/u/presubmit/stdout