### PR TITLE
layers: Remove unimplementable union of struct sType

### DIFF
--- a/layers/error_message/unimplementable_validation.h
+++ b/layers/error_message/unimplementable_validation.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 LunarG, Inc.
- * Copyright (c) 2023-2024 Valve Corporation
+ * Copyright (c) 2023-2025 LunarG, Inc.
+ * Copyright (c) 2023-2025 Valve Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,6 +93,12 @@ const char* unimplementable_validation[] = {
 
     // https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/6639#note_468463
     "VUID-VkIndirectCommandsVertexBufferTokenEXT-vertexBindingUnit-11134",
+
+    // Unlike things like VkIndirectCommandsTokenDataEXT/VkDescriptorDataEXT this is
+    // an union of pNext structs that have no way to hit without hitting other things first
+    "VUID-VkAccelerationStructureGeometryKHR-triangles-parameter",
+    "VUID-VkAccelerationStructureGeometryKHR-instances-parameter",
+    "VUID-VkAccelerationStructureGeometryKHR-aabbs-parameter",
 
     // These implicit VUs ask to check for a valid structure that has no sType,
     // there is nothing that can actually be validated

--- a/layers/stateless/sl_ray_tracing.cpp
+++ b/layers/stateless/sl_ray_tracing.cpp
@@ -990,9 +990,6 @@ bool StatelessValidation::ValidateAccelerationStructureBuildGeometryInfoKHR(cons
                                    "VUID-VkAccelerationStructureGeometryKHR-geometryType-parameter");
         if (geom.geometryType == VK_GEOMETRY_TYPE_TRIANGLES_KHR) {
             const Location triangles_loc = geometry_loc.dot(Field::triangles);
-            skip |= ValidateStructType(triangles_loc, &geom.geometry.triangles,
-                                       VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_TRIANGLES_DATA_KHR, true,
-                                       "VUID-VkAccelerationStructureGeometryKHR-triangles-parameter", kVUIDUndefined);
 
             skip |= ValidateAccelerationStructureGeometryTrianglesDataKHR(geom.geometry.triangles, triangles_loc);
 
@@ -1010,16 +1007,10 @@ bool StatelessValidation::ValidateAccelerationStructureBuildGeometryInfoKHR(cons
             }
         } else if (geom.geometryType == VK_GEOMETRY_TYPE_INSTANCES_KHR) {
             const Location instances_loc = geometry_loc.dot(Field::instances);
-            skip |= ValidateStructType(instances_loc, &geom.geometry.instances,
-                                       VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_INSTANCES_DATA_KHR, true,
-                                       "VUID-VkAccelerationStructureGeometryKHR-instances-parameter", kVUIDUndefined);
 
             skip |= ValidateAccelerationStructureGeometryInstancesDataKHR(geom.geometry.instances, instances_loc);
         } else if (geom.geometryType == VK_GEOMETRY_TYPE_AABBS_KHR) {
             const Location aabbs_loc = geometry_loc.dot(Field::aabbs);
-            skip |= ValidateStructType(aabbs_loc, &geom.geometry.aabbs,
-                                       VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_AABBS_DATA_KHR, true,
-                                       "VUID-VkAccelerationStructureGeometryKHR-aabbs-parameter", kVUIDUndefined);
 
             skip |= ValidateAccelerationStructureGeometryAabbsDataKHR(geom.geometry.aabbs, aabbs_loc);
 


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9116

@ziga-lunarg pointed out in https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/9121 (and I confirmed) there is no way to hit these implicit VUs, so just moving them out of the code as we have no way to test them