### PR TITLE
gpu: Remove unused LinkFunction

### DIFF
--- a/layers/gpu/spirv/buffer_device_address_pass.cpp
+++ b/layers/gpu/spirv/buffer_device_address_pass.cpp
@@ -25,8 +25,8 @@ namespace spirv {
 
 // By appending the LinkInfo, it will attempt at linking stage to add the function.
 uint32_t BufferDeviceAddressPass::GetLinkFunctionId() {
-    static LinkInfo link_info = {instrumentation_buffer_device_address_comp, instrumentation_buffer_device_address_comp_size,
-                                 LinkFunctions::inst_buffer_device_address, 0, "inst_buffer_device_address"};
+    static LinkInfo link_info = {instrumentation_buffer_device_address_comp, instrumentation_buffer_device_address_comp_size, 0,
+                                 "inst_buffer_device_address"};
 
     if (link_function_id == 0) {
         link_function_id = module_.TakeNextId();

--- a/layers/gpu/spirv/descriptor_class_general_buffer_pass.cpp
+++ b/layers/gpu/spirv/descriptor_class_general_buffer_pass.cpp
@@ -29,8 +29,8 @@ DescriptorClassGeneralBufferPass::DescriptorClassGeneralBufferPass(Module& modul
 // By appending the LinkInfo, it will attempt at linking stage to add the function.
 uint32_t DescriptorClassGeneralBufferPass::GetLinkFunctionId() {
     static LinkInfo link_info = {instrumentation_descriptor_class_general_buffer_comp,
-                                 instrumentation_descriptor_class_general_buffer_comp_size,
-                                 LinkFunctions::inst_descriptor_class_general_buffer, 0, "inst_descriptor_class_general_buffer"};
+                                 instrumentation_descriptor_class_general_buffer_comp_size, 0,
+                                 "inst_descriptor_class_general_buffer"};
 
     if (link_function_id == 0) {
         link_function_id = module_.TakeNextId();

--- a/layers/gpu/spirv/descriptor_class_texel_buffer_pass.cpp
+++ b/layers/gpu/spirv/descriptor_class_texel_buffer_pass.cpp
@@ -29,8 +29,7 @@ DescriptorClassTexelBufferPass::DescriptorClassTexelBufferPass(Module& module) :
 // By appending the LinkInfo, it will attempt at linking stage to add the function.
 uint32_t DescriptorClassTexelBufferPass::GetLinkFunctionId() {
     static LinkInfo link_info = {instrumentation_descriptor_class_texel_buffer_comp,
-                                 instrumentation_descriptor_class_texel_buffer_comp_size,
-                                 LinkFunctions::inst_descriptor_class_texel_buffer, 0, "inst_descriptor_class_texel_buffer"};
+                                 instrumentation_descriptor_class_texel_buffer_comp_size, 0, "inst_descriptor_class_texel_buffer"};
 
     if (link_function_id == 0) {
         link_function_id = module_.TakeNextId();

--- a/layers/gpu/spirv/descriptor_indexing_oob_pass.cpp
+++ b/layers/gpu/spirv/descriptor_indexing_oob_pass.cpp
@@ -29,12 +29,12 @@ namespace spirv {
 // By appending the LinkInfo, it will attempt at linking stage to add the function.
 uint32_t DescriptorIndexingOOBPass::GetLinkFunctionId() {
     // This pass has 2 variations of GLSL we can pull in. Non-Bindless is simpler and we want to use when possible
-    static LinkInfo link_info_bindless = {
-        instrumentation_descriptor_indexing_oob_bindless_comp, instrumentation_descriptor_indexing_oob_bindless_comp_size,
-        LinkFunctions::inst_descriptor_indexing_oob_bindless, 0, "inst_descriptor_indexing_oob_bindless"};
-    static LinkInfo link_info_non_bindless = {
-        instrumentation_descriptor_indexing_oob_non_bindless_comp, instrumentation_descriptor_indexing_oob_non_bindless_comp_size,
-        LinkFunctions::inst_descriptor_indexing_oob_non_bindless, 0, "inst_descriptor_indexing_oob_non_bindless"};
+    static LinkInfo link_info_bindless = {instrumentation_descriptor_indexing_oob_bindless_comp,
+                                          instrumentation_descriptor_indexing_oob_bindless_comp_size, 0,
+                                          "inst_descriptor_indexing_oob_bindless"};
+    static LinkInfo link_info_non_bindless = {instrumentation_descriptor_indexing_oob_non_bindless_comp,
+                                              instrumentation_descriptor_indexing_oob_non_bindless_comp_size, 0,
+                                              "inst_descriptor_indexing_oob_non_bindless"};
 
     if (link_function_id == 0) {
         link_function_id = module_.TakeNextId();

--- a/layers/gpu/spirv/link.h
+++ b/layers/gpu/spirv/link.h
@@ -19,24 +19,12 @@
 namespace gpuav {
 namespace spirv {
 
-// Functions name match those found in the GLSL for ease of searching
-enum class LinkFunctions {
-    inst_buffer_device_address,
-    inst_descriptor_indexing_oob_bindless,
-    inst_descriptor_indexing_oob_non_bindless,
-    inst_descriptor_class_general_buffer,
-    inst_descriptor_class_texel_buffer,
-    inst_ray_query,
-    inst_post_process_descriptor_index,
-};
-
 struct LinkInfo {
     // SPIR-V module to link in
     const uint32_t* words;
     const uint32_t word_count;
 
     // Information about the function it has
-    LinkFunctions function;
     uint32_t function_id;
 
     // used for debugging

--- a/layers/gpu/spirv/post_process_descriptor_indexing.cpp
+++ b/layers/gpu/spirv/post_process_descriptor_indexing.cpp
@@ -28,8 +28,7 @@ PostProcessDescriptorIndexingPass::PostProcessDescriptorIndexingPass(Module& mod
 // By appending the LinkInfo, it will attempt at linking stage to add the function.
 uint32_t PostProcessDescriptorIndexingPass::GetLinkFunctionId() {
     static LinkInfo link_info = {instrumentation_post_process_descriptor_index_comp,
-                                 instrumentation_post_process_descriptor_index_comp_size,
-                                 LinkFunctions::inst_post_process_descriptor_index, 0, "inst_post_process_descriptor_index"};
+                                 instrumentation_post_process_descriptor_index_comp_size, 0, "inst_post_process_descriptor_index"};
 
     if (link_function_id == 0) {
         link_function_id = module_.TakeNextId();

--- a/layers/gpu/spirv/ray_query_pass.cpp
+++ b/layers/gpu/spirv/ray_query_pass.cpp
@@ -25,8 +25,7 @@ namespace spirv {
 
 // By appending the LinkInfo, it will attempt at linking stage to add the function.
 uint32_t RayQueryPass::GetLinkFunctionId() {
-    static LinkInfo link_info = {instrumentation_ray_query_comp, instrumentation_ray_query_comp_size, LinkFunctions::inst_ray_query,
-                                 0, "inst_ray_query"};
+    static LinkInfo link_info = {instrumentation_ray_query_comp, instrumentation_ray_query_comp_size, 0, "inst_ray_query"};
 
     if (link_function_id == 0) {
         link_function_id = module_.TakeNextId();


### PR DESCRIPTION
I added the `LinkFunctions` before I just added the `OpName` and so far I have found/thought of no good reason to keep these here, so removing until we actually find a real reason to use them