### PR TITLE
gpu: Default Image Layout to off

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -778,6 +778,20 @@
                                     ]
                                 },
                                 {
+                                    "key": "gpuav_image_layout",
+                                    "label": "Image Layout",
+                                    "description": "(Warning - still known to have false positives) Use GPU-AV to detect which descriptors where accessed. Then using post processing, check that the layout of each image subresource is correct whenever it is used by a command buffer.",
+                                    "type": "BOOL",
+                                    "default": false,
+                                    "platforms": [ "WINDOWS", "LINUX" ],
+                                    "dependence": {
+                                        "mode": "ALL",
+                                        "settings": [
+                                            { "key": "gpuav_enable", "value": true }
+                                        ]
+                                    }
+                                },
+                                {
                                     "key": "gpuav_advanced_settings",
                                     "label": "Advanced Settings",
                                     "description": "GPU-AV advanced settings",

--- a/layers/gpu/core/gpuav_settings.h
+++ b/layers/gpu/core/gpuav_settings.h
@@ -30,6 +30,9 @@ struct GpuAVSettings {
     bool validate_buffer_copies = true;
     bool validate_index_buffers = true;
 
+    // Currently turned of due to some false positives still observed
+    bool validate_image_layout = false;
+
     bool vma_linear_output = true;
 
     bool debug_validate_instrumented_shaders = false;

--- a/layers/gpu/descriptor_validation/gpuav_image_layout.cpp
+++ b/layers/gpu/descriptor_validation/gpuav_image_layout.cpp
@@ -158,6 +158,8 @@ static bool VerifyImageLayoutRange(const Validator &gpuav, const vvl::CommandBuf
                                    VkImageAspectFlags aspect_mask, VkImageLayout explicit_layout, const RangeFactory &range_factory,
                                    const Location &loc, const char *mismatch_layout_vuid, bool *error) {
     bool skip = false;
+    if (!gpuav.gpuav_settings.validate_image_layout) return skip;
+
     const auto image_layout_registry = cb_state.GetImageLayoutRegistry(image_state.VkHandle());
     if (!image_layout_registry) {
         return skip;

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -204,6 +204,7 @@ const char *VK_LAYER_GPUAV_INDIRECT_DISPATCHES_BUFFERS = "gpuav_indirect_dispatc
 const char *VK_LAYER_GPUAV_INDIRECT_TRACE_RAYS_BUFFERS = "gpuav_indirect_trace_rays_buffers";
 const char *VK_LAYER_GPUAV_BUFFER_COPIES = "gpuav_buffer_copies";
 const char *VK_LAYER_GPUAV_INDEX_BUFFERS = "gpuav_index_buffers";
+const char *VK_LAYER_GPUAV_IMAGE_LAYOUT = "gpuav_image_layout";
 
 const char *VK_LAYER_GPUAV_RESERVE_BINDING_SLOT = "gpuav_reserve_binding_slot";
 const char *VK_LAYER_GPUAV_VMA_LINEAR_OUTPUT = "gpuav_vma_linear_output";
@@ -610,6 +611,8 @@ static void ValidateLayerSettingsProvided(const VkLayerSettingsCreateInfoEXT *la
         } else if (strcmp(VK_LAYER_GPUAV_BUFFER_COPIES, setting.pSettingName) == 0) {
             required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
         } else if (strcmp(VK_LAYER_GPUAV_INDEX_BUFFERS, setting.pSettingName) == 0) {
+            required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
+        } else if (strcmp(VK_LAYER_GPUAV_IMAGE_LAYOUT, setting.pSettingName) == 0) {
             required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
         } else if (strcmp(VK_LAYER_GPUAV_RESERVE_BINDING_SLOT, setting.pSettingName) == 0) {
             required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
@@ -1108,6 +1111,10 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
         if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_INDEX_BUFFERS)) {
             vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_INDEX_BUFFERS, gpuav_settings.validate_index_buffers);
         }
+    }
+
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_IMAGE_LAYOUT)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_IMAGE_LAYOUT, gpuav_settings.validate_image_layout);
     }
 
     if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_RESERVE_BINDING_SLOT)) {

--- a/layers/vk_layer_settings.txt
+++ b/layers/vk_layer_settings.txt
@@ -141,6 +141,13 @@ khronos_validation.enables =
 # Use VMA linear memory allocations for GPU-AV output buffers
 #khronos_validation.gpuav_vma_linear_output = true
 
+# Use GPU-AV to do Image Layout checks
+# =====================
+# (Warning - still known to have false positives)
+# Use GPU-AV to detect which descriptors where accessed.
+# Then using post processing, check that the layout of each image subresource is correct whenever it is used by a command buffer
+#khronos_validation.gpuav_image_layout = true
+
 # Fine Grained Locking
 # =====================
 # Enable fine grained locking for Core Validation, which should improve

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -270,6 +270,11 @@ class GpuAVRayQueryTest : public GpuAVTest {
     void InitGpuAVRayQuery();
 };
 
+class GpuAVImageLayout : public GpuAVTest {
+  public:
+    void InitGpuAVImageLayout();
+};
+
 class DebugPrintfTests : public VkLayerTest {
   public:
     void InitDebugPrintfFramework(void *p_next = nullptr, bool reserve_slot = false);

--- a/tests/unit/gpu_av_image_layout.cpp
+++ b/tests/unit/gpu_av_image_layout.cpp
@@ -16,7 +16,7 @@
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
 
-class NegativeGpuAVImageLayout : public GpuAVTest {};
+class NegativeGpuAVImageLayout : public GpuAVImageLayout {};
 
 TEST_F(NegativeGpuAVImageLayout, ImageArrayDynamicIndexing) {
     TEST_DESCRIPTION("GPU validation: test that only dynamically used indices are validated");
@@ -24,8 +24,7 @@ TEST_F(NegativeGpuAVImageLayout, ImageArrayDynamicIndexing) {
     AddRequiredFeature(vkt::Feature::runtimeDescriptorArray);
     AddRequiredFeature(vkt::Feature::descriptorBindingPartiallyBound);
     AddRequiredFeature(vkt::Feature::descriptorBindingVariableDescriptorCount);
-    RETURN_IF_SKIP(InitGpuAvFramework());
-    RETURN_IF_SKIP(InitState());
+    RETURN_IF_SKIP(InitGpuAVImageLayout());
     InitRenderTarget();
 
     // Make a uniform buffer to be passed to the shader that contains the invalid array index.
@@ -150,8 +149,7 @@ TEST_F(NegativeGpuAVImageLayout, DISABLED_Mutable) {
     AddRequiredExtensions(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_MUTABLE_DESCRIPTOR_TYPE_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::mutableDescriptorType);
-    RETURN_IF_SKIP(InitGpuAvFramework());
-    RETURN_IF_SKIP(InitState());
+    RETURN_IF_SKIP(InitGpuAVImageLayout());
 
     const char *cs = R"glsl(
         #version 450
@@ -222,8 +220,7 @@ TEST_F(NegativeGpuAVImageLayout, DescriptorArrayLayout) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/1998");
     AddRequiredExtensions(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::descriptorBindingPartiallyBound);
-    RETURN_IF_SKIP(InitGpuAvFramework());
-    RETURN_IF_SKIP(InitState());
+    RETURN_IF_SKIP(InitGpuAVImageLayout());
     RETURN_IF_SKIP(InitRenderTarget());
 
     char const *fs_source = R"glsl(
@@ -291,8 +288,7 @@ TEST_F(NegativeGpuAVImageLayout, DescriptorArrayLayout) {
 
 TEST_F(NegativeGpuAVImageLayout, MultiArrayLayers) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/1998");
-    RETURN_IF_SKIP(InitGpuAvFramework());
-    RETURN_IF_SKIP(InitState());
+    RETURN_IF_SKIP(InitGpuAVImageLayout());
     RETURN_IF_SKIP(InitRenderTarget());
 
     auto image_ci = vkt::Image::ImageCreateInfo2D(128, 128, 1, 2, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
@@ -371,8 +367,7 @@ TEST_F(NegativeGpuAVImageLayout, MultipleCommandBuffersSameDescriptorSet) {
     AddRequiredExtensions(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::descriptorBindingSampledImageUpdateAfterBind);
     AddRequiredFeature(vkt::Feature::descriptorBindingStorageBufferUpdateAfterBind);
-    RETURN_IF_SKIP(InitGpuAvFramework());
-    RETURN_IF_SKIP(InitState());
+    RETURN_IF_SKIP(InitGpuAVImageLayout());
 
     vkt::CommandBuffer cb_0(*m_device, m_command_pool);
     vkt::CommandBuffer cb_1(*m_device, m_command_pool);

--- a/tests/unit/gpu_av_image_layout_positive.cpp
+++ b/tests/unit/gpu_av_image_layout_positive.cpp
@@ -15,14 +15,27 @@
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
 
-class PositiveGpuAVImageLayout : public GpuAVTest {};
+class PositiveGpuAVImageLayout : public GpuAVImageLayout {};
+
+void GpuAVImageLayout::InitGpuAVImageLayout() {
+    // Turned off because things like https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8688 and
+    // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8869 are still showing false positives Need to manually turn
+    // on settings while the default is "off"
+    const VkBool32 value_true = true;
+    const VkLayerSettingEXT layer_setting = {OBJECT_LAYER_NAME, "gpuav_image_layout", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1,
+                                             &value_true};
+    VkLayerSettingsCreateInfoEXT layer_settings_create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1,
+                                                               &layer_setting};
+
+    RETURN_IF_SKIP(InitGpuAvFramework(&layer_settings_create_info));
+    RETURN_IF_SKIP(InitState());
+}
 
 TEST_F(PositiveGpuAVImageLayout, DescriptorArrayLayout) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/1998");
     AddRequiredExtensions(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::descriptorBindingPartiallyBound);
-    RETURN_IF_SKIP(InitGpuAvFramework());
-    RETURN_IF_SKIP(InitState());
+    RETURN_IF_SKIP(InitGpuAVImageLayout());
     RETURN_IF_SKIP(InitRenderTarget());
 
     char const *fs_source = R"glsl(

--- a/tests/unit/layer_settings_positive.cpp
+++ b/tests/unit/layer_settings_positive.cpp
@@ -25,7 +25,7 @@ TEST_F(PositiveLayerSettings, AllSettings) {
     const VkBool32 disable = VK_FALSE;
     const uint32_t one = 1;
     const uint32_t one_k = 1024;
-    std::array<VkLayerSettingEXT, 51> settings = {{
+    std::vector<VkLayerSettingEXT> settings = {{
         {OBJECT_LAYER_NAME, "enables", VK_LAYER_SETTING_TYPE_STRING_EXT, 1, &some_string},
         {OBJECT_LAYER_NAME, "validate_best_practices", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable},
         {OBJECT_LAYER_NAME, "validate_best_practices_arm", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable},
@@ -69,6 +69,7 @@ TEST_F(PositiveLayerSettings, AllSettings) {
         {OBJECT_LAYER_NAME, "gpuav_indirect_trace_rays_buffers", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable},
         {OBJECT_LAYER_NAME, "gpuav_buffer_copies", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable},
         {OBJECT_LAYER_NAME, "gpuav_index_buffers", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable},
+        {OBJECT_LAYER_NAME, "gpuav_image_layout", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable},
         {OBJECT_LAYER_NAME, "gpuav_reserve_binding_slot", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable},
         {OBJECT_LAYER_NAME, "gpuav_vma_linear_output", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable},
         {OBJECT_LAYER_NAME, "syncval_submit_time_validation", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable},
@@ -78,8 +79,8 @@ TEST_F(PositiveLayerSettings, AllSettings) {
         {OBJECT_LAYER_NAME, "debug_action", VK_LAYER_SETTING_TYPE_STRING_EXT, 1, &action_ignore},
         {OBJECT_LAYER_NAME, "report_flags", VK_LAYER_SETTING_TYPE_STRING_EXT, 1, &warning},
     }};
-    VkLayerSettingsCreateInfoEXT create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, settings.size(),
-                                                settings.data()};
+    VkLayerSettingsCreateInfoEXT create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr,
+                                                (uint32_t)settings.size(), settings.data()};
     Monitor().ExpectSuccess(kErrorBit | kWarningBit);
     RETURN_IF_SKIP(InitFramework(&create_info));
     RETURN_IF_SKIP(InitState());


### PR DESCRIPTION
https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8688
and 
https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8869

are showing that we still have some false positives around Image Layouts with GPU-AV

For short term, created a setting (which we probably should have had anyway) and made the default off