### PR TITLE
gpuav: Handle case where indirect cmd stride is 0

### DIFF
--- a/tests/unit/gpu_av_index_buffer_positive.cpp
+++ b/tests/unit/gpu_av_index_buffer_positive.cpp
@@ -43,7 +43,7 @@ TEST_F(PositiveGpuAVIndexBuffer, BadVertexIndex) {
     vkt::Buffer index_buffer = vkt::IndexBuffer<uint32_t>(*m_device, {0, std::numeric_limits<uint32_t>::max(), 42});
 
     vk::CmdBindIndexBuffer(m_command_buffer.handle(), index_buffer.handle(), 0, VK_INDEX_TYPE_UINT32);
-    vk::CmdDrawIndexedIndirect(m_command_buffer.handle(), draw_params_buffer.handle(), 0, 1, sizeof(VkDrawIndexedIndirectCommand));
+    vk::CmdDrawIndexedIndirect(m_command_buffer.handle(), draw_params_buffer.handle(), 0, 1, 0);
     m_command_buffer.EndRenderPass();
     m_command_buffer.end();
     m_default_queue->Submit(m_command_buffer);


### PR DESCRIPTION
Follow-up to https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/9019
Same "prevent / 0" fix 