### PR TITLE
sync: Convert NegativeSyncVal.BufferCopy errors to new style

### DIFF
--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -146,11 +146,12 @@ void CommandBufferAccessContext::Reset() {
     dynamic_rendering_info_.reset();
 }
 
-std::string CommandBufferAccessContext::FormatUsage(const char *usage_string, const ResourceFirstAccess &access) const {
+std::string CommandBufferAccessContext::FormatUsage(const char *usage_string, const ResourceFirstAccess &access,
+                                                    ReportKeyValues &key_values) const {
     std::stringstream out;
     assert(access.usage_info);
     out << "(" << usage_string << ": " << access.usage_info->name;
-    out << ", " << FormatUsage(access.TagEx()) << ")";
+    out << ", " << FormatUsage(access.TagEx(), key_values) << ")";
     return out.str();
 }
 

--- a/layers/sync/sync_commandbuffer.h
+++ b/layers/sync/sync_commandbuffer.h
@@ -213,7 +213,7 @@ class CommandExecutionContext {
     virtual const SyncEventsContext *GetCurrentEventsContext() const = 0;
     virtual QueueId GetQueueId() const = 0;
     virtual VulkanTypedHandle Handle() const = 0;
-    virtual std::string FormatUsage(ResourceUsageTagEx tag_ex) const = 0;
+    virtual std::string FormatUsage(ResourceUsageTagEx tag_ex, ReportKeyValues &extra_properties) const = 0;
     virtual void AddUsageRecordExtraProperties(ResourceUsageTag tag, ReportKeyValues &extra_properties) const = 0;
 
     std::string FormatHazard(const HazardResult &hazard, ReportKeyValues &key_values) const;
@@ -266,10 +266,10 @@ class CommandBufferAccessContext : public CommandExecutionContext, DebugNameProv
     void Reset();
 
     ReportUsageInfo GetReportUsageInfo(ResourceUsageTagEx tag_ex) const;
-    std::string FormatUsage(ResourceUsageTagEx tag_ex) const override;
+    std::string FormatUsage(ResourceUsageTagEx tag_ex, ReportKeyValues &extra_properties) const override;
     void AddUsageRecordExtraProperties(ResourceUsageTag tag, ReportKeyValues &extra_properties) const override;
-    std::string FormatUsage(const char *usage_string,
-                            const ResourceFirstAccess &access) const;  //  Only command buffers have "first usage"
+    std::string FormatUsage(const char *usage_string, const ResourceFirstAccess &access,
+                            ReportKeyValues &key_values) const;  //  Only command buffers have "first usage"
     AccessContext *GetCurrentAccessContext() override { return current_context_; }
     SyncEventsContext *GetCurrentEventsContext() override { return &events_context_; }
     const AccessContext *GetCurrentAccessContext() const override { return current_context_; }

--- a/layers/sync/sync_reporting.h
+++ b/layers/sync/sync_reporting.h
@@ -54,6 +54,7 @@ struct ReportKeyValues {
     void Add(std::string_view key, uint64_t value);
 
     std::string GetExtraPropertiesSection(bool pretty_print) const;
+    const std::string* FindProperty(const std::string &key) const;
 };
 
 struct ReportUsageInfo {
@@ -73,6 +74,7 @@ inline constexpr const char *kPropertyAccess = "access";
 inline constexpr const char *kPropertyPriorAccess = "prior_access";
 inline constexpr const char *kPropertyReadBarriers = "read_barriers";
 inline constexpr const char *kPropertyWriteBarriers = "write_barriers";
+inline constexpr const char *kPropertyDebugRegion = "debug_region";
 inline constexpr const char *kPropertyLoadOp = "load_op";
 inline constexpr const char *kPropertyStoreOp = "store_op";
 inline constexpr const char *kPropertyResolveMode = "resolve_mode";

--- a/layers/sync/sync_submit.h
+++ b/layers/sync/sync_submit.h
@@ -295,7 +295,7 @@ class QueueBatchContext : public CommandExecutionContext, public std::enable_sha
     ~QueueBatchContext();
     void Trim();
 
-    std::string FormatUsage(ResourceUsageTagEx tag_ex) const override;
+    std::string FormatUsage(ResourceUsageTagEx tag_ex, ReportKeyValues &extra_properties) const override;
     void AddUsageRecordExtraProperties(ResourceUsageTag tag, ReportKeyValues &extra_properties) const override;
     AccessContext *GetCurrentAccessContext() override { return current_access_context_; }
     const AccessContext *GetCurrentAccessContext() const override { return current_access_context_; }


### PR DESCRIPTION
Used `NegativeSyncVal.BufferCopy` test as work scope to convert its errors to new style. Code is of r&d style (ugly), the focus it to finalize message structure first. Need to go over more use cases to have better idea which formatting helpers will be needed.

`WRITE_AFTER_READ` hazard for buffer copy without barrier:
OLD:
> vkCmdCopyBuffer(): Hazard WRITE_AFTER_READ for dstBuffer VkBuffer 0xf56c9b0000000004[], region 0. Access info (usage: SYNC_COPY_TRANSFER_WRITE, prior_usage: SYNC_COPY_TRANSFER_READ, read_barriers: VkPipelineStageFlags2(0), command: vkCmdCopyBuffer, resource: VkBuffer 0xf56c9b0000000004[]).

NEW: 
> vkCmdCopyBuffer(): WRITE_AFTER_READ hazard detected. vkCmdCopyBuffer writes to VkBuffer 0xf56c9b0000000004[], which was previously read by another vkCmdCopyBuffer command. No sufficient synchronization is present to ensure that a write (VK_ACCESS_2_TRANSFER_WRITE_BIT) at the VK_PIPELINE_STAGE_2_COPY_BIT stage does not conflict with a prior read (VK_ACCESS_2_TRANSFER_READ_BIT) at the same stage. An execution dependency is sufficient to prevent this hazard.


