### PR TITLE
Fix C++23 build error in function_base_block.h

### DIFF
--- a/layers/gpu/spirv/function_basic_block.h
+++ b/layers/gpu/spirv/function_basic_block.h
@@ -19,13 +19,13 @@
 #include <memory>
 #include <spirv/unified1/spirv.hpp>
 #include "containers/custom_containers.h"
+#include "instruction.h"
 
 namespace gpuav {
 namespace spirv {
 
 class Module;
 struct Function;
-struct Instruction;
 
 // Core data structure of module.
 // The vector acts as our linked list to iterator and make occasional insertions.


### PR DESCRIPTION
Trying to build with C++23 fails due to the Instruction type being incomplete (probably std::unique_ptr<> requirements became stricter). This patch fixes the error by #including the type instead of forward declaring.

There are a few other C++23 build errors related to the use of std::aligned_storage, but fixing those is beyond the scope of this patch.