### PR TITLE
Fix crash when dst buffer has no memory

### DIFF
--- a/layers/core_checks/cc_copy_blit_resolve.cpp
+++ b/layers/core_checks/cc_copy_blit_resolve.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (C) 2015-2024 Google Inc.
+/* Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (C) 2015-2025 Google Inc.
  * Modifications Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -680,8 +680,8 @@ bool CoreChecks::ValidateCmdCopyBufferBounds(VkCommandBuffer cb, const vvl::Buff
     const auto *src_binding = src_buffer_state.Binding();
     const auto *dst_binding = dst_buffer_state.Binding();
 
-    const bool validate_no_memory_overlaps =
-        !are_buffers_sparse && (regionCount > 0) && src_binding && (src_binding->memory_state == dst_binding->memory_state);
+    const bool validate_no_memory_overlaps = !are_buffers_sparse && (regionCount > 0) && src_binding && dst_binding &&
+                                             (src_binding->memory_state == dst_binding->memory_state);
 
     using MemoryRange = vvl::BindableMemoryTracker::BufferRange;
 

--- a/tests/unit/copy_buffer_image.cpp
+++ b/tests/unit/copy_buffer_image.cpp
@@ -3210,3 +3210,27 @@ TEST_F(NegativeCopyBufferImage, UpdateBuffer) {
 
     m_command_buffer.End();
 }
+
+TEST_F(NegativeCopyBufferImage, CopyToBufferWithoutMemoryBound) {
+    TEST_DESCRIPTION("Copy to dst buffer that has no memory bound");
+    RETURN_IF_SKIP(Init());
+
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
+    buffer_ci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+    buffer_ci.size = 32u;
+    vkt::Buffer src_buffer(*m_device, buffer_ci);
+    vkt::Buffer dst_buffer(*m_device, buffer_ci, vkt::no_mem);
+
+    m_command_buffer.Begin();
+
+    VkBufferCopy region;
+    region.srcOffset = 0u;
+    region.dstOffset = 0u;
+    region.size = 32u;
+
+    m_errorMonitor->SetDesiredError("VUID-vkCmdCopyBuffer-dstBuffer-00121");
+    vk::CmdCopyBuffer(m_command_buffer, src_buffer.handle(), dst_buffer.handle(), 1u, &region);
+    m_errorMonitor->VerifyFound();
+
+    m_command_buffer.End();
+}


### PR DESCRIPTION
@spencer-lunarg There was no test for `VUID-vkCmdCopyBuffer-dstBuffer-00121` and it would have found this