### PR TITLE
layers: Fix annotated spec link

### DIFF
--- a/layers/error_message/logging.cpp
+++ b/layers/error_message/logging.cpp
@@ -602,11 +602,14 @@ bool DebugReport::LogMsg(VkFlags msg_flags, const LogObjectList &objects, const 
         // this point in the error reporting path
         uint32_t num_vuids = sizeof(vuid_spec_text) / sizeof(vuid_spec_text_pair);
         const char *spec_text = nullptr;
+        // Only the Antora site will make use of the sections
         std::string spec_url_section;
         for (uint32_t i = 0; i < num_vuids; i++) {
             if (0 == strncmp(vuid_text.data(), vuid_spec_text[i].vuid, vuid_text.size())) {
                 spec_text = vuid_spec_text[i].spec_text;
+#ifndef ANNOTATED_SPEC_LINK
                 spec_url_section = vuid_spec_text[i].url_id;
+#endif
                 break;
             }
         }
@@ -634,7 +637,9 @@ bool DebugReport::LogMsg(VkFlags msg_flags, const LogObjectList &objects, const 
             full_message.append(spec_text);
             full_message.append(" (");
             full_message.append(spec_url_base);
+#ifndef ANNOTATED_SPEC_LINK
             full_message.append(spec_url_section);
+#endif
             full_message.append("#");  // CMake hates hashes
             full_message.append(vuid_text);
             full_message.append(")");

--- a/tests/unit/others.cpp
+++ b/tests/unit/others.cpp
@@ -173,20 +173,18 @@ TEST_F(VkLayerTest, RequiredParameter) {
     m_errorMonitor->VerifyFound();
 }
 
+#ifdef ANNOTATED_SPEC_LINK
 TEST_F(VkLayerTest, SpecLinksImplicit) {
     TEST_DESCRIPTION("Test that spec links in a typical error message are well-formed");
     RETURN_IF_SKIP(Init());
 
-#ifdef ANNOTATED_SPEC_LINK
     std::string major_version = std::to_string(VK_VERSION_MAJOR(VK_HEADER_VERSION_COMPLETE));
     std::string minor_version = std::to_string(VK_VERSION_MINOR(VK_HEADER_VERSION_COMPLETE));
     std::string patch_version = std::to_string(VK_VERSION_PATCH(VK_HEADER_VERSION_COMPLETE));
-    std::string spec_version = "doc/view/" + major_version + "." + minor_version + "." + patch_version + ".0/windows";
-#else   // ANNOTATED_SPEC_LINK
     // keep VUID seperate otherwise vk_validation_stats.py will get confused
-    std::string spec_version = "https://docs.vulkan.org/spec/latest/chapters/features.html#" +
+    std::string spec_version = "doc/view/" + major_version + "." + minor_version + "." + patch_version + ".0/windows/1." +
+                               minor_version + "-extensions/vkspec.html#" +
                                std::string("VUID-vkGetPhysicalDeviceFeatures-pFeatures-parameter");
-#endif  // ANNOTATED_SPEC_LINK
 
     m_errorMonitor->SetDesiredError(spec_version.c_str());
     vk::GetPhysicalDeviceFeatures(Gpu(), nullptr);
@@ -197,29 +195,52 @@ TEST_F(VkLayerTest, SpecLinksExplicit) {
     TEST_DESCRIPTION("Test that spec links in a typical error message are well-formed");
     RETURN_IF_SKIP(Init());
 
-#ifdef ANNOTATED_SPEC_LINK
     std::string major_version = std::to_string(VK_VERSION_MAJOR(VK_HEADER_VERSION_COMPLETE));
     std::string minor_version = std::to_string(VK_VERSION_MINOR(VK_HEADER_VERSION_COMPLETE));
     std::string patch_version = std::to_string(VK_VERSION_PATCH(VK_HEADER_VERSION_COMPLETE));
-    std::string spec_version = "doc/view/" + major_version + "." + minor_version + "." + patch_version + ".0/windows";
-#else   // ANNOTATED_SPEC_LINK
     // keep VUID seperate otherwise vk_validation_stats.py will get confused
-    std::string spec_version =
-        "https://docs.vulkan.org/spec/latest/chapters/memory.html#" + std::string("VUID-vkAllocateMemory-pAllocateInfo-01714");
-#endif  // ANNOTATED_SPEC_LINK
+    std::string spec_version = "doc/view/" + major_version + "." + minor_version + "." + patch_version + ".0/windows/1." +
+                               minor_version + "-extensions/vkspec.html#" + std::string("VUID-VkBufferCreateInfo-size-00912");
 
-    VkPhysicalDeviceMemoryProperties memory_info;
-    vk::GetPhysicalDeviceMemoryProperties(Gpu(), &memory_info);
-
-    VkMemoryAllocateInfo mem_alloc = vku::InitStructHelper();
-    mem_alloc.memoryTypeIndex = memory_info.memoryTypeCount;
-    mem_alloc.allocationSize = 4;
-
-    VkDeviceMemory mem;
+    VkBufferCreateInfo info = vku::InitStructHelper();
+    info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+    info.size = 0;
     m_errorMonitor->SetDesiredError(spec_version.c_str());
-    vk::AllocateMemory(device(), &mem_alloc, nullptr, &mem);
+    vkt::Buffer buffer(*m_device, info, vkt::no_mem);
     m_errorMonitor->VerifyFound();
 }
+
+#else   // ANNOTATED_SPEC_LINK
+
+TEST_F(VkLayerTest, SpecLinksImplicit) {
+    TEST_DESCRIPTION("Test that spec links in a typical error message are well-formed");
+    RETURN_IF_SKIP(Init());
+
+    // keep VUID seperate otherwise vk_validation_stats.py will get confused
+    std::string spec_version = "https://docs.vulkan.org/spec/latest/chapters/features.html#" +
+                               std::string("VUID-vkGetPhysicalDeviceFeatures-pFeatures-parameter");
+
+    m_errorMonitor->SetDesiredError(spec_version.c_str());
+    vk::GetPhysicalDeviceFeatures(Gpu(), nullptr);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(VkLayerTest, SpecLinksExplicit) {
+    TEST_DESCRIPTION("Test that spec links in a typical error message are well-formed");
+    RETURN_IF_SKIP(Init());
+
+    // keep VUID seperate otherwise vk_validation_stats.py will get confused
+    std::string spec_version =
+        "https://docs.vulkan.org/spec/latest/chapters/resources.html#" + std::string("VUID-VkBufferCreateInfo-size-00912");
+
+    VkBufferCreateInfo info = vku::InitStructHelper();
+    info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+    info.size = 0;
+    m_errorMonitor->SetDesiredError(spec_version.c_str());
+    vkt::Buffer buffer(*m_device, info, vkt::no_mem);
+    m_errorMonitor->VerifyFound();
+}
+#endif  // ANNOTATED_SPEC_LINK
 
 TEST_F(VkLayerTest, DeviceIDPropertiesUnsupported) {
     TEST_DESCRIPTION("VkPhysicalDeviceIDProperties cannot be used without extensions in 1.0");


### PR DESCRIPTION
Followup of https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/9016 to fix `ANNOTATED_SPEC_LINK`