### PR TITLE
sync: Ignore aspect mask of depth-stencil attachment view

### DIFF
--- a/layers/sync/sync_access_context.h
+++ b/layers/sync/sync_access_context.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2019-2024 Valve Corporation
- * Copyright (c) 2019-2024 LunarG, Inc.
+ * Copyright (c) 2019-2025 Valve Corporation
+ * Copyright (c) 2019-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -238,7 +238,6 @@ class AttachmentViewGen {
 
   private:
     const syncval_state::ImageViewState *view_ = nullptr;
-    VkImageAspectFlags view_mask_ = 0U;
     std::array<std::optional<ImageRangeGen>, Gen::kGenSize> gen_store_;
 };
 

--- a/layers/sync/sync_image.h
+++ b/layers/sync/sync_image.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2019-2024 Valve Corporation
- * Copyright (c) 2019-2024 LunarG, Inc.
+ * Copyright (c) 2019-2025 Valve Corporation
+ * Copyright (c) 2019-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,8 @@ class ImageViewState : public vvl::ImageView {
     ImageViewState(const std::shared_ptr<vvl::Image> &image_state, VkImageView handle, const VkImageViewCreateInfo *ci,
                    VkFormatFeatureFlags2 ff, const VkFilterCubicImageViewImageFormatPropertiesEXT &cubic_props);
     const ImageState *GetImageState() const { return static_cast<const syncval_state::ImageState *>(image_state.get()); }
-    ImageRangeGen MakeImageRangeGen(const VkOffset3D &offset, const VkExtent3D &extent, VkImageAspectFlags aspect_mask = 0) const;
+    ImageRangeGen MakeImageRangeGen(const VkOffset3D &offset, const VkExtent3D &extent,
+                                    VkImageAspectFlags override_depth_stencil_aspect_mask = 0) const;
     const ImageRangeGen &GetFullViewImageRangeGen() const { return view_range_gen; }
 
   protected:

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -3647,16 +3647,15 @@ ImageRangeGen syncval_state::ImageViewState::MakeImageRangeGen() const {
 }
 
 ImageRangeGen syncval_state::ImageViewState::MakeImageRangeGen(const VkOffset3D &offset, const VkExtent3D &extent,
-                                                               const VkImageAspectFlags aspect_mask) const {
+                                                               VkImageAspectFlags override_depth_stencil_aspect_mask) const {
     if (Invalid()) ImageRangeGen();
 
-    // Intentional copy
     VkImageSubresourceRange subresource_range = normalized_subresource_range;
-    if (aspect_mask) {
-        subresource_range.aspectMask &= aspect_mask;
-        assert(subresource_range.aspectMask);
+
+    if (override_depth_stencil_aspect_mask != 0) {
+        assert((override_depth_stencil_aspect_mask & kDepthStencilAspects) == override_depth_stencil_aspect_mask);
+        subresource_range.aspectMask = override_depth_stencil_aspect_mask;
     }
 
     return GetImageState()->MakeImageRangeGen(subresource_range, offset, extent, IsDepthSliced());
 }
-


### PR DESCRIPTION
Determine available depth/stencil components based on ImageView format instead of aspect mask for depth-stencil attachments.
ImageView's aspect mask should be ignored for depth-stencil attachment according to the specification.

Based on this answer https://gitlab.khronos.org/vulkan/vulkan/-/issues/4130#note_510453
