### PR TITLE
Fixes for VkBindMemoryStatus

### DIFF
--- a/layers/core_checks/cc_device_memory.cpp
+++ b/layers/core_checks/cc_device_memory.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (C) 2015-2024 Google Inc.
+/* Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (C) 2015-2025 Google Inc.
  * Modifications Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -2096,7 +2096,12 @@ void CoreChecks::PostCallRecordBindImageMemory2(VkDevice device, uint32_t bindIn
         // if bindInfoCount is 1, we know for sure if that single image was bound or not
         if (bindInfoCount > 1) {
             for (uint32_t i = 0; i < bindInfoCount; i++) {
-                if (auto image_state = Get<vvl::Image>(pBindInfos[i].image)) {
+                // If user passed in VkBindMemoryStatus, we can update which buffers are good or not
+                if (auto *bind_memory_status = vku::FindStructInPNextChain<VkBindMemoryStatus>(pBindInfos[i].pNext)) {
+                    if (bind_memory_status->pResult && *bind_memory_status->pResult == VK_SUCCESS) {
+                        UpdateBindImageMemoryState(pBindInfos[i]);
+                    }
+                } else if (auto image_state = Get<vvl::Image>(pBindInfos[i].image)) {
                     image_state->indeterminate_state = true;
                 }
             }

--- a/layers/core_checks/cc_device_memory.cpp
+++ b/layers/core_checks/cc_device_memory.cpp
@@ -2092,15 +2092,15 @@ bool CoreChecks::PreCallValidateBindImageMemory2(VkDevice device, uint32_t bindI
 
 void CoreChecks::PostCallRecordBindImageMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo *pBindInfos,
                                                 const RecordObject &record_obj) {
-    // Don't check |record_obj.result| as some bind might be valid
+    // Don't check |record_obj.result| as some binds might still be valid
     BaseClass::PostCallRecordBindImageMemory2(device, bindInfoCount, pBindInfos, record_obj);
 
     for (uint32_t i = 0; i < bindInfoCount; i++) {
         if (auto image_state = Get<vvl::Image>(pBindInfos[i].image)) {
             // Need to protect if some VkBindMemoryStatus are not VK_SUCCESS
-            if (image_state->MemState()) {
-                image_state->SetInitialLayoutMap();
-            }
+            if (!image_state->HasBeenBound()) continue;
+
+            image_state->SetInitialLayoutMap();
         }
     }
 }

--- a/layers/gpu/descriptor_validation/gpuav_image_layout.cpp
+++ b/layers/gpu/descriptor_validation/gpuav_image_layout.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (C) 2015-2024 Google Inc.
+/* Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (C) 2015-2025 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -668,26 +668,22 @@ void Validator::PostCallRecordBindImageMemory(VkDevice device, VkImage image, Vk
 
 void Validator::PostCallRecordBindImageMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo *pBindInfos,
                                                const RecordObject &record_obj) {
-    if (VK_SUCCESS != record_obj.result) return;
+    // Don't check |record_obj.result| as some bind might be valid
     BaseClass::PostCallRecordBindImageMemory2(device, bindInfoCount, pBindInfos, record_obj);
 
     for (uint32_t i = 0; i < bindInfoCount; i++) {
         if (auto image_state = Get<vvl::Image>(pBindInfos[i].image)) {
-            image_state->SetInitialLayoutMap();
+            // Need to protect if some VkBindMemoryStatus are not VK_SUCCESS
+            if (image_state->MemState()) {
+                image_state->SetInitialLayoutMap();
+            }
         }
     }
 }
 
 void Validator::PostCallRecordBindImageMemory2KHR(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo *pBindInfos,
                                                   const RecordObject &record_obj) {
-    if (VK_SUCCESS != record_obj.result) return;
-    BaseClass::PostCallRecordBindImageMemory2KHR(device, bindInfoCount, pBindInfos, record_obj);
-
-    for (uint32_t i = 0; i < bindInfoCount; i++) {
-        if (auto image_state = Get<vvl::Image>(pBindInfos[i].image)) {
-            image_state->SetInitialLayoutMap();
-        }
-    }
+    PostCallRecordBindImageMemory2(device, bindInfoCount, pBindInfos, record_obj);
 }
 
 void Validator::PreCallRecordCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,

--- a/layers/gpu/descriptor_validation/gpuav_image_layout.cpp
+++ b/layers/gpu/descriptor_validation/gpuav_image_layout.cpp
@@ -668,15 +668,15 @@ void Validator::PostCallRecordBindImageMemory(VkDevice device, VkImage image, Vk
 
 void Validator::PostCallRecordBindImageMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo *pBindInfos,
                                                const RecordObject &record_obj) {
-    // Don't check |record_obj.result| as some bind might be valid
+    // Don't check |record_obj.result| as some binds might still be valid
     BaseClass::PostCallRecordBindImageMemory2(device, bindInfoCount, pBindInfos, record_obj);
 
     for (uint32_t i = 0; i < bindInfoCount; i++) {
         if (auto image_state = Get<vvl::Image>(pBindInfos[i].image)) {
             // Need to protect if some VkBindMemoryStatus are not VK_SUCCESS
-            if (image_state->MemState()) {
-                image_state->SetInitialLayoutMap();
-            }
+            if (!image_state->HasBeenBound()) continue;
+
+            image_state->SetInitialLayoutMap();
         }
     }
 }

--- a/layers/state_tracker/device_memory_state.h
+++ b/layers/state_tracker/device_memory_state.h
@@ -260,6 +260,7 @@ class Bindable : public StateObject {
                ((external_memory_handle_types & VK_EXTERNAL_MEMORY_HANDLE_TYPE_SCREEN_BUFFER_BIT_QNX) != 0);
     }
 
+    // Will be false if VkBindMemoryStatus had a non-success result
     const vvl::DeviceMemory *MemState() const {
         const MEM_BINDING *binding = Binding();
         return binding ? binding->memory_state.get() : nullptr;

--- a/layers/state_tracker/device_memory_state.h
+++ b/layers/state_tracker/device_memory_state.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (C) 2015-2024 Google Inc.
+/* Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (C) 2015-2025 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -340,6 +340,7 @@ class Bindable : public StateObject {
     const bool unprotected;  // can't be used for protected memory
 
     // For when an array of binds don't succeed and the object is in an indeterminate state
+    // This is solved if the app provides VkBindMemoryStatus
     bool indeterminate_state = false;
 
   private:

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (C) 2015-2024 Google Inc.
+/* Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (C) 2015-2025 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -147,6 +147,9 @@ class Image : public Bindable {
     bool IsCreateInfoDedicatedAllocationImageAliasingCompatible(const VkImageCreateInfo &other_create_info) const;
 
     bool IsSwapchainImage() const { return create_from_swapchain != VK_NULL_HANDLE; }
+
+    // TODO - need to understand if VkBindImageMemorySwapchainInfoKHR counts as "bound"
+    bool HasBeenBound() const { return (MemState() != nullptr) || (bind_swapchain); }
 
     inline bool IsImageTypeEqual(const VkImageCreateInfo &other_create_info) const {
         return create_info.imageType == other_create_info.imageType;

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -1793,7 +1793,7 @@ void ValidationStateTracker::PostCallRecordBindBufferMemory2(VkDevice device, ui
         // if bindInfoCount is 1, we know for sure if that single buffer was bound or not
         if (bindInfoCount > 1) {
             for (uint32_t i = 0; i < bindInfoCount; i++) {
-                // If user passed in VkBindMemoryStatus, we can update which buffers are good or not
+                // If user passed in VkBindMemoryStatus, we can update which buffers are valid or not
                 if (auto *bind_memory_status = vku::FindStructInPNextChain<VkBindMemoryStatus>(pBindInfos[i].pNext)) {
                     if (bind_memory_status->pResult && *bind_memory_status->pResult == VK_SUCCESS) {
                         UpdateBindBufferMemoryState(pBindInfos[i]);
@@ -3737,7 +3737,7 @@ void ValidationStateTracker::PostCallRecordBindImageMemory2(VkDevice device, uin
         // if bindInfoCount is 1, we know for sure if that single image was bound or not
         if (bindInfoCount > 1) {
             for (uint32_t i = 0; i < bindInfoCount; i++) {
-                // If user passed in VkBindMemoryStatus, we can update which buffers are good or not
+                // If user passed in VkBindMemoryStatus, we can update which images are valid or not
                 if (auto *bind_memory_status = vku::FindStructInPNextChain<VkBindMemoryStatus>(pBindInfos[i].pNext)) {
                     if (bind_memory_status->pResult && *bind_memory_status->pResult == VK_SUCCESS) {
                         UpdateBindImageMemoryState(pBindInfos[i]);

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -1793,7 +1793,12 @@ void ValidationStateTracker::PostCallRecordBindBufferMemory2(VkDevice device, ui
         // if bindInfoCount is 1, we know for sure if that single buffer was bound or not
         if (bindInfoCount > 1) {
             for (uint32_t i = 0; i < bindInfoCount; i++) {
-                if (auto buffer_state = Get<vvl::Buffer>(pBindInfos[i].buffer)) {
+                // If user passed in VkBindMemoryStatus, we can update which buffers are good or not
+                if (auto *bind_memory_status = vku::FindStructInPNextChain<VkBindMemoryStatus>(pBindInfos[i].pNext)) {
+                    if (bind_memory_status->pResult && *bind_memory_status->pResult == VK_SUCCESS) {
+                        UpdateBindBufferMemoryState(pBindInfos[i]);
+                    }
+                } else if (auto buffer_state = Get<vvl::Buffer>(pBindInfos[i].buffer)) {
                     buffer_state->indeterminate_state = true;
                 }
             }

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (C) 2015-2024 Google Inc.
+/* Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (C) 2015-2025 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -269,9 +269,6 @@ class ValidationStateTracker : public ValidationObject {
     }
     ValidationStateTracker(vvl::dispatch::Instance* inst, LayerObjectTypeId type) : BaseClass(inst, type), instance_state(this) {}
     ~ValidationStateTracker();
-
-    static VkBindImageMemoryInfo ConvertImageMemoryInfo(VkDevice device, VkImage image, VkDeviceMemory mem,
-                                                        VkDeviceSize memoryOffset);
 
     template <typename State, typename HandleType = typename state_object::Traits<State>::HandleType>
     void Add(std::shared_ptr<State>&& state_object) {

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -1475,8 +1475,8 @@ class ValidationStateTracker : public ValidationObject {
     void RecordImportFenceState(VkFence fence, VkExternalFenceHandleTypeFlagBits handle_type, VkFenceImportFlags flags);
     void RecordMappedMemory(VkDeviceMemory mem, VkDeviceSize offset, VkDeviceSize size, void** ppData);
     void RecordVulkanSurface(VkSurfaceKHR* pSurface);
-    void UpdateBindBufferMemoryState(VkBuffer buffer, VkDeviceMemory mem, VkDeviceSize memoryOffset);
-    void UpdateBindImageMemoryState(const VkBindImageMemoryInfo& bindInfo);
+    void UpdateBindBufferMemoryState(const VkBindBufferMemoryInfo& bind_info);
+    void UpdateBindImageMemoryState(const VkBindImageMemoryInfo& bind_info);
     void UpdateAllocateDescriptorSetsData(const VkDescriptorSetAllocateInfo*, vvl::AllocateDescriptorSetsData&) const;
 
     void PostCallRecordCopyAccelerationStructureKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2019-2024 The Khronos Group Inc.
- * Copyright (c) 2019-2024 Valve Corporation
- * Copyright (c) 2019-2024 LunarG, Inc.
+/* Copyright (c) 2019-2025 The Khronos Group Inc.
+ * Copyright (c) 2019-2025 Valve Corporation
+ * Copyright (c) 2019-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -2958,11 +2958,14 @@ void SyncValidator::PreCallRecordCmdExecuteCommands(VkCommandBuffer commandBuffe
     }
 }
 
-void SyncValidator::PostCallRecordBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory mem, VkDeviceSize memoryOffset,
+void SyncValidator::PostCallRecordBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory memory, VkDeviceSize memoryOffset,
                                                   const RecordObject &record_obj) {
-    BaseClass::PostCallRecordBindImageMemory(device, image, mem, memoryOffset, record_obj);
+    BaseClass::PostCallRecordBindImageMemory(device, image, memory, memoryOffset, record_obj);
     if (VK_SUCCESS != record_obj.result) return;
-    const VkBindImageMemoryInfo bind_info = ConvertImageMemoryInfo(device, image, mem, memoryOffset);
+    VkBindImageMemoryInfo bind_info = vku::InitStructHelper();
+    bind_info.image = image;
+    bind_info.memory = memory;
+    bind_info.memoryOffset = memoryOffset;
     UpdateSyncImageMemoryBindState(1, &bind_info);
 }
 

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -264,7 +264,7 @@ void SyncValidator::UpdateSyncImageMemoryBindState(uint32_t count, const VkBindI
         auto image_state = Get<ImageState>(info.image);
 
         // Need to protect if some VkBindMemoryStatus are not VK_SUCCESS
-        if (!image_state->MemState()) continue;
+        if (!image_state->HasBeenBound()) continue;
 
         if (image_state->IsTiled()) {
             image_state->SetOpaqueBaseAddress(*this);
@@ -2975,7 +2975,7 @@ void SyncValidator::PostCallRecordBindImageMemory(VkDevice device, VkImage image
 
 void SyncValidator::PostCallRecordBindImageMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo *pBindInfos,
                                                    const RecordObject &record_obj) {
-    // Don't check |record_obj.result| as some bind might be valid
+    // Don't check |record_obj.result| as some binds might still be valid
     BaseClass::PostCallRecordBindImageMemory2(device, bindInfoCount, pBindInfos, record_obj);
 
     UpdateSyncImageMemoryBindState(bindInfoCount, pBindInfos);

--- a/tests/unit/buffer_positive.cpp
+++ b/tests/unit/buffer_positive.cpp
@@ -280,39 +280,3 @@ TEST_F(PositiveBuffer, BufferUsageFlags2Usage) {
     buffer_ci.usage = 0xBAD0000;
     CreateBufferTest(*this, &buffer_ci, {});
 }
-
-TEST_F(PositiveBuffer, BindMemoryStatus) {
-    TEST_DESCRIPTION("Use VkBindMemoryStatus when binding buffer to memory.");
-
-    SetTargetApiVersion(VK_API_VERSION_1_1);
-    AddRequiredFeature(vkt::Feature::maintenance6);
-    AddRequiredExtensions(VK_KHR_MAINTENANCE_6_EXTENSION_NAME);
-    RETURN_IF_SKIP(Init());
-    if (IsPlatformMockICD()) {
-        GTEST_SKIP() << "Test not supported by MockICD, skipping";
-    }
-
-    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
-    buffer_ci.size = 32u;
-    buffer_ci.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
-
-    vkt::Buffer buffer;
-    buffer.InitNoMemory(*m_device, buffer_ci);
-
-    VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
-    alloc_info.allocationSize = 32u;
-    vkt::DeviceMemory memory(*m_device, alloc_info);
-
-    VkResult result = VK_RESULT_MAX_ENUM;
-
-    VkBindMemoryStatus bind_memory_status = vku::InitStructHelper();
-    bind_memory_status.pResult = &result;
-
-    VkBindBufferMemoryInfo bindInfo = vku::InitStructHelper(&bind_memory_status);
-    bindInfo.buffer = buffer.handle();
-    bindInfo.memory = memory.handle();
-    bindInfo.memoryOffset = 0u;
-    vk::BindBufferMemory2(device(), 1u, &bindInfo);
-
-    ASSERT_NE(result, VK_RESULT_MAX_ENUM);
-}

--- a/tests/unit/memory.cpp
+++ b/tests/unit/memory.cpp
@@ -2296,11 +2296,11 @@ TEST_F(NegativeMemory, DISABLED_PartialBoundBuffer) {
 
     VkBindBufferMemoryInfo bind_buffer_infos[2];
     bind_buffer_infos[0] = vku::InitStructHelper();
-    bind_buffer_infos[0].buffer = buffer_0.handle();
-    bind_buffer_infos[0].memory = buffer_memory.handle();
+    bind_buffer_infos[0].buffer = buffer_0;
+    bind_buffer_infos[0].memory = buffer_memory;
     bind_buffer_infos[1] = vku::InitStructHelper();
-    bind_buffer_infos[1].buffer = buffer_1.handle();
-    bind_buffer_infos[1].memory = buffer_memory.handle();
+    bind_buffer_infos[1].buffer = buffer_1;
+    bind_buffer_infos[1].memory = buffer_memory;
 
     VkResult result = vk::BindBufferMemory2KHR(device(), 2, bind_buffer_infos);
     if (result == VK_SUCCESS) {


### PR DESCRIPTION
`VkBindMemoryStatus` was added in `VK_KHR_maintenance6` (which is now part of 1.4)

I allows cases where people batch many things in `vkBindImageMemory2` but provides a way to know which buffer/images actually bound memory or not

This was not well plumbed out throughout the VVL