### PR TITLE
tests: Fix compilation on Windows ARM64

### DIFF
--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -29,6 +29,12 @@
 #include <vulkan/utility/vk_format_utils.h>
 #include <vulkan/utility/vk_struct_helper.hpp>
 
+// Remove Windows macro that prevents usage of its name in any scope of the program.
+// For example, BitstreamBuffer::MemoryBarrier() won't compile on ARM64.
+#if defined(VK_USE_PLATFORM_WIN32_KHR) && defined(MemoryBarrier)
+#undef MemoryBarrier
+#endif
+
 #include "binding.h"
 #include "containers/custom_containers.h"
 #include "generated/vk_extension_helper.h"


### PR DESCRIPTION
Fixes video test errror:
> D:\vvl\tests\framework\video_objects.h(483,29): error C2061: syntax error: identifier '_ARM64_BARRIER_SY' [D:\vvl\build\Debug\tests\vk_layer_validation_tests.vcxproj]
  (compiling source file '../../../tests/unit/video.cpp')

We already have similar define for the layer code in sync_utils.h.