### PR TITLE
chassis: Remove tls caching of device/instance state

### DIFF
--- a/tests/unit/instanceless.cpp
+++ b/tests/unit/instanceless.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2020-2024 The Khronos Group Inc.
- * Copyright (c) 2020-2024 Valve Corporation
- * Copyright (c) 2020-2024 LunarG, Inc.
+/* Copyright (c) 2020-2025 The Khronos Group Inc.
+ * Copyright (c) 2020-2025 Valve Corporation
+ * Copyright (c) 2020-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@
 //       tested if the debug extensions are made robust enough
 
 #include <memory>
+#include <thread>
 #include <vector>
 
 #include "utils/cast_utils.h"
@@ -393,4 +394,42 @@ TEST_F(NegativeInstanceless, DISABLED_VkLayerSettingEXT) {
         vk::CreateInstance(&ici, nullptr, &dummy_instance);
         Monitor().VerifyFound();
     }
+}
+
+// Test for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9181
+TEST_F(NegativeInstanceless, DestroyDeviceRace) {
+    TEST_DESCRIPTION("Test vkDestroyDevice from multiple threads to make sure handle lookup isn't accessing stale data");
+    RETURN_IF_SKIP(InitFramework());
+    const auto ici = GetInstanceCreateInfo();
+
+    VkInstance instance;
+    ASSERT_EQ(VK_SUCCESS, vk::CreateInstance(&ici, nullptr, &instance));
+    uint32_t physical_device_count = 1;
+    VkPhysicalDevice physical_device;
+    const VkResult err = vk::EnumeratePhysicalDevices(instance, &physical_device_count, &physical_device);
+    ASSERT_TRUE(err == VK_SUCCESS || err == VK_INCOMPLETE) << string_VkResult(err);
+    ASSERT_EQ(physical_device_count, 1);
+
+    float dqci_priorities[] = {1.0};
+    VkDeviceQueueCreateInfo dqci = vku::InitStructHelper();
+    dqci.queueFamilyIndex = 0;
+    dqci.queueCount = 1;
+    dqci.pQueuePriorities = dqci_priorities;
+
+    VkDeviceCreateInfo dci = vku::InitStructHelper();
+    dci.queueCreateInfoCount = 1;
+    dci.pQueueCreateInfos = &dqci;
+
+    VkDevice device;
+    ASSERT_EQ(VK_SUCCESS, vk::CreateDevice(physical_device, &dci, nullptr, &device));
+
+    const auto& destroy_func = [device]() { vk::DestroyDevice(device, nullptr); };
+    std::thread destroy_thread(destroy_func);
+    destroy_thread.join();
+
+    VkDevice device2;
+    ASSERT_EQ(VK_SUCCESS, vk::CreateDevice(physical_device, &dci, nullptr, &device2));
+
+    vk::DestroyDevice(device2, nullptr);
+    vk::DestroyInstance(instance, nullptr);
 }


### PR DESCRIPTION
It is possible for a the tls cache to contain a destroyed object in multithreaded applications.

Fixes #9181