### PR TITLE
tests: Cleanup syncval buffer copy test

### DIFF
--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -5735,3 +5735,19 @@ TEST_F(NegativeSyncVal, ExpandedMetaStage3) {
     m_errorMonitor->VerifyFound();
     m_command_buffer.End();
 }
+
+TEST_F(NegativeSyncVal, AmdBufferMarker) {
+    TEST_DESCRIPTION("Hazard with AMD buffer marker accesses");
+    AddRequiredExtensions(VK_AMD_BUFFER_MARKER_EXTENSION_NAME);
+    RETURN_IF_SKIP(InitSyncVal());
+
+    vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+    vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
+
+    m_command_buffer.Begin();
+    m_command_buffer.Copy(buffer_b, buffer_a);
+    m_errorMonitor->SetDesiredError("SYNC-HAZARD-WRITE-AFTER-WRITE");
+    vk::CmdWriteBufferMarkerAMD(m_command_buffer, VK_PIPELINE_STAGE_TRANSFER_BIT, buffer_a, 0, 1);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}


### PR DESCRIPTION
Split up big test into several parts.
Remove  CmdFillBuffer/CmdUpdateBuffer sections since we have separate tests for these functions.
