### PR TITLE
layers: Mark OpArrayLength as static usage

### DIFF
--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -116,7 +116,7 @@ class Pipeline : public StateObject {
 
     const vvl::unordered_set<uint32_t> fragmentShader_writable_output_location_list;
 
-    // NOTE: this map is 'almost' const and used in performance critical code paths.
+    // NOTE: this map is used in performance critical code paths.
     // The values of existing entries in the samplers_used_by_image map
     // are updated at various times. Locking requirements are TBD.
     const ActiveSlotMap active_slots;

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -21,6 +21,8 @@
 
 #include "utils/hash_util.h"
 #include "generated/spirv_grammar_helper.h"
+
+#include <spirv/unified1/spirv.hpp>
 #include <spirv/1.2/GLSL.std.450.h>
 #include <spirv/unified1/NonSemanticShaderDebugInfo100.h>
 #include "error_message/spirv_logging.h"
@@ -346,6 +348,10 @@ static void FindPointersAndObjects(const Instruction& insn, vvl::unordered_set<u
         case spv::OpAccessChain:
         case spv::OpInBoundsAccessChain:
             result.insert(insn.Word(3));  // base ptr
+            break;
+        case spv::OpArrayLength:
+            // This is not an access of memory, but counts as static usage of the variable
+            result.insert(insn.Word(3));
             break;
         case spv::OpSampledImage:
         case spv::OpImageSampleImplicitLod:

--- a/layers/state_tracker/shader_stage_state.cpp
+++ b/layers/state_tracker/shader_stage_state.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2024 The Khronos Group Inc.
- * Copyright (c) 2024 Valve Corporation
- * Copyright (c) 2024 LunarG, Inc.
+/* Copyright (c) 2024-2025 The Khronos Group Inc.
+ * Copyright (c) 2024-2025 Valve Corporation
+ * Copyright (c) 2024-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@
 #include "state_tracker/shader_module.h"
 #include <vulkan/utility/vk_safe_struct.hpp>
 
+// Common for both Pipeline and Shader Object
 void GetActiveSlots(ActiveSlotMap &active_slots, const std::shared_ptr<const spirv::EntryPoint> &entrypoint) {
     if (!entrypoint) {
         return;
@@ -35,7 +36,7 @@ void GetActiveSlots(ActiveSlotMap &active_slots, const std::shared_ptr<const spi
     }
 }
 
-// static
+// Used by pipeline
 ActiveSlotMap GetActiveSlots(const std::vector<ShaderStageState> &stage_states) {
     ActiveSlotMap active_slots;
     for (const auto &stage : stage_states) {
@@ -44,6 +45,7 @@ ActiveSlotMap GetActiveSlots(const std::vector<ShaderStageState> &stage_states) 
     return active_slots;
 }
 
+// Used by Shader Object
 ActiveSlotMap GetActiveSlots(const std::shared_ptr<const spirv::EntryPoint> &entrypoint) {
     ActiveSlotMap active_slots;
     GetActiveSlots(active_slots, entrypoint);

--- a/layers/state_tracker/shader_stage_state.h
+++ b/layers/state_tracker/shader_stage_state.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2024 The Khronos Group Inc.
- * Copyright (c) 2024 Valve Corporation
- * Copyright (c) 2024 LunarG, Inc.
+/* Copyright (c) 2024-2025 The Khronos Group Inc.
+ * Copyright (c) 2024-2025 Valve Corporation
+ * Copyright (c) 2024-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,7 +79,8 @@ inline bool operator<(const DescriptorRequirement &a, const DescriptorRequiremen
 // < binding index (of descriptor set) : meta data >
 typedef std::unordered_multimap<uint32_t, DescriptorRequirement> BindingVariableMap;
 
-// Capture which slots (set#->bindings) are actually used by the shaders of this pipeline
+// Capture which slots (set#->bindings) are actually used by the shaders of this pipeline/shaderObject.
+// This is same as "statically used" in vkspec.html#shaders-staticuse
 using ActiveSlotMap = vvl::unordered_map<uint32_t, BindingVariableMap>;
 
 void GetActiveSlots(ActiveSlotMap &active_slots, const std::shared_ptr<const spirv::EntryPoint> &entrypoint);


### PR DESCRIPTION
all from https://gitlab.khronos.org/vulkan/vulkan/-/issues/4145

Basically if you go

```glsl
layout(set = 0, binding = 0) buffer SSBO {
    uint x[];
};

void main() {
   x.length();
}
```

here `x` is **not** accessed, but the descriptor is still referenced and counts as statically used. The lack of marking this as statically used was preventing tracking and didn't appear until late