### PR TITLE
build: Roll SPIRV-Tools back to v2024.4.rc2

### DIFF
--- a/layers/vulkan/generated/spirv_tools_commit_id.h
+++ b/layers/vulkan/generated/spirv_tools_commit_id.h
@@ -23,4 +23,4 @@
 
 #pragma once
 
-#define SPIRV_TOOLS_COMMIT_ID "a4084887e4a71473a77d8f1109057e1c3c421da0"
+#define SPIRV_TOOLS_COMMIT_ID "4d2f0b40bfe290dea6c6904dafdf7fd8328ba346"

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -43,7 +43,7 @@
                 "-DSPIRV_SKIP_TESTS=ON",
                 "-DSPIRV_SKIP_EXECUTABLES=OFF"
             ],
-            "commit": "a4084887e4a71473a77d8f1109057e1c3c421da0"
+            "commit": "4d2f0b40bfe290dea6c6904dafdf7fd8328ba346"
         },
         {
             "name": "robin-hood-hashing",


### PR DESCRIPTION
This aligns it with the version in the upcoming SDK release.