### PR TITLE
vvl: Add Tracy GPU profiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # ~~~
-# Copyright (c) 2014-2024 Valve Corporation
-# Copyright (c) 2014-2024 LunarG, Inc.
+# Copyright (c) 2014-2025 Valve Corporation
+# Copyright (c) 2014-2025 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -98,6 +98,13 @@ if (VVL_ENABLE_TRACY)
 
     if(VVL_ENABLE_TRACY_CPU_MEMORY)
         add_compile_definitions(VVL_TRACY_CPU_MEMORY)
+    endif()
+
+    if(VVL_ENABLE_TRACY_GPU)
+        add_compile_definitions(
+            VVL_TRACY_GPU
+            TRACY_VK_USE_SYMBOL_TABLE
+        )
     endif()
 endif()
 

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -452,7 +452,7 @@ if (VVL_ENABLE_TRACY)
     FetchContent_Declare(
         tracy
         GIT_REPOSITORY https://github.com/wolfpld/tracy.git
-        GIT_TAG v0.11.0
+        GIT_TAG v0.11.1
         GIT_SHALLOW TRUE
         GIT_PROGRESS TRUE)
 

--- a/layers/profiling/profiling.cpp
+++ b/layers/profiling/profiling.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
+/* Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,11 @@
 
 #include "profiling/profiling.h"
 
+#include "containers/custom_containers.h"
+#include "vulkan/generated/dispatch_functions.h"
+
 #include <cstdlib>
+#include <thread>
 
 #if defined(VVL_TRACY_CPU_MEMORY)
 
@@ -153,5 +157,243 @@ __attribute__((constructor)) static void so_attach(void) { tracy::StartupProfile
 #endif  // #if defined(_WIN32)
 
 #endif  // #if TRACY_MANUAL_LIFETIME
+
+#if defined(VVL_TRACY_GPU)
+
+// To do things properly, should be a per device object
+static std::array<TracyVkCtx, 8> tracy_vk_contexts;
+
+TracyVkCtx &GetTracyVkCtx() {
+    static std::atomic<uint32_t> context_counter = {0};
+    uint32_t context_i = context_counter.fetch_add(1, std::memory_order_relaxed);
+    context_i = context_i % (uint32_t)tracy_vk_contexts.size();
+    assert(tracy_vk_contexts[context_i]);
+    return tracy_vk_contexts[context_i];
+}
+
+static std::vector<std::unique_ptr<TracyVkCollector>> queue_to_collector_map;
+
+PFN_vkResetCommandBuffer TracyVkCollector::ResetCommandBuffer = nullptr;
+PFN_vkBeginCommandBuffer TracyVkCollector::BeginCommandBuffer = nullptr;
+PFN_vkEndCommandBuffer TracyVkCollector::EndCommandBuffer = nullptr;
+PFN_vkQueueSubmit TracyVkCollector::QueueSubmit = nullptr;
+
+void TracyVkCollector::Create(VkDevice device, VkQueue queue, uint32_t queue_family_i) {
+    if (std::find_if(queue_to_collector_map.begin(), queue_to_collector_map.end(),
+                     [queue](const std::unique_ptr<TracyVkCollector> &collector) { return collector->queue == queue; }) !=
+        queue_to_collector_map.end()) {
+        return;
+    }
+
+    std::unique_ptr<TracyVkCollector> collector = std::make_unique<TracyVkCollector>();
+    collector->device = device;
+    collector->queue = queue;
+
+    VkCommandPoolCreateInfo cmd_pool_ci = vku::InitStructHelper();
+    cmd_pool_ci.flags = VK_COMMAND_POOL_CREATE_TRANSIENT_BIT | VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+    cmd_pool_ci.queueFamilyIndex = queue_family_i;
+    VkResult result = DispatchCreateCommandPool(device, &cmd_pool_ci, nullptr, &collector->cmd_pool);
+    assert(result == VK_SUCCESS);
+
+    VkCommandBufferAllocateInfo cmd_buf_ai = vku::InitStructHelper();
+    cmd_buf_ai.commandPool = collector->cmd_pool;
+    cmd_buf_ai.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    cmd_buf_ai.commandBufferCount = 1;
+
+    result = DispatchAllocateCommandBuffers(device, &cmd_buf_ai, &collector->cmd_buf);
+    assert(result == VK_SUCCESS);
+
+    VkFenceCreateInfo fence_ci = vku::InitStructHelper();
+    fence_ci.flags = VK_FENCE_CREATE_SIGNALED_BIT;
+    result = DispatchCreateFence(device, &fence_ci, nullptr, &collector->fence);
+    assert(result == VK_SUCCESS);
+
+    (void)result;
+
+    collector->collect_thread = std::thread([collector_ptr = collector.get()]() {
+        tracy::SetThreadName("TracyVkCollector::Collect Worker");
+
+        while (true) {
+            std::unique_lock<std::mutex> collect_lock(collector_ptr->collect_mutex);
+            collector_ptr->collect_cv.wait(
+                collect_lock, [collector_ptr]() { return collector_ptr->should_collect || collector_ptr->should_abort; });
+            if (collector_ptr->should_abort) {
+                collect_lock.unlock();
+                return;
+            }
+            collector_ptr->should_collect = false;
+            collect_lock.unlock();
+
+            // VVL_TracyMessageStream("[tracyvk] Collecting TracyVkCollector: device: " << collector_ptr->device
+            //                                                                          << " queue: " << collector_ptr->queue);
+            {
+                VVL_ZoneScopedN("Wait for collect cmd buf fence");
+                const VkResult wait_result =
+                    DispatchWaitForFences(collector_ptr->device, 1, &collector_ptr->fence, VK_TRUE, 16'000'000);
+                assert(wait_result == VK_SUCCESS || wait_result == VK_TIMEOUT);
+                if (wait_result == VK_TIMEOUT) {
+                    VVL_ZoneScopedN("Wait for collect cmd buf fence timeout - setting should_collect to true");
+                    collect_lock.lock();
+                    collector_ptr->should_collect = true;
+                    collect_lock.unlock();
+                    continue;
+                }
+            }
+            {
+                // Due to CPU calls to get query results happening in tracy_vk_ctx->Collect,
+                // the collect command buffer has to be reset and prepared every time
+                // ---
+                VVL_ZoneScopedN("Preparing collect cmd buf");
+                DispatchResetFences(collector_ptr->device, 1, &collector_ptr->fence);
+                TracyVkCollector::ResetCommandBuffer(collector_ptr->cmd_buf, 0);
+
+                VkCommandBufferBeginInfo cmd_buf_bi = vku::InitStructHelper();
+                cmd_buf_bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+                TracyVkCollector::BeginCommandBuffer(collector_ptr->cmd_buf, &cmd_buf_bi);
+                for (TracyVkCtx &tracy_vk_ctx : tracy_vk_contexts) {
+                    tracy_vk_ctx->Collect(collector_ptr->cmd_buf);
+                }
+                TracyVkCollector::EndCommandBuffer(collector_ptr->cmd_buf);
+
+                // No need to guard cmd buffer creation with a mutex,
+                // The VkFence is in charge of synchronizing accesses
+                std::lock_guard<std::mutex> collect_cb_lock(collector_ptr->collect_cb_mutex);
+                collector_ptr->collect_cb_ready = true;
+            }
+        }
+    });
+
+    queue_to_collector_map.emplace_back(std::move(collector));
+    VVL_TracyMessageStream("[tracyvk] Added TracyVkCollector (now " << queue_to_collector_map.size()
+                                                                    << " of them): device: " << device << " queue: " << queue
+                                                                    << " queue family i:" << queue_family_i);
+}
+
+void TracyVkCollector::Destroy(TracyVkCollector &collector) {
+    VVL_TracyMessageStream("[tracyvk] Destroying TracyVkCollector: device: " << collector.device << " queue: " << collector.queue);
+
+    {
+        std::lock_guard<std::mutex> collect_lock(collector.collect_mutex);
+        collector.should_abort = true;
+        collector.collect_cv.notify_one();
+    }
+    collector.collect_thread.join();
+
+    if (collector.fence != VK_NULL_HANDLE) {
+        DispatchDestroyFence(collector.device, collector.fence, nullptr);
+        collector.fence = VK_NULL_HANDLE;
+    }
+
+    if (collector.cmd_buf != VK_NULL_HANDLE) {
+        DispatchFreeCommandBuffers(collector.device, collector.cmd_pool, 1, &collector.cmd_buf);
+        collector.cmd_buf = VK_NULL_HANDLE;
+    }
+
+    if (collector.cmd_pool != VK_NULL_HANDLE) {
+        DispatchDestroyCommandPool(collector.device, collector.cmd_pool, nullptr);
+        collector.cmd_pool = VK_NULL_HANDLE;
+    }
+
+    collector.device = VK_NULL_HANDLE;
+    collector.queue = VK_NULL_HANDLE;
+}
+
+void TracyVkCollector::Collect() {
+    VVL_ZoneScoped;
+    std::lock_guard<std::mutex> collect_lock(collect_mutex);
+    should_collect = true;
+    collect_cv.notify_one();
+}
+
+std::optional<std::pair<VkCommandBuffer, VkFence>> TracyVkCollector::TryGetCollectCb(VkQueue queue) {
+    if (this->queue != queue) {
+        return std::nullopt;
+    }
+
+    std::lock_guard<std::mutex> collect_lock(collect_cb_mutex);
+    if (collect_cb_ready) {
+        collect_cb_ready = false;
+        return std::make_pair(cmd_buf, fence);
+    }
+    return std::nullopt;
+}
+
+// Not thread safe for now, should be fine to profile GFXR traces
+TracyVkCollector &TracyVkCollector::GetTracyVkCollector(VkQueue queue) {
+    VVL_TracyMessageStream("[tracyvk] Getting TracyVkCollector for queue " << queue);
+    for (const std::unique_ptr<TracyVkCollector> &collector : queue_to_collector_map) {
+        if (collector->queue == queue) return *collector;
+    }
+    assert(false);
+    return *queue_to_collector_map[0];
+}
+
+void TracyVkCollector::TrySubmitCollectCb(VkQueue queue) {
+    VVL_ZoneScoped;
+    TracyVkCollector &collector = GetTracyVkCollector(queue);
+
+    std::optional<std::pair<VkCommandBuffer, VkFence>> collect_cb = collector.TryGetCollectCb(queue);
+    if (collect_cb.has_value()) {
+        VkSubmitInfo submit_info = vku::InitStructHelper();
+        submit_info.commandBufferCount = 1;
+        submit_info.pCommandBuffers = &collect_cb->first;
+        const VkResult tracy_collect_result = QueueSubmit(queue, 1, &submit_info, collect_cb->second);
+        assert(tracy_collect_result);
+        (void)tracy_collect_result;
+    }
+}
+
+void InitTracyVk(VkInstance instance, VkPhysicalDevice gpu, VkDevice device, PFN_vkGetInstanceProcAddr GetInstanceProcAddr,
+                 PFN_vkGetDeviceProcAddr GetDeviceProcAddr, PFN_vkResetCommandBuffer ResetCommandBuffer,
+                 PFN_vkBeginCommandBuffer BeginCommandBuffer, PFN_vkEndCommandBuffer EndCommandBuffer,
+                 PFN_vkQueueSubmit QueueSubmit) {
+    TracyVkCollector::ResetCommandBuffer = ResetCommandBuffer;
+    TracyVkCollector::BeginCommandBuffer = BeginCommandBuffer;
+    TracyVkCollector::EndCommandBuffer = EndCommandBuffer;
+    TracyVkCollector::QueueSubmit = QueueSubmit;
+
+    for (TracyVkCtx &tracy_vk_ctx : tracy_vk_contexts) {
+        tracy_vk_ctx = TracyVkContextHostCalibrated(instance, gpu, device, GetInstanceProcAddr, GetDeviceProcAddr);
+        assert(tracy_vk_ctx);
+    }
+}
+
+void CleanupTracyVk(VkDevice device) {
+    for (size_t i = 0; i < queue_to_collector_map.size(); ++i) {
+        if (queue_to_collector_map[i]->device == device) {
+            TracyVkCollector::Destroy(*queue_to_collector_map[i]);
+            queue_to_collector_map[i] = nullptr;
+            std::swap(queue_to_collector_map[i], queue_to_collector_map[queue_to_collector_map.size() - 1]);
+            queue_to_collector_map.resize(queue_to_collector_map.size() - 1);
+        }
+    }
+
+    for (TracyVkCtx &tracy_vk_ctx : tracy_vk_contexts) {
+        if (tracy_vk_ctx) {
+            TracyVkDestroy(tracy_vk_ctx);
+        }
+    }
+}
+
+static vvl::concurrent_unordered_map<VkCommandBuffer, tracy::VkCtxScope *> &GetCbToCtxScopeMap() {
+    static vvl::concurrent_unordered_map<VkCommandBuffer, tracy::VkCtxScope *> cb_to_ctx_scope_map;
+    return cb_to_ctx_scope_map;
+}
+
+void TracyVkZoneStart(tracy::VkCtx *ctx, const tracy::SourceLocationData *srcloc, VkCommandBuffer cmd_buf) {
+    VVL_ZoneScoped;
+    auto ctx_scope = new tracy::VkCtxScope(ctx, srcloc, cmd_buf, true);
+    GetCbToCtxScopeMap().insert(cmd_buf, ctx_scope);
+}
+void TracyVkZoneEnd(VkCommandBuffer cmd_buf) {
+    VVL_ZoneScoped;
+    auto iter = GetCbToCtxScopeMap().pop(cmd_buf);
+    if (iter != GetCbToCtxScopeMap().end()) {
+        assert(iter->second);
+        delete iter->second;
+    }
+}
+
+#endif
 
 #endif  // #if defined(TRACY_ENABLE)

--- a/layers/profiling/profiling.md
+++ b/layers/profiling/profiling.md
@@ -2,18 +2,20 @@
 
 The [Tracy](https://github.com/wolfpld/tracy) profiler has been setup. Get the doc [here](https://github.com/wolfpld/tracy/releases/latest/download/tracy.pdf).
 
-Tested with Tracy version 0.11
+Tested with Tracy version 0.11.1
 
 Relevant CMake options:
 - `-D VVL_ENABLE_TRACY` Enable Tracy
 - `-D VVL_ENABLE_TRACY_CPU_MEMORY` Enable Tracy CPU memory profiling
 - `-D VVL_TRACY_CALLSTACK=<N>` Define maximum collected call stack size (default: 48)
+- `-D VVL_ENABLE_TRACY_GPU` Enable GPU profiling: (only retrieves timings for draw, dispatch and trace rays commands)
 
 ⚠️ Having a big call stack size can have a noticeable impact on performance
 
 ⚠️ Make sure your the various dependencies are compiled with the same optimisations levels and debug as VVL, otherwise expect crashes in `TracyAlloc/Free`
 
-- To enable retrieving data from kernel facilities, for instance to have fine grained info on CPU usage, run the application VVL is injected into with elevated privileges. If you use VkConfig to enable VVL, do not forget to also launch it with elevated privileges.
+- To enable retrieving data from kernel facilities, for instance to have fine grained info on CPU usage by performing sampling, run the application VVL is injected into with elevated privileges. If you use VkConfig to enable VVL, do not forget to also launch it with elevated privileges.
+⚠️ On windows, having other application running with elevated privileges can cause Tracy sampling to fail.
 
 ## Limitations
 
@@ -26,3 +28,17 @@ Relevant CMake options:
 => It is thus assumed that application only create one instance, as of writing it appears to be the case in most applications.
 
 - CPU memory profiling cannot be used with Mimalloc. It needs to be setup, a quick stab at it showed that it is blowing up Tracy.
+
+## GPU profiling 
+
+- Implementation implicitly relies on the following Vulkan features:
+VK_EXT_calibrated_timestamps
+VK_EXT_host_query_reset
+vkGetPhysicalDeviceCalibrateableTimeDomainsEXT returning VK_TIME_DOMAIN_CLOCK_MONOTONIC_RAW_EXT on Windows and VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER on Unix
+
+Those features seem to be present on all drivers used by the main VVL developpers.
+
+⚠️ Required features are added by hacking into `ValidationStateTracker::PreCallRecordCreateDevice`, so profiling can only work if `ValidationStateTracker` is somehow instantiated.
+
+When looking at the `Statistics > GPU` window of a trace, you may noticed that some action commands are missing compared to the amount of action commands submitted by the host.
+It just means that by the time application shuts down, not all GPU time stamp queries have been retrieved.

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -435,6 +435,9 @@ class ValidationStateTracker : public ValidationObject {
     virtual std::shared_ptr<vvl::PhysicalDevice> CreatePhysicalDeviceState(VkPhysicalDevice handle);
     void PostCallRecordCreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                       VkInstance* pInstance, const RecordObject& record_obj) override;
+    void PreCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo,
+                                   const VkAllocationCallbacks* pAllocator, VkDevice* pDevice, const RecordObject& record_obj,
+                                   vku::safe_VkDeviceCreateInfo* modified_create_info) override;
     void PostCallRecordGetAccelerationStructureMemoryRequirementsNV(VkDevice device,
                                                                     const VkAccelerationStructureMemoryRequirementsInfoNV* pInfo,
                                                                     VkMemoryRequirements2* pMemoryRequirements,

--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -3,9 +3,9 @@
 
 /***************************************************************************
  *
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
  * Copyright (c) 2015-2024 Google Inc.
  * Copyright (c) 2023-2024 RasterGrid Kft.
  *
@@ -395,6 +395,9 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceQueue(VkDevice device, uint32_t queueFamilyI
             vo->PostCallRecordGetDeviceQueue(device, queueFamilyIndex, queueIndex, pQueue, record_obj);
         }
     }
+#if defined(VVL_TRACY_GPU)
+    TracyVkCollector::Create(device, *pQueue, queueFamilyIndex);
+#endif
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence) {
@@ -423,6 +426,9 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit(VkQueue queue, uint32_t submitCount, 
     {
         VVL_ZoneScopedN("Dispatch");
         result = device_dispatch->QueueSubmit(queue, submitCount, pSubmits, fence);
+#if defined(VVL_TRACY_GPU)
+        TracyVkCollector::TrySubmitCollectCb(queue);
+#endif
     }
     record_obj.result = result;
     {
@@ -4509,6 +4515,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRenderPass(VkCommandBuffer commandBuffer, con
     }
     {
         VVL_ZoneScopedN("Dispatch");
+        VVL_TracyVkNamedZoneStart(GetTracyVkCtx(), commandBuffer, "gpu_RenderPass");
         device_dispatch->CmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents);
     }
     {
@@ -4580,6 +4587,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRenderPass(VkCommandBuffer commandBuffer) {
     {
         VVL_ZoneScopedN("Dispatch");
         device_dispatch->CmdEndRenderPass(commandBuffer);
+        VVL_TracyVkNamedZoneEnd(commandBuffer);
     }
     {
         VVL_ZoneScopedN("PostCallRecord");
@@ -5316,6 +5324,9 @@ VKAPI_ATTR void VKAPI_CALL GetDeviceQueue2(VkDevice device, const VkDeviceQueueI
             vo->PostCallRecordGetDeviceQueue2(device, pQueueInfo, pQueue, record_obj);
         }
     }
+#if defined(VVL_TRACY_GPU)
+    TracyVkCollector::Create(device, *pQueue, pQueueInfo->queueFamilyIndex);
+#endif
 }
 
 VKAPI_ATTR VkResult VKAPI_CALL CreateSamplerYcbcrConversion(VkDevice device, const VkSamplerYcbcrConversionCreateInfo* pCreateInfo,
@@ -5817,6 +5828,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRenderPass2(VkCommandBuffer commandBuffer, co
     }
     {
         VVL_ZoneScopedN("Dispatch");
+        VVL_TracyVkNamedZoneStart(GetTracyVkCtx(), commandBuffer, "gpu_RenderPass2");
         device_dispatch->CmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo);
     }
     {
@@ -5889,6 +5901,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRenderPass2(VkCommandBuffer commandBuffer, cons
     {
         VVL_ZoneScopedN("Dispatch");
         device_dispatch->CmdEndRenderPass2(commandBuffer, pSubpassEndInfo);
+        VVL_TracyVkNamedZoneEnd(commandBuffer);
     }
     {
         VVL_ZoneScopedN("PostCallRecord");
@@ -6522,6 +6535,9 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit2(VkQueue queue, uint32_t submitCount,
     {
         VVL_ZoneScopedN("Dispatch");
         result = device_dispatch->QueueSubmit2(queue, submitCount, pSubmits, fence);
+#if defined(VVL_TRACY_GPU)
+        TracyVkCollector::TrySubmitCollectCb(queue);
+#endif
     }
     record_obj.result = result;
     {
@@ -6774,6 +6790,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRendering(VkCommandBuffer commandBuffer, cons
     }
     {
         VVL_ZoneScopedN("Dispatch");
+        VVL_TracyVkNamedZoneStart(GetTracyVkCtx(), commandBuffer, "gpu_Rendering");
         device_dispatch->CmdBeginRendering(commandBuffer, pRenderingInfo);
     }
     {
@@ -6810,6 +6827,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRendering(VkCommandBuffer commandBuffer) {
     {
         VVL_ZoneScopedN("Dispatch");
         device_dispatch->CmdEndRendering(commandBuffer);
+        VVL_TracyVkNamedZoneEnd(commandBuffer);
     }
     {
         VVL_ZoneScopedN("PostCallRecord");
@@ -9940,6 +9958,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRenderingKHR(VkCommandBuffer commandBuffer, c
     }
     {
         VVL_ZoneScopedN("Dispatch");
+        VVL_TracyVkNamedZoneStart(GetTracyVkCtx(), commandBuffer, "gpu_RenderingKHR");
         device_dispatch->CmdBeginRenderingKHR(commandBuffer, pRenderingInfo);
     }
     {
@@ -9976,6 +9995,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRenderingKHR(VkCommandBuffer commandBuffer) {
     {
         VVL_ZoneScopedN("Dispatch");
         device_dispatch->CmdEndRenderingKHR(commandBuffer);
+        VVL_TracyVkNamedZoneEnd(commandBuffer);
     }
     {
         VVL_ZoneScopedN("PostCallRecord");
@@ -11124,6 +11144,7 @@ VKAPI_ATTR void VKAPI_CALL CmdBeginRenderPass2KHR(VkCommandBuffer commandBuffer,
     }
     {
         VVL_ZoneScopedN("Dispatch");
+        VVL_TracyVkNamedZoneStart(GetTracyVkCtx(), commandBuffer, "gpu_RenderPass2KHR");
         device_dispatch->CmdBeginRenderPass2KHR(commandBuffer, pRenderPassBegin, pSubpassBeginInfo);
     }
     {
@@ -11196,6 +11217,7 @@ VKAPI_ATTR void VKAPI_CALL CmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, c
     {
         VVL_ZoneScopedN("Dispatch");
         device_dispatch->CmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo);
+        VVL_TracyVkNamedZoneEnd(commandBuffer);
     }
     {
         VVL_ZoneScopedN("PostCallRecord");
@@ -13406,6 +13428,9 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit2KHR(VkQueue queue, uint32_t submitCou
     {
         VVL_ZoneScopedN("Dispatch");
         result = device_dispatch->QueueSubmit2KHR(queue, submitCount, pSubmits, fence);
+#if defined(VVL_TRACY_GPU)
+        TracyVkCollector::TrySubmitCollectCb(queue);
+#endif
     }
     record_obj.result = result;
     {

--- a/layers/vulkan/generated/validation_object.cpp
+++ b/layers/vulkan/generated/validation_object.cpp
@@ -3,9 +3,9 @@
 
 /***************************************************************************
  *
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
  * Copyright (c) 2015-2024 Google Inc.
  * Copyright (c) 2023-2024 RasterGrid Kft.
  *

--- a/layers/vulkan/generated/validation_object_methods.h
+++ b/layers/vulkan/generated/validation_object_methods.h
@@ -3,9 +3,9 @@
 
 /***************************************************************************
  *
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
  * Copyright (c) 2015-2024 Google Inc.
  * Copyright (c) 2023-2024 RasterGrid Kft.
  *


### PR DESCRIPTION
Add initial support for Tracy GPU profiling
=> Allows to get GPU timings for GPU commands. For now, only draws, dispatches and trace rays commands are profiled.

Some implementation details:

GPU profiling relies on timestamp queries. Timestamps have to be added to command buffers, their status is then queried from the host, and available queried are reset after inspection, with a call to `vkCmdResetQueryPool`.
A worker thread is in charge of scanning query results, doing it on the main threads showed serious performance issues.
From testing against GFXR traces threading seems to work, still need to test on live games. A review on this threading part would be especially appreciated!

And if you can time the time to pull this PR and test it locally, that would be awesome, since no new CI tests are added for this.