### PR TITLE
Fix message for VkDescriptorBufferInfo-range-00342

### DIFF
--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -1622,7 +1622,7 @@ bool CoreChecks::ValidateBufferUpdate(const VkDescriptorBufferInfo &buffer_info,
         }
         if (buffer_info.range > (buffer_state->create_info.size - buffer_info.offset)) {
             skip |= LogError("VUID-VkDescriptorBufferInfo-range-00342", buffer_info.buffer, buffer_info_loc.dot(Field::range),
-                             "(%" PRIu64 ") is larger than buffer size (%" PRIu64 ") + offset (%" PRIu64 ").", buffer_info.range,
+                             "(%" PRIu64 ") is larger than buffer size (%" PRIu64 ") - offset (%" PRIu64 ").", buffer_info.range,
                              buffer_state->create_info.size, buffer_info.offset);
         }
     }


### PR DESCRIPTION
Fixed the error message for VkDescriptorBufferInfo-range-00342.  Swapped the (incorrect) '+' for a '-'.

Relevant doc:
https://registry.khronos.org/vulkan/specs/latest/man/html/VkDescriptorBufferInfo.html#VUID-VkDescriptorBufferInfo-range-00342