### PR TITLE
gpuav: Do GPU-AV Post Processing with uint32_t only

### DIFF
--- a/layers/error_message/spirv_logging.h
+++ b/layers/error_message/spirv_logging.h
@@ -18,12 +18,23 @@
 #pragma once
 #include <vector>
 #include <sstream>
+#include <cstdint>
 
 namespace spirv {
 class Instruction;
-}
 
 // When producing error messages for SPIR-V related items and the user generated the shader with debug information, we can use these
 // helpers to print out information from their High Level source instead of some cryptic SPIR-V jargon
-void GetShaderSourceInfo(std::ostringstream &ss, const std::vector<spirv::Instruction> &instructions,
+//
+// Due to GPU-AV not being able to create spirv::Instructions fast enough, we do most work here with a raw uint32_t byte stream
+void GetShaderSourceInfo(std::ostringstream &ss, const std::vector<uint32_t> &instructions,
                          const spirv::Instruction &last_line_insn);
+
+// These are used where we can't use normal spirv::Instructions.
+// The main spot is post-processisng error message in GPU-AV, the time it takes to interchange back from a vector<uint32_t> to a
+// vector<Instructions> is too high to do mid-frame. Most things just need these simple helpers
+const char* GetOpString(const std::vector<uint32_t>& instructions, uint32_t string_id);
+uint32_t GetConstantValue(const std::vector<uint32_t>& instructions, uint32_t constant_id);
+void GetExecutionModelNames(const std::vector<uint32_t>& instructions, std::ostringstream& ss);
+uint32_t GetDebugLineOffset(const std::vector<uint32_t>& instructions, uint32_t instruction_position);
+}  // namespace spirv

--- a/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
@@ -1060,15 +1060,10 @@ bool LogInstrumentationError(Validator &gpuav, const CommandBuffer &cb_state, co
             instrumented_shader = &it->second;
         }
 
-        // If we somehow can't find our state, we can still report our error message
-        std::vector<Instruction> instructions;
-        if (instrumented_shader && !instrumented_shader->instrumented_spirv.empty()) {
-            ::spirv::GenerateInstructions(instrumented_shader->instrumented_spirv, instructions);
-        }
         std::string debug_region_name = cb_state.GetDebugLabelRegion(label_command_i, initial_label_stack);
         Location loc_with_debug_region(loc, debug_region_name);
         std::string debug_info_message = gpuav.GenerateDebugInfoMessage(
-            cb_state.VkHandle(), instructions, error_record[gpuav::glsl::kHeaderStageIdOffset],
+            cb_state.VkHandle(), error_record[gpuav::glsl::kHeaderStageIdOffset],
             error_record[gpuav::glsl::kHeaderStageInfoOffset_0], error_record[gpuav::glsl::kHeaderStageInfoOffset_1],
             error_record[gpuav::glsl::kHeaderStageInfoOffset_2], error_record[gpuav::glsl::kHeaderInstructionIdOffset],
             instrumented_shader, shader_id, pipeline_bind_point, operation_index);

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.h
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.h
@@ -162,11 +162,10 @@ class GpuShaderInstrumentor : public vvl::Device {
 
     bool IsSelectiveInstrumentationEnabled(const void *pNext);
 
-    std::string GenerateDebugInfoMessage(VkCommandBuffer commandBuffer, const std::vector<Instruction> &instructions,
-                                         uint32_t stage_id, uint32_t stage_info_0, uint32_t stage_info_1, uint32_t stage_info_2,
-                                         uint32_t instruction_position, const InstrumentedShader *instrumented_shader,
-                                         uint32_t shader_id, VkPipelineBindPoint pipeline_bind_point,
-                                         uint32_t operation_index) const;
+    std::string GenerateDebugInfoMessage(VkCommandBuffer commandBuffer, uint32_t stage_id, uint32_t stage_info_0,
+                                         uint32_t stage_info_1, uint32_t stage_info_2, uint32_t instruction_position,
+                                         const InstrumentedShader *instrumented_shader, uint32_t shader_id,
+                                         VkPipelineBindPoint pipeline_bind_point, uint32_t operation_index) const;
 
   protected:
     bool NeedPipelineCreationShaderInstrumentation(vvl::Pipeline &pipeline_state, const Location &loc);

--- a/layers/gpuav/spirv/instruction.h
+++ b/layers/gpuav/spirv/instruction.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2024 LunarG, Inc.
+/* Copyright (c) 2024-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ struct Instruction {
     // operand id, return 0 if no type
     uint32_t TypeId() const { return (type_id_index_ == 0) ? 0 : words_[type_id_index_]; }
 
-    // Increments Lenght() as well
+    // Increments Length() as well
     void AppendWord(uint32_t word);
 
     void ReplaceResultId(uint32_t new_result_id);

--- a/layers/state_tracker/shader_instruction.cpp
+++ b/layers/state_tracker/shader_instruction.cpp
@@ -186,22 +186,4 @@ spv::StorageClass Instruction::StorageClass() const {
     return storage_class;
 }
 
-// When logging from things such as GPU-AV, we need to do some SPIR-V processing, but is just to inspect single instructions without
-// knowledge of the rest of the module. This function just turns the saved vector of uint32_t into the Instruction class to make it
-// easier to use.
-void GenerateInstructions(const vvl::span<const uint32_t>& spirv, std::vector<Instruction>& instructions) {
-    // Need to use until we have native std::span in c++20
-    using spirv_iterator = vvl::enumeration<const uint32_t, const uint32_t*>::iterator;
-
-    assert(instructions.empty());
-    spirv_iterator it = spirv.begin();
-    it += 5;  // skip first 5 word of header
-    instructions.reserve(spirv.size() * 4);
-
-    while (it != spirv.end()) {
-        auto new_insn = instructions.emplace_back(it);
-        it += new_insn.Length();
-    }
-}
-
 }  // namespace spirv

--- a/layers/state_tracker/shader_instruction.h
+++ b/layers/state_tracker/shader_instruction.h
@@ -104,6 +104,4 @@ class Instruction {
 #endif
 };
 
-void GenerateInstructions(const vvl::span<const uint32_t>& spirv, std::vector<Instruction>& instructions);
-
 }  // namespace spirv

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -1422,7 +1422,7 @@ std::string Module::DescribeInstruction(const Instruction& error_insn) const {
     std::ostringstream ss;
     ss << error_insn.Describe();
     ss << "\nFrom shader debug information ";
-    GetShaderSourceInfo(ss, static_data_.instructions, *last_line_inst);
+    GetShaderSourceInfo(ss, words_, *last_line_inst);
     return ss.str();
 }
 

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -37,7 +37,7 @@ struct Module;
 
 static constexpr uint32_t kInvalidValue = std::numeric_limits<uint32_t>::max();
 
-// Need to find a way to know if actually array lenght of zero, or a runtime array.
+// Need to find a way to know if actually array length of zero, or a runtime array.
 static constexpr uint32_t kRuntimeArray = std::numeric_limits<uint32_t>::max();
 
 // This is the common info for both OpDecorate and OpMemberDecorate


### PR DESCRIPTION
@arno-lunarg found https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/9381 was not good enough and we need to not use `spirv::Instruction` at all and resort to doing old-fashion `vector<uint32_t>` parsing

Added some helpers and I think it is tolerable (as parsing SPIR-V can be)