### PR TITLE
layers: Full cleanup how we do vvl::RenderPass

### DIFF
--- a/layers/best_practices/best_practices_validation.h
+++ b/layers/best_practices/best_practices_validation.h
@@ -949,7 +949,8 @@ class BestPractices : public ValidationStateTracker {
 
     void RecordSetDepthTestState(bp_state::CommandBuffer& cb_state, VkCompareOp new_depth_compare_op, bool new_depth_test_enable);
 
-    void RecordCmdBeginRenderingCommon(bp_state::CommandBuffer& cb_state);
+    void RecordCmdBeginRenderingCommon(bp_state::CommandBuffer& cb_state, const VkRenderPassBeginInfo* pRenderPassBegin,
+                                       const VkRenderingInfo* pRenderingInfo);
     void RecordCmdEndRenderingCommon(bp_state::CommandBuffer& cb_state, const vvl::RenderPass& rp_state);
 
     void RecordBindZcullScope(bp_state::CommandBuffer& cb_state, VkImage depth_attachment,

--- a/layers/best_practices/bp_drawdispatch.cpp
+++ b/layers/best_practices/bp_drawdispatch.cpp
@@ -28,7 +28,7 @@ bool BestPractices::ValidateCmdDrawType(VkCommandBuffer cmd_buffer, const Locati
     bool skip = false;
     const auto cb_state = GetRead<bp_state::CommandBuffer>(cmd_buffer);
     if (const auto* pipe = cb_state->GetCurrentPipeline(VK_PIPELINE_BIND_POINT_GRAPHICS)) {
-        if (const auto rp_state = pipe->RenderPassState()) {
+        if (const auto rp_state = cb_state->active_render_pass.get()) {
             for (uint32_t i = 0; i < rp_state->create_info.subpassCount; ++i) {
                 const auto& subpass = rp_state->create_info.pSubpasses[i];
                 const auto* ds_state = pipe->DepthStencilState();

--- a/layers/core_checks/cc_device.cpp
+++ b/layers/core_checks/cc_device.cpp
@@ -152,10 +152,9 @@ bool CoreChecks::ValidateDeviceMaskToCommandBuffer(const vvl::CommandBuffer &cb_
 bool CoreChecks::ValidateDeviceMaskToRenderPass(const vvl::CommandBuffer &cb_state, uint32_t deviceMask, const Location loc,
                                                 const char *vuid) const {
     bool skip = false;
-    if ((deviceMask & cb_state.active_render_pass_device_mask) != deviceMask) {
-        skip |=
-            LogError(vuid, cb_state.Handle(), loc, "(0x%" PRIx32 ") is not a subset of %s device mask (0x%" PRIx32 ").", deviceMask,
-                     FormatHandle(cb_state.activeRenderPass->Handle()).c_str(), cb_state.active_render_pass_device_mask);
+    if (cb_state.active_render_pass && ((deviceMask & cb_state.render_pass_device_mask) != deviceMask)) {
+        skip |= LogError(vuid, cb_state.Handle(), loc, "(0x%" PRIx32 ") is not a subset of %s device mask (0x%" PRIx32 ").",
+                         deviceMask, FormatHandle(cb_state.active_render_pass->Handle()).c_str(), cb_state.render_pass_device_mask);
     }
     return skip;
 }
@@ -606,9 +605,7 @@ bool CoreChecks::PreCallValidateCmdSetDeviceMask(VkCommandBuffer commandBuffer, 
     skip |= ValidateDeviceMaskToPhysicalDeviceCount(deviceMask, objlist, loc, "VUID-vkCmdSetDeviceMask-deviceMask-00108");
     skip |= ValidateDeviceMaskToZero(deviceMask, objlist, loc, "VUID-vkCmdSetDeviceMask-deviceMask-00109");
     skip |= ValidateDeviceMaskToCommandBuffer(cb_state, deviceMask, objlist, loc, "VUID-vkCmdSetDeviceMask-deviceMask-00110");
-    if (cb_state.activeRenderPass) {
-        skip |= ValidateDeviceMaskToRenderPass(cb_state, deviceMask, loc, "VUID-vkCmdSetDeviceMask-deviceMask-00111");
-    }
+    skip |= ValidateDeviceMaskToRenderPass(cb_state, deviceMask, loc, "VUID-vkCmdSetDeviceMask-deviceMask-00111");
     return skip;
 }
 

--- a/layers/core_checks/cc_device_generated_commands.cpp
+++ b/layers/core_checks/cc_device_generated_commands.cpp
@@ -578,12 +578,12 @@ bool CoreChecks::PreCallValidateCmdExecuteGeneratedCommandsEXT(VkCommandBuffer c
             "was created with VK_INDIRECT_COMMANDS_LAYOUT_USAGE_EXPLICIT_PREPROCESS_BIT_EXT but isPreprocessed is VK_FALSE.");
     }
 
-    if (cb_state.activeRenderPass) {
+    if (const vvl::RenderPass* rp_state = cb_state.active_render_pass.get()) {
         uint32_t view_mask = 0;
-        if (cb_state.activeRenderPass->UsesDynamicRendering()) {
-            view_mask = cb_state.activeRenderPass->dynamic_rendering_begin_rendering_info.viewMask;
+        if (rp_state->UsesDynamicRendering()) {
+            view_mask = rp_state->dynamic_rendering_begin_rendering_info.viewMask;
         } else {
-            const auto* render_pass_info = cb_state.activeRenderPass->create_info.ptr();
+            const auto* render_pass_info = rp_state->create_info.ptr();
             const auto subpass_desc = render_pass_info->pSubpasses[cb_state.GetActiveSubpass()];
             view_mask = subpass_desc.viewMask;
         }

--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -46,11 +46,11 @@ bool CoreChecks::ValidateCmdDrawInstance(const vvl::CommandBuffer &cb_state, uin
     const auto *pipeline_state = cb_state.GetCurrentPipeline(VK_PIPELINE_BIND_POINT_GRAPHICS);
 
     // Verify maxMultiviewInstanceIndex
-    if (cb_state.activeRenderPass && cb_state.activeRenderPass->has_multiview_enabled &&
+    if (cb_state.active_render_pass && cb_state.active_render_pass->has_multiview_enabled &&
         ((static_cast<uint64_t>(instanceCount) + static_cast<uint64_t>(firstInstance)) >
          static_cast<uint64_t>(phys_dev_props_core11.maxMultiviewInstanceIndex))) {
         LogObjectList objlist = cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS);
-        objlist.add(cb_state.activeRenderPass->Handle());
+        objlist.add(cb_state.active_render_pass->Handle());
         skip |= LogError(vuid.max_multiview_instance_index_02688, objlist, loc,
                          "renderpass instance has multiview enabled, and maxMultiviewInstanceIndex: %" PRIu32
                          ", but instanceCount: %" PRIu32 " and firstInstance: %" PRIu32 ".",

--- a/layers/core_checks/cc_image_layout.cpp
+++ b/layers/core_checks/cc_image_layout.cpp
@@ -143,7 +143,7 @@ bool CoreChecks::VerifyImageLayout(const vvl::CommandBuffer &cb_state, const vvl
 }
 
 void CoreChecks::TransitionFinalSubpassLayouts(vvl::CommandBuffer &cb_state) {
-    auto render_pass_state = cb_state.activeRenderPass.get();
+    auto render_pass_state = cb_state.active_render_pass.get();
     auto framebuffer_state = cb_state.activeFramebuffer.get();
     if (!render_pass_state || !framebuffer_state) {
         return;

--- a/layers/core_checks/cc_shader_object.cpp
+++ b/layers/core_checks/cc_shader_object.cpp
@@ -619,10 +619,10 @@ bool CoreChecks::ValidateDrawShaderObject(const LastBound& last_bound_state, con
     bool skip = false;
     const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
 
-    if (cb_state.activeRenderPass && !cb_state.activeRenderPass->UsesDynamicRendering()) {
+    if (cb_state.active_render_pass && !cb_state.active_render_pass->UsesDynamicRendering()) {
         skip |= LogError(vuid.render_pass_began_08876, cb_state.Handle(), vuid.loc(),
                          "Shader objects must be used with dynamic rendering, but VkRenderPass %s is active.",
-                         FormatHandle(cb_state.activeRenderPass->Handle()).c_str());
+                         FormatHandle(cb_state.active_render_pass->Handle()).c_str());
     }
 
     skip |= ValidateDrawShaderObjectLinking(last_bound_state, vuid);

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -649,7 +649,7 @@ class CoreChecks : public ValidationStateTracker {
                                            QFOTransferCBScoreboards<QFOImageTransferBarrier>* qfo_image_scoreboards,
                                            QFOTransferCBScoreboards<QFOBufferTransferBarrier>* qfo_buffer_scoreboards) const;
     bool ValidateDrawPipelineRenderpass(const LastBound& last_bound_state, const vvl::Pipeline& pipeline,
-                                        const vvl::DrawDispatchVuid& vuid) const;
+                                        const vvl::RenderPass& rp_state, const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateDrawPipelineDynamicRenderpass(const LastBound& last_bound_state, const vvl::Pipeline& pipeline,
                                                const VkRenderingInfo& rendering_info, const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateDrawPipelineDynamicRenderpassSampleCount(const LastBound& last_bound_state, const vvl::Pipeline& pipeline,
@@ -1630,6 +1630,8 @@ class CoreChecks : public ValidationStateTracker {
     bool PreCallValidateEndCommandBuffer(VkCommandBuffer commandBuffer, const ErrorObject& error_obj) const override;
     bool PreCallValidateResetCommandBuffer(VkCommandBuffer commandBuffer, VkCommandBufferResetFlags flags,
                                            const ErrorObject& error_obj) const override;
+    bool ValidateCmdBindPipelineRenderPassMultisample(const vvl::CommandBuffer& cb_state, const vvl::Pipeline& pipeline_state,
+                                                      const vvl::RenderPass& rp_state, const Location& loc) const;
     bool PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint, VkPipeline pipeline,
                                         const ErrorObject& error_obj) const override;
     bool PreCallValidateCreateShadersEXT(VkDevice device, uint32_t createInfoCount, const VkShaderCreateInfoEXT* pCreateInfos,

--- a/layers/gpuav/core/gpuav_record.cpp
+++ b/layers/gpuav/core/gpuav_record.cpp
@@ -231,7 +231,8 @@ void Validator::PostCallRecordCmdEndRenderingKHR(VkCommandBuffer commandBuffer, 
 }
 
 void Validator::RecordCmdNextSubpassLayouts(vvl::CommandBuffer &cb_state, VkSubpassContents contents) {
-    TransitionSubpassLayouts(cb_state, *cb_state.activeRenderPass, cb_state.GetActiveSubpass());
+    ASSERT_AND_RETURN(cb_state.active_render_pass);
+    TransitionSubpassLayouts(cb_state, *cb_state.active_render_pass, cb_state.GetActiveSubpass());
 }
 
 void Validator::PostCallRecordCmdNextSubpass(VkCommandBuffer commandBuffer, VkSubpassContents contents,

--- a/layers/gpuav/descriptor_validation/gpuav_image_layout.cpp
+++ b/layers/gpuav/descriptor_validation/gpuav_image_layout.cpp
@@ -307,7 +307,7 @@ void TransitionBeginRenderPassLayouts(vvl::CommandBuffer &cb_state, const vvl::R
 }
 
 void TransitionFinalSubpassLayouts(vvl::CommandBuffer &cb_state) {
-    auto render_pass_state = cb_state.activeRenderPass.get();
+    auto render_pass_state = cb_state.active_render_pass.get();
     auto framebuffer_state = cb_state.activeFramebuffer.get();
     if (!render_pass_state || !framebuffer_state) {
         return;

--- a/layers/gpuav/validation_cmd/gpuav_validation_cmd_common.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_validation_cmd_common.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2018-2024 The Khronos Group Inc.
- * Copyright (c) 2018-2024 Valve Corporation
- * Copyright (c) 2018-2024 LunarG, Inc.
+/* Copyright (c) 2018-2025 The Khronos Group Inc.
+ * Copyright (c) 2018-2025 Valve Corporation
+ * Copyright (c) 2018-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,9 +80,10 @@ void RestorablePipelineState::Create(CommandBuffer &cb_state, VkPipelineBindPoin
         push_descriptor_set_writes_ = last_bound.push_descriptor_set->GetWrites();
     }
 
-    // Do not handle cb_state.activeRenderPass->use_dynamic_rendering_inherited for now
-    if (bind_point == VK_PIPELINE_BIND_POINT_GRAPHICS && cb_state.activeRenderPass->use_dynamic_rendering) {
-        rendering_info_ = &cb_state.activeRenderPass->dynamic_rendering_begin_rendering_info;
+    // Do not handle cb_state.active_render_pass->use_dynamic_rendering_inherited for now
+    if (bind_point == VK_PIPELINE_BIND_POINT_GRAPHICS && cb_state.active_render_pass &&
+        cb_state.active_render_pass->use_dynamic_rendering) {
+        rendering_info_ = &cb_state.active_render_pass->dynamic_rendering_begin_rendering_info;
         DispatchCmdEndRendering(cb_state.VkHandle());
 
         VkRenderingInfo rendering_info = vku::InitStructHelper();

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (C) 2015-2024 Google Inc.
+/* Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (C) 2015-2025 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -417,21 +417,31 @@ class CommandBuffer : public RefcountedStateObject {
     // Track if any dynamic state is set that is static in the currently bound pipeline
     bool dirtyStaticState;
 
+    // Device Mask at start of command buffer
     uint32_t initial_device_mask;
+    // Device mask from vkCmdBeginRenderPass/vkCmdBeginRendering
+    uint32_t render_pass_device_mask;
 
-    // The RenderPass created from vkCmdBeginRenderPass or vkCmdBeginRendering
-    std::shared_ptr<vvl::RenderPass> activeRenderPass;
+    // This is null if we are outside a renderPass/rendering
+    //
+    // There are 4 ways we populate this pointer
+    // 1. vkCmdBeginRenderPass this becomes a reference to the state created a vkCreateRenderPass time.
+    // 2. VkCommandBufferInheritanceInfo same as (1) but for secondary command buffers.
+    // 3. vkCmdBeginRendering we create the state object and store it here.
+    // 4. VkCommandBufferInheritanceRenderingInfo same as (3) but for secondary command buffers.
+    std::shared_ptr<vvl::RenderPass> active_render_pass;
+
     // Used for both type of renderPass
     AttachmentSource attachment_source;
     // There is no concept of "attachment index" with dynamic rendering, we use this for both dynamic/non-dynamic rendering though.
     // The attachments are packed the following: | color | color resolve | depth | depth resolve | stencil | stencil resolve |
     std::vector<AttachmentInfo> active_attachments;
     vvl::unordered_set<uint32_t> active_color_attachments_index;
-    uint32_t active_render_pass_device_mask;
     bool has_render_pass_striped;
     uint32_t striped_count;
+    VkRect2D render_area;
     // only when not using dynamic rendering
-    vku::safe_VkRenderPassBeginInfo active_render_pass_begin_info;
+    const VkRenderPassSampleLocationsBeginInfoEXT *sample_locations_begin_info;
     std::vector<SubpassInfo> active_subpasses;
 
     VkSubpassContents activeSubpassContents;

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -2548,7 +2548,7 @@ void ValidationStateTracker::PostCallRecordCmdBindPipeline(VkCommandBuffer comma
 
     if (enabled_features.variableMultisampleRate == VK_FALSE) {
         if (const auto *multisample_state = pipe_state->MultisampleState(); multisample_state) {
-            if (const auto &render_pass = cb_state->activeRenderPass; render_pass) {
+            if (const auto &render_pass = cb_state->active_render_pass) {
                 const uint32_t subpass = cb_state->GetActiveSubpass();
                 // if render pass uses no attachment, all bound pipelines in the same subpass must have the same
                 // pMultisampleState->rasterizationSamples. To check that, record pMultisampleState->rasterizationSamples of the
@@ -3327,11 +3327,11 @@ void ValidationStateTracker::PostCallRecordCmdBeginQuery(VkCommandBuffer command
 
     uint32_t num_queries = 1;
     uint32_t subpass = 0;
-    const bool inside_render_pass = cb_state->activeRenderPass != 0;
+    const bool inside_render_pass = cb_state->active_render_pass != nullptr;
     // If render pass instance has multiview enabled, query uses N consecutive query indices
     if (inside_render_pass) {
         subpass = cb_state->GetActiveSubpass();
-        uint32_t bits = cb_state->activeRenderPass->GetViewMaskBits(subpass);
+        uint32_t bits = cb_state->active_render_pass->GetViewMaskBits(subpass);
         num_queries = std::max(num_queries, bits);
     }
     for (uint32_t i = 0; i < num_queries; ++i) {
@@ -3355,11 +3355,11 @@ void ValidationStateTracker::PostCallRecordCmdEndQuery(VkCommandBuffer commandBu
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     uint32_t num_queries = 1;
     uint32_t subpass = 0;
-    const bool inside_render_pass = cb_state->activeRenderPass != 0;
+    const bool inside_render_pass = cb_state->active_render_pass != nullptr;
     // If render pass instance has multiview enabled, query uses N consecutive query indices
     if (inside_render_pass) {
         subpass = cb_state->GetActiveSubpass();
-        uint32_t bits = cb_state->activeRenderPass->GetViewMaskBits(subpass);
+        uint32_t bits = cb_state->active_render_pass->GetViewMaskBits(subpass);
         num_queries = std::max(num_queries, bits);
     }
 
@@ -3601,7 +3601,7 @@ void ValidationStateTracker::PostCallRecordCmdBeginConditionalRenderingEXT(
 
     cb_state->RecordCmd(record_obj.location.function);
     cb_state->conditional_rendering_active = true;
-    cb_state->conditional_rendering_inside_render_pass = cb_state->activeRenderPass != nullptr;
+    cb_state->conditional_rendering_inside_render_pass = cb_state->active_render_pass != nullptr;
     cb_state->conditional_rendering_subpass = cb_state->GetActiveSubpass();
 }
 
@@ -4706,11 +4706,11 @@ void ValidationStateTracker::PostCallRecordCmdBeginQueryIndexedEXT(VkCommandBuff
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     uint32_t num_queries = 1;
     uint32_t subpass = 0;
-    const bool inside_render_pass = cb_state->activeRenderPass != 0;
+    const bool inside_render_pass = cb_state->active_render_pass != nullptr;
     // If render pass instance has multiview enabled, query uses N consecutive query indices
     if (inside_render_pass) {
         subpass = cb_state->GetActiveSubpass();
-        uint32_t bits = cb_state->activeRenderPass->GetViewMaskBits(subpass);
+        uint32_t bits = cb_state->active_render_pass->GetViewMaskBits(subpass);
         num_queries = std::max(num_queries, bits);
     }
 
@@ -4734,11 +4734,11 @@ void ValidationStateTracker::PostCallRecordCmdEndQueryIndexedEXT(VkCommandBuffer
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     uint32_t num_queries = 1;
     uint32_t subpass = 0;
-    const bool inside_render_pass = cb_state->activeRenderPass != 0;
+    const bool inside_render_pass = cb_state->active_render_pass != nullptr;
     // If render pass instance has multiview enabled, query uses N consecutive query indices
     if (inside_render_pass) {
         subpass = cb_state->GetActiveSubpass();
-        uint32_t bits = cb_state->activeRenderPass->GetViewMaskBits(subpass);
+        uint32_t bits = cb_state->active_render_pass->GetViewMaskBits(subpass);
         num_queries = std::max(num_queries, bits);
     }
 

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2019-2024 Valve Corporation
- * Copyright (c) 2019-2024 LunarG, Inc.
+ * Copyright (c) 2019-2025 Valve Corporation
+ * Copyright (c) 2019-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -356,8 +356,8 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
                         HazardResult hazard;
 
                         if (sync_index == SYNC_FRAGMENT_SHADER_INPUT_ATTACHMENT_READ) {
-                            const VkExtent3D extent = CastTo3D(cb_state_->active_render_pass_begin_info.renderArea.extent);
-                            const VkOffset3D offset = CastTo3D(cb_state_->active_render_pass_begin_info.renderArea.offset);
+                            const VkExtent3D extent = CastTo3D(cb_state_->render_area.extent);
+                            const VkOffset3D offset = CastTo3D(cb_state_->render_area.offset);
                             // Input attachments are subject to raster ordering rules
                             hazard =
                                 current_context_->DetectHazard(*img_view_state, offset, extent, sync_index, SyncOrdering::kRaster);
@@ -486,8 +486,8 @@ void CommandBufferAccessContext::RecordDispatchDrawDescriptorSet(VkPipelineBindP
                         }
                         const ResourceUsageTagEx tag_ex = AddCommandHandle(tag, img_view_state->GetImageState()->Handle());
                         if (sync_index == SYNC_FRAGMENT_SHADER_INPUT_ATTACHMENT_READ) {
-                            const VkExtent3D extent = CastTo3D(cb_state_->active_render_pass_begin_info.renderArea.extent);
-                            const VkOffset3D offset = CastTo3D(cb_state_->active_render_pass_begin_info.renderArea.offset);
+                            const VkExtent3D extent = CastTo3D(cb_state_->render_area.extent);
+                            const VkOffset3D offset = CastTo3D(cb_state_->render_area.offset);
                             current_context_->UpdateAccessState(*img_view_state, sync_index, SyncOrdering::kRaster, offset, extent,
                                                                 tag_ex);
                         } else {


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9334

so `vvl::RenderPass`

- For normal vulkan1.0 we create this at `vkCreateRenderPass` time
- For Dynamic Rendering, we create the object on the spot
- There are 2 places that consume render passes (command buffer and pipeline)
    - Both need to either consume a `VkRenderPass` handle or create a `vvl::RenderPass` on the spot
- The command buffer state had some issue tracking what is a
    - RenderPass state value (something you would find in  vkCreateRenderPass)
    - RenderPass begin value (something at vkCmdBeginRenderPass/vkCmdBeginRendering)
- I try to pass around references/null check things early like we do for the other "normal" state objects