### PR TITLE
tests: Skip test if descriptor set alloc fails

### DIFF
--- a/tests/unit/ycbcr_positive.cpp
+++ b/tests/unit/ycbcr_positive.cpp
@@ -328,6 +328,9 @@ TEST_F(PositiveYcbcr, ImageLayout) {
         m_device, {
                       {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, &sampler.handle()},
                   });
+    if (!descriptor_set.set_) {
+        GTEST_SKIP() << "Can't allocate descriptor with immutable sampler";
+    }
 
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
     descriptor_set.WriteDescriptorImageInfo(0, view.handle(), sampler.handle());


### PR DESCRIPTION
This test would fail on one of my devices.

The test `PositiveYcbcr.ImageQuerySizeLod` has the same check.