### PR TITLE
gpuav: Fix Post Processing failing on zero bindingCount

### DIFF
--- a/layers/gpuav/descriptor_validation/gpuav_descriptor_set.cpp
+++ b/layers/gpuav/descriptor_validation/gpuav_descriptor_set.cpp
@@ -259,6 +259,15 @@ VkDeviceAddress DescriptorSet::GetTypeAddress(Validator &gpuav, const Location &
     return input_buffer_.Address();
 }
 
+// There are times we need a dummy address because the app is legally using something that doesn't require a post process buffer
+bool DescriptorSet::CanPostProcess() const {
+    // When no descriptors (only inline, zero bindingCount, etc)
+    if (GetNonInlineDescriptorCount() == 0) {
+        return false;
+    }
+    return true;
+}
+
 VkDeviceAddress DescriptorSet::GetPostProcessBuffer(Validator &gpuav, const Location &loc) {
     auto guard = Lock();
     // Each set only needs to create its post process buffer once. It is based on total descriptor count, and even with things like
@@ -267,8 +276,7 @@ VkDeviceAddress DescriptorSet::GetPostProcessBuffer(Validator &gpuav, const Loca
         return post_process_buffer_.Address();
     }
 
-    if (GetNonInlineDescriptorCount() == 0) {
-        // no descriptors case, return a dummy state object
+    if (!CanPostProcess()) {
         return post_process_buffer_.Address();
     }
 

--- a/layers/gpuav/descriptor_validation/gpuav_descriptor_set.h
+++ b/layers/gpuav/descriptor_validation/gpuav_descriptor_set.h
@@ -45,6 +45,7 @@ class DescriptorSet : public vvl::DescriptorSet {
     VkDeviceAddress GetTypeAddress(Validator &gpuav, const Location &loc);
     VkDeviceAddress GetPostProcessBuffer(Validator &gpuav, const Location &loc);
     bool HasPostProcessBuffer() const { return !post_process_buffer_.IsDestroyed(); }
+    bool CanPostProcess() const;
 
     std::vector<DescriptorAccess> GetDescriptorAccesses(const Location &loc, uint32_t shader_set) const;
 

--- a/layers/gpuav/descriptor_validation/gpuav_descriptor_validation.cpp
+++ b/layers/gpuav/descriptor_validation/gpuav_descriptor_validation.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2020-2024 The Khronos Group Inc.
- * Copyright (c) 2020-2024 Valve Corporation
- * Copyright (c) 2020-2024 LunarG, Inc.
+/* Copyright (c) 2020-2025 The Khronos Group Inc.
+ * Copyright (c) 2020-2025 Valve Corporation
+ * Copyright (c) 2020-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -231,8 +231,12 @@ void UpdateBoundDescriptors(Validator &gpuav, CommandBuffer &cb_state, VkPipelin
                 // validating the 2nd instance of it
                 continue;
             }
-            validated_desc_sets.emplace(bound_descriptor_set->VkHandle());
+
             if (!bound_descriptor_set->HasPostProcessBuffer()) {
+                if (!bound_descriptor_set->CanPostProcess()) {
+                    continue;  // hit a dummy object used as a placeholder
+                }
+
                 std::stringstream error;
                 error << "In CommandBuffer::ValidateBindlessDescriptorSets, action_command_snapshots[" << action_index
                       << "].descriptor_command_binding.bound_descriptor_sets[" << set_index
@@ -241,6 +245,7 @@ void UpdateBoundDescriptors(Validator &gpuav, CommandBuffer &cb_state, VkPipelin
                 gpuav->InternalError(gpuav->device, loc, error.str().c_str());
                 return false;
             }
+            validated_desc_sets.emplace(bound_descriptor_set->VkHandle());
 
             vvl::DescriptorValidator context(state_, *this, *bound_descriptor_set, set_index, VK_NULL_HANDLE /*framebuffer*/,
                                              draw_loc);


### PR DESCRIPTION
Hit a crash in a trace using GPU-AV, root issue was the Descriptor Set was created with `VkDescriptorSetLayoutCreateInfo::bindingCount = 0` 

In this case, we save resources and don't create a Post Processing buffer (there are no descriptors in it!)

but then we were mixing up this case with a case where the somehow we did lose track of the descriptor