### PR TITLE
sync: Rename video test suite

### DIFF
--- a/tests/framework/video_objects.h
+++ b/tests/framework/video_objects.h
@@ -3645,8 +3645,8 @@ class VkVideoSyncLayerTest : public VkVideoLayerTest {
     VkValidationFeaturesEXT features_ = {VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT, nullptr, 1u, enables_, 4, disables_};
 };
 
-class NegativeVideoSyncVal : public VkVideoSyncLayerTest {};
-class PositiveVideoSyncVal : public VkVideoSyncLayerTest {};
+class NegativeSyncValVideo : public VkVideoSyncLayerTest {};
+class PositiveSyncValVideo : public VkVideoSyncLayerTest {};
 
 class VkVideoBestPracticesLayerTest : public VkVideoLayerTest {
   public:

--- a/tests/unit/video.cpp
+++ b/tests/unit/video.cpp
@@ -16622,7 +16622,7 @@ TEST_F(NegativeVideo, ImageLayoutUsageMismatch) {
     cb.End();
 }
 
-TEST_F(NegativeVideoSyncVal, DecodeOutputPicture) {
+TEST_F(NegativeSyncValVideo, DecodeOutputPicture) {
     TEST_DESCRIPTION("Test video decode output picture sync hazard");
 
     RETURN_IF_SKIP(Init());
@@ -16652,7 +16652,7 @@ TEST_F(NegativeVideoSyncVal, DecodeOutputPicture) {
     cb.End();
 }
 
-TEST_F(NegativeVideoSyncVal, DecodeReconstructedPicture) {
+TEST_F(NegativeSyncValVideo, DecodeReconstructedPicture) {
     TEST_DESCRIPTION("Test video decode reconstructed picture sync hazard");
 
     RETURN_IF_SKIP(Init());
@@ -16707,7 +16707,7 @@ TEST_F(NegativeVideoSyncVal, DecodeReconstructedPicture) {
     cb.End();
 }
 
-TEST_F(NegativeVideoSyncVal, DecodeReferencePicture) {
+TEST_F(NegativeSyncValVideo, DecodeReferencePicture) {
     TEST_DESCRIPTION("Test video decode reference picture sync hazard");
 
     RETURN_IF_SKIP(Init());
@@ -16757,7 +16757,7 @@ TEST_F(NegativeVideoSyncVal, DecodeReferencePicture) {
     cb.End();
 }
 
-TEST_F(NegativeVideoSyncVal, EncodeBitstream) {
+TEST_F(NegativeSyncValVideo, EncodeBitstream) {
     TEST_DESCRIPTION("Test video encode bitstream sync hazard");
 
     RETURN_IF_SKIP(Init());
@@ -16787,7 +16787,7 @@ TEST_F(NegativeVideoSyncVal, EncodeBitstream) {
     cb.End();
 }
 
-TEST_F(NegativeVideoSyncVal, EncodeReconstructedPicture) {
+TEST_F(NegativeSyncValVideo, EncodeReconstructedPicture) {
     TEST_DESCRIPTION("Test video encode reconstructed picture sync hazard");
 
     RETURN_IF_SKIP(Init());
@@ -16841,7 +16841,7 @@ TEST_F(NegativeVideoSyncVal, EncodeReconstructedPicture) {
     cb.End();
 }
 
-TEST_F(NegativeVideoSyncVal, EncodeReferencePicture) {
+TEST_F(NegativeSyncValVideo, EncodeReferencePicture) {
     TEST_DESCRIPTION("Test video encode reference picture sync hazard");
 
     RETURN_IF_SKIP(Init());
@@ -16891,7 +16891,7 @@ TEST_F(NegativeVideoSyncVal, EncodeReferencePicture) {
     cb.End();
 }
 
-TEST_F(NegativeVideoSyncVal, EncodeQuantizationMap) {
+TEST_F(NegativeSyncValVideo, EncodeQuantizationMap) {
     TEST_DESCRIPTION("Test video encode quantization map sync hazard");
 
     AddRequiredExtensions(VK_KHR_VIDEO_ENCODE_QUANTIZATION_MAP_EXTENSION_NAME);

--- a/tests/unit/video_positive.cpp
+++ b/tests/unit/video_positive.cpp
@@ -1208,7 +1208,7 @@ TEST_F(PositiveVideo, GetEncodedSessionParamsAV1) {
     vk::GetEncodedVideoSessionParametersKHR(device(), &get_info, &feedback_info, &data_size, nullptr);
 }
 
-TEST_F(PositiveVideoSyncVal, ImageRangeGenYcbcrSubsampling) {
+TEST_F(PositiveSyncValVideo, ImageRangeGenYcbcrSubsampling) {
     TEST_DESCRIPTION(
         "Test that subsampled YCbCr image planes are handled correctly "
         "by the image range generation utilities used by sync validation");
@@ -1257,7 +1257,7 @@ TEST_F(PositiveVideoSyncVal, ImageRangeGenYcbcrSubsampling) {
     cb.End();
 }
 
-TEST_F(PositiveVideoSyncVal, DecodeCoincide) {
+TEST_F(PositiveSyncValVideo, DecodeCoincide) {
     TEST_DESCRIPTION("Test video decode in coincide mode without sync hazards");
 
     RETURN_IF_SKIP(Init());
@@ -1302,7 +1302,7 @@ TEST_F(PositiveVideoSyncVal, DecodeCoincide) {
     cb.End();
 }
 
-TEST_F(PositiveVideoSyncVal, DecodeDistinct) {
+TEST_F(PositiveSyncValVideo, DecodeDistinct) {
     TEST_DESCRIPTION("Test video decode in distinct mode without sync hazards");
 
     RETURN_IF_SKIP(Init());
@@ -1345,7 +1345,7 @@ TEST_F(PositiveVideoSyncVal, DecodeDistinct) {
     cb.End();
 }
 
-TEST_F(PositiveVideoSyncVal, Encode) {
+TEST_F(PositiveSyncValVideo, Encode) {
     TEST_DESCRIPTION("Test video without sync hazards");
 
     RETURN_IF_SKIP(Init());
@@ -1387,7 +1387,7 @@ TEST_F(PositiveVideoSyncVal, Encode) {
     cb.End();
 }
 
-TEST_F(PositiveVideoSyncVal, EncodeQuantizationMap) {
+TEST_F(PositiveSyncValVideo, EncodeQuantizationMap) {
     TEST_DESCRIPTION("Test video encode quantization map without sync hazards");
 
     AddRequiredExtensions(VK_KHR_VIDEO_ENCODE_QUANTIZATION_MAP_EXTENSION_NAME);


### PR DESCRIPTION
To make it consistent with other syncval tests.
`NegativeSyncVal*` should pattern match all negative tests.

Existing syncval test suites:
NegativeSyncVal
NegativeSyncValWsi
NegativeSyncValTimelineSemaphore

cc @aqnuep 