### PR TITLE
layers: Add warning for using Pointer in shader interface

### DIFF
--- a/layers/core_checks/cc_shader_interface.cpp
+++ b/layers/core_checks/cc_shader_interface.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (C) 2015-2024 Google Inc.
+/* Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (C) 2015-2025 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -513,16 +513,17 @@ bool CoreChecks::ValidateInterfaceBetweenStages(const spirv::Module &producer, c
 
     for (const auto &[interface_slot, stage_variable] : producer_entrypoint.output_interface_slots) {
         auto &slot = slot_map[interface_slot.Location()][interface_slot.Component()];
-        if (stage_variable->nested_struct || stage_variable->physical_storage_buffer) {
+        if (stage_variable->nested_struct) {
             return skip;  // TODO workaround
         }
         slot.output = stage_variable;
         slot.output_type = interface_slot.type;
         slot.output_width = interface_slot.bit_width;
     }
+
     for (const auto &[interface_slot, stage_variable] : consumer_entrypoint.input_interface_slots) {
         auto &slot = slot_map[interface_slot.Location()][interface_slot.Component()];
-        if (stage_variable->nested_struct || stage_variable->physical_storage_buffer) {
+        if (stage_variable->nested_struct) {
             return skip;  // TODO workaround
         }
         slot.input = stage_variable;

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -763,6 +763,8 @@ class CoreChecks : public ValidationStateTracker {
                                     const spirv::StatelessData& stateless_data, const Location& loc) const;
     bool ValidateExecutionModes(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
                                 const spirv::StatelessData& stateless_data, const Location& loc) const;
+    bool ValidatePhysicalStorageBuffers(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
+                                        const Location& loc) const;
     bool ValidateShaderExecutionModes(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
                                       VkShaderStageFlagBits stage, const vvl::Pipeline* pipeline, const Location& loc) const;
     bool ValidateInterfaceVertexInput(const vvl::Pipeline& pipeline, const spirv::Module& module_state,

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2024 The Khronos Group Inc.
+/* Copyright (c) 2021-2025 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -359,7 +359,6 @@ struct StageInterfaceVariable : public VariableBase {
     const Instruction &base_type;
     const bool is_builtin;
     bool nested_struct;
-    bool physical_storage_buffer;
 
     const std::vector<InterfaceSlot> interface_slots;  // Only for User Defined variables
     const std::vector<uint32_t> builtin_block;
@@ -528,6 +527,8 @@ struct EntryPoint {
 
     bool has_passthrough{false};
     bool has_alpha_to_coverage_variable{false};  // only for Fragment shaders
+
+    bool has_physical_storage_buffer_interface{false};
 
     EntryPoint(const Module &module_state, const Instruction &entrypoint_insn, const ImageAccessMap &image_access_map,
                const AccessChainVariableMap &access_chain_map, const VariableAccessMap &variable_access_map,

--- a/tests/unit/shader_interface_positive.cpp
+++ b/tests/unit/shader_interface_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (c) 2015-2024 Google, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2025 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1518,4 +1518,38 @@ TEST_F(PositiveShaderInterface, MissingInputAttachmentIndex) {
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
     pipe.gp_ci_.renderPass = rp.Handle();
     pipe.CreateGraphicsPipeline();
+}
+
+TEST_F(PositiveShaderInterface, PhysicalStorageBufferGlslang3) {
+    TEST_DESCRIPTION(
+        "Taken from glslang spv.bufferhandle3.frag test - just creating the shader is valid, interface is tested elsewhere");
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_EXT_SCALAR_BLOCK_LAYOUT_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    RETURN_IF_SKIP(Init());
+
+    char const *fs_source = R"glsl(
+        #version 450
+        #extension GL_EXT_buffer_reference : enable
+
+        layout(buffer_reference, std430) buffer t3 {
+            int h;
+        };
+
+        layout(set = 1, binding = 2, buffer_reference, std430) buffer t4 {
+            layout(offset = 0)  int j;
+            t3 k;
+        } x;
+
+        layout(set = 0, binding = 0, std430) buffer t5 {
+            t4 m;
+        } s5;
+
+        layout(location = 0) flat in t4 k;
+
+        t4 foo(t4 y) { return y; }
+        void main() {}
+    )glsl";
+
+    VkShaderObj fs(this, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT);
 }


### PR DESCRIPTION
(long details in https://gitlab.khronos.org/spirv/SPIR-V/-/issues/779)

but the tl;dr is we have no real CTS coverage or spec language around using a pointer for a shader interface and how it works for things like the amount of `Location` slots used

For the time being, we should at least warn the users as this is ticking timebomb for someone to get trapped in. Also having these tests help regression around the shader interface code that has to dance around this