### PR TITLE
layers: Fix vertex input when unused

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -83,8 +83,6 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateComputePipelineDerivatives(PipelineStates& pipeline_states, uint32_t pipe_index, const Location& loc) const;
     bool ValidateMultiViewShaders(const vvl::Pipeline& pipeline, const Location& multiview_loc, uint32_t view_mask,
                                   bool dynamic_rendering) const;
-    bool ValidateDrawPipelineVertexAttribute(const vvl::CommandBuffer& cb_state, const vvl::Pipeline& pipeline,
-                                             const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateGraphicsPipeline(const vvl::Pipeline& pipeline, const void* pipeline_ci_pnext,
                                   const Location& create_info_loc) const;
     bool ValidImageBufferQueue(const vvl::CommandBuffer& cb_state, const VulkanTypedHandle& object, uint32_t queueFamilyIndex,

--- a/layers/state_tracker/pipeline_sub_state.cpp
+++ b/layers/state_tracker/pipeline_sub_state.cpp
@@ -36,9 +36,9 @@ VertexInputState::VertexInputState(const vvl::Pipeline &p, const vku::safe_VkGra
 
     if (input_state) {
         if (input_state->vertexBindingDescriptionCount) {
-            for (const auto [i, bd] :
+            for (const auto [i, description] :
                  vvl::enumerate(input_state->pVertexBindingDescriptions, input_state->vertexBindingDescriptionCount)) {
-                bindings.emplace(bd.binding, VertexBindingState(i, &bd));
+                bindings.emplace(description.binding, VertexBindingState(i, &description));
             }
             const auto *divisor_info = vku::FindStructInPNextChain<VkPipelineVertexInputDivisorStateCreateInfo>(input_state->pNext);
             if (divisor_info) {
@@ -50,13 +50,13 @@ VertexInputState::VertexInputState(const vvl::Pipeline &p, const vku::safe_VkGra
                 }
             }
         }
-        for (const auto [i, ad] :
+        for (const auto [i, description] :
              vvl::enumerate(input_state->pVertexAttributeDescriptions, input_state->vertexAttributeDescriptionCount)) {
-            auto *binding_state = vvl::Find(bindings, ad.binding);
+            auto *binding_state = vvl::Find(bindings, description.binding);
             if (!binding_state) {
                 continue;
             }
-            binding_state->locations.emplace(ad.location, VertexAttrState(i, &ad));
+            binding_state->locations.emplace(description.location, VertexAttrState(i, &description));
         }
     }
 }

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -3207,6 +3207,7 @@ void ValidationStateTracker::PreCallRecordCmdBindVertexBuffers(VkCommandBuffer c
         auto buffer_state = Get<vvl::Buffer>(pBuffers[i]);
         // the stride is set from the pipeline or dynamic state
         vvl::VertexBufferBinding &vertex_buffer_binding = cb_state->current_vertex_buffer_binding_info[i + firstBinding];
+        vertex_buffer_binding.bound = true;
         vertex_buffer_binding.buffer = pBuffers[i];
         vertex_buffer_binding.offset = pOffsets[i];
         vertex_buffer_binding.effective_size =
@@ -5316,6 +5317,7 @@ void ValidationStateTracker::PostCallRecordCmdBindVertexBuffers2(VkCommandBuffer
     for (uint32_t i = 0; i < bindingCount; ++i) {
         auto buffer_state = Get<vvl::Buffer>(pBuffers[i]);
         vvl::VertexBufferBinding &vertex_buffer_binding = cb_state->current_vertex_buffer_binding_info[i + firstBinding];
+        vertex_buffer_binding.bound = true;
         vertex_buffer_binding.buffer = pBuffers[i];
         vertex_buffer_binding.offset = pOffsets[i];
         vertex_buffer_binding.effective_size = pSizes ? pSizes[i] : VK_WHOLE_SIZE;
@@ -5584,15 +5586,15 @@ void ValidationStateTracker::PostCallRecordCmdSetVertexInputEXT(
     // "The vertex attribute description for any location not specified in the pVertexAttributeDescriptions array becomes undefined"
     vertex_bindings.clear();
 
-    for (const auto [i, bd] : vvl::enumerate(pVertexBindingDescriptions, vertexBindingDescriptionCount)) {
-        vertex_bindings.insert_or_assign(bd.binding, VertexBindingState(i, &bd));
+    for (const auto [i, description] : vvl::enumerate(pVertexBindingDescriptions, vertexBindingDescriptionCount)) {
+        vertex_bindings.insert_or_assign(description.binding, VertexBindingState(i, &description));
 
-        cb_state->current_vertex_buffer_binding_info[bd.binding].stride = bd.stride;
+        cb_state->current_vertex_buffer_binding_info[description.binding].stride = description.stride;
     }
 
-    for (const auto [i, ad] : vvl::enumerate(pVertexAttributeDescriptions, vertexAttributeDescriptionCount)) {
-        if (auto *binding_state = vvl::Find(vertex_bindings, ad.binding)) {
-            binding_state->locations.insert_or_assign(ad.location, VertexAttrState(i, &ad));
+    for (const auto [i, description] : vvl::enumerate(pVertexAttributeDescriptions, vertexAttributeDescriptionCount)) {
+        if (auto *binding_state = vvl::Find(vertex_bindings, description.binding)) {
+            binding_state->locations.insert_or_assign(description.location, VertexAttrState(i, &description));
         }
     }
 }

--- a/layers/state_tracker/vertex_index_buffer_state.h
+++ b/layers/state_tracker/vertex_index_buffer_state.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (C) 2015-2024 Google Inc.
+/* Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (C) 2015-2025 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -24,7 +24,11 @@
 namespace vvl {
 class Buffer;
 
+// Data for a given binding, that can be updated by calls like vkCmdBindVertexBuffers and vkCmdSetVertexInputEXT
 struct VertexBufferBinding {
+    // buffer might be VK_NULL_HANDLE because it was set or by default, we need to actually know if the command buffer binds or not
+    bool bound;
+
     VkBuffer buffer;  // VK_NULL_HANDLE is valid if using nullDescriptor
     // Binding valid size: 0 if buffer is not tracked, actual size if VK_WHOLE_SIZE was specified,
     // clamped up to 0 if specified size is greater than the size actually left in the buffer
@@ -32,7 +36,7 @@ struct VertexBufferBinding {
     VkDeviceSize offset;
     VkDeviceSize stride;
 
-    VertexBufferBinding() : buffer(VK_NULL_HANDLE), effective_size(0), offset(0), stride(0) {}
+    VertexBufferBinding() : bound(false), buffer(VK_NULL_HANDLE), effective_size(0), offset(0), stride(0) {}
 
     void reset() { *this = VertexBufferBinding(); }
 };

--- a/tests/unit/best_practices_positive.cpp
+++ b/tests/unit/best_practices_positive.cpp
@@ -268,7 +268,7 @@ TEST_F(VkPositiveBestPracticesLayerTest, VertexBufferNotForAllDraws) {
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit | kPerformanceWarningBit);
     m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
-    vk::CmdBindVertexBuffers(m_command_buffer.handle(), 1, 1, &vbo.handle(), &kZeroDeviceSize);
+    vk::CmdBindVertexBuffers(m_command_buffer.handle(), 0, 1, &vbo.handle(), &kZeroDeviceSize);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe0.Handle());
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);

--- a/tests/unit/multiview.cpp
+++ b/tests/unit/multiview.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (c) 2015-2024 Google, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2025 Google, Inc.
  * Modifications Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2021 ARM, Inc. All rights reserved.
  *
@@ -498,8 +498,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
-        m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-04008");
-        m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-02721");
+        m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-04007");
         vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
         m_errorMonitor->VerifyFound();
 
@@ -509,8 +508,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
             m_command_buffer.NextSubpass();
             vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipelines[i].handle());
 
-            m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-04008");
-            m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-02721");
+            m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-04007");
             vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
             m_errorMonitor->VerifyFound();
         }


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9305

We had the VUs a bit mixed up

-  `VUID-vkCmdDraw-None-04007` - Makes sure you call `vkCmdBindVertexBuffers` on the binding
-  `VUID-vkCmdDraw-None-04008` - If you bound VK_NULL_HANDLE, need `nullDescriptor`
- ` VUID-vkCmdDraw-None-02721` - The values are OOB inside (also done on GPU-AV)