### PR TITLE
Validate update descriptor set with template

### DIFF
--- a/layers/object_tracker/object_tracker_utils.cpp
+++ b/layers/object_tracker/object_tracker_utils.cpp
@@ -300,25 +300,29 @@ bool ObjectLifetimes::ValidateDescriptorWrite(VkWriteDescriptorSet const *desc, 
         case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
         case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
         case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE: {
-            for (uint32_t i = 0; i < desc->descriptorCount; ++i) {
-                skip |= ValidateObject(desc->pImageInfo[i].imageView, kVulkanObjectTypeImageView, true,
-                                       "VUID-VkWriteDescriptorSet-descriptorType-02996",
-                                       "VUID-vkUpdateDescriptorSets-pDescriptorWrites-06239",
-                                       loc.dot(Field::pImageInfo, i).dot(Field::imageView));
-                if (!null_descriptor_enabled && desc->pImageInfo[i].imageView == VK_NULL_HANDLE) {
-                    skip |= LogError("VUID-VkWriteDescriptorSet-descriptorType-02997", desc->dstSet,
-                                     loc.dot(Field::pImageInfo, i).dot(Field::imageView), "is VK_NULL_HANDLE.");
+            if (desc->pImageInfo) {
+                for (uint32_t i = 0; i < desc->descriptorCount; ++i) {
+                    skip |= ValidateObject(desc->pImageInfo[i].imageView, kVulkanObjectTypeImageView, true,
+                                           "VUID-VkWriteDescriptorSet-descriptorType-02996",
+                                           "VUID-vkUpdateDescriptorSets-pDescriptorWrites-06239",
+                                           loc.dot(Field::pImageInfo, i).dot(Field::imageView));
+                    if (!null_descriptor_enabled && desc->pImageInfo[i].imageView == VK_NULL_HANDLE) {
+                        skip |= LogError("VUID-VkWriteDescriptorSet-descriptorType-02997", desc->dstSet,
+                                         loc.dot(Field::pImageInfo, i).dot(Field::imageView), "is VK_NULL_HANDLE.");
+                    }
                 }
             }
             break;
         }
         case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT: {
             // Input attachments can never be null
-            for (uint32_t i = 0; i < desc->descriptorCount; ++i) {
-                skip |= ValidateObject(desc->pImageInfo[i].imageView, kVulkanObjectTypeImageView, false,
-                                       "VUID-VkWriteDescriptorSet-descriptorType-07683",
-                                       "VUID-vkUpdateDescriptorSets-pDescriptorWrites-06239",
-                                       loc.dot(Field::pImageInfo, i).dot(Field::imageView));
+            if (desc->pImageInfo) {
+                for (uint32_t i = 0; i < desc->descriptorCount; ++i) {
+                    skip |= ValidateObject(desc->pImageInfo[i].imageView, kVulkanObjectTypeImageView, false,
+                                           "VUID-VkWriteDescriptorSet-descriptorType-07683",
+                                           "VUID-vkUpdateDescriptorSets-pDescriptorWrites-06239",
+                                           loc.dot(Field::pImageInfo, i).dot(Field::imageView));
+                }
             }
             break;
         }
@@ -326,13 +330,15 @@ bool ObjectLifetimes::ValidateDescriptorWrite(VkWriteDescriptorSet const *desc, 
         case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
         case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
         case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC: {
-            for (uint32_t i = 0; i < desc->descriptorCount; ++i) {
-                skip |= ValidateObject(
-                    desc->pBufferInfo[i].buffer, kVulkanObjectTypeBuffer, true, "VUID-VkDescriptorBufferInfo-buffer-parameter",
-                    "VUID-vkUpdateDescriptorSets-pDescriptorWrites-06237", loc.dot(Field::pBufferInfo, i).dot(Field::buffer));
-                if (!null_descriptor_enabled && desc->pBufferInfo[i].buffer == VK_NULL_HANDLE) {
-                    skip |= LogError("VUID-VkDescriptorBufferInfo-buffer-02998", desc->dstSet,
-                                     loc.dot(Field::pBufferInfo, i).dot(Field::buffer), "is VK_NULL_HANDLE.");
+            if (desc->pBufferInfo) {
+                for (uint32_t i = 0; i < desc->descriptorCount; ++i) {
+                    skip |= ValidateObject(
+                        desc->pBufferInfo[i].buffer, kVulkanObjectTypeBuffer, true, "VUID-VkDescriptorBufferInfo-buffer-parameter",
+                        "VUID-vkUpdateDescriptorSets-pDescriptorWrites-06237", loc.dot(Field::pBufferInfo, i).dot(Field::buffer));
+                    if (!null_descriptor_enabled && desc->pBufferInfo[i].buffer == VK_NULL_HANDLE) {
+                        skip |= LogError("VUID-VkDescriptorBufferInfo-buffer-02998", desc->dstSet,
+                                         loc.dot(Field::pBufferInfo, i).dot(Field::buffer), "is VK_NULL_HANDLE.");
+                    }
                 }
             }
             break;

--- a/layers/state_tracker/descriptor_sets.cpp
+++ b/layers/state_tracker/descriptor_sets.cpp
@@ -813,6 +813,9 @@ bool vvl::SamplerDescriptor::Invalid() const { return !sampler_state_ || sampler
 void vvl::ImageSamplerDescriptor::WriteUpdate(DescriptorSet &set_state, const ValidationStateTracker &dev_data,
                                                           const VkWriteDescriptorSet &update, const uint32_t index,
                                                           bool is_bindless) {
+    if (!update.pImageInfo) {
+        return;
+    }
     const auto &image_info = update.pImageInfo[index];
     if (!immutable_) {
         ReplaceStatePtr(set_state, sampler_state_, dev_data.GetConstCastShared<vvl::Sampler>(image_info.sampler), is_bindless);

--- a/tests/framework/binding.cpp
+++ b/tests/framework/binding.cpp
@@ -1802,6 +1802,29 @@ void DescriptorSet::destroy() noexcept {
 }
 DescriptorSet::~DescriptorSet() noexcept { destroy(); }
 
+void DescriptorUpdateTemplate::Init(const Device &dev, const VkDescriptorUpdateTemplateCreateInfo &info) {
+    if (vk::CreateDescriptorUpdateTemplateKHR) {
+        NON_DISPATCHABLE_HANDLE_INIT(vk::CreateDescriptorUpdateTemplateKHR, dev, &info);
+    } else {
+        NON_DISPATCHABLE_HANDLE_INIT(vk::CreateDescriptorUpdateTemplate, dev, &info);
+    }
+}
+
+void DescriptorUpdateTemplate::destroy() noexcept {
+    if (!initialized()) {
+        return;
+    }
+    if (vk::DestroyDescriptorUpdateTemplateKHR) {
+        vk::DestroyDescriptorUpdateTemplateKHR(device(), handle(), nullptr);
+    } else {
+        vk::DestroyDescriptorUpdateTemplate(device(), handle(), nullptr);
+    }
+    handle_ = VK_NULL_HANDLE;
+    internal::NonDispHandle<decltype(handle_)>::destroy();
+}
+
+DescriptorUpdateTemplate::~DescriptorUpdateTemplate() noexcept { destroy(); }
+
 NON_DISPATCHABLE_HANDLE_DTOR(CommandPool, vk::DestroyCommandPool)
 
 void CommandPool::Init(const Device &dev, const VkCommandPoolCreateInfo &info) {

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -1114,6 +1114,19 @@ class DescriptorSet : public internal::NonDispHandle<VkDescriptorSet> {
     DescriptorPool *containing_pool_;
 };
 
+class DescriptorUpdateTemplate : public internal::NonDispHandle<VkDescriptorUpdateTemplate> {
+  public:
+    ~DescriptorUpdateTemplate() noexcept;
+    void destroy() noexcept;
+
+    explicit DescriptorUpdateTemplate() : NonDispHandle() {}
+    explicit DescriptorUpdateTemplate(const Device &dev, const VkDescriptorUpdateTemplateCreateInfo &info) { Init(dev, info); }
+    void Init(const Device &dev, const VkDescriptorUpdateTemplateCreateInfo &info);
+    void SetName(const char *name) {
+        NonDispHandle<VkDescriptorUpdateTemplate>::SetName(VK_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE, name);
+    }
+};
+
 class CommandPool : public internal::NonDispHandle<VkCommandPool> {
   public:
     ~CommandPool() noexcept;

--- a/tests/unit/push_descriptor.cpp
+++ b/tests/unit/push_descriptor.cpp
@@ -888,9 +888,11 @@ TEST_F(NegativePushDescriptor, DescriptorWriteMissingImageInfo) {
     AddRequiredExtensions(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    OneOffDescriptorSet descriptor_set(m_device, {
-                                                     {0, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_ALL, nullptr},
-                                                 });
+    OneOffDescriptorSet descriptor_set(m_device,
+                                       {
+                                           {0, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr},
+                                       },
+                                       VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT);
 
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 


### PR DESCRIPTION
Closes #8251

The issue here is that while `vkCmdUpdateDescriptorSets` can be validated in stateless, `vkUpdateDescriptorSetWithTemplate` cannot and can only be in core checks. 