### PR TITLE
gpuav: Disable vertex buffer fetching validation

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -779,7 +779,7 @@
                                             "label": "Index buffers",
                                             "type": "BOOL",
                                             "default": true,
-                                            "description": "Validate that indexed draws do not fetch indices outside of the bounds of the index buffer. Also validates that those indices are not out of the bounds of the fetched vertex buffers.",
+                                            "description": "Validate that indexed draws do not fetch indices outside of the bounds of the index buffer.",
                                             "platforms": [ "WINDOWS", "LINUX" ],
                                             "dependence": {
                                                 "mode": "ALL",

--- a/layers/gpu/core/gpuav_record.cpp
+++ b/layers/gpu/core/gpuav_record.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2018-2024 The Khronos Group Inc.
- * Copyright (c) 2018-2024 Valve Corporation
- * Copyright (c) 2018-2024 LunarG, Inc.
+/* Copyright (c) 2018-2025 The Khronos Group Inc.
+ * Copyright (c) 2018-2025 Valve Corporation
+ * Copyright (c) 2018-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -526,8 +526,11 @@ void Validator::PreCallRecordCmdDrawIndexedIndirect(VkCommandBuffer commandBuffe
 
     valcmd::DrawIndexedIndirectIndexBuffer(*this, *cb_state, record_obj.location, buffer, offset, stride, count, VK_NULL_HANDLE, 0,
                                            "VUID-VkDrawIndexedIndirectCommand-robustBufferAccess2-08798");
+// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9163
+#if 0
     valcmd::DrawIndexedIndirectVertexBuffer(*this, *cb_state, record_obj.location, buffer, offset, stride, count, VK_NULL_HANDLE, 0,
                                             "VUID-vkCmdDrawIndexedIndirect-None-02721");
+#endif
     valcmd::FirstInstance<VkDrawIndexedIndirectCommand>(*this, *cb_state, record_obj.location, buffer, offset, count,
                                                         VK_NULL_HANDLE, 0, "VUID-VkDrawIndexedIndirectCommand-firstInstance-00554");
     PreCallSetupShaderInstrumentationResources(*this, *cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, record_obj.location);
@@ -671,8 +674,11 @@ void Validator::PreCallRecordCmdDrawIndexedIndirectCount(VkCommandBuffer command
 
     valcmd::DrawIndexedIndirectIndexBuffer(*this, *cb_state, record_obj.location, buffer, offset, stride, maxDrawCount, countBuffer,
                                            countBufferOffset, "VUID-VkDrawIndexedIndirectCommand-robustBufferAccess2-08798");
+// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9163
+#if 0
     valcmd::DrawIndexedIndirectVertexBuffer(*this, *cb_state, record_obj.location, buffer, offset, stride, maxDrawCount,
                                             countBuffer, countBufferOffset, "VUID-vkCmdDrawIndexedIndirectCount-None-02721");
+#endif
     PreCallSetupShaderInstrumentationResources(*this, *cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, record_obj.location);
     descriptor::PreCallActionCommand(*this, *cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, record_obj.location);
 }

--- a/tests/unit/gpu_av_index_buffer.cpp
+++ b/tests/unit/gpu_av_index_buffer.cpp
@@ -54,8 +54,8 @@ TEST_F(NegativeGpuAVIndexBuffer, IndexBufferOOB) {
     m_default_queue->Wait();
     m_errorMonitor->VerifyFound();
 }
-
-TEST_F(NegativeGpuAVIndexBuffer, IndirectDrawBadVertexIndex32) {
+// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9163
+TEST_F(NegativeGpuAVIndexBuffer, DISABLED_IndirectDrawBadVertexIndex32) {
     TEST_DESCRIPTION("Validate illegal index buffer values - uint32_t index");
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     RETURN_IF_SKIP(InitGpuAvFramework());
@@ -119,7 +119,8 @@ TEST_F(NegativeGpuAVIndexBuffer, IndirectDrawBadVertexIndex32) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeGpuAVIndexBuffer, IndirectDrawBadVertexIndex16) {
+// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9163
+TEST_F(NegativeGpuAVIndexBuffer, DISABLED_IndirectDrawBadVertexIndex16) {
     TEST_DESCRIPTION("Validate illegal index buffer values - uint16_t index");
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     RETURN_IF_SKIP(InitGpuAvFramework());
@@ -184,7 +185,8 @@ TEST_F(NegativeGpuAVIndexBuffer, IndirectDrawBadVertexIndex16) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeGpuAVIndexBuffer, IndirectDrawBadVertexIndex8) {
+// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9163
+TEST_F(NegativeGpuAVIndexBuffer, DISABLED_IndirectDrawBadVertexIndex8) {
     TEST_DESCRIPTION("Validate illegal index buffer values - uint8_t index");
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_INDEX_TYPE_UINT8_EXTENSION_NAME);
@@ -251,7 +253,8 @@ TEST_F(NegativeGpuAVIndexBuffer, IndirectDrawBadVertexIndex8) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeGpuAVIndexBuffer, DrawBadVertexIndex32) {
+// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9163
+TEST_F(NegativeGpuAVIndexBuffer, DISABLED_DrawBadVertexIndex32) {
     TEST_DESCRIPTION("Validate illegal index buffer values - uint32_t index");
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     RETURN_IF_SKIP(InitGpuAvFramework());
@@ -406,7 +409,8 @@ TEST_F(NegativeGpuAVIndexBuffer, DISABLED_DrawInSecondaryCmdBufferBadVertexIndex
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeGpuAVIndexBuffer, DrawBadVertexIndex16) {
+// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9163
+TEST_F(NegativeGpuAVIndexBuffer, DISABLED_DrawBadVertexIndex16) {
     TEST_DESCRIPTION("Validate illegal index buffer values - uint16_t index");
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     RETURN_IF_SKIP(InitGpuAvFramework());
@@ -463,7 +467,8 @@ TEST_F(NegativeGpuAVIndexBuffer, DrawBadVertexIndex16) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeGpuAVIndexBuffer, DrawBadVertexIndex16_2) {
+// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9163
+TEST_F(NegativeGpuAVIndexBuffer, DISABLED_DrawBadVertexIndex16_2) {
     TEST_DESCRIPTION("Validate illegal index buffer values - uint16_t index");
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     RETURN_IF_SKIP(InitGpuAvFramework());
@@ -542,7 +547,8 @@ TEST_F(NegativeGpuAVIndexBuffer, DrawBadVertexIndex16_2) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeGpuAVIndexBuffer, DrawBadVertexIndex8) {
+// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9163
+TEST_F(NegativeGpuAVIndexBuffer, DISABLED_DrawBadVertexIndex8) {
     TEST_DESCRIPTION("Validate illegal index buffer values - uint8_t index");
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_INDEX_TYPE_UINT8_EXTENSION_NAME);
@@ -602,7 +608,8 @@ TEST_F(NegativeGpuAVIndexBuffer, DrawBadVertexIndex8) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeGpuAVIndexBuffer, DrawBadVertexIndex16DebugLabel) {
+// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9163
+TEST_F(NegativeGpuAVIndexBuffer, DISABLED_DrawBadVertexIndex16DebugLabel) {
     TEST_DESCRIPTION(
         "Validate illegal index buffer values - uint16_t index. Also make sure debug label regions are properly accounted for.");
     AddRequiredExtensions(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
@@ -694,7 +701,8 @@ TEST_F(NegativeGpuAVIndexBuffer, DrawBadVertexIndex16DebugLabel) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeGpuAVIndexBuffer, IndirectDrawBadVertexIndex32DebugLabel) {
+// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9163
+TEST_F(NegativeGpuAVIndexBuffer, DISABLED_IndirectDrawBadVertexIndex32DebugLabel) {
     TEST_DESCRIPTION(
         "Validate illegal index buffer values - uint32_t index. Also make sure debug label regions are properly accounted for.");
     AddRequiredExtensions(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);


### PR DESCRIPTION
Second half of the fix for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9141
It can be too slow, stalling the GPU. I am moving validation to instrumentation