### PR TITLE
layers: Fix enabling extensions from api version

### DIFF
--- a/layers/chassis/chassis_manual.cpp
+++ b/layers/chassis/chassis_manual.cpp
@@ -329,7 +329,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice gpu, const VkDevice
     device_dispatch->device = *pDevice;
     // Save local info in device object
     device_dispatch->api_version = device_dispatch->device_extensions.InitFromDeviceCreateInfo(
-        &instance_dispatch->instance_extensions, instance_dispatch->api_version,
+        &instance_dispatch->instance_extensions, device_dispatch->api_version,
         reinterpret_cast<VkDeviceCreateInfo*>(&modified_create_info));
     layer_init_device_dispatch_table(*pDevice, &device_dispatch->device_dispatch_table, fpGetDeviceProcAddr);
 


### PR DESCRIPTION
Closes #9090

The device extensions should be loaded from `VkPhysicalDeviceProperties::apiVersion` and not the instance api version. 

Currently the instance api version is used and if it is higher than device api version extensions will be enabled for the device which it does not have. In the linked issue the problem was that instance api version was 1.3 and device only 1.1, so`VkPhysicalDeviceVulkan11Properties` and `VkPhysicalDeviceVulkan12Properties` were used in `state_tracker.cpp:766`, and these structs were passed into `vkGetPhysicalDeviceProperties2()` and were not filled in. Even though the driver supported VK_KHR_multiview those same properties in `VkPhysicalDeviceVulkan11Properties` were 0.