### PR TITLE
gpuav: Fix selection of instrumentation desc set pipeline layout

### DIFF
--- a/layers/error_message/error_strings.h
+++ b/layers/error_message/error_strings.h
@@ -85,7 +85,8 @@
 
 [[maybe_unused]] static std::string string_VkPushConstantRange(VkPushConstantRange range) {
     std::stringstream ss;
-    ss << "[" << range.offset << ", " << (range.offset + range.size) << "]";
+    ss << "[" << range.offset << ", " << (range.offset + range.size)
+       << ") - stageFlags: " << string_VkShaderStageFlags(range.stageFlags);
     return ss.str();
 }
 

--- a/tests/unit/gpu_av_descriptor_indexing_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_indexing_positive.cpp
@@ -1338,9 +1338,8 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetGraphicsShader
 
     VkPipelineLayoutCreateInfo pipeline_layout_ci = vku::InitStructHelper();
     pipeline_layout_ci.pSetLayouts = set_layouts.data();
-
     pipeline_layout_ci.setLayoutCount = 2;
-    const vkt::PipelineLayout pipeline_layout_2(*m_device, pipeline_layout_ci);
+    const vkt::PipelineLayout pipeline_layout(*m_device, pipeline_layout_ci);
 
     char const *vs_source_1 = R"glsl(
         #version 450
@@ -1418,7 +1417,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetGraphicsShader
     m_command_buffer.Begin(&begin_info);
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
 
-    vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout_2, 0, 2,
+    vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0, 2,
                               descriptor_sets.data(), 0, nullptr);
 
     vk::CmdBindShadersEXT(m_command_buffer.handle(), size32(stages), stages.data(), shaders_2.data());
@@ -1433,95 +1432,6 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetGraphicsShader
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
 
     m_command_buffer.EndRendering();
-    m_command_buffer.End();
-    m_default_queue->Submit(m_command_buffer);
-    m_default_queue->Wait();
-}
-
-TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetGraphicsPushConstants) {
-    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8377");
-    SetTargetApiVersion(VK_API_VERSION_1_2);
-    AddRequiredFeature(vkt::Feature::descriptorBindingStorageBufferUpdateAfterBind);
-    RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
-    InitRenderTarget();
-
-    // Create 2 pipeline layouts. Pipeline layout 2 starts the same as pipeline layout 1, with one push constant range,
-    // but one more push constant range is added to it, for a total of 2.
-    // The descriptor set layout of both pipeline layout are empty, thus compatible
-    // GPU-AV should work as expected.
-
-    std::array<VkPushConstantRange, 2> push_constant_ranges;
-    push_constant_ranges[0].stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
-    push_constant_ranges[0].offset = 0;
-    push_constant_ranges[0].size = 2 * sizeof(uint32_t);
-    push_constant_ranges[1].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-    push_constant_ranges[1].offset = push_constant_ranges[0].size;
-    push_constant_ranges[1].size = sizeof(uint32_t);
-
-    VkPipelineLayoutCreateInfo pipeline_layout_ci = vku::InitStructHelper();
-    pipeline_layout_ci.pushConstantRangeCount = 1;
-    pipeline_layout_ci.pPushConstantRanges = push_constant_ranges.data();
-
-    auto pipeline_layout_1 = std::make_unique<vkt::PipelineLayout>(*m_device, pipeline_layout_ci);
-    pipeline_layout_ci.pushConstantRangeCount = 2;
-    const vkt::PipelineLayout pipeline_layout_2(*m_device, pipeline_layout_ci);
-
-    char const *vs_source_1 = R"glsl(
-        #version 450
-        layout(push_constant, std430) uniform foo_0 { uint a; uint b; };
-        void main() {}
-    )glsl";
-    char const *vs_source_2 = R"glsl(
-        #version 450
-        layout(push_constant, std430) uniform foo_1 { uint a; uint b; };
-        void main() {}
-    )glsl";
-    char const *fs_source_2 = R"glsl(
-        #version 450
-        layout(push_constant, std430) uniform foo_1 { uint c; };
-        void main() {}
-    )glsl";
-
-    VkShaderObj vs_1(this, vs_source_1, VK_SHADER_STAGE_VERTEX_BIT);
-    VkShaderObj vs_2(this, vs_source_2, VK_SHADER_STAGE_VERTEX_BIT);
-    VkShaderObj fs_2(this, fs_source_2, VK_SHADER_STAGE_FRAGMENT_BIT);
-
-    CreatePipelineHelper pipe_1(*this);
-    pipe_1.shader_stages_ = {vs_1.GetStageCreateInfo(), pipe_1.fs_->GetStageCreateInfo()};
-    pipe_1.gp_ci_.layout = pipeline_layout_1->handle();
-    pipe_1.CreateGraphicsPipeline();
-    pipeline_layout_1 = nullptr;
-
-    CreatePipelineHelper pipe_2(*this);
-    pipe_2.shader_stages_ = {vs_2.GetStageCreateInfo(), fs_2.GetStageCreateInfo()};
-    pipe_2.gp_ci_.layout = pipeline_layout_2.handle();
-    pipe_2.CreateGraphicsPipeline();
-
-    std::array<uint32_t, 3> push_constants_data = {{1, 2, 3}};
-
-    VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
-    m_command_buffer.Begin(&begin_info);
-    m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
-
-    vk::CmdPushConstants(m_command_buffer.handle(), pipeline_layout_2.handle(), VK_SHADER_STAGE_VERTEX_BIT, 0,
-                         static_cast<uint32_t>(2 * sizeof(uint32_t)), &push_constants_data[0]);
-    vk::CmdPushConstants(m_command_buffer.handle(), pipeline_layout_2.handle(), VK_SHADER_STAGE_FRAGMENT_BIT,
-                         static_cast<uint32_t>(2 * sizeof(uint32_t)), static_cast<uint32_t>(1 * sizeof(uint32_t)),
-                         &push_constants_data[2]);
-
-    vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe_2.Handle());
-    vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
-    vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
-
-    vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe_1.Handle());
-    vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
-    vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
-
-    vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe_2.Handle());
-    vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
-    vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
-
-    m_command_buffer.EndRenderPass();
     m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();


### PR DESCRIPTION
Added tests that showed issues with the selection of the pipeline layout used to bind the instrumentation descriptor set. Now, when trying to get pipeline layout from last bound pipeline, if it has been destroyed it is temporarily re-created and used to bind instrumentation descriptor set.
Trying to get a pipeline layout from another source (for the new test, pipeline layout specified in last vkCmdPushConstants call) lead to the dreaded vkCmdDraw-None-08600