### PR TITLE
sync: Add new report properties

### DIFF
--- a/layers/sync/sync_error_messages.h
+++ b/layers/sync/sync_error_messages.h
@@ -39,112 +39,119 @@ class ErrorMessages {
   public:
     explicit ErrorMessages(vvl::Device& validator);
 
-    std::string Error(const HazardResult& hazard, const char* description, const CommandBufferAccessContext& cb_context) const;
+    std::string Error(const HazardResult& hazard, const char* description, const CommandBufferAccessContext& cb_context,
+                      vvl::Func command) const;
 
     std::string BufferError(const HazardResult& hazard, VkBuffer buffer, const char* buffer_description,
-                            const CommandBufferAccessContext& cb_context) const;
+                            const CommandBufferAccessContext& cb_context, vvl::Func command) const;
 
     std::string BufferRegionError(const HazardResult& hazard, VkBuffer buffer, bool is_src_buffer, uint32_t region_index,
                                   const CommandBufferAccessContext& cb_context, const vvl::Func command) const;
 
     std::string ImageRegionError(const HazardResult& hazard, VkImage image, bool is_src_image, uint32_t region_index,
-                                 const CommandBufferAccessContext& cb_context) const;
+                                 const CommandBufferAccessContext& cb_context, vvl::Func command) const;
 
     std::string ImageSubresourceRangeError(const HazardResult& hazard, VkImage image, uint32_t subresource_range_index,
-                                           const CommandBufferAccessContext& cb_context) const;
+                                           const CommandBufferAccessContext& cb_context, vvl::Func command) const;
 
     std::string BeginRenderingError(const HazardResult& hazard, const syncval_state::DynamicRenderingInfo::Attachment& attachment,
-                                    const CommandBufferAccessContext& cb_context) const;
+                                    const CommandBufferAccessContext& cb_context, vvl::Func command) const;
 
     std::string EndRenderingResolveError(const HazardResult& hazard, const VulkanTypedHandle& image_view_handle,
-                                         VkResolveModeFlagBits resolve_mode, const CommandBufferAccessContext& cb_context) const;
+                                         VkResolveModeFlagBits resolve_mode, const CommandBufferAccessContext& cb_context,
+                                         vvl::Func command) const;
 
     std::string EndRenderingStoreError(const HazardResult& hazard, const VulkanTypedHandle& image_view_handle,
-                                       VkAttachmentStoreOp store_op, const CommandBufferAccessContext& cb_context) const;
+                                       VkAttachmentStoreOp store_op, const CommandBufferAccessContext& cb_context,
+                                       vvl::Func command) const;
 
     std::string DrawDispatchImageError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
                                        const vvl::ImageView& image_view, const vvl::Pipeline& pipeline,
                                        const vvl::DescriptorSet& descriptor_set, VkDescriptorType descriptor_type,
-                                       VkImageLayout image_layout, uint32_t descriptor_binding, uint32_t binding_index) const;
+                                       VkImageLayout image_layout, uint32_t descriptor_binding, uint32_t binding_index,
+                                       vvl::Func command) const;
 
     std::string DrawDispatchTexelBufferError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
                                              const vvl::BufferView& buffer_view, const vvl::Pipeline& pipeline,
                                              const vvl::DescriptorSet& descriptor_set, VkDescriptorType descriptor_type,
-                                             uint32_t descriptor_binding, uint32_t binding_index) const;
+                                             uint32_t descriptor_binding, uint32_t binding_index, vvl::Func command) const;
 
     std::string DrawDispatchBufferError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
                                         const vvl::Buffer& buffer, const vvl::Pipeline& pipeline,
                                         const vvl::DescriptorSet& descriptor_set, VkDescriptorType descriptor_type,
-                                        uint32_t descriptor_binding, uint32_t binding_index) const;
+                                        uint32_t descriptor_binding, uint32_t binding_index, vvl::Func command) const;
 
     std::string DrawVertexBufferError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
-                                      const vvl::Buffer& vertex_buffer) const;
+                                      const vvl::Buffer& vertex_buffer, vvl::Func command) const;
 
     std::string DrawIndexBufferError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
-                                     const vvl::Buffer& index_buffer) const;
+                                     const vvl::Buffer& index_buffer, vvl::Func command) const;
 
     std::string DrawAttachmentError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
-                                    const vvl::ImageView& attachment_view) const;
+                                    const vvl::ImageView& attachment_view, vvl::Func command) const;
 
     std::string ClearColorAttachmentError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
-                                          const std::string& subpass_attachment_info) const;
+                                          const std::string& subpass_attachment_info, vvl::Func command) const;
 
     std::string ClearDepthStencilAttachmentError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
-                                                 const std::string& subpass_attachment_info, VkImageAspectFlagBits aspect) const;
+                                                 const std::string& subpass_attachment_info, VkImageAspectFlagBits aspect,
+                                                 vvl::Func command) const;
 
     std::string PipelineBarrierError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
-                                     uint32_t image_barrier_index, const vvl::Image& image) const;
+                                     uint32_t image_barrier_index, const vvl::Image& image, vvl::Func command) const;
 
     std::string WaitEventsError(const HazardResult& hazard, const CommandExecutionContext& exec_context,
-                                uint32_t image_barrier_index, const vvl::Image& image) const;
+                                uint32_t image_barrier_index, const vvl::Image& image, vvl::Func command) const;
 
     std::string FirstUseError(const HazardResult& hazard, const CommandExecutionContext& exec_context,
                               const CommandBufferAccessContext& recorded_context, uint32_t command_buffer_index,
-                              VkCommandBuffer recorded_handle) const;
+                              VkCommandBuffer recorded_handle, vvl::Func command) const;
 
     std::string RenderPassResolveError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context, uint32_t subpass,
                                        const char* aspect_name, const char* attachment_name, uint32_t src_attachment,
-                                       uint32_t dst_attachment) const;
+                                       uint32_t dst_attachment, vvl::Func command) const;
 
     std::string RenderPassLayoutTransitionVsStoreOrResolveError(const HazardResult& hazard, uint32_t subpass, uint32_t attachment,
                                                                 VkImageLayout old_layout, VkImageLayout new_layout,
-                                                                uint32_t store_resolve_subpass) const;
+                                                                uint32_t store_resolve_subpass, vvl::Func command) const;
 
     std::string RenderPassLayoutTransitionError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
                                                 uint32_t subpass, uint32_t attachment, VkImageLayout old_layout,
-                                                VkImageLayout new_layout) const;
+                                                VkImageLayout new_layout, vvl::Func command) const;
 
     std::string RenderPassLoadOpVsLayoutTransitionError(const HazardResult& hazard, uint32_t subpass, uint32_t attachment,
-                                                        const char* aspect_name, VkAttachmentLoadOp load_op) const;
+                                                        const char* aspect_name, VkAttachmentLoadOp load_op,
+                                                        vvl::Func command) const;
 
     std::string RenderPassLoadOpError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context, uint32_t subpass,
-                                      uint32_t attachment, const char* aspect_name, VkAttachmentLoadOp load_op) const;
+                                      uint32_t attachment, const char* aspect_name, VkAttachmentLoadOp load_op,
+                                      vvl::Func command) const;
 
     std::string RenderPassStoreOpError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context, uint32_t subpass,
                                        uint32_t attachment, const char* aspect_name, const char* store_op_type_name,
-                                       VkAttachmentStoreOp store_op) const;
+                                       VkAttachmentStoreOp store_op, vvl::Func command) const;
 
     std::string RenderPassColorAttachmentError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
-                                               const vvl::ImageView& view, uint32_t attachment) const;
+                                               const vvl::ImageView& view, uint32_t attachment, vvl::Func command) const;
 
     std::string RenderPassDepthStencilAttachmentError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
-                                                      const vvl::ImageView& view, bool is_depth) const;
+                                                      const vvl::ImageView& view, bool is_depth, vvl::Func command) const;
 
     std::string RenderPassFinalLayoutTransitionVsStoreOrResolveError(const HazardResult& hazard,
-                                                                   const CommandBufferAccessContext& cb_context, uint32_t subpass,
-                                                                   uint32_t attachment, VkImageLayout old_layout,
-                                                                   VkImageLayout new_layout) const;
+                                                                     const CommandBufferAccessContext& cb_context, uint32_t subpass,
+                                                                     uint32_t attachment, VkImageLayout old_layout,
+                                                                     VkImageLayout new_layout, vvl::Func command) const;
 
     std::string RenderPassFinalLayoutTransitionError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
                                                      uint32_t subpass, uint32_t attachment, VkImageLayout old_layout,
-                                                     VkImageLayout new_layout) const;
+                                                     VkImageLayout new_layout, vvl::Func command) const;
 
     std::string PresentError(const HazardResult& hazard, const QueueBatchContext& batch_context, uint32_t present_index,
-                             const VulkanTypedHandle& swapchain_handle, uint32_t image_index,
-                             const VulkanTypedHandle& image_handle) const;
+                             const VulkanTypedHandle& swapchain_handle, uint32_t image_index, const VulkanTypedHandle& image_handle,
+                             vvl::Func command) const;
 
     std::string VideoReferencePictureError(const HazardResult& hazard, uint32_t reference_picture_index,
-                                           const CommandBufferAccessContext& cb_context) const;
+                                           const CommandBufferAccessContext& cb_context, vvl::Func command) const;
 
   private:
     void AddCbContextExtraProperties(const CommandBufferAccessContext& cb_context, ResourceUsageTag tag,

--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -406,8 +406,8 @@ bool SyncOpPipelineBarrier::Validate(const CommandBufferAccessContext &cb_contex
             // PHASE1 TODO -- add tag information to log msg when useful.
             const Location loc(command_);
             const auto &sync_state = cb_context.GetSyncState();
-            const auto error =
-                sync_state.error_messages_.PipelineBarrierError(hazard, cb_context, image_barrier.barrier_index, image_state);
+            const auto error = sync_state.error_messages_.PipelineBarrierError(hazard, cb_context, image_barrier.barrier_index,
+                                                                               image_state, command_);
             skip |= sync_state.SyncError(hazard.Hazard(), image_state.Handle(), loc, error);
         }
     }
@@ -637,8 +637,8 @@ bool SyncOpWaitEvents::DoValidate(const CommandExecutionContext &exec_context, c
                     *image_state, subresource_range, sync_event->scope.exec_scope, src_access_scope, queue_id,
                     sync_event->FirstScope(), sync_event->first_scope_tag, AccessContext::DetectOptions::kDetectAll);
                 if (hazard.IsHazard()) {
-                    const auto error = sync_state.error_messages_.WaitEventsError(hazard, exec_context,
-                                                                                  image_memory_barrier.barrier_index, *image_state);
+                    const auto error = sync_state.error_messages_.WaitEventsError(
+                        hazard, exec_context, image_memory_barrier.barrier_index, *image_state, command_);
                     skip |= sync_state.SyncError(hazard.Hazard(), image_state->Handle(), loc, error);
                     break;
                 }
@@ -1176,8 +1176,9 @@ bool ReplayState::DetectFirstUseHazard(const ResourceUsageRange &first_use_range
             const SyncValidator &sync_state = exec_context_.GetSyncState();
             const auto handle = exec_context_.Handle();
             const VkCommandBuffer recorded_handle = recorded_context_.GetCBState().VkHandle();
+            // TODO: figure out the last parameter for vvl::Func
             const auto error =
-                sync_state.error_messages_.FirstUseError(hazard, exec_context_, recorded_context_, index_, recorded_handle);
+                sync_state.error_messages_.FirstUseError(hazard, exec_context_, recorded_context_, index_, recorded_handle, vvl::Func::Empty);
             skip |= sync_state.SyncError(hazard.Hazard(), handle, error_obj_.location, error);
         }
     }

--- a/layers/sync/sync_reporting.cpp
+++ b/layers/sync/sync_reporting.cpp
@@ -61,18 +61,23 @@ static auto SortKeyValues(const std::vector<ReportKeyValues::KeyValue> &key_valu
         if (key == kPropertyMessageType) {
             return 0;
         }
-        // then some common properties
-        const char *common_properties[] = {kPropertyAccess, kPropertyPriorAccess, kPropertyReadBarriers, kPropertyWriteBarriers};
-        if (IsValueIn(key, common_properties)) {
+        // followed by hazard type
+        if (key == kPropertyHazardType) {
             return 1;
+        }
+        // then some common properties
+        const char *common_properties[] = {kPropertyAccess,       kPropertyPriorAccess,  kPropertyCommand,
+                                           kPropertyPriorCommand, kPropertyReadBarriers, kPropertyWriteBarriers};
+        if (IsValueIn(key, common_properties)) {
+            return 2;
         }
         // debug properties are at the end
         const char *debug_properties[] = {kPropertySeqNo, kPropertySubCmd, kPropertyResetNo, kPropertyBatchTag};
         if (IsValueIn(key, debug_properties)) {
-            return 3;
+            return 4;
         }
         // everything else
-        return 2;
+        return 3;
     };
     auto sorted = key_values;
     std::stable_sort(sorted.begin(), sorted.end(), [&get_sort_order](const auto &a, const auto &b) {
@@ -448,6 +453,7 @@ std::string CommandBufferAccessContext::FormatUsage(ResourceUsageTagEx tag_ex, R
 void CommandBufferAccessContext::AddUsageRecordExtraProperties(ResourceUsageTag tag, ReportKeyValues &extra_properties) const {
     if (tag >= access_log_->size()) return;
     const ResourceUsageRecord &record = (*access_log_)[tag];
+    extra_properties.Add(kPropertyPriorCommand, vvl::String(record.command));
     extra_properties.Add(kPropertySeqNo, record.seq_num);
     if (record.sub_command != 0) {
         extra_properties.Add(kPropertySubCmd, record.sub_command);

--- a/layers/sync/sync_reporting.h
+++ b/layers/sync/sync_reporting.h
@@ -25,7 +25,7 @@ class CommandBuffer;
 class StateObject;
 class Image;
 class Queue;
-}
+}  // namespace vvl
 class DebugReport;
 class SyncValidator;
 struct DeviceFeatures;
@@ -54,7 +54,7 @@ struct ReportKeyValues {
     void Add(std::string_view key, uint64_t value);
 
     std::string GetExtraPropertiesSection(bool pretty_print) const;
-    const std::string* FindProperty(const std::string &key) const;
+    const std::string *FindProperty(const std::string &key) const;
 };
 
 struct ReportUsageInfo {
@@ -70,17 +70,19 @@ std::string FormatSyncAccesses(const SyncAccessFlags &sync_accesses, VkQueueFlag
                                bool format_as_extra_property);
 
 inline constexpr const char *kPropertyMessageType = "message_type";
+inline constexpr const char *kPropertyHazardType = "hazard_type";
+inline constexpr const char *kPropertyCommand = "command";
+inline constexpr const char *kPropertyPriorCommand = "prior_command";
+inline constexpr const char *kPropertyDebugRegion = "debug_region";
 inline constexpr const char *kPropertyAccess = "access";
 inline constexpr const char *kPropertyPriorAccess = "prior_access";
 inline constexpr const char *kPropertyReadBarriers = "read_barriers";
 inline constexpr const char *kPropertyWriteBarriers = "write_barriers";
-inline constexpr const char *kPropertyDebugRegion = "debug_region";
 inline constexpr const char *kPropertyLoadOp = "load_op";
 inline constexpr const char *kPropertyStoreOp = "store_op";
 inline constexpr const char *kPropertyResolveMode = "resolve_mode";
 inline constexpr const char *kPropertyOldLayout = "old_layout";
 inline constexpr const char *kPropertyNewLayout = "new_layout";
-inline constexpr const char *kPropertyResourceParameter = "resource_parameter";
 inline constexpr const char *kPropertyDescriptorType = "descriptor_type";
 inline constexpr const char *kPropertyImageLayout = "image_layout";
 inline constexpr const char *kPropertyImageAspect = "image_aspect";
@@ -90,4 +92,3 @@ inline constexpr const char *kPropertySeqNo = "seq_no";
 inline constexpr const char *kPropertySubCmd = "subcmd";
 inline constexpr const char *kPropertyResetNo = "reset_no";
 inline constexpr const char *kPropertyBatchTag = "batch_tag";
-

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -451,8 +451,9 @@ bool QueueBatchContext::DoQueuePresentValidate(const Location& loc, const Presen
             const auto queue_handle = queue_state_->Handle();
             const auto swap_handle = vvl::StateObject::Handle(presented.swapchain_state.lock());
             const auto image_handle = vvl::StateObject::Handle(presented.image);
-            const auto error = sync_state_.error_messages_.PresentError(hazard, *this, presented.present_index, swap_handle,
-                                                                        presented.image_index, image_handle);
+            const auto error =
+                sync_state_.error_messages_.PresentError(hazard, *this, presented.present_index, swap_handle, presented.image_index,
+                                                         image_handle, vvl::Func::vkQueuePresentKHR);
             skip |= sync_state_.SyncError(hazard.Hazard(), queue_handle, loc, error);
             if (skip) break;
         }

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -520,7 +520,8 @@ bool SyncValidator::PreCallValidateCmdCopyImage(VkCommandBuffer commandBuffer, V
                                                 copy_region.extent, false, SYNC_COPY_TRANSFER_READ);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, srcImage);
-                const auto error = error_messages_.ImageRegionError(hazard, srcImage, true, region, *cb_access_context);
+                const auto error = error_messages_.ImageRegionError(hazard, srcImage, true, region, *cb_access_context,
+                                                                    error_obj.location.function);
                 skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
             }
         }
@@ -530,7 +531,8 @@ bool SyncValidator::PreCallValidateCmdCopyImage(VkCommandBuffer commandBuffer, V
                                                 copy_region.extent, false, SYNC_COPY_TRANSFER_WRITE);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, dstImage);
-                const auto error = error_messages_.ImageRegionError(hazard, dstImage, false, region, *cb_access_context);
+                const auto error = error_messages_.ImageRegionError(hazard, dstImage, false, region, *cb_access_context,
+                                                                    error_obj.location.function);
                 skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
             }
             if (skip) break;
@@ -594,8 +596,8 @@ bool SyncValidator::PreCallValidateCmdCopyImage2(VkCommandBuffer commandBuffer, 
                                                 copy_region.extent, false, SYNC_COPY_TRANSFER_READ);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, pCopyImageInfo->srcImage);
-                const auto error =
-                    error_messages_.ImageRegionError(hazard, pCopyImageInfo->srcImage, true, region, *cb_access_context);
+                const auto error = error_messages_.ImageRegionError(hazard, pCopyImageInfo->srcImage, true, region,
+                                                                    *cb_access_context, error_obj.location.function);
                 // TODO: this error not covered by the test
                 skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
             }
@@ -606,8 +608,8 @@ bool SyncValidator::PreCallValidateCmdCopyImage2(VkCommandBuffer commandBuffer, 
                                                 copy_region.extent, false, SYNC_COPY_TRANSFER_WRITE);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, pCopyImageInfo->dstImage);
-                const auto error =
-                    error_messages_.ImageRegionError(hazard, pCopyImageInfo->dstImage, false, region, *cb_access_context);
+                const auto error = error_messages_.ImageRegionError(hazard, pCopyImageInfo->dstImage, false, region,
+                                                                    *cb_access_context, error_obj.location.function);
                 skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
             }
             if (skip) break;
@@ -1090,7 +1092,8 @@ bool SyncValidator::ValidateCmdCopyBufferToImage(VkCommandBuffer commandBuffer, 
                                            copy_region.imageExtent, false, SYNC_COPY_TRANSFER_WRITE);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, dstImage);
-                const auto error = error_messages_.ImageRegionError(hazard, dstImage, false, region, *cb_access_context);
+                const auto error =
+                    error_messages_.ImageRegionError(hazard, dstImage, false, region, *cb_access_context, loc.function);
                 skip |= SyncError(hazard.Hazard(), objlist, loc, error);
             }
             if (skip) break;
@@ -1205,7 +1208,8 @@ bool SyncValidator::ValidateCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, 
                                                 copy_region.imageExtent, false, SYNC_COPY_TRANSFER_READ);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, srcImage);
-                const auto error = error_messages_.ImageRegionError(hazard, srcImage, true, region, *cb_access_context);
+                const auto error =
+                    error_messages_.ImageRegionError(hazard, srcImage, true, region, *cb_access_context, loc.function);
                 skip |= SyncError(hazard.Hazard(), objlist, loc, error);
             }
             if (dst_memory != VK_NULL_HANDLE) {
@@ -1336,7 +1340,8 @@ bool SyncValidator::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage 
                                                 SYNC_BLIT_TRANSFER_READ);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, srcImage);
-                const auto error = error_messages_.ImageRegionError(hazard, srcImage, true, region, *cb_access_context);
+                const auto error =
+                    error_messages_.ImageRegionError(hazard, srcImage, true, region, *cb_access_context, loc.function);
                 skip |= SyncError(hazard.Hazard(), objlist, loc, error);
             }
         }
@@ -1352,7 +1357,8 @@ bool SyncValidator::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage 
                                                 SYNC_BLIT_TRANSFER_WRITE);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, dstImage);
-                const auto error = error_messages_.ImageRegionError(hazard, dstImage, false, region, *cb_access_context);
+                const auto error =
+                    error_messages_.ImageRegionError(hazard, dstImage, false, region, *cb_access_context, loc.function);
                 skip |= SyncError(hazard.Hazard(), objlist, loc, error);
             }
             if (skip) break;
@@ -1458,7 +1464,7 @@ bool SyncValidator::ValidateIndirectBuffer(const CommandBufferAccessContext &cb_
         auto hazard = context.DetectHazard(*buf_state, SYNC_DRAW_INDIRECT_INDIRECT_COMMAND_READ, range);
         if (hazard.IsHazard()) {
             const LogObjectList objlist(cb_context.GetCBState().Handle(), buf_state->Handle());
-            const auto error = error_messages_.BufferError(hazard, buffer, "indirect", cb_context);
+            const auto error = error_messages_.BufferError(hazard, buffer, "indirect", cb_context, loc.function);
             skip |= SyncError(hazard.Hazard(), objlist, loc, error);
         }
     } else {
@@ -1467,7 +1473,7 @@ bool SyncValidator::ValidateIndirectBuffer(const CommandBufferAccessContext &cb_
             auto hazard = context.DetectHazard(*buf_state, SYNC_DRAW_INDIRECT_INDIRECT_COMMAND_READ, range);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(cb_context.GetCBState().Handle(), buf_state->Handle());
-                const auto error = error_messages_.BufferError(hazard, buffer, "indirect", cb_context);
+                const auto error = error_messages_.BufferError(hazard, buffer, "indirect", cb_context, loc.function);
                 skip |= SyncError(hazard.Hazard(), objlist, loc, error);
                 break;
             }
@@ -1507,7 +1513,7 @@ bool SyncValidator::ValidateCountBuffer(const CommandBufferAccessContext &cb_con
     auto hazard = context.DetectHazard(*count_buf_state, SYNC_DRAW_INDIRECT_INDIRECT_COMMAND_READ, range);
     if (hazard.IsHazard()) {
         const LogObjectList objlist(cb_context.GetCBState().Handle(), count_buf_state->Handle());
-        const auto error = error_messages_.BufferError(hazard, buffer, "countBuffer", cb_context);
+        const auto error = error_messages_.BufferError(hazard, buffer, "countBuffer", cb_context, loc.function);
         skip |= SyncError(hazard.Hazard(), objlist, loc, error);
     }
     return skip;
@@ -1898,7 +1904,8 @@ bool SyncValidator::PreCallValidateCmdClearColorImage(VkCommandBuffer commandBuf
             auto hazard = context->DetectHazard(*image_state, SYNC_CLEAR_TRANSFER_WRITE, range, false);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, image);
-                const auto error = error_messages_.ImageSubresourceRangeError(hazard, image, index, *cb_access_context);
+                const auto error = error_messages_.ImageSubresourceRangeError(hazard, image, index, *cb_access_context,
+                                                                              error_obj.location.function);
                 skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
             }
         }
@@ -1954,7 +1961,8 @@ bool SyncValidator::PreCallValidateCmdClearDepthStencilImage(VkCommandBuffer com
             auto hazard = context->DetectHazard(*image_state, SYNC_CLEAR_TRANSFER_WRITE, range, false);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, image);
-                const auto error = error_messages_.ImageSubresourceRangeError(hazard, image, index, *cb_access_context);
+                const auto error = error_messages_.ImageSubresourceRangeError(hazard, image, index, *cb_access_context,
+                                                                              error_obj.location.function);
                 skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
             }
         }
@@ -2042,7 +2050,8 @@ bool SyncValidator::PreCallValidateCmdCopyQueryPoolResults(VkCommandBuffer comma
         auto hazard = context->DetectHazard(*dst_buffer, SYNC_COPY_TRANSFER_WRITE, range);
         if (hazard.IsHazard()) {
             const LogObjectList objlist(commandBuffer, queryPool, dstBuffer);
-            const auto error = error_messages_.BufferError(hazard, dstBuffer, "dstBuffer", *cb_access_context);
+            const auto error =
+                error_messages_.BufferError(hazard, dstBuffer, "dstBuffer", *cb_access_context, error_obj.location.function);
             skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
         }
     }
@@ -2095,7 +2104,8 @@ bool SyncValidator::PreCallValidateCmdFillBuffer(VkCommandBuffer commandBuffer, 
         auto hazard = context->DetectHazard(*dst_buffer, SYNC_CLEAR_TRANSFER_WRITE, range);
         if (hazard.IsHazard()) {
             const LogObjectList objlist(commandBuffer, dstBuffer);
-            const auto error = error_messages_.BufferError(hazard, dstBuffer, "dstBuffer", *cb_access_context);
+            const auto error =
+                error_messages_.BufferError(hazard, dstBuffer, "dstBuffer", *cb_access_context, error_obj.location.function);
             skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
         }
     }
@@ -2145,7 +2155,8 @@ bool SyncValidator::PreCallValidateCmdResolveImage(VkCommandBuffer commandBuffer
                                                 resolve_region.srcOffset, resolve_region.extent, false, SYNC_RESOLVE_TRANSFER_READ);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, srcImage);
-                const auto error = error_messages_.ImageRegionError(hazard, srcImage, true, region, *cb_access_context);
+                const auto error = error_messages_.ImageRegionError(hazard, srcImage, true, region, *cb_access_context,
+                                                                    error_obj.location.function);
                 skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
             }
         }
@@ -2156,7 +2167,8 @@ bool SyncValidator::PreCallValidateCmdResolveImage(VkCommandBuffer commandBuffer
                                       resolve_region.extent, false, SYNC_RESOLVE_TRANSFER_WRITE);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, dstImage);
-                const auto error = error_messages_.ImageRegionError(hazard, dstImage, false, region, *cb_access_context);
+                const auto error = error_messages_.ImageRegionError(hazard, dstImage, false, region, *cb_access_context,
+                                                                    error_obj.location.function);
                 skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
             }
             if (skip) break;
@@ -2224,8 +2236,8 @@ bool SyncValidator::PreCallValidateCmdResolveImage2(VkCommandBuffer commandBuffe
                                                 resolve_region.srcOffset, resolve_region.extent, false, SYNC_RESOLVE_TRANSFER_READ);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, pResolveImageInfo->srcImage);
-                const auto error =
-                    error_messages_.ImageRegionError(hazard, pResolveImageInfo->srcImage, true, region, *cb_access_context);
+                const auto error = error_messages_.ImageRegionError(hazard, pResolveImageInfo->srcImage, true, region,
+                                                                    *cb_access_context, error_obj.location.function);
                 // TODO: this error is not covered by the test
                 skip |= SyncError(hazard.Hazard(), objlist, region_loc, error);
             }
@@ -2237,8 +2249,8 @@ bool SyncValidator::PreCallValidateCmdResolveImage2(VkCommandBuffer commandBuffe
                                       resolve_region.extent, false, SYNC_RESOLVE_TRANSFER_WRITE);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, pResolveImageInfo->dstImage);
-                const auto error =
-                    error_messages_.ImageRegionError(hazard, pResolveImageInfo->dstImage, false, region, *cb_access_context);
+                const auto error = error_messages_.ImageRegionError(hazard, pResolveImageInfo->dstImage, false, region,
+                                                                    *cb_access_context, error_obj.location.function);
                 // TODO: this error is not covered by the test
                 skip |= SyncError(hazard.Hazard(), objlist, region_loc, error);
             }
@@ -2312,7 +2324,8 @@ bool SyncValidator::PreCallValidateCmdUpdateBuffer(VkCommandBuffer commandBuffer
         auto hazard = context->DetectHazard(*dst_buffer, SYNC_CLEAR_TRANSFER_WRITE, range);
         if (hazard.IsHazard()) {
             const LogObjectList objlist(commandBuffer, dstBuffer);
-            const auto error = error_messages_.BufferError(hazard, dstBuffer, "dstBuffer", *cb_access_context);
+            const auto error =
+                error_messages_.BufferError(hazard, dstBuffer, "dstBuffer", *cb_access_context, error_obj.location.function);
             skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
         }
     }
@@ -2359,7 +2372,8 @@ bool SyncValidator::PreCallValidateCmdWriteBufferMarkerAMD(VkCommandBuffer comma
         const ResourceAccessRange range = MakeRange(dstOffset, 4);
         auto hazard = context->DetectHazard(*dst_buffer, SYNC_COPY_TRANSFER_WRITE, range);
         if (hazard.IsHazard()) {
-            const auto error = error_messages_.BufferError(hazard, dstBuffer, "dstBuffer", *cb_access_context);
+            const auto error =
+                error_messages_.BufferError(hazard, dstBuffer, "dstBuffer", *cb_access_context, error_obj.location.function);
             skip |= SyncError(hazard.Hazard(), dstBuffer, error_obj.location, error);
         }
     }
@@ -2410,7 +2424,8 @@ bool SyncValidator::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuff
         auto hazard = context->DetectHazard(*src_buffer, SYNC_VIDEO_DECODE_VIDEO_DECODE_READ, src_range);
         if (hazard.IsHazard()) {
             // TODO: there are no tests for this error
-            const auto error = error_messages_.BufferError(hazard, pDecodeInfo->srcBuffer, "bitstream buffer", *cb_access_context);
+            const auto error = error_messages_.BufferError(hazard, pDecodeInfo->srcBuffer, "bitstream buffer", *cb_access_context,
+                                                           error_obj.location.function);
             skip |= SyncError(hazard.Hazard(), src_buffer->Handle(), decode_info_loc.dot(Field::srcBuffer), error);
         }
     }
@@ -2419,7 +2434,8 @@ bool SyncValidator::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuff
     if (dst_resource) {
         auto hazard = context->DetectHazard(*vs_state, dst_resource, SYNC_VIDEO_DECODE_VIDEO_DECODE_WRITE);
         if (hazard.IsHazard()) {
-            const auto error = error_messages_.Error(hazard, "decode output picture", *cb_access_context);
+            const auto error =
+                error_messages_.Error(hazard, "decode output picture", *cb_access_context, error_obj.location.function);
             skip |= SyncError(hazard.Hazard(), dst_resource.image_view_state->Handle(),
                               decode_info_loc.dot(Field::dstPictureResource), error);
         }
@@ -2431,7 +2447,8 @@ bool SyncValidator::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuff
             auto hazard = context->DetectHazard(*vs_state, setup_resource, SYNC_VIDEO_DECODE_VIDEO_DECODE_WRITE);
             if (hazard.IsHazard()) {
                 // TODO: there are no tests for this error
-                const auto error = error_messages_.Error(hazard, "reconstructed picture", *cb_access_context);
+                const auto error =
+                    error_messages_.Error(hazard, "reconstructed picture", *cb_access_context, error_obj.location.function);
                 skip |= SyncError(hazard.Hazard(), setup_resource.image_view_state->Handle(),
                                   decode_info_loc.dot(Field::pSetupReferenceSlot).dot(Field::pPictureResource), error);
             }
@@ -2444,7 +2461,8 @@ bool SyncValidator::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuff
             if (reference_resource) {
                 auto hazard = context->DetectHazard(*vs_state, reference_resource, SYNC_VIDEO_DECODE_VIDEO_DECODE_READ);
                 if (hazard.IsHazard()) {
-                    const auto error = error_messages_.VideoReferencePictureError(hazard, i, *cb_access_context);
+                    const auto error =
+                        error_messages_.VideoReferencePictureError(hazard, i, *cb_access_context, error_obj.location.function);
                     skip |= SyncError(hazard.Hazard(), reference_resource.image_view_state->Handle(),
                                       decode_info_loc.dot(Field::pReferenceSlots, i).dot(Field::pPictureResource), error);
                 }
@@ -2521,7 +2539,8 @@ bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuff
         const ResourceAccessRange src_range = MakeRange(*dst_buffer, pEncodeInfo->dstBufferOffset, pEncodeInfo->dstBufferRange);
         auto hazard = context->DetectHazard(*dst_buffer, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_WRITE, src_range);
         if (hazard.IsHazard()) {
-            const auto error = error_messages_.BufferError(hazard, pEncodeInfo->dstBuffer, "bitstream buffer", *cb_access_context);
+            const auto error = error_messages_.BufferError(hazard, pEncodeInfo->dstBuffer, "bitstream buffer", *cb_access_context,
+                                                           error_obj.location.function);
             skip |= SyncError(hazard.Hazard(), dst_buffer->Handle(), encode_info_loc.dot(Field::dstBuffer), error);
         }
     }
@@ -2531,7 +2550,8 @@ bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuff
         auto hazard = context->DetectHazard(*vs_state, src_resource, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_READ);
         if (hazard.IsHazard()) {
             // TODO: there are no tests for this error
-            const auto error = error_messages_.Error(hazard, "encode input picture", *cb_access_context);
+            const auto error =
+                error_messages_.Error(hazard, "encode input picture", *cb_access_context, error_obj.location.function);
             skip |= SyncError(hazard.Hazard(), src_resource.image_view_state->Handle(),
                               encode_info_loc.dot(Field::srcPictureResource), error);
         }
@@ -2542,7 +2562,8 @@ bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuff
         if (setup_resource) {
             auto hazard = context->DetectHazard(*vs_state, setup_resource, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_WRITE);
             if (hazard.IsHazard()) {
-                const auto error = error_messages_.Error(hazard, "reconstructed picture", *cb_access_context);
+                const auto error =
+                    error_messages_.Error(hazard, "reconstructed picture", *cb_access_context, error_obj.location.function);
                 skip |= SyncError(hazard.Hazard(), setup_resource.image_view_state->Handle(),
                                   encode_info_loc.dot(Field::pSetupReferenceSlot).dot(Field::pPictureResource), error);
             }
@@ -2555,7 +2576,8 @@ bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuff
             if (reference_resource) {
                 auto hazard = context->DetectHazard(*vs_state, reference_resource, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_READ);
                 if (hazard.IsHazard()) {
-                    const auto error = error_messages_.VideoReferencePictureError(hazard, i, *cb_access_context);
+                    const auto error =
+                        error_messages_.VideoReferencePictureError(hazard, i, *cb_access_context, error_obj.location.function);
                     skip |= SyncError(hazard.Hazard(), reference_resource.image_view_state->Handle(),
                                       encode_info_loc.dot(Field::pReferenceSlots, i).dot(Field::pPictureResource), error);
                 }
@@ -2575,7 +2597,8 @@ bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuff
                                                     SyncOrdering::kOrderingNone);
                 if (hazard.IsHazard()) {
                     // TODO: there are no tests for this error
-                    const auto error = error_messages_.Error(hazard, "quantization map", *cb_access_context);
+                    const auto error =
+                        error_messages_.Error(hazard, "quantization map", *cb_access_context, error_obj.location.function);
                     skip |= SyncError(hazard.Hazard(), image_view_state->Handle(),
                                       encode_info_loc.pNext(Struct::VkVideoEncodeQuantizationMapInfoKHR, Field::quantizationMap),
                                       error);
@@ -2868,7 +2891,8 @@ bool SyncValidator::PreCallValidateCmdWriteBufferMarker2AMD(VkCommandBuffer comm
         auto hazard = context->DetectHazard(*dst_buffer, SYNC_COPY_TRANSFER_WRITE, range);
         if (hazard.IsHazard()) {
             // TODO: there are no tests for this error
-            const auto error = error_messages_.BufferError(hazard, dstBuffer, "dstBuffer", *cb_access_context);
+            const auto error =
+                error_messages_.BufferError(hazard, dstBuffer, "dstBuffer", *cb_access_context, error_obj.location.function);
             skip |= SyncError(hazard.Hazard(), dstBuffer, error_obj.location, error);
         }
     }
@@ -3610,7 +3634,8 @@ bool SyncValidator::PreCallValidateCmdBuildAccelerationStructuresKHR(
         auto hazard = context.DetectHazard(scratch_buffer, SYNC_ACCELERATION_STRUCTURE_BUILD_ACCELERATION_STRUCTURE_WRITE, range);
         if (hazard.IsHazard()) {
             const LogObjectList objlist(commandBuffer, scratch_buffer.Handle());
-            const auto error = error_messages_.BufferError(hazard, scratch_buffer.VkHandle(), "scratch buffer", cb_context);
+            const auto error = error_messages_.BufferError(hazard, scratch_buffer.VkHandle(), "scratch buffer", cb_context,
+                                                           error_obj.location.function);
             skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
         }
     }


### PR DESCRIPTION
Add these properties (used by most commands):
`hazard_type`, `command`, `prior_command`

Remove: `resource_parameter`. Can be derived from `hazard_type`