### PR TITLE
tests: Add missing barrier tests

### DIFF
--- a/layers/sync/sync_vuid_maps.cpp
+++ b/layers/sync/sync_vuid_maps.cpp
@@ -42,6 +42,8 @@ const vvl::unordered_map<VkPipelineStageFlags2, std::string> &GetFeatureNameMap(
         {VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR, "shadingRate"},
         {VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR, "rayTracing"},
         {VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR, "rayTracing"},
+        {VK_PIPELINE_STAGE_2_SUBPASS_SHADER_BIT_HUAWEI, "subpassShading"},
+        {VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI, "invocationMask"},
     };
     return feature_name_map;
 }


### PR DESCRIPTION
Adds tests for:
VUID-vkCmdPipelineBarrier-dstStageMask-04091
 VUID-vkCmdPipelineBarrier-dstStageMask-04092
 VUID-vkCmdPipelineBarrier-dstStageMask-04093
 VUID-vkCmdPipelineBarrier-dstStageMask-04094
 VUID-vkCmdPipelineBarrier-dstStageMask-03937
 VUID-vkCmdPipelineBarrier-dstStageMask-07318
 VUID-VkBufferMemoryBarrier2-dstStageMask-04957
 VUID-VkBufferMemoryBarrier2-dstStageMask-04995