### PR TITLE
printf: Don't do work when there is no printf instruction

### DIFF
--- a/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2020-2024 The Khronos Group Inc.
- * Copyright (c) 2020-2024 Valve Corporation
- * Copyright (c) 2020-2024 LunarG, Inc.
+/* Copyright (c) 2020-2025 The Khronos Group Inc.
+ * Copyright (c) 2020-2025 Valve Corporation
+ * Copyright (c) 2020-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -305,8 +305,13 @@ void PreCallSetupShaderInstrumentationResources(Validator &gpuav, CommandBuffer 
     // bindings of the instrumentation descriptor set
     assert(gpuav.instrumentation_bindings_.size() == 8);
 
+    // If nothing was updated, we don't want bind anything
+    if (!last_bound.WasInstrumented()) return;
+
     if (gpuav.gpuav_settings.debug_printf_enabled) {
         if (!debug_printf::UpdateInstrumentationDescSet(gpuav, cb_state, instrumentation_desc_set, bind_point, loc)) {
+            // TODO - need cleaner way to indicate if we want to return because of an error or because we want to save from doing
+            // unnecessary work
             return;
         }
     }

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.h
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2020-2024 The Khronos Group Inc.
- * Copyright (c) 2020-2024 Valve Corporation
- * Copyright (c) 2020-2024 LunarG, Inc.
+/* Copyright (c) 2020-2025 The Khronos Group Inc.
+ * Copyright (c) 2020-2025 Valve Corporation
+ * Copyright (c) 2020-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -1430,3 +1430,18 @@ const spirv::EntryPoint *LastBound::GetFragmentEntryPoint() const {
     }
     return nullptr;
 }
+
+bool LastBound::WasInstrumented() const {
+    if (pipeline_state) {
+        return pipeline_state->instrumentation_data.was_instrumented;
+    }
+    for (uint32_t i = 0; i < kShaderObjectStageCount; ++i) {
+        const auto stage = static_cast<ShaderObjectStage>(i);
+        if (!IsValidShaderBound(stage)) continue;
+        const vvl::ShaderObject *shader = GetShaderState(stage);
+        if (shader && shader->instrumentation_data.was_instrumented) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -754,6 +754,9 @@ struct LastBound {
     std::string DescribeNonCompatibleSet(uint32_t set, const vvl::ShaderObject &shader_object_state) const;
 
     const spirv::EntryPoint *GetFragmentEntryPoint() const;
+
+    // For GPU-AV
+    bool WasInstrumented() const;
 };
 
 // Used to compare 2 layouts independently when not tied to the last bound object


### PR DESCRIPTION
Found using `VK_LAYER_PRINTF_ONLY_PRESET` slows down things way too much by default. With this change, find that when an app uses no printf in their shader (because assuming only 1 of there many pipelines will even have it) you regain near "normal" FPS again

note - `VK_LAYER_PRINTF_ONLY_PRESET` turns off everything but DebugPrintf just like vkconfig does