### PR TITLE
sync: Fix sync reporting message

### DIFF
--- a/layers/sync/sync_reporting.cpp
+++ b/layers/sync/sync_reporting.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2024 The Khronos Group Inc.
- * Copyright (c) 2024 Valve Corporation
- * Copyright (c) 2024 LunarG, Inc.
+/* Copyright (c) 2025 The Khronos Group Inc.
+ * Copyright (c) 2025 Valve Corporation
+ * Copyright (c) 2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -296,7 +296,7 @@ std::string CommandExecutionContext::FormatHazard(const HazardResult &hazard, Re
     std::stringstream out;
     assert(hazard.IsHazard());
     out << FormatHazardState(hazard.State(), queue_flags_, key_values);
-    out << ", " << FormatUsage(hazard.TagEx()) << ")";
+    out << FormatUsage(hazard.TagEx()) << ")";
     return out.str();
 }
 


### PR DESCRIPTION
> SYNC-HAZARD-WRITE-AFTER-READ(ERROR / SPEC): msgNum: 929810911 - Validation Error: [ SYNC-HAZARD-WRITE-AFTER-READ ] Object 0: handle = 0x228138fdf10, type = VK_OBJECT_TYPE_QUEUE; | MessageID = 0x376bc9df | vkQueueSubmit(): Hazard WRITE_AFTER_READ for entry 0, VkCommandBuffer 0x22813bc5c70[], Submitted access info (submitted_usage: SYNC_IMAGE_LAYOUT_TRANSITION, command: vkCmdBeginRenderPass). Access info (prior_usage: SYNC_PRESENT_ENGINE_SYNCVAL_PRESENT_ACQUIRE_READ_SYNCVAL, read_barriers: VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT|VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT, , vkAcquireNextImageKHR aquire_tag:1: VkSwapchainKHR 0xcfef35000000000a[], image_index: 0image: VkImage 0xec4bec000000000b[]).

There was `, ,` in the message