### PR TITLE
sync: Add example of new style of syncval reporting

### DIFF
--- a/layers/sync/sync_error_messages.h
+++ b/layers/sync/sync_error_messages.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2024 The Khronos Group Inc.
- * Copyright (c) 2024 Valve Corporation
- * Copyright (c) 2024 LunarG, Inc.
+/* Copyright (c) 2025 The Khronos Group Inc.
+ * Copyright (c) 2025 Valve Corporation
+ * Copyright (c) 2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ class ErrorMessages {
                             const CommandBufferAccessContext& cb_context) const;
 
     std::string BufferRegionError(const HazardResult& hazard, VkBuffer buffer, bool is_src_buffer, uint32_t region_index,
-                                  const CommandBufferAccessContext& cb_context) const;
+                                  const CommandBufferAccessContext& cb_context, const vvl::Func command) const;
 
     std::string ImageRegionError(const HazardResult& hazard, VkImage image, bool is_src_image, uint32_t region_index,
                                  const CommandBufferAccessContext& cb_context) const;

--- a/layers/sync/sync_reporting.h
+++ b/layers/sync/sync_reporting.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2024 The Khronos Group Inc.
- * Copyright (c) 2024 Valve Corporation
- * Copyright (c) 2024 LunarG, Inc.
+/* Copyright (c) 2025 The Khronos Group Inc.
+ * Copyright (c) 2025 Valve Corporation
+ * Copyright (c) 2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,19 @@
 
 #pragma once
 
-#include "sync/sync_commandbuffer.h"
+#include "generated/error_location_helper.h"
+#include "generated/sync_validation_types.h"
+
+namespace vvl {
+class CommandBuffer;
+class StateObject;
+class Image;
+class Queue;
+}
+class DebugReport;
+class SyncValidator;
+struct DeviceFeatures;
+struct DeviceExtensions;
 
 struct SyncNodeFormatter {
     const DebugReport *debug_report;
@@ -43,6 +55,18 @@ struct ReportKeyValues {
 
     std::string GetExtraPropertiesSection(bool pretty_print) const;
 };
+
+struct ReportUsageInfo {
+    vvl::Func command = vvl::Func::Empty;
+};
+
+std::vector<std::pair<VkPipelineStageFlags2, VkAccessFlags2>> ConvertSyncAccessesToCompactVkForm(
+    const SyncAccessFlags &sync_accesses, VkQueueFlags allowed_queue_flags, const DeviceFeatures &features,
+    const DeviceExtensions &device_extensions);
+
+std::string FormatSyncAccesses(const SyncAccessFlags &sync_accesses, VkQueueFlags allowed_queue_flags,
+                               const DeviceFeatures &features, const DeviceExtensions &device_extensions,
+                               bool format_as_extra_property);
 
 inline constexpr const char *kPropertyMessageType = "message_type";
 inline constexpr const char *kPropertyAccess = "access";

--- a/layers/sync/sync_submit.h
+++ b/layers/sync/sync_submit.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2019-2024 Valve Corporation
- * Copyright (c) 2019-2024 LunarG, Inc.
+ * Copyright (c) 2019-2025 Valve Corporation
+ * Copyright (c) 2019-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -265,6 +265,7 @@ class QueueBatchContext : public CommandExecutionContext, public std::enable_sha
         ~PresentResourceRecord() override {}
         PresentResourceRecord(const PresentedImageRecord &presented) : presented_(presented) {}
         std::ostream &Format(std::ostream &out, const SyncValidator &sync_state) const override;
+        vvl::Func GetCommand() const override { return vvl::Func::vkQueuePresentKHR; }
 
       private:
         PresentedImageRecord presented_;
@@ -277,6 +278,7 @@ class QueueBatchContext : public CommandExecutionContext, public std::enable_sha
         AcquireResourceRecord(const PresentedImageRecord &presented, ResourceUsageTag tag, vvl::Func command)
             : presented_(presented), acquire_tag_(tag), command_(command) {}
         std::ostream &Format(std::ostream &out, const SyncValidator &sync_state) const override;
+        vvl::Func GetCommand() const override { return command_; }
 
       private:
         PresentedImageRecord presented_;

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -364,7 +364,8 @@ bool SyncValidator::PreCallValidateCmdCopyBuffer(VkCommandBuffer commandBuffer, 
             auto hazard = context->DetectHazard(*src_buffer, SYNC_COPY_TRANSFER_READ, src_range);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, srcBuffer);
-                const auto error = error_messages_.BufferRegionError(hazard, srcBuffer, true, region, *cb_context);
+                const auto error =
+                    error_messages_.BufferRegionError(hazard, srcBuffer, true, region, *cb_context, error_obj.location.function);
                 skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
             }
         }
@@ -373,7 +374,8 @@ bool SyncValidator::PreCallValidateCmdCopyBuffer(VkCommandBuffer commandBuffer, 
             auto hazard = context->DetectHazard(*dst_buffer, SYNC_COPY_TRANSFER_WRITE, dst_range);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, dstBuffer);
-                const auto error = error_messages_.BufferRegionError(hazard, dstBuffer, false, region, *cb_context);
+                const auto error =
+                    error_messages_.BufferRegionError(hazard, dstBuffer, false, region, *cb_context, error_obj.location.function);
                 skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
             }
         }
@@ -432,7 +434,8 @@ bool SyncValidator::PreCallValidateCmdCopyBuffer2(VkCommandBuffer commandBuffer,
                 // TODO -- add tag information to log msg when useful.
                 // TODO: there are no tests for this error
                 const LogObjectList objlist(commandBuffer, pCopyBufferInfo->srcBuffer);
-                const auto error = error_messages_.BufferRegionError(hazard, pCopyBufferInfo->srcBuffer, true, region, *cb_context);
+                const auto error = error_messages_.BufferRegionError(hazard, pCopyBufferInfo->srcBuffer, true, region, *cb_context,
+                                                                     error_obj.location.function);
                 skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
             }
         }
@@ -442,8 +445,8 @@ bool SyncValidator::PreCallValidateCmdCopyBuffer2(VkCommandBuffer commandBuffer,
             if (hazard.IsHazard()) {
                 // TODO: there are no tests for this error
                 const LogObjectList objlist(commandBuffer, pCopyBufferInfo->dstBuffer);
-                const auto error =
-                    error_messages_.BufferRegionError(hazard, pCopyBufferInfo->dstBuffer, false, region, *cb_context);
+                const auto error = error_messages_.BufferRegionError(hazard, pCopyBufferInfo->dstBuffer, false, region, *cb_context,
+                                                                     error_obj.location.function);
                 skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
             }
         }
@@ -1076,7 +1079,8 @@ bool SyncValidator::ValidateCmdCopyBufferToImage(VkCommandBuffer commandBuffer, 
                 if (hazard.IsHazard()) {
                     // PHASE1 TODO -- add tag information to log msg when useful.
                     const LogObjectList objlist(commandBuffer, srcBuffer);
-                    const auto error = error_messages_.BufferRegionError(hazard, srcBuffer, true, region, *cb_access_context);
+                    const auto error =
+                        error_messages_.BufferRegionError(hazard, srcBuffer, true, region, *cb_access_context, loc.function);
                     skip |= SyncError(hazard.Hazard(), objlist, loc, error);
                 }
             }
@@ -1210,7 +1214,8 @@ bool SyncValidator::ValidateCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, 
                 hazard = context->DetectHazard(*dst_buffer, SYNC_COPY_TRANSFER_WRITE, dst_range);
                 if (hazard.IsHazard()) {
                     const LogObjectList objlist(commandBuffer, dstBuffer);
-                    const auto error = error_messages_.BufferRegionError(hazard, dstBuffer, false, region, *cb_access_context);
+                    const auto error =
+                        error_messages_.BufferRegionError(hazard, dstBuffer, false, region, *cb_access_context, loc.function);
                     skip |= SyncError(hazard.Hazard(), objlist, loc, error);
                 }
             }

--- a/tests/unit/sync_val_reporting.cpp
+++ b/tests/unit/sync_val_reporting.cpp
@@ -1048,7 +1048,7 @@ TEST_F(NegativeSyncValReporting, ReportAllTransferMetaStage) {
 
     // Check that error reporting merged internal representation of transfer stage accesses into a compact form
     m_errorMonitor->SetDesiredErrorRegex("SYNC-HAZARD-WRITE-AFTER-WRITE",
-                                         "VK_ACCESS_2_TRANSFER_WRITE_BIT accesses on VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT stage");
+                                         "VK_ACCESS_2_TRANSFER_WRITE_BIT accesses at VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT stage");
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
     m_errorMonitor->VerifyFound();
     m_command_buffer.End();
@@ -1111,7 +1111,7 @@ TEST_F(NegativeSyncValReporting, DoNotReportUnsupportedStage) {
     // If error reporting does not skip unsupported ACCELERATION_STRUCTURE_COPY_BIT_KHR then the following error message won't
     // be able to use short form (TRANSFER_WRITE+TRANSFER_READ != "all accesses" in that case)
     m_errorMonitor->SetDesiredErrorRegex("SYNC-HAZARD-WRITE-AFTER-WRITE",
-                                         "all accesses on VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT stage");
+                                         "all accesses at VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT stage");
 
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
     m_errorMonitor->VerifyFound();


### PR DESCRIPTION
This demonstrates new style of synval error messages. Only one specific use case is updated. The following work will involve converting other messages and reworking reporting helpers.

OLD:
> vkCmdCopyBuffer(): Hazard WRITE_AFTER_WRITE for dstBuffer VkBuffer 0xf443490000000006[], region 0. Access info (usage: SYNC_COPY_TRANSFER_WRITE, prior_usage: SYNC_COPY_TRANSFER_WRITE, write_barriers: VK_ACCESS_2_TRANSFER_WRITE_BIT accesses on VK_PIPELINE_STAGE_2_CLEAR_BIT stage, command: vkCmdCopyBuffer, resource: VkBuffer 0xf443490000000006[]).

NEW:
> vkCmdCopyBuffer(): WRITE_AFTER_WRITE hazard detected. vkCmdCopyBuffer writes to VkBuffer 0xf443490000000006[], which was written earlier by another vkCmdCopyBuffer command. The existed synchronization protects VK_ACCESS_2_TRANSFER_WRITE_BIT accesses at VK_PIPELINE_STAGE_2_CLEAR_BIT stage but not at VK_PIPELINE_STAGE_2_COPY_BIT stage.

p.s. still need to add `region` info to new message