### PR TITLE
layers: Revert CountBuffer back to warning

### DIFF
--- a/layers/gpu/cmd_validation/gpuav_draw.h
+++ b/layers/gpu/cmd_validation/gpuav_draw.h
@@ -53,7 +53,7 @@ void FirstInstance(Validator &gpuav, CommandBuffer &cb_state, const Location &lo
 void CountBuffer(Validator &gpuav, CommandBuffer &cb_state, const Location &loc, VkBuffer draw_buffer,
                  VkDeviceSize draw_buffer_offset, uint32_t draw_indirect_struct_byte_size, vvl::Struct draw_indirect_struct_name,
                  uint32_t draw_cmds_byte_stride, VkBuffer count_buffer, VkDeviceSize count_buffer_offset,
-                 const char *vuid_draw_buffer_size, const char *vuid_max_draw_count);
+                 const char *vuid_max_draw_count);
 
 void DrawMeshIndirect(Validator &gpuav, CommandBuffer &cb_state, const Location &loc, VkBuffer draw_buffer,
                       VkDeviceSize draw_buffer_offset, uint32_t draw_cmds_byte_stride, VkBuffer count_buffer,

--- a/layers/gpu/core/gpuav_record.cpp
+++ b/layers/gpu/core/gpuav_record.cpp
@@ -581,7 +581,7 @@ void Validator::PreCallRecordCmdDrawIndirectCount(VkCommandBuffer commandBuffer,
 
     valcmd::CountBuffer(*this, *cb_state, record_obj.location, buffer, offset, sizeof(VkDrawIndirectCommand),
                         vvl::Struct::VkDrawIndirectCommand, stride, countBuffer, countBufferOffset,
-                        "VUID-vkCmdDrawIndirectCount-countBuffer-03122", "VUID-vkCmdDrawIndirectCount-countBuffer-02717");
+                        "VUID-vkCmdDrawIndirectCount-countBuffer-02717");
     valcmd::FirstInstance<VkDrawIndirectCommand>(*this, *cb_state, record_obj.location, buffer, offset, maxDrawCount, countBuffer,
                                                  countBufferOffset, "VUID-VkDrawIndirectCommand-firstInstance-00501");
     PreCallSetupShaderInstrumentationResources(*this, *cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, record_obj.location);
@@ -664,7 +664,6 @@ void Validator::PreCallRecordCmdDrawIndexedIndirectCount(VkCommandBuffer command
     }
     valcmd::CountBuffer(*this, *cb_state, record_obj.location, buffer, offset, sizeof(VkDrawIndexedIndirectCommand),
                         vvl::Struct::VkDrawIndexedIndirectCommand, stride, countBuffer, countBufferOffset,
-                        "VUID-vkCmdDrawIndexedIndirectCount-countBuffer-03154",
                         "VUID-vkCmdDrawIndexedIndirectCount-countBuffer-02717");
     valcmd::FirstInstance<VkDrawIndexedIndirectCommand>(*this, *cb_state, record_obj.location, buffer, offset, maxDrawCount,
                                                         countBuffer, countBufferOffset,
@@ -673,7 +672,7 @@ void Validator::PreCallRecordCmdDrawIndexedIndirectCount(VkCommandBuffer command
     valcmd::DrawIndexedIndirectIndexBuffer(*this, *cb_state, record_obj.location, buffer, offset, stride, maxDrawCount, countBuffer,
                                            countBufferOffset, "VUID-VkDrawIndexedIndirectCommand-robustBufferAccess2-08798");
     valcmd::DrawIndexedIndirectVertexBuffer(*this, *cb_state, record_obj.location, buffer, offset, stride, maxDrawCount,
-                                            countBuffer, countBufferOffset, "VUID-VkDrawIndexedIndirectCommand-None-00552");
+                                            countBuffer, countBufferOffset, "VUID-vkCmdDrawIndexedIndirectCount-None-02721");
     PreCallSetupShaderInstrumentationResources(*this, *cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, record_obj.location);
     descriptor::PreCallActionCommand(*this, *cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, record_obj.location);
 }
@@ -728,7 +727,7 @@ void Validator::PreCallRecordCmdDrawMeshTasksIndirectNV(VkCommandBuffer commandB
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
         return;
     }
-    
+
     PreCallSetupShaderInstrumentationResources(*this, *cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, record_obj.location);
     descriptor::PreCallActionCommand(*this, *cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, record_obj.location);
 }
@@ -767,7 +766,6 @@ void Validator::PreCallRecordCmdDrawMeshTasksIndirectCountNV(VkCommandBuffer com
 
     valcmd::CountBuffer(*this, *cb_state, record_obj.location, buffer, offset, sizeof(VkDrawMeshTasksIndirectCommandNV),
                         vvl::Struct::VkDrawMeshTasksIndirectCommandNV, stride, countBuffer, countBufferOffset,
-                        "VUID-vkCmdDrawMeshTasksIndirectCountNV-countBuffer-02192",
                         "VUID-vkCmdDrawMeshTasksIndirectCountNV-countBuffer-02717");
     PreCallSetupShaderInstrumentationResources(*this, *cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, record_obj.location);
     descriptor::PreCallActionCommand(*this, *cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, record_obj.location);
@@ -866,7 +864,6 @@ void Validator::PreCallRecordCmdDrawMeshTasksIndirectCountEXT(VkCommandBuffer co
 
     valcmd::CountBuffer(*this, *cb_state, record_obj.location, buffer, offset, sizeof(VkDrawMeshTasksIndirectCommandEXT),
                         vvl::Struct::VkDrawMeshTasksIndirectCommandEXT, stride, countBuffer, countBufferOffset,
-                        "VUID-vkCmdDrawMeshTasksIndirectCountEXT-countBuffer-07099",
                         "VUID-vkCmdDrawMeshTasksIndirectCountEXT-countBuffer-02717");
     PreCallSetupShaderInstrumentationResources(*this, *cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, record_obj.location);
     descriptor::PreCallActionCommand(*this, *cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, record_obj.location);

--- a/scripts/vk_validation_stats.py
+++ b/scripts/vk_validation_stats.py
@@ -492,8 +492,11 @@ def main(argv):
     layer_source_files.extend(glob.glob(os.path.join(repo_relative('layers/object_tracker/'), '*.cpp')))
     layer_source_files.extend(glob.glob(os.path.join(repo_relative('layers/drawdispatch/'), '*.cpp')))
     layer_source_files.extend(glob.glob(os.path.join(repo_relative('layers/gpu/'), '*.cpp')))
-    layer_source_files.extend(glob.glob(os.path.join(repo_relative('layers/gpu/error_message'), '*.cpp')))
-    layer_source_files.extend(glob.glob(os.path.join(repo_relative('layers/gpu/instrumentation'), '*.cpp')))
+    layer_source_files.extend(glob.glob(os.path.join(repo_relative('layers/gpu/cmd_validation/'), '*.cpp')))
+    layer_source_files.extend(glob.glob(os.path.join(repo_relative('layers/gpu/core/'), '*.cpp')))
+    layer_source_files.extend(glob.glob(os.path.join(repo_relative('layers/gpu/descriptor_validation/'), '*.cpp')))
+    layer_source_files.extend(glob.glob(os.path.join(repo_relative('layers/gpu/error_message/'), '*.cpp')))
+    layer_source_files.extend(glob.glob(os.path.join(repo_relative('layers/gpu/instrumentation/'), '*.cpp')))
 
     test_source_files = glob.glob(os.path.join(repo_relative('tests/unit'), '*.cpp'))
 

--- a/tests/framework/error_monitor.cpp
+++ b/tests/framework/error_monitor.cpp
@@ -205,6 +205,13 @@ void ErrorMonitor::SetDesiredErrorRegex(const char *vuid, std::string regex_str,
     }
 }
 
+void ErrorMonitor::SetDesiredWarningRegex(const char *vuid, std::string regex_str, uint32_t count /*= 1*/) {
+    const std::regex regex(regex_str);
+    for (uint32_t i = 0; i < count; i++) {
+        SetDesiredFailureMsgRegex(kWarningBit, vuid, regex_str, regex);
+    }
+}
+
 void ErrorMonitor::SetDesiredWarning(const char *msg, uint32_t count) {
     for (uint32_t i = 0; i < count; ++i) {
         SetDesiredFailureMsg(kWarningBit, msg);

--- a/tests/framework/error_monitor.h
+++ b/tests/framework/error_monitor.h
@@ -63,7 +63,8 @@ class ErrorMonitor {
     void SetDesiredError(const char *msg, uint32_t count = 1);
     // Regex uses modified ECMAScript regular expression grammar https://eel.is/c++draft/re.grammar
     void SetDesiredErrorRegex(const char *vuid, std::string regex_str, uint32_t count = 1);
-    // And use this for warnings
+    // And use this for
+    void SetDesiredWarningRegex(const char *vuid, std::string regex_str, uint32_t count = 1);
     void SetDesiredWarning(const char *msg, uint32_t count = 1);
     void SetDesiredInfo(const char *msg, uint32_t count = 1);
 

--- a/tests/unit/gpu_av_indirect_buffer.cpp
+++ b/tests/unit/gpu_av_indirect_buffer.cpp
@@ -233,9 +233,10 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
     m_command_buffer.Begin(&begin_info);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
-    m_errorMonitor->SetDesiredErrorRegex("VUID-vkCmdDrawIndirectCount-countBuffer-03122",
-                                         "Indirect draw count of 2 would exceed size \\(16\\) of buffer .* stride = 16 offset = 0 "
-                                         ".* = 32");
+    m_errorMonitor->SetDesiredWarningRegex(
+        "WARNING-GPU-AV-drawCount",
+        "Indirect draw count of 2 would exceed size \\(16\\) of buffer .* stride = 16 offset = 0 "
+        ".* = 32");
     vk::CmdDrawIndirectCountKHR(m_command_buffer.handle(), draw_buffer.handle(), 0, count_buffer.handle(), 0, 1,
                                 sizeof(VkDrawIndirectCommand));
     m_command_buffer.EndRenderPass();
@@ -252,9 +253,10 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     // Offset of 4 should error
-    m_errorMonitor->SetDesiredErrorRegex("VUID-vkCmdDrawIndirectCount-countBuffer-03122",
-                                         "Indirect draw count of 1 would exceed size \\(16\\) of buffer .* stride = 16 offset = 4 "
-                                         ".* = 20");
+    m_errorMonitor->SetDesiredWarningRegex(
+        "WARNING-GPU-AV-drawCount",
+        "Indirect draw count of 1 would exceed size \\(16\\) of buffer .* stride = 16 offset = 4 "
+        ".* = 20");
     vk::CmdDrawIndirectCountKHR(m_command_buffer.handle(), draw_buffer.handle(), 4, count_buffer.handle(), 0, 1,
                                 sizeof(VkDrawIndirectCommand));
     m_command_buffer.EndRenderPass();
@@ -281,9 +283,10 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vkt::Buffer index_buffer(*m_device, 3 * sizeof(uint32_t), VK_BUFFER_USAGE_INDEX_BUFFER_BIT);
     vk::CmdBindIndexBuffer(m_command_buffer.handle(), index_buffer.handle(), 0, VK_INDEX_TYPE_UINT32);
-    m_errorMonitor->SetDesiredErrorRegex("VUID-vkCmdDrawIndexedIndirectCount-countBuffer-03154",
-                                         "Indirect draw count of 2 would exceed size \\(20\\) of buffer .* stride = 20 offset = 0 "
-                                         ".* = 40");
+    m_errorMonitor->SetDesiredWarningRegex(
+        "WARNING-GPU-AV-drawCount",
+        "Indirect draw count of 2 would exceed size \\(20\\) of buffer .* stride = 20 offset = 0 "
+        ".* = 40");
 
     vk::CmdDrawIndexedIndirectCountKHR(m_command_buffer.handle(), indexed_draw_buffer.handle(), 0, count_buffer.handle(), 0, 1,
                                        sizeof(VkDrawIndexedIndirectCommand));
@@ -302,9 +305,10 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindIndexBuffer(m_command_buffer.handle(), index_buffer.handle(), 0, VK_INDEX_TYPE_UINT32);
     // Offset of 4 should error
-    m_errorMonitor->SetDesiredErrorRegex("VUID-vkCmdDrawIndexedIndirectCount-countBuffer-03154",
-                                         "Indirect draw count of 1 would exceed size \\(20\\) of buffer .* stride = 20 offset = 4 "
-                                         ".* = 24");
+    m_errorMonitor->SetDesiredWarningRegex(
+        "WARNING-GPU-AV-drawCount",
+        "Indirect draw count of 1 would exceed size \\(20\\) of buffer .* stride = 20 offset = 4 "
+        ".* = 24");
     vk::CmdDrawIndexedIndirectCountKHR(m_command_buffer.handle(), indexed_draw_buffer.handle(), 4, count_buffer.handle(), 0, 1,
                                        sizeof(VkDrawIndexedIndirectCommand));
     m_command_buffer.EndRenderPass();
@@ -337,8 +341,8 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
         mesh_draw_ptr->groupCountY = 0;
         mesh_draw_ptr->groupCountZ = 0;
         mesh_draw_buffer.memory().unmap();
-        m_errorMonitor->SetDesiredErrorRegex(
-            "VUID-vkCmdDrawMeshTasksIndirectCountEXT-countBuffer-07099",
+        m_errorMonitor->SetDesiredWarningRegex(
+            "WARNING-GPU-AV-drawCount",
             "Indirect draw count of 1 would exceed size \\(12\\) of buffer .* stride = 12 offset = 8 "
             ".* = 20");
         count_ptr = static_cast<uint32_t *>(count_buffer.memory().map());
@@ -355,8 +359,8 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
         m_default_queue->Wait();
         m_errorMonitor->VerifyFound();
 
-        m_errorMonitor->SetDesiredErrorRegex(
-            "VUID-vkCmdDrawMeshTasksIndirectCountEXT-countBuffer-07099",
+        m_errorMonitor->SetDesiredWarningRegex(
+            "WARNING-GPU-AV-drawCount",
             "Indirect draw count of 2 would exceed size \\(12\\) of buffer .* stride = 12 offset = 4 "
             ".* = 28");
         count_ptr = static_cast<uint32_t *>(count_buffer.memory().map());


### PR DESCRIPTION
https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/8953 reverted the changes from https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/8743

The VUIDs removed don't exists in the spec anymore 