### PR TITLE
layers: Update how we do format size checks

### DIFF
--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -3179,19 +3179,20 @@ bool CoreChecks::PreCallValidateGetDescriptorEXT(VkDevice device, const VkDescri
     if (address_info && address_info->range != VK_WHOLE_SIZE &&
         (pDescriptorInfo->type == VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER ||
          pDescriptorInfo->type == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER)) {
-        const VKU_FORMAT_INFO format_info = vkuGetFormatInfo(address_info->format);
+        const VkDeviceSize texels_per_block = static_cast<VkDeviceSize>(vkuFormatTexelsPerBlock(address_info->format));
+        const VkDeviceSize texel_block_size = static_cast<VkDeviceSize>(GetTexelBufferFormatSize(address_info->format));
         const VkDeviceSize texels =
-            SafeDivision(address_info->range, format_info.block_size) * static_cast<VkDeviceSize>(format_info.texel_per_block);
+            SafeDivision(address_info->range, texel_block_size) * static_cast<VkDeviceSize>(texels_per_block);
         if (texels > static_cast<VkDeviceSize>(phys_dev_props.limits.maxTexelBufferElements)) {
             const char *vuid = pDescriptorInfo->type == VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER
                                    ? "VUID-VkDescriptorGetInfoEXT-type-09427"
                                    : "VUID-VkDescriptorGetInfoEXT-type-09428";
             skip |= LogError(vuid, device, data_loc.dot(data_field).dot(Field::range),
-                             "(%" PRIuLEAST64 "), %s texel block size (%" PRIu32 "), and texels-per-block (%" PRIu32
+                             "(%" PRIuLEAST64 "), %s texel block size (%" PRIuLEAST64 "), and texels per block (%" PRIuLEAST64
                              ") is a total of (%" PRIuLEAST64
                              ") texels which is more than VkPhysicalDeviceLimits::maxTexelBufferElements (%" PRIuLEAST32 ").",
-                             address_info->range, string_VkFormat(address_info->format), format_info.block_size,
-                             format_info.texel_per_block, texels, phys_dev_props.limits.maxTexelBufferElements);
+                             address_info->range, string_VkFormat(address_info->format), texel_block_size, texels_per_block, texels,
+                             phys_dev_props.limits.maxTexelBufferElements);
         }
     }
 

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -2335,7 +2335,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
         const bool class_compatible = vkuFormatCompatibilityClass(view_format) == vkuFormatCompatibilityClass(image_format);
         // "uncompressed format that is size-compatible" so if compressed, same as not being compatible
         const bool size_compatible =
-            vkuFormatIsCompressed(view_format) ? false : vkuFormatElementSize(view_format) == vkuFormatElementSize(image_format);
+            vkuFormatIsCompressed(view_format) ? false : AreFormatsSizeCompatible(view_format, image_format);
         if (!class_compatible && !size_compatible) {
             skip |= LogError("VUID-VkImageViewCreateInfo-image-01583", pCreateInfo->image, create_info_loc.dot(Field::image),
                              "was created with VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT bit and "

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -203,14 +203,14 @@ bool CoreChecks::ValidateGraphicsPipelinePortability(const vvl::Pipeline &pipeli
                 for (const auto &attrib_state : binding_state.second.locations) {
                     const auto &attrib = attrib_state.second.desc;
                     const auto &desc = binding_state.second.desc;
-                    if ((attrib.offset + vkuFormatElementSize(attrib.format)) > desc.stride) {
+                    if ((attrib.offset + GetVertexInputFormatSize(attrib.format)) > desc.stride) {
                         skip |= LogError("VUID-VkVertexInputAttributeDescription-vertexAttributeAccessBeyondStride-04457", device,
                                          create_info_loc,
                                          "(portability error): attribute.offset (%" PRIu32
                                          ") + "
                                          "sizeof(vertex_description.format) (%" PRIu32
                                          ") is larger than the vertex stride (%" PRIu32 ").",
-                                         attrib.offset, vkuFormatElementSize(attrib.format), desc.stride);
+                                         attrib.offset, GetVertexInputFormatSize(attrib.format), desc.stride);
                     }
                 }
             }
@@ -4152,7 +4152,7 @@ bool CoreChecks::ValidateDrawPipelineVertexAttribute(const vvl::CommandBuffer &c
             const VkFormat attribute_format = attr_desc.format;
             const VkDeviceSize vertex_buffer_stride = vertex_buffer->stride;
             if (pipeline.IsDynamic(CB_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE)) {
-                const VkDeviceSize attribute_binding_extent = attribute_offset + vkuFormatElementSize(attribute_format);
+                const VkDeviceSize attribute_binding_extent = attribute_offset + GetVertexInputFormatSize(attribute_format);
                 if (vertex_buffer_stride != 0 && vertex_buffer_stride < attribute_binding_extent) {
                     const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
                     skip |= LogError("VUID-vkCmdBindVertexBuffers2-pStrides-06209", objlist, vuid.loc(),
@@ -4168,7 +4168,7 @@ bool CoreChecks::ValidateDrawPipelineVertexAttribute(const vvl::CommandBuffer &c
             // Use 1 as vertex/instance index to use buffer stride as well
             const VkDeviceSize attrib_address = vertex_buffer_offset + vertex_buffer_stride + attribute_offset;
 
-            VkDeviceSize vtx_attrib_req_alignment = vkuFormatElementSize(attribute_format);
+            VkDeviceSize vtx_attrib_req_alignment = GetVertexInputFormatSize(attribute_format);
 
             // TODO - There is no real spec language describing these, but also almost no one supports these formats for vertex
             // input and this check should probably just removed and do the safe division always. Will need to run against CTS

--- a/layers/core_checks/cc_shader_interface.cpp
+++ b/layers/core_checks/cc_shader_interface.cpp
@@ -52,11 +52,8 @@ bool CoreChecks::ValidateInterfaceVertexInput(const vvl::Pipeline &pipeline, con
     }
 
     for (uint32_t i = 0; i < input_state->vertexAttributeDescriptionCount; ++i) {
-        // Vertex input attributes use VkFormat, but only to make use of how they define sizes, things such as
-        // depth/multi-plane/compressed will never be used here because they would mean nothing. So we can ensure these are
-        // "standard" color formats being used
         const VkFormat format = input_state->pVertexAttributeDescriptions[i].format;
-        const uint32_t format_size = vkuFormatElementSize(format);
+        const uint32_t format_size = GetVertexInputFormatSize(format);
         // Vulkan Spec: Location is made up of 16 bytes, never can have 0 Locations
         const uint32_t bytes_in_location = 16;
         const uint32_t num_locations = ((format_size - 1) / bytes_in_location) + 1;

--- a/layers/gpuav/descriptor_validation/gpuav_descriptor_set.cpp
+++ b/layers/gpuav/descriptor_validation/gpuav_descriptor_set.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 Valve Corporation
- * Copyright (c) 2023-2024 LunarG, Inc.
+/* Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 Valve Corporation
+ * Copyright (c) 2023-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,7 +77,7 @@ static glsl::DescriptorState GetInData(const vvl::TexelDescriptor &desc) {
         return glsl::DescriptorState(DescriptorClass::TexelBuffer, glsl::kNullDescriptor, vvl::kU32Max);
     }
     auto view_size = buffer_view_state->Size();
-    uint32_t res_size = static_cast<uint32_t>(view_size / vkuFormatElementSize(buffer_view_state->create_info.format));
+    uint32_t res_size = static_cast<uint32_t>(view_size / GetTexelBufferFormatSize(buffer_view_state->create_info.format));
     return glsl::DescriptorState(DescriptorClass::TexelBuffer, buffer_view_state->id, res_size);
 }
 
@@ -126,7 +126,7 @@ static glsl::DescriptorState GetInData(const vvl::MutableDescriptor &desc) {
                 return glsl::DescriptorState(desc_class, glsl::kNullDescriptor, vvl::kU32Max);
             }
             auto view_size = buffer_view_state->Size();
-            uint32_t res_size = static_cast<uint32_t>(view_size / vkuFormatElementSize(buffer_view_state->create_info.format));
+            uint32_t res_size = static_cast<uint32_t>(view_size / GetTexelBufferFormatSize(buffer_view_state->create_info.format));
             return glsl::DescriptorState(desc_class, buffer_view_state->id, res_size);
         }
         case DescriptorClass::PlainSampler: {

--- a/layers/gpuav/validation_cmd/gpuav_draw.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_draw.cpp
@@ -839,7 +839,7 @@ static std::optional<SmallestVertexBufferBinding> SmallestVertexAttributesCount(
         // #ARNO_TODO: Should I only loop over vertex attributes actually used by bound pipelines,
         // according to its vertex shader?
         for (const auto &[Location, attrib] : vertex_binding_desc.locations) {
-            const VkDeviceSize attribute_size = vkuFormatElementSize(attrib.desc.format);
+            const VkDeviceSize attribute_size = GetVertexInputFormatSize(attrib.desc.format);
 
             const VkDeviceSize stride =
                 vbb.stride != 0 ? vbb.stride : attribute_size;  // Tracked stride should already handle all possible value origin

--- a/layers/stateless/sl_image.cpp
+++ b/layers/stateless/sl_image.cpp
@@ -652,7 +652,7 @@ bool StatelessValidation::ValidateCreateImageFormatList(const VkImageCreateInfo 
         } else if (view_format_class != image_format_class) {
             if (image_flags & VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT) {
                 const bool size_compatible =
-                    !vkuFormatIsCompressed(view_format) && vkuFormatElementSize(view_format) == vkuFormatElementSize(image_format);
+                    !vkuFormatIsCompressed(view_format) && AreFormatsSizeCompatible(view_format, image_format);
                 if (!size_compatible) {
                     skip |= LogError("VUID-VkImageCreateInfo-pNext-06722", device, format_loc,
                                      "(%s) and VkImageCreateInfo::format (%s) are not compatible or size-compatible.",

--- a/layers/utils/vk_layer_utils.cpp
+++ b/layers/utils/vk_layer_utils.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2016, 2020-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2016, 2020-2024 Valve Corporation
- * Copyright (c) 2015-2016, 2020-2024 LunarG, Inc.
+/* Copyright (c) 2015-2016, 2020-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2016, 2020-2025 Valve Corporation
+ * Copyright (c) 2015-2016, 2020-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,4 +104,19 @@ VkExtent3D GetEffectiveExtent(const VkImageCreateInfo &ci, const VkImageAspectFl
 bool RangesIntersect(int64_t x, uint64_t x_size, int64_t y, uint64_t y_size) {
     auto intersection = GetRangeIntersection(x, x_size, y, y_size);
     return intersection.non_empty();
+}
+
+// Implements the vkspec.html#formats-size-compatibility section of the spec
+bool AreFormatsSizeCompatible(VkFormat a, VkFormat b) {
+    const bool is_a_depth_stencil = vkuFormatIsDepthOrStencil(a);
+    const bool is_b_depth_stencil = vkuFormatIsDepthOrStencil(b);
+    if (is_a_depth_stencil && !is_b_depth_stencil) {
+        return vkuFormatIsDepthStencilWithColorSizeCompatible(b, a);
+    } else if (!is_a_depth_stencil && is_b_depth_stencil) {
+        return vkuFormatIsDepthStencilWithColorSizeCompatible(a, b);
+    } else if (is_a_depth_stencil && is_b_depth_stencil) {
+        return a == b;
+    }
+    // Both non-depth/stencil
+    return vkuFormatTexelBlockSize(a) == vkuFormatTexelBlockSize(b);
 }

--- a/layers/utils/vk_layer_utils.h
+++ b/layers/utils/vk_layer_utils.h
@@ -344,6 +344,22 @@ static inline bool IsAnyPlaneAspect(VkImageAspectFlags aspect_mask) {
     return (aspect_mask & valid_planes) != 0;
 }
 
+static inline uint32_t GetVertexInputFormatSize(VkFormat format) {
+    // Vertex input attributes use VkFormat, but only to make use of how they define sizes, things such as
+    // depth/multi-plane/compressed will never be used here because they would mean nothing. So we can ensure these are "standard"
+    // color formats being used. This function is a wrapper to make it more clear of the intent.
+    return vkuFormatTexelBlockSize(format);
+}
+
+static inline uint32_t GetTexelBufferFormatSize(VkFormat format) {
+    // The spec says "If format is a block-compressed format, then bufferFeatures must not support any features for the format"
+    // For Texel Buffers, we can assume the texel blocks are a 1x1x1 extent
+    // See https://gitlab.khronos.org/vulkan/vulkan/-/issues/4155 for more details
+    return vkuFormatTexelBlockSize(format);
+}
+
+bool AreFormatsSizeCompatible(VkFormat a, VkFormat b);
+
 static const VkShaderStageFlags kShaderStageAllGraphics =
     VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT | VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT |
     VK_SHADER_STAGE_GEOMETRY_BIT | VK_SHADER_STAGE_FRAGMENT_BIT | VK_SHADER_STAGE_TASK_BIT_EXT | VK_SHADER_STAGE_MESH_BIT_EXT;

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -15,7 +15,7 @@
             "sub_dir": "Vulkan-Utility-Libraries",
             "build_dir": "Vulkan-Utility-Libraries/build",
             "install_dir": "Vulkan-Utility-Libraries/build/install",
-            "commit": "v1.4.305",
+            "commit": "f07e27717a642fa193c967440f21ed634ea17987",
             "deps": [
                 {
                     "var_name": "VULKAN_HEADERS_INSTALL_DIR",

--- a/tests/unit/buffer.cpp
+++ b/tests/unit/buffer.cpp
@@ -192,7 +192,7 @@ TEST_F(NegativeBuffer, BufferViewCreateInfoEntries) {
     buff_view_ci.range = 0;
     CreateBufferViewTest(*this, &buff_view_ci, {"VUID-VkBufferViewCreateInfo-range-00928"});
 
-    uint32_t format_size = vkuFormatElementSize(buff_view_ci.format);
+    const uint32_t format_size = vkuFormatTexelBlockSize(buff_view_ci.format);
     // Range must be a multiple of the element size of format, so add one to ensure it is not
     buff_view_ci.range = format_size + 1;
     CreateBufferViewTest(*this, &buff_view_ci, {"VUID-VkBufferViewCreateInfo-range-00929"});
@@ -259,7 +259,7 @@ TEST_F(NegativeBuffer, BufferViewMaxTexelBufferElements) {
 
     vkt::Buffer buffer(*m_device, 1024, VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT);
 
-    uint32_t format_size = vkuFormatElementSize(format_with_uniform_texel_support);
+    const uint32_t format_size = vkuFormatTexelBlockSize(format_with_uniform_texel_support);
     const VkDeviceSize large_resource_size =
         2 * static_cast<VkDeviceSize>(format_size) * static_cast<VkDeviceSize>(dev_limits.maxTexelBufferElements);
     vkt::Buffer large_buffer(*m_device, large_resource_size, VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT);

--- a/tests/unit/descriptor_buffer.cpp
+++ b/tests/unit/descriptor_buffer.cpp
@@ -1655,7 +1655,7 @@ TEST_F(NegativeDescriptorBuffer, MaxTexelBufferElements) {
     if (!(format_properties.bufferFeatures & VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT)) {
         GTEST_SKIP() << "Test requires support for VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT";
     }
-    VkDeviceSize format_size = static_cast<VkDeviceSize>(vkuFormatElementSize(VK_FORMAT_R8G8B8A8_UNORM));
+    VkDeviceSize format_size = static_cast<VkDeviceSize>(vkuFormatTexelBlockSize(VK_FORMAT_R8G8B8A8_UNORM));
 
     VkDescriptorAddressInfoEXT dai = vku::InitStructHelper();
     dai.address = 0;


### PR DESCRIPTION
Uses 

- https://github.com/KhronosGroup/Vulkan-Utility-Libraries/pull/261
- https://github.com/KhronosGroup/Vulkan-Utility-Libraries/pull/262
- https://github.com/KhronosGroup/Vulkan-Utility-Libraries/pull/263

Main aim to get rid of things like `vkuFormatElementSize` (as `element` is not a proper spec term) and stick to `texel` and `texel blocks`

Also where these are used (ex - vertex input, texel buffer, etc) have different inherent spec restrictions that the current code was assuming, but hard to track down