### PR TITLE
layers: Add debug option to help compare error messages

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -1145,6 +1145,14 @@
                             "type": "BOOL",
                             "default": false,
                             "platforms": [ "WINDOWS", "LINUX", "MACOS", "ANDROID" ]
+                        },
+                        {
+                            "key": "debug_stable_messages",
+                            "label": "Stable messages",
+                            "view": "ADVANCED",
+                            "description": "Improves the reproducibility of error messages by removing fields that can vary between application runs (e.g., dispatchable handles) for comparison purposes.",
+                            "type": "BOOL",
+                            "default": false
                         }
                     ]
                 },

--- a/layers/error_message/logging.h
+++ b/layers/error_message/logging.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
+/* Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -199,6 +199,7 @@ class DebugReport {
     bool force_default_log_callback{false};
     uint32_t device_created = 0;
     MessageFormatSettings message_format_settings;
+    bool debug_stable_messages{false};
 
     void SetUtilsObjectName(const VkDebugUtilsObjectNameInfoEXT *pNameInfo);
     void SetMarkerObjectName(const VkDebugMarkerObjectNameInfoEXT *pNameInfo);

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2020-2024 The Khronos Group Inc.
- * Copyright (c) 2020-2024 Valve Corporation
- * Copyright (c) 2020-2024 LunarG, Inc.
+/* Copyright (c) 2020-2025 The Khronos Group Inc.
+ * Copyright (c) 2020-2025 Valve Corporation
+ * Copyright (c) 2020-2025 LunarG, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -173,6 +173,7 @@ const char *VK_LAYER_DUPLICATE_MESSAGE_LIMIT = "duplicate_message_limit";
 const char *VK_LAYER_FINE_GRAINED_LOCKING = "fine_grained_locking";
 // Debug settings used for internal development
 const char *VK_LAYER_DEBUG_DISABLE_SPIRV_VAL = "debug_disable_spirv_val";
+const char *VK_LAYER_DEBUG_STABLE_MESSAGES = "debug_stable_messages";
 
 // DebugPrintf (which is now part of GPU-AV internally)
 // ---
@@ -772,6 +773,11 @@ static void ProcessDebugReportSettings(ConfigAndEnvSettings *settings_data, VkuL
         vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_LOG_FILENAME, log_filename);
     }
     const bool is_stdout = log_filename.compare("stdout") == 0;
+
+    // Debug mode to simplify comparison of error messages between application runs
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_DEBUG_STABLE_MESSAGES)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_DEBUG_STABLE_MESSAGES, debug_report->debug_stable_messages);
+    }
 
     // Default
     std::vector<std::string> debug_actions_list = {"VK_DBG_LAYER_ACTION_DEFAULT", "VK_DBG_LAYER_ACTION_LOG_MSG"};


### PR DESCRIPTION
Something I found useful when working with error message code. Helps to finds changes/regressions by removing dispatchable handles for comparison purposes. 

The usual scenario I run entire test suite of negative tests with `--print-vu` + `--gtest_print_time=0` and output result to a file. Then do the code changes, generate another file and compare them. For syncval negative tests if there are no changes then two files are binary equal (should be the same for other tests).

This also works with captures, but the message callback in addition to the main message can add additional fields that vary. This happens for example in doom capture, but added information is always on separate lines which adds a constant diff and it is still easy to detect changes. For CS2 there is no such difference and the outputs are identical except the lines with FPS/timing info.

Enabled by: `VK_LAYER_DEBUG_STABLE_MESSAGES=true`
