### PR TITLE
gpuav: Fix UseAllDescriptorSlotsPipelineLayout

### DIFF
--- a/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
@@ -289,6 +289,9 @@ void PreCallSetupShaderInstrumentationResources(Validator &gpuav, CommandBuffer 
     const auto lv_bind_point = ConvertToLvlBindPoint(bind_point);
     const LastBound &last_bound = cb_state.lastBound[lv_bind_point];
 
+    // If nothing was updated, we don't want to bind anything
+    if (!last_bound.WasInstrumented()) return;
+
     if (!last_bound.pipeline_state && !last_bound.HasShaderObjects()) {
         gpuav.InternalError(cb_state.VkHandle(), loc, "Neither pipeline state nor shader object states were found.");
         return;
@@ -304,9 +307,6 @@ void PreCallSetupShaderInstrumentationResources(Validator &gpuav, CommandBuffer 
     // Pathetic way of trying to make sure we take care of updating all
     // bindings of the instrumentation descriptor set
     assert(gpuav.instrumentation_bindings_.size() == 8);
-
-    // If nothing was updated, we don't want bind anything
-    if (!last_bound.WasInstrumented()) return;
 
     if (gpuav.gpuav_settings.debug_printf_enabled) {
         if (!debug_printf::UpdateInstrumentationDescSet(gpuav, cb_state, instrumentation_desc_set, bind_point, loc)) {
@@ -468,6 +468,9 @@ void PostCallSetupShaderInstrumentationResources(Validator &gpuav, CommandBuffer
 
     const LvlBindPoint lv_bind_point = ConvertToLvlBindPoint(bind_point);
     const LastBound &last_bound = cb_state.lastBound[lv_bind_point];
+
+    // If nothing was updated, we don't want to bind anything
+    if (!last_bound.WasInstrumented()) return;
 
     // Only need to rebind application desc sets if they have been disturbed by GPU-AV binding its instrumentation desc set.
     // - Can happen if the pipeline layout used to bind instrumentation descriptor set is not compatible with the one used by the

--- a/tests/unit/gpu_av.cpp
+++ b/tests/unit/gpu_av.cpp
@@ -609,9 +609,7 @@ TEST_F(NegativeGpuAV, UseAllDescriptorSlotsPipelineLayout) {
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, bad_pipe_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
-    m_errorMonitor->SetDesiredWarning("Unable to bind instrumentation descriptor set, it would override application's bound set");
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_errorMonitor->VerifyFound();
     m_command_buffer.End();
 
     // normally would produce a VUID-vkCmdDispatch-storageBuffers-06936 warning, but we didn't instrument the shader in the end


### PR DESCRIPTION
https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/9266 plus fix for `UseAllDescriptorSlotsPipelineLayout`