### PR TITLE
sync: Fix creating dynamic rendering attachments in sync val

### DIFF
--- a/layers/sync/sync_renderpass.cpp
+++ b/layers/sync/sync_renderpass.cpp
@@ -976,9 +976,11 @@ syncval_state::DynamicRenderingInfo::Attachment::Attachment(const SyncValidator 
     if (view) {
         if (type == AttachmentType::kColor) {
             view_gen = view->MakeImageRangeGen(offset, extent);
-        } else if (type == AttachmentType::kDepth) {
+        } else if (type == AttachmentType::kDepth &&
+                   (view->normalized_subresource_range.aspectMask & VK_IMAGE_ASPECT_DEPTH_BIT) != 0) {
             view_gen = view->MakeImageRangeGen(offset, extent, VK_IMAGE_ASPECT_DEPTH_BIT);
-        } else {
+        } else if (type == AttachmentType::kStencil &&
+                   (view->normalized_subresource_range.aspectMask & VK_IMAGE_ASPECT_STENCIL_BIT) != 0) {
             view_gen = view->MakeImageRangeGen(offset, extent, VK_IMAGE_ASPECT_STENCIL_BIT);
         }
 


### PR DESCRIPTION
Syncval would assert if dynamic rendering contains a depth attachment without depth aspect or stencil attachment without stencil aspect