### PR TITLE
sync: Add copy region info to buffer messages

### DIFF
--- a/layers/sync/sync_error_messages.h
+++ b/layers/sync/sync_error_messages.h
@@ -45,8 +45,9 @@ class ErrorMessages {
     std::string BufferError(const HazardResult& hazard, VkBuffer buffer, const char* buffer_description,
                             const CommandBufferAccessContext& cb_context, vvl::Func command) const;
 
-    std::string BufferRegionError(const HazardResult& hazard, VkBuffer buffer, bool is_src_buffer, uint32_t region_index,
-                                  const CommandBufferAccessContext& cb_context, const vvl::Func command) const;
+    std::string BufferRegionError(const HazardResult& hazard, VkBuffer buffer, uint32_t region_index,
+                                  ResourceAccessRange region_range, const CommandBufferAccessContext& cb_context,
+                                  const vvl::Func command) const;
 
     std::string ImageRegionError(const HazardResult& hazard, VkImage image, bool is_src_image, uint32_t region_index,
                                  const CommandBufferAccessContext& cb_context, vvl::Func command) const;

--- a/layers/sync/sync_reporting.h
+++ b/layers/sync/sync_reporting.h
@@ -78,6 +78,7 @@ inline constexpr const char *kPropertyAccess = "access";
 inline constexpr const char *kPropertyPriorAccess = "prior_access";
 inline constexpr const char *kPropertyReadBarriers = "read_barriers";
 inline constexpr const char *kPropertyWriteBarriers = "write_barriers";
+inline constexpr const char *kPropertyCopyRegion = "copy_region";
 inline constexpr const char *kPropertyLoadOp = "load_op";
 inline constexpr const char *kPropertyStoreOp = "store_op";
 inline constexpr const char *kPropertyResolveMode = "resolve_mode";


### PR DESCRIPTION
> vkCmdCopyBuffer(): WRITE_AFTER_WRITE hazard detected. vkCmdCopyBuffer writes to VkBuffer 0xf443490000000006[], which was previously written by another vkCmdCopyBuffer command. The current synchronization protects VK_ACCESS_2_TRANSFER_WRITE_BIT accesses at VK_PIPELINE_STAGE_2_CLEAR_BIT but not at VK_PIPELINE_STAGE_2_COPY_BIT. **Hazardous copy region: 0 (offset = 0, size = 256).**