### PR TITLE
scripts: Set default arch to arm64 on ARM64 machines

### DIFF
--- a/scripts/update_deps.py
+++ b/scripts/update_deps.py
@@ -642,6 +642,14 @@ def CreateHelper(args, repos, filename):
                                       dir=escape(repo.install_dir)))
 
 
+def GetDefaultArch():
+    machine = platform.machine().lower()
+    if  machine == "arm64" or machine == "aarch64":
+        return 'arm64'
+    else:
+        return '64'
+
+
 def main():
     parser = argparse.ArgumentParser(
         description='Get and build dependent repos at known-good commits')
@@ -702,7 +710,7 @@ def main():
         choices=['32', '64', 'x86', 'x64', 'win32', 'win64', 'arm64'],
         type=str.lower,
         help="Set build files architecture (Visual Studio Generator Only)",
-        default='64')
+        default=GetDefaultArch())
     parser.add_argument(
         '--config',
         dest='config',


### PR DESCRIPTION
Current default configuration tries to build x64 on ARM64 which fails. It's possible to specify --arch, but it's nicer if by default it's a workable configuration.

This is how it fails:
> D:\vvl-temp\external\Debug\64\SPIRV-Tools\build\install\lib\SPIRV-Tools-opt.lib : warning LNK4272: library machine type
 'x64' conflicts with target machine type 'ARM64' [D:\vvl-temp\build\Debug\layers\vvl.vcxproj]
D:\vvl-temp\external\Debug\64\SPIRV-Tools\build\install\lib\SPIRV-Tools.lib : warning LNK4272: library machine type 'x6
4' conflicts with target machine type 'ARM64' [D:\vvl-temp\build\Debug\layers\vvl.vcxproj]
D:\vvl-temp\external\Debug\64\Vulkan-Utility-Libraries\build\install\lib\VulkanLayerSettings.lib : warning LNK4272: lib
rary machine type 'x64' conflicts with target machine type 'ARM64' [D:\vvl-temp\build\Debug\layers\vvl.vcxproj]
D:\vvl-temp\external\Debug\64\Vulkan-Utility-Libraries\build\install\lib\VulkanSafeStruct.lib : warning LNK4272: librar
y machine type 'x64' conflicts with target machine type 'ARM64' [D:\vvl-temp\build\Debug\layers\vvl.vcxproj]
D:\vvl-temp\external\Debug\64\mimalloc\build\install\lib\mimalloc-2.1\mimalloc-static-debug.lib : warning LNK4272: libr
ary machine type 'x64' conflicts with target machine type 'ARM64' [D:\vvl-temp\build\Debug\layers\vvl.vcxproj]
