### PR TITLE
layers: Move VK_EXT_robustness2 check to corechecks

### DIFF
--- a/layers/core_checks/cc_pipeline.cpp
+++ b/layers/core_checks/cc_pipeline.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (C) 2015-2024 Google Inc.
+/* Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (C) 2015-2025 Google Inc.
  * Modifications Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -126,6 +126,37 @@ bool CoreChecks::ValidatePipelineRobustnessCreateInfo(const vvl::Pipeline &pipel
                          "is VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS "
                          "but robustImageAccess2 is not supported.");
     }
+
+    if (!has_robust_buffer_access2) {
+        if (pipeline_robustness_info.storageBuffers == VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2) {
+            skip |= LogError(
+                "VUID-VkPipelineRobustnessCreateInfo-robustBufferAccess2-06931", device,
+                loc.pNext(Struct::VkPipelineRobustnessCreateInfo, Field::storageBuffers),
+                "is VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2, but robustBufferAccess2 is not supported.");
+        }
+        if (pipeline_robustness_info.uniformBuffers == VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2) {
+            skip |= LogError(
+                "VUID-VkPipelineRobustnessCreateInfo-robustBufferAccess2-06932", device,
+                loc.pNext(Struct::VkPipelineRobustnessCreateInfo, Field::uniformBuffers),
+                "is VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2, but robustBufferAccess2 is not supported.");
+        }
+        if (pipeline_robustness_info.vertexInputs == VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2) {
+            skip |= LogError(
+                "VUID-VkPipelineRobustnessCreateInfo-robustBufferAccess2-06933", device,
+                loc.pNext(Struct::VkPipelineRobustnessCreateInfo, Field::vertexInputs),
+                "is VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2, but robustBufferAccess2 is not supported.");
+        }
+    }
+
+    if (!has_robust_image_access2) {
+        if (pipeline_robustness_info.images == VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2) {
+            skip |= LogError(
+                "VUID-VkPipelineRobustnessCreateInfo-robustImageAccess2-06934", device,
+                loc.pNext(Struct::VkPipelineRobustnessCreateInfo, Field::images),
+                "is VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2, but robustImageAccess2 is not supported.");
+        }
+    }
+
     return skip;
 }
 

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -751,6 +751,18 @@ void ValidationStateTracker::PostCreateDevice(const VkDeviceCreateInfo *pCreateI
         has_robust_image_access =
             (api_version >= VK_API_VERSION_1_3 || IsExtEnabled(instance_extensions.vk_khr_get_physical_device_properties2)) &&
             phys_dev_extensions.find(vvl::Extension::_VK_EXT_image_robustness) != phys_dev_extensions.end();
+
+        if (IsExtEnabled(instance_extensions.vk_khr_get_physical_device_properties2) &&
+            phys_dev_extensions.find(vvl::Extension::_VK_EXT_image_robustness) != phys_dev_extensions.end()) {
+            VkPhysicalDeviceRobustness2FeaturesEXT robustness_2_features = vku::InitStructHelper();
+            VkPhysicalDeviceFeatures2 features2 = vku::InitStructHelper(&robustness_2_features);
+            DispatchGetPhysicalDeviceFeatures2Helper(physical_device, &features2);
+            has_robust_image_access2 = robustness_2_features.robustImageAccess2;
+            has_robust_buffer_access2 = robustness_2_features.robustBufferAccess2;
+        } else {
+            has_robust_image_access2 = false;
+            has_robust_buffer_access2 = false;
+        }
     }
 
     const auto &dev_ext = device_extensions;

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -1816,9 +1816,10 @@ class ValidationStateTracker : public ValidationObject {
     // Enabling the other robustness features can reduce performance on GPU, so just the
     // support is needed to check
     bool has_robust_image_access;  // VK_EXT_image_robustness
-    // TODO - Issue 5657
-    // bool has_robust_image_access2;  // VK_EXT_robustness2
-    // bool has_robust_buffer_access2; // VK_EXT_robustness2
+    // Validation requires special handling for VkPhysicalDeviceRobustness2FeaturesEXT, because for some cases robustness features
+    // // need to only be supported, not enabled
+    bool has_robust_image_access2;   // VK_EXT_robustness2
+    bool has_robust_buffer_access2;  // VK_EXT_robustness2
 
     // Device extension properties -- storing properties gathered from VkPhysicalDeviceProperties2::pNext chain
     struct DeviceExtensionProperties {

--- a/layers/stateless/sl_instance_device.cpp
+++ b/layers/stateless/sl_instance_device.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (C) 2015-2024 Google Inc.
+/* Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (C) 2015-2025 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -246,12 +246,6 @@ void StatelessValidation::CommonPostCallRecordEnumeratePhysicalDevice(const VkPh
                     discard_rectangles_extension_version = ext_props[j].specVersion;
                 } else if (extension == vvl::Extension::_VK_NV_scissor_exclusive) {
                     scissor_exclusive_extension_version = ext_props[j].specVersion;
-                } else if (extension == vvl::Extension::_VK_EXT_robustness2 &&
-                           IsExtEnabled(instance_extensions.vk_khr_get_physical_device_properties2)) {
-                    VkPhysicalDeviceRobustness2FeaturesEXT robustness_2_features = vku::InitStructHelper();
-                    VkPhysicalDeviceFeatures2 features2 = vku::InitStructHelper(&robustness_2_features);
-                    DispatchGetPhysicalDeviceFeatures2Helper(phys_device, &features2);
-                    device_supported_robustness_2_features[phys_device] = robustness_2_features;
                 }
             }
 

--- a/layers/stateless/sl_pipeline.cpp
+++ b/layers/stateless/sl_pipeline.cpp
@@ -139,9 +139,6 @@ bool StatelessValidation::ValidatePipelineShaderStageCreateInfoCommon(const VkPi
                              string_VkPipelineShaderStageCreateFlags(create_info.flags).c_str());
         }
     }
-    if (const auto *pipeline_robustness_info = vku::FindStructInPNextChain<VkPipelineRobustnessCreateInfo>(create_info.pNext)) {
-        skip |= ValidatePipelineRobustnessCreateInfo(*pipeline_robustness_info, loc);
-    }
     return skip;
 }
 
@@ -254,50 +251,6 @@ bool StatelessValidation::ValidatePipelineRenderingCreateInfo(const VkPipelineRe
             skip |= ValidateRangedEnum(loc.pNext(Struct::VkPipelineRenderingCreateInfo, Field::pColorAttachmentFormats, j),
                                        vvl::Enum::VkFormat, rendering_struct.pColorAttachmentFormats[j],
                                        "VUID-VkGraphicsPipelineCreateInfo-renderPass-06580");
-        }
-    }
-
-    return skip;
-}
-
-bool StatelessValidation::ValidatePipelineRobustnessCreateInfo(const VkPipelineRobustnessCreateInfo &robustness_create_info,
-                                                               const Location &loc) const {
-    bool skip = false;
-
-    VkPhysicalDeviceRobustness2FeaturesEXT supported_robustness_2_features = vku::InitStructHelper();
-
-    const auto &dev_robustness_enumerated = device_supported_robustness_2_features.find(physical_device);
-    if (dev_robustness_enumerated != device_supported_robustness_2_features.end()) {
-        supported_robustness_2_features = dev_robustness_enumerated->second;
-    }
-
-    if (!supported_robustness_2_features.robustBufferAccess2) {
-        if (robustness_create_info.storageBuffers == VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2) {
-            skip |= LogError(
-                "VUID-VkPipelineRobustnessCreateInfo-robustBufferAccess2-06931", device,
-                loc.pNext(Struct::VkPipelineRobustnessCreateInfo, Field::storageBuffers),
-                "is VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2, but robustBufferAccess2 is not supported.");
-        }
-        if (robustness_create_info.uniformBuffers == VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2) {
-            skip |= LogError(
-                "VUID-VkPipelineRobustnessCreateInfo-robustBufferAccess2-06932", device,
-                loc.pNext(Struct::VkPipelineRobustnessCreateInfo, Field::uniformBuffers),
-                "is VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2, but robustBufferAccess2 is not supported.");
-        }
-        if (robustness_create_info.vertexInputs == VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2) {
-            skip |= LogError(
-                "VUID-VkPipelineRobustnessCreateInfo-robustBufferAccess2-06933", device,
-                loc.pNext(Struct::VkPipelineRobustnessCreateInfo, Field::vertexInputs),
-                "is VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2, but robustBufferAccess2 is not supported.");
-        }
-    }
-
-    if (!supported_robustness_2_features.robustImageAccess2) {
-        if (robustness_create_info.images == VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2) {
-            skip |= LogError(
-                "VUID-VkPipelineRobustnessCreateInfo-robustImageAccess2-06934", device,
-                loc.pNext(Struct::VkPipelineRobustnessCreateInfo, Field::images),
-                "is VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2, but robustImageAccess2 is not supported.");
         }
     }
 
@@ -1278,11 +1231,6 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(
         }
 
         skip |= ValidatePipelineBinaryInfo(create_info.pNext, create_info.flags, pipelineCache, create_info_loc);
-
-        if (const auto *pipeline_robustness_info =
-                vku::FindStructInPNextChain<VkPipelineRobustnessCreateInfo>(pCreateInfos[i].pNext)) {
-            skip |= ValidatePipelineRobustnessCreateInfo(*pipeline_robustness_info, create_info_loc);
-        }
     }
 
     return skip;
@@ -1420,11 +1368,6 @@ bool StatelessValidation::manual_PreCallValidateCreateComputePipelines(VkDevice 
         skip |= ValidatePipelineShaderStageCreateInfoCommon(create_info.stage, create_info_loc.dot(Field::stage));
 
         skip |= ValidatePipelineBinaryInfo(create_info.pNext, create_info.flags, pipelineCache, create_info_loc);
-
-        if (const auto *pipeline_robustness_info =
-                vku::FindStructInPNextChain<VkPipelineRobustnessCreateInfo>(pCreateInfos[i].pNext)) {
-            skip |= ValidatePipelineRobustnessCreateInfo(*pipeline_robustness_info, create_info_loc);
-        }
     }
     return skip;
 }

--- a/layers/stateless/sl_ray_tracing.cpp
+++ b/layers/stateless/sl_ray_tracing.cpp
@@ -655,11 +655,6 @@ bool StatelessValidation::manual_PreCallValidateCreateRayTracingPipelinesKHR(
         }
 
         skip |= ValidatePipelineBinaryInfo(create_info.pNext, create_info.flags, pipelineCache, create_info_loc);
-
-        if (const auto *pipeline_robustness_info =
-                vku::FindStructInPNextChain<VkPipelineRobustnessCreateInfo>(pCreateInfos[i].pNext)) {
-            skip |= ValidatePipelineRobustnessCreateInfo(*pipeline_robustness_info, create_info_loc);
-        }
     }
 
     return skip;

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -34,17 +34,13 @@ class StatelessValidation : public ValidationObject {
 
   public:
     StatelessValidation(vvl::dispatch::Device *dev, StatelessValidation *instance_vo)
-        : BaseClass(dev, LayerObjectTypeParameterValidation),
-          device_supported_robustness_2_features(instance_vo->device_supported_robustness_2_features) {}
+        : BaseClass(dev, LayerObjectTypeParameterValidation) {}
     StatelessValidation(vvl::dispatch::Instance *inst) : BaseClass(inst, LayerObjectTypeParameterValidation) {}
     ~StatelessValidation() {}
 
     VkPhysicalDeviceLimits device_limits = {};
     vvl::unordered_map<VkPhysicalDevice, VkPhysicalDeviceProperties *> physical_device_properties_map;
     vvl::unordered_map<VkPhysicalDevice, vvl::unordered_set<vvl::Extension>> device_extensions_enumerated{};
-    // Validation requires special handling for VkPhysicalDeviceRobustness2FeaturesEXT, because for some cases robustness features
-    // need to only be supported, not enabled
-    vvl::unordered_map<VkPhysicalDevice, VkPhysicalDeviceRobustness2FeaturesEXT> device_supported_robustness_2_features{};
     // We have a copy of this in Stateless and ValidationStateTracker, could move the ValidationObject, but we don't have a way to
     // set it at the ValidationObject level
     DeviceFeatures enabled_features = {};
@@ -462,8 +458,6 @@ class StatelessValidation : public ValidationObject {
     bool ValidatePipelineBinaryInfo(const void *next, VkPipelineCreateFlags flags, VkPipelineCache pipelineCache,
                                     const Location &loc) const;
     bool ValidatePipelineRenderingCreateInfo(const VkPipelineRenderingCreateInfo &rendering_struct, const Location &loc) const;
-    bool ValidatePipelineRobustnessCreateInfo(const VkPipelineRobustnessCreateInfo &robustness_create_info,
-                                              const Location &loc) const;
     bool ValidateCreateGraphicsPipelinesFlags(const VkPipelineCreateFlags2KHR flags, const Location &flags_loc) const;
     bool manual_PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount,
                                                        const VkGraphicsPipelineCreateInfo *pCreateInfos,


### PR DESCRIPTION
followup to https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/9088 (after spending more time looking into it)

I think this stuff is better suited in CoreChecks state tracking than stateless, we already had a `ValidatePipelineRobustnessCreateInfo` doing the same logic and rather keep the "check if the extension is supported" logic together 