### PR TITLE
tests: Fix massive syncval tests failure on Windows Arm

### DIFF
--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -3962,12 +3962,13 @@ TEST_F(NegativeSyncVal, DestroyedUnusedDescriptors) {
                                        },
                                        0, &layout_createinfo_binding_flags, 0);
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
+
+    const uint32_t zeroit_value = 0;
+    vkt::Buffer doit_buffer(*m_device, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, &zeroit_value, sizeof(uint32_t));
+
     VkBufferCreateInfo buffer_create_info = vku::InitStructHelper();
     buffer_create_info.size = 32;
     buffer_create_info.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
-
-    vkt::Buffer doit_buffer(*m_device, buffer_create_info);
-
     auto buffer = std::make_unique<vkt::Buffer>();
     buffer->init(*m_device, buffer_create_info);
 
@@ -4115,8 +4116,6 @@ TEST_F(NegativeSyncVal, DestroyedUnusedDescriptors) {
     vk::CmdDrawIndexed(m_command_buffer.handle(), 1, 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
-    m_default_queue->Submit(m_command_buffer);
-    m_default_queue->Wait();
 }
 
 TEST_F(NegativeSyncVal, TestInvalidExternalSubpassDependency) {


### PR DESCRIPTION
The problem was, that after DestroyedUnusedDescriptors, all other tests started to fail. Investigation shown that Adreno driver does not like when uniform buffer is removed even it is not dynamically used.

The solution is simple. DestroyedUnusedDescriptors triggers record time validation of descriptors (ValidateDispatchDrawDescriptorSet). If we remove QueueSubmit we still run the same validation but also make the test stable on Adreno driver.

NOTE: One of *many* potential reasons (just to demo at least one possibility) why deleting uniform buffer that is not dynamically used can be problematic, is that native gpu isa compiler can generate load insructions early in the shader to deal with latency. There can be a heuristic that says it's better to send memory load requests early in the beginning of the shader (even if load might not be needed due to branch) than pay for load by stalling in the middle. Saw such load reordering by AMD compiler, don't remember if that involved moving outside conditions. VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT_EXT flag should prevent such optimization but if compiler does not do this it can result exactly in this problem.