### PR TITLE
tests: Add Test for 00073

### DIFF
--- a/layers/sync/sync_vuid_maps.cpp
+++ b/layers/sync/sync_vuid_maps.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2021-2024 The Khronos Group Inc.
- * Copyright (c) 2021-2024 Valve Corporation
- * Copyright (c) 2021-2024 LunarG, Inc.
- * Copyright (C) 2021-2024 Google Inc.
+/* Copyright (c) 2021-2025 The Khronos Group Inc.
+ * Copyright (c) 2021-2025 Valve Corporation
+ * Copyright (c) 2021-2025 LunarG, Inc.
+ * Copyright (C) 2021-2025 Google Inc.
  * Modifications Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1331,7 +1331,7 @@ static const vvl::unordered_map<SubmitError, std::vector<Entry>> &GetSubmitError
          }},
         {SubmitError::kSecondaryCmdNotSimultaneous,
          {
-             {Key(Func::vkQueueSubmit2), "VUID-vkQueueSubmit-pCommandBuffers-00073"},
+             {Key(Func::vkQueueSubmit), "VUID-vkQueueSubmit-pCommandBuffers-00073"},
              {Key(Func::vkQueueSubmit2), "VUID-vkQueueSubmit2-commandBuffer-03877"},
          }},
         {SubmitError::kCmdWrongQueueFamily,


### PR DESCRIPTION
@ziga-lunarg showed in https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/9130 that `VUID-vkCmdExecuteCommands-pCommandBuffers-00091` is not needed (going to remove from spec) but it showed we were missing a test (and not had a bug) for `VUID-vkQueueSubmit-pCommandBuffers-00073`