### PR TITLE
layers: Improve profile error messages

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -352,7 +352,8 @@ class CoreChecks : public ValidationStateTracker {
     bool IsSupportedVideoFormat(const VkImageCreateInfo& image_ci, const VkVideoProfileInfoKHR* profile) const;
     bool IsVideoFormatSupported(VkFormat format, VkImageUsageFlags image_usage, const VkVideoProfileInfoKHR* profile) const;
     bool IsBufferCompatibleWithVideoSession(const vvl::Buffer& buffer_state, const vvl::VideoSession& vs_state) const;
-    bool IsImageCompatibleWithVideoSession(const vvl::Image& image_state, const vvl::VideoSession& vs_state) const;
+    bool IsImageCompatibleWithVideoSession(const vvl::Image& image_state, const vvl::VideoSession& vs_state,
+                                           std::string& error_message) const;
     void EnqueueVerifyVideoSessionInitialized(vvl::CommandBuffer& cb_state, vvl::VideoSession& vs_state, const Location& loc,
                                               const char* vuid);
     void EnqueueVerifyVideoInlineQueryUnavailable(vvl::CommandBuffer& cb_state, const VkVideoInlineQueryInfoKHR& query_info,

--- a/layers/error_message/error_strings.h
+++ b/layers/error_message/error_strings.h
@@ -107,3 +107,12 @@
 }
 
 [[maybe_unused]] static std::string string_VkBool32(VkBool32 value) { return value ? "VK_TRUE" : "VK_FALSE"; }
+
+[[maybe_unused]] static std::string string_VkVideoProfileInfoKHR(const VkVideoProfileInfoKHR &profile) {
+    std::stringstream ss;
+    ss << "videoCodecOperation = " << string_VkVideoCodecOperationFlagBitsKHR(profile.videoCodecOperation) << '\n';
+    ss << "chromaSubsampling = " << string_VkVideoChromaSubsamplingFlagsKHR(profile.chromaSubsampling) << '\n';
+    ss << "lumaBitDepth = " << string_VkVideoComponentBitDepthFlagsKHR(profile.lumaBitDepth) << '\n';
+    ss << "chromaBitDepth = " << string_VkVideoComponentBitDepthFlagsKHR(profile.chromaBitDepth);
+    return ss.str();
+}

--- a/layers/state_tracker/video_session_state.cpp
+++ b/layers/state_tracker/video_session_state.cpp
@@ -1,5 +1,5 @@
-/* Copyright (c) 2022-2024 The Khronos Group Inc.
- * Copyright (c) 2022-2024 RasterGrid Kft.
+/* Copyright (c) 2022-2025 The Khronos Group Inc.
+ * Copyright (c) 2022-2025 RasterGrid Kft.
  * Modifications Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +18,7 @@
 #include "state_tracker/image_state.h"
 #include "state_tracker/state_tracker.h"
 #include "generated/dispatch_functions.h"
+#include "error_message/error_strings.h"
 
 #include <sstream>
 
@@ -39,6 +40,23 @@ VideoProfileDesc::~VideoProfileDesc() {
     if (cache_) {
         cache_->Release(this);
     }
+}
+
+std::string VideoProfileDesc::Describe() const {
+    std::stringstream ss;
+    ss << string_VkVideoProfileInfoKHR(profile_.base) << '\n';
+    if (profile_.is_decode) {
+        ss << "VkVideoDecodeUsageInfoKHR::videoUsageHints = "
+           << string_VkVideoDecodeUsageFlagsKHR(profile_.decode_usage.videoUsageHints) << '\n';
+    } else if (profile_.is_encode) {
+        ss << "VkVideoEncodeUsageInfoKHR::videoUsageHints = "
+           << string_VkVideoEncodeUsageFlagsKHR(profile_.encode_usage.videoUsageHints) << '\n';
+        ss << "VkVideoEncodeUsageInfoKHR::videoContentHints = "
+           << string_VkVideoEncodeContentFlagsKHR(profile_.encode_usage.videoContentHints) << '\n';
+        ss << "VkVideoEncodeUsageInfoKHR::tuningMode = " << string_VkVideoEncodeTuningModeKHR(profile_.encode_usage.tuningMode)
+           << '\n';
+    }
+    return ss.str();
 }
 
 bool VideoProfileDesc::InitProfile(VkVideoProfileInfoKHR const *profile) {

--- a/layers/state_tracker/video_session_state.h
+++ b/layers/state_tracker/video_session_state.h
@@ -1,5 +1,5 @@
-/* Copyright (c) 2022-2024 The Khronos Group Inc.
- * Copyright (c) 2022-2024 RasterGrid Kft.
+/* Copyright (c) 2022-2025 The Khronos Group Inc.
+ * Copyright (c) 2022-2025 RasterGrid Kft.
  * Modifications Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -104,6 +104,7 @@ class VideoProfileDesc : public std::enable_shared_from_this<VideoProfileDesc> {
     VideoProfileDesc(VkPhysicalDevice physical_device, VkVideoProfileInfoKHR const *profile);
     ~VideoProfileDesc();
 
+    std::string Describe() const;
     const Profile &GetProfile() const { return profile_; }
     const Capabilities &GetCapabilities() const { return capabilities_; }
 


### PR DESCRIPTION
This an attempt at https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8625

@aqnuep I agree with Mike that just saying `IsImageCompatibleWithVideoSession` failed doesn't help the user narrow things down. I was going to try and add some more helper to print things out (without wasting cycles when things are valid) but realize I don't know enough about Video to know **what** information would be helpful, so making this PR in hope you can come up with something similar to solve the issue

A new error message now looks like

```
Validation Error: [ VUID-VkVideoBeginCodingInfoKHR-pPictureResource-07240 ] ... 
vkCmdBeginVideoCodingKHR(): pBeginInfo->pReferenceSlots[0].pPictureResource->imageViewBinding (VkImageView 0xd10d270000000018[] created from VkImage 0xd897d90000000016[]) is not compatible with the video profile VkVideoSessionKHR 0xe7f79a0000000005[] was created with.
The image was create without VK_IMAGE_CREATE_VIDEO_PROFILE_INDEPENDENT_BIT_KHR and could not find an profile for the image supported with the profile:
videoCodecOperation = VK_VIDEO_CODEC_OPERATION_ENCODE_AV1_BIT_KHR
chromaSubsampling = VK_VIDEO_CHROMA_SUBSAMPLING_422_BIT_KHR
lumaBitDepth = VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR
chromaBitDepth = VK_VIDEO_COMPONENT_BIT_DEPTH_8_BIT_KHR
VkVideoEncodeUsageInfoKHR::videoUsageHints = VkVideoEncodeUsageFlagsKHR(0)
VkVideoEncodeUsageInfoKHR::videoContentHints = VkVideoEncodeContentFlagsKHR(0)
VkVideoEncodeUsageInfoKHR::tuningMode = VK_VIDEO_ENCODE_TUNING_MODE_DEFAULT_KHR
```

(Note, we had this same issue with showing why two pipeline layers were not compatible, see `DescribePipelineLayoutSetNonCompatible`)