### PR TITLE
cmake: Remove outdated check

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -469,13 +469,6 @@ endif()
 target_include_directories(vvl SYSTEM PRIVATE external)
 
 if (ANDROID)
-    # https://gitlab.kitware.com/cmake/cmake/issues/18787
-    # https://github.com/android-ndk/ndk/issues/463
-    # "Users should be able to reliably use the toolchain provided by the NDK r23 or later when using CMake 3.21 or later" - Professional CMake
-    if (CMAKE_VERSION VERSION_LESS "3.21")
-        message(FATAL_ERROR "Android build requires at least CMake 3.21!")
-    endif()
-
     # Required for __android_log_print. Marking as PUBLIC since the tests use __android_log_print as well.
     target_link_libraries(VkLayer_utils PUBLIC log)
 


### PR DESCRIPTION
The cmake minimum is now 3.22.1