### PR TITLE
gpuav: Switch to device local allocations

### DIFF
--- a/layers/gpuav/core/gpuav_setup.cpp
+++ b/layers/gpuav/core/gpuav_setup.cpp
@@ -498,28 +498,32 @@ void Validator::PostCreateDevice(const VkDeviceCreateInfo *pCreateInfo, const Lo
         desc_heap_.emplace(*this, num_descs, loc);
     }
 
-    VkBufferCreateInfo error_buffer_ci = vku::InitStructHelper();
-    error_buffer_ci.size = glsl::kErrorBufferByteSize;
-    error_buffer_ci.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
-    VmaAllocationCreateInfo alloc_create_info = {};
-    alloc_create_info.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-    uint32_t mem_type_index;
-    result = vmaFindMemoryTypeIndexForBufferInfo(vma_allocator_, &error_buffer_ci, &alloc_create_info, &mem_type_index);
-    if (result != VK_SUCCESS) {
-        InternalVmaError(device, loc, "Unable to find memory type index.");
-        return;
-    }
-    VmaPoolCreateInfo vma_pool_ci = {};
-    vma_pool_ci.memoryTypeIndex = mem_type_index;
-    vma_pool_ci.blockSize = 0;
-    vma_pool_ci.maxBlockCount = 0;
-    if (gpuav_settings.vma_linear_output) {
-        vma_pool_ci.flags = VMA_POOL_CREATE_LINEAR_ALGORITHM_BIT;
-    }
-    result = vmaCreatePool(vma_allocator_, &vma_pool_ci, &output_buffer_pool_);
-    if (result != VK_SUCCESS) {
-        InternalVmaError(device, loc, "Unable to create VMA memory pool.");
-        return;
+    // Create error logging buffer allocation pool
+    {
+        VkBufferCreateInfo error_buffer_ci = vku::InitStructHelper();
+        error_buffer_ci.size = glsl::kErrorBufferByteSize;
+        error_buffer_ci.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+        VmaAllocationCreateInfo error_buffer_alloc_ci = {};
+        error_buffer_alloc_ci.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+        error_buffer_alloc_ci.preferredFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+        uint32_t mem_type_index;
+        result = vmaFindMemoryTypeIndexForBufferInfo(vma_allocator_, &error_buffer_ci, &error_buffer_alloc_ci, &mem_type_index);
+        if (result != VK_SUCCESS) {
+            InternalVmaError(device, loc, "Unable to find memory type index.");
+            return;
+        }
+        VmaPoolCreateInfo vma_pool_ci = {};
+        vma_pool_ci.memoryTypeIndex = mem_type_index;
+        vma_pool_ci.blockSize = 0;
+        vma_pool_ci.maxBlockCount = 0;
+        if (gpuav_settings.vma_linear_output) {
+            vma_pool_ci.flags = VMA_POOL_CREATE_LINEAR_ALGORITHM_BIT;
+        }
+        result = vmaCreatePool(vma_allocator_, &vma_pool_ci, &output_buffer_pool_);
+        if (result != VK_SUCCESS) {
+            InternalVmaError(device, loc, "Unable to create VMA memory pool.");
+            return;
+        }
     }
 
     // Create command indices buffer
@@ -532,6 +536,7 @@ void Validator::PostCreateDevice(const VkDeviceCreateInfo *pCreateInfo, const Lo
         assert(output_buffer_pool_);
         alloc_info.pool = output_buffer_pool_;
         alloc_info.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+        alloc_info.preferredFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
         const bool success = indices_buffer_.Create(loc, &buffer_info, &alloc_info);
         if (!success) {
             return;

--- a/layers/gpuav/debug_printf/debug_printf.cpp
+++ b/layers/gpuav/debug_printf/debug_printf.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2020-2024 The Khronos Group Inc.
- * Copyright (c) 2020-2024 Valve Corporation
- * Copyright (c) 2020-2024 LunarG, Inc.
+/* Copyright (c) 2020-2025 The Khronos Group Inc.
+ * Copyright (c) 2020-2025 Valve Corporation
+ * Copyright (c) 2020-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -385,6 +385,7 @@ bool UpdateInstrumentationDescSet(Validator &gpuav, CommandBuffer &cb_state, VkD
     buffer_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
     VmaAllocationCreateInfo alloc_info = {};
     alloc_info.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+    alloc_info.preferredFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
     alloc_info.pool = gpuav.output_buffer_pool_;
     const bool success = debug_printf_output_buffer.Create(loc, &buffer_info, &alloc_info);
     if (!success) {

--- a/layers/gpuav/resources/gpuav_state_trackers.cpp
+++ b/layers/gpuav/resources/gpuav_state_trackers.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2018-2024 The Khronos Group Inc.
- * Copyright (c) 2018-2024 Valve Corporation
- * Copyright (c) 2018-2024 LunarG, Inc.
+/* Copyright (c) 2018-2025 The Khronos Group Inc.
+ * Copyright (c) 2018-2025 Valve Corporation
+ * Copyright (c) 2018-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -139,6 +139,7 @@ static bool AllocateErrorLogsBuffer(Validator &gpuav, VkCommandBuffer command_bu
     buffer_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
     VmaAllocationCreateInfo alloc_info = {};
     alloc_info.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+    alloc_info.preferredFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
     alloc_info.pool = gpuav.output_buffer_pool_;
     const bool success = error_output_buffer.Create(loc, &buffer_info, &alloc_info);
     if (!success) {
@@ -187,6 +188,7 @@ void CommandBuffer::AllocateResources(const Location &loc) {
         buffer_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
         VmaAllocationCreateInfo alloc_info = {};
         alloc_info.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+        alloc_info.preferredFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
         alloc_info.pool = gpuav->output_buffer_pool_;
         const bool success = cmd_errors_counts_buffer_.Create(loc, &buffer_info, &alloc_info);
         if (!success) {


### PR DESCRIPTION
Showed significant gains for the Tiny Mesh Large sample: Modifying so that it emits OOB errors, render passes are ~300 ms long without this change, and ~20 ms with it (baseline without GPU-AV instrumentation: ~2.5 ms)