### PR TITLE
tests: Fix tests failing on RADV ToT

### DIFF
--- a/tests/unit/dynamic_state.cpp
+++ b/tests/unit/dynamic_state.cpp
@@ -5682,6 +5682,9 @@ TEST_F(NegativeDynamicState, RebindSamePipeline) {
         (driver_properties.conformanceVersion.minor == 3 && driver_properties.conformanceVersion.subminor > 7)) {
         GTEST_SKIP() << "conformanceVersion is greater than the version the test requires";
     }
+    if (driver_properties.conformanceVersion.major == 0) {
+        GTEST_SKIP() << "conformanceVersion is invalid";  // happens in some non-conformant mesa drivers
+    }
 
     CreatePipelineHelper pipe(*this);
     pipe.CreateGraphicsPipeline();

--- a/tests/unit/shader_cooperative_matrix.cpp
+++ b/tests/unit/shader_cooperative_matrix.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (c) 2015-2024 Google, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2025 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -553,9 +553,13 @@ TEST_F(NegativeShaderCooperativeMatrix, MatchSizeWithProperties) {
     RETURN_IF_SKIP(InitCooperativeMatrixKHR());
 
     VkPhysicalDeviceCooperativeMatrixPropertiesKHR props = vku::InitStructHelper();
-    GetPhysicalDeviceProperties2(props);
+    VkPhysicalDeviceVulkan11Properties props11 = vku::InitStructHelper(&props);
+    GetPhysicalDeviceProperties2(props11);
     if ((props.cooperativeMatrixSupportedStages & VK_SHADER_STAGE_COMPUTE_BIT) == 0) {
         GTEST_SKIP() << "Compute stage is not supported";
+    }
+    if (props11.subgroupSize > 32) {
+        GTEST_SKIP() << "local_size_x (32) is not a multiple of subgroupSize";
     }
 
     if (HasValidProperty(VK_SCOPE_SUBGROUP_KHR, 8, 8, 16, VK_COMPONENT_TYPE_FLOAT16_KHR)) {


### PR DESCRIPTION
`NegativeShaderCooperativeMatrix.MatchSizeWithProperties` and `NegativeDynamicState.RebindSamePipeline` were failing on ToT RADV for me and here are some quick fixes