### PR TITLE
syncval: Split Device and Instance ValidationObjects

### DIFF
--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2019-2024 Valve Corporation
- * Copyright (c) 2019-2024 LunarG, Inc.
+ * Copyright (c) 2019-2025 Valve Corporation
+ * Copyright (c) 2019-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,14 @@
 #include "sync/sync_stats.h"
 #include "sync/sync_submit.h"
 
+namespace syncval {
+// sync validation has no instance-level functionality
+class Instance : public ValidationStateTracker {
+  public:
+    Instance(vvl::dispatch::Instance *dispatch) : ValidationStateTracker(dispatch, LayerObjectTypeSyncValidation) {}
+};
+}  // namespace syncval
+
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkImage, syncval_state::ImageState, vvl::Image)
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkImageView, syncval_state::ImageViewState, vvl::ImageView)
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkCommandBuffer, syncval_state::CommandBuffer, vvl::CommandBuffer)
@@ -41,7 +49,7 @@ class SyncValidator : public ValidationStateTracker, public SyncStageAccess {
     using Struct = vvl::Struct;
     using Field = vvl::Field;
 
-    SyncValidator(vvl::dispatch::Device *dev, SyncValidator *instance_vo)
+    SyncValidator(vvl::dispatch::Device *dev, syncval::Instance *instance_vo)
         : BaseClass(dev, instance_vo, LayerObjectTypeSyncValidation), error_messages_(*this) {}
     SyncValidator(vvl::dispatch::Instance *inst) : BaseClass(inst, LayerObjectTypeSyncValidation), error_messages_(*this) {}
     ~SyncValidator();

--- a/layers/vulkan/generated/dispatch_object.cpp
+++ b/layers/vulkan/generated/dispatch_object.cpp
@@ -63,7 +63,7 @@ void Instance::InitValidationObjects() {
         object_dispatch.emplace_back(new gpuav::Validator(this));
     }
     if (settings.enabled[sync_validation]) {
-        object_dispatch.emplace_back(new SyncValidator(this));
+        object_dispatch.emplace_back(new syncval::Instance(this));
     }
 }
 
@@ -96,7 +96,7 @@ void Device::InitValidationObjects() {
     }
     if (settings.enabled[sync_validation]) {
         object_dispatch.emplace_back(new SyncValidator(
-            this, static_cast<SyncValidator*>(dispatch_instance->GetValidationObject(LayerObjectTypeSyncValidation))));
+            this, static_cast<syncval::Instance*>(dispatch_instance->GetValidationObject(LayerObjectTypeSyncValidation))));
     }
 }
 

--- a/scripts/generators/dispatch_object_generator.py
+++ b/scripts/generators/dispatch_object_generator.py
@@ -40,45 +40,52 @@ class APISpecific:
                 return [
                     {
                         'include': 'thread_tracker/thread_safety_validation.h',
-                        'class': 'ThreadSafety',
-                        'enabled': '!settings.disabled[thread_safety]',
+                        'device': 'ThreadSafety',
+                        'instance': 'ThreadSafety',
                         'type': 'LayerObjectTypeThreading',
+                        'enabled': '!settings.disabled[thread_safety]'
                     },
                     {
                         'include': 'stateless/stateless_validation.h',
-                        'class': 'StatelessValidation',
-                        'enabled': '!settings.disabled[stateless_checks]',
+                        'device': 'StatelessValidation',
+                        'instance': 'StatelessValidation',
                         'type': 'LayerObjectTypeParameterValidation',
+                        'enabled': '!settings.disabled[stateless_checks]'
                     },
                     {
                         'include': 'object_tracker/object_lifetime_validation.h',
-                        'class': 'ObjectLifetimes',
-                        'enabled': '!settings.disabled[object_tracking]',
+                        'device': 'ObjectLifetimes',
+                        'instance': 'ObjectLifetimes',
                         'type': 'LayerObjectTypeObjectTracker',
+                        'enabled': '!settings.disabled[object_tracking]'
                     },
                     {
                         'include': 'core_checks/core_validation.h',
-                        'class': 'CoreChecks',
-                        'enabled': '!settings.disabled[core_checks]',
+                        'device': 'CoreChecks',
+                        'instance': 'CoreChecks',
                         'type': 'LayerObjectTypeCoreValidation',
+                        'enabled': '!settings.disabled[core_checks]'
                     },
                     {
                         'include': 'best_practices/best_practices_validation.h',
-                        'class': 'BestPractices',
-                        'enabled': 'settings.enabled[best_practices]',
+                        'device': 'BestPractices',
+                        'instance': 'BestPractices',
                         'type': 'LayerObjectTypeBestPractices',
+                        'enabled': 'settings.enabled[best_practices]'
                     },
                     {
                         'include': 'gpuav/core/gpuav.h',
-                        'class': 'gpuav::Validator',
-                        'enabled': 'settings.enabled[gpu_validation] || settings.enabled[debug_printf_validation]',
+                        'device': 'gpuav::Validator',
+                        'instance': 'gpuav::Validator',
                         'type': 'LayerObjectTypeGpuAssisted',
+                        'enabled': 'settings.enabled[gpu_validation] || settings.enabled[debug_printf_validation]'
                     },
                     {
                         'include': 'sync/sync_validation.h',
-                        'class': 'SyncValidator',
-                        'enabled': 'settings.enabled[sync_validation]',
+                        'device': 'SyncValidator',
+                        'instance': 'syncval::Instance',
                         'type': 'LayerObjectTypeSyncValidation',
+                        'enabled': 'settings.enabled[sync_validation]'
                     }
                 ]
 
@@ -337,7 +344,7 @@ class DispatchObjectGenerator(BaseGenerator):
                  // Note that this DEFINES THE ORDER IN WHICH THE LAYER VALIDATION OBJECTS ARE CALLED
              ''')
         for layer in APISpecific.getValidationLayerList(self.targetApiName):
-             classname = layer['class']
+             classname = layer['instance']
              out.append(f'''
                  if ({layer["enabled"]}) {{
                      object_dispatch.emplace_back(new {classname}(this));
@@ -350,12 +357,13 @@ class DispatchObjectGenerator(BaseGenerator):
                  // Note that this DEFINES THE ORDER IN WHICH THE LAYER VALIDATION OBJECTS ARE CALLED
              ''')
         for layer in APISpecific.getValidationLayerList(self.targetApiName):
-             classname = layer['class']
-             typeid= layer['type']
-             instance = f'static_cast<{classname}*>(dispatch_instance->GetValidationObject({typeid}))'
+             classname = layer['device']
+             layer_type = layer['type']
+             instance = layer['instance']
+             instance_arg = f'static_cast<{instance}*>(dispatch_instance->GetValidationObject({layer_type}))'
              out.append(f'''
                  if ({layer["enabled"]}) {{
-                     object_dispatch.emplace_back(new {classname}(this, {instance}));
+                     object_dispatch.emplace_back(new {classname}(this, {instance_arg}));
                  }}''')
         out.append('\n')
         out.append('}\n')


### PR DESCRIPTION
This is the start of splitting class ValidationObject into separate Device and Instance classes. Syncval has nothing happening at Instance level so it gets to go first. Once all the leaf classes are split, ValidationStateTracker and ValidationObject can be split. This seems backwards but allows it to happen incrementally rather than in 1 giant PR