### PR TITLE
layers: Improve Descriptors error messages

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -31,6 +31,7 @@ typedef vvl::unordered_map<const vvl::Image*, std::optional<GlobalImageLayoutRan
 
 namespace vvl {
 struct DrawDispatchVuid;
+class DescriptorBinding;
 }  // namespace vvl
 
 namespace spirv {
@@ -598,27 +599,40 @@ class CoreChecks : public ValidationStateTracker {
                                            const vvl::PipelineLayout& fs_layout, std::string& error_msg) const;
 
     // Validate contents of a CopyUpdate
-    using DescriptorSet = vvl::DescriptorSet;
     bool ValidateCopyUpdate(const VkCopyDescriptorSet& update, const Location& copy_loc) const;
-    bool VerifyCopyUpdateContents(const VkCopyDescriptorSet& update, const DescriptorSet& src_set, VkDescriptorType src_type,
-                                  uint32_t src_index, const DescriptorSet& dst_set, VkDescriptorType dst_type, uint32_t dst_index,
-                                  const Location& copy_loc) const;
-    bool VerifyUpdateConsistency(const DescriptorSet& set, uint32_t binding, uint32_t offset, uint32_t update_count,
-                                 const char* vuid, const Location& set_loc) const;
+    bool ValidateCopyUpdateDescriptorSetLayoutFlags(const VkCopyDescriptorSet& update, const vvl::DescriptorSetLayout& src_layout,
+                                                    const vvl::DescriptorSetLayout& dst_layout, const Location& copy_loc) const;
+    bool ValidateCopyUpdateDescriptorPoolFlags(const VkCopyDescriptorSet& update, const vvl::DescriptorSet& src_set,
+                                               const vvl::DescriptorSet& dst_set, const Location& copy_loc) const;
+    bool ValidateCopyUpdateDescriptorTypes(const VkCopyDescriptorSet& update, const vvl::DescriptorSet& src_set,
+                                           const vvl::DescriptorSet& dst_set, const vvl::DescriptorSetLayout& src_layout,
+                                           const vvl::DescriptorSetLayout& dst_layout, const Location& copy_loc) const;
+    bool VerifyUpdateConsistency(const vvl::DescriptorSet& set, uint32_t binding, uint32_t offset, uint32_t update_count,
+                                 bool is_copy, const Location& set_loc) const;
     // Validate contents of a WriteUpdate
-    bool ValidateWriteUpdate(const DescriptorSet& dst_set, const VkWriteDescriptorSet& update, const Location& write_loc,
+    bool ValidateWriteUpdate(const vvl::DescriptorSet& dst_set, const VkWriteDescriptorSet& update, const Location& write_loc,
                              bool push) const;
-    bool VerifyWriteUpdateContents(const DescriptorSet& dst_set, const VkWriteDescriptorSet& update, const uint32_t index,
-                                   const Location& write_loc, bool push) const;
+    bool ValidateWriteUpdateDescriptorType(const vvl::DescriptorSetLayout& dst_layout, const vvl::DescriptorSet& dst_set,
+                                           const vvl::DescriptorBinding& dst_binding, const VkWriteDescriptorSet& update,
+                                           const Location& write_loc) const;
+    bool ValidateWriteUpdateBufferInfo(const vvl::DescriptorSetLayout& dst_layout, const VkWriteDescriptorSet& update,
+                                       const Location& write_loc) const;
+    bool ValidateWriteUpdateInlineUniformBlock(const vvl::DescriptorSetLayout& dst_layout, const VkWriteDescriptorSet& update,
+                                               const Location& write_loc) const;
+    bool ValidateWriteUpdateAccelerationStructureKHR(const vvl::DescriptorSetLayout& dst_layout, const VkWriteDescriptorSet& update,
+                                                     const Location& write_loc) const;
+    bool ValidateWriteUpdateAccelerationStructureNV(const vvl::DescriptorSetLayout& dst_layout, const VkWriteDescriptorSet& update,
+                                                    const Location& write_loc) const;
+    bool VerifyWriteUpdateContents(const vvl::DescriptorSet& dst_set, const VkWriteDescriptorSet& update, const Location& write_loc,
+                                   bool push) const;
     // Shared helper functions - These are useful because the shared sampler image descriptor type
     //  performs common functions with both sampler and image descriptors so they can share their common functions
     bool ValidateImageUpdate(const vvl::ImageView& view_state, VkImageLayout image_layout, VkDescriptorType type,
                              const Location& image_info_loc) const;
     // Validate contents of a push descriptor update
-    bool ValidatePushDescriptorsUpdate(const DescriptorSet& push_set, uint32_t descriptorWriteCount,
+    bool ValidatePushDescriptorsUpdate(const vvl::DescriptorSet& push_set, uint32_t descriptorWriteCount,
                                        const VkWriteDescriptorSet* pDescriptorWrites, const Location& loc) const;
     // Descriptor Set Validation Functions
-    bool ValidateSampler(VkSampler) const;
     bool ValidateBufferUsage(const vvl::Buffer& buffer_state, VkDescriptorType type, const Location& buffer_loc) const;
     bool ValidateBufferUpdate(const VkDescriptorBufferInfo& buffer_info, VkDescriptorType type,
                               const Location& buffer_info_loc) const;

--- a/layers/object_tracker/object_tracker_utils.cpp
+++ b/layers/object_tracker/object_tracker_utils.cpp
@@ -302,6 +302,7 @@ bool ObjectLifetimes::ValidateDescriptorWrite(VkWriteDescriptorSet const *desc, 
         case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE: {
             if (desc->pImageInfo) {
                 for (uint32_t i = 0; i < desc->descriptorCount; ++i) {
+                    // Only validate image here, we have to validate Sampler state tracker object
                     skip |= ValidateObject(desc->pImageInfo[i].imageView, kVulkanObjectTypeImageView, true,
                                            "VUID-VkWriteDescriptorSet-descriptorType-02996",
                                            "VUID-vkUpdateDescriptorSets-pDescriptorWrites-06239",
@@ -365,8 +366,10 @@ bool ObjectLifetimes::ValidateDescriptorWrite(VkWriteDescriptorSet const *desc, 
             }
             break;
         }
-        // TODO - These need to be checked as well
+        // handled in core check because need to know if using immutable samplers or not
         case VK_DESCRIPTOR_TYPE_SAMPLER:
+
+        // TODO - These need to be checked as well
         case VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK:
         case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV:
         case VK_DESCRIPTOR_TYPE_SAMPLE_WEIGHT_IMAGE_QCOM:

--- a/tests/unit/buffer.cpp
+++ b/tests/unit/buffer.cpp
@@ -90,7 +90,6 @@ TEST_F(NegativeBuffer, BufferViewObject) {
     // Then destroy view itself and verify that same error is hit
     VkResult err;
 
-    m_errorMonitor->SetDesiredError("VUID-VkWriteDescriptorSet-descriptorType-02994");
     RETURN_IF_SKIP(Init());
 
     OneOffDescriptorSet descriptor_set(m_device, {
@@ -104,7 +103,7 @@ TEST_F(NegativeBuffer, BufferViewObject) {
         bvci.format = VK_FORMAT_R32_SFLOAT;
         bvci.range = VK_WHOLE_SIZE;
 
-        err = vk::CreateBufferView(device(), &bvci, NULL, &view);
+        err = vk::CreateBufferView(device(), &bvci, nullptr, &view);
         ASSERT_EQ(VK_SUCCESS, err);
     }
     // First Destroy buffer underlying view which should hit error in CV
@@ -116,13 +115,14 @@ TEST_F(NegativeBuffer, BufferViewObject) {
     descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
     descriptor_write.pTexelBufferView = &view;
 
-    vk::UpdateDescriptorSets(device(), 1, &descriptor_write, 0, NULL);
+    m_errorMonitor->SetDesiredError("VUID-VkWriteDescriptorSet-descriptorType-02994");
+    vk::UpdateDescriptorSets(device(), 1, &descriptor_write, 0, nullptr);
     m_errorMonitor->VerifyFound();
 
     // Now destroy view itself and verify same error, which is hit in PV this time
-    vk::DestroyBufferView(device(), view, NULL);
+    vk::DestroyBufferView(device(), view, nullptr);
     m_errorMonitor->SetDesiredError("VUID-VkWriteDescriptorSet-descriptorType-02994");
-    vk::UpdateDescriptorSets(device(), 1, &descriptor_write, 0, NULL);
+    vk::UpdateDescriptorSets(device(), 1, &descriptor_write, 0, nullptr);
     m_errorMonitor->VerifyFound();
 }
 


### PR DESCRIPTION
`VUID-vkUpdateDescriptorSets-pDescriptorWrites-06238` was missing and it lead down a rabbit hole of cleaning up the Write/Copy descriptor error messages and grouping things together to make it easier when dealing with the many `VkDescriptorType`