### PR TITLE
scripts: Fix struct alias codegen from command param

### DIFF
--- a/layers/vulkan/generated/dispatch_object.cpp
+++ b/layers/vulkan/generated/dispatch_object.cpp
@@ -7208,7 +7208,21 @@ VkResult Device::GetMemoryRemoteAddressNV(VkDevice device, const VkMemoryGetRemo
 
 VkResult Device::GetPipelinePropertiesEXT(VkDevice device, const VkPipelineInfoEXT* pPipelineInfo,
                                           VkBaseOutStructure* pPipelineProperties) {
-    VkResult result = device_dispatch_table.GetPipelinePropertiesEXT(device, pPipelineInfo, pPipelineProperties);
+    if (!wrap_handles) return device_dispatch_table.GetPipelinePropertiesEXT(device, pPipelineInfo, pPipelineProperties);
+    vku::safe_VkPipelineInfoKHR var_local_pPipelineInfo;
+    vku::safe_VkPipelineInfoKHR* local_pPipelineInfo = nullptr;
+    {
+        if (pPipelineInfo) {
+            local_pPipelineInfo = &var_local_pPipelineInfo;
+            local_pPipelineInfo->initialize(pPipelineInfo);
+
+            if (pPipelineInfo->pipeline) {
+                local_pPipelineInfo->pipeline = Unwrap(pPipelineInfo->pipeline);
+            }
+        }
+    }
+    VkResult result =
+        device_dispatch_table.GetPipelinePropertiesEXT(device, (const VkPipelineInfoKHR*)local_pPipelineInfo, pPipelineProperties);
 
     return result;
 }

--- a/layers/vulkan/generated/object_tracker.cpp
+++ b/layers/vulkan/generated/object_tracker.cpp
@@ -6785,8 +6785,19 @@ bool Device::PreCallValidateGetMemoryRemoteAddressNV(VkDevice device,
     return skip;
 }
 
-// vkGetPipelinePropertiesEXT:
-// Checked by chassis: device: "VUID-vkGetPipelinePropertiesEXT-device-parameter"
+bool Device::PreCallValidateGetPipelinePropertiesEXT(VkDevice device, const VkPipelineInfoEXT* pPipelineInfo,
+                                                     VkBaseOutStructure* pPipelineProperties, const ErrorObject& error_obj) const {
+    bool skip = false;
+    // Checked by chassis: device: "VUID-vkGetPipelinePropertiesEXT-device-parameter"
+    if (pPipelineInfo) {
+        [[maybe_unused]] const Location pPipelineInfo_loc = error_obj.location.dot(Field::pPipelineInfo);
+        skip |=
+            ValidateObject(pPipelineInfo->pipeline, kVulkanObjectTypePipeline, false, "VUID-VkPipelineInfoKHR-pipeline-parameter",
+                           "VUID-VkPipelineInfoKHR-pipeline-parent", pPipelineInfo_loc.dot(Field::pipeline));
+    }
+
+    return skip;
+}
 
 // vkCmdSetPatchControlPointsEXT:
 // Checked by chassis: commandBuffer: "VUID-vkCmdSetPatchControlPointsEXT-commandBuffer-parameter"
@@ -7891,10 +7902,9 @@ bool Device::PreCallValidateGetMemoryMetalHandleEXT(VkDevice device, const VkMem
     // Checked by chassis: device: "VUID-vkGetMemoryMetalHandleEXT-device-parameter"
     if (pGetMetalHandleInfo) {
         [[maybe_unused]] const Location pGetMetalHandleInfo_loc = error_obj.location.dot(Field::pGetMetalHandleInfo);
-        skip |=
-            ValidateObject(pGetMetalHandleInfo->memory, kVulkanObjectTypeDeviceMemory, false,
-                           "VUID-VkMemoryGetMetalHandleInfoEXT-memory-parameter",
-                           "UNASSIGNED-VkMemoryGetMetalHandleInfoEXT-memory-parent", pGetMetalHandleInfo_loc.dot(Field::memory));
+        skip |= ValidateObject(pGetMetalHandleInfo->memory, kVulkanObjectTypeDeviceMemory, false,
+                               "VUID-VkMemoryGetMetalHandleInfoEXT-memory-parameter",
+                               "VUID-VkMemoryGetMetalHandleInfoEXT-memory-parent", pGetMetalHandleInfo_loc.dot(Field::memory));
     }
 
     return skip;

--- a/layers/vulkan/generated/object_tracker_device_methods.h
+++ b/layers/vulkan/generated/object_tracker_device_methods.h
@@ -1108,6 +1108,8 @@ bool PreCallValidateCmdBindInvocationMaskHUAWEI(VkCommandBuffer commandBuffer, V
                                                 const ErrorObject& error_obj) const override;
 bool PreCallValidateGetMemoryRemoteAddressNV(VkDevice device, const VkMemoryGetRemoteAddressInfoNV* pMemoryGetRemoteAddressInfo,
                                              VkRemoteAddressNV* pAddress, const ErrorObject& error_obj) const override;
+bool PreCallValidateGetPipelinePropertiesEXT(VkDevice device, const VkPipelineInfoEXT* pPipelineInfo,
+                                             VkBaseOutStructure* pPipelineProperties, const ErrorObject& error_obj) const override;
 bool PreCallValidateCreateMicromapEXT(VkDevice device, const VkMicromapCreateInfoEXT* pCreateInfo,
                                       const VkAllocationCallbacks* pAllocator, VkMicromapEXT* pMicromap,
                                       const ErrorObject& error_obj) const override;

--- a/layers/vulkan/generated/stateless_validation_helper.cpp
+++ b/layers/vulkan/generated/stateless_validation_helper.cpp
@@ -23658,8 +23658,19 @@ bool Device::PreCallValidateGetAccelerationStructureMemoryRequirementsNV(
 
         skip |= context.ValidateRequiredHandle(pInfo_loc.dot(Field::accelerationStructure), pInfo->accelerationStructure);
     }
-    skip |= context.ValidateRequiredPointer(loc.dot(Field::pMemoryRequirements), pMemoryRequirements,
-                                            "VUID-vkGetAccelerationStructureMemoryRequirementsNV-pMemoryRequirements-parameter");
+    skip |= context.ValidateStructType(loc.dot(Field::pMemoryRequirements), pMemoryRequirements,
+                                       VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2, true,
+                                       "VUID-vkGetAccelerationStructureMemoryRequirementsNV-pMemoryRequirements-parameter",
+                                       "VUID-VkMemoryRequirements2-sType-sType");
+    if (pMemoryRequirements != nullptr) {
+        [[maybe_unused]] const Location pMemoryRequirements_loc = loc.dot(Field::pMemoryRequirements);
+        constexpr std::array allowed_structs_VkMemoryRequirements2 = {VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS};
+
+        skip |= context.ValidateStructPnext(
+            pMemoryRequirements_loc, pMemoryRequirements->pNext, allowed_structs_VkMemoryRequirements2.size(),
+            allowed_structs_VkMemoryRequirements2.data(), GeneratedVulkanHeaderVersion, "VUID-VkMemoryRequirements2-pNext-pNext",
+            "VUID-VkMemoryRequirements2-sType-unique", false);
+    }
     return skip;
 }
 
@@ -26171,8 +26182,16 @@ bool Device::PreCallValidateGetPipelinePropertiesEXT(VkDevice device, const VkPi
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(extensions.vk_ext_pipeline_properties))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_pipeline_properties});
-    skip |= context.ValidateRequiredPointer(loc.dot(Field::pPipelineInfo), pPipelineInfo,
-                                            "VUID-vkGetPipelinePropertiesEXT-pPipelineInfo-parameter");
+    skip |=
+        context.ValidateStructType(loc.dot(Field::pPipelineInfo), pPipelineInfo, VK_STRUCTURE_TYPE_PIPELINE_INFO_KHR, true,
+                                   "VUID-vkGetPipelinePropertiesEXT-pPipelineInfo-parameter", "VUID-VkPipelineInfoKHR-sType-sType");
+    if (pPipelineInfo != nullptr) {
+        [[maybe_unused]] const Location pPipelineInfo_loc = loc.dot(Field::pPipelineInfo);
+        skip |= context.ValidateStructPnext(pPipelineInfo_loc, pPipelineInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
+                                            "VUID-VkPipelineInfoKHR-pNext-pNext", kVUIDUndefined, true);
+
+        skip |= context.ValidateRequiredHandle(pPipelineInfo_loc.dot(Field::pipeline), pPipelineInfo->pipeline);
+    }
     if (!skip) skip |= manual_PreCallValidateGetPipelinePropertiesEXT(device, pPipelineInfo, pPipelineProperties, context);
     return skip;
 }

--- a/scripts/generators/base_generator.py
+++ b/scripts/generators/base_generator.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2023-2024 Valve Corporation
-# Copyright (c) 2023-2024 LunarG, Inc.
-# Copyright (c) 2023-2024 RasterGrid Kft.
+# Copyright (c) 2023-2025 Valve Corporation
+# Copyright (c) 2023-2025 LunarG, Inc.
+# Copyright (c) 2023-2025 RasterGrid Kft.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -315,6 +315,14 @@ class BaseGenerator(OutputGenerator):
                         if structName in self.vk.structs:
                             struct = self.vk.structs[structName]
                             struct.extensions.extend([extension] if extension not in struct.extensions else [])
+
+        # While we update struct alias inside other structs, the command itself might have the struct as a first level param.
+        # We use this time to update params to have the promoted name
+        # Example - https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9322
+        for command in self.vk.commands.values():
+            for member in command.params:
+                if member.type in self.structAliasMap:
+                    member.type = self.structAliasMap[member.type]
 
     def endFile(self):
         # This is the point were reg.py has ran, everything is collected

--- a/scripts/generators/object_tracker_generator.py
+++ b/scripts/generators/object_tracker_generator.py
@@ -799,6 +799,10 @@ bool Device::ReportUndestroyedObjects(const Location& loc) const {
             return '"UNASSIGNED-VkDescriptorDataEXT-pSampler-parent"'
         if structName == 'VkVideoEncodeQuantizationMapInfoKHR' and memberName == 'quantizationMap':
             return '"UNASSIGNED-VkVideoEncodeQuantizationMapInfoKHR-quantizationMap-parent"'
+        if structName == 'VkPipelineInfoKHR' and memberName == 'pipeline':
+            return '"VUID-VkPipelineInfoKHR-pipeline-parent"'
+        if structName == 'VkMemoryGetMetalHandleInfoEXT' and memberName == 'memory':
+            return '"VUID-VkMemoryGetMetalHandleInfoEXT-memory-parent"'
 
         # Common parents because the structs have more then one handle that needs to be check
         if (structName == 'VkBufferMemoryBarrier' and memberName == 'buffer') or (structName == 'VkImageMemoryBarrier' and memberName == 'image'):

--- a/tests/framework/binding.cpp
+++ b/tests/framework/binding.cpp
@@ -1519,12 +1519,12 @@ VkMemoryRequirements2 AccelerationStructureNV::MemoryRequirements() const {
         (PFN_vkGetAccelerationStructureMemoryRequirementsNV)vk::GetDeviceProcAddr(device(),
                                                                                   "vkGetAccelerationStructureMemoryRequirementsNV");
     assert(vkGetAccelerationStructureMemoryRequirementsNV != nullptr);
-    VkMemoryRequirements2 memoryRequirements = {};
-    VkAccelerationStructureMemoryRequirementsInfoNV memoryRequirementsInfo = vku::InitStructHelper();
-    memoryRequirementsInfo.type = VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_OBJECT_NV;
-    memoryRequirementsInfo.accelerationStructure = handle();
-    vkGetAccelerationStructureMemoryRequirementsNV(device(), &memoryRequirementsInfo, &memoryRequirements);
-    return memoryRequirements;
+    VkMemoryRequirements2 memory_requirements = vku::InitStructHelper();
+    VkAccelerationStructureMemoryRequirementsInfoNV memory_requirements_info = vku::InitStructHelper();
+    memory_requirements_info.type = VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_OBJECT_NV;
+    memory_requirements_info.accelerationStructure = handle();
+    vkGetAccelerationStructureMemoryRequirementsNV(device(), &memory_requirements_info, &memory_requirements);
+    return memory_requirements;
 }
 
 VkMemoryRequirements2 AccelerationStructureNV::BuildScratchMemoryRequirements() const {
@@ -1533,13 +1533,13 @@ VkMemoryRequirements2 AccelerationStructureNV::BuildScratchMemoryRequirements() 
                                                                                   "vkGetAccelerationStructureMemoryRequirementsNV");
     assert(vkGetAccelerationStructureMemoryRequirementsNV != nullptr);
 
-    VkAccelerationStructureMemoryRequirementsInfoNV memoryRequirementsInfo = vku::InitStructHelper();
-    memoryRequirementsInfo.type = VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_BUILD_SCRATCH_NV;
-    memoryRequirementsInfo.accelerationStructure = handle();
+    VkAccelerationStructureMemoryRequirementsInfoNV memory_requirements_info = vku::InitStructHelper();
+    memory_requirements_info.type = VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_BUILD_SCRATCH_NV;
+    memory_requirements_info.accelerationStructure = handle();
 
-    VkMemoryRequirements2 memoryRequirements = {};
-    vkGetAccelerationStructureMemoryRequirementsNV(device(), &memoryRequirementsInfo, &memoryRequirements);
-    return memoryRequirements;
+    VkMemoryRequirements2 memory_requirements = vku::InitStructHelper();
+    vkGetAccelerationStructureMemoryRequirementsNV(device(), &memory_requirements_info, &memory_requirements);
+    return memory_requirements;
 }
 
 void AccelerationStructureNV::init(const Device &dev, const VkAccelerationStructureCreateInfoNV &info, bool init_memory) {


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9322

Basically the Struct Alias broke down because 

- `vkGetPipelinePropertiesEXT` has a `VkPipelineInfoEXT` param
- `vkGetPipelineExecutablePropertiesKHR` has a `VkPipelineInfoKHR` param