### PR TITLE
Small misc Sync Test fixes

### DIFF
--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -442,7 +442,7 @@ inline const Semaphore no_semaphore;  // equivalent to vkt::Semaphore{}
 class Event : public internal::NonDispHandle<VkEvent> {
   public:
     Event() = default;
-    Event(const Device &dev) { init(dev, vku::InitStruct<VkEventCreateInfo>()); }
+    Event(const Device &dev) { init(dev, CreateInfo(0)); }
     Event(const Device &dev, const VkEventCreateInfo &info) { init(dev, info); }
     ~Event() noexcept;
     void destroy() noexcept;

--- a/tests/unit/sync_object.cpp
+++ b/tests/unit/sync_object.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (c) 2015-2024 Google, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2025 Google, Inc.
  * Modifications Copyright (C) 2020-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -4250,4 +4250,93 @@ TEST_F(NegativeSyncObject, BinarySyncDependsOnTimelineWait5) {
 
     m_second_queue->Submit(vkt::no_cmd, vkt::TimelineSignal(timeline_semaphore, 1));
     m_device->Wait();
+}
+
+TEST_F(NegativeSyncObject, CmdWaitEvents2KHRUsedButSynchronizaion2Disabled) {
+    TEST_DESCRIPTION("Using CmdWaitEvents2KHR when synchronization2 is not enabled");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+
+    vkt::Event event(*m_device);
+    VkEvent event_handle = event.handle();
+    VkDependencyInfo dependency_info = vku::InitStructHelper();
+
+    m_command_buffer.Begin();
+    m_errorMonitor->SetDesiredError("VUID-vkCmdWaitEvents2-synchronization2-03836");
+    vk::CmdWaitEvents2KHR(m_command_buffer.handle(), 1, &event_handle, &dependency_info);
+    m_errorMonitor->VerifyFound();
+
+    if (DeviceValidationVersion() >= VK_API_VERSION_1_3) {
+        m_errorMonitor->SetDesiredError("VUID-vkCmdWaitEvents2-synchronization2-03836");
+        vk::CmdWaitEvents2(m_command_buffer.handle(), 1, &event_handle, &dependency_info);
+        m_errorMonitor->VerifyFound();
+    }
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeSyncObject, Sync2FeatureDisabled) {
+    TEST_DESCRIPTION("Call sync2 functions when the feature is disabled");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+
+    const bool vulkan_13 = (DeviceValidationVersion() >= VK_API_VERSION_1_3);
+    bool timestamp = false;
+
+    uint32_t queue_count;
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_count, NULL);
+    std::vector<VkQueueFamilyProperties> queue_props(queue_count);
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_count, queue_props.data());
+    if (queue_props[m_device->graphics_queue_node_index_].timestampValidBits > 0) {
+        timestamp = true;
+    }
+
+    m_command_buffer.Begin();
+
+    VkDependencyInfo dependency_info = vku::InitStructHelper();
+
+    m_errorMonitor->SetDesiredError("VUID-vkCmdPipelineBarrier2-synchronization2-03848");
+    vk::CmdPipelineBarrier2KHR(m_command_buffer.handle(), &dependency_info);
+    m_errorMonitor->VerifyFound();
+
+    vkt::Event event(*m_device);
+
+    VkPipelineStageFlagBits2 stage = VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT;
+
+    m_errorMonitor->SetDesiredError("VUID-vkCmdResetEvent2-synchronization2-03829");
+    vk::CmdResetEvent2KHR(m_command_buffer.handle(), event.handle(), stage);
+    m_errorMonitor->VerifyFound();
+
+    m_errorMonitor->SetDesiredError("VUID-vkCmdSetEvent2-synchronization2-03824");
+    vk::CmdSetEvent2KHR(m_command_buffer.handle(), event.handle(), &dependency_info);
+    m_errorMonitor->VerifyFound();
+
+    if (timestamp) {
+        vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_TIMESTAMP, 1);
+
+        m_errorMonitor->SetDesiredError("VUID-vkCmdWriteTimestamp2-synchronization2-03858");
+        vk::CmdWriteTimestamp2KHR(m_command_buffer.handle(), stage, query_pool.handle(), 0);
+        m_errorMonitor->VerifyFound();
+        if (vulkan_13) {
+            m_errorMonitor->SetDesiredError("VUID-vkCmdWriteTimestamp2-synchronization2-03858");
+            vk::CmdWriteTimestamp2(m_command_buffer.handle(), stage, query_pool.handle(), 0);
+            m_errorMonitor->VerifyFound();
+        }
+    }
+    if (vulkan_13) {
+        m_errorMonitor->SetDesiredError("VUID-vkCmdPipelineBarrier2-synchronization2-03848");
+        vk::CmdPipelineBarrier2(m_command_buffer.handle(), &dependency_info);
+        m_errorMonitor->VerifyFound();
+
+        m_errorMonitor->SetDesiredError("VUID-vkCmdResetEvent2-synchronization2-03829");
+        vk::CmdResetEvent2(m_command_buffer.handle(), event.handle(), stage);
+        m_errorMonitor->VerifyFound();
+
+        m_errorMonitor->SetDesiredError("VUID-vkCmdSetEvent2-synchronization2-03824");
+        vk::CmdSetEvent2(m_command_buffer.handle(), event.handle(), &dependency_info);
+        m_errorMonitor->VerifyFound();
+    }
+
+    m_command_buffer.End();
 }

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (c) 2015-2024 Google, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2025 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -3826,103 +3826,6 @@ TEST_F(NegativeSyncVal, EventsCommandHazards) {
     vk::CmdCopyBuffer(cb, buffer_a.handle(), buffer_b.handle(), 1, &front2front);
     m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_TRANSFER_BIT);
     vk::CmdExecuteCommands(cb, 1, &scb1);
-    m_command_buffer.End();
-}
-
-TEST_F(NegativeSyncVal, CmdWaitEvents2KHRUsedButSynchronizaion2Disabled) {
-    TEST_DESCRIPTION("Using CmdWaitEvents2KHR when synchronization2 is not enabled");
-    SetTargetApiVersion(VK_API_VERSION_1_3);
-
-    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitFramework());
-    RETURN_IF_SKIP(InitState());
-
-    bool vulkan_13 = (DeviceValidationVersion() >= VK_API_VERSION_1_3);
-
-    vkt::Event event;
-    event.init(*m_device, vkt::Event::CreateInfo(0));
-    VkEvent event_handle = event.handle();
-
-    VkDependencyInfo dependency_info = vku::InitStructHelper();
-
-    m_command_buffer.Begin();
-    m_errorMonitor->SetDesiredError("VUID-vkCmdWaitEvents2-synchronization2-03836");
-    vk::CmdWaitEvents2KHR(m_command_buffer.handle(), 1, &event_handle, &dependency_info);
-    m_errorMonitor->VerifyFound();
-    if (vulkan_13) {
-        m_errorMonitor->SetDesiredError("VUID-vkCmdWaitEvents2-synchronization2-03836");
-        vk::CmdWaitEvents2(m_command_buffer.handle(), 1, &event_handle, &dependency_info);
-        m_errorMonitor->VerifyFound();
-    }
-    m_command_buffer.End();
-}
-
-TEST_F(NegativeSyncVal, Sync2FeatureDisabled) {
-    TEST_DESCRIPTION("Call sync2 functions when the feature is disabled");
-
-    SetTargetApiVersion(VK_API_VERSION_1_3);
-    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
-
-    RETURN_IF_SKIP(Init());
-
-    bool vulkan_13 = (DeviceValidationVersion() >= VK_API_VERSION_1_3);
-
-    bool timestamp = false;
-
-    uint32_t queue_count;
-    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_count, NULL);
-    std::vector<VkQueueFamilyProperties> queue_props(queue_count);
-    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_count, queue_props.data());
-    if (queue_props[m_device->graphics_queue_node_index_].timestampValidBits > 0) {
-        timestamp = true;
-    }
-
-    m_command_buffer.Begin();
-
-    VkDependencyInfo dependency_info = vku::InitStructHelper();
-
-    m_errorMonitor->SetDesiredError("VUID-vkCmdPipelineBarrier2-synchronization2-03848");
-    vk::CmdPipelineBarrier2KHR(m_command_buffer.handle(), &dependency_info);
-    m_errorMonitor->VerifyFound();
-
-    vkt::Event event(*m_device);
-
-    VkPipelineStageFlagBits2 stage = VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT;
-
-    m_errorMonitor->SetDesiredError("VUID-vkCmdResetEvent2-synchronization2-03829");
-    vk::CmdResetEvent2KHR(m_command_buffer.handle(), event.handle(), stage);
-    m_errorMonitor->VerifyFound();
-
-    m_errorMonitor->SetDesiredError("VUID-vkCmdSetEvent2-synchronization2-03824");
-    vk::CmdSetEvent2KHR(m_command_buffer.handle(), event.handle(), &dependency_info);
-    m_errorMonitor->VerifyFound();
-
-    if (timestamp) {
-        vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_TIMESTAMP, 1);
-
-        m_errorMonitor->SetDesiredError("VUID-vkCmdWriteTimestamp2-synchronization2-03858");
-        vk::CmdWriteTimestamp2KHR(m_command_buffer.handle(), stage, query_pool.handle(), 0);
-        m_errorMonitor->VerifyFound();
-        if (vulkan_13) {
-            m_errorMonitor->SetDesiredError("VUID-vkCmdWriteTimestamp2-synchronization2-03858");
-            vk::CmdWriteTimestamp2(m_command_buffer.handle(), stage, query_pool.handle(), 0);
-            m_errorMonitor->VerifyFound();
-        }
-    }
-    if (vulkan_13) {
-        m_errorMonitor->SetDesiredError("VUID-vkCmdPipelineBarrier2-synchronization2-03848");
-        vk::CmdPipelineBarrier2(m_command_buffer.handle(), &dependency_info);
-        m_errorMonitor->VerifyFound();
-
-        m_errorMonitor->SetDesiredError("VUID-vkCmdResetEvent2-synchronization2-03829");
-        vk::CmdResetEvent2(m_command_buffer.handle(), event.handle(), stage);
-        m_errorMonitor->VerifyFound();
-
-        m_errorMonitor->SetDesiredError("VUID-vkCmdSetEvent2-synchronization2-03824");
-        vk::CmdSetEvent2(m_command_buffer.handle(), event.handle(), &dependency_info);
-        m_errorMonitor->VerifyFound();
-    }
-
     m_command_buffer.End();
 }
 

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -1713,7 +1713,7 @@ TEST_F(NegativeSyncVal, CmdDispatchDrawHazards) {
         }
     )glsl";
 
-    vkt::Event event(*m_device, vkt::Event::CreateInfo(0));
+    vkt::Event event(*m_device);
     VkEvent event_handle = event.handle();
 
     CreateComputePipelineHelper pipe(*this);
@@ -3539,8 +3539,7 @@ TEST_F(NegativeSyncVal, EventsBufferCopy) {
     VkBufferCopy front2back = {0, 128, 128};
     VkBufferCopy back2back = {128, 128, 128};
 
-    vkt::Event event;
-    event.init(*m_device, vkt::Event::CreateInfo(0));
+    vkt::Event event(*m_device);
     VkEvent event_handle = event.handle();
 
     auto cb = m_command_buffer.handle();
@@ -3623,8 +3622,7 @@ TEST_F(NegativeSyncVal, EventsCopyImageHazards) {
     vkt::Image image_b(*m_device, image_ci, vkt::set_layout);
     vkt::Image image_c(*m_device, image_ci, vkt::set_layout);
 
-    vkt::Event event;
-    event.init(*m_device, vkt::Event::CreateInfo(0));
+    vkt::Event event(*m_device);
     VkEvent event_handle = event.handle();
 
     VkImageSubresourceLayers layers_all{VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 2};
@@ -3733,9 +3731,7 @@ TEST_F(NegativeSyncVal, EventsCommandHazards) {
     RETURN_IF_SKIP(InitSyncValFramework());
     RETURN_IF_SKIP(InitState());
 
-    vkt::Event event;
-    event.init(*m_device, vkt::Event::CreateInfo(0));
-
+    vkt::Event event(*m_device);
     const VkEvent event_handle = event.handle();
 
     m_command_buffer.Begin();


### PR DESCRIPTION
- Move 2 tests to Sync Object
- Use `vkt::Event` the same everywhere