### PR TITLE
layers: Remove win32 handle on memory free

### DIFF
--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -1444,6 +1444,30 @@ void ValidationStateTracker::PreCallRecordFreeMemory(VkDevice device, VkDeviceMe
     if (auto mem_info = Get<vvl::DeviceMemory>(mem)) {
         fake_memory.Free(mem_info->fake_base_address);
     }
+    {
+        WriteLockGuard guard(fd_handle_map_lock_);
+        for (auto it = fd_handle_map_.begin(); it != fd_handle_map_.end();) {
+            if (it->second.device_memory == mem) {
+                it = fd_handle_map_.erase(it);
+                break;
+            } else {
+                ++it;
+            }
+        }
+    }
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+    {
+        WriteLockGuard guard(win32_handle_map_lock_);
+        for (auto it = win32_handle_map_.begin(); it != win32_handle_map_.end();) {
+            if (it->second.device_memory == mem) {
+                it = win32_handle_map_.erase(it);
+                break;
+            } else {
+                ++it;
+            }
+        }
+    }
+#endif
     Destroy<vvl::DeviceMemory>(mem);
 }
 
@@ -3788,6 +3812,7 @@ void ValidationStateTracker::PostCallRecordGetMemoryWin32HandleKHR(VkDevice devi
         external_info.memory_type_index = memory_state->allocate_info.memoryTypeIndex;
         external_info.dedicated_buffer = memory_state->GetDedicatedBuffer();
         external_info.dedicated_image = memory_state->GetDedicatedImage();
+        external_info.device_memory = pGetWin32HandleInfo->memory;
 
         WriteLockGuard guard(win32_handle_map_lock_);
         // `insert_or_assign` ensures that information is updated when the system decides to re-use
@@ -3809,6 +3834,7 @@ void ValidationStateTracker::PostCallRecordGetMemoryFdKHR(VkDevice device, const
         external_info.memory_type_index = memory_state->allocate_info.memoryTypeIndex;
         external_info.dedicated_buffer = memory_state->GetDedicatedBuffer();
         external_info.dedicated_image = memory_state->GetDedicatedImage();
+        external_info.device_memory = memory_state->VkHandle();
 
         WriteLockGuard guard(fd_handle_map_lock_);
         // `insert_or_assign` ensures that information is updated when the system decides to re-use

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -1735,6 +1735,7 @@ class ValidationStateTracker : public ValidationObject {
         uint32_t memory_type_index;
         VkBuffer dedicated_buffer;
         VkImage dedicated_image;
+        VkDeviceMemory device_memory;
 
         // External Semaphore
         VkSemaphoreCreateFlags semaphore_flags = 0;


### PR DESCRIPTION
Closes #8874 

I have a test that reproduced this, but I can't submit it, because it is not reliable. 

```
TEST_F(PositiveExternalMemorySync, Test) {
    TEST_DESCRIPTION("");

    {
        SetTargetApiVersion(VK_API_VERSION_1_1);
        AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME);
        RETURN_IF_SKIP(Init());

        const auto handle_type = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;

        VkExternalMemoryBufferCreateInfo external_buffer_info = vku::InitStructHelper();
        external_buffer_info.handleTypes = handle_type;
        auto buffer_info = vkt::Buffer::CreateInfo(4096u, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT);
        buffer_info.pNext = &external_buffer_info;
        vkt::Buffer buffer_export(*m_device, buffer_info, vkt::no_mem);

        auto alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer_export.MemoryRequirements(), 0u);

        VkExportMemoryAllocateInfo export_info = {VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO_KHR, nullptr, handle_type};
        alloc_info.pNext = &export_info;

        vkt::DeviceMemory memory_export;
        memory_export.init(*m_device, alloc_info);

        // Bind exported memory
        buffer_export.BindMemory(memory_export, 0);

        VkMemoryGetWin32HandleInfoKHR mghi = vku::InitStructHelper();
        mghi.memory = memory_export.handle();
        mghi.handleType = handle_type;
        HANDLE handle;
        vk::GetMemoryWin32HandleKHR(device(), &mghi, &handle);
        printf("Test1 handle: %p\n", handle);
        prevHandle = handle;
        CloseHandle(handle);
    }
    {
        const auto handle_type = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;

        VkExternalMemoryBufferCreateInfo external_buffer_info = vku::InitStructHelper();
        external_buffer_info.handleTypes = handle_type;
        auto buffer_info = vkt::Buffer::CreateInfo(8192u, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT);
        buffer_info.pNext = &external_buffer_info;
        vkt::Buffer buffer_export(*m_device, buffer_info, vkt::no_mem);

        auto alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer_export.MemoryRequirements(), 0u);

        VkExportMemoryAllocateInfo export_info = vku::InitStructHelper();
        export_info.handleTypes = handle_type;
        alloc_info.pNext = &export_info;

        vkt::DeviceMemory memory_export;
        memory_export.init(*m_device, alloc_info);

        // Bind exported memory
        buffer_export.BindMemory(memory_export, 0);

        VkMemoryGetWin32HandleInfoKHR mghi = vku::InitStructHelper();
        mghi.memory = memory_export.handle();
        mghi.handleType = handle_type;
        HANDLE handle;
        vk::GetMemoryWin32HandleKHR(device(), &mghi, &handle);
        std::vector<HANDLE> duplicated_handles;

        HANDLE same_handle;
        if (handle == prevHandle) {
            same_handle = handle;
        } else {
            while (true) {
                HANDLE duplicated;
                DuplicateHandle(GetCurrentProcess(),   // Source process handle
                                handle,                // Handle to duplicate
                                GetCurrentProcess(),   // Target process handle (same process here)
                                &duplicated,           // Pointer to the new handle
                                0,                     // Desired access (0 means same as source handle)
                                FALSE,                 // Handle is not inheritable
                                DUPLICATE_SAME_ACCESS  // Options (use same access rights as source handle)
                );

                duplicated_handles.push_back(duplicated);
                if (duplicated == prevHandle) {
                    same_handle = duplicated;
                    break;
                }
                if (duplicated_handles.size() > 20) {
                    for (const auto& duplicated_handle : duplicated_handles) {
                        CloseHandle(duplicated_handle);
                    }
                    duplicated_handles.clear();
                }
            }
        }
        printf("Test2 handle: %p\n", same_handle);

        {
            auto import_buffer_info =
                vkt::Buffer::CreateInfo(16386u, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT);
            import_buffer_info.pNext = &external_buffer_info;
            vkt::Buffer buffer_import(*m_device, import_buffer_info, vkt::no_mem);

            auto import_alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer_import.MemoryRequirements(), 0u);

            VkImportMemoryWin32HandleInfoKHR import_info = vku::InitStructHelper();
            import_info.handleType = handle_type;
            import_info.handle = same_handle;
            import_alloc_info.pNext = &import_info;

            vkt::DeviceMemory memory_import;
            memory_import.init(*m_device, import_alloc_info);

            // Bind exported memory
            buffer_import.BindMemory(memory_import, 0);
        }

        for (const auto& duplicated_handle : duplicated_handles) {
            CloseHandle(duplicated_handle);
        }
        CloseHandle(handle);
    }
}
```