### PR TITLE
gpuav: Keep instruction count to make error message faster

### DIFF
--- a/layers/gpuav/debug_printf/debug_printf.cpp
+++ b/layers/gpuav/debug_printf/debug_printf.cpp
@@ -210,13 +210,13 @@ void AnalyzeAndGenerateMessage(Validator &gpuav, VkCommandBuffer command_buffer,
         }
 
         // without the instrumented spirv, there is nothing valuable to print out
-        if (!instrumented_shader || instrumented_shader->instrumented_spirv.empty()) {
+        if (!instrumented_shader || instrumented_shader->original_spirv.empty()) {
             gpuav.InternalWarning(queue, loc, "Can't find instructions from any handles in shader_map");
             return;
         }
 
         std::vector<Instruction> instructions;
-        ::spirv::GenerateInstructions(instrumented_shader->instrumented_spirv, instructions);
+        ::spirv::GenerateInstructions(instrumented_shader->original_spirv, instrumented_shader->instruction_count, instructions);
 
         // Search through the shader source for the printf format string for this invocation
         std::string format_string = FindFormatString(instructions, debug_record->format_string_id);

--- a/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
@@ -1062,8 +1062,9 @@ bool LogInstrumentationError(Validator &gpuav, const CommandBuffer &cb_state, co
 
         // If we somehow can't find our state, we can still report our error message
         std::vector<Instruction> instructions;
-        if (instrumented_shader && !instrumented_shader->instrumented_spirv.empty()) {
-            ::spirv::GenerateInstructions(instrumented_shader->instrumented_spirv, instructions);
+        if (instrumented_shader && !instrumented_shader->original_spirv.empty()) {
+            ::spirv::GenerateInstructions(instrumented_shader->original_spirv, instrumented_shader->instruction_count,
+                                          instructions);
         }
         std::string debug_region_name = cb_state.GetDebugLabelRegion(label_command_i, initial_label_stack);
         Location loc_with_debug_region(loc, debug_region_name);

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.h
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.h
@@ -58,7 +58,10 @@ struct InstrumentedShader {
     VkPipeline pipeline;
     VkShaderModule shader_module;
     VkShaderEXT shader_object;
-    std::vector<uint32_t> instrumented_spirv;
+    // Keep original SPIR-V to map bad Shader Debug Info line numbers
+    std::vector<uint32_t> original_spirv;
+    // we will need to turn the vector<uint32_t> back into an vector<Instruction> and faster to know how many to reserve
+    uint32_t instruction_count;
 };
 
 // Historically this was an common interface to both GPU-AV and DebugPrintf before the were merged together.

--- a/layers/state_tracker/shader_instruction.cpp
+++ b/layers/state_tracker/shader_instruction.cpp
@@ -189,11 +189,16 @@ spv::StorageClass Instruction::StorageClass() const {
 // When logging from things such as GPU-AV, we need to do some SPIR-V processing, but is just to inspect single instructions without
 // knowledge of the rest of the module. This function just turns the saved vector of uint32_t into the Instruction class to make it
 // easier to use.
-void GenerateInstructions(const vvl::span<const uint32_t>& spirv, std::vector<Instruction>& instructions) {
+void GenerateInstructions(const vvl::span<const uint32_t>& spirv, uint32_t instruction_count,
+                          std::vector<Instruction>& instructions) {
     // Need to use until we have native std::span in c++20
     using spirv_iterator = vvl::enumeration<const uint32_t, const uint32_t*>::iterator;
 
     assert(instructions.empty());
+
+    // profiling showed this is a huge bottleneck to not have this reserved
+    instructions.reserve(instruction_count);
+
     spirv_iterator it = spirv.begin();
     it += 5;  // skip first 5 word of header
     instructions.reserve(spirv.size() * 4);

--- a/layers/state_tracker/shader_instruction.h
+++ b/layers/state_tracker/shader_instruction.h
@@ -104,6 +104,7 @@ class Instruction {
 #endif
 };
 
-void GenerateInstructions(const vvl::span<const uint32_t>& spirv, std::vector<Instruction>& instructions);
+void GenerateInstructions(const vvl::span<const uint32_t>& spirv, uint32_t instruction_count,
+                          std::vector<Instruction>& instructions);
 
 }  // namespace spirv

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -747,6 +747,8 @@ struct Module {
         return std::any_of(static_data_.capability_list.begin(), static_data_.capability_list.end(),
                            [find_capability](const spv::Capability &capability) { return capability == find_capability; });
     }
+
+    uint32_t InstructionCount() const { return (uint32_t)static_data_.instructions.size(); }
 };
 
 }  // namespace spirv


### PR DESCRIPTION
Found by @arno-lunarg in profiling that we really freeze up in `GenerateInstructions` and this hopefully solves it