### PR TITLE
build: Remove usage of deprecated std::aligned_storage/union

### DIFF
--- a/layers/containers/subresource_adapter.h
+++ b/layers/containers/subresource_adapter.h
@@ -20,6 +20,7 @@
  */
 #pragma once
 
+#include <cstddef>
 #include <vector>
 #include "range_vector.h"
 #include "custom_containers.h"
@@ -761,13 +762,13 @@ class BothRangeMap {
     }
     BigMap* MakeBigMap() {
         if (BigMode()) {
-            return new (&backing_store) BigMap();
+            return new (backing_store) BigMap();
         }
         return nullptr;
     }
     SmallMap* MakeSmallMap(index_type limit) {
         if (SmallMode()) {
-            return new (&backing_store) SmallMap(limit);
+            return new (backing_store) SmallMap(limit);
         }
         return nullptr;
     }
@@ -777,8 +778,7 @@ class BothRangeMap {
     BigMap* big_map_ = nullptr;
     SmallMap* small_map_ = nullptr;
 
-    using Storage = typename std::aligned_union<0, SmallMap, BigMap>::type;
-    Storage backing_store;
+    alignas(std::max(alignof(SmallMap), alignof(BigMap))) std::byte backing_store[std::max(sizeof(SmallMap), sizeof(BigMap))];
 };
 
 }  // namespace subresource_adapter


### PR DESCRIPTION
These are deprecated in c++23.

Note: in the one instance where the default Align value was used for std::aligned_storage<Len, Alignment> (i.e.
std::aligned_storage<Len>), this patch now adopts an implementation similar to libc++ to avoid behavior changes.