### PR TITLE
layers: Combine vkCmdSetDiscardRectangleEXT check

### DIFF
--- a/tests/unit/shader_object_positive.cpp
+++ b/tests/unit/shader_object_positive.cpp
@@ -1649,21 +1649,21 @@ TEST_F(PositiveShaderObject, DiscardRectangleModeEXT) {
         GTEST_SKIP() << "need VK_EXT_discard_rectangles version 2";
     }
     InitDynamicRenderTarget();
+    VkPhysicalDeviceDiscardRectanglePropertiesEXT discard_rectangle_properties = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(discard_rectangle_properties);
+    std::vector<VkRect2D> discard_rectangles(discard_rectangle_properties.maxDiscardRectangles);
 
-    const vkt::Shader vertShader(*m_device, VK_SHADER_STAGE_VERTEX_BIT, GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl));
+    const vkt::Shader vert_shader(*m_device, VK_SHADER_STAGE_VERTEX_BIT, GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl));
 
-    const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
-                                 GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
+    const vkt::Shader frag_shader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
+                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
     m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     vk::CmdSetDiscardRectangleEnableEXT(m_command_buffer.handle(), VK_TRUE);
-    VkRect2D discardRectangle;
-    discardRectangle.offset = {};
-    discardRectangle.extent = {100u, 100u};
-    vk::CmdSetDiscardRectangleEXT(m_command_buffer.handle(), 0u, 1u, &discardRectangle);
+    vk::CmdSetDiscardRectangleEXT(m_command_buffer.handle(), 0u, discard_rectangles.size(), discard_rectangles.data());
     vk::CmdSetDiscardRectangleModeEXT(m_command_buffer.handle(), VK_DISCARD_RECTANGLE_MODE_EXCLUSIVE_EXT);
-    m_command_buffer.BindVertFragShader(vertShader, fragShader);
+    m_command_buffer.BindVertFragShader(vert_shader, frag_shader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
     m_command_buffer.End();


### PR DESCRIPTION
For change in https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/7099

New VU error looks like

> [ VUID-vkCmdDraw-None-07751 ] vkCmdDraw(): vkCmdSetDiscardRectangleEXT was not set for discard rectangle index 1 for this command buffer. Need to set once for each in discardRectangleCount (2). (There was a call to vkCmdBindPipeline that didn't have VK_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT and invalidated the prior vkCmdSetDiscardRectangleEXT call).
