### PR TITLE
sync: Replace unsupported sparse assert with todo comment

### DIFF
--- a/layers/state_tracker/device_memory_state.cpp
+++ b/layers/state_tracker/device_memory_state.cpp
@@ -379,7 +379,7 @@ std::pair<VkDeviceMemory, MemoryRange> vvl::Bindable::GetResourceMemoryOverlap(
 }
 
 VkDeviceSize vvl::Bindable::GetFakeBaseAddress() const {
-    assert(!sparse);  // not implemented yet
+    // TODO: Sparse resources are not implemented yet
     const auto *binding = Binding();
     return binding ? binding->memory_offset + binding->memory_state->fake_base_address : 0;
 }


### PR DESCRIPTION
A lot of CTS tests assert here when they use sparse resources. They seem to pass fine if the assert is just removed