### PR TITLE
gpuav: Add fix to allow instrumeting linked functions

### DIFF
--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
@@ -27,6 +27,7 @@
 #include "chassis/chassis_modification_state.h"
 #include "gpuav/shaders/gpuav_error_codes.h"
 #include "utils/vk_layer_utils.h"
+#include "utils/shader_utils.h"
 #include "sync/sync_utils.h"
 #include "state_tracker/pipeline_state.h"
 #include "error_message/spirv_logging.h"
@@ -47,7 +48,6 @@
 #include "gpuav/spirv/vertex_attribute_fetch_oob.h"
 
 #include <cassert>
-#include <fstream>
 #include <string>
 
 namespace gpuav {
@@ -1153,9 +1153,7 @@ bool GpuShaderInstrumentor::InstrumentShader(const vvl::span<const uint32_t> &in
 
     if (gpuav_settings.debug_dump_instrumented_shaders) {
         std::string file_name = "dump_" + std::to_string(unique_shader_id) + "_before.spv";
-        std::ofstream debug_file(file_name, std::ios::out | std::ios::binary);
-        debug_file.write(reinterpret_cast<const char *>(input_spirv.data()),
-                         static_cast<std::streamsize>(input_spirv.size() * sizeof(uint32_t)));
+        DumpSpirvToFile(file_name, reinterpret_cast<const char *>(input_spirv.data()), input_spirv.size() * sizeof(uint32_t));
     }
 
     spirv::Settings module_settings{};
@@ -1233,9 +1231,8 @@ bool GpuShaderInstrumentor::InstrumentShader(const vvl::span<const uint32_t> &in
 
     if (gpuav_settings.debug_dump_instrumented_shaders) {
         std::string file_name = "dump_" + std::to_string(unique_shader_id) + "_after.spv";
-        std::ofstream debug_file(file_name, std::ios::out | std::ios::binary);
-        debug_file.write(reinterpret_cast<char *>(out_instrumented_spirv.data()),
-                         static_cast<std::streamsize>(out_instrumented_spirv.size() * sizeof(uint32_t)));
+        DumpSpirvToFile(file_name, reinterpret_cast<const char *>(out_instrumented_spirv.data()),
+                        out_instrumented_spirv.size() * sizeof(uint32_t));
     }
 
     spv_target_env target_env = PickSpirvEnv(api_version, IsExtEnabled(extensions.vk_khr_spirv_1_4));

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
@@ -1215,7 +1215,7 @@ bool GpuShaderInstrumentor::InstrumentShader(const vvl::span<const uint32_t> &in
     // 2. We might want to debug the above passes and want to inject our own debug printf calls
     if (gpuav_settings.debug_printf_enabled) {
         // binding slot allows debug printf to be slotted in the same set as GPU-AV if needed
-        spirv::DebugPrintfPass pass(module, glsl::kBindingInstDebugPrintf);
+        spirv::DebugPrintfPass pass(module, intenral_only_debug_printf_, glsl::kBindingInstDebugPrintf);
         modified |= pass.Run();
     }
 

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.h
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.h
@@ -228,6 +228,8 @@ class GpuShaderInstrumentor : public vvl::Device {
     vvl::concurrent_unordered_map<uint32_t, InstrumentedShader> instrumented_shaders_map_;
     std::vector<VkDescriptorSetLayoutBinding> instrumentation_bindings_;
 
+    std::vector<spirv::InternalOnlyDebugPrintf> intenral_only_debug_printf_;
+
   private:
     void Cleanup();
     // These are objects used to inject our descriptor set into the command buffer

--- a/layers/gpuav/spirv/debug_printf_pass.cpp
+++ b/layers/gpuav/spirv/debug_printf_pass.cpp
@@ -486,6 +486,17 @@ bool DebugPrintfPass::Instrument() {
                 if (!Validate(*(function.get()))) continue;  // if not valid, don't attempt to instrument it
                 instrumentations_count_++;
 
+                // Save the OpString here so we can use it later
+                if (function->instrumentation_added_) {
+                    for (const auto& debug_inst : module_.debug_source_) {
+                        const uint32_t string_id = (*inst_it)->Word(5);
+                        if (debug_inst->Opcode() == spv::OpString && debug_inst->ResultId() == string_id) {
+                            intenral_only_debug_printf_.emplace_back(
+                                InternalOnlyDebugPrintf{module_.shader_id_, string_id, debug_inst->GetAsString(2)});
+                        }
+                    }
+                }
+
                 CreateFunctionCall(block_it, &inst_it);
 
                 // remove the OpExtInst incase they don't support VK_KHR_non_semantic_info

--- a/layers/gpuav/spirv/debug_printf_pass.h
+++ b/layers/gpuav/spirv/debug_printf_pass.h
@@ -16,6 +16,7 @@
 
 #include <stdint.h>
 #include "pass.h"
+#include "interface.h"
 
 namespace gpuav {
 namespace spirv {
@@ -25,7 +26,8 @@ struct Type;
 // Create a pass to instrument NonSemantic.DebugPrintf (GL_EXT_debug_printf) instructions
 class DebugPrintfPass : public Pass {
   public:
-    DebugPrintfPass(Module& module, uint32_t binding_slot = 0) : Pass(module), binding_slot_(binding_slot) {}
+    DebugPrintfPass(Module& module, std::vector<InternalOnlyDebugPrintf>& debug_printf, uint32_t binding_slot = 0)
+        : Pass(module), intenral_only_debug_printf_(debug_printf), binding_slot_(binding_slot) {}
     const char* Name() const final { return "DebugPrintfPass"; }
 
     bool Instrument() final;
@@ -41,6 +43,9 @@ class DebugPrintfPass : public Pass {
     void Reset() final;
 
     bool Validate(const Function& current_function);
+
+    // for debugging instrumented shaders
+    std::vector<InternalOnlyDebugPrintf>& intenral_only_debug_printf_;
 
     const uint32_t binding_slot_;
     uint32_t ext_import_id_ = 0;

--- a/layers/gpuav/spirv/descriptor_class_general_buffer_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_class_general_buffer_pass.cpp
@@ -175,6 +175,7 @@ void DescriptorClassGeneralBufferPass::PrintDebugInfo() const {
 bool DescriptorClassGeneralBufferPass::Instrument() {
     // Can safely loop function list as there is no injecting of new Functions until linking time
     for (const auto& function : module_.functions_) {
+        if (function->instrumentation_added_) continue;
         for (auto block_it = function->blocks_.begin(); block_it != function->blocks_.end(); ++block_it) {
             if ((*block_it)->loop_header_) {
                 continue;  // Currently can't properly handle injecting CFG logic into a loop header block

--- a/layers/gpuav/spirv/descriptor_class_texel_buffer_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_class_texel_buffer_pass.cpp
@@ -182,6 +182,7 @@ void DescriptorClassTexelBufferPass::PrintDebugInfo() const {
 bool DescriptorClassTexelBufferPass::Instrument() {
     // Can safely loop function list as there is no injecting of new Functions until linking time
     for (const auto& function : module_.functions_) {
+        if (function->instrumentation_added_) continue;
         for (auto block_it = function->blocks_.begin(); block_it != function->blocks_.end(); ++block_it) {
             if ((*block_it)->loop_header_) {
                 continue;  // Currently can't properly handle injecting CFG logic into a loop header block

--- a/layers/gpuav/spirv/function_basic_block.cpp
+++ b/layers/gpuav/spirv/function_basic_block.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2024 LunarG, Inc.
+/* Copyright (c) 2024-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,7 +104,7 @@ void BasicBlock::CreateInstruction(spv::Op opcode, const std::vector<uint32_t>& 
     }
 }
 
-Function::Function(Module& module, std::unique_ptr<Instruction> function_inst) : module_(module) {
+Function::Function(Module& module, std::unique_ptr<Instruction> function_inst) : module_(module), instrumentation_added_(false) {
     // Used when loading initial SPIR-V
     pre_block_inst_.emplace_back(std::move(function_inst));  // OpFunction
 }

--- a/layers/gpuav/spirv/function_basic_block.h
+++ b/layers/gpuav/spirv/function_basic_block.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2024 LunarG, Inc.
+/* Copyright (c) 2024-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,8 +64,10 @@ using BasicBlockList = std::vector<std::unique_ptr<BasicBlock>>;
 using BasicBlockIt = BasicBlockList::iterator;
 
 struct Function {
+    // Used to add functions building up SPIR-V the first time
     Function(Module& module, std::unique_ptr<Instruction> function_inst);
-    Function(Module& module) : module_(module) {}
+    // Used to link in new functions
+    Function(Module& module) : module_(module), instrumentation_added_(true) {}
 
     void ToBinary(std::vector<uint32_t>& out);
 
@@ -101,6 +103,9 @@ struct Function {
     uint32_t stage_info_y_id_ = 0;
     uint32_t stage_info_z_id_ = 0;
     uint32_t stage_info_w_id_ = 0;
+
+    // The main usage of this is for things like DebugPrintf that might want to actually run over previously instrumented functions
+    const bool instrumentation_added_;
 };
 
 using FunctionList = std::vector<std::unique_ptr<Function>>;

--- a/layers/gpuav/spirv/inject_conditional_function_pass.cpp
+++ b/layers/gpuav/spirv/inject_conditional_function_pass.cpp
@@ -117,6 +117,7 @@ BasicBlockIt InjectConditionalFunctionPass::InjectFunction(Function* function, B
 bool InjectConditionalFunctionPass::Instrument() {
     // Can safely loop function list as there is no injecting of new Functions until linking time
     for (const auto& function : module_.functions_) {
+        if (function->instrumentation_added_) continue;
         for (auto block_it = function->blocks_.begin(); block_it != function->blocks_.end(); ++block_it) {
             if ((*block_it)->loop_header_) {
                 continue;  // Currently can't properly handle injecting CFG logic into a loop header block

--- a/layers/gpuav/spirv/inject_function_pass.cpp
+++ b/layers/gpuav/spirv/inject_function_pass.cpp
@@ -24,6 +24,7 @@ InjectFunctionPass::InjectFunctionPass(Module& module) : Pass(module) { module.u
 bool InjectFunctionPass::Instrument() {
     // Can safely loop function list as there is no injecting of new Functions until linking time
     for (const auto& function : module_.functions_) {
+        if (function->instrumentation_added_) continue;
         for (auto block_it = function->blocks_.begin(); block_it != function->blocks_.end(); ++block_it) {
             if ((*block_it)->loop_header_) {
                 continue;  // Currently can't properly handle injecting CFG logic into a loop header block

--- a/layers/gpuav/spirv/interface.h
+++ b/layers/gpuav/spirv/interface.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2024 LunarG, Inc.
+/* Copyright (c) 2024-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 
 #pragma once
 #include <stdint.h>
+#include <string>
 
 // The goal is to keep instrumentation a standalone executable for testing, but it will need runtime information interfaced with it.
 // We declare all types that either the running instance of GPU-AV or the standalone executable testing will need.
@@ -44,6 +45,15 @@ namespace spirv {
 struct BindingLayout {
     uint32_t start;
     uint32_t count;
+};
+
+// When running the DebugPrintf pass, if we detect an instrumented shader has a printf call (for debugging) we can hold them until
+// we need them after GPU execution. (Note, this is needed because we don't store the instrumented SPIR-V and have no way to get the
+// OpString back afterwards)
+struct InternalOnlyDebugPrintf {
+    uint32_t unique_shader_id;
+    uint32_t op_string_id;
+    std::string op_string_text;
 };
 
 }  // namespace spirv

--- a/layers/gpuav/spirv/post_process_descriptor_indexing.cpp
+++ b/layers/gpuav/spirv/post_process_descriptor_indexing.cpp
@@ -173,6 +173,7 @@ void PostProcessDescriptorIndexingPass::Reset() {
 
 bool PostProcessDescriptorIndexingPass::Instrument() {
     for (const auto& function : module_.functions_) {
+        if (function->instrumentation_added_) continue;
         for (auto block_it = function->blocks_.begin(); block_it != function->blocks_.end(); ++block_it) {
             auto& block_instructions = (*block_it)->instructions_;
             for (auto inst_it = block_instructions.begin(); inst_it != block_instructions.end(); ++inst_it) {

--- a/layers/gpuav/spirv/post_process_descriptor_indexing_pass.cpp
+++ b/layers/gpuav/spirv/post_process_descriptor_indexing_pass.cpp
@@ -173,6 +173,7 @@ void PostProcessDescriptorIndexingPass::Reset() {
 
 bool PostProcessDescriptorIndexingPass::Instrument() {
     for (const auto& function : module_.functions_) {
+        if (function->instrumentation_added_) continue;
         for (auto block_it = function->blocks_.begin(); block_it != function->blocks_.end(); ++block_it) {
             auto& block_instructions = (*block_it)->instructions_;
             for (auto inst_it = block_instructions.begin(); inst_it != block_instructions.end(); ++inst_it) {

--- a/layers/gpuav/spirv/vertex_attribute_fetch_oob.cpp
+++ b/layers/gpuav/spirv/vertex_attribute_fetch_oob.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2018-2024 The Khronos Group Inc.
- * Copyright (c) 2018-2024 Valve Corporation
- * Copyright (c) 2018-2024 LunarG, Inc.
+/* Copyright (c) 2025 The Khronos Group Inc.
+ * Copyright (c) 2025 Valve Corporation
+ * Copyright (c) 2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,7 @@ bool VertexAttributeFetchOob::Instrument() {
 
         const uint32_t vertex_shader_entry_point_id = entry_point_inst->Word(2);
         for (const auto& function : module_.functions_) {
+            if (function->instrumentation_added_) continue;
             const uint32_t function_id = function->GetDef().Word(2);
             if (vertex_shader_entry_point_id != function_id) continue;
 

--- a/layers/utils/shader_utils.cpp
+++ b/layers/utils/shader_utils.cpp
@@ -26,6 +26,8 @@
 
 #include "generated/spirv_tools_commit_id.h"
 
+#include <fstream>
+
 void ValidationCache::GetUUID(uint8_t *uuid) {
     const char *sha1_str = SPIRV_TOOLS_COMMIT_ID;
     // Convert sha1_str from a hex string to binary. We only need VK_UUID_SIZE bytes of
@@ -182,4 +184,10 @@ void AdjustValidatorOptions(const DeviceExtensions &device_extensions, const Dev
     if (out_hash) {
         *out_hash = hash_util::ShaderHash(&settings, sizeof(Settings));
     }
+}
+
+// This is used to help dump SPIR-V while debugging intermediate phases of any altercations to the SPIR-V
+void DumpSpirvToFile(std::string file_name, const char *spirv_data, size_t spirv_size) {
+    std::ofstream debug_file(file_name, std::ios::out | std::ios::binary);
+    debug_file.write(spirv_data, spirv_size);
 }

--- a/layers/utils/shader_utils.h
+++ b/layers/utils/shader_utils.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (C) 2015-2023 Google Inc.
+/* Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (C) 2015-2025 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -115,3 +115,4 @@ spv_target_env PickSpirvEnv(const APIVersion &api_version, bool spirv_1_4);
 void AdjustValidatorOptions(const DeviceExtensions &device_extensions, const DeviceFeatures &enabled_features,
                             spvtools::ValidatorOptions &out_options, uint32_t *out_hash);
 
+void DumpSpirvToFile(std::string file_name, const char *spirv_data, size_t spirv_size);


### PR DESCRIPTION
Currently for linked in functions we just cheated and put everything in `pre_block_inst_`

This creates a proper `BasicBlock` to store the linked function instructions. This will allow being able to run the DebugPrintf on instrumented code