### PR TITLE
tests: Fix test failure on Windows Arm

### DIFF
--- a/tests/framework/external_memory_sync.cpp
+++ b/tests/framework/external_memory_sync.cpp
@@ -216,11 +216,11 @@ bool HandleTypeNeedsDedicatedAllocation(VkPhysicalDevice gpu, const VkImageCreat
     return (external_features & VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT) != 0;
 }
 
-bool SemaphoreExportImportSupported(VkPhysicalDevice gpu, VkExternalSemaphoreHandleTypeFlagBits handle_type) {
+bool SemaphoreExportImportSupported(VkPhysicalDevice gpu, VkExternalSemaphoreHandleTypeFlagBits handle_type, void *p_next) {
     constexpr auto export_import_flags =
         VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT | VK_EXTERNAL_SEMAPHORE_FEATURE_IMPORTABLE_BIT;
 
-    VkPhysicalDeviceExternalSemaphoreInfo info = vku::InitStructHelper();
+    VkPhysicalDeviceExternalSemaphoreInfo info = vku::InitStructHelper(p_next);
     info.handleType = handle_type;
     VkExternalSemaphoreProperties properties = vku::InitStructHelper();
     vk::GetPhysicalDeviceExternalSemaphoreProperties(gpu, &info, &properties);

--- a/tests/framework/external_memory_sync.h
+++ b/tests/framework/external_memory_sync.h
@@ -44,4 +44,5 @@ bool HandleTypeNeedsDedicatedAllocation(VkPhysicalDevice gpu, const VkBufferCrea
 bool HandleTypeNeedsDedicatedAllocation(VkPhysicalDevice gpu, const VkImageCreateInfo &image_create_info,
                                         VkExternalMemoryHandleTypeFlagBits handle_type);
 
-bool SemaphoreExportImportSupported(VkPhysicalDevice gpu, VkExternalSemaphoreHandleTypeFlagBits handle_type);
+bool SemaphoreExportImportSupported(VkPhysicalDevice gpu, VkExternalSemaphoreHandleTypeFlagBits handle_type,
+                                    void *p_next = nullptr);

--- a/tests/unit/sync_object_positive.cpp
+++ b/tests/unit/sync_object_positive.cpp
@@ -1482,15 +1482,16 @@ TEST_F(PositiveSyncObject, WaitTimelineSemaphoreWithWin32HandleRetrieved) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
     constexpr auto handle_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT;
-    if (!SemaphoreExportImportSupported(Gpu(), handle_type)) {
-        GTEST_SKIP() << "Semaphore does not support export and import through Win32 handle";
-    }
 
-    // Create exportable timeline semaphore
     VkSemaphoreTypeCreateInfo semaphore_type_create_info = vku::InitStructHelper();
     semaphore_type_create_info.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
     semaphore_type_create_info.initialValue = 0;
 
+    if (!SemaphoreExportImportSupported(Gpu(), handle_type, &semaphore_type_create_info)) {
+        GTEST_SKIP() << "Semaphore does not support export and import through Win32 handle";
+    }
+
+    // Create exportable timeline semaphore
     VkExportSemaphoreCreateInfo export_info = vku::InitStructHelper(&semaphore_type_create_info);
     export_info.handleTypes = handle_type;
 


### PR DESCRIPTION
Current Windows Adreno driver supports only binary semaphore export. The test incorrectly queried support for timeline semaphores and because of that failed. The fix takes into account VkSemaphoreTypeCreateInfo.