### PR TITLE
layers: Improve Push Descriptor error messages

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (C) 2015-2024 Google Inc.
+/* Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (C) 2015-2025 Google Inc.
  * Modifications Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022-2024 RasterGrid Kft.
  *
@@ -32,6 +32,7 @@ typedef vvl::unordered_map<const vvl::Image*, std::optional<GlobalImageLayoutRan
 namespace vvl {
 struct DrawDispatchVuid;
 class DescriptorBinding;
+struct DslErrorSource;
 }  // namespace vvl
 
 namespace spirv {
@@ -612,27 +613,22 @@ class CoreChecks : public ValidationStateTracker {
                                  bool is_copy, const Location& set_loc) const;
     // Validate contents of a WriteUpdate
     bool ValidateWriteUpdate(const vvl::DescriptorSet& dst_set, const VkWriteDescriptorSet& update, const Location& write_loc,
-                             bool push) const;
-    bool ValidateWriteUpdateDescriptorType(const vvl::DescriptorSetLayout& dst_layout, const vvl::DescriptorSet& dst_set,
-                                           const vvl::DescriptorBinding& dst_binding, const VkWriteDescriptorSet& update,
-                                           const Location& write_loc) const;
-    bool ValidateWriteUpdateBufferInfo(const vvl::DescriptorSetLayout& dst_layout, const VkWriteDescriptorSet& update,
-                                       const Location& write_loc) const;
-    bool ValidateWriteUpdateInlineUniformBlock(const vvl::DescriptorSetLayout& dst_layout, const VkWriteDescriptorSet& update,
-                                               const Location& write_loc) const;
-    bool ValidateWriteUpdateAccelerationStructureKHR(const vvl::DescriptorSetLayout& dst_layout, const VkWriteDescriptorSet& update,
-                                                     const Location& write_loc) const;
-    bool ValidateWriteUpdateAccelerationStructureNV(const vvl::DescriptorSetLayout& dst_layout, const VkWriteDescriptorSet& update,
-                                                    const Location& write_loc) const;
+                             const vvl::DslErrorSource& dsl_error_source) const;
+    bool ValidateWriteUpdateDescriptorType(const VkWriteDescriptorSet& update, const Location& write_loc) const;
+    bool ValidateWriteUpdateBufferInfo(const VkWriteDescriptorSet& update, const Location& write_loc) const;
+    bool ValidateWriteUpdateInlineUniformBlock(const VkWriteDescriptorSet& update, const Location& write_loc) const;
+    bool ValidateWriteUpdateAccelerationStructureKHR(const VkWriteDescriptorSet& update, const Location& write_loc) const;
+    bool ValidateWriteUpdateAccelerationStructureNV(const VkWriteDescriptorSet& update, const Location& write_loc) const;
     bool VerifyWriteUpdateContents(const vvl::DescriptorSet& dst_set, const VkWriteDescriptorSet& update, const Location& write_loc,
-                                   bool push) const;
+                                   bool is_push_descriptor) const;
     // Shared helper functions - These are useful because the shared sampler image descriptor type
     //  performs common functions with both sampler and image descriptors so they can share their common functions
     bool ValidateImageUpdate(const vvl::ImageView& view_state, VkImageLayout image_layout, VkDescriptorType type,
                              const Location& image_info_loc) const;
     // Validate contents of a push descriptor update
     bool ValidatePushDescriptorsUpdate(const vvl::DescriptorSet& push_set, uint32_t descriptorWriteCount,
-                                       const VkWriteDescriptorSet* pDescriptorWrites, const Location& loc) const;
+                                       const VkWriteDescriptorSet* pDescriptorWrites, const vvl::DslErrorSource& dsl_error_source,
+                                       const Location& loc) const;
     // Descriptor Set Validation Functions
     bool ValidateBufferUsage(const vvl::Buffer& buffer_state, VkDescriptorType type, const Location& buffer_loc) const;
     bool ValidateBufferUpdate(const VkDescriptorBufferInfo& buffer_info, VkDescriptorType type,

--- a/layers/state_tracker/descriptor_sets.cpp
+++ b/layers/state_tracker/descriptor_sets.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (C) 2015-2024 Google Inc.
+/* Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (C) 2015-2025 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1426,4 +1426,16 @@ bool vvl::MutableDescriptor::Invalid() const {
             break;
     }
     return false;
+}
+
+std::string vvl::DslErrorSource::PrintMessage(const ValidationObject &error_logger) const {
+    std::stringstream msg;
+    msg << " (The VkDescriptorSetLayout was used to ";
+    if (pipeline_layout_handle_ == VK_NULL_HANDLE) {
+        msg << "allocate " << error_logger.FormatHandle(ds_handle_);
+    } else {
+        msg << "create " << error_logger.FormatHandle(pipeline_layout_handle_) << " at pSetLayouts[" << set_ << "]";
+    }
+    msg << ")";
+    return msg.str();
 }

--- a/layers/state_tracker/pipeline_layout_state.h
+++ b/layers/state_tracker/pipeline_layout_state.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (C) 2015-2024 Google Inc.
+/* Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (C) 2015-2025 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -87,14 +87,6 @@ class PipelineLayout : public StateObject {
     PipelineLayout(const Container &layouts) : PipelineLayout(vvl::span<const PipelineLayout *const>{layouts}) {}
 
     VkPipelineLayout VkHandle() const { return handle_.Cast<VkPipelineLayout>(); }
-
-    std::shared_ptr<vvl::DescriptorSetLayout const> GetDsl(uint32_t set) const {
-        std::shared_ptr<vvl::DescriptorSetLayout const> dsl = nullptr;
-        if (set < set_layouts.size()) {
-            dsl = set_layouts[set];
-        }
-        return dsl;
-    }
 
     VkPipelineLayoutCreateFlags CreateFlags() const { return create_flags; }
 };

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -4516,17 +4516,17 @@ void ValidationStateTracker::PreCallRecordCmdPushDescriptorSetWithTemplate(VkCom
                                                                            const RecordObject &record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto template_state = Get<vvl::DescriptorUpdateTemplate>(descriptorUpdateTemplate);
-    auto layout_data = Get<vvl::PipelineLayout>(layout);
-    if (!cb_state || !template_state || !layout_data) {
+    auto pipeline_layout = Get<vvl::PipelineLayout>(layout);
+    if (!cb_state || !template_state || !pipeline_layout) {
         return;
     }
 
     cb_state->RecordCmd(record_obj.location.function);
-    auto dsl = layout_data->GetDsl(set);
+    auto dsl = pipeline_layout->set_layouts[set];
     const auto &template_ci = template_state->create_info;
     // Decode the template into a set of write updates
     vvl::DecodedTemplateUpdate decoded_template(*this, VK_NULL_HANDLE, template_state.get(), pData, dsl->VkHandle());
-    cb_state->PushDescriptorSetState(template_ci.pipelineBindPoint, *layout_data, record_obj.location.function, set,
+    cb_state->PushDescriptorSetState(template_ci.pipelineBindPoint, *pipeline_layout, record_obj.location.function, set,
                                      static_cast<uint32_t>(decoded_template.desc_writes.size()),
                                      decoded_template.desc_writes.data());
 }
@@ -4543,19 +4543,19 @@ void ValidationStateTracker::PreCallRecordCmdPushDescriptorSetWithTemplate2(
     const RecordObject &record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto template_state = Get<vvl::DescriptorUpdateTemplate>(pPushDescriptorSetWithTemplateInfo->descriptorUpdateTemplate);
-    auto layout_data = Get<vvl::PipelineLayout>(pPushDescriptorSetWithTemplateInfo->layout);
-    if (!cb_state || !template_state || !layout_data) {
+    auto pipeline_layout = Get<vvl::PipelineLayout>(pPushDescriptorSetWithTemplateInfo->layout);
+    if (!cb_state || !template_state || !pipeline_layout) {
         return;
     }
 
     cb_state->RecordCmd(record_obj.location.function);
-    auto dsl = layout_data->GetDsl(pPushDescriptorSetWithTemplateInfo->set);
+    auto dsl = pipeline_layout->set_layouts[pPushDescriptorSetWithTemplateInfo->set];
     const auto &template_ci = template_state->create_info;
     // Decode the template into a set of write updates
     vvl::DecodedTemplateUpdate decoded_template(*this, VK_NULL_HANDLE, template_state.get(),
                                                 pPushDescriptorSetWithTemplateInfo->pData, dsl->VkHandle());
     cb_state->PushDescriptorSetState(
-        template_ci.pipelineBindPoint, *layout_data, record_obj.location.function, pPushDescriptorSetWithTemplateInfo->set,
+        template_ci.pipelineBindPoint, *pipeline_layout, record_obj.location.function, pPushDescriptorSetWithTemplateInfo->set,
         static_cast<uint32_t>(decoded_template.desc_writes.size()), decoded_template.desc_writes.data());
 }
 

--- a/tests/unit/descriptors.cpp
+++ b/tests/unit/descriptors.cpp
@@ -2217,7 +2217,7 @@ TEST_F(NegativeDescriptors, DSTypeMismatch) {
 
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
-    descriptor_set.WriteDescriptorImageInfo(0, VK_NULL_HANDLE, sampler.handle(), VK_DESCRIPTOR_TYPE_SAMPLER);
+    descriptor_set.WriteDescriptorImageInfo(0, VK_NULL_HANDLE, sampler, VK_DESCRIPTOR_TYPE_SAMPLER);
     descriptor_set.UpdateDescriptorSets();
 
     m_errorMonitor->VerifyFound();
@@ -2246,7 +2246,7 @@ TEST_F(NegativeDescriptors, DSUpdateIndex) {
                                                  });
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
     // This is the wrong type, but out of bounds will be flagged first
-    descriptor_set.WriteDescriptorImageInfo(2, VK_NULL_HANDLE, sampler.handle(), VK_DESCRIPTOR_TYPE_SAMPLER);
+    descriptor_set.WriteDescriptorImageInfo(2, VK_NULL_HANDLE, sampler, VK_DESCRIPTOR_TYPE_SAMPLER);
     descriptor_set.UpdateDescriptorSets();
     m_errorMonitor->VerifyFound();
 }
@@ -2260,7 +2260,7 @@ TEST_F(NegativeDescriptors, DSUpdateEmptyBinding) {
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
     // descriptor_write.descriptorCount = 1, Lie here to avoid parameter_validation error
     // This is the wrong type, but empty binding error will be flagged first
-    descriptor_set.WriteDescriptorImageInfo(0, VK_NULL_HANDLE, sampler.handle(), VK_DESCRIPTOR_TYPE_SAMPLER);
+    descriptor_set.WriteDescriptorImageInfo(0, VK_NULL_HANDLE, sampler, VK_DESCRIPTOR_TYPE_SAMPLER);
     m_errorMonitor->SetDesiredError("VUID-VkWriteDescriptorSet-dstBinding-00316");
     descriptor_set.UpdateDescriptorSets();
     m_errorMonitor->VerifyFound();
@@ -2273,7 +2273,7 @@ TEST_F(NegativeDescriptors, UpdateIndexSmaller) {
                                                      {2, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_ALL, nullptr},
                                                  });
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
-    descriptor_set.WriteDescriptorImageInfo(1, VK_NULL_HANDLE, sampler.handle(), VK_DESCRIPTOR_TYPE_SAMPLER);
+    descriptor_set.WriteDescriptorImageInfo(1, VK_NULL_HANDLE, sampler, VK_DESCRIPTOR_TYPE_SAMPLER);
     m_errorMonitor->SetDesiredError("VUID-VkWriteDescriptorSet-dstBinding-00316");
     descriptor_set.UpdateDescriptorSets();
     m_errorMonitor->VerifyFound();
@@ -2517,8 +2517,6 @@ TEST_F(NegativeDescriptors, Maint1BindingSliceOf3DImage) {
 
 TEST_F(NegativeDescriptors, UpdateDestroyDescriptorSetLayout) {
     TEST_DESCRIPTION("Attempt updates to descriptor sets with destroyed descriptor set layouts");
-    // TODO: Update to match the descriptor set layout specific VUIDs/VALIDATION_ERROR_* when present
-
     RETURN_IF_SKIP(Init());
 
     // Set up the descriptor (resource) and write/copy operations to use.


### PR DESCRIPTION
This mainly cleans up the `VkWriteDescriptorSet` checks to provide a better error message when using `VK_KHR_push_descriptor` (now promoted to 1.4)

the tl;dr is for the normal flow, you look at `VkWriteDescriptorSet::dstSet` to get the VkDescriptorSetLayout... but with Push Descriptors, you use the `VkPipelineLayout` at the `vkCmdPushDescriptorSet` call

Many error messages were really confusing because it would talk about the `VkDescriptorSet`, but there isn't one with Push Descriptors