### PR TITLE
gpuav: Follow up on only set resources when needed

### DIFF
--- a/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
@@ -289,6 +289,9 @@ void PreCallSetupShaderInstrumentationResources(Validator &gpuav, CommandBuffer 
     const auto lv_bind_point = ConvertToLvlBindPoint(bind_point);
     const LastBound &last_bound = cb_state.lastBound[lv_bind_point];
 
+    // If nothing was updated, we don't want bind anything
+    if (!last_bound.WasInstrumented()) return;
+
     if (!last_bound.pipeline_state && !last_bound.HasShaderObjects()) {
         gpuav.InternalError(cb_state.VkHandle(), loc, "Neither pipeline state nor shader object states were found.");
         return;
@@ -305,8 +308,7 @@ void PreCallSetupShaderInstrumentationResources(Validator &gpuav, CommandBuffer 
     // bindings of the instrumentation descriptor set
     assert(gpuav.instrumentation_bindings_.size() == 8);
 
-    // If nothing was updated, we don't want bind anything
-    if (!last_bound.WasInstrumented()) return;
+    
 
     if (gpuav.gpuav_settings.debug_printf_enabled) {
         if (!debug_printf::UpdateInstrumentationDescSet(gpuav, cb_state, instrumentation_desc_set, bind_point, loc)) {
@@ -468,6 +470,9 @@ void PostCallSetupShaderInstrumentationResources(Validator &gpuav, CommandBuffer
 
     const LvlBindPoint lv_bind_point = ConvertToLvlBindPoint(bind_point);
     const LastBound &last_bound = cb_state.lastBound[lv_bind_point];
+
+    // If nothing was updated, we don't want bind anything
+    if (!last_bound.WasInstrumented()) return;
 
     // Only need to rebind application desc sets if they have been disturbed by GPU-AV binding its instrumentation desc set.
     // - Can happen if the pipeline layout used to bind instrumentation descriptor set is not compatible with the one used by the


### PR DESCRIPTION
- Move last_bound.WasInstrumented() up a bit in PreCall
- Add it to PostCall