### PR TITLE
layers: Fix getting bind memory status result

### DIFF
--- a/layers/chassis/dispatch_object_manual.cpp
+++ b/layers/chassis/dispatch_object_manual.cpp
@@ -1,8 +1,8 @@
 /***************************************************************************
  *
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,9 @@
 #include "state_tracker/pipeline_state.h"
 
 #define OBJECT_LAYER_DESCRIPTION "khronos_validation"
+
+#define DISPATCH_MAX_STACK_ALLOCATIONS 32
+
 namespace vvl {
 namespace dispatch {
 
@@ -1879,6 +1882,152 @@ VkResult Device::CreateIndirectExecutionSetEXT(VkDevice device, const VkIndirect
     if (VK_SUCCESS == result) {
         *pIndirectExecutionSet = WrapNew(*pIndirectExecutionSet);
     }
+    return result;
+}
+
+VkResult Device::BindBufferMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindBufferMemoryInfo *pBindInfos) {
+    if (!wrap_handles) return device_dispatch_table.BindBufferMemory2(device, bindInfoCount, pBindInfos);
+    small_vector<vku::safe_VkBindBufferMemoryInfo, DISPATCH_MAX_STACK_ALLOCATIONS> var_local_pBindInfos;
+    vku::safe_VkBindBufferMemoryInfo *local_pBindInfos = nullptr;
+    {
+        if (pBindInfos) {
+            var_local_pBindInfos.resize(bindInfoCount);
+            local_pBindInfos = var_local_pBindInfos.data();
+            for (uint32_t index0 = 0; index0 < bindInfoCount; ++index0) {
+                local_pBindInfos[index0].initialize(&pBindInfos[index0]);
+
+                if (pBindInfos[index0].buffer) {
+                    local_pBindInfos[index0].buffer = Unwrap(pBindInfos[index0].buffer);
+                }
+                if (pBindInfos[index0].memory) {
+                    local_pBindInfos[index0].memory = Unwrap(pBindInfos[index0].memory);
+                }
+            }
+        }
+    }
+    VkResult result =
+        device_dispatch_table.BindBufferMemory2(device, bindInfoCount, (const VkBindBufferMemoryInfo *)local_pBindInfos);
+
+    if (pBindInfos) {
+        for (uint32_t index0 = 0; index0 < bindInfoCount; ++index0) {
+            auto *bind_memory_status = vku::FindStructInPNextChain<VkBindMemoryStatus>(pBindInfos[index0].pNext);
+            if (bind_memory_status) {
+                auto *local_bind_memory_status = vku::FindStructInPNextChain<VkBindMemoryStatus>(local_pBindInfos[index0].pNext);
+                *bind_memory_status->pResult = *local_bind_memory_status->pResult;
+            }
+        }
+    }
+
+    return result;
+}
+
+VkResult Device::BindImageMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo *pBindInfos) {
+    if (!wrap_handles) return device_dispatch_table.BindImageMemory2(device, bindInfoCount, pBindInfos);
+    small_vector<vku::safe_VkBindImageMemoryInfo, DISPATCH_MAX_STACK_ALLOCATIONS> var_local_pBindInfos;
+    vku::safe_VkBindImageMemoryInfo *local_pBindInfos = nullptr;
+    {
+        if (pBindInfos) {
+            var_local_pBindInfos.resize(bindInfoCount);
+            local_pBindInfos = var_local_pBindInfos.data();
+            for (uint32_t index0 = 0; index0 < bindInfoCount; ++index0) {
+                local_pBindInfos[index0].initialize(&pBindInfos[index0]);
+                UnwrapPnextChainHandles(local_pBindInfos[index0].pNext);
+
+                if (pBindInfos[index0].image) {
+                    local_pBindInfos[index0].image = Unwrap(pBindInfos[index0].image);
+                }
+                if (pBindInfos[index0].memory) {
+                    local_pBindInfos[index0].memory = Unwrap(pBindInfos[index0].memory);
+                }
+            }
+        }
+    }
+    VkResult result =
+        device_dispatch_table.BindImageMemory2(device, bindInfoCount, (const VkBindImageMemoryInfo *)local_pBindInfos);
+
+    if (pBindInfos) {
+        for (uint32_t index0 = 0; index0 < bindInfoCount; ++index0) {
+            auto *bind_memory_status = vku::FindStructInPNextChain<VkBindMemoryStatus>(pBindInfos[index0].pNext);
+            if (bind_memory_status) {
+                auto *local_bind_memory_status = vku::FindStructInPNextChain<VkBindMemoryStatus>(local_pBindInfos[index0].pNext);
+                *bind_memory_status->pResult = *local_bind_memory_status->pResult;
+            }
+        }
+    }
+
+    return result;
+}
+
+VkResult Device::BindBufferMemory2KHR(VkDevice device, uint32_t bindInfoCount, const VkBindBufferMemoryInfo *pBindInfos) {
+    if (!wrap_handles) return device_dispatch_table.BindBufferMemory2KHR(device, bindInfoCount, pBindInfos);
+    small_vector<vku::safe_VkBindBufferMemoryInfo, DISPATCH_MAX_STACK_ALLOCATIONS> var_local_pBindInfos;
+    vku::safe_VkBindBufferMemoryInfo *local_pBindInfos = nullptr;
+    {
+        if (pBindInfos) {
+            var_local_pBindInfos.resize(bindInfoCount);
+            local_pBindInfos = var_local_pBindInfos.data();
+            for (uint32_t index0 = 0; index0 < bindInfoCount; ++index0) {
+                local_pBindInfos[index0].initialize(&pBindInfos[index0]);
+
+                if (pBindInfos[index0].buffer) {
+                    local_pBindInfos[index0].buffer = Unwrap(pBindInfos[index0].buffer);
+                }
+                if (pBindInfos[index0].memory) {
+                    local_pBindInfos[index0].memory = Unwrap(pBindInfos[index0].memory);
+                }
+            }
+        }
+    }
+    VkResult result =
+        device_dispatch_table.BindBufferMemory2KHR(device, bindInfoCount, (const VkBindBufferMemoryInfo *)local_pBindInfos);
+
+    if (pBindInfos) {
+        for (uint32_t index0 = 0; index0 < bindInfoCount; ++index0) {
+            auto *bind_memory_status = vku::FindStructInPNextChain<VkBindMemoryStatus>(pBindInfos[index0].pNext);
+            if (bind_memory_status) {
+                auto *local_bind_memory_status = vku::FindStructInPNextChain<VkBindMemoryStatus>(local_pBindInfos[index0].pNext);
+                *bind_memory_status->pResult = *local_bind_memory_status->pResult;
+            }
+        }
+    }
+
+    return result;
+}
+
+VkResult Device::BindImageMemory2KHR(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo *pBindInfos) {
+    if (!wrap_handles) return device_dispatch_table.BindImageMemory2KHR(device, bindInfoCount, pBindInfos);
+    small_vector<vku::safe_VkBindImageMemoryInfo, DISPATCH_MAX_STACK_ALLOCATIONS> var_local_pBindInfos;
+    vku::safe_VkBindImageMemoryInfo *local_pBindInfos = nullptr;
+    {
+        if (pBindInfos) {
+            var_local_pBindInfos.resize(bindInfoCount);
+            local_pBindInfos = var_local_pBindInfos.data();
+            for (uint32_t index0 = 0; index0 < bindInfoCount; ++index0) {
+                local_pBindInfos[index0].initialize(&pBindInfos[index0]);
+                UnwrapPnextChainHandles(local_pBindInfos[index0].pNext);
+
+                if (pBindInfos[index0].image) {
+                    local_pBindInfos[index0].image = Unwrap(pBindInfos[index0].image);
+                }
+                if (pBindInfos[index0].memory) {
+                    local_pBindInfos[index0].memory = Unwrap(pBindInfos[index0].memory);
+                }
+            }
+        }
+    }
+    VkResult result =
+        device_dispatch_table.BindImageMemory2KHR(device, bindInfoCount, (const VkBindImageMemoryInfo *)local_pBindInfos);
+
+    if (pBindInfos) {
+        for (uint32_t index0 = 0; index0 < bindInfoCount; ++index0) {
+            auto *bind_memory_status = vku::FindStructInPNextChain<VkBindMemoryStatus>(pBindInfos[index0].pNext);
+            if (bind_memory_status) {
+                auto *local_bind_memory_status = vku::FindStructInPNextChain<VkBindMemoryStatus>(local_pBindInfos[index0].pNext);
+                *bind_memory_status->pResult = *local_bind_memory_status->pResult;
+            }
+        }
+    }
+
     return result;
 }
 

--- a/layers/vulkan/generated/dispatch_functions.h
+++ b/layers/vulkan/generated/dispatch_functions.h
@@ -3,9 +3,9 @@
 
 /***************************************************************************
  *
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/layers/vulkan/generated/dispatch_object.cpp
+++ b/layers/vulkan/generated/dispatch_object.cpp
@@ -3,9 +3,9 @@
 
 /***************************************************************************
  *
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1864,58 +1864,6 @@ void Device::CmdEndRenderPass(VkCommandBuffer commandBuffer) { device_dispatch_t
 void Device::CmdExecuteCommands(VkCommandBuffer commandBuffer, uint32_t commandBufferCount,
                                 const VkCommandBuffer* pCommandBuffers) {
     device_dispatch_table.CmdExecuteCommands(commandBuffer, commandBufferCount, pCommandBuffers);
-}
-
-VkResult Device::BindBufferMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindBufferMemoryInfo* pBindInfos) {
-    if (!wrap_handles) return device_dispatch_table.BindBufferMemory2(device, bindInfoCount, pBindInfos);
-    small_vector<vku::safe_VkBindBufferMemoryInfo, DISPATCH_MAX_STACK_ALLOCATIONS> var_local_pBindInfos;
-    vku::safe_VkBindBufferMemoryInfo* local_pBindInfos = nullptr;
-    {
-        if (pBindInfos) {
-            var_local_pBindInfos.resize(bindInfoCount);
-            local_pBindInfos = var_local_pBindInfos.data();
-            for (uint32_t index0 = 0; index0 < bindInfoCount; ++index0) {
-                local_pBindInfos[index0].initialize(&pBindInfos[index0]);
-
-                if (pBindInfos[index0].buffer) {
-                    local_pBindInfos[index0].buffer = Unwrap(pBindInfos[index0].buffer);
-                }
-                if (pBindInfos[index0].memory) {
-                    local_pBindInfos[index0].memory = Unwrap(pBindInfos[index0].memory);
-                }
-            }
-        }
-    }
-    VkResult result =
-        device_dispatch_table.BindBufferMemory2(device, bindInfoCount, (const VkBindBufferMemoryInfo*)local_pBindInfos);
-
-    return result;
-}
-
-VkResult Device::BindImageMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo* pBindInfos) {
-    if (!wrap_handles) return device_dispatch_table.BindImageMemory2(device, bindInfoCount, pBindInfos);
-    small_vector<vku::safe_VkBindImageMemoryInfo, DISPATCH_MAX_STACK_ALLOCATIONS> var_local_pBindInfos;
-    vku::safe_VkBindImageMemoryInfo* local_pBindInfos = nullptr;
-    {
-        if (pBindInfos) {
-            var_local_pBindInfos.resize(bindInfoCount);
-            local_pBindInfos = var_local_pBindInfos.data();
-            for (uint32_t index0 = 0; index0 < bindInfoCount; ++index0) {
-                local_pBindInfos[index0].initialize(&pBindInfos[index0]);
-                UnwrapPnextChainHandles(local_pBindInfos[index0].pNext);
-
-                if (pBindInfos[index0].image) {
-                    local_pBindInfos[index0].image = Unwrap(pBindInfos[index0].image);
-                }
-                if (pBindInfos[index0].memory) {
-                    local_pBindInfos[index0].memory = Unwrap(pBindInfos[index0].memory);
-                }
-            }
-        }
-    }
-    VkResult result = device_dispatch_table.BindImageMemory2(device, bindInfoCount, (const VkBindImageMemoryInfo*)local_pBindInfos);
-
-    return result;
 }
 
 void Device::GetDeviceGroupPeerMemoryFeatures(VkDevice device, uint32_t heapIndex, uint32_t localDeviceIndex,
@@ -4182,59 +4130,6 @@ void Device::DestroySamplerYcbcrConversionKHR(VkDevice device, VkSamplerYcbcrCon
     if (!wrap_handles) return device_dispatch_table.DestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator);
     ycbcrConversion = Erase(ycbcrConversion);
     device_dispatch_table.DestroySamplerYcbcrConversionKHR(device, ycbcrConversion, pAllocator);
-}
-
-VkResult Device::BindBufferMemory2KHR(VkDevice device, uint32_t bindInfoCount, const VkBindBufferMemoryInfo* pBindInfos) {
-    if (!wrap_handles) return device_dispatch_table.BindBufferMemory2KHR(device, bindInfoCount, pBindInfos);
-    small_vector<vku::safe_VkBindBufferMemoryInfo, DISPATCH_MAX_STACK_ALLOCATIONS> var_local_pBindInfos;
-    vku::safe_VkBindBufferMemoryInfo* local_pBindInfos = nullptr;
-    {
-        if (pBindInfos) {
-            var_local_pBindInfos.resize(bindInfoCount);
-            local_pBindInfos = var_local_pBindInfos.data();
-            for (uint32_t index0 = 0; index0 < bindInfoCount; ++index0) {
-                local_pBindInfos[index0].initialize(&pBindInfos[index0]);
-
-                if (pBindInfos[index0].buffer) {
-                    local_pBindInfos[index0].buffer = Unwrap(pBindInfos[index0].buffer);
-                }
-                if (pBindInfos[index0].memory) {
-                    local_pBindInfos[index0].memory = Unwrap(pBindInfos[index0].memory);
-                }
-            }
-        }
-    }
-    VkResult result =
-        device_dispatch_table.BindBufferMemory2KHR(device, bindInfoCount, (const VkBindBufferMemoryInfo*)local_pBindInfos);
-
-    return result;
-}
-
-VkResult Device::BindImageMemory2KHR(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo* pBindInfos) {
-    if (!wrap_handles) return device_dispatch_table.BindImageMemory2KHR(device, bindInfoCount, pBindInfos);
-    small_vector<vku::safe_VkBindImageMemoryInfo, DISPATCH_MAX_STACK_ALLOCATIONS> var_local_pBindInfos;
-    vku::safe_VkBindImageMemoryInfo* local_pBindInfos = nullptr;
-    {
-        if (pBindInfos) {
-            var_local_pBindInfos.resize(bindInfoCount);
-            local_pBindInfos = var_local_pBindInfos.data();
-            for (uint32_t index0 = 0; index0 < bindInfoCount; ++index0) {
-                local_pBindInfos[index0].initialize(&pBindInfos[index0]);
-                UnwrapPnextChainHandles(local_pBindInfos[index0].pNext);
-
-                if (pBindInfos[index0].image) {
-                    local_pBindInfos[index0].image = Unwrap(pBindInfos[index0].image);
-                }
-                if (pBindInfos[index0].memory) {
-                    local_pBindInfos[index0].memory = Unwrap(pBindInfos[index0].memory);
-                }
-            }
-        }
-    }
-    VkResult result =
-        device_dispatch_table.BindImageMemory2KHR(device, bindInfoCount, (const VkBindImageMemoryInfo*)local_pBindInfos);
-
-    return result;
 }
 
 void Device::GetDescriptorSetLayoutSupportKHR(VkDevice device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo,

--- a/layers/vulkan/generated/dispatch_object_device_methods.h
+++ b/layers/vulkan/generated/dispatch_object_device_methods.h
@@ -3,9 +3,9 @@
 
 /***************************************************************************
  *
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/layers/vulkan/generated/dispatch_object_instance_methods.h
+++ b/layers/vulkan/generated/dispatch_object_instance_methods.h
@@ -3,9 +3,9 @@
 
 /***************************************************************************
  *
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/layers/vulkan/generated/feature_requirements_helper.cpp
+++ b/layers/vulkan/generated/feature_requirements_helper.cpp
@@ -3,9 +3,9 @@
 
 /***************************************************************************
  *
- * Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 Valve Corporation
- * Copyright (c) 2023-2024 LunarG, Inc.
+ * Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 Valve Corporation
+ * Copyright (c) 2023-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -4357,21 +4357,21 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
-                case Feature::constantAlphaColorBlendFactors : {
-                auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
-                    vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
-                if (!vk_struct) {
-                    vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
-                    *vk_struct = vku::InitStructHelper();
-                    if (*inout_pnext_chain) {
-                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
-                    } else {
-                        *inout_pnext_chain = vk_struct;
-                    }
+            case Feature::constantAlphaColorBlendFactors : {
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
                 }
-                return {&vk_struct->constantAlphaColorBlendFactors,
-                        "VkPhysicalDevicePortabilitySubsetFeaturesKHR::constantAlphaColorBlendFactors"};
             }
+            return {&vk_struct->constantAlphaColorBlendFactors,
+                    "VkPhysicalDevicePortabilitySubsetFeaturesKHR::constantAlphaColorBlendFactors"};
+        }
 #endif  // VK_ENABLE_BETA_EXTENSIONS
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 

--- a/layers/vulkan/generated/feature_requirements_helper.h
+++ b/layers/vulkan/generated/feature_requirements_helper.h
@@ -3,9 +3,9 @@
 
 /***************************************************************************
  *
- * Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 Valve Corporation
- * Copyright (c) 2023-2024 LunarG, Inc.
+ * Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 Valve Corporation
+ * Copyright (c) 2023-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/generators/dispatch_object_generator.py
+++ b/scripts/generators/dispatch_object_generator.py
@@ -1,9 +1,9 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2015-2024 The Khronos Group Inc.
-# Copyright (c) 2015-2024 Valve Corporation
-# Copyright (c) 2015-2024 LunarG, Inc.
-# Copyright (c) 2015-2024 Google Inc.
+# Copyright (c) 2015-2025 The Khronos Group Inc.
+# Copyright (c) 2015-2025 Valve Corporation
+# Copyright (c) 2015-2025 LunarG, Inc.
+# Copyright (c) 2015-2025 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -163,9 +163,14 @@ class DispatchObjectGenerator(BaseGenerator):
             'vkGetDisplayModePropertiesKHR',
             'vkGetDisplayModeProperties2KHR',
             'vkGetDisplayPlaneSupportedDisplaysKHR',
-            # need to handle binaries in VkPipelineBinaryHandlesInfoKHR as output, not input.
+            # Need to handle binaries in VkPipelineBinaryHandlesInfoKHR as output, not input.
             'vkCreatePipelineBinariesKHR',
             'vkGetPipelineKeyKHR',
+            # Need to handle VkBindMemoryStatus
+            'vkBindBufferMemory2',
+            'vkBindBufferMemory2KHR',
+            'vkBindImageMemory2',
+            'vkBindImageMemory2KHR',
             )
 
         # List of all extension structs strings containing handles
@@ -202,9 +207,9 @@ class DispatchObjectGenerator(BaseGenerator):
 
             /***************************************************************************
             *
-            * Copyright (c) 2015-2024 The Khronos Group Inc.
-            * Copyright (c) 2015-2024 Valve Corporation
-            * Copyright (c) 2015-2024 LunarG, Inc.
+            * Copyright (c) 2015-2025 The Khronos Group Inc.
+            * Copyright (c) 2015-2025 Valve Corporation
+            * Copyright (c) 2015-2025 LunarG, Inc.
             *
             * Licensed under the Apache License, Version 2.0 (the "License");
             * you may not use this file except in compliance with the License.

--- a/scripts/generators/feature_requirements.py
+++ b/scripts/generators/feature_requirements.py
@@ -1,9 +1,9 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2015-2024 The Khronos Group Inc.
-# Copyright (c) 2015-2024 Valve Corporation
-# Copyright (c) 2015-2024 LunarG, Inc.
-# Copyright (c) 2015-2024 Google Inc.
+# Copyright (c) 2015-2025 The Khronos Group Inc.
+# Copyright (c) 2015-2025 Valve Corporation
+# Copyright (c) 2015-2025 LunarG, Inc.
+# Copyright (c) 2015-2025 Google Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -42,9 +42,9 @@ class FeatureRequirementsGenerator(BaseGenerator):
 
             /***************************************************************************
             *
-            * Copyright (c) 2023-2024 The Khronos Group Inc.
-            * Copyright (c) 2023-2024 Valve Corporation
-            * Copyright (c) 2023-2024 LunarG, Inc.
+            * Copyright (c) 2023-2025 The Khronos Group Inc.
+            * Copyright (c) 2023-2025 Valve Corporation
+            * Copyright (c) 2023-2025 LunarG, Inc.
             *
             * Licensed under the Apache License, Version 2.0 (the "License");
             * you may not use this file except in compliance with the License.


### PR DESCRIPTION
When handle wrapping was enabled, `VkBindMemoryStatus` was not handled correctly