### PR TITLE
state: Tear down state maps correctly in destructor

### DIFF
--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -258,7 +258,12 @@ class ValidationStateTracker : public ValidationObject {
         return (MapTraits::kInstanceScope && (this->*map_member).empty()) ? instance_state->*map_member : this->*map_member;
     }
 
+    // Helper to clean up the state object maps in the correct order
+    void DestroyObjectMaps();
+
   public:
+    ~ValidationStateTracker();
+
     static VkBindImageMemoryInfo ConvertImageMemoryInfo(VkDevice device, VkImage image, VkDeviceMemory mem,
                                                         VkDeviceSize memoryOffset);
 


### PR DESCRIPTION
We had logic in the vkDestroyDevice() code path that cleans up the state maps in a specific order to handle interdependencies between state object types. This also needs to be called in the destructor, in case an application exits without destroying vulkan objects. In that case, everything gets destroyed via an atexit() callback and it still needs to use the correct ordering.