### PR TITLE
tests: Remove deprecated helpers

### DIFF
--- a/tests/framework/barrier_queue_family.cpp
+++ b/tests/framework/barrier_queue_family.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 Valve Corporation
- * Copyright (c) 2023-2024 LunarG, Inc.
+ * Copyright (c) 2023-2025 Valve Corporation
+ * Copyright (c) 2023-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -217,12 +217,12 @@ void Barrier2QueueFamilyTestHelper::operator()(const std::string &img_err, const
 void ValidOwnershipTransferOp(ErrorMonitor *monitor, vkt::Queue *queue, vkt::CommandBuffer &cb, VkPipelineStageFlags src_stages,
                               VkPipelineStageFlags dst_stages, const VkBufferMemoryBarrier *buf_barrier,
                               const VkImageMemoryBarrier *img_barrier) {
-    cb.begin();
+    cb.Begin();
     uint32_t num_buf_barrier = (buf_barrier) ? 1 : 0;
     uint32_t num_img_barrier = (img_barrier) ? 1 : 0;
     vk::CmdPipelineBarrier(cb.handle(), src_stages, dst_stages, 0, 0, nullptr, num_buf_barrier, buf_barrier, num_img_barrier,
                            img_barrier);
-    cb.end();
+    cb.End();
     queue->Submit(cb);
     queue->Wait();
 }
@@ -237,14 +237,14 @@ void ValidOwnershipTransfer(ErrorMonitor *monitor, vkt::Queue *queue_from, vkt::
 
 void ValidOwnershipTransferOp(ErrorMonitor *monitor, vkt::Queue *queue, vkt::CommandBuffer &cb,
                               const VkBufferMemoryBarrier2 *buf_barrier, const VkImageMemoryBarrier2 *img_barrier) {
-    cb.begin();
+    cb.Begin();
     VkDependencyInfo dep_info = vku::InitStructHelper();
     dep_info.bufferMemoryBarrierCount = (buf_barrier) ? 1 : 0;
     dep_info.pBufferMemoryBarriers = buf_barrier;
     dep_info.imageMemoryBarrierCount = (img_barrier) ? 1 : 0;
     dep_info.pImageMemoryBarriers = img_barrier;
     vk::CmdPipelineBarrier2KHR(cb.handle(), &dep_info);
-    cb.end();
+    cb.End();
     queue->Submit(cb);
     queue->Wait();
 }

--- a/tests/framework/binding.cpp
+++ b/tests/framework/binding.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1457,9 +1457,9 @@ void Image::SetLayout(VkImageAspectFlags aspect, VkImageLayout image_layout) {
     CommandBuffer cmd_buf(*device_, pool);
 
     /* Build command buffer to set image layout in the driver */
-    cmd_buf.begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
+    cmd_buf.Begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
     SetLayout(cmd_buf, aspect, image_layout);
-    cmd_buf.end();
+    cmd_buf.End();
 
     auto graphics_queue = device_->QueuesWithGraphicsCapability()[0];
     graphics_queue->Submit(cmd_buf);
@@ -1884,7 +1884,7 @@ void CommandBuffer::Begin(VkCommandBufferUsageFlags flags) {
     hinfo.queryFlags = 0;
     hinfo.pipelineStatistics = 0;
 
-    begin(&info);
+    Begin(&info);
 }
 
 void CommandBuffer::End() {

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2016, 2020-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2016, 2020-2024 Valve Corporation
- * Copyright (c) 2015-2016, 2020-2024 LunarG, Inc.
+ * Copyright (c) 2015-2016, 2020-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2016, 2020-2025 Valve Corporation
+ * Copyright (c) 2015-2016, 2020-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -262,8 +262,6 @@ class Device : public internal::Handle<VkDevice> {
 
     void SetName(const char *name) { Handle<VkDevice>::SetName(handle_, VK_OBJECT_TYPE_DEVICE, name); }
     const PhysicalDevice &Physical() const { return physical_device_; }
-    // Deprecated, use Physical()
-    const PhysicalDevice &phy() const { return physical_device_; }
 
     std::vector<const char *> GetEnabledExtensions() { return enabled_extensions_; }
     bool IsEnabledExtension(const char *extension) const;
@@ -372,15 +370,6 @@ class DeviceMemory : public internal::NonDispHandle<VkDeviceMemory> {
 
     // vkUnmapMemory()
     void Unmap() const;
-
-    // Deprecated, use Map() and Unmap()
-    const void *map(VkFlags flags) const { return Map(flags); }
-    void *map(VkFlags flags) { return Map(flags); }
-    const void *map() const { return Map(0); }
-    void *map() { return Map(0); }
-
-    // vkUnmapMemory()
-    void unmap() const { return Unmap(); };
 
     static VkMemoryAllocateInfo GetResourceAllocInfo(const Device &dev, const VkMemoryRequirements &reqs,
                                                      VkMemoryPropertyFlags mem_props, void *alloc_info_pnext = nullptr);
@@ -635,14 +624,8 @@ class Buffer : public internal::NonDispHandle<VkBuffer> {
     const DeviceMemory &Memory() const { return internal_mem_; }
     DeviceMemory &Memory() { return internal_mem_; }
 
-    // Deprecated, use Memory()
-    const DeviceMemory &memory() const { return internal_mem_; }
-    DeviceMemory &memory() { return internal_mem_; }
-
     // vkGetObjectMemoryRequirements()
     VkMemoryRequirements MemoryRequirements() const;
-    // Deprecated, use MemoryRequirements()
-    VkMemoryRequirements memory_requirements() const { return MemoryRequirements(); };
 
     // Allocate and bind memory
     // The assumption that this object was created in no_mem configuration
@@ -689,8 +672,6 @@ class Buffer : public internal::NonDispHandle<VkBuffer> {
     }
 
     [[nodiscard]] VkDeviceAddress Address() const;
-    // Deprecated, use Address()
-    [[nodiscard]] VkDeviceAddress address() const { return Address(); };
 
   private:
     VkBufferCreateInfo create_info_;
@@ -755,14 +736,8 @@ class Image : public internal::NonDispHandle<VkImage> {
     const DeviceMemory &Memory() const { return internal_mem_; }
     DeviceMemory &Memory() { return internal_mem_; }
 
-    // Deprecated, use Memory()
-    const DeviceMemory &memory() const { return internal_mem_; }
-    DeviceMemory &memory() { return internal_mem_; }
-
     // vkGetObjectMemoryRequirements()
     VkMemoryRequirements MemoryRequirements() const;
-    // Deprecated, use MemoryRequirements()
-    VkMemoryRequirements memory_requirements() const { return MemoryRequirements(); };
 
     // Allocate and bind memory
     // The assumption that this object was created in no_mem configuration
@@ -1175,14 +1150,6 @@ class CommandBuffer : public internal::Handle<VkCommandBuffer> {
     void End();
     void Reset(VkCommandBufferResetFlags flags);
     void Reset() { Reset(VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT); }
-
-    // Deprecated, use Begin(), End(), Reset()
-    void begin(const VkCommandBufferBeginInfo *info) { Begin(info); };
-    void begin(VkCommandBufferUsageFlags flags) { Begin(flags); };
-    void begin() { Begin(0u); }
-    void end() { End(); };
-    void reset(VkCommandBufferResetFlags flags) { Reset(flags); };
-    void reset() { Reset(VK_COMMAND_BUFFER_RESET_RELEASE_RESOURCES_BIT); }
 
     static VkCommandBufferAllocateInfo CreateInfo(VkCommandPool const &pool);
 

--- a/tests/framework/buffer_helper.h
+++ b/tests/framework/buffer_helper.h
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2024 The Khronos Group Inc.
- * Copyright (c) 2024 Valve Corporation
- * Copyright (c) 2024 LunarG, Inc.
+ * Copyright (c) 2024-2025 The Khronos Group Inc.
+ * Copyright (c) 2024-2025 Valve Corporation
+ * Copyright (c) 2024-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,9 +47,9 @@ template <typename IndirectCmdT>
 Buffer IndirectBuffer(const Device &dev, const std::vector<IndirectCmdT> &indirect_cmds) {
     vkt::Buffer indirect_buffer(dev, indirect_cmds.size() * sizeof(IndirectCmdT), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                 VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    auto *indirect_buffer_ptr = static_cast<IndirectCmdT *>(indirect_buffer.memory().map());
+    auto *indirect_buffer_ptr = static_cast<IndirectCmdT *>(indirect_buffer.Memory().Map());
     std::copy(indirect_cmds.data(), indirect_cmds.data() + indirect_cmds.size(), indirect_buffer_ptr);
-    indirect_buffer.memory().unmap();
+    indirect_buffer.Memory().Unmap();
     return indirect_buffer;
 }
 

--- a/tests/framework/queue_submit_context.cpp
+++ b/tests/framework/queue_submit_context.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (c) 2015-2024 Google, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2025 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,8 +86,8 @@ void QSTestContext::Begin(vkt::CommandBuffer& cb) {
     info.flags = VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT;
     info.pInheritanceInfo = nullptr;
 
-    cb.reset();
-    cb.begin(&info);
+    cb.Reset();
+    cb.Begin(&info);
     current_cb = &cb;
 }
 

--- a/tests/framework/ray_tracing_objects.h
+++ b/tests/framework/ray_tracing_objects.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024 Valve Corporation
- * Copyright (c) 2024 LunarG, Inc.
+ * Copyright (c) 2024-2025 Valve Corporation
+ * Copyright (c) 2024-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -251,9 +251,9 @@ void BuildHostAccelerationStructuresKHR(VkDevice device, std::vector<BuildGeomet
 //    as_build_info.GetDstAS().SetBufferMemoryPropertyFlags(VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
 //    as_build_info.SetFlags(VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR);
 //
-//    m_command_buffer.begin();
+//    m_command_buffer.Begin();
 //    as_build_info.BuildCmdBuffer(*m_device, m_command_buffer.handle());
-//    m_command_buffer.end();
+//    m_command_buffer.End();
 // }
 namespace blueprint {
 GeometryKHR GeometrySimpleOnDeviceTriangleInfo(const vkt::Device& device, size_t triangles_count = 1);

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,8 +79,6 @@ class VkRenderFramework : public VkTestFramework {
     VkDevice device() const { return m_device->handle(); }
     vkt::Device *DeviceObj() const { return m_device; }
     VkPhysicalDevice Gpu() const;
-    // Deprecated, use Gpu()
-    VkPhysicalDevice gpu() const { return Gpu(); }
     VkRenderPass RenderPass() const { return m_renderPass; }
     VkFramebuffer Framebuffer() const { return m_framebuffer->handle(); }
 
@@ -89,8 +87,6 @@ class VkRenderFramework : public VkTestFramework {
 
     ErrorMonitor &Monitor();
     const VkPhysicalDeviceProperties &PhysicalDeviceProps() const;
-    // Deprecated, use PhysicalDeviceProps()
-    const VkPhysicalDeviceProperties &physDevProps() const { return PhysicalDeviceProps(); }
 
     bool InstanceLayerSupported(const char *layer_name, uint32_t spec_version = 0, uint32_t impl_version = 0);
     bool InstanceExtensionSupported(const char *extension_name, uint32_t spec_version = 0);

--- a/tests/framework/video_objects.h
+++ b/tests/framework/video_objects.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2022-2024 The Khronos Group Inc.
- * Copyright (c) 2022-2024 RasterGrid Kft.
+ * Copyright (c) 2022-2025 The Khronos Group Inc.
+ * Copyright (c) 2022-2025 RasterGrid Kft.
  * Modifications Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -524,7 +524,7 @@ class BitstreamBuffer {
 
             VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
             VkMemoryPropertyFlags mem_props = is_protected ? VK_MEMORY_PROPERTY_PROTECTED_BIT : 0;
-            ASSERT_TRUE(device_->phy().SetMemoryType(mem_req.memoryTypeBits, &alloc_info, mem_props));
+            ASSERT_TRUE(device_->Physical().SetMemoryType(mem_req.memoryTypeBits, &alloc_info, mem_props));
             alloc_info.allocationSize = mem_req.size;
 
             ASSERT_EQ(VK_SUCCESS, vk::AllocateMemory(device_->handle(), &alloc_info, nullptr, &memory_));
@@ -626,7 +626,7 @@ class VideoPictureResource {
 
             VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
             VkMemoryPropertyFlags mem_props = is_protected ? VK_MEMORY_PROPERTY_PROTECTED_BIT : 0;
-            ASSERT_TRUE(device_->phy().SetMemoryType(mem_req.memoryTypeBits, &alloc_info, mem_props));
+            ASSERT_TRUE(device_->Physical().SetMemoryType(mem_req.memoryTypeBits, &alloc_info, mem_props));
             alloc_info.allocationSize = mem_req.size;
 
             ASSERT_EQ(VK_SUCCESS, vk::AllocateMemory(device_->handle(), &alloc_info, nullptr, &memory_));
@@ -2343,7 +2343,7 @@ class VideoContext {
         for (uint32_t i = 0; i < mem_req_count; ++i) {
             VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
 
-            ASSERT_TRUE(device_->phy().SetMemoryType(mem_reqs[i].memoryRequirements.memoryTypeBits, &alloc_info, 0));
+            ASSERT_TRUE(device_->Physical().SetMemoryType(mem_reqs[i].memoryRequirements.memoryTypeBits, &alloc_info, 0));
             alloc_info.allocationSize = mem_reqs[i].memoryRequirements.size;
 
             VkDeviceMemory memory = VK_NULL_HANDLE;
@@ -2801,14 +2801,14 @@ class VkVideoLayerTest : public VkLayerTest {
 
         VkPhysicalDeviceProtectedMemoryProperties prot_mem_props = vku::InitStructHelper();
         VkPhysicalDeviceProperties2 props = vku::InitStructHelper(&prot_mem_props);
-        vk::GetPhysicalDeviceProperties2(gpu(), &props);
+        vk::GetPhysicalDeviceProperties2(Gpu(), &props);
 
         protected_no_fault_supported_ = (prot_mem_props.protectedNoFault == VK_TRUE);
 
         RETURN_IF_SKIP(InitState());
 
         uint32_t qf_count;
-        vk::GetPhysicalDeviceQueueFamilyProperties2(gpu(), &qf_count, nullptr);
+        vk::GetPhysicalDeviceQueueFamilyProperties2(Gpu(), &qf_count, nullptr);
 
         queue_family_props_.resize(qf_count, vku::InitStruct<VkQueueFamilyProperties2>());
         queue_family_video_props_.resize(qf_count, vku::InitStruct<VkQueueFamilyVideoPropertiesKHR>());
@@ -2817,7 +2817,7 @@ class VkVideoLayerTest : public VkLayerTest {
             queue_family_props_[i].pNext = &queue_family_video_props_[i];
             queue_family_video_props_[i].pNext = &queue_family_query_result_status_props_[i];
         }
-        vk::GetPhysicalDeviceQueueFamilyProperties2(gpu(), &qf_count, queue_family_props_.data());
+        vk::GetPhysicalDeviceQueueFamilyProperties2(Gpu(), &qf_count, queue_family_props_.data());
 
         InitConfigs();
 
@@ -2981,7 +2981,7 @@ class VkVideoLayerTest : public VkLayerTest {
     }
 
     bool GetCodecCapabilities(VideoConfig& config) {
-        if (vk::GetPhysicalDeviceVideoCapabilitiesKHR(gpu(), config.Profile(), config.Caps()) != VK_SUCCESS) {
+        if (vk::GetPhysicalDeviceVideoCapabilitiesKHR(Gpu(), config.Profile(), config.Caps()) != VK_SUCCESS) {
             return false;
         }
 
@@ -3012,13 +3012,13 @@ class VkVideoLayerTest : public VkLayerTest {
             if (decode_caps->flags & VK_VIDEO_DECODE_CAPABILITY_DPB_AND_OUTPUT_DISTINCT_BIT_KHR) {
                 info.imageUsage = VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR;
 
-                VkResult result = vk::GetPhysicalDeviceVideoFormatPropertiesKHR(gpu(), &info, &count, nullptr);
+                VkResult result = vk::GetPhysicalDeviceVideoFormatPropertiesKHR(Gpu(), &info, &count, nullptr);
                 if (result != VK_SUCCESS || count == 0) {
                     return false;
                 }
 
                 std::vector<VkVideoFormatPropertiesKHR> pic_props(count, vku::InitStruct<VkVideoFormatPropertiesKHR>());
-                result = vk::GetPhysicalDeviceVideoFormatPropertiesKHR(gpu(), &info, &count, pic_props.data());
+                result = vk::GetPhysicalDeviceVideoFormatPropertiesKHR(Gpu(), &info, &count, pic_props.data());
                 if (result != VK_SUCCESS) {
                     return false;
                 }
@@ -3029,13 +3029,13 @@ class VkVideoLayerTest : public VkLayerTest {
 
                 info.imageUsage = VK_IMAGE_USAGE_VIDEO_DECODE_DPB_BIT_KHR;
 
-                result = vk::GetPhysicalDeviceVideoFormatPropertiesKHR(gpu(), &info, &count, nullptr);
+                result = vk::GetPhysicalDeviceVideoFormatPropertiesKHR(Gpu(), &info, &count, nullptr);
                 if (result != VK_SUCCESS || count == 0) {
                     return false;
                 }
                 std::vector<VkVideoFormatPropertiesKHR> dpb_props(count, vku::InitStruct<VkVideoFormatPropertiesKHR>());
 
-                result = vk::GetPhysicalDeviceVideoFormatPropertiesKHR(gpu(), &info, &count, dpb_props.data());
+                result = vk::GetPhysicalDeviceVideoFormatPropertiesKHR(Gpu(), &info, &count, dpb_props.data());
                 if (result != VK_SUCCESS) {
                     return false;
                 }
@@ -3049,13 +3049,13 @@ class VkVideoLayerTest : public VkLayerTest {
             } else if (decode_caps->flags & VK_VIDEO_DECODE_CAPABILITY_DPB_AND_OUTPUT_COINCIDE_BIT_KHR) {
                 info.imageUsage = VK_IMAGE_USAGE_VIDEO_DECODE_DPB_BIT_KHR | VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR;
 
-                VkResult result = vk::GetPhysicalDeviceVideoFormatPropertiesKHR(gpu(), &info, &count, nullptr);
+                VkResult result = vk::GetPhysicalDeviceVideoFormatPropertiesKHR(Gpu(), &info, &count, nullptr);
                 if (result != VK_SUCCESS || count == 0) {
                     return false;
                 }
                 std::vector<VkVideoFormatPropertiesKHR> dpb_props(count, vku::InitStruct<VkVideoFormatPropertiesKHR>());
 
-                result = vk::GetPhysicalDeviceVideoFormatPropertiesKHR(gpu(), &info, &count, dpb_props.data());
+                result = vk::GetPhysicalDeviceVideoFormatPropertiesKHR(Gpu(), &info, &count, dpb_props.data());
                 if (result != VK_SUCCESS) {
                     return false;
                 }
@@ -3074,13 +3074,13 @@ class VkVideoLayerTest : public VkLayerTest {
 
             info.imageUsage = VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR;
 
-            VkResult result = vk::GetPhysicalDeviceVideoFormatPropertiesKHR(gpu(), &info, &count, nullptr);
+            VkResult result = vk::GetPhysicalDeviceVideoFormatPropertiesKHR(Gpu(), &info, &count, nullptr);
             if (result != VK_SUCCESS || count == 0) {
                 return false;
             }
 
             std::vector<VkVideoFormatPropertiesKHR> pic_props(count, vku::InitStruct<VkVideoFormatPropertiesKHR>());
-            result = vk::GetPhysicalDeviceVideoFormatPropertiesKHR(gpu(), &info, &count, pic_props.data());
+            result = vk::GetPhysicalDeviceVideoFormatPropertiesKHR(Gpu(), &info, &count, pic_props.data());
             if (result != VK_SUCCESS) {
                 return false;
             }
@@ -3091,13 +3091,13 @@ class VkVideoLayerTest : public VkLayerTest {
 
             info.imageUsage = VK_IMAGE_USAGE_VIDEO_ENCODE_DPB_BIT_KHR;
 
-            result = vk::GetPhysicalDeviceVideoFormatPropertiesKHR(gpu(), &info, &count, nullptr);
+            result = vk::GetPhysicalDeviceVideoFormatPropertiesKHR(Gpu(), &info, &count, nullptr);
             if (result != VK_SUCCESS || count == 0) {
                 return false;
             }
             std::vector<VkVideoFormatPropertiesKHR> dpb_props(count, vku::InitStruct<VkVideoFormatPropertiesKHR>());
 
-            result = vk::GetPhysicalDeviceVideoFormatPropertiesKHR(gpu(), &info, &count, dpb_props.data());
+            result = vk::GetPhysicalDeviceVideoFormatPropertiesKHR(Gpu(), &info, &count, dpb_props.data());
             if (result != VK_SUCCESS) {
                 return false;
             }
@@ -3128,7 +3128,7 @@ class VkVideoLayerTest : public VkLayerTest {
 
                     info.imageUsage = quant_map_type.image_usage;
 
-                    result = vk::GetPhysicalDeviceVideoFormatPropertiesKHR(gpu(), &info, &count, nullptr);
+                    result = vk::GetPhysicalDeviceVideoFormatPropertiesKHR(Gpu(), &info, &count, nullptr);
                     if (result != VK_SUCCESS || count == 0) {
                         return false;
                     }
@@ -3161,7 +3161,7 @@ class VkVideoLayerTest : public VkLayerTest {
                     }
 
                     result =
-                        vk::GetPhysicalDeviceVideoFormatPropertiesKHR(gpu(), &info, &count, quant_map_type.format_props.data());
+                        vk::GetPhysicalDeviceVideoFormatPropertiesKHR(Gpu(), &info, &count, quant_map_type.format_props.data());
                     // This should never happen since the initial call to get count was fine.
                     if (result != VK_SUCCESS) {
                         return false;

--- a/tests/unit/copy_buffer_image.cpp
+++ b/tests/unit/copy_buffer_image.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (c) 2015-2024 Google, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2025 Google, Inc.
  * Modifications Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1945,7 +1945,7 @@ TEST_F(NegativeCopyBufferImage, ImageFormatSizeMismatch2) {
     } else if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_R8_UINT, VK_IMAGE_TILING_OPTIMAL,
                                            VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
         GTEST_SKIP() << "Required VK_FORMAT_R8_UINT features not supported";
-    } else if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_G8_B8R8_2PLANE_420_UNORM, VK_IMAGE_TILING_OPTIMAL,
+    } else if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_G8_B8R8_2PLANE_420_UNORM, VK_IMAGE_TILING_OPTIMAL,
                                            VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
         GTEST_SKIP() << "Format not supported";
     }

--- a/tests/unit/debug_printf_ray_tracing.cpp
+++ b/tests/unit/debug_printf_ray_tracing.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2020-2024 The Khronos Group Inc.
- * Copyright (c) 2020-2024 Valve Corporation
- * Copyright (c) 2020-2024 LunarG, Inc.
- * Copyright (c) 2020-2024 Google, Inc.
+ * Copyright (c) 2020-2025 The Khronos Group Inc.
+ * Copyright (c) 2020-2025 Valve Corporation
+ * Copyright (c) 2020-2025 LunarG, Inc.
+ * Copyright (c) 2020-2025 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,9 +69,9 @@ class NegativeDebugPrintfRayTracing : public DebugPrintfTests {
             vkt::as::blueprint::BuildGeometryInfoOnDeviceBottomLevel(*m_device, std::move(cube)));
 
         // Build Bottom Level Acceleration Structure
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         out_cube_blas->BuildCmdBuffer(m_command_buffer.handle());
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         m_default_queue->Submit(m_command_buffer);
         m_device->Wait();
@@ -126,9 +126,9 @@ class NegativeDebugPrintfRayTracing : public DebugPrintfTests {
         tlas.SetNullInfos(false);
         tlas.SetNullBuildRangeInfos(false);
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         tlas.BuildCmdBuffer(m_command_buffer.handle());
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         m_default_queue->Submit(m_command_buffer);
         m_device->Wait();
@@ -904,14 +904,14 @@ TEST_F(NegativeDebugPrintfRayTracing, Raygen) {
 
     pipeline.Build();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(), 0, 1,
                               &pipeline.GetDescriptorSet().set_, 0, nullptr);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
     vkt::rt::TraceRaysSbt trace_rays_sbt = pipeline.GetTraceRaysSbt();
     vk::CmdTraceRaysKHR(m_command_buffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
                         &trace_rays_sbt.callable_sbt, 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_errorMonitor->SetDesiredInfo("In Raygen");
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -934,18 +934,18 @@ TEST_F(NegativeDebugPrintfRayTracing, RaygenOneMissShaderOneClosestHitShader) {
         vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device, vkt::as::GeometryKHR::Type::Triangle));
 
     // Build Bottom Level Acceleration Structure
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     blas->BuildCmdBuffer(m_command_buffer.handle());
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 
     // Build Top Level Acceleration Structure
     vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceTopLevel(*m_device, blas);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     tlas.BuildCmdBuffer(m_command_buffer.handle());
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
@@ -953,9 +953,9 @@ TEST_F(NegativeDebugPrintfRayTracing, RaygenOneMissShaderOneClosestHitShader) {
     // Buffer used to count invocations for the 3 shader types
     vkt::Buffer debug_buffer(*m_device, 3 * sizeof(uint32_t), VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
                              kHostVisibleMemProps);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdFillBuffer(m_command_buffer.handle(), debug_buffer.handle(), 0, debug_buffer.CreateInfo().size, 0);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
@@ -1062,7 +1062,7 @@ TEST_F(NegativeDebugPrintfRayTracing, RaygenOneMissShaderOneClosestHitShader) {
     const uint32_t ray_gen_depth = 1;
     const uint32_t ray_gen_rays_count = ray_gen_width * ray_gen_height * ray_gen_depth;
     for (uint32_t frame = 0; frame < frames_count; ++frame) {
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(),
                                   0, 1, &pipeline.GetDescriptorSet().set_, 0, nullptr);
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
@@ -1071,7 +1071,7 @@ TEST_F(NegativeDebugPrintfRayTracing, RaygenOneMissShaderOneClosestHitShader) {
         vk::CmdTraceRaysKHR(m_command_buffer.handle(), &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt,
                             &trace_rays_sbt.hit_sbt, &trace_rays_sbt.callable_sbt, ray_gen_width, ray_gen_height, ray_gen_depth);
 
-        m_command_buffer.end();
+        m_command_buffer.End();
         for (uint32_t i = 0; i < ray_gen_rays_count; ++i) {
             std::string msg = "In Raygen " + std::to_string(frame * ray_gen_rays_count + i);
             m_errorMonitor->SetDesiredInfo(msg.c_str());
@@ -1091,11 +1091,11 @@ TEST_F(NegativeDebugPrintfRayTracing, RaygenOneMissShaderOneClosestHitShader) {
         m_errorMonitor->VerifyFound();
     }
 
-    auto debug_buffer_ptr = static_cast<uint32_t*>(debug_buffer.memory().map());
+    auto debug_buffer_ptr = static_cast<uint32_t*>(debug_buffer.Memory().Map());
     ASSERT_EQ(debug_buffer_ptr[0], ray_gen_rays_count * frames_count);
     ASSERT_EQ(debug_buffer_ptr[1], 3 * ray_gen_rays_count * frames_count);
     ASSERT_EQ(debug_buffer_ptr[2], 2 * ray_gen_rays_count * frames_count);
-    debug_buffer.memory().unmap();
+    debug_buffer.Memory().Unmap();
 }
 
 TEST_F(NegativeDebugPrintfRayTracing, OneMultiEntryPointsShader) {
@@ -1118,18 +1118,18 @@ TEST_F(NegativeDebugPrintfRayTracing, OneMultiEntryPointsShader) {
         vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device, vkt::as::GeometryKHR::Type::Triangle));
 
     // Build Bottom Level Acceleration Structure
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     blas->BuildCmdBuffer(m_command_buffer.handle());
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 
     // Build Top Level Acceleration Structure
     vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceTopLevel(*m_device, blas);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     tlas.BuildCmdBuffer(m_command_buffer.handle());
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
@@ -1137,9 +1137,9 @@ TEST_F(NegativeDebugPrintfRayTracing, OneMultiEntryPointsShader) {
     // Buffer used to count invocations for the 3 shader types
     vkt::Buffer debug_buffer(*m_device, 3 * sizeof(uint32_t), VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
                              kHostVisibleMemProps);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdFillBuffer(m_command_buffer.handle(), debug_buffer.handle(), 0, debug_buffer.CreateInfo().size, 0);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
@@ -1161,7 +1161,7 @@ TEST_F(NegativeDebugPrintfRayTracing, OneMultiEntryPointsShader) {
 
     uint32_t frames_count = 42;
     for (uint32_t frame = 0; frame < frames_count; ++frame) {
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(),
                                   0, 1, &pipeline.GetDescriptorSet().set_, 0, nullptr);
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
@@ -1170,7 +1170,7 @@ TEST_F(NegativeDebugPrintfRayTracing, OneMultiEntryPointsShader) {
         vk::CmdTraceRaysKHR(m_command_buffer.handle(), &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt,
                             &trace_rays_sbt.hit_sbt, &trace_rays_sbt.callable_sbt, 1, 1, 1);
 
-        m_command_buffer.end();
+        m_command_buffer.End();
         m_errorMonitor->SetDesiredInfo("In Raygen");
         m_errorMonitor->SetDesiredInfo("In Miss", 3);
         m_errorMonitor->SetDesiredInfo("In Closest Hit", 2);
@@ -1179,11 +1179,11 @@ TEST_F(NegativeDebugPrintfRayTracing, OneMultiEntryPointsShader) {
     }
     m_errorMonitor->VerifyFound();
 
-    auto debug_buffer_ptr = static_cast<uint32_t*>(debug_buffer.memory().map());
+    auto debug_buffer_ptr = static_cast<uint32_t*>(debug_buffer.Memory().Map());
     ASSERT_EQ(debug_buffer_ptr[0], frames_count);
     ASSERT_EQ(debug_buffer_ptr[1], 3 * frames_count);
     ASSERT_EQ(debug_buffer_ptr[2], 2 * frames_count);
-    debug_buffer.memory().unmap();
+    debug_buffer.Memory().Unmap();
 }
 
 TEST_F(NegativeDebugPrintfRayTracing, OneMultiEntryPointsShader2CmdTraceRays) {
@@ -1204,9 +1204,9 @@ TEST_F(NegativeDebugPrintfRayTracing, OneMultiEntryPointsShader2CmdTraceRays) {
     // Buffer used to count invocations for the 2 * 3 shaders
     vkt::Buffer debug_buffer(*m_device, 2 * 3 * sizeof(uint32_t),
                              VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, kHostVisibleMemProps);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdFillBuffer(m_command_buffer.handle(), debug_buffer.handle(), 0, debug_buffer.CreateInfo().size, 0);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
@@ -1231,7 +1231,7 @@ TEST_F(NegativeDebugPrintfRayTracing, OneMultiEntryPointsShader2CmdTraceRays) {
 
     uint32_t frames_count = 42;
     for (uint32_t frame = 0; frame < frames_count; ++frame) {
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(),
                                   0, 1, &pipeline.GetDescriptorSet().set_, 0, nullptr);
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
@@ -1246,7 +1246,7 @@ TEST_F(NegativeDebugPrintfRayTracing, OneMultiEntryPointsShader2CmdTraceRays) {
         vk::CmdTraceRaysKHR(m_command_buffer.handle(), &sbt_ray_gen_2.ray_gen_sbt, &sbt_ray_gen_2.miss_sbt, &sbt_ray_gen_2.hit_sbt,
                             &sbt_ray_gen_2.callable_sbt, 1, 1, 1);
 
-        m_command_buffer.end();
+        m_command_buffer.End();
         m_errorMonitor->SetDesiredInfo("In Raygen 1");
         m_errorMonitor->SetDesiredInfo("In Raygen 2");
         m_errorMonitor->SetDesiredInfo("In Miss 1", 2);
@@ -1259,14 +1259,14 @@ TEST_F(NegativeDebugPrintfRayTracing, OneMultiEntryPointsShader2CmdTraceRays) {
     m_errorMonitor->VerifyFound();
 
     // Check debug buffer to cross check that every expected shader invocation happened
-    auto debug_buffer_ptr = static_cast<uint32_t*>(debug_buffer.memory().map());
+    auto debug_buffer_ptr = static_cast<uint32_t*>(debug_buffer.Memory().Map());
     ASSERT_EQ(debug_buffer_ptr[0], 1 * frames_count);
     ASSERT_EQ(debug_buffer_ptr[1], 1 * frames_count);
     ASSERT_EQ(debug_buffer_ptr[2], (2 + 0) * frames_count);
     ASSERT_EQ(debug_buffer_ptr[3], (1 + 1) * frames_count);
     ASSERT_EQ(debug_buffer_ptr[4], (1 + 1) * frames_count);
     ASSERT_EQ(debug_buffer_ptr[5], (1 + 2) * frames_count);
-    debug_buffer.memory().unmap();
+    debug_buffer.Memory().Unmap();
 }
 
 TEST_F(NegativeDebugPrintfRayTracing, OneMultiEntryPointsShader2CmdTraceRaysIndirect) {
@@ -1289,9 +1289,9 @@ TEST_F(NegativeDebugPrintfRayTracing, OneMultiEntryPointsShader2CmdTraceRaysIndi
     // Buffer used to count invocations for the 2 * 3 shaders
     vkt::Buffer debug_buffer(*m_device, 2 * 3 * sizeof(uint32_t),
                              VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, kHostVisibleMemProps);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdFillBuffer(m_command_buffer.handle(), debug_buffer.handle(), 0, debug_buffer.CreateInfo().size, 0);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
@@ -1319,18 +1319,18 @@ TEST_F(NegativeDebugPrintfRayTracing, OneMultiEntryPointsShader2CmdTraceRaysIndi
 
     uint32_t frames_count = 42;
     for (uint32_t frame = 0; frame < frames_count; ++frame) {
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(),
                                   0, 1, &pipeline.GetDescriptorSet().set_, 0, nullptr);
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
 
         // Invoke ray gen shader 1
-        vk::CmdTraceRaysIndirect2KHR(m_command_buffer.handle(), sbt_ray_gen_1.address());
+        vk::CmdTraceRaysIndirect2KHR(m_command_buffer.handle(), sbt_ray_gen_1.Address());
 
         // Invoke ray gen shader 2
-        vk::CmdTraceRaysIndirect2KHR(m_command_buffer.handle(), sbt_ray_gen_2.address());
+        vk::CmdTraceRaysIndirect2KHR(m_command_buffer.handle(), sbt_ray_gen_2.Address());
 
-        m_command_buffer.end();
+        m_command_buffer.End();
         m_errorMonitor->SetDesiredInfo("In Raygen 1");
         m_errorMonitor->SetDesiredInfo("In Raygen 2");
         m_errorMonitor->SetDesiredInfo("In Miss 1", 2);
@@ -1343,14 +1343,14 @@ TEST_F(NegativeDebugPrintfRayTracing, OneMultiEntryPointsShader2CmdTraceRaysIndi
     }
 
     // Check debug buffer to cross check that every expected shader invocation happened
-    auto debug_buffer_ptr = static_cast<uint32_t*>(debug_buffer.memory().map());
+    auto debug_buffer_ptr = static_cast<uint32_t*>(debug_buffer.Memory().Map());
     ASSERT_EQ(debug_buffer_ptr[0], 1 * frames_count);
     ASSERT_EQ(debug_buffer_ptr[1], 1 * frames_count);
     ASSERT_EQ(debug_buffer_ptr[2], (2 + 0) * frames_count);
     ASSERT_EQ(debug_buffer_ptr[3], (1 + 1) * frames_count);
     ASSERT_EQ(debug_buffer_ptr[4], (1 + 1) * frames_count);
     ASSERT_EQ(debug_buffer_ptr[5], (1 + 2) * frames_count);
-    debug_buffer.memory().unmap();
+    debug_buffer.Memory().Unmap();
 }
 
 TEST_F(NegativeDebugPrintfRayTracing, OneMultiEntryPointsShader2CmdTraceRaysIndirectDeferredBuild) {
@@ -1373,9 +1373,9 @@ TEST_F(NegativeDebugPrintfRayTracing, OneMultiEntryPointsShader2CmdTraceRaysIndi
     // Buffer used to count invocations for the 2 * 3 shaders
     vkt::Buffer debug_buffer(*m_device, 2 * 3 * sizeof(uint32_t),
                              VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, kHostVisibleMemProps);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdFillBuffer(m_command_buffer.handle(), debug_buffer.handle(), 0, debug_buffer.CreateInfo().size, 0);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
@@ -1408,18 +1408,18 @@ TEST_F(NegativeDebugPrintfRayTracing, OneMultiEntryPointsShader2CmdTraceRaysIndi
 
     uint32_t frames_count = 1;
     for (uint32_t frame = 0; frame < frames_count; ++frame) {
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(),
                                   0, 1, &pipeline.GetDescriptorSet().set_, 0, nullptr);
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
 
         // Invoke ray gen shader 1
-        vk::CmdTraceRaysIndirect2KHR(m_command_buffer.handle(), sbt_ray_gen_1.address());
+        vk::CmdTraceRaysIndirect2KHR(m_command_buffer.handle(), sbt_ray_gen_1.Address());
 
         // Invoke ray gen shader 2
-        vk::CmdTraceRaysIndirect2KHR(m_command_buffer.handle(), sbt_ray_gen_2.address());
+        vk::CmdTraceRaysIndirect2KHR(m_command_buffer.handle(), sbt_ray_gen_2.Address());
 
-        m_command_buffer.end();
+        m_command_buffer.End();
         m_errorMonitor->SetDesiredInfo("In Raygen 1", ray_gen_1_rays_count);
         m_errorMonitor->SetDesiredInfo("In Raygen 2");
         m_errorMonitor->SetDesiredInfo("In Miss 1", 2 * ray_gen_1_rays_count + 0);
@@ -1432,12 +1432,12 @@ TEST_F(NegativeDebugPrintfRayTracing, OneMultiEntryPointsShader2CmdTraceRaysIndi
     m_errorMonitor->VerifyFound();
 
     // Check debug buffer to cross check that every expected shader invocation happened
-    auto debug_buffer_ptr = static_cast<uint32_t*>(debug_buffer.memory().map());
+    auto debug_buffer_ptr = static_cast<uint32_t*>(debug_buffer.Memory().Map());
     ASSERT_EQ(debug_buffer_ptr[0], 1 * ray_gen_1_rays_count * frames_count);
     ASSERT_EQ(debug_buffer_ptr[1], 1 * frames_count);
     ASSERT_EQ(debug_buffer_ptr[2], (2 * ray_gen_1_rays_count + 0) * frames_count);
     ASSERT_EQ(debug_buffer_ptr[3], (1 * ray_gen_1_rays_count + 1) * frames_count);
     ASSERT_EQ(debug_buffer_ptr[4], (1 * ray_gen_1_rays_count + 1) * frames_count);
     ASSERT_EQ(debug_buffer_ptr[5], (1 * ray_gen_1_rays_count + 2) * frames_count);
-    debug_buffer.memory().unmap();
+    debug_buffer.Memory().Unmap();
 }

--- a/tests/unit/fragment_shading_rate.cpp
+++ b/tests/unit/fragment_shading_rate.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (c) 2015-2024 Google, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2025 Google, Inc.
  * Modifications Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -172,7 +172,7 @@ TEST_F(NegativeFragmentShadingRate, CombinerOpsLimit) {
     VkFragmentShadingRateCombinerOpKHR combinerOps[2] = {VK_FRAGMENT_SHADING_RATE_COMBINER_OP_KEEP_KHR,
                                                          VK_FRAGMENT_SHADING_RATE_COMBINER_OP_KEEP_KHR};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     {
         // primitiveFragmentShadingRate
         combinerOps[0] = VK_FRAGMENT_SHADING_RATE_COMBINER_OP_MUL_KHR;

--- a/tests/unit/gpu_av_buffer_device_address_positive.cpp
+++ b/tests/unit/gpu_av_buffer_device_address_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2020-2024 The Khronos Group Inc.
- * Copyright (c) 2020-2024 Valve Corporation
- * Copyright (c) 2020-2024 LunarG, Inc.
- * Copyright (c) 2020-2024 Google, Inc.
+ * Copyright (c) 2020-2025 The Khronos Group Inc.
+ * Copyright (c) 2020-2025 Valve Corporation
+ * Copyright (c) 2020-2025 LunarG, Inc.
+ * Copyright (c) 2020-2025 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1679,10 +1679,10 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, SharedPipelineLayoutSubsetGraphicsPushC
             uint i;
         };
 
-        layout(push_constant, std430) uniform foo_0 { 
+        layout(push_constant, std430) uniform foo_0 {
             Ptr ptr;
-            uint a; 
-            uint b; 
+            uint a;
+            uint b;
         };
         void main() {
             ptr.i = a + b;
@@ -1711,7 +1711,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, SharedPipelineLayoutSubsetGraphicsPushC
 
     vkt::Buffer out_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
 
-    std::array<VkDeviceAddress, 3> push_constants_data = {{out_buffer.address(), VkDeviceAddress(2) << 32 | 1u, 3}};
+    std::array<VkDeviceAddress, 3> push_constants_data = {{out_buffer.Address(), VkDeviceAddress(2) << 32 | 1u, 3}};
 
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
     m_command_buffer.Begin(&begin_info);
@@ -1778,10 +1778,10 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, SharedPipelineLayoutSubsetGraphicsPushC
             uint i;
         };
 
-        layout(push_constant, std430) uniform foo_0 { 
+        layout(push_constant, std430) uniform foo_0 {
             Ptr ptr;
-            uint a; 
-            uint b; 
+            uint a;
+            uint b;
         };
         void main() {
             ptr.i = a + b;
@@ -1824,7 +1824,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, SharedPipelineLayoutSubsetGraphicsPushC
 
     vkt::Buffer out_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
 
-    std::array<VkDeviceAddress, 3> push_constants_data = {{out_buffer.address(), VkDeviceAddress(2) << 32 | 1u, 3}};
+    std::array<VkDeviceAddress, 3> push_constants_data = {{out_buffer.Address(), VkDeviceAddress(2) << 32 | 1u, 3}};
 
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
     m_command_buffer.Begin(&begin_info);

--- a/tests/unit/gpu_av_index_buffer.cpp
+++ b/tests/unit/gpu_av_index_buffer.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2020-2024 The Khronos Group Inc.
- * Copyright (c) 2020-2024 Valve Corporation
- * Copyright (c) 2020-2024 LunarG, Inc.
- * Copyright (c) 2020-2024 Google, Inc.
+ * Copyright (c) 2020-2025 The Khronos Group Inc.
+ * Copyright (c) 2020-2025 Valve Corporation
+ * Copyright (c) 2020-2025 LunarG, Inc.
+ * Copyright (c) 2020-2025 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ TEST_F(NegativeGpuAVIndexBuffer, IndexBufferOOB) {
     vk::CmdBindIndexBuffer(m_command_buffer.handle(), index_buffer.handle(), 0, VK_INDEX_TYPE_UINT32);
     vk::CmdDrawIndexedIndirect(m_command_buffer.handle(), draw_params_buffer.handle(), 0, 1, sizeof(VkDrawIndexedIndirectCommand));
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
     m_errorMonitor->VerifyFound();
@@ -65,9 +65,9 @@ TEST_F(NegativeGpuAVIndexBuffer, IndirectDrawBadVertexIndex32) {
 
     char const *vsSource = R"glsl(
         #version 450
-        
+
         layout(location=0) in vec3 pos;
-        
+
         void main() {
         gl_Position = vec4(pos, 1.0);
         }
@@ -112,7 +112,7 @@ TEST_F(NegativeGpuAVIndexBuffer, IndirectDrawBadVertexIndex32) {
     vk::CmdDrawIndexedIndirect(m_command_buffer.handle(), draw_params_buffer.handle(), 0, 1, sizeof(VkDrawIndexedIndirectCommand));
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -129,9 +129,9 @@ TEST_F(NegativeGpuAVIndexBuffer, IndirectDrawBadVertexIndex16) {
 
     char const *vsSource = R"glsl(
         #version 450
-        
+
         layout(location=0) in vec3 pos;
-        
+
         void main() {
         gl_Position = vec4(pos, 1.0);
         }
@@ -177,7 +177,7 @@ TEST_F(NegativeGpuAVIndexBuffer, IndirectDrawBadVertexIndex16) {
     vk::CmdDrawIndexedIndirect(m_command_buffer.handle(), draw_params_buffer.handle(), 0, 1, sizeof(VkDrawIndexedIndirectCommand));
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -197,9 +197,9 @@ TEST_F(NegativeGpuAVIndexBuffer, IndirectDrawBadVertexIndex8) {
 
     char const *vsSource = R"glsl(
         #version 450
-        
+
         layout(location=0) in vec3 pos;
-        
+
         void main() {
         gl_Position = vec4(pos, 1.0);
         }
@@ -244,7 +244,7 @@ TEST_F(NegativeGpuAVIndexBuffer, IndirectDrawBadVertexIndex8) {
     vk::CmdDrawIndexedIndirect(m_command_buffer.handle(), draw_params_buffer.handle(), 0, 1, sizeof(VkDrawIndexedIndirectCommand));
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -261,9 +261,9 @@ TEST_F(NegativeGpuAVIndexBuffer, DrawBadVertexIndex32) {
 
     char const *vsSource = R"glsl(
         #version 450
-        
+
         layout(location=0) in vec3 pos;
-        
+
         void main() {
         gl_Position = vec4(pos, 1.0);
         }
@@ -309,7 +309,7 @@ TEST_F(NegativeGpuAVIndexBuffer, DrawBadVertexIndex32) {
     vk::CmdDrawIndexed(m_command_buffer.handle(), 3, 1, 0, 3, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -326,9 +326,9 @@ TEST_F(NegativeGpuAVIndexBuffer, DISABLED_DrawInSecondaryCmdBufferBadVertexIndex
 
     char const *vsSource = R"glsl(
         #version 450
-        
+
         layout(location=0) in vec3 pos;
-        
+
         void main() {
         gl_Position = vec4(pos, 1.0);
         }
@@ -367,7 +367,7 @@ TEST_F(NegativeGpuAVIndexBuffer, DISABLED_DrawInSecondaryCmdBufferBadVertexIndex
             secondary_cmd_buffers.emplace_back(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
         secondary_cmd_buffers_handles.push_back(secondary_cmd_buffer.handle());
 
-        secondary_cmd_buffer.begin(&secondary_begin_info);
+        secondary_cmd_buffer.Begin(&secondary_begin_info);
         vk::CmdBindPipeline(secondary_cmd_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
         VkDeviceSize vertex_buffer_offset = 0;
@@ -389,7 +389,7 @@ TEST_F(NegativeGpuAVIndexBuffer, DISABLED_DrawInSecondaryCmdBufferBadVertexIndex
                                              "index_buffer\\[2\\] \\(42\\) \\+ vertexOffset \\(3\\) = Vertex index 45");
         vk::CmdDrawIndexed(secondary_cmd_buffer.handle(), 3, 1, 0, 3, 0);
 
-        secondary_cmd_buffer.end();
+        secondary_cmd_buffer.End();
     }
 
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
@@ -399,7 +399,7 @@ TEST_F(NegativeGpuAVIndexBuffer, DISABLED_DrawInSecondaryCmdBufferBadVertexIndex
     vk::CmdExecuteCommands(m_command_buffer.handle(), size32(secondary_cmd_buffers_handles), secondary_cmd_buffers_handles.data());
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -416,9 +416,9 @@ TEST_F(NegativeGpuAVIndexBuffer, DrawBadVertexIndex16) {
 
     char const *vsSource = R"glsl(
         #version 450
-        
+
         layout(location=0) in vec3 pos;
-        
+
         void main() {
         gl_Position = vec4(pos, 1.0);
         }
@@ -456,7 +456,7 @@ TEST_F(NegativeGpuAVIndexBuffer, DrawBadVertexIndex16) {
     vk::CmdDrawIndexed(m_command_buffer.handle(), 3, 1, 0, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -479,11 +479,11 @@ TEST_F(NegativeGpuAVIndexBuffer, DrawBadVertexIndex16_2) {
 
     char const *vsSource = R"glsl(
         #version 450
-        
+
         layout(location=0) in vec3 pos;
         layout(location=1) in vec2 uv;
         layout(location=2) in vec3 normal;
-        
+
         void main() {
         gl_Position = vec4(pos + uv.xyx + normal, 1.0);
         }
@@ -535,7 +535,7 @@ TEST_F(NegativeGpuAVIndexBuffer, DrawBadVertexIndex16_2) {
     vk::CmdDrawIndexed(m_command_buffer.handle(), 3, 1, 0, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -554,9 +554,9 @@ TEST_F(NegativeGpuAVIndexBuffer, DrawBadVertexIndex8) {
 
     char const *vsSource = R"glsl(
         #version 450
-        
+
         layout(location=0) in vec3 pos;
-        
+
         void main() {
         gl_Position = vec4(pos, 1.0);
         }
@@ -595,7 +595,7 @@ TEST_F(NegativeGpuAVIndexBuffer, DrawBadVertexIndex8) {
     vk::CmdDrawIndexed(m_command_buffer.handle(), 3, 1, 0, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -620,11 +620,11 @@ TEST_F(NegativeGpuAVIndexBuffer, DrawBadVertexIndex16DebugLabel) {
 
     char const *vsSource = R"glsl(
         #version 450
-        
+
         layout(location=0) in vec3 pos;
         layout(location=1) in vec2 uv;
         layout(location=2) in vec3 normal;
-        
+
         void main() {
         gl_Position = vec4(pos + uv.xyx + normal, 1.0);
         }
@@ -687,7 +687,7 @@ TEST_F(NegativeGpuAVIndexBuffer, DrawBadVertexIndex16DebugLabel) {
     vk::CmdEndDebugUtilsLabelEXT(m_command_buffer);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -706,9 +706,9 @@ TEST_F(NegativeGpuAVIndexBuffer, IndirectDrawBadVertexIndex32DebugLabel) {
 
     char const *vsSource = R"glsl(
         #version 450
-        
+
         layout(location=0) in vec3 pos;
-        
+
         void main() {
         gl_Position = vec4(pos, 1.0);
         }
@@ -764,7 +764,7 @@ TEST_F(NegativeGpuAVIndexBuffer, IndirectDrawBadVertexIndex32DebugLabel) {
     vk::CmdEndDebugUtilsLabelEXT(m_command_buffer);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();

--- a/tests/unit/gpu_av_index_buffer_positive.cpp
+++ b/tests/unit/gpu_av_index_buffer_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2020-2024 The Khronos Group Inc.
- * Copyright (c) 2020-2024 Valve Corporation
- * Copyright (c) 2020-2024 LunarG, Inc.
- * Copyright (c) 2020-2024 Google, Inc.
+ * Copyright (c) 2020-2025 The Khronos Group Inc.
+ * Copyright (c) 2020-2025 Valve Corporation
+ * Copyright (c) 2020-2025 LunarG, Inc.
+ * Copyright (c) 2020-2025 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ TEST_F(PositiveGpuAVIndexBuffer, BadVertexIndex) {
     vkt::Buffer draw_params_buffer = vkt::IndirectBuffer<VkDrawIndexedIndirectCommand>(*m_device, {draw_params});
 
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
-    m_command_buffer.begin(&begin_info);
+    m_command_buffer.Begin(&begin_info);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vkt::Buffer index_buffer = vkt::IndexBuffer<uint32_t>(*m_device, {0, std::numeric_limits<uint32_t>::max(), 42});
@@ -45,7 +45,7 @@ TEST_F(PositiveGpuAVIndexBuffer, BadVertexIndex) {
     vk::CmdBindIndexBuffer(m_command_buffer.handle(), index_buffer.handle(), 0, VK_INDEX_TYPE_UINT32);
     vk::CmdDrawIndexedIndirect(m_command_buffer.handle(), draw_params_buffer.handle(), 0, 1, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }
@@ -77,14 +77,14 @@ TEST_F(PositiveGpuAVIndexBuffer, VertexIndex) {
     vkt::Buffer draw_params_buffer = vkt::IndirectBuffer<VkDrawIndexedIndirectCommand>(*m_device, {draw_params});
 
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
-    m_command_buffer.begin(&begin_info);
+    m_command_buffer.Begin(&begin_info);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
     vk::CmdBindIndexBuffer(m_command_buffer.handle(), index_buffer.handle(), 0, VK_INDEX_TYPE_UINT32);
     vk::CmdDrawIndexedIndirect(m_command_buffer.handle(), draw_params_buffer.handle(), 0, 1, sizeof(VkDrawIndexedIndirectCommand));
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }
@@ -106,9 +106,9 @@ TEST_F(PositiveGpuAVIndexBuffer, DrawIndexedDynamicStates) {
 
     char const *vsSource = R"glsl(
         #version 450
-        
+
         layout(location=0) in vec3 pos;
-        
+
         void main() {
             gl_Position = vec4(pos, 1.0);
         }
@@ -138,7 +138,7 @@ TEST_F(PositiveGpuAVIndexBuffer, DrawIndexedDynamicStates) {
     VkDeviceSize vertex_buffer_offset = 0;
 
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
-    m_command_buffer.begin(&begin_info);
+    m_command_buffer.Begin(&begin_info);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -158,7 +158,7 @@ TEST_F(PositiveGpuAVIndexBuffer, DrawIndexedDynamicStates) {
     vk::CmdDrawIndexed(m_command_buffer.handle(), 3, 1, 0, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();

--- a/tests/unit/gpu_av_indirect_buffer.cpp
+++ b/tests/unit/gpu_av_indirect_buffer.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2020-2024 The Khronos Group Inc.
- * Copyright (c) 2020-2024 Valve Corporation
- * Copyright (c) 2020-2024 LunarG, Inc.
- * Copyright (c) 2020-2024 Google, Inc.
+ * Copyright (c) 2020-2025 The Khronos Group Inc.
+ * Copyright (c) 2020-2025 Valve Corporation
+ * Copyright (c) 2020-2025 LunarG, Inc.
+ * Copyright (c) 2020-2025 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -226,7 +226,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
 
     CreatePipelineHelper pipe(*this);
     pipe.CreateGraphicsPipeline();
-    uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.memory().map());
+    uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
     *count_ptr = 2;
     count_buffer.Memory().Unmap();
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
@@ -245,7 +245,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
     m_default_queue->Wait();
     m_errorMonitor->VerifyFound();
 
-    count_ptr = static_cast<uint32_t *>(count_buffer.memory().map());
+    count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
     *count_ptr = 1;
     count_buffer.Memory().Unmap();
 
@@ -296,7 +296,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
     m_default_queue->Wait();
     m_errorMonitor->VerifyFound();
 
-    count_ptr = static_cast<uint32_t *>(count_buffer.memory().map());
+    count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
     *count_ptr = 1;
     count_buffer.Memory().Unmap();
 
@@ -340,12 +340,12 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
         mesh_draw_ptr->groupCountX = 0;
         mesh_draw_ptr->groupCountY = 0;
         mesh_draw_ptr->groupCountZ = 0;
-        mesh_draw_buffer.memory().unmap();
+        mesh_draw_buffer.Memory().Unmap();
         m_errorMonitor->SetDesiredWarningRegex(
             "WARNING-GPU-AV-drawCount",
             "Indirect draw count of 1 would exceed size \\(12\\) of buffer .* stride = 12 offset = 8 "
             ".* = 20");
-        count_ptr = static_cast<uint32_t *>(count_buffer.memory().map());
+        count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
         *count_ptr = 1;
         count_buffer.Memory().Unmap();
         m_command_buffer.Begin(&begin_info);
@@ -363,7 +363,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
             "WARNING-GPU-AV-drawCount",
             "Indirect draw count of 2 would exceed size \\(12\\) of buffer .* stride = 12 offset = 4 "
             ".* = 28");
-        count_ptr = static_cast<uint32_t *>(count_buffer.memory().map());
+        count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
         *count_ptr = 2;
         count_buffer.Memory().Unmap();
         m_command_buffer.Begin(&begin_info);
@@ -437,7 +437,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, Mesh) {
     vk::CmdDrawMeshTasksIndirectEXT(m_command_buffer.handle(), draw_buffer.handle(), 0, 3,
                                     (sizeof(VkDrawMeshTasksIndirectCommandEXT) + 4));
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     if (mesh_shader_props.maxMeshWorkGroupCount[0] < std::numeric_limits<uint32_t>::max()) {
         draw_ptr[8] = mesh_shader_props.maxMeshWorkGroupCount[0] + 1;
@@ -653,7 +653,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, FirstInstance) {
     vk::CmdDrawIndirect(m_command_buffer.handle(), draw_params_buffer.handle(), 0, 4, sizeof(VkDrawIndirectCommand));
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();

--- a/tests/unit/gpu_av_indirect_buffer_positive.cpp
+++ b/tests/unit/gpu_av_indirect_buffer_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2020-2024 The Khronos Group Inc.
- * Copyright (c) 2020-2024 Valve Corporation
- * Copyright (c) 2020-2024 LunarG, Inc.
- * Copyright (c) 2020-2024 Google, Inc.
+ * Copyright (c) 2020-2025 The Khronos Group Inc.
+ * Copyright (c) 2020-2025 Valve Corporation
+ * Copyright (c) 2020-2025 LunarG, Inc.
+ * Copyright (c) 2020-2025 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -171,7 +171,7 @@ TEST_F(PositiveGpuAVIndirectBuffer, Mesh) {
     vk::CmdDrawMeshTasksIndirectEXT(m_command_buffer.handle(), draw_buffer.handle(), 0, 3,
                                     (sizeof(VkDrawMeshTasksIndirectCommandEXT) + 4));
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -235,7 +235,7 @@ TEST_F(PositiveGpuAVIndirectBuffer, MeshSingleCommand) {
 
     vk::CmdDrawMeshTasksIndirectEXT(m_command_buffer.handle(), draw_buffer.handle(), 0, 1, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -269,7 +269,7 @@ TEST_F(PositiveGpuAVIndirectBuffer, FirstInstanceSingleDrawIndirectCommand) {
     vk::CmdDrawIndirect(m_command_buffer.handle(), draw_params_buffer.handle(), 0, 1, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();

--- a/tests/unit/ray_tracing_positive.cpp
+++ b/tests/unit/ray_tracing_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (c) 2015-2024 Google, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2025 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1417,12 +1417,12 @@ TEST_F(PositiveRayTracing, BasicOpacityMicromapBuild) {
     {
         char* ptr;
 
-        vk::MapMemory(device(), vertexBuffer.memory(), 0, VK_WHOLE_SIZE, 0, (void**)&ptr);
+        vk::MapMemory(device(), vertexBuffer.Memory(), 0, VK_WHOLE_SIZE, 0, (void**)&ptr);
 
         memcpy(ptr, &vertexData[0], sizeof(vertexData));
         memcpy(ptr+sizeof(vertexData), &indexData[0], sizeof(indexData));
 
-        vk::UnmapMemory(device(), vertexBuffer.memory());
+        vk::UnmapMemory(device(), vertexBuffer.Memory());
     }
 
     VkAccelerationStructureBuildSizesInfoKHR bottomASBuildSizesInfo{VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_SIZES_INFO_KHR};
@@ -1672,12 +1672,12 @@ TEST_F(PositiveRayTracing, SerializeAccelerationStructure) {
 
     VkCopyAccelerationStructureToMemoryInfoKHR copy_accel_struct_to_memory_info = vku::InitStructHelper();
     copy_accel_struct_to_memory_info.src = blas.GetDstAS()->handle();
-    copy_accel_struct_to_memory_info.dst.deviceAddress = serialized_accel_struct_buffer.address();
+    copy_accel_struct_to_memory_info.dst.deviceAddress = serialized_accel_struct_buffer.Address();
     copy_accel_struct_to_memory_info.mode = VK_COPY_ACCELERATION_STRUCTURE_MODE_SERIALIZE_KHR;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdCopyAccelerationStructureToMemoryKHR(m_command_buffer.handle(), &copy_accel_struct_to_memory_info);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 
@@ -1693,15 +1693,15 @@ TEST_F(PositiveRayTracing, SerializeAccelerationStructure) {
     deserialized_blas.GetDstAS()->Build();
 
     VkCopyMemoryToAccelerationStructureInfoKHR copy_memory_to_accel_struct_info = vku::InitStructHelper();
-    copy_memory_to_accel_struct_info.src.deviceAddress = serialized_accel_struct_buffer.address();
+    copy_memory_to_accel_struct_info.src.deviceAddress = serialized_accel_struct_buffer.Address();
     copy_memory_to_accel_struct_info.dst = deserialized_blas.GetDstAS()->handle();
     copy_memory_to_accel_struct_info.mode = VK_COPY_ACCELERATION_STRUCTURE_MODE_DESERIALIZE_KHR;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vk::CmdCopyMemoryToAccelerationStructureKHR(m_command_buffer.handle(), &copy_memory_to_accel_struct_info);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 

--- a/tests/unit/robustness.cpp
+++ b/tests/unit/robustness.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 Valve Corporation
- * Copyright (c) 2023-2024 LunarG, Inc.
+ * Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 Valve Corporation
+ * Copyright (c) 2023-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -224,7 +224,7 @@ TEST_F(NegativeRobustness, PipelineRobustnessRobustImageAccessNotExposed) {
     if (DeviceValidationVersion() > VK_API_VERSION_1_2) {
         GTEST_SKIP() << "version 1.3 enables extensions which we don't want";
     }
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_IMAGE_ROBUSTNESS_EXTENSION_NAME)) {
+    if (DeviceExtensionSupported(Gpu(), nullptr, VK_EXT_IMAGE_ROBUSTNESS_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_EXT_image_robustness is supported";
     }
 

--- a/tests/unit/shader_object.cpp
+++ b/tests/unit/shader_object.cpp
@@ -1,6 +1,6 @@
 ﻿/*
- * Copyright (c) 2023-2024 Nintendo
- * Copyright (c) 2023-2024 LunarG, Inc.
+ * Copyright (c) 2023-2025 Nintendo
+ * Copyright (c) 2023-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -6980,7 +6980,7 @@ TEST_F(NegativeShaderObject, SetPrimitiveTopologyNonPatch) {
                                  GLSLToSPV(VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT, kTessellationEvalMinimalGlsl));
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT,
@@ -6995,7 +6995,7 @@ TEST_F(NegativeShaderObject, SetPrimitiveTopologyNonPatch) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeShaderObject, DescriptorWrongStage) {

--- a/tests/unit/shader_object_positive.cpp
+++ b/tests/unit/shader_object_positive.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 Nintendo
- * Copyright (c) 2023-2024 LunarG, Inc.
+ * Copyright (c) 2023-2025 Nintendo
+ * Copyright (c) 2023-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1681,7 +1681,7 @@ TEST_F(PositiveShaderObject, SetPatchControlPointsEXT) {
                                  GLSLToSPV(VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT, kTessellationEvalMinimalGlsl));
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_PATCH_CONTROL_POINTS_EXT, VK_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY});
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT,
@@ -1694,5 +1694,5 @@ TEST_F(PositiveShaderObject, SetPatchControlPointsEXT) {
     vk::CmdSetPatchControlPointsEXT(m_command_buffer.handle(), 3);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (c) 2015-2024 Google, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2025 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1939,10 +1939,10 @@ TEST_F(PositiveSyncVal, QueueFamilyOwnershipTransfer) {
         release_dependency.imageMemoryBarrierCount = 1;
         release_dependency.pImageMemoryBarriers = &release_barrier;
 
-        transfer_command_buffer.begin();
+        transfer_command_buffer.Begin();
         vk::CmdCopyBufferToImage2(transfer_command_buffer, &copy_info);
         vk::CmdPipelineBarrier2(transfer_command_buffer, &release_dependency);
-        transfer_command_buffer.end();
+        transfer_command_buffer.End();
 
         transfer_queue->Submit2(transfer_command_buffer, vkt::Signal(semaphore));
     }
@@ -1969,9 +1969,9 @@ TEST_F(PositiveSyncVal, QueueFamilyOwnershipTransfer) {
         acquire_dependency.imageMemoryBarrierCount = 1;
         acquire_dependency.pImageMemoryBarriers = &acquire_barrier;
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vk::CmdPipelineBarrier2(m_command_buffer, &acquire_dependency);
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         m_default_queue->Submit2(m_command_buffer, vkt::Wait(semaphore));
     }

--- a/tests/unit/vertex_input.cpp
+++ b/tests/unit/vertex_input.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (c) 2015-2024 Google, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2025 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1860,7 +1860,7 @@ TEST_F(NegativeVertexInput, VertexInputRebinding) {
     VkDeviceSize offsets[2] = {0, 0};
     VkBuffer buffers[2] = {vertex_buffer.handle(), vertex_buffer.handle()};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindVertexBuffers(m_command_buffer.handle(), 0, 2, buffers, offsets);
@@ -1874,5 +1874,5 @@ TEST_F(NegativeVertexInput, VertexInputRebinding) {
     vk::CmdDraw(m_command_buffer.handle(), 3u, 3u, 0u, 0u);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }

--- a/tests/unit/vertex_input_positive.cpp
+++ b/tests/unit/vertex_input_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (c) 2015-2024 Google, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2025 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1087,7 +1087,7 @@ TEST_F(PositiveVertexInput, VertexInputRebinding) {
     VkDeviceSize offsets[2] = {0, 0};
     VkBuffer buffers[2] = {vertex_buffer.handle(), vertex_buffer.handle()};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdSetVertexInputEXT(m_command_buffer.handle(), 2, bindings, 2, attributes);
@@ -1099,5 +1099,5 @@ TEST_F(PositiveVertexInput, VertexInputRebinding) {
     vk::CmdBindVertexBuffers(m_command_buffer.handle(), 0, 2, buffers, offsets);
     vk::CmdDraw(m_command_buffer.handle(), 3u, 3u, 0u, 0u);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }

--- a/tests/unit/video.cpp
+++ b/tests/unit/video.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2022-2024 The Khronos Group Inc.
- * Copyright (c) 2022-2024 RasterGrid Kft.
+ * Copyright (c) 2022-2025 The Khronos Group Inc.
+ * Copyright (c) 2022-2025 RasterGrid Kft.
  * Modifications Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -86,14 +86,14 @@ TEST_F(NegativeVideo, VideoProfileInvalidLumaChromaSubsampling) {
     m_errorMonitor->SetDesiredError("VUID-VkVideoProfileInfoKHR-chromaSubsampling-07013");
     profile = *config.Profile();
     profile.chromaSubsampling = VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR | VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR;
-    vk::GetPhysicalDeviceVideoCapabilitiesKHR(gpu(), &profile, config.Caps());
+    vk::GetPhysicalDeviceVideoCapabilitiesKHR(Gpu(), &profile, config.Caps());
     m_errorMonitor->VerifyFound();
 
     // Multiple bits in lumaBitDepth
     m_errorMonitor->SetDesiredError("VUID-VkVideoProfileInfoKHR-lumaBitDepth-07014");
     profile = *config.Profile();
     profile.lumaBitDepth = VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR | VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR;
-    vk::GetPhysicalDeviceVideoCapabilitiesKHR(gpu(), &profile, config.Caps());
+    vk::GetPhysicalDeviceVideoCapabilitiesKHR(Gpu(), &profile, config.Caps());
     m_errorMonitor->VerifyFound();
 
     // Multiple bits in chromaBitDepth
@@ -101,7 +101,7 @@ TEST_F(NegativeVideo, VideoProfileInvalidLumaChromaSubsampling) {
     profile = *config.Profile();
     profile.chromaSubsampling = VK_VIDEO_CHROMA_SUBSAMPLING_420_BIT_KHR;
     profile.chromaBitDepth = VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR | VK_VIDEO_COMPONENT_BIT_DEPTH_10_BIT_KHR;
-    vk::GetPhysicalDeviceVideoCapabilitiesKHR(gpu(), &profile, config.Caps());
+    vk::GetPhysicalDeviceVideoCapabilitiesKHR(Gpu(), &profile, config.Caps());
     m_errorMonitor->VerifyFound();
 }
 
@@ -120,7 +120,7 @@ TEST_F(NegativeVideo, VideoProfileMissingCodecInfo) {
 
         // Missing codec-specific info for H.264 decode profile
         m_errorMonitor->SetDesiredError("VUID-VkVideoProfileInfoKHR-videoCodecOperation-07179");
-        vk::GetPhysicalDeviceVideoCapabilitiesKHR(gpu(), &profile, config.Caps());
+        vk::GetPhysicalDeviceVideoCapabilitiesKHR(Gpu(), &profile, config.Caps());
         m_errorMonitor->VerifyFound();
     }
 
@@ -132,7 +132,7 @@ TEST_F(NegativeVideo, VideoProfileMissingCodecInfo) {
 
         // Missing codec-specific info for H.265 decode profile
         m_errorMonitor->SetDesiredError("VUID-VkVideoProfileInfoKHR-videoCodecOperation-07180");
-        vk::GetPhysicalDeviceVideoCapabilitiesKHR(gpu(), &profile, config.Caps());
+        vk::GetPhysicalDeviceVideoCapabilitiesKHR(Gpu(), &profile, config.Caps());
         m_errorMonitor->VerifyFound();
     }
 
@@ -144,7 +144,7 @@ TEST_F(NegativeVideo, VideoProfileMissingCodecInfo) {
 
         // Missing codec-specific info for AV1 decode profile
         m_errorMonitor->SetDesiredError("VUID-VkVideoProfileInfoKHR-videoCodecOperation-09256");
-        vk::GetPhysicalDeviceVideoCapabilitiesKHR(gpu(), &profile, config.Caps());
+        vk::GetPhysicalDeviceVideoCapabilitiesKHR(Gpu(), &profile, config.Caps());
         m_errorMonitor->VerifyFound();
     }
 
@@ -156,7 +156,7 @@ TEST_F(NegativeVideo, VideoProfileMissingCodecInfo) {
 
         // Missing codec-specific info for H.264 encode profile
         m_errorMonitor->SetDesiredError("VUID-VkVideoProfileInfoKHR-videoCodecOperation-07181");
-        vk::GetPhysicalDeviceVideoCapabilitiesKHR(gpu(), &profile, config.Caps());
+        vk::GetPhysicalDeviceVideoCapabilitiesKHR(Gpu(), &profile, config.Caps());
         m_errorMonitor->VerifyFound();
     }
 
@@ -168,7 +168,7 @@ TEST_F(NegativeVideo, VideoProfileMissingCodecInfo) {
 
         // Missing codec-specific info for H.265 encode profile
         m_errorMonitor->SetDesiredError("VUID-VkVideoProfileInfoKHR-videoCodecOperation-07182");
-        vk::GetPhysicalDeviceVideoCapabilitiesKHR(gpu(), &profile, config.Caps());
+        vk::GetPhysicalDeviceVideoCapabilitiesKHR(Gpu(), &profile, config.Caps());
         m_errorMonitor->VerifyFound();
     }
 
@@ -180,7 +180,7 @@ TEST_F(NegativeVideo, VideoProfileMissingCodecInfo) {
 
         // Missing codec-specific info for AV1 encode profile
         m_errorMonitor->SetDesiredError("VUID-VkVideoProfileInfoKHR-videoCodecOperation-10262");
-        vk::GetPhysicalDeviceVideoCapabilitiesKHR(gpu(), &profile, config.Caps());
+        vk::GetPhysicalDeviceVideoCapabilitiesKHR(Gpu(), &profile, config.Caps());
         m_errorMonitor->VerifyFound();
     }
 }
@@ -200,13 +200,13 @@ TEST_F(NegativeVideo, CapabilityQueryMissingChain) {
         // Missing decode caps struct for decode profile
         m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceVideoCapabilitiesKHR-pVideoProfile-07183");
         caps.pNext = &decode_h264_caps;
-        vk::GetPhysicalDeviceVideoCapabilitiesKHR(gpu(), config.Profile(), &caps);
+        vk::GetPhysicalDeviceVideoCapabilitiesKHR(Gpu(), config.Profile(), &caps);
         m_errorMonitor->VerifyFound();
 
         // Missing H.264 decode caps struct for H.264 decode profile
         m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceVideoCapabilitiesKHR-pVideoProfile-07184");
         caps.pNext = &decode_caps;
-        vk::GetPhysicalDeviceVideoCapabilitiesKHR(gpu(), config.Profile(), &caps);
+        vk::GetPhysicalDeviceVideoCapabilitiesKHR(Gpu(), config.Profile(), &caps);
         m_errorMonitor->VerifyFound();
     }
 
@@ -220,13 +220,13 @@ TEST_F(NegativeVideo, CapabilityQueryMissingChain) {
         // Missing decode caps struct for decode profile
         m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceVideoCapabilitiesKHR-pVideoProfile-07183");
         caps.pNext = &decode_h265_caps;
-        vk::GetPhysicalDeviceVideoCapabilitiesKHR(gpu(), config.Profile(), &caps);
+        vk::GetPhysicalDeviceVideoCapabilitiesKHR(Gpu(), config.Profile(), &caps);
         m_errorMonitor->VerifyFound();
 
         // Missing H.265 decode caps struct for H.265 decode profile
         m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceVideoCapabilitiesKHR-pVideoProfile-07185");
         caps.pNext = &decode_caps;
-        vk::GetPhysicalDeviceVideoCapabilitiesKHR(gpu(), config.Profile(), &caps);
+        vk::GetPhysicalDeviceVideoCapabilitiesKHR(Gpu(), config.Profile(), &caps);
         m_errorMonitor->VerifyFound();
     }
 
@@ -240,13 +240,13 @@ TEST_F(NegativeVideo, CapabilityQueryMissingChain) {
         // Missing decode caps struct for decode profile
         m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceVideoCapabilitiesKHR-pVideoProfile-07183");
         caps.pNext = &decode_av1_caps;
-        vk::GetPhysicalDeviceVideoCapabilitiesKHR(gpu(), config.Profile(), &caps);
+        vk::GetPhysicalDeviceVideoCapabilitiesKHR(Gpu(), config.Profile(), &caps);
         m_errorMonitor->VerifyFound();
 
         // Missing AV1 decode caps struct for AV1 decode profile
         m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceVideoCapabilitiesKHR-pVideoProfile-09257");
         caps.pNext = &decode_caps;
-        vk::GetPhysicalDeviceVideoCapabilitiesKHR(gpu(), config.Profile(), &caps);
+        vk::GetPhysicalDeviceVideoCapabilitiesKHR(Gpu(), config.Profile(), &caps);
         m_errorMonitor->VerifyFound();
     }
 
@@ -260,13 +260,13 @@ TEST_F(NegativeVideo, CapabilityQueryMissingChain) {
         // Missing encode caps struct for encode profile
         m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceVideoCapabilitiesKHR-pVideoProfile-07186");
         caps.pNext = &encode_h264_caps;
-        vk::GetPhysicalDeviceVideoCapabilitiesKHR(gpu(), config.Profile(), &caps);
+        vk::GetPhysicalDeviceVideoCapabilitiesKHR(Gpu(), config.Profile(), &caps);
         m_errorMonitor->VerifyFound();
 
         // Missing H.264 encode caps struct for H.264 encode profile
         m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceVideoCapabilitiesKHR-pVideoProfile-07187");
         caps.pNext = &encode_caps;
-        vk::GetPhysicalDeviceVideoCapabilitiesKHR(gpu(), config.Profile(), &caps);
+        vk::GetPhysicalDeviceVideoCapabilitiesKHR(Gpu(), config.Profile(), &caps);
         m_errorMonitor->VerifyFound();
     }
 
@@ -280,13 +280,13 @@ TEST_F(NegativeVideo, CapabilityQueryMissingChain) {
         // Missing encode caps struct for encode profile
         m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceVideoCapabilitiesKHR-pVideoProfile-07186");
         caps.pNext = &encode_h265_caps;
-        vk::GetPhysicalDeviceVideoCapabilitiesKHR(gpu(), config.Profile(), &caps);
+        vk::GetPhysicalDeviceVideoCapabilitiesKHR(Gpu(), config.Profile(), &caps);
         m_errorMonitor->VerifyFound();
 
         // Missing H.265 encode caps struct for H.265 encode profile
         m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceVideoCapabilitiesKHR-pVideoProfile-07188");
         caps.pNext = &encode_caps;
-        vk::GetPhysicalDeviceVideoCapabilitiesKHR(gpu(), config.Profile(), &caps);
+        vk::GetPhysicalDeviceVideoCapabilitiesKHR(Gpu(), config.Profile(), &caps);
         m_errorMonitor->VerifyFound();
     }
 
@@ -300,13 +300,13 @@ TEST_F(NegativeVideo, CapabilityQueryMissingChain) {
         // Missing encode caps struct for encode profile
         m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceVideoCapabilitiesKHR-pVideoProfile-07186");
         caps.pNext = &encode_av1_caps;
-        vk::GetPhysicalDeviceVideoCapabilitiesKHR(gpu(), config.Profile(), &caps);
+        vk::GetPhysicalDeviceVideoCapabilitiesKHR(Gpu(), config.Profile(), &caps);
         m_errorMonitor->VerifyFound();
 
         // Missing AV1 encode caps struct for AV1 encode profile
         m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceVideoCapabilitiesKHR-pVideoProfile-10263");
         caps.pNext = &encode_caps;
-        vk::GetPhysicalDeviceVideoCapabilitiesKHR(gpu(), config.Profile(), &caps);
+        vk::GetPhysicalDeviceVideoCapabilitiesKHR(Gpu(), config.Profile(), &caps);
         m_errorMonitor->VerifyFound();
     }
 }
@@ -325,14 +325,14 @@ TEST_F(NegativeVideo, VideoFormatQueryMissingProfile) {
     uint32_t format_count = 0;
 
     m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceVideoFormatPropertiesKHR-pNext-06812");
-    vk::GetPhysicalDeviceVideoFormatPropertiesKHR(gpu(), &format_info, &format_count, nullptr);
+    vk::GetPhysicalDeviceVideoFormatPropertiesKHR(Gpu(), &format_info, &format_count, nullptr);
     m_errorMonitor->VerifyFound();
 
     auto profile_list = vku::InitStruct<VkVideoProfileListInfoKHR>();
     format_info.pNext = &profile_list;
 
     m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceVideoFormatPropertiesKHR-pNext-06812");
-    vk::GetPhysicalDeviceVideoFormatPropertiesKHR(gpu(), &format_info, &format_count, nullptr);
+    vk::GetPhysicalDeviceVideoFormatPropertiesKHR(Gpu(), &format_info, &format_count, nullptr);
     m_errorMonitor->VerifyFound();
 }
 
@@ -350,7 +350,7 @@ TEST_F(NegativeVideo, EncodeQualityLevelPropsUnsupportedProfile) {
     quality_level_info.pVideoProfile = config.Profile();
 
     m_errorMonitor->SetDesiredError("VUID-VkPhysicalDeviceVideoEncodeQualityLevelInfoKHR-pVideoProfile-08259");
-    vk::GetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR(gpu(), &quality_level_info, config.EncodeQualityLevelProps());
+    vk::GetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR(Gpu(), &quality_level_info, config.EncodeQualityLevelProps());
     m_errorMonitor->VerifyFound();
 }
 
@@ -368,7 +368,7 @@ TEST_F(NegativeVideo, EncodeQualityLevelPropsProfileNotEncode) {
     quality_level_info.pVideoProfile = config.Profile();
 
     m_errorMonitor->SetDesiredError("VUID-VkPhysicalDeviceVideoEncodeQualityLevelInfoKHR-pVideoProfile-08260");
-    vk::GetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR(gpu(), &quality_level_info, config.EncodeQualityLevelProps());
+    vk::GetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR(Gpu(), &quality_level_info, config.EncodeQualityLevelProps());
     m_errorMonitor->VerifyFound();
 }
 
@@ -387,7 +387,7 @@ TEST_F(NegativeVideo, EncodeQualityLevelPropsInvalidQualityLevel) {
     quality_level_info.qualityLevel = config.EncodeCaps()->maxQualityLevels;
 
     m_errorMonitor->SetDesiredError("VUID-VkPhysicalDeviceVideoEncodeQualityLevelInfoKHR-qualityLevel-08261");
-    vk::GetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR(gpu(), &quality_level_info, config.EncodeQualityLevelProps());
+    vk::GetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR(Gpu(), &quality_level_info, config.EncodeQualityLevelProps());
     m_errorMonitor->VerifyFound();
 }
 
@@ -409,7 +409,7 @@ TEST_F(NegativeVideo, EncodeQualityLevelPropsMissingCodecInfo) {
         // Missing codec-specific info for H.264 encode profile
         m_errorMonitor->SetAllowedFailureMsg("VUID-VkPhysicalDeviceVideoEncodeQualityLevelInfoKHR-pVideoProfile-08259");
         m_errorMonitor->SetDesiredError("VUID-VkVideoProfileInfoKHR-videoCodecOperation-07181");
-        vk::GetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR(gpu(), &quality_level_info, config.EncodeQualityLevelProps());
+        vk::GetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR(Gpu(), &quality_level_info, config.EncodeQualityLevelProps());
         m_errorMonitor->VerifyFound();
     }
 
@@ -422,7 +422,7 @@ TEST_F(NegativeVideo, EncodeQualityLevelPropsMissingCodecInfo) {
         // Missing codec-specific info for H.265 encode profile
         m_errorMonitor->SetAllowedFailureMsg("VUID-VkPhysicalDeviceVideoEncodeQualityLevelInfoKHR-pVideoProfile-08259");
         m_errorMonitor->SetDesiredError("VUID-VkVideoProfileInfoKHR-videoCodecOperation-07182");
-        vk::GetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR(gpu(), &quality_level_info, config.EncodeQualityLevelProps());
+        vk::GetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR(Gpu(), &quality_level_info, config.EncodeQualityLevelProps());
         m_errorMonitor->VerifyFound();
     }
 
@@ -435,7 +435,7 @@ TEST_F(NegativeVideo, EncodeQualityLevelPropsMissingCodecInfo) {
         // Missing codec-specific info for AV1 encode profile
         m_errorMonitor->SetAllowedFailureMsg("VUID-VkPhysicalDeviceVideoEncodeQualityLevelInfoKHR-pVideoProfile-08259");
         m_errorMonitor->SetDesiredError("VUID-VkVideoProfileInfoKHR-videoCodecOperation-10262");
-        vk::GetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR(gpu(), &quality_level_info, config.EncodeQualityLevelProps());
+        vk::GetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR(Gpu(), &quality_level_info, config.EncodeQualityLevelProps());
         m_errorMonitor->VerifyFound();
     }
 }
@@ -454,7 +454,7 @@ TEST_F(NegativeVideo, EncodeQualityLevelPropsMissingChain) {
 
         // Missing codec-specific output structure for H.264 encode profile
         m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR-pQualityLevelInfo-08257");
-        vk::GetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR(gpu(), &quality_level_info, &quality_level_props);
+        vk::GetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR(Gpu(), &quality_level_info, &quality_level_props);
         m_errorMonitor->VerifyFound();
     }
 
@@ -464,7 +464,7 @@ TEST_F(NegativeVideo, EncodeQualityLevelPropsMissingChain) {
 
         // Missing codec-specific output structure for H.265 encode profile
         m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR-pQualityLevelInfo-08258");
-        vk::GetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR(gpu(), &quality_level_info, &quality_level_props);
+        vk::GetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR(Gpu(), &quality_level_info, &quality_level_props);
         m_errorMonitor->VerifyFound();
     }
 
@@ -474,7 +474,7 @@ TEST_F(NegativeVideo, EncodeQualityLevelPropsMissingChain) {
 
         // Missing codec-specific output structure for AV1 encode profile
         m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR-pQualityLevelInfo-10305");
-        vk::GetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR(gpu(), &quality_level_info, &quality_level_props);
+        vk::GetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR(Gpu(), &quality_level_info, &quality_level_props);
         m_errorMonitor->VerifyFound();
     }
 }
@@ -1084,7 +1084,7 @@ TEST_F(NegativeVideo, BindVideoSessionMemory) {
     std::vector<VkBindVideoSessionMemoryInfoKHR> bind_info(mem_req_count, vku::InitStruct<VkBindVideoSessionMemoryInfoKHR>());
     for (uint32_t i = 0; i < mem_req_count; ++i) {
         VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
-        ASSERT_TRUE(m_device->phy().SetMemoryType(mem_reqs[i].memoryRequirements.memoryTypeBits, &alloc_info, 0));
+        ASSERT_TRUE(m_device->Physical().SetMemoryType(mem_reqs[i].memoryRequirements.memoryTypeBits, &alloc_info, 0));
         alloc_info.allocationSize = mem_reqs[i].memoryRequirements.size * 2;
 
         VkDeviceMemory memory = VK_NULL_HANDLE;
@@ -1128,7 +1128,7 @@ TEST_F(NegativeVideo, BindVideoSessionMemory) {
     // Incompatible memory type
     uint32_t invalid_mem_type_index = vvl::kU32Max;
     uint32_t invalid_mem_type_req_index = vvl::kU32Max;
-    auto mem_props = m_device->phy().memory_properties_;
+    auto mem_props = m_device->Physical().memory_properties_;
     for (uint32_t i = 0; i < mem_req_count; ++i) {
         uint32_t mem_type_bits = mem_reqs[i].memoryRequirements.memoryTypeBits;
         for (uint32_t mem_type_index = 0; mem_type_index < mem_props.memoryTypeCount; ++mem_type_index) {
@@ -3808,7 +3808,7 @@ TEST_F(NegativeVideo, BeginCodingSessionMemoryNotBound) {
         if (i == mem_req_count / 2) continue;
 
         VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
-        m_device->phy().SetMemoryType(mem_reqs[i].memoryRequirements.memoryTypeBits, &alloc_info, 0);
+        m_device->Physical().SetMemoryType(mem_reqs[i].memoryRequirements.memoryTypeBits, &alloc_info, 0);
         alloc_info.allocationSize = mem_reqs[i].memoryRequirements.size;
 
         VkDeviceMemory memory = VK_NULL_HANDLE;
@@ -16047,7 +16047,7 @@ TEST_F(NegativeVideo, CreateImageViewProfileIndependent) {
         VK_FORMAT_FEATURE_VIDEO_DECODE_OUTPUT_BIT_KHR | VK_FORMAT_FEATURE_VIDEO_DECODE_DPB_BIT_KHR |
         VK_FORMAT_FEATURE_VIDEO_ENCODE_INPUT_BIT_KHR | VK_FORMAT_FEATURE_VIDEO_ENCODE_DPB_BIT_KHR;
     VkFormatProperties format_props;
-    vk::GetPhysicalDeviceFormatProperties(gpu(), format, &format_props);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), format, &format_props);
     if ((format_props.optimalTilingFeatures & video_format_flags) != 0) {
         GTEST_SKIP() << "Test expects R8G8_SNORM format to not support video usage";
     }
@@ -17021,7 +17021,7 @@ TEST_F(NegativeVideoBestPractices, BindVideoSessionMemory) {
     // Create non-video-related DeviceMemory
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.allocationSize = buf_mem_reqs.size;
-    ASSERT_TRUE(m_device->phy().SetMemoryType(buf_mem_reqs.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT));
+    ASSERT_TRUE(m_device->Physical().SetMemoryType(buf_mem_reqs.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT));
     vkt::DeviceMemory memory(*m_device, alloc_info);
 
     // Set VkBindVideoSessionMemoryInfoKHR::memory to an allocation created before GetVideoSessionMemoryRequirementsKHR was called

--- a/tests/unit/video_positive.cpp
+++ b/tests/unit/video_positive.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2022-2024 The Khronos Group Inc.
- * Copyright (c) 2022-2024 RasterGrid Kft.
+ * Copyright (c) 2022-2025 The Khronos Group Inc.
+ * Copyright (c) 2022-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -596,7 +596,7 @@ TEST_F(PositiveVideo, EncodeRateControlVirtualBufferSize) {
 
     vkt::CommandBuffer& cb = context.CmdBuffer();
 
-    cb.begin();
+    cb.Begin();
     cb.BeginVideoCoding(context.Begin());
 
     // initialVirtualBufferSizeInMs can be less than virtualBufferSizeInMs
@@ -610,7 +610,7 @@ TEST_F(PositiveVideo, EncodeRateControlVirtualBufferSize) {
     cb.ControlVideoCoding(context.Control().RateControl(rc_info));
 
     cb.EndVideoCoding(context.End());
-    cb.end();
+    cb.End();
 }
 
 TEST_F(PositiveVideo, VideoEncodeAV1) {

--- a/tests/unit/wsi.cpp
+++ b/tests/unit/wsi.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (c) 2015-2024 Google, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2025 Google, Inc.
  * Modifications Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -3527,14 +3527,14 @@ TEST_F(NegativeWsi, ImageCompressionPropertiesSwapchainWithoutFeature) {
     surface_info.surface = m_surface.Handle();
 
     uint32_t surface_format_count;
-    vk::GetPhysicalDeviceSurfaceFormats2KHR(gpu(), &surface_info, &surface_format_count, nullptr);
+    vk::GetPhysicalDeviceSurfaceFormats2KHR(Gpu(), &surface_info, &surface_format_count, nullptr);
 
     std::vector<VkSurfaceFormat2KHR> surface_formats(surface_format_count, vku::InitStruct<VkSurfaceFormat2KHR>());
     VkImageCompressionPropertiesEXT image_compression_control = vku::InitStructHelper();
     surface_formats[0].pNext = &image_compression_control;
 
     m_errorMonitor->SetDesiredError("VUID-VkSurfaceFormat2KHR-pNext-06750");
-    vk::GetPhysicalDeviceSurfaceFormats2KHR(gpu(), &surface_info, &surface_format_count, surface_formats.data());
+    vk::GetPhysicalDeviceSurfaceFormats2KHR(Gpu(), &surface_info, &surface_format_count, surface_formats.data());
     m_errorMonitor->VerifyFound();
 }
 


### PR DESCRIPTION
Starting off the new year with removing the various Deprecated renaming of lowercase function helper names