### PR TITLE
gpu: Fix Chaining of Accesses for General Buffer

### DIFF
--- a/layers/gpu/spirv/descriptor_class_general_buffer_pass.cpp
+++ b/layers/gpu/spirv/descriptor_class_general_buffer_pass.cpp
@@ -15,6 +15,7 @@
 
 #include "descriptor_class_general_buffer_pass.h"
 #include "instruction.h"
+#include "utils/vk_layer_utils.h"
 #include "module.h"
 #include <spirv/unified1/spirv.hpp>
 #include <iostream>
@@ -89,7 +90,7 @@ void DescriptorClassGeneralBufferPass::Reset() {
 bool DescriptorClassGeneralBufferPass::RequiresInstrumentation(const Function& function, const Instruction& inst) {
     const uint32_t opcode = inst.Opcode();
 
-    if (opcode != spv::OpLoad && opcode != spv::OpStore) {
+    if (!IsValueIn(spv::Op(opcode), {spv::OpLoad, spv::OpStore, spv::OpAtomicStore, spv::OpAtomicLoad, spv::OpAtomicExchange})) {
         return false;
     }
 

--- a/layers/gpu/spirv/descriptor_class_general_buffer_pass.h
+++ b/layers/gpu/spirv/descriptor_class_general_buffer_pass.h
@@ -37,7 +37,12 @@ class DescriptorClassGeneralBufferPass : public Pass {
     uint32_t link_function_id = 0;
     uint32_t GetLinkFunctionId();
 
-    const Instruction* access_chain_inst_ = nullptr;
+    // List of OpAccessChains fom the Store/Load down to the OpVariable
+    // The front() will be closet to the exact spot accesssed
+    // The back() will be closest to the OpVariable
+    // (note GLSL will try to always create a single large OpAccessChain)
+    std::vector<const Instruction*> access_chain_insts_;
+    // The OpVariable that is being accessed
     const Instruction* var_inst_ = nullptr;
 
     uint32_t descriptor_set_ = 0;

--- a/layers/gpu/spirv/descriptor_class_general_buffer_pass.h
+++ b/layers/gpu/spirv/descriptor_class_general_buffer_pass.h
@@ -42,8 +42,8 @@ class DescriptorClassGeneralBufferPass : public Pass {
     // The back() will be closest to the OpVariable
     // (note GLSL will try to always create a single large OpAccessChain)
     std::vector<const Instruction*> access_chain_insts_;
-    // The OpVariable that is being accessed
-    const Instruction* var_inst_ = nullptr;
+    // The Type of the OpVariable that is being accessed
+    const Type* descriptor_type_ = nullptr;
 
     uint32_t descriptor_set_ = 0;
     uint32_t descriptor_binding_ = 0;

--- a/layers/gpu/spirv/module.cpp
+++ b/layers/gpu/spirv/module.cpp
@@ -709,6 +709,9 @@ void Module::PostProcess() {
 
     // The instrumentation code has atomicAdd() to update the output buffer
     // If the incoming code only has VulkanMemoryModel it will need to support device scope
+    //
+    // Found that QueueFamily was added to mostly solve this, if a device doesn't support Device scope we could use QueueFamily, the
+    // issue is that the GLSL we have is static and if we use QueueFamily then we "need" the MemoryModel enabled
     if (HasCapability(spv::CapabilityVulkanMemoryModel)) {
         if (!support_memory_model_device_scope_) {
             InternalError(

--- a/layers/gpu/spirv/pass.h
+++ b/layers/gpu/spirv/pass.h
@@ -24,6 +24,7 @@ namespace spirv {
 class Module;
 struct Variable;
 struct BasicBlock;
+struct Type;
 
 // Info we know is the same regardless what pass is consuming the CreateFunctionCall()
 struct InjectionData {
@@ -43,9 +44,10 @@ class Pass {
     uint32_t GetStageInfo(Function& function, BasicBlockIt target_block_it, InstructionIt& target_inst_it);
 
     const Instruction* GetDecoration(uint32_t id, spv::Decoration decoration);
-    const Instruction* GetMemeberDecoration(uint32_t id, uint32_t member_index, spv::Decoration decoration);
+    const Instruction* GetMemberDecoration(uint32_t id, uint32_t member_index, spv::Decoration decoration);
 
-    uint32_t GetLastByte(const Instruction& var_inst, std::vector<const Instruction*>& access_chain_insts, BasicBlock& block,
+    uint32_t FindTypeByteSize(uint32_t type_id, uint32_t matrix_stride = 0, bool col_major = false, bool in_matrix = false);
+    uint32_t GetLastByte(const Type& descriptor_type, std::vector<const Instruction*>& access_chain_insts, BasicBlock& block,
                          InstructionIt* inst_it);
     // Generate SPIR-V needed to help convert things to be uniformly uint32_t
     // If no inst_it is passed in, any new instructions will be added to end of the Block

--- a/layers/gpu/spirv/pass.h
+++ b/layers/gpu/spirv/pass.h
@@ -45,7 +45,7 @@ class Pass {
     const Instruction* GetDecoration(uint32_t id, spv::Decoration decoration);
     const Instruction* GetMemeberDecoration(uint32_t id, uint32_t member_index, spv::Decoration decoration);
 
-    uint32_t GetLastByte(const Instruction& var_inst, const Instruction& access_chain_inst, BasicBlock& block,
+    uint32_t GetLastByte(const Instruction& var_inst, std::vector<const Instruction*>& access_chain_insts, BasicBlock& block,
                          InstructionIt* inst_it);
     // Generate SPIR-V needed to help convert things to be uniformly uint32_t
     // If no inst_it is passed in, any new instructions will be added to end of the Block

--- a/layers/gpu/spirv/type_manager.h
+++ b/layers/gpu/spirv/type_manager.h
@@ -103,6 +103,7 @@ class TypeManager {
 
     const Type& AddType(std::unique_ptr<Instruction> new_inst, SpvType spv_type);
     const Type* FindTypeById(uint32_t id) const;
+    const Type* FindValueTypeById(uint32_t id) const;
     const Type* FindFunctionType(const Instruction& inst) const;
     // There shouldn't be a case where we need to query for a specific type, but then not add it if not found.
     const Type& GetTypeVoid();
@@ -135,8 +136,6 @@ class TypeManager {
 
     const Variable& AddVariable(std::unique_ptr<Instruction> new_inst, const Type& type);
     const Variable* FindVariableById(uint32_t id) const;
-
-    uint32_t FindTypeByteSize(uint32_t type_id, uint32_t matrix_stride = 0, bool col_major = false, bool in_matrix = false);
 
   private:
     Module& module_;

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -2150,11 +2150,11 @@ TypeStructSize TypeStructInfo::GetSize(const Module& module_state) const {
     for (uint32_t i = 0; i < members.size(); i++) {
         const auto& member = members[i];
         // all struct elements are required to have offset decorations in Block
-        const uint32_t memeber_offset = member.decorations->offset;
-        offset = std::min(offset, memeber_offset);
-        if (memeber_offset > highest_element_offset) {
+        const uint32_t member_offset = member.decorations->offset;
+        offset = std::min(offset, member_offset);
+        if (member_offset > highest_element_offset) {
             highest_element_index = i;
-            highest_element_offset = memeber_offset;
+            highest_element_offset = member_offset;
         }
     }
 

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -260,6 +260,11 @@ class GpuAVDescriptorIndexingTest : public GpuAVTest {
     void InitGpuVUDescriptorIndexing();
 };
 
+class GpuAVDescriptorClassGeneralBuffer : public GpuAVTest {
+  public:
+    void ComputeStorageBufferTest(const char *shader, bool is_glsl, VkDeviceSize buffer_size, const char *expected_error = nullptr);
+};
+
 class GpuAVRayQueryTest : public GpuAVTest {
   public:
     void InitGpuAVRayQuery();

--- a/tests/unit/gpu_av_descriptor_class_general_buffer.cpp
+++ b/tests/unit/gpu_av_descriptor_class_general_buffer.cpp
@@ -1774,3 +1774,93 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, ChainOfAccessChains) {
     )";
     ComputeStorageBufferTest(cs_source, false, 32, "VUID-vkCmdDispatch-storageBuffers-06936");
 }
+
+TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, AtomicStore) {
+    char const *cs_source = R"glsl(
+        #version 450
+        #extension GL_KHR_memory_scope_semantics : enable
+        layout(set = 0, binding = 0, std430) buffer foo {
+            uvec4 a;
+            uint b;
+        };
+
+        void main() {
+            atomicStore(b, 0u, gl_ScopeDevice, gl_StorageSemanticsBuffer, gl_SemanticsRelaxed);
+        }
+    )glsl";
+    ComputeStorageBufferTest(cs_source, true, 16, "VUID-vkCmdDispatch-storageBuffers-06936");
+}
+
+TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, AtomicLoad) {
+    char const *cs_source = R"glsl(
+        #version 450
+        #extension GL_KHR_memory_scope_semantics : enable
+        layout(set = 0, binding = 0, std430) buffer foo {
+            uvec4 a;
+            uvec4 b;
+        };
+
+        void main() {
+            a.x = atomicLoad(b.x, gl_ScopeDevice, gl_StorageSemanticsBuffer, gl_SemanticsRelaxed);
+        }
+    )glsl";
+    ComputeStorageBufferTest(cs_source, true, 16, "VUID-vkCmdDispatch-storageBuffers-06936");
+}
+
+TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, AtomicExchange) {
+    char const *cs_source = R"glsl(
+        #version 450
+        #extension GL_KHR_memory_scope_semantics : enable
+        layout(set = 0, binding = 0, std430) buffer foo {
+            uvec4 a;
+            uint b;
+        };
+
+        void main() {
+            atomicExchange(b, a.x);
+        }
+    )glsl";
+    ComputeStorageBufferTest(cs_source, true, 16, "VUID-vkCmdDispatch-storageBuffers-06936");
+}
+
+TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, AtomicsDescriptorIndex) {
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    RETURN_IF_SKIP(InitGpuAvFramework());
+    RETURN_IF_SKIP(InitState());
+
+    char const *cs_source = R"glsl(
+        #version 450
+        #extension GL_KHR_memory_scope_semantics : enable
+        layout(set = 0, binding = 0, std430) buffer SSBO {
+            uvec4 a;
+            uint b;
+        } ssbo[2];
+
+        void main() {
+            atomicStore(ssbo[0].b, 0u, gl_ScopeDevice, gl_StorageSemanticsBuffer, gl_SemanticsRelaxed); // valid
+            atomicStore(ssbo[1].b, 0u, gl_ScopeDevice, gl_StorageSemanticsBuffer, gl_SemanticsRelaxed); // invalid
+        }
+    )glsl";
+
+    CreateComputePipelineHelper pipe(*this);
+    pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 2, VK_SHADER_STAGE_ALL, nullptr}};
+    pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
+    pipe.CreateComputePipeline();
+
+    vkt::Buffer in_buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
+    pipe.descriptor_set_->WriteDescriptorBufferInfo(0, in_buffer.handle(), 0, 32, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 0);
+    pipe.descriptor_set_->WriteDescriptorBufferInfo(0, in_buffer.handle(), 32, 16, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);
+    pipe.descriptor_set_->UpdateDescriptorSets();
+
+    m_command_buffer.Begin();
+    vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
+    vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
+                              &pipe.descriptor_set_->set_, 0, nullptr);
+    vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
+    m_command_buffer.End();
+
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-storageBuffers-06936");
+    m_default_queue->Submit(m_command_buffer);
+    m_default_queue->Wait();
+    m_errorMonitor->VerifyFound();
+}

--- a/tests/unit/gpu_av_descriptor_class_general_buffer_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_class_general_buffer_positive.cpp
@@ -835,6 +835,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, ArrayCopyGLSL) {
 }
 
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, ArrayCopySlang) {
+    TEST_DESCRIPTION("Note that in slang and array copy is really a struct copy");
     // struct Bar {
     //     uint4 a;
     //     uint b[4];
@@ -960,6 +961,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, ArrayCopyTwoBindingsGLSL) {
 }
 
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, ArrayCopyTwoBindingsSlang) {
+    TEST_DESCRIPTION("Note that in slang and array copy is really a struct copy");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
@@ -987,7 +989,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, ArrayCopyTwoBindingsSlang) {
     //     foo1[0].b = foo2[0].e;
     // }
     char const *cs_source = R"(
-                 OpCapability Shader
+               OpCapability Shader
                OpExtension "SPV_KHR_storage_buffer_storage_class"
                OpMemoryModel Logical GLSL450
                OpEntryPoint GLCompute %main "main" %foo1 %foo2
@@ -1096,6 +1098,55 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, StructCopyGLSL) {
         }
     )glsl";
     ComputeStorageBufferTest(cs_source, true, 32);
+}
+TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, StructCopyGLSL2) {
+    char const *cs_source = R"glsl(
+        #version 450
+
+        struct Bar {
+            vec4 x;
+        };
+
+        layout(set = 0, binding = 0, std430) buffer foo {
+            uvec4 a;
+            Bar b; // size 16 at offset 16
+            uint c;
+        };
+
+        void main() {
+            Bar new_bar;
+            b = new_bar;
+        }
+    )glsl";
+    ComputeStorageBufferTest(cs_source, true, 32);
+}
+
+TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, StructCopyGLSL3) {
+    char const *cs_source = R"glsl(
+        #version 450
+
+        struct Bar2 {
+            vec4 x;
+        };
+
+        struct Bar {
+            uint x;
+            Bar2 y;
+        };
+
+        layout(set = 0, binding = 0, std430) buffer foo {
+            uvec4 a;
+            uvec4 padding;
+            Bar b; // size 32 at offset 32
+            uint c;
+        };
+
+        void main() {
+            Bar new_bar;
+            b = new_bar;
+        }
+    )glsl";
+    ComputeStorageBufferTest(cs_source, true, 64);
 }
 
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, StructCopySlang) {

--- a/tests/unit/gpu_av_descriptor_class_general_buffer_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_class_general_buffer_positive.cpp
@@ -15,7 +15,36 @@
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
 
-class PositiveGpuAVDescriptorClassGeneralBuffer : public GpuAVTest {};
+class PositiveGpuAVDescriptorClassGeneralBuffer : public GpuAVDescriptorClassGeneralBuffer {};
+
+void GpuAVDescriptorClassGeneralBuffer::ComputeStorageBufferTest(const char *shader, bool is_glsl, VkDeviceSize buffer_size,
+                                                                 const char *expected_error) {
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    RETURN_IF_SKIP(InitGpuAvFramework());
+    RETURN_IF_SKIP(InitState());
+
+    CreateComputePipelineHelper pipe(*this);
+    pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};
+    pipe.cs_ = std::make_unique<VkShaderObj>(this, shader, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2,
+                                             is_glsl ? SPV_SOURCE_GLSL : SPV_SOURCE_ASM);
+    pipe.CreateComputePipeline();
+
+    vkt::Buffer in_buffer(*m_device, buffer_size, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
+    pipe.descriptor_set_->WriteDescriptorBufferInfo(0, in_buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    pipe.descriptor_set_->UpdateDescriptorSets();
+
+    m_command_buffer.Begin();
+    vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
+    vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
+                              &pipe.descriptor_set_->set_, 0, nullptr);
+    vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
+    m_command_buffer.End();
+
+    if (expected_error) m_errorMonitor->SetDesiredError(expected_error);
+    m_default_queue->Submit(m_command_buffer);
+    m_default_queue->Wait();
+    if (expected_error) m_errorMonitor->VerifyFound();
+}
 
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, Basic) {
     AddRequiredExtensions(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME);
@@ -772,4 +801,443 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, RobustBuffer) {
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
+}
+
+TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, VectorArray) {
+    char const *cs_source = R"glsl(
+        #version 450
+        layout(set = 0, binding = 0) buffer foo {
+            uvec4 a[8]; // stride 16
+        };
+        void main() {
+            a[3].y = 44; // write at byte[52:56]
+        }
+    )glsl";
+
+    ComputeStorageBufferTest(cs_source, true, 64);
+}
+
+TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, ArrayCopyGLSL) {
+    char const *cs_source = R"glsl(
+        #version 450
+        layout(set = 0, binding = 0) buffer foo {
+            uvec4 a;
+            uint b[4];
+            uint c;
+        };
+
+        void main() {
+            uint d[4] = {4, 5, 6, 7};
+            b = d;
+        }
+    )glsl";
+    ComputeStorageBufferTest(cs_source, true, 32);
+}
+
+TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, ArrayCopySlang) {
+    // struct Bar {
+    //     uint4 a;
+    //     uint b[4];
+    //     uint c;
+    // };
+    //
+    // [[vk::binding(0, 0)]]
+    // RWStructuredBuffer<Bar> foo;
+    //
+    // [shader("compute")]
+    // void main() {
+    //     uint d[4] = {4, 5, 6, 7};
+    //     foo[0].b = d;
+    // }
+    char const *cs_source = R"(
+               OpCapability Shader
+               OpExtension "SPV_KHR_storage_buffer_storage_class"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %foo
+               OpExecutionMode %main LocalSize 1 1 1
+               OpDecorate %_arr_uint_int_4 ArrayStride 4
+               OpMemberDecorate %_Array_std430_uint4 0 Offset 0
+               OpMemberDecorate %Bar_std430 0 Offset 0
+               OpMemberDecorate %Bar_std430 1 Offset 16
+               OpMemberDecorate %Bar_std430 2 Offset 32
+               OpDecorate %_runtimearr_Bar_std430 ArrayStride 48
+               OpDecorate %RWStructuredBuffer Block
+               OpMemberDecorate %RWStructuredBuffer 0 Offset 0
+               OpDecorate %foo Binding 0
+               OpDecorate %foo DescriptorSet 0
+               OpDecorate %_arr_uint_int_4_0 ArrayStride 4
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+       %uint = OpTypeInt 32 0
+     %v4uint = OpTypeVector %uint 4
+      %int_4 = OpConstant %int 4
+%_arr_uint_int_4 = OpTypeArray %uint %int_4
+%_Array_std430_uint4 = OpTypeStruct %_arr_uint_int_4
+ %Bar_std430 = OpTypeStruct %v4uint %_Array_std430_uint4 %uint
+%_ptr_StorageBuffer_Bar_std430 = OpTypePointer StorageBuffer %Bar_std430
+%_runtimearr_Bar_std430 = OpTypeRuntimeArray %Bar_std430
+%RWStructuredBuffer = OpTypeStruct %_runtimearr_Bar_std430
+%_ptr_StorageBuffer_RWStructuredBuffer = OpTypePointer StorageBuffer %RWStructuredBuffer
+      %int_1 = OpConstant %int 1
+%_ptr_StorageBuffer__Array_std430_uint4 = OpTypePointer StorageBuffer %_Array_std430_uint4
+%_arr_uint_int_4_0 = OpTypeArray %uint %int_4
+         %25 = OpTypeFunction %_Array_std430_uint4 %_arr_uint_int_4_0
+     %uint_4 = OpConstant %uint 4
+     %uint_5 = OpConstant %uint 5
+     %uint_6 = OpConstant %uint 6
+     %uint_7 = OpConstant %uint 7
+         %35 = OpConstantComposite %_arr_uint_int_4_0 %uint_4 %uint_5 %uint_6 %uint_7
+        %foo = OpVariable %_ptr_StorageBuffer_RWStructuredBuffer StorageBuffer
+       %main = OpFunction %void None %3
+          %4 = OpLabel
+         %14 = OpAccessChain %_ptr_StorageBuffer_Bar_std430 %foo %int_0 %int_0
+         %21 = OpAccessChain %_ptr_StorageBuffer__Array_std430_uint4 %14 %int_1
+         %22 = OpFunctionCall %_Array_std430_uint4 %packStorage %35
+               OpStore %21 %22
+               OpReturn
+               OpFunctionEnd
+%packStorage = OpFunction %_Array_std430_uint4 None %25
+         %26 = OpFunctionParameter %_arr_uint_int_4_0
+         %27 = OpLabel
+         %28 = OpCompositeExtract %uint %26 0
+         %29 = OpCompositeExtract %uint %26 1
+         %30 = OpCompositeExtract %uint %26 2
+         %31 = OpCompositeExtract %uint %26 3
+         %32 = OpCompositeConstruct %_arr_uint_int_4 %28 %29 %30 %31
+         %33 = OpCompositeConstruct %_Array_std430_uint4 %32
+               OpReturnValue %33
+               OpFunctionEnd
+    )";
+    ComputeStorageBufferTest(cs_source, false, 32);
+}
+
+TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, ArrayCopyTwoBindingsGLSL) {
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    RETURN_IF_SKIP(InitGpuAvFramework());
+    RETURN_IF_SKIP(InitState());
+
+    char const *cs_source = R"glsl(
+        #version 450
+        layout(set = 0, binding = 0, std430) buffer foo1 {
+            uvec4 a;
+            uint b[4];
+            uint c;
+        };
+
+        layout(set = 0, binding = 1, std430) buffer foo2 {
+            uint d;
+            uint e[4];
+            uvec2 f;
+        };
+
+        void main() {
+            b = e;
+        }
+    )glsl";
+
+    CreateComputePipelineHelper pipe(*this);
+    pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
+                          {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};
+    pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
+    pipe.CreateComputePipeline();
+
+    vkt::Buffer in_buffer(*m_device, 256, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
+    pipe.descriptor_set_->WriteDescriptorBufferInfo(0, in_buffer.handle(), 0, 64, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    pipe.descriptor_set_->WriteDescriptorBufferInfo(1, in_buffer.handle(), 64, 64, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    pipe.descriptor_set_->UpdateDescriptorSets();
+
+    m_command_buffer.Begin();
+    vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
+    vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
+                              &pipe.descriptor_set_->set_, 0, nullptr);
+    vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
+    m_command_buffer.End();
+
+    m_default_queue->Submit(m_command_buffer);
+    m_default_queue->Wait();
+}
+
+TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, ArrayCopyTwoBindingsSlang) {
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    RETURN_IF_SKIP(InitGpuAvFramework());
+    RETURN_IF_SKIP(InitState());
+
+    // struct Bar1 {
+    //     uint4 a;
+    //     uint b[4];
+    //     uint c;
+    // };
+    //
+    // struct Bar2 {
+    //     uint4 d;
+    //     uint e[4];
+    //     uint f;
+    // };
+    //
+    // [[vk::binding(0, 0)]]
+    // RWStructuredBuffer<Bar1> foo1;
+    //
+    // [[vk::binding(1, 0)]]
+    // RWStructuredBuffer<Bar2> foo2;
+    //
+    // [shader("compute")]
+    // void main() {
+    //     foo1[0].b = foo2[0].e;
+    // }
+    char const *cs_source = R"(
+                 OpCapability Shader
+               OpExtension "SPV_KHR_storage_buffer_storage_class"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %foo1 %foo2
+               OpExecutionMode %main LocalSize 1 1 1
+               OpDecorate %_arr_uint_int_4 ArrayStride 4
+               OpMemberDecorate %_Array_std430_uint4 0 Offset 0
+               OpMemberDecorate %Bar1_std430 0 Offset 0
+               OpMemberDecorate %Bar1_std430 1 Offset 16
+               OpMemberDecorate %Bar1_std430 2 Offset 32
+               OpDecorate %_runtimearr_Bar1_std430 ArrayStride 48
+               OpDecorate %RWStructuredBuffer Block
+               OpMemberDecorate %RWStructuredBuffer 0 Offset 0
+               OpDecorate %foo1 Binding 0
+               OpDecorate %foo1 DescriptorSet 0
+               OpMemberDecorate %Bar2_std430 0 Offset 0
+               OpMemberDecorate %Bar2_std430 1 Offset 16
+               OpMemberDecorate %Bar2_std430 2 Offset 32
+               OpDecorate %_runtimearr_Bar2_std430 ArrayStride 48
+               OpDecorate %RWStructuredBuffer_0 Block
+               OpMemberDecorate %RWStructuredBuffer_0 0 Offset 0
+               OpDecorate %foo2 Binding 1
+               OpDecorate %foo2 DescriptorSet 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+        %int = OpTypeInt 32 1
+      %int_4 = OpConstant %int 4
+      %int_0 = OpConstant %int 0
+     %v4uint = OpTypeVector %uint 4
+%_arr_uint_int_4 = OpTypeArray %uint %int_4
+%_Array_std430_uint4 = OpTypeStruct %_arr_uint_int_4
+%Bar1_std430 = OpTypeStruct %v4uint %_Array_std430_uint4 %uint
+%_ptr_StorageBuffer_Bar1_std430 = OpTypePointer StorageBuffer %Bar1_std430
+%_runtimearr_Bar1_std430 = OpTypeRuntimeArray %Bar1_std430
+%RWStructuredBuffer = OpTypeStruct %_runtimearr_Bar1_std430
+%_ptr_StorageBuffer_RWStructuredBuffer = OpTypePointer StorageBuffer %RWStructuredBuffer
+      %int_1 = OpConstant %int 1
+%_ptr_StorageBuffer__Array_std430_uint4 = OpTypePointer StorageBuffer %_Array_std430_uint4
+%Bar2_std430 = OpTypeStruct %v4uint %_Array_std430_uint4 %uint
+%_ptr_StorageBuffer_Bar2_std430 = OpTypePointer StorageBuffer %Bar2_std430
+%_runtimearr_Bar2_std430 = OpTypeRuntimeArray %Bar2_std430
+%RWStructuredBuffer_0 = OpTypeStruct %_runtimearr_Bar2_std430
+%_ptr_StorageBuffer_RWStructuredBuffer_0 = OpTypePointer StorageBuffer %RWStructuredBuffer_0
+       %foo1 = OpVariable %_ptr_StorageBuffer_RWStructuredBuffer StorageBuffer
+       %foo2 = OpVariable %_ptr_StorageBuffer_RWStructuredBuffer_0 StorageBuffer
+       %main = OpFunction %void None %3
+          %4 = OpLabel
+         %17 = OpAccessChain %_ptr_StorageBuffer_Bar1_std430 %foo1 %int_0 %int_0
+         %24 = OpAccessChain %_ptr_StorageBuffer__Array_std430_uint4 %17 %int_1
+         %27 = OpAccessChain %_ptr_StorageBuffer_Bar2_std430 %foo2 %int_0 %int_0
+         %32 = OpAccessChain %_ptr_StorageBuffer__Array_std430_uint4 %27 %int_1
+         %33 = OpLoad %_Array_std430_uint4 %32
+         %64 = OpCompositeExtract %_arr_uint_int_4 %33 0
+         %65 = OpCompositeExtract %uint %64 0
+         %66 = OpCompositeExtract %uint %64 1
+         %67 = OpCompositeExtract %uint %64 2
+         %68 = OpCompositeExtract %uint %64 3
+        %110 = OpCompositeConstruct %_arr_uint_int_4 %65 %66 %67 %68
+         %83 = OpCompositeConstruct %_Array_std430_uint4 %110
+               OpStore %24 %83
+               OpReturn
+               OpFunctionEnd
+    )";
+
+    CreateComputePipelineHelper pipe(*this);
+    pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
+                          {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};
+    pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
+    pipe.CreateComputePipeline();
+
+    vkt::Buffer in_buffer(*m_device, 256, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
+    pipe.descriptor_set_->WriteDescriptorBufferInfo(0, in_buffer.handle(), 0, 64, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    pipe.descriptor_set_->WriteDescriptorBufferInfo(1, in_buffer.handle(), 64, 64, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    pipe.descriptor_set_->UpdateDescriptorSets();
+
+    m_command_buffer.Begin();
+    vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
+    vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
+                              &pipe.descriptor_set_->set_, 0, nullptr);
+    vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
+    m_command_buffer.End();
+
+    m_default_queue->Submit(m_command_buffer);
+    m_default_queue->Wait();
+}
+
+TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, StructCopyGLSL) {
+    char const *cs_source = R"glsl(
+        #version 450
+
+        struct Bar {
+            uint x;
+            uint y;
+            uint z[2];
+        };
+
+        layout(set = 0, binding = 0, std430) buffer foo {
+            uvec4 a;
+            Bar b; // size 16 at offset 16
+            uint c;
+        };
+
+        void main() {
+            Bar new_bar;
+            b = new_bar;
+        }
+    )glsl";
+    ComputeStorageBufferTest(cs_source, true, 32);
+}
+
+TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, StructCopySlang) {
+    // struct Bar {
+    //   uint x;
+    //   uint y;
+    //   uint z[2];
+    // };
+    //
+    // struct FooBuffer {
+    //   float4 a;
+    //   Bar b;
+    //   uint c;
+    // };
+    //
+    // [[vk::binding(0, 0)]]
+    // RWStructuredBuffer<FooBuffer> foo;
+    //
+    // [shader("compute")]
+    // void main() {
+    //   foo[1].b = foo[0].b;
+    // }
+    char const *cs_source = R"(
+               OpCapability Shader
+               OpExtension "SPV_KHR_storage_buffer_storage_class"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %foo
+               OpExecutionMode %main LocalSize 1 1 1
+               OpDecorate %_arr_uint_int_2 ArrayStride 4
+               OpMemberDecorate %_Array_std430_uint2 0 Offset 0
+               OpMemberDecorate %Bar_std430 0 Offset 0
+               OpMemberDecorate %Bar_std430 1 Offset 4
+               OpMemberDecorate %Bar_std430 2 Offset 8
+               OpMemberDecorate %FooBuffer_std430 0 Offset 0
+               OpMemberDecorate %FooBuffer_std430 1 Offset 16
+               OpMemberDecorate %FooBuffer_std430 2 Offset 32
+               OpDecorate %_runtimearr_FooBuffer_std430 ArrayStride 48
+               OpDecorate %RWStructuredBuffer Block
+               OpMemberDecorate %RWStructuredBuffer 0 Offset 0
+               OpDecorate %foo Binding 0
+               OpDecorate %foo DescriptorSet 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+      %int_1 = OpConstant %int 1
+      %int_0 = OpConstant %int 0
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+       %uint = OpTypeInt 32 0
+      %int_2 = OpConstant %int 2
+%_arr_uint_int_2 = OpTypeArray %uint %int_2
+%_Array_std430_uint2 = OpTypeStruct %_arr_uint_int_2
+ %Bar_std430 = OpTypeStruct %uint %uint %_Array_std430_uint2
+%FooBuffer_std430 = OpTypeStruct %v4float %Bar_std430 %uint
+%_ptr_StorageBuffer_FooBuffer_std430 = OpTypePointer StorageBuffer %FooBuffer_std430
+%_runtimearr_FooBuffer_std430 = OpTypeRuntimeArray %FooBuffer_std430
+%RWStructuredBuffer = OpTypeStruct %_runtimearr_FooBuffer_std430
+%_ptr_StorageBuffer_RWStructuredBuffer = OpTypePointer StorageBuffer %RWStructuredBuffer
+%_ptr_StorageBuffer_Bar_std430 = OpTypePointer StorageBuffer %Bar_std430
+        %foo = OpVariable %_ptr_StorageBuffer_RWStructuredBuffer StorageBuffer
+       %main = OpFunction %void None %3
+          %4 = OpLabel
+         %17 = OpAccessChain %_ptr_StorageBuffer_FooBuffer_std430 %foo %int_0 %int_1
+         %23 = OpAccessChain %_ptr_StorageBuffer_Bar_std430 %17 %int_1
+         %24 = OpAccessChain %_ptr_StorageBuffer_FooBuffer_std430 %foo %int_0 %int_0
+         %25 = OpAccessChain %_ptr_StorageBuffer_Bar_std430 %24 %int_1
+         %26 = OpLoad %Bar_std430 %25
+         %80 = OpCompositeExtract %uint %26 0
+         %81 = OpCompositeExtract %uint %26 1
+         %82 = OpCompositeExtract %_Array_std430_uint2 %26 2
+         %87 = OpCompositeExtract %_arr_uint_int_2 %82 0
+         %88 = OpCompositeExtract %uint %87 0
+         %89 = OpCompositeExtract %uint %87 1
+        %163 = OpCompositeConstruct %_arr_uint_int_2 %88 %89
+        %149 = OpCompositeConstruct %_Array_std430_uint2 %163
+        %121 = OpCompositeConstruct %Bar_std430 %80 %81 %149
+               OpStore %23 %121
+               OpReturn
+               OpFunctionEnd
+    )";
+    ComputeStorageBufferTest(cs_source, false, 80);
+}
+
+TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, ChainOfAccessChains) {
+    TEST_DESCRIPTION("Slang can sometimes generate a single OpAccessChain like GLSL/HLSL");
+
+    // struct Bar {
+    //     uint a;
+    //     uint d[4];
+    // };
+    //
+    // [[vk::binding(0, 0)]]
+    // RWStructuredBuffer<Bar> foo; // 20 byte stride
+    //
+    // [shader("compute")]
+    // void main() {
+    //     foo[1].d[3] = 44;
+    // }
+    char const *cs_source = R"(
+               OpCapability Shader
+               OpExtension "SPV_KHR_storage_buffer_storage_class"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %foo
+               OpExecutionMode %main LocalSize 1 1 1
+               OpDecorate %_arr_uint_int_4 ArrayStride 4
+               OpMemberDecorate %_Array_std430_uint4 0 Offset 0
+               OpMemberDecorate %Bar_std430 0 Offset 0
+               OpMemberDecorate %Bar_std430 1 Offset 4
+               OpDecorate %_runtimearr_Bar_std430 ArrayStride 20
+               OpDecorate %RWStructuredBuffer Block
+               OpMemberDecorate %RWStructuredBuffer 0 Offset 0
+               OpDecorate %foo Binding 0
+               OpDecorate %foo DescriptorSet 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+      %int_1 = OpConstant %int 1
+       %uint = OpTypeInt 32 0
+      %int_4 = OpConstant %int 4
+%_arr_uint_int_4 = OpTypeArray %uint %int_4
+%_Array_std430_uint4 = OpTypeStruct %_arr_uint_int_4
+ %Bar_std430 = OpTypeStruct %uint %_Array_std430_uint4
+%_ptr_StorageBuffer_Bar_std430 = OpTypePointer StorageBuffer %Bar_std430
+%_runtimearr_Bar_std430 = OpTypeRuntimeArray %Bar_std430
+%RWStructuredBuffer = OpTypeStruct %_runtimearr_Bar_std430
+%_ptr_StorageBuffer_RWStructuredBuffer = OpTypePointer StorageBuffer %RWStructuredBuffer
+%_ptr_StorageBuffer__Array_std430_uint4 = OpTypePointer StorageBuffer %_Array_std430_uint4
+%_ptr_StorageBuffer__arr_uint_int_4 = OpTypePointer StorageBuffer %_arr_uint_int_4
+%_ptr_StorageBuffer_uint = OpTypePointer StorageBuffer %uint
+      %int_3 = OpConstant %int 3
+    %uint_44 = OpConstant %uint 44
+        %foo = OpVariable %_ptr_StorageBuffer_RWStructuredBuffer StorageBuffer
+       %main = OpFunction %void None %3
+          %4 = OpLabel
+         %14 = OpAccessChain %_ptr_StorageBuffer_Bar_std430 %foo %int_0 %int_1
+         %20 = OpAccessChain %_ptr_StorageBuffer__Array_std430_uint4 %14 %int_1
+         %22 = OpAccessChain %_ptr_StorageBuffer__arr_uint_int_4 %20 %int_0
+         %24 = OpAccessChain %_ptr_StorageBuffer_uint %22 %int_3
+               OpStore %24 %uint_44
+               OpReturn
+               OpFunctionEnd
+    )";
+    ComputeStorageBufferTest(cs_source, false, 48);
 }

--- a/tests/unit/pipeline_topology_positive.cpp
+++ b/tests/unit/pipeline_topology_positive.cpp
@@ -168,7 +168,7 @@ TEST_F(PositivePipelineTopology, LoosePointSizeWrite) {
     }
 }
 
-TEST_F(PositivePipelineTopology, PointSizeStructMemeberWritten) {
+TEST_F(PositivePipelineTopology, PointSizeStructMemberWritten) {
     TEST_DESCRIPTION("Write built-in PointSize within a struct");
 
     SetTargetApiVersion(VK_API_VERSION_1_1); // At least 1.1 is required for maintenance4


### PR DESCRIPTION
This fixes case when you go

```
%36 = OpAccessChain %23 %35 0
%37 = OpAccessChain %20 %36 1
```

instead of `%36 = OpAccessChain %23 %35 0 1` 

While here, added lots of test to fix checking when copying between Array/Structs