### PR TITLE
layers: Update vvl::enumerate to return reference

### DIFF
--- a/layers/containers/custom_containers.h
+++ b/layers/containers/custom_containers.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2017, 2019-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2017, 2019-2024 Valve Corporation
- * Copyright (c) 2015-2017, 2019-2024 LunarG, Inc.
+/* Copyright (c) 2015-2017, 2019-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2017, 2019-2025 Valve Corporation
+ * Copyright (c) 2015-2017, 2019-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -864,8 +864,8 @@ class IndexedIterator {
   public:
     IndexedIterator(T *data, IndexType index = 0) : index_(index), data_(data) {}
 
-    IndexedIterator<T, IndexType> &operator*() { return *this; }
-    const IndexedIterator<T, IndexType> &operator*() const { return *this; }
+    std::pair<IndexType, T &> operator*() { return std::pair<IndexType, T &>(index_, *data_); }
+    std::pair<IndexType, T> operator*() const { return std::make_pair(index_, *data_); }
 
     // prefix increment
     IndexedIterator<T, IndexType> &operator++() {
@@ -910,20 +910,26 @@ span<T> make_span(T *begin, T *end) {
 }
 
 template <typename T, typename IndexType>
-enumeration<T, IndexedIterator<T, IndexType>> enumerate(T *begin, IndexType count) {
+auto enumerate(T *begin, IndexType count) {
     return enumeration<T, IndexedIterator<T, IndexType>>(begin, count);
 }
 template <typename T>
-enumeration<T, IndexedIterator<T>> enumerate(T *begin, T *end) {
+auto enumerate(T *begin, T *end) {
     return enumeration<T, IndexedIterator<T>>(begin, end);
 }
 
 template <typename Container>
-enumeration<typename Container::value_type, IndexedIterator<typename Container::value_type, typename Container::size_type>>
-enumerate(Container &container) {
+auto enumerate(Container &container) {
     return enumeration<typename Container::value_type,
                        IndexedIterator<typename Container::value_type, typename Container::size_type>>(container.data(),
                                                                                                        container.size());
+}
+
+template <typename Container>
+auto enumerate(const Container &container) {
+    return enumeration<std::add_const_t<typename Container::value_type>,
+                       IndexedIterator<std::add_const_t<typename Container::value_type>, typename Container::size_type>>(
+        container.data(), container.size());
 }
 
 template <typename BaseType>

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -3042,12 +3042,12 @@ bool CoreChecks::ValidateGraphicsPipelineDynamicRendering(const vvl::Pipeline &p
             !pipeline.IsColorBlendStateDynamic()) {
             for (const auto [i, format] :
                  vvl::enumerate(rendering_struct->pColorAttachmentFormats, rendering_struct->colorAttachmentCount)) {
-                if (*format != VK_FORMAT_UNDEFINED) {
+                if (format != VK_FORMAT_UNDEFINED) {
                     skip |= LogError(
                         "VUID-VkGraphicsPipelineCreateInfo-renderPass-09037", device, create_info_loc.dot(Field::pColorBlendState),
                         "is NULL, but %s is %" PRIu32 " and pColorAttachmentFormats[%" PRIu32 "] is %s.",
                         create_info_loc.pNext(Struct::VkPipelineRenderingCreateInfo, Field::colorAttachmentCount).Fields().c_str(),
-                        rendering_struct->colorAttachmentCount, i, string_VkFormat(*format));
+                        rendering_struct->colorAttachmentCount, i, string_VkFormat(format));
                 }
             }
         }

--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -179,13 +179,13 @@ bool CoreChecks::ValidateAccelerationStructuresMemoryAlisasing(const LogObjectLi
 
         const Location other_info_j_loc = error_obj.location.dot(Field::pInfos, other_info_j);
 
-        const auto other_dst_as_state = Get<vvl::AccelerationStructureKHR>(other_info->dstAccelerationStructure);
-        const auto other_src_as_state = Get<vvl::AccelerationStructureKHR>(other_info->srcAccelerationStructure);
+        const auto other_dst_as_state = Get<vvl::AccelerationStructureKHR>(other_info.dstAccelerationStructure);
+        const auto other_src_as_state = Get<vvl::AccelerationStructureKHR>(other_info.srcAccelerationStructure);
 
         // Validate destination acceleration structure's memory is not overlapped by another source acceleration structure's
         // memory that is going to be updated by this cmd
         if (dst_as_state && other_src_as_state) {
-            if (other_info->mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR) {
+            if (other_info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR) {
                 const char *vuid = error_obj.location.function == Func::vkCmdBuildAccelerationStructuresKHR
                                        ? "VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03701"
                                    : error_obj.location.function == Func::vkCmdBuildAccelerationStructuresIndirectKHR
@@ -862,10 +862,10 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresKHR(
     for (const auto [info_i, info] : vvl::enumerate(pInfos, infoCount)) {
         const Location info_loc = error_obj.location.dot(Field::pInfos, info_i);
 
-        if (const auto src_as_state = Get<vvl::AccelerationStructureKHR>(info->srcAccelerationStructure)) {
-            if (info->mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR) {
+        if (const auto src_as_state = Get<vvl::AccelerationStructureKHR>(info.srcAccelerationStructure)) {
+            if (info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR) {
                 if (!src_as_state->buffer_state) {
-                    const LogObjectList objlist(device, commandBuffer, info->srcAccelerationStructure);
+                    const LogObjectList objlist(device, commandBuffer, info.srcAccelerationStructure);
                     skip |= LogError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03708", objlist, info_loc.dot(Field::mode),
                                      "is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR but the buffer associated with "
                                      "srcAccelerationStructure is not valid.");
@@ -877,11 +877,11 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresKHR(
             }
         }
 
-        if (const auto dst_as_state = Get<vvl::AccelerationStructureKHR>(info->dstAccelerationStructure)) {
+        if (const auto dst_as_state = Get<vvl::AccelerationStructureKHR>(info.dstAccelerationStructure)) {
             skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *dst_as_state->buffer_state,
                                                   info_loc.dot(Field::dstAccelerationStructure),
                                                   "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03707");
-            if (info->type == VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR) {
+            if (info.type == VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR) {
                 if (dst_as_state->create_info.type != VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR &&
                     dst_as_state->create_info.type != VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR) {
                     const LogObjectList objlist(device, commandBuffer);
@@ -891,7 +891,7 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresKHR(
                         string_VkAccelerationStructureTypeKHR(dst_as_state->create_info.type));
                 }
             }
-            if (info->type == VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR) {
+            if (info.type == VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR) {
                 if (dst_as_state->create_info.type != VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR &&
                     dst_as_state->create_info.type != VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR) {
                     const LogObjectList objlist(device, commandBuffer);
@@ -903,9 +903,9 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresKHR(
             }
         }
 
-        skip |= CommonBuildAccelerationStructureValidation(*info, info_loc, commandBuffer);
+        skip |= CommonBuildAccelerationStructureValidation(info, info_loc, commandBuffer);
 
-        skip |= ValidateAccelerationBuffers(commandBuffer, info_i, *info, ppBuildRangeInfos[info_i], info_loc);
+        skip |= ValidateAccelerationBuffers(commandBuffer, info_i, info, ppBuildRangeInfos[info_i], info_loc);
 
         skip |= ValidateAccelerationStructuresMemoryAlisasing(commandBuffer, infoCount, pInfos, info_i, error_obj);
 
@@ -926,11 +926,11 @@ bool CoreChecks::PreCallValidateBuildAccelerationStructuresKHR(
 
     for (const auto [info_i, info] : vvl::enumerate(pInfos, infoCount)) {
         const Location info_loc = error_obj.location.dot(Field::pInfos, info_i);
-        auto src_as_state = Get<vvl::AccelerationStructureKHR>(info->srcAccelerationStructure);
-        auto dst_as_state = Get<vvl::AccelerationStructureKHR>(info->dstAccelerationStructure);
+        auto src_as_state = Get<vvl::AccelerationStructureKHR>(info.srcAccelerationStructure);
+        auto dst_as_state = Get<vvl::AccelerationStructureKHR>(info.dstAccelerationStructure);
 
         if (src_as_state) {
-            if (info->mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR) {
+            if (info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR) {
                 skip |= ValidateAccelStructBufferMemoryIsHostVisible(*src_as_state, info_loc.dot(Field::srcAccelerationStructure),
                                                                      "VUID-vkBuildAccelerationStructuresKHR-pInfos-03723");
                 skip |=
@@ -946,12 +946,12 @@ bool CoreChecks::PreCallValidateBuildAccelerationStructuresKHR(
             skip |= ValidateAccelStructBufferMemoryIsNotMultiInstance(*dst_as_state, info_loc.dot(Field::dstAccelerationStructure),
                                                                       "VUID-vkBuildAccelerationStructuresKHR-pInfos-03775");
 
-            if (!(info->mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR &&
-                  (info->flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR))) {
+            if (!(info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR &&
+                  (info.flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR))) {
                 const VkDeviceSize as_minimum_size =
-                    rt::ComputeAccelerationStructureSize(rt::BuildType::Host, device, *info, ppBuildRangeInfos[info_i]);
+                    rt::ComputeAccelerationStructureSize(rt::BuildType::Host, device, info, ppBuildRangeInfos[info_i]);
                 if (dst_as_state->create_info.size < as_minimum_size) {
-                    const LogObjectList objlist(info->dstAccelerationStructure);
+                    const LogObjectList objlist(info.dstAccelerationStructure);
                     skip |= LogError("VUID-vkBuildAccelerationStructuresKHR-pInfos-10126", objlist,
                                      info_loc.dot(Field::dstAccelerationStructure),
                                      " was created with size (%" PRIu64
@@ -961,10 +961,10 @@ bool CoreChecks::PreCallValidateBuildAccelerationStructuresKHR(
                 }
             }
 
-            if (info->type == VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR) {
+            if (info.type == VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR) {
                 if (dst_as_state->create_info.type != VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR &&
                     dst_as_state->create_info.type != VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR) {
-                    skip |= LogError("VUID-vkBuildAccelerationStructuresKHR-pInfos-03700", info->dstAccelerationStructure,
+                    skip |= LogError("VUID-vkBuildAccelerationStructuresKHR-pInfos-03700", info.dstAccelerationStructure,
                                      info_loc.dot(Field::type),
                                      "is VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR, but its dstAccelerationStructure was "
                                      "built with type %s.",
@@ -972,11 +972,11 @@ bool CoreChecks::PreCallValidateBuildAccelerationStructuresKHR(
                 }
             }
 
-            if (info->type == VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR) {
+            if (info.type == VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR) {
                 if (dst_as_state->create_info.type != VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR &&
                     dst_as_state->create_info.type != VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR) {
                     skip |= LogError(
-                        "VUID-vkBuildAccelerationStructuresKHR-pInfos-03699", info->dstAccelerationStructure,
+                        "VUID-vkBuildAccelerationStructuresKHR-pInfos-03699", info.dstAccelerationStructure,
                         info_loc.dot(Field::type),
                         "is VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR, but its dstAccelerationStructure was built with type %s.",
                         string_VkAccelerationStructureTypeKHR(dst_as_state->create_info.type));
@@ -985,16 +985,16 @@ bool CoreChecks::PreCallValidateBuildAccelerationStructuresKHR(
         }
 
         skip |= ValidateAccelerationStructuresMemoryAlisasing(LogObjectList(), infoCount, pInfos, info_i, error_obj);
-        const VkDeviceSize scratch_i_size = rt::ComputeScratchSize(rt::BuildType::Host, device, *info, ppBuildRangeInfos[info_i]);
-        auto scratch_i_host_addr = reinterpret_cast<uint64_t>(info->scratchData.hostAddress);
+        const VkDeviceSize scratch_i_size = rt::ComputeScratchSize(rt::BuildType::Host, device, info, ppBuildRangeInfos[info_i]);
+        auto scratch_i_host_addr = reinterpret_cast<uint64_t>(info.scratchData.hostAddress);
         const sparse_container::range<uint64_t> scratch_addr_range(scratch_i_host_addr, scratch_i_host_addr + scratch_i_size);
 
         assert(infoCount > info_i);
         for (auto [other_info_j, other_info] : vvl::enumerate(pInfos + info_i + 1, infoCount - (info_i + 1))) {
             const Location other_info_j_loc = error_obj.location.dot(Field::pInfos, other_info_j + info_i + 1);
             const VkDeviceSize other_scratch_size =
-                rt::ComputeScratchSize(rt::BuildType::Host, device, *other_info, ppBuildRangeInfos[other_info_j]);
-            auto other_scratch_host_addr = reinterpret_cast<uint64_t>(other_info->scratchData.hostAddress);
+                rt::ComputeScratchSize(rt::BuildType::Host, device, other_info, ppBuildRangeInfos[other_info_j]);
+            auto other_scratch_host_addr = reinterpret_cast<uint64_t>(other_info.scratchData.hostAddress);
             const sparse_container::range<uint64_t> other_scratch_addr_range(other_scratch_host_addr,
                                                                              other_scratch_host_addr + other_scratch_size);
 
@@ -1008,28 +1008,28 @@ bool CoreChecks::PreCallValidateBuildAccelerationStructuresKHR(
                     ".\n"
                     "%s.hostAddress is %p and assumed scratch size is %" PRIu64 ".",
                     other_info_j_scratch_str.c_str(), string_range_hex(scratch_addr_range & other_scratch_addr_range).c_str(),
-                    info_i_scratch_str.c_str(), info->scratchData.hostAddress, scratch_i_size, other_info_j_scratch_str.c_str(),
-                    other_info->scratchData.hostAddress, other_scratch_size);
+                    info_i_scratch_str.c_str(), info.scratchData.hostAddress, scratch_i_size, other_info_j_scratch_str.c_str(),
+                    other_info.scratchData.hostAddress, other_scratch_size);
             }
         }
 
-        skip |= CommonBuildAccelerationStructureValidation(*info, info_loc, LogObjectList());
+        skip |= CommonBuildAccelerationStructureValidation(info, info_loc, LogObjectList());
 
-        for (uint32_t geom_i = 0; geom_i < info->geometryCount; ++geom_i) {
-            const VkAccelerationStructureGeometryKHR &geom = rt::GetGeometry(*info, geom_i);
+        for (uint32_t geom_i = 0; geom_i < info.geometryCount; ++geom_i) {
+            const VkAccelerationStructureGeometryKHR &geom = rt::GetGeometry(info, geom_i);
 
             if (geom.geometryType != VK_GEOMETRY_TYPE_INSTANCES_KHR) {
                 continue;
             }
 
-            const Location geometry_loc = info_loc.dot(info->pGeometries ? Field::pGeometries : Field::ppGeometries, geom_i);
+            const Location geometry_loc = info_loc.dot(info.pGeometries ? Field::pGeometries : Field::ppGeometries, geom_i);
 
-            if (info->mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR && src_as_state &&
+            if (info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR && src_as_state &&
                 src_as_state->build_info_khr.has_value()) {
                 if (geom_i < src_as_state->build_range_infos.size()) {
                     if (const uint32_t recorded_primitive_count = src_as_state->build_range_infos[geom_i].primitiveCount;
                         recorded_primitive_count != ppBuildRangeInfos[info_i][geom_i].primitiveCount) {
-                        const LogObjectList objlist(info->srcAccelerationStructure);
+                        const LogObjectList objlist(info.srcAccelerationStructure);
                         skip |= LogError("VUID-vkCmdBuildAccelerationStructuresKHR-primitiveCount-03769", objlist, geometry_loc,
                                          " has corresponding VkAccelerationStructureBuildRangeInfoKHR %s[%" PRIu32
                                          "], but this build range has its primitiveCount member set to (%" PRIu32
@@ -1110,34 +1110,34 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresIndirectKHR(VkComm
     for (const auto [info_i, info] : vvl::enumerate(pInfos, infoCount)) {
         const Location info_loc = error_obj.location.dot(Field::pInfos, info_i);
 
-        if (auto src_as_state = Get<vvl::AccelerationStructureKHR>(info->srcAccelerationStructure)) {
-            if (info->mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR) {
+        if (auto src_as_state = Get<vvl::AccelerationStructureKHR>(info.srcAccelerationStructure)) {
+            if (info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR) {
                 skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *src_as_state->buffer_state,
                                                       info_loc.dot(Field::srcAccelerationStructure),
                                                       "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03708");
             }
         }
 
-        if (auto dst_as_state = Get<vvl::AccelerationStructureKHR>(info->dstAccelerationStructure)) {
+        if (auto dst_as_state = Get<vvl::AccelerationStructureKHR>(info.dstAccelerationStructure)) {
             skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *dst_as_state->buffer_state,
                                                   info_loc.dot(Field::dstAccelerationStructure),
                                                   "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03707");
-            if (info->type == VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR) {
+            if (info.type == VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR) {
                 if (dst_as_state->create_info.type != VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR &&
                     dst_as_state->create_info.type != VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR) {
-                    skip |= LogError("VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03700",
-                                     info->dstAccelerationStructure, info_loc.dot(Field::type),
+                    skip |= LogError("VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03700", info.dstAccelerationStructure,
+                                     info_loc.dot(Field::type),
                                      "is VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR, but its dstAccelerationStructure was "
                                      "built with type %s.",
                                      string_VkAccelerationStructureTypeKHR(dst_as_state->create_info.type));
                 }
             }
 
-            if (info->type == VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR) {
+            if (info.type == VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR) {
                 if (dst_as_state->create_info.type != VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR &&
                     dst_as_state->create_info.type != VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR) {
                     skip |= LogError(
-                        "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03699", info->dstAccelerationStructure,
+                        "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03699", info.dstAccelerationStructure,
                         info_loc.dot(Field::type),
                         "is VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR, but its dstAccelerationStructure was built with type %s.",
                         string_VkAccelerationStructureTypeKHR(dst_as_state->create_info.type));
@@ -1147,9 +1147,9 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresIndirectKHR(VkComm
 
         skip |= ValidateAccelerationStructuresMemoryAlisasing(commandBuffer, infoCount, pInfos, info_i, error_obj);
 
-        skip |= CommonBuildAccelerationStructureValidation(*info, info_loc, commandBuffer);
+        skip |= CommonBuildAccelerationStructureValidation(info, info_loc, commandBuffer);
 
-        skip |= ValidateAccelerationBuffers(commandBuffer, info_i, *info, nullptr, info_loc);
+        skip |= ValidateAccelerationBuffers(commandBuffer, info_i, info, nullptr, info_loc);
     }
     return skip;
 }

--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -1177,11 +1177,11 @@ bool CoreChecks::VerifyFramebufferAndRenderPassImageViews(const VkRenderPassBegi
 
     if (enabled_features.externalFormatResolve && !android_external_format_resolve_null_color_attachment_prop) {
         for (const auto [i, subpass] : vvl::enumerate(render_pass_create_info->pSubpasses, render_pass_create_info->subpassCount)) {
-            if (!subpass->pResolveAttachments || !subpass->pColorAttachments) {
+            if (!subpass.pResolveAttachments || !subpass.pColorAttachments) {
                 continue;
             }
-            const uint32_t resolve_attachment = subpass->pResolveAttachments[0].attachment;
-            const uint32_t color_attachment = subpass->pColorAttachments[0].attachment;
+            const uint32_t resolve_attachment = subpass.pResolveAttachments[0].attachment;
+            const uint32_t color_attachment = subpass.pColorAttachments[0].attachment;
             if (resolve_attachment == VK_ATTACHMENT_UNUSED || color_attachment == VK_ATTACHMENT_UNUSED) {
                 continue;
             }
@@ -4274,14 +4274,14 @@ bool CoreChecks::PreCallValidateCreateFramebuffer(VkDevice device, const VkFrame
                             framebuffer_attachments_create_info->attachmentImageInfoCount)) {
             const Location attachment_image_info_loc =
                 create_info_loc.pNext(Struct::VkFramebufferAttachmentsCreateInfo, Field::pAttachmentImageInfos, i);
-            if (attachment_image_info->pNext != nullptr) {
+            if (attachment_image_info.pNext != nullptr) {
                 skip |= LogError("VUID-VkFramebufferAttachmentImageInfo-pNext-pNext", device,
                                  attachment_image_info_loc.dot(Field::pNext), "is not NULL.");
             }
             for (const auto [j, view_format] :
-                 vvl::enumerate(attachment_image_info->pViewFormats, attachment_image_info->viewFormatCount)) {
+                 vvl::enumerate(attachment_image_info.pViewFormats, attachment_image_info.viewFormatCount)) {
                 // VK_ANDROID_external_format_resolve can have a valid undefined format
-                if (*view_format == VK_FORMAT_UNDEFINED && rp_state->create_info.pAttachments[i].format != VK_FORMAT_UNDEFINED) {
+                if (view_format == VK_FORMAT_UNDEFINED && rp_state->create_info.pAttachments[i].format != VK_FORMAT_UNDEFINED) {
                     skip |= LogError("VUID-VkFramebufferAttachmentImageInfo-viewFormatCount-09536", device,
                                      attachment_image_info_loc.dot(Field::pViewFormats, j), "is VK_FORMAT_UNDEFINED.");
                 }

--- a/layers/gpuav/descriptor_validation/gpuav_image_layout.cpp
+++ b/layers/gpuav/descriptor_validation/gpuav_image_layout.cpp
@@ -569,12 +569,12 @@ void Validator::PreCallRecordCmdCopyBufferToImage(VkCommandBuffer commandBuffer,
 
     std::vector<VkBufferImageCopy2> regions_2(regionCount);
     for (const auto [i, region] : vvl::enumerate(pRegions, regionCount)) {
-        regions_2[i].bufferOffset = region->bufferOffset;
-        regions_2[i].bufferRowLength = region->bufferRowLength;
-        regions_2[i].bufferImageHeight = region->bufferImageHeight;
-        regions_2[i].imageSubresource = region->imageSubresource;
-        regions_2[i].imageOffset = region->imageOffset;
-        regions_2[i].imageExtent = region->imageExtent;
+        regions_2[i].bufferOffset = region.bufferOffset;
+        regions_2[i].bufferRowLength = region.bufferRowLength;
+        regions_2[i].bufferImageHeight = region.bufferImageHeight;
+        regions_2[i].imageSubresource = region.imageSubresource;
+        regions_2[i].imageOffset = region.imageOffset;
+        regions_2[i].imageExtent = region.imageExtent;
     }
 
     VkCopyBufferToImageInfo2 copy_buffer_to_image_info = vku::InitStructHelper();

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
@@ -835,7 +835,7 @@ void GpuShaderInstrumentor::BuildDescriptorSetLayoutInfo(const VkShaderCreateInf
                                                          InstrumentationDescriptorSetLayouts &out_instrumentation_dsl) {
     out_instrumentation_dsl.set_index_to_bindings_layout_lut.resize(create_info.setLayoutCount);
     for (const auto [set_layout_index, set_layout] : vvl::enumerate(create_info.pSetLayouts, create_info.setLayoutCount)) {
-        if (auto set_layout_state = Get<vvl::DescriptorSetLayout>(*set_layout)) {
+        if (auto set_layout_state = Get<vvl::DescriptorSetLayout>(set_layout)) {
             BuildDescriptorSetLayoutInfo(*set_layout_state, set_layout_index, out_instrumentation_dsl);
         }
     }

--- a/layers/gpuav/validation_cmd/gpuav_copy_buffer_to_image.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_copy_buffer_to_image.cpp
@@ -293,7 +293,7 @@ void InsertCopyBufferToImageValidation(Validator &gpuav, const Location &loc, Co
             desc_writes[i].dstBinding = static_cast<uint32_t>(i);
             desc_writes[i].descriptorCount = 1;
             desc_writes[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-            desc_writes[i].pBufferInfo = desc_buffer_info;
+            desc_writes[i].pBufferInfo = &desc_buffer_info;
             desc_writes[i].dstSet = validation_desc_set;
         }
         DispatchUpdateDescriptorSets(gpuav.device, static_cast<uint32_t>(desc_writes.size()), desc_writes.data(), 0, nullptr);

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -482,19 +482,19 @@ static bool ValidateLayerSettingsCreateInfo(const VkLayerSettingsCreateInfoEXT *
     if (layer_settings->pSettings) {
         for (const auto [i, setting] : vvl::enumerate(layer_settings->pSettings, layer_settings->settingCount)) {
             const Location setting_loc = create_info_loc.dot(vvl::Field::pSettings, i);
-            if (setting->valueCount > 0 && !setting->pValues) {
+            if (setting.valueCount > 0 && !setting.pValues) {
                 ss << "[ VUID-VkLayerSettingEXT-valueCount-10070 ] " << setting_loc.dot(vvl::Field::pValues).Message()
                    << " is NULL";
                 printf("Validation Layer Error: %s\n", ss.str().c_str());
                 valid = false;
             }
-            if (!setting->pLayerName) {
+            if (!setting.pLayerName) {
                 ss << "[ VUID-VkLayerSettingEXT-pLayerName-parameter ] " << setting_loc.dot(vvl::Field::pLayerName).Message()
                    << " is NULL";
                 printf("Validation Layer Error: %s\n", ss.str().c_str());
                 valid = false;
             }
-            if (!setting->pSettingName) {
+            if (!setting.pSettingName) {
                 ss << "[ VUID-VkLayerSettingEXT-pSettingName-parameter ] " << setting_loc.dot(vvl::Field::pSettingName).Message()
                    << " is NULL";
                 printf("Validation Layer Error: %s\n", ss.str().c_str());

--- a/layers/state_tracker/pipeline_layout_state.cpp
+++ b/layers/state_tracker/pipeline_layout_state.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (C) 2015-2024 Google Inc.
+/* Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (C) 2015-2025 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -74,17 +74,16 @@ std::string PipelineLayoutCompatDef::DescribeDifference(const PipelineLayoutComp
         if (push_constant_ranges->empty()) {
             ss << "Empty\n";
         } else {
-            for (const auto &[pcr_i, pcr] : vvl::enumerate(push_constant_ranges->data(), push_constant_ranges->size())) {
-                ss << "VkPushConstantRange[ " << pcr_i << " ]: " << string_VkPushConstantRange(*pcr) << '\n';
+            for (const auto [pcr_i, pcr] : vvl::enumerate(push_constant_ranges->data(), push_constant_ranges->size())) {
+                ss << "VkPushConstantRange[ " << pcr_i << " ]: " << string_VkPushConstantRange(pcr) << '\n';
             }
         }
         ss << "But pipeline layout of last bound pipeline or last bound shaders has following push constant ranges:\n";
         if (push_constant_ranges->empty()) {
             ss << "Empty\n";
         } else {
-            for (const auto &[pcr_i, pcr] :
-                 vvl::enumerate(other.push_constant_ranges->data(), other.push_constant_ranges->size())) {
-                ss << "VkPushConstantRange[ " << pcr_i << " ]: " << string_VkPushConstantRange(*pcr) << '\n';
+            for (const auto [pcr_i, pcr] : vvl::enumerate(other.push_constant_ranges->data(), other.push_constant_ranges->size())) {
+                ss << "VkPushConstantRange[ " << pcr_i << " ]: " << string_VkPushConstantRange(pcr) << '\n';
             }
         }
     } else {

--- a/layers/state_tracker/pipeline_sub_state.cpp
+++ b/layers/state_tracker/pipeline_sub_state.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2017, 2019-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2017, 2019-2024 Valve Corporation
- * Copyright (c) 2015-2017, 2019-2024 LunarG, Inc.
+/* Copyright (c) 2015-2017, 2019-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2017, 2019-2025 Valve Corporation
+ * Copyright (c) 2015-2017, 2019-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,25 +38,25 @@ VertexInputState::VertexInputState(const vvl::Pipeline &p, const vku::safe_VkGra
         if (input_state->vertexBindingDescriptionCount) {
             for (const auto [i, bd] :
                  vvl::enumerate(input_state->pVertexBindingDescriptions, input_state->vertexBindingDescriptionCount)) {
-                bindings.emplace(bd->binding, VertexBindingState(i, bd));
+                bindings.emplace(bd.binding, VertexBindingState(i, &bd));
             }
             const auto *divisor_info = vku::FindStructInPNextChain<VkPipelineVertexInputDivisorStateCreateInfo>(input_state->pNext);
             if (divisor_info) {
                 for (const auto [i, di] :
                      vvl::enumerate(divisor_info->pVertexBindingDivisors, divisor_info->vertexBindingDivisorCount)) {
-                    if (auto *binding_state = vvl::Find(bindings, di->binding)) {
-                        binding_state->desc.divisor = di->divisor;
+                    if (auto *binding_state = vvl::Find(bindings, di.binding)) {
+                        binding_state->desc.divisor = di.divisor;
                     }
                 }
             }
         }
         for (const auto [i, ad] :
              vvl::enumerate(input_state->pVertexAttributeDescriptions, input_state->vertexAttributeDescriptionCount)) {
-            auto *binding_state = vvl::Find(bindings, ad->binding);
+            auto *binding_state = vvl::Find(bindings, ad.binding);
             if (!binding_state) {
                 continue;
             }
-            binding_state->locations.emplace(ad->location, VertexAttrState(i, ad));
+            binding_state->locations.emplace(ad.location, VertexAttrState(i, &ad));
         }
     }
 }

--- a/layers/state_tracker/ray_tracing_state.h
+++ b/layers/state_tracker/ray_tracing_state.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (C) 2015-2024 Google Inc.
+/* Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (C) 2015-2025 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -116,7 +116,7 @@ class AccelerationStructureKHR : public StateObject {
     void UpdateBuildRangeInfos(const VkAccelerationStructureBuildRangeInfoKHR *p_build_range_infos, uint32_t geometry_count) {
         build_range_infos.resize(geometry_count);
         for (const auto [i, build_range] : vvl::enumerate(p_build_range_infos, geometry_count)) {
-            build_range_infos[i] = *build_range;
+            build_range_infos[i] = build_range;
         }
     }
 

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -2712,9 +2712,9 @@ void ValidationStateTracker::PostCallRecordCmdBuildAccelerationStructuresKHR(
 
     cb_state->RecordCmd(record_obj.location.function);
     for (const auto [i, info] : vvl::enumerate(pInfos, infoCount)) {
-        RecordDeviceAccelerationStructureBuildInfo(*cb_state, *info);
-        if (auto dst_as_state = Get<vvl::AccelerationStructureKHR>(info->dstAccelerationStructure)) {
-            dst_as_state->UpdateBuildRangeInfos(ppBuildRangeInfos[i], info->geometryCount);
+        RecordDeviceAccelerationStructureBuildInfo(*cb_state, info);
+        if (auto dst_as_state = Get<vvl::AccelerationStructureKHR>(info.dstAccelerationStructure)) {
+            dst_as_state->UpdateBuildRangeInfos(ppBuildRangeInfos[i], info.geometryCount);
         }
     }
     cb_state->has_build_as_cmd = true;
@@ -5585,14 +5585,14 @@ void ValidationStateTracker::PostCallRecordCmdSetVertexInputEXT(
     vertex_bindings.clear();
 
     for (const auto [i, bd] : vvl::enumerate(pVertexBindingDescriptions, vertexBindingDescriptionCount)) {
-        vertex_bindings.insert_or_assign(bd->binding, VertexBindingState(i, bd));
+        vertex_bindings.insert_or_assign(bd.binding, VertexBindingState(i, &bd));
 
-        cb_state->current_vertex_buffer_binding_info[bd->binding].stride = bd->stride;
+        cb_state->current_vertex_buffer_binding_info[bd.binding].stride = bd.stride;
     }
 
     for (const auto [i, ad] : vvl::enumerate(pVertexAttributeDescriptions, vertexAttributeDescriptionCount)) {
-        if (auto *binding_state = vvl::Find(vertex_bindings, ad->binding)) {
-            binding_state->locations.insert_or_assign(ad->location, VertexAttrState(i, ad));
+        if (auto *binding_state = vvl::Find(vertex_bindings, ad.binding)) {
+            binding_state->locations.insert_or_assign(ad.location, VertexAttrState(i, &ad));
         }
     }
 }

--- a/layers/stateless/sl_descriptor.cpp
+++ b/layers/stateless/sl_descriptor.cpp
@@ -586,20 +586,20 @@ bool StatelessValidation::ValidateDescriptorSetLayoutCreateInfo(const VkDescript
     if (create_info.pBindings != nullptr) {
         const auto *mutable_descriptor_type = vku::FindStructInPNextChain<VkMutableDescriptorTypeCreateInfoEXT>(create_info.pNext);
         for (const auto [i, binding] : vvl::enumerate(create_info.pBindings, create_info.bindingCount)) {
-            if (binding->descriptorCount == 0) {
+            if (binding.descriptorCount == 0) {
                 continue;
             }
 
             const Location binding_loc = create_info_loc.dot(Field::pBindings, i);
-            VkShaderStageFlags stage_flags = binding->stageFlags;
+            VkShaderStageFlags stage_flags = binding.stageFlags;
             if (stage_flags != 0) {
                 if (stage_flags != VK_SHADER_STAGE_ALL && ((stage_flags & (~AllVkShaderStageFlagBitsExcludingStageAll)) != 0)) {
                     skip |= LogError(
                         "VUID-VkDescriptorSetLayoutBinding-descriptorCount-09465", device, binding_loc.dot(Field::descriptorCount),
-                        "is %" PRIu32 " but stageFlags is invalid (0x%" PRIx32 ").", binding->descriptorCount, stage_flags);
+                        "is %" PRIu32 " but stageFlags is invalid (0x%" PRIx32 ").", binding.descriptorCount, stage_flags);
                 }
 
-                if ((binding->descriptorType == VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT) &&
+                if ((binding.descriptorType == VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT) &&
                     (stage_flags != VK_SHADER_STAGE_FRAGMENT_BIT)) {
                     skip |= LogError("VUID-VkDescriptorSetLayoutBinding-descriptorType-01510", device,
                                      binding_loc.dot(Field::stageFlags),
@@ -608,7 +608,7 @@ bool StatelessValidation::ValidateDescriptorSetLayoutCreateInfo(const VkDescript
                 }
             }
 
-            if (binding->descriptorType == VK_DESCRIPTOR_TYPE_MUTABLE_EXT) {
+            if (binding.descriptorType == VK_DESCRIPTOR_TYPE_MUTABLE_EXT) {
                 if (mutable_descriptor_type) {
                     if (i >= mutable_descriptor_type->mutableDescriptorTypeListCount) {
                         skip |= LogError(
@@ -623,7 +623,7 @@ bool StatelessValidation::ValidateDescriptorSetLayoutCreateInfo(const VkDescript
                                      "is VK_DESCRIPTOR_TYPE_MUTABLE_EXT but VkMutableDescriptorTypeCreateInfoEXT is not "
                                      "included in the pNext chain.");
                 }
-                if (binding->pImmutableSamplers) {
+                if (binding.pImmutableSamplers) {
                     skip |= LogError("VUID-VkDescriptorSetLayoutCreateInfo-descriptorType-04594", device,
                                      binding_loc.dot(Field::descriptorType),
                                      "is VK_DESCRIPTOR_TYPE_MUTABLE_EXT but pImmutableSamplers is not NULL.");
@@ -636,17 +636,17 @@ bool StatelessValidation::ValidateDescriptorSetLayoutCreateInfo(const VkDescript
                 }
             }
 
-            if (has_push_descriptor_flag && binding->descriptorType == VK_DESCRIPTOR_TYPE_MUTABLE_EXT) {
+            if (has_push_descriptor_flag && binding.descriptorType == VK_DESCRIPTOR_TYPE_MUTABLE_EXT) {
                 skip |= LogError("VUID-VkDescriptorSetLayoutCreateInfo-flags-04591", device, binding_loc.dot(Field::descriptorType),
                                  "is VK_DESCRIPTOR_TYPE_MUTABLE_EXT, but flags includes "
                                  "VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT.");
             }
 
-            if (has_descriptor_buffer_flag && ((binding->descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC) ||
-                                               (binding->descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC))) {
+            if (has_descriptor_buffer_flag && ((binding.descriptorType == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC) ||
+                                               (binding.descriptorType == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC))) {
                 skip |= LogError("VUID-VkDescriptorSetLayoutCreateInfo-flags-08000", device, binding_loc.dot(Field::descriptorType),
                                  "is %s, but flags includes VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT.",
-                                 string_VkDescriptorType(binding->descriptorType));
+                                 string_VkDescriptorType(binding.descriptorType));
             }
         }
 

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -1997,7 +1997,7 @@ bool SyncValidator::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBu
         Location attachment_loc = error_obj.location.dot(Field::pAttachments, attachment_index);
         for (const auto [rect_index, rect] : vvl::enumerate(pRects, rectCount)) {
             Location rect_loc = attachment_loc.dot(Field::pRects, rect_index);
-            skip |= cb_state->access_context.ValidateClearAttachment(rect_loc, *attachment, *rect);
+            skip |= cb_state->access_context.ValidateClearAttachment(rect_loc, attachment, rect);
         }
     }
     return skip;

--- a/layers/utils/ray_tracing_utils.cpp
+++ b/layers/utils/ray_tracing_utils.cpp
@@ -1,5 +1,5 @@
-/* Copyright (c) 2024 Valve Corporation
- * Copyright (c) 2024 LunarG, Inc.
+/* Copyright (c) 2025 Valve Corporation
+ * Copyright (c) 2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ static VkAccelerationStructureBuildSizesInfoKHR ComputeBuildSizes(const VkDevice
                                                                   const VkAccelerationStructureBuildRangeInfoKHR *range_infos) {
     std::vector<uint32_t> primitive_counts(build_info.geometryCount);
     for (const auto [i, build_range] : vvl::enumerate(range_infos, build_info.geometryCount)) {
-        primitive_counts[i] = build_range->primitiveCount;
+        primitive_counts[i] = build_range.primitiveCount;
     }
     VkAccelerationStructureBuildSizesInfoKHR size_info = vku::InitStructHelper();
     DispatchGetAccelerationStructureBuildSizesKHR(device, build_type, &build_info, primitive_counts.data(), &size_info);

--- a/tests/framework/ray_tracing_objects.cpp
+++ b/tests/framework/ray_tracing_objects.cpp
@@ -646,8 +646,8 @@ void BuildGeometryInfoKHR::VkCmdBuildAccelerationStructuresIndirectKHR(VkCommand
 
     pGeometries.reserve(geometries_.size());
     for (const auto [i, geometry] : vvl::enumerate(geometries_)) {
-        pGeometries[i] = &geometry->GetVkObj();
-        ranges_info[i] = geometry->GetFullBuildRange();
+        pGeometries[i] = &geometry.GetVkObj();
+        ranges_info[i] = geometry.GetFullBuildRange();
     }
     if (use_null_geometries_) {
         vk_info_.pGeometries = nullptr;
@@ -714,11 +714,11 @@ VkAccelerationStructureBuildSizesInfoKHR BuildGeometryInfoKHR::GetSizeInfo(bool 
     }
 
     for (const auto &[geometry_i, geometry] : vvl::enumerate(geometries_)) {
-        primitives_count[geometry_i] = geometry->GetFullBuildRange().primitiveCount;
+        primitives_count[geometry_i] = geometry.GetFullBuildRange().primitiveCount;
         if (use_ppGeometries) {
-            pGeometries.emplace_back(&geometry->GetVkObj());
+            pGeometries.emplace_back(&geometry.GetVkObj());
         } else {
-            geometries.emplace_back(geometry->GetVkObj());
+            geometries.emplace_back(geometry.GetVkObj());
         }
     }
     vk_info_.geometryCount = static_cast<uint32_t>(geometries_.size());
@@ -746,7 +746,7 @@ VkAccelerationStructureBuildSizesInfoKHR BuildGeometryInfoKHR::GetSizeInfo(bool 
 std::vector<VkAccelerationStructureBuildRangeInfoKHR> BuildGeometryInfoKHR::GetBuildRangeInfosFromGeometries() {
     std::vector<VkAccelerationStructureBuildRangeInfoKHR> range_infos(geometries_.size());
     for (const auto [i, geometry] : vvl::enumerate(geometries_)) {
-        range_infos[i] = geometry->GetFullBuildRange();
+        range_infos[i] = geometry.GetFullBuildRange();
     }
 
     return range_infos;

--- a/tests/unit/gpu_av_buffer_device_address.cpp
+++ b/tests/unit/gpu_av_buffer_device_address.cpp
@@ -1131,13 +1131,13 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd430LinkedList) {
 
     // Make sure shader wrote values to all nodes but the last
     for (auto [buffer_i, buffer] : vvl::enumerate(storage_buffers.data(), nodes_count - 1)) {
-        auto storage_buffer_ptr = static_cast<float *>(buffer->Memory().Map());
+        auto storage_buffer_ptr = static_cast<float *>(buffer.Memory().Map());
 
         ASSERT_EQ(storage_buffer_ptr[0], float(3 * buffer_i + 1));
         ASSERT_EQ(storage_buffer_ptr[1], float(3 * buffer_i + 2));
         ASSERT_EQ(storage_buffer_ptr[2], float(3 * buffer_i + 3));
 
-        buffer->Memory().Unmap();
+        buffer.Memory().Unmap();
     }
 }
 

--- a/tests/unit/gpu_av_buffer_device_address_positive.cpp
+++ b/tests/unit/gpu_av_buffer_device_address_positive.cpp
@@ -868,13 +868,13 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreStd430LinkedList) {
 
     // Make sure shader wrote values to all nodes
     for (auto [buffer_i, buffer] : vvl::enumerate(storage_buffers)) {
-        auto storage_buffer_ptr = static_cast<float *>(buffer->Memory().Map());
+        auto storage_buffer_ptr = static_cast<float *>(buffer.Memory().Map());
 
         ASSERT_EQ(storage_buffer_ptr[0], float(3 * buffer_i + 1));
         ASSERT_EQ(storage_buffer_ptr[1], float(3 * buffer_i + 2));
         ASSERT_EQ(storage_buffer_ptr[2], float(3 * buffer_i + 3));
 
-        buffer->Memory().Unmap();
+        buffer.Memory().Unmap();
     }
 }
 

--- a/tests/unit/gpu_av_positive.cpp
+++ b/tests/unit/gpu_av_positive.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 Valve Corporation
- * Copyright (c) 2023-2024 LunarG, Inc.
+/* Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 Valve Corporation
+ * Copyright (c) 2023-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1107,7 +1107,7 @@ TEST_P(PositiveGpuAVParameterized, SettingsCombinations) {
         VkBool32 &layer_setting_value = layer_settings_values[setting_name_i];
 
         layer_setting_value = (setting_values & (1u << setting_name_i)) ? VK_TRUE : VK_FALSE;
-        layer_setting = {OBJECT_LAYER_NAME, *setting_name, VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &layer_setting_value};
+        layer_setting = {OBJECT_LAYER_NAME, setting_name, VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &layer_setting_value};
     }
 
     VkLayerSettingsCreateInfoEXT layer_settings_create_info = vku::InitStructHelper();

--- a/tests/unit/sparse_buffer_positive.cpp
+++ b/tests/unit/sparse_buffer_positive.cpp
@@ -1,9 +1,9 @@
 
 /*
- * Copyright (c) 2024 The Khronos Group Inc.
- * Copyright (c) 2024 Valve Corporation
- * Copyright (c) 2024 LunarG, Inc.
- * Copyright (c) 2024 Collabora, Inc.
+ * Copyright (c) 2025 The Khronos Group Inc.
+ * Copyright (c) 2025 Valve Corporation
+ * Copyright (c) 2025 LunarG, Inc.
+ * Copyright (c) 2025 Collabora, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -577,11 +577,11 @@ TEST_F(PositiveSparseBuffer, BufferCopiesValidationStressTest2) {
     }
 
     std::vector<VkSparseMemoryBind> buffer_memory_binds(memory_chunks_count);
-    for (auto& [i, mem_bind] : vvl::enumerate(buffer_memory_binds)) {
-        mem_bind->size = memory_size;
-        mem_bind->memory = memory_chunks[i].handle();
-        mem_bind->resourceOffset = i * memory_size;
-        mem_bind->memoryOffset = 0;
+    for (auto [i, mem_bind] : vvl::enumerate(buffer_memory_binds)) {
+        mem_bind.size = memory_size;
+        mem_bind.memory = memory_chunks[i].handle();
+        mem_bind.resourceOffset = i * memory_size;
+        mem_bind.memoryOffset = 0;
     }
 
     std::array<VkSparseBufferMemoryBindInfo, 1> buffer_memory_bind_infos = {};

--- a/tests/vvl_utils/small_vector.cpp
+++ b/tests/vvl_utils/small_vector.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2024 The Khronos Group Inc.
- * Copyright (c) 2024 Valve Corporation
- * Copyright (c) 2024 LunarG, Inc.
+ * Copyright (c) 2025 The Khronos Group Inc.
+ * Copyright (c) 2025 Valve Corporation
+ * Copyright (c) 2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -431,7 +431,18 @@ TEST(CustomContainer, Enumerate) {
     size_t indices_i = 0;
     for (auto [i, x] : vvl::enumerate(sv)) {
         ASSERT_TRUE(i == indices_i);
-        ASSERT_TRUE(*x == ref_elements[indices_i]);
+        ASSERT_TRUE(x == ref_elements[indices_i]);
+        ++indices_i;
+    }
+}
+
+TEST(CustomContainer, EnumerateConst) {
+    const std::vector<int> sv{1, 2, 3, 4};
+    std::array ref_elements = {1, 2, 3, 4};
+    size_t indices_i = 0;
+    for (auto [i, x] : vvl::enumerate(sv)) {
+        ASSERT_TRUE(i == indices_i);
+        ASSERT_TRUE(x == ref_elements[indices_i]);
         ++indices_i;
     }
 }


### PR DESCRIPTION
This matches behavior of `std::views::enumerate` - enumerated object is returned as a reference instead of a pointer.
Would minimize changes if we start using C++ 23 in the future.
