### PR TITLE
layers: Move maxMemoryAllocationSize check

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1298,9 +1298,6 @@ class CoreChecks : public ValidationStateTracker {
     void PostCallRecordAllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo* pAllocateInfo,
                                               VkDescriptorSet* pDescriptorSets, const RecordObject& record_obj,
                                               vvl::AllocateDescriptorSetsData& ads_state) override;
-    void PostCallRecordAllocateMemory(VkDevice device, const VkMemoryAllocateInfo* pAllocateInfo,
-                                      const VkAllocationCallbacks* pAllocator, VkDeviceMemory* pMemory,
-                                      const RecordObject& record_obj) override;
     bool PreCallValidateCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                                     const VkRayTracingPipelineCreateInfoNV* pCreateInfos,
                                                     const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,

--- a/tests/unit/memory.cpp
+++ b/tests/unit/memory.cpp
@@ -2327,26 +2327,22 @@ TEST_F(NegativeMemory, DISABLED_PartialBoundBuffer) {
     m_errorMonitor->VerifyFound();
 }
 
-// Can see test work, but things like lavapipe will not trigger it
-// Hard to really write a test that will work everywhere, but can enable to confirm
-TEST_F(NegativeMemory, DISABLED_MaxMemoryAllocationSize) {
+TEST_F(NegativeMemory, MaxMemoryAllocationSize) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(Init());
-    if (IsPlatformMockICD()) {
-        GTEST_SKIP() << "MockICD may not fail on limit";
+    if (!IsPlatformMockICD()) {
+        GTEST_SKIP() << "Can't test well on real hardware";
     }
 
     VkPhysicalDeviceVulkan11Properties props11 = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(props11);
 
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
-    alloc_info.memoryTypeIndex = 0;
     alloc_info.allocationSize = props11.maxMemoryAllocationSize + 64;
 
-    VkDeviceMemory memory;
     m_errorMonitor->SetAllowedFailureMsg("VUID-vkAllocateMemory-pAllocateInfo-01713");  // need to bypass stateless
-    m_errorMonitor->SetDesiredWarning("WARNING-CoreValidation-AllocateMemory-maxMemoryAllocationSize");
-    vk::AllocateMemory(device(), &alloc_info, nullptr, &memory);
+    m_errorMonitor->SetDesiredError("UNASSIGNED-vkAllocateMemory-maxMemoryAllocationSize");
+    vkt::DeviceMemory memory(*m_device, alloc_info);
     m_errorMonitor->VerifyFound();
 }
 


### PR DESCRIPTION
This was discussed a LOT in the working group last two weeks (https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/7073)

Basically this **should** be a VU, but can't because of technically it is "defined" what the app will return, but this is impossible for CTS to catch and there is no hardware vendor had a reason why an app should ever try to go above this limit, so we are adding it as a pro-active error 