### PR TITLE
build: Add missing header includes

### DIFF
--- a/layers/external/inplace_function.h
+++ b/layers/external/inplace_function.h
@@ -29,9 +29,11 @@
 
 #pragma once
 
+#include <cstddef>
+#include <functional>
+#include <memory>
 #include <type_traits>
 #include <utility>
-#include <functional>
 
 #ifndef SG14_INPLACE_FUNCTION_THROW
 #define SG14_INPLACE_FUNCTION_THROW(x) throw(x)

--- a/layers/gpu/resources/gpuav_vulkan_objects.h
+++ b/layers/gpu/resources/gpuav_vulkan_objects.h
@@ -20,6 +20,7 @@
 #include "containers/custom_containers.h"
 #include "vma/vma.h"
 
+#include <typeinfo>
 #include <unordered_map>
 #include <vector>
 

--- a/layers/utils/vk_layer_utils.h
+++ b/layers/utils/vk_layer_utils.h
@@ -18,18 +18,19 @@
 
 #pragma once
 
+#include <algorithm>
+#include <atomic>
+#include <bitset>
 #include <cassert>
 #include <cctype>
-#include <cstring>
-#include <string>
-#include <vector>
-#include <bitset>
-#include <shared_mutex>
-#include <optional>
 #include <cmath>
-#include <atomic>
+#include <cstring>
 #include <memory>
-#include <algorithm>
+#include <optional>
+#include <shared_mutex>
+#include <string>
+#include <type_traits>
+#include <vector>
 
 #include <vulkan/utility/vk_format_utils.h>
 #include <vulkan/utility/vk_concurrent_unordered_map.hpp>


### PR DESCRIPTION
This is to fix build error when we set use_libcxx_modules=true in chromium build.