### PR TITLE
layers: Fix -Werror=array-bounds error

### DIFF
--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1705,7 +1705,8 @@ bool CommandBuffer::HasExternalFormatResolveAttachment() const {
 }
 
 void CommandBuffer::BindShader(VkShaderStageFlagBits shader_stage, vvl::ShaderObject *shader_object_state) {
-    auto &last_bound_state = lastBound[ConvertToPipelineBindPoint(shader_stage)];
+    const VkPipelineBindPoint pipeline_bind_point = ConvertToPipelineBindPoint(shader_stage);
+    auto &last_bound_state = lastBound[ConvertToLvlBindPoint(pipeline_bind_point)];
     const auto stage_index = static_cast<uint32_t>(ConvertToShaderObjectStage(shader_stage));
     last_bound_state.shader_object_bound[stage_index] = true;
     last_bound_state.shader_object_states[stage_index] = shader_object_state;


### PR DESCRIPTION
VkPipelineBindPoint doesn't index nicely into an array.

i.e. VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR = 1000165000

Note I found this issue by trying to compile the VVL codebase with `-fsanitize=undefined` as an experiment:
https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html

<details>

<summary>Compiler Error</summary>

```
[153/427] Building CXX object layers/CMakeFiles/vvl.dir/state_tracker/cmd_buffer_state.cpp.o
FAILED: layers/CMakeFiles/vvl.dir/state_tracker/cmd_buffer_state.cpp.o 
ccache /usr/bin/c++ -DVK_ENABLE_BETA_EXTENSIONS -DVK_USE_PLATFORM_WAYLAND_KHR -DVK_USE_PLATFORM_XCB_KHR -DVK_USE_PLATFORM_XLIB_KHR -DVK_USE_PLATFORM_XLIB_XRANDR_EXT -Dvvl_EXPORTS -I/home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/layers/. -I/home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/layers/vulkan -isystem /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/layers/external -isystem /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build-ci/external/SPIRV-Headers/build/install/include -isystem /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build-ci/external/SPIRV-Tools/build/install/include -isystem /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build-ci/external/Vulkan-Headers/build/install/include -isystem /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build-ci/external/Vulkan-Utility-Libraries/build/install/include -fsanitize=undefined -fno-sanitize=vptr -O3 -DNDEBUG -std=c++17 -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -Werror -Wall -Wextra -Wpointer-arith -Wno-unused-parameter -MD -MT layers/CMakeFiles/vvl.dir/state_tracker/cmd_buffer_state.cpp.o -MF layers/CMakeFiles/vvl.dir/state_tracker/cmd_buffer_state.cpp.o.d -o layers/CMakeFiles/vvl.dir/state_tracker/cmd_buffer_state.cpp.o -c /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/layers/state_tracker/cmd_buffer_state.cpp
In file included from /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/build-ci/external/Vulkan-Utility-Libraries/build/install/include/vulkan/utility/vk_concurrent_unordered_map.hpp:14,
                 from /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/layers/./containers/custom_containers.h:41,
                 from /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/layers/./state_tracker/state_object.h:22,
                 from /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/layers/./state_tracker/cmd_buffer_state.h:21,
                 from /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/layers/state_tracker/cmd_buffer_state.cpp:20:
In member function ‘constexpr std::array<_Tp, _Nm>::value_type& std::array<_Tp, _Nm>::operator[](size_type) [with _Tp = LastBound; long unsigned int _Nm = 3]’,
    inlined from ‘void vvl::CommandBuffer::BindShader(VkShaderStageFlagBits, vvl::ShaderObject*)’ at /home/runner/work/Vulkan-ValidationLayers/Vulkan-ValidationLayers/layers/state_tracker/cmd_buffer_state.cpp:1708:80:
/usr/include/c++/13/array:203:24: error: array subscript 1000165000 is above array bounds of ‘std::__array_traits<LastBound, 3>::_Type’ {aka ‘LastBound [3]’} [-Werror=array-bounds=]
  203 |         return _M_elems[__n];
      |                ~~~~~~~~^
/usr/include/c++/13/array: In member function ‘void vvl::CommandBuffer::BindShader(VkShaderStageFlagBits, vvl::ShaderObject*)’:
/usr/include/c++/13/array:109:55: note: while referencing ‘std::array<LastBound, 3>::_M_elems’
  109 |       typename __array_traits<_Tp, _Nm>::_Type        _M_elems;
      |                                                       ^~~~~~~~
cc1plus: all warnings being treated as errors
```

</details>