### PR TITLE
layers: More cleaup of format size compatibility

### DIFF
--- a/layers/stateless/sl_image.cpp
+++ b/layers/stateless/sl_image.cpp
@@ -21,6 +21,7 @@
 #include "error_message/error_strings.h"
 #include "stateless/stateless_validation.h"
 #include "generated/enum_flag_bits.h"
+#include "utils/vk_layer_utils.h"
 
 bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, const VkImageCreateInfo *pCreateInfo,
                                                             const VkAllocationCallbacks *pAllocator, VkImage *pImage,
@@ -651,16 +652,15 @@ bool StatelessValidation::ValidateCreateImageFormatList(const VkImageCreateInfo 
             }
         } else if (view_format_class != image_format_class) {
             if (image_flags & VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT) {
-                const bool size_compatible =
-                    !vkuFormatIsCompressed(view_format) && AreFormatsSizeCompatible(view_format, image_format);
-                if (!size_compatible) {
+                if (!AreFormatsSizeCompatible(view_format, image_format)) {
                     skip |= LogError("VUID-VkImageCreateInfo-pNext-06722", device, format_loc,
-                                     "(%s) and VkImageCreateInfo::format (%s) are not compatible or size-compatible.",
-                                     string_VkFormat(view_format), string_VkFormat(image_format));
+                                     "(%s) and VkImageCreateInfo::format (%s) are not class compatible or size-compatible. %s",
+                                     string_VkFormat(view_format), string_VkFormat(image_format),
+                                     DescribeFormatsSizeCompatible(view_format, image_format).c_str());
                 }
             } else {
                 skip |= LogError("VUID-VkImageCreateInfo-pNext-06722", device, format_loc,
-                                 "(%s) and VkImageCreateInfo::format (%s) are not compatible.", string_VkFormat(view_format),
+                                 "(%s) and VkImageCreateInfo::format (%s) are not class compatible.", string_VkFormat(view_format),
                                  string_VkFormat(image_format));
             }
         }

--- a/layers/utils/vk_layer_utils.h
+++ b/layers/utils/vk_layer_utils.h
@@ -359,6 +359,7 @@ static inline uint32_t GetTexelBufferFormatSize(VkFormat format) {
 }
 
 bool AreFormatsSizeCompatible(VkFormat a, VkFormat b);
+std::string DescribeFormatsSizeCompatible(VkFormat a, VkFormat b);
 
 static const VkShaderStageFlags kShaderStageAllGraphics =
     VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT | VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT |

--- a/tests/unit/image_positive.cpp
+++ b/tests/unit/image_positive.cpp
@@ -592,6 +592,50 @@ TEST_F(PositiveImage, BlockTexelViewCompatibleMultipleLayers) {
     vkt::ImageView view(*m_device, ivci);
 }
 
+TEST_F(PositiveImage, ImageFormatListSizeCompatibleUncompressed) {
+    AddRequiredExtensions(VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_BC3_UNORM_BLOCK, VK_IMAGE_TILING_OPTIMAL,
+                                    VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
+        GTEST_SKIP() << "Required formats/features not supported";
+    }
+
+    const VkFormat formats[1] = {VK_FORMAT_R32G32B32A32_UINT};
+    VkImageFormatListCreateInfo format_list = vku::InitStructHelper(nullptr);
+    format_list.viewFormatCount = 1;
+    format_list.pViewFormats = formats;
+
+    auto image_ci = vkt::Image::ImageCreateInfo2D(128, 128, 1, 1, VK_FORMAT_BC3_UNORM_BLOCK, VK_IMAGE_USAGE_SAMPLED_BIT);
+    image_ci.pNext = &format_list;
+    image_ci.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT;
+
+    vkt::Image image(*m_device, image_ci);
+}
+
+TEST_F(PositiveImage, ImageFormatListSizeCompatibleCompressed) {
+    AddRequiredExtensions(VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_BC3_UNORM_BLOCK, VK_IMAGE_TILING_OPTIMAL,
+                                    VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
+        GTEST_SKIP() << "Required formats/features not supported";
+    }
+
+    const VkFormat formats[2] = {VK_FORMAT_BC3_UNORM_BLOCK, VK_FORMAT_BC2_UNORM_BLOCK};
+    VkImageFormatListCreateInfo format_list = vku::InitStructHelper(nullptr);
+    format_list.viewFormatCount = 2;
+    format_list.pViewFormats = formats;
+
+    auto image_ci = vkt::Image::ImageCreateInfo2D(128, 128, 1, 1, VK_FORMAT_BC3_UNORM_BLOCK, VK_IMAGE_USAGE_SAMPLED_BIT);
+    image_ci.pNext = &format_list;
+    image_ci.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT;
+
+    vkt::Image image(*m_device, image_ci);
+}
+
 TEST_F(PositiveImage, ImageAlignmentControl) {
     AddRequiredExtensions(VK_MESA_IMAGE_ALIGNMENT_CONTROL_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::imageAlignmentControl);


### PR DESCRIPTION
More cleanup around using `texel` and `texel block` correctly and consistently everywhere