### PR TITLE
gpu: Add support for multiple access chains

### DIFF
--- a/layers/gpu/spirv/type_manager.h
+++ b/layers/gpu/spirv/type_manager.h
@@ -53,6 +53,7 @@ struct Type {
 
     bool operator==(Type const& other) const;
     uint32_t Id() const { return inst_.ResultId(); }
+    bool IsArray() const { return spv_type_ == SpvType::kArray || spv_type_ == SpvType::kRuntimeArray; }
 
     const SpvType spv_type_;
     const Instruction& inst_;

--- a/tests/unit/gpu_av_descriptor_class_general_buffer_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_class_general_buffer_positive.cpp
@@ -1354,3 +1354,93 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, AtomicsDescriptorIndex) {
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }
+
+TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, DescriptorIndexSlang) {
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    RETURN_IF_SKIP(InitGpuAvFramework());
+    RETURN_IF_SKIP(InitState());
+
+    // struct Bar {
+    //   uint4 a;
+    //   uint b[4];
+    //   uint c;
+    //   uint d;
+    // };
+    //
+    // [[vk::binding(0, 0)]]
+    // RWStructuredBuffer<Bar> foo[2]; // stride of 48 bytes
+    //
+    // [shader("compute")]
+    // void main() {
+    //   foo[1][1].d = 0;
+    // }
+    char const *cs_source = R"(
+               OpCapability Shader
+               OpExtension "SPV_KHR_storage_buffer_storage_class"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %foo
+               OpExecutionMode %main LocalSize 1 1 1
+               OpDecorate %_arr_uint_int_4 ArrayStride 4
+               OpMemberDecorate %_Array_std430_uint4 0 Offset 0
+               OpMemberDecorate %Bar_std430 0 Offset 0
+               OpMemberDecorate %Bar_std430 1 Offset 16
+               OpMemberDecorate %Bar_std430 2 Offset 32
+               OpMemberDecorate %Bar_std430 3 Offset 36
+               OpDecorate %_runtimearr_Bar_std430 ArrayStride 48
+               OpDecorate %RWStructuredBuffer Block
+               OpMemberDecorate %RWStructuredBuffer 0 Offset 0
+               OpDecorate %_arr_RWStructuredBuffer_int_2 ArrayStride 0
+               OpDecorate %foo Binding 0
+               OpDecorate %foo DescriptorSet 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+     %v4uint = OpTypeVector %uint 4
+        %int = OpTypeInt 32 1
+      %int_4 = OpConstant %int 4
+%_arr_uint_int_4 = OpTypeArray %uint %int_4
+%_Array_std430_uint4 = OpTypeStruct %_arr_uint_int_4
+ %Bar_std430 = OpTypeStruct %v4uint %_Array_std430_uint4 %uint %uint
+%_runtimearr_Bar_std430 = OpTypeRuntimeArray %Bar_std430
+%RWStructuredBuffer = OpTypeStruct %_runtimearr_Bar_std430
+      %int_2 = OpConstant %int 2
+%_arr_RWStructuredBuffer_int_2 = OpTypeArray %RWStructuredBuffer %int_2
+%_ptr_StorageBuffer__arr_RWStructuredBuffer_int_2 = OpTypePointer StorageBuffer %_arr_RWStructuredBuffer_int_2
+%_ptr_StorageBuffer_RWStructuredBuffer = OpTypePointer StorageBuffer %RWStructuredBuffer
+      %int_1 = OpConstant %int 1
+      %int_0 = OpConstant %int 0
+%_ptr_StorageBuffer_Bar_std430 = OpTypePointer StorageBuffer %Bar_std430
+      %int_3 = OpConstant %int 3
+%_ptr_StorageBuffer_uint = OpTypePointer StorageBuffer %uint
+     %uint_0 = OpConstant %uint 0
+        %foo = OpVariable %_ptr_StorageBuffer__arr_RWStructuredBuffer_int_2 StorageBuffer
+       %main = OpFunction %void None %3
+          %4 = OpLabel
+         %19 = OpAccessChain %_ptr_StorageBuffer_RWStructuredBuffer %foo %int_1
+         %23 = OpAccessChain %_ptr_StorageBuffer_Bar_std430 %19 %int_0 %int_1
+         %26 = OpAccessChain %_ptr_StorageBuffer_uint %23 %int_3
+               OpStore %26 %uint_0
+               OpReturn
+               OpFunctionEnd
+    )";
+
+    CreateComputePipelineHelper pipe(*this);
+    pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 2, VK_SHADER_STAGE_ALL, nullptr}};
+    pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
+    pipe.CreateComputePipeline();
+
+    vkt::Buffer in_buffer(*m_device, 96, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
+    pipe.descriptor_set_->WriteDescriptorBufferInfo(0, in_buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 0);
+    pipe.descriptor_set_->WriteDescriptorBufferInfo(0, in_buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);
+    pipe.descriptor_set_->UpdateDescriptorSets();
+
+    m_command_buffer.Begin();
+    vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
+    vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
+                              &pipe.descriptor_set_->set_, 0, nullptr);
+    vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
+    m_command_buffer.End();
+
+    m_default_queue->Submit(m_command_buffer);
+    m_default_queue->Wait();
+}

--- a/tests/unit/gpu_av_descriptor_indexing.cpp
+++ b/tests/unit/gpu_av_descriptor_indexing.cpp
@@ -3841,3 +3841,97 @@ TEST_F(NegativeGpuAVDescriptorIndexing, CommandBufferRerecordSameDescriptorSet) 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }
+
+TEST_F(NegativeGpuAVDescriptorIndexing, MultipleAccessChains) {
+    TEST_DESCRIPTION("Slang will produce a chain of OpAccessChains");
+    RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
+
+    // struct Bar {
+    //     uint x;
+    // };
+    //
+    // [[vk::binding(0, 0)]]
+    // RWStructuredBuffer<Bar> foo[4];
+    //
+    // [shader("compute")]
+    // void main() {
+    //     uint index = foo[0][0].x;
+    //     foo[index][7].x = 8;
+    // }
+    char const *cs_source = R"(
+               OpCapability Shader
+               OpExtension "SPV_KHR_storage_buffer_storage_class"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %foo
+               OpExecutionMode %main LocalSize 1 1 1
+               OpMemberDecorate %Bar_std430 0 Offset 0
+               OpDecorate %_runtimearr_Bar_std430 ArrayStride 4
+               OpDecorate %RWStructuredBuffer Block
+               OpMemberDecorate %RWStructuredBuffer 0 Offset 0
+               OpDecorate %_arr_RWStructuredBuffer_int_4 ArrayStride 0
+               OpDecorate %foo Binding 0
+               OpDecorate %foo DescriptorSet 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+ %Bar_std430 = OpTypeStruct %uint
+%_runtimearr_Bar_std430 = OpTypeRuntimeArray %Bar_std430
+%RWStructuredBuffer = OpTypeStruct %_runtimearr_Bar_std430
+        %int = OpTypeInt 32 1
+      %int_4 = OpConstant %int 4
+%_arr_RWStructuredBuffer_int_4 = OpTypeArray %RWStructuredBuffer %int_4
+%_ptr_StorageBuffer__arr_RWStructuredBuffer_int_4 = OpTypePointer StorageBuffer %_arr_RWStructuredBuffer_int_4
+%_ptr_StorageBuffer_RWStructuredBuffer = OpTypePointer StorageBuffer %RWStructuredBuffer
+      %int_0 = OpConstant %int 0
+%_ptr_StorageBuffer_Bar_std430 = OpTypePointer StorageBuffer %Bar_std430
+%_ptr_StorageBuffer_uint = OpTypePointer StorageBuffer %uint
+      %int_7 = OpConstant %int 7
+     %uint_8 = OpConstant %uint 8
+        %foo = OpVariable %_ptr_StorageBuffer__arr_RWStructuredBuffer_int_4 StorageBuffer
+       %main = OpFunction %void None %3
+          %4 = OpLabel
+         %15 = OpAccessChain %_ptr_StorageBuffer_RWStructuredBuffer %foo %int_0
+         %18 = OpAccessChain %_ptr_StorageBuffer_Bar_std430 %15 %int_0 %int_0
+         %20 = OpAccessChain %_ptr_StorageBuffer_uint %18 %int_0
+      %index = OpLoad %uint %20
+         %22 = OpAccessChain %_ptr_StorageBuffer_RWStructuredBuffer %foo %index
+         %24 = OpAccessChain %_ptr_StorageBuffer_Bar_std430 %22 %int_0 %int_7
+         %25 = OpAccessChain %_ptr_StorageBuffer_uint %24 %int_0
+               OpStore %25 %uint_8
+               OpReturn
+               OpFunctionEnd
+    )";
+
+    OneOffDescriptorSet descriptor_set(m_device, {
+                                                     {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 4, VK_SHADER_STAGE_ALL, nullptr},
+                                                 });
+    const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
+
+    vkt::Buffer buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
+    descriptor_set.WriteDescriptorBufferInfo(0, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 0);
+    descriptor_set.WriteDescriptorBufferInfo(0, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);
+    descriptor_set.WriteDescriptorBufferInfo(0, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 2);
+    descriptor_set.WriteDescriptorBufferInfo(0, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 3);
+    descriptor_set.UpdateDescriptorSets();
+
+    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    buffer_ptr[0] = 9;
+    buffer.Memory().Unmap();
+
+    CreateComputePipelineHelper pipe(*this);
+    pipe.cp_ci_.layout = pipeline_layout.handle();
+    pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
+    pipe.CreateComputePipeline();
+
+    m_command_buffer.Begin();
+    vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
+    vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 1,
+                              &descriptor_set.set_, 0, nullptr);
+    vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
+    m_command_buffer.End();
+
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-None-10068");
+    m_default_queue->Submit(m_command_buffer);
+    m_default_queue->Wait();
+    m_errorMonitor->VerifyFound();
+}

--- a/tests/unit/gpu_av_descriptor_post_process_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_post_process_positive.cpp
@@ -745,3 +745,133 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, SharedDescriptorDifferentOpVariableId
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }
+
+TEST_F(PositiveGpuAVDescriptorPostProcess, DescriptorIndexingSlang) {
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::runtimeDescriptorArray);
+    RETURN_IF_SKIP(InitGpuAvFramework());
+    RETURN_IF_SKIP(InitState());
+
+    // [[vk::binding(0, 0)]]
+    // Texture2D texture[];
+    // [[vk::binding(1, 0)]]
+    // SamplerState sampler;
+    //
+    // struct StorageBuffer {
+    //     uint data; // Will be zero
+    //     float4 color;
+    // };
+    //
+    // [[vk::binding(2, 0)]]
+    // RWStructuredBuffer<StorageBuffer> storageBuffer;
+    //
+    // [shader("compute")]
+    // void main() {
+    //     uint dataIndex = storageBuffer[0].data;
+    //     float4 sampledColor = texture[dataIndex].Sample(sampler, float2(0));
+    //     storageBuffer[0].color = sampledColor;
+    // }
+    char const *cs_source = R"(
+               OpCapability RuntimeDescriptorArray
+               OpCapability Shader
+               OpExtension "SPV_KHR_storage_buffer_storage_class"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %storageBuffer %texture %sampler
+               OpExecutionMode %main LocalSize 1 1 1
+               OpMemberDecorate %StorageBuffer_std430 0 Offset 0
+               OpMemberDecorate %StorageBuffer_std430 1 Offset 16
+               OpDecorate %_runtimearr_StorageBuffer_std430 ArrayStride 32
+               OpDecorate %RWStructuredBuffer Block
+               OpMemberDecorate %RWStructuredBuffer 0 Offset 0
+               OpDecorate %storageBuffer Binding 2
+               OpDecorate %storageBuffer DescriptorSet 0
+               OpDecorate %_runtimearr_21 ArrayStride 8
+               OpDecorate %texture Binding 0
+               OpDecorate %texture DescriptorSet 0
+               OpDecorate %sampler Binding 1
+               OpDecorate %sampler DescriptorSet 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+       %uint = OpTypeInt 32 0
+      %float = OpTypeFloat 32
+    %v4float = OpTypeVector %float 4
+%StorageBuffer_std430 = OpTypeStruct %uint %v4float
+%_ptr_StorageBuffer_StorageBuffer_std430 = OpTypePointer StorageBuffer %StorageBuffer_std430
+%_runtimearr_StorageBuffer_std430 = OpTypeRuntimeArray %StorageBuffer_std430
+%RWStructuredBuffer = OpTypeStruct %_runtimearr_StorageBuffer_std430
+%_ptr_StorageBuffer_RWStructuredBuffer = OpTypePointer StorageBuffer %RWStructuredBuffer
+%_ptr_StorageBuffer_uint = OpTypePointer StorageBuffer %uint
+         %21 = OpTypeImage %float 2D 2 0 0 1 Unknown
+%_runtimearr_21 = OpTypeRuntimeArray %21
+%_ptr_UniformConstant__runtimearr_21 = OpTypePointer UniformConstant %_runtimearr_21
+%_ptr_UniformConstant_21 = OpTypePointer UniformConstant %21
+         %28 = OpTypeSampler
+%_ptr_UniformConstant_28 = OpTypePointer UniformConstant %28
+         %32 = OpTypeSampledImage %21
+    %v2float = OpTypeVector %float 2
+    %float_0 = OpConstant %float 0
+         %36 = OpConstantComposite %v2float %float_0 %float_0
+      %int_1 = OpConstant %int 1
+%_ptr_StorageBuffer_v4float = OpTypePointer StorageBuffer %v4float
+%storageBuffer = OpVariable %_ptr_StorageBuffer_RWStructuredBuffer StorageBuffer
+    %texture = OpVariable %_ptr_UniformConstant__runtimearr_21 UniformConstant
+    %sampler = OpVariable %_ptr_UniformConstant_28 UniformConstant
+       %main = OpFunction %void None %3
+          %4 = OpLabel
+         %12 = OpAccessChain %_ptr_StorageBuffer_StorageBuffer_std430 %storageBuffer %int_0 %int_0
+         %18 = OpAccessChain %_ptr_StorageBuffer_uint %12 %int_0
+  %dataIndex = OpLoad %uint %18
+         %25 = OpAccessChain %_ptr_UniformConstant_21 %texture %dataIndex
+         %26 = OpLoad %21 %25
+         %27 = OpLoad %21 %25
+         %29 = OpLoad %28 %sampler
+%sampledImage = OpSampledImage %32 %27 %29
+    %sampled = OpImageSampleExplicitLod %v4float %sampledImage %36 None
+         %38 = OpCopyObject %v4float %sampled
+         %39 = OpAccessChain %_ptr_StorageBuffer_StorageBuffer_std430 %storageBuffer %int_0 %int_0
+         %42 = OpAccessChain %_ptr_StorageBuffer_v4float %39 %int_1
+               OpStore %42 %38
+               OpReturn
+               OpFunctionEnd
+    )";
+
+    vkt::Buffer buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
+    uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    *buffer_ptr = 0;
+    buffer.Memory().Unmap();
+
+    vkt::Image image(*m_device, 16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    vkt::ImageView image_view = image.CreateView();
+    vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
+
+    OneOffDescriptorSet descriptor_set(m_device, {{0, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 2, VK_SHADER_STAGE_ALL, nullptr},
+                                                  {1, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_ALL, nullptr},
+                                                  {2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}});
+    const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
+    descriptor_set.WriteDescriptorImageInfo(0, image_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
+                                            VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 0);
+    descriptor_set.WriteDescriptorImageInfo(0, image_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
+                                            VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 1);
+    descriptor_set.WriteDescriptorImageInfo(1, VK_NULL_HANDLE, sampler, VK_DESCRIPTOR_TYPE_SAMPLER);
+    descriptor_set.WriteDescriptorBufferInfo(2, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    descriptor_set.UpdateDescriptorSets();
+
+    CreateComputePipelineHelper pipe(*this);
+    pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
+    pipe.cp_ci_.layout = pipeline_layout.handle();
+    pipe.CreateComputePipeline();
+
+    m_command_buffer.Begin();
+    vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
+    vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout, 0, 1,
+                              &descriptor_set.set_, 0, nullptr);
+    vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
+    m_command_buffer.End();
+
+    m_default_queue->Submit(m_command_buffer);
+    m_default_queue->Wait();
+}


### PR DESCRIPTION
Adds more Slang shaders that use chains of `OpAccessChains` and finally fixed the various TODO to add support for it
