### PR TITLE
sync: Minor cleanup

### DIFF
--- a/layers/sync/sync_access_state.cpp
+++ b/layers/sync/sync_access_state.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2019-2024 Valve Corporation
- * Copyright (c) 2019-2024 LunarG, Inc.
+ * Copyright (c) 2019-2025 Valve Corporation
+ * Copyright (c) 2019-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -958,11 +958,12 @@ HazardResult::HazardState::HazardState(const ResourceAccessState *access_state_,
 
 SyncExecScope SyncExecScope::MakeSrc(VkQueueFlags queue_flags, VkPipelineStageFlags2 mask_param,
                                      const VkPipelineStageFlags2 disabled_feature_mask) {
+    const VkPipelineStageFlags2 expanded_mask = sync_utils::ExpandPipelineStages(mask_param, queue_flags, disabled_feature_mask);
+
     SyncExecScope result;
     result.mask_param = mask_param;
-    result.expanded_mask = sync_utils::ExpandPipelineStages(mask_param, queue_flags, disabled_feature_mask);
-    result.exec_scope = sync_utils::WithEarlierPipelineStages(result.expanded_mask);
-    result.valid_accesses = SyncStageAccess::AccessScopeByStage(result.expanded_mask);
+    result.exec_scope = sync_utils::WithEarlierPipelineStages(expanded_mask);
+    result.valid_accesses = SyncStageAccess::AccessScopeByStage(expanded_mask);
     // ALL_COMMANDS stage includes all accesses performed by the gpu, not only accesses defined by the stages
     if (mask_param & VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT) {
         result.valid_accesses |= SYNC_IMAGE_LAYOUT_TRANSITION_BIT;
@@ -971,11 +972,11 @@ SyncExecScope SyncExecScope::MakeSrc(VkQueueFlags queue_flags, VkPipelineStageFl
 }
 
 SyncExecScope SyncExecScope::MakeDst(VkQueueFlags queue_flags, VkPipelineStageFlags2 mask_param) {
+    const VkPipelineStageFlags2 expanded_mask = sync_utils::ExpandPipelineStages(mask_param, queue_flags);
     SyncExecScope result;
     result.mask_param = mask_param;
-    result.expanded_mask = sync_utils::ExpandPipelineStages(mask_param, queue_flags);
-    result.exec_scope = sync_utils::WithLaterPipelineStages(result.expanded_mask);
-    result.valid_accesses = SyncStageAccess::AccessScopeByStage(result.expanded_mask);
+    result.exec_scope = sync_utils::WithLaterPipelineStages(expanded_mask);
+    result.valid_accesses = SyncStageAccess::AccessScopeByStage(expanded_mask);
     // ALL_COMMANDS stage includes all accesses performed by the gpu, not only accesses defined by the stages
     if (mask_param & VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT) {
         result.valid_accesses |= SYNC_IMAGE_LAYOUT_TRANSITION_BIT;

--- a/layers/sync/sync_access_state.h
+++ b/layers/sync/sync_access_state.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2019-2024 The Khronos Group Inc.
- * Copyright (c) 2019-2024 Valve Corporation
- * Copyright (c) 2019-2024 LunarG, Inc.
+/* Copyright (c) 2019-2025 The Khronos Group Inc.
+ * Copyright (c) 2019-2025 Valve Corporation
+ * Copyright (c) 2019-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,15 +114,13 @@ class HazardResult {
 };
 
 struct SyncExecScope {
-    VkPipelineStageFlags2 mask_param;     // the xxxStageMask parameter passed by the caller
-    VkPipelineStageFlags2 expanded_mask;  // all stage bits covered by any 'catch all bits' in the parameter (eg. ALL_GRAPHICS_BIT).
-    VkPipelineStageFlags2 exec_scope;     // all earlier or later stages that would be affected by a barrier using this scope.
-    SyncAccessFlags valid_accesses;       // all valid accesses that can be used with this scope.
+    VkPipelineStageFlags2 mask_param;  // the xxxStageMask parameter passed by the caller
+    VkPipelineStageFlags2 exec_scope;  // all earlier or later stages that would be affected by a barrier using this scope.
+    SyncAccessFlags valid_accesses;    // all valid accesses that can be used with this scope.
 
-    SyncExecScope() : mask_param(0), expanded_mask(0), exec_scope(0), valid_accesses(0) {}
-    SyncExecScope(VkPipelineStageFlags2 mask_param_, VkPipelineStageFlags2 expanded_mask_, VkPipelineStageFlags2 exec_scope_,
-                  const SyncAccessFlags &valid_accesses_)
-        : mask_param(mask_param_), expanded_mask(expanded_mask_), exec_scope(exec_scope_), valid_accesses(valid_accesses_) {}
+    SyncExecScope() : mask_param(0), exec_scope(0), valid_accesses(0) {}
+    SyncExecScope(VkPipelineStageFlags2 mask_param, VkPipelineStageFlags2 exec_scope, const SyncAccessFlags &valid_accesses)
+        : mask_param(mask_param), exec_scope(exec_scope), valid_accesses(valid_accesses) {}
 
     static SyncExecScope MakeSrc(VkQueueFlags queue_flags, VkPipelineStageFlags2 src_stage_mask,
                                  const VkPipelineStageFlags2 disabled_feature_mask = 0);

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2019-2024 Valve Corporation
- * Copyright (c) 2019-2024 LunarG, Inc.
+ * Copyright (c) 2019-2025 Valve Corporation
+ * Copyright (c) 2019-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -223,7 +223,6 @@ class ApplyAcquireNextSemaphoreAction {
     const SyncExecScope& getPresentSrcScope() const {
         static const SyncExecScope kPresentSrcScope =
             SyncExecScope(VK_PIPELINE_STAGE_2_PRESENT_ENGINE_BIT_SYNCVAL,  // mask_param (unused)
-                          VK_PIPELINE_STAGE_2_PRESENT_ENGINE_BIT_SYNCVAL,  // expanded_mask
                           VK_PIPELINE_STAGE_2_PRESENT_ENGINE_BIT_SYNCVAL,  // exec_scope
                           getPresentValidAccesses());                      // valid_accesses
         return kPresentSrcScope;


### PR DESCRIPTION
* Remove `SyncExecScope ::expanded_state` which is not used
* Break dependency between `BatchBarrierOp` and `PipelineBarrierOp` (inheritance). It easier not to inherit, than inherit and then deal with inherited members that are not applicated to the derived type.