### PR TITLE
layers: Move syncval format helper to shared utils

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -345,6 +345,8 @@ vvl_sources = [
   "layers/utils/ray_tracing_utils.h",
   "layers/utils/shader_utils.cpp",
   "layers/utils/shader_utils.h",
+  "layers/utils/text_utils.cpp",
+  "layers/utils/text_utils.h",
   "layers/utils/vk_layer_extension_utils.cpp",
   "layers/utils/vk_layer_extension_utils.h",
   "layers/utils/vk_layer_utils.cpp",

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -61,6 +61,8 @@ target_sources(VkLayer_utils PRIVATE
     utils/vk_layer_extension_utils.h
     utils/ray_tracing_utils.cpp
     utils/ray_tracing_utils.h
+    utils/text_utils.cpp
+    utils/text_utils.h
     utils/vk_layer_utils.cpp
     utils/vk_layer_utils.h
     utils/vk_struct_compare.cpp

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -25,6 +25,7 @@
 #include "state_tracker/buffer_state.h"
 #include "state_tracker/render_pass_state.h"
 #include "state_tracker/shader_module.h"
+#include "utils/text_utils.h"
 
 SyncAccessIndex GetSyncStageAccessIndexsByDescriptorSet(VkDescriptorType descriptor_type,
                                                         const spirv::ResourceInterfaceVariable &variable,
@@ -1048,7 +1049,7 @@ void CommandBufferAccessContext::CheckCommandTagDebugCheckpoint() {
         if (object_name.empty()) {
             object_name = debug_report.GetMarkerObjectNameNoLock(cmdbuf_handle);
         }
-        vvl::ToLower(object_name);
+        text::ToLower(object_name);
         return object_name;
     };
     if (sync_state_.debug_command_number == command_number_ && sync_state_.debug_reset_count == reset_count_) {

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -25,6 +25,7 @@
 #include "state_tracker/buffer_state.h"
 #include "utils/convert_utils.h"
 #include "utils/ray_tracing_utils.h"
+#include "utils/text_utils.h"
 #include "vk_layer_config.h"
 
 SyncValidator::~SyncValidator() {
@@ -758,7 +759,7 @@ void SyncValidator::PostCreateDevice(const VkDeviceCreateInfo *pCreateInfo, cons
         debug_reset_count = static_cast<uint32_t>(std::stoul(env_debug_reset_count));
     }
     debug_cmdbuf_pattern = GetEnvironment("VK_SYNCVAL_DEBUG_CMDBUF_PATTERN");
-    vvl::ToLower(debug_cmdbuf_pattern);
+    text::ToLower(debug_cmdbuf_pattern);
 }
 
 void SyncValidator::PostCallRecordCreateSemaphore(VkDevice device, const VkSemaphoreCreateInfo *pCreateInfo,

--- a/layers/utils/text_utils.cpp
+++ b/layers/utils/text_utils.cpp
@@ -1,0 +1,70 @@
+/* Copyright (c) 2025 The Khronos Group Inc.
+ * Copyright (c) 2025 Valve Corporation
+ * Copyright (c) 2025 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "text_utils.h"
+#include <algorithm>
+#include <cassert>
+#include <vector>
+
+namespace text {
+
+std::string VFormat(const char *format, va_list argptr) {
+    // Counts actual characters. Null terminator is accounted separately.
+    const int initial_max_symbol_count = 1024;
+
+    // Use vector as the output buffer for c-style formatting routines.
+    // Do not write directly to std::string internal storage because its
+    // structure and null terminator convention is not standardized.
+    std::vector<char> buffer(initial_max_symbol_count + 1 /*null terminator*/);
+
+    // The va_list will be modified by the call to vsnprintf. Use a copy in case we need to try again.
+    va_list argptr2;
+    va_copy(argptr2, argptr);
+    const int symbol_count = vsnprintf(buffer.data(), buffer.size(), format, argptr2);
+    va_end(argptr2);
+
+    if (symbol_count < 0) {
+        assert(false && "unexpected vsnprintf error");
+        return {};
+    }
+    if (symbol_count > initial_max_symbol_count) {
+        buffer.resize(symbol_count + 1 /*null terminator*/);
+        vsnprintf(buffer.data(), buffer.size(), format, argptr);
+    }
+    std::string str(buffer.data());
+    return str;
+}
+
+std::string Format(const char *format, ...) {
+    va_list argptr;
+    va_start(argptr, format);
+    std::string str = VFormat(format, argptr);
+    va_end(argptr);
+    return str;
+}
+
+void ToLower(std::string &str) {
+    // std::tolower() returns int which can cause compiler warnings
+    std::transform(str.begin(), str.end(), str.begin(), [](char c) { return static_cast<char>(std::tolower(c)); });
+}
+
+void ToUpper(std::string &str) {
+    // std::toupper() returns int which can cause compiler warnings
+    std::transform(str.begin(), str.end(), str.begin(), [](char c) { return static_cast<char>(std::toupper(c)); });
+}
+
+}  // namespace text

--- a/layers/utils/text_utils.h
+++ b/layers/utils/text_utils.h
@@ -1,0 +1,33 @@
+/* Copyright (c) 2025 The Khronos Group Inc.
+ * Copyright (c) 2025 Valve Corporation
+ * Copyright (c) 2025 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdarg>
+#include <string>
+
+namespace text {
+
+// vsprintf style formatting
+std::string VFormat(const char *format, va_list argptr);
+
+// sprintf style formatting
+std::string Format(const char *format, ...);
+
+void ToLower(std::string &str);
+void ToUpper(std::string &str);
+
+}  // namespace text

--- a/layers/utils/vk_layer_utils.h
+++ b/layers/utils/vk_layer_utils.h
@@ -524,18 +524,6 @@ bool RangesIntersect(int64_t x, uint64_t x_size, int64_t y, uint64_t y_size);
 
 namespace vvl {
 
-static inline void ToLower(std::string &str) {
-    // std::tolower() returns int which can cause compiler warnings
-    transform(str.begin(), str.end(), str.begin(),
-              [](char c) { return static_cast<char>(std::tolower(c)); });
-}
-
-static inline void ToUpper(std::string &str) {
-    // std::toupper() returns int which can cause compiler warnings
-    transform(str.begin(), str.end(), str.begin(),
-              [](char c) { return static_cast<char>(std::toupper(c)); });
-}
-
 // The standard does not specify the value of data() for zero-sized contatiners as being null or non-null,
 // only that it is not dereferenceable.
 //


### PR DESCRIPTION
Add helper to share implementation between logging.cpp and syncval. The helper also addresses some issues in the implementation from logging.cpp.