### PR TITLE
sync: Error messages update

### DIFF
--- a/layers/error_message/error_location.h
+++ b/layers/error_message/error_location.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2021-2024 The Khronos Group Inc.
- * Copyright (c) 2021-2024 Valve Corporation
- * Copyright (c) 2021-2024 LunarG, Inc.
- * Copyright (C) 2021-2022 Google Inc.
+/* Copyright (c) 2021-2025 The Khronos Group Inc.
+ * Copyright (c) 2021-2025 Valve Corporation
+ * Copyright (c) 2021-2025 LunarG, Inc.
+ * Copyright (C) 2021-2025 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,7 +57,11 @@ struct Location {
           debug_region(&debug_region) {}
 
     void AppendFields(std::ostream &out) const;
+
+    // Returns concatenated fields, does not include function part.
     std::string Fields() const;
+
+    // Returns location representation as it appears in the error message. Used by the LogError().
     std::string Message() const;
 
     // the dot() method is for walking down into a structure that is being validated

--- a/layers/sync/sync_error_messages.cpp
+++ b/layers/sync/sync_error_messages.cpp
@@ -183,16 +183,18 @@ void ErrorMessages::AddCbContextExtraProperties(const CommandBufferAccessContext
 
 std::string ErrorMessages::Error(const HazardResult& hazard, const std::string& resouce_description,
                                  const CommandBufferAccessContext& cb_context, vvl::Func command) const {
-    const auto format = "Hazard %s for %s. Access info %s.";
     ReportKeyValues key_values;
+    cb_context.FormatHazard(hazard, key_values);
+    key_values.Add(kPropertyMessageType, "GeneralError");
+    key_values.Add(kPropertyHazardType, string_SyncHazard(hazard.Hazard()));
+    key_values.Add(kPropertyCommand, vvl::String(command));
+    AddCbContextExtraProperties(cb_context, hazard.Tag(), key_values);
 
-    const std::string access_info = cb_context.FormatHazard(hazard, key_values);
-    std::string message = Format(format, string_SyncHazard(hazard.Hazard()), resouce_description.c_str(), access_info.c_str());
+    std::stringstream ss;
+    FormatCommonMessage(hazard, resouce_description, command, key_values, cb_context, ss);
+
+    std::string message = ss.str();
     if (extra_properties_) {
-        key_values.Add(kPropertyMessageType, "GeneralError");
-        key_values.Add(kPropertyHazardType, string_SyncHazard(hazard.Hazard()));
-        key_values.Add(kPropertyCommand, vvl::String(command));
-        AddCbContextExtraProperties(cb_context, hazard.Tag(), key_values);
         message += key_values.GetExtraPropertiesSection(pretty_print_extra_);
     }
     return message;

--- a/layers/sync/sync_error_messages.cpp
+++ b/layers/sync/sync_error_messages.cpp
@@ -192,7 +192,11 @@ std::string ErrorMessages::BufferRegionError(const HazardResult& hazard, VkBuffe
         ss << "No sufficient synchronization is present to ensure that a " << access_type << " (";
         ss << string_VkAccessFlagBits2(access.access_mask) << ") at ";
         ss << string_VkPipelineStageFlagBits2(access.stage_mask) << " does not conflict with a prior ";
-        ss << prior_access_type << " (" << string_VkAccessFlags2(prior_access.access_mask) << ") at ";
+        ss << prior_access_type;
+        if (prior_access.access_mask != access.access_mask) {
+            ss << " (" << string_VkAccessFlags2(prior_access.access_mask) << ")";
+        }
+        ss << " at ";
         if (prior_access.stage_mask == access.stage_mask) {
             ss << "the same stage.";
         } else {
@@ -217,14 +221,14 @@ std::string ErrorMessages::BufferRegionError(const HazardResult& hazard, VkBuffe
         ss << string_VkPipelineStageFlagBits2(access.stage_mask) << ".";
     }
 
-    // Copy region information
-    ss << " Hazardous copy region: " << region_index << " (offset = " << region_range.begin;
-    ss << ", size = " << region_range.end - region_range.begin << ").";
-
     // Give a hint for WAR hazard
     if (IsValueIn(hazard_type, {WRITE_AFTER_READ, WRITE_RACING_READ, PRESENT_AFTER_READ})) {
         ss << " An execution dependency is sufficient to prevent this hazard.";
     }
+
+    // Copy region information
+    ss << " Hazardous copy region: " << region_index << " (offset = " << region_range.begin;
+    ss << ", size = " << region_range.end - region_range.begin << ").";
 
     std::string message = ss.str();
     if (extra_properties_) {

--- a/layers/sync/sync_error_messages.h
+++ b/layers/sync/sync_error_messages.h
@@ -39,13 +39,13 @@ class ErrorMessages {
   public:
     explicit ErrorMessages(vvl::Device& validator);
 
-    std::string Error(const HazardResult& hazard, const char* description, const CommandBufferAccessContext& cb_context,
-                      vvl::Func command) const;
+    std::string Error(const HazardResult& hazard, const std::string& resouce_description,
+                      const CommandBufferAccessContext& cb_context, vvl::Func command) const;
 
     std::string BufferError(const HazardResult& hazard, VkBuffer buffer, const char* buffer_description,
                             const CommandBufferAccessContext& cb_context, vvl::Func command) const;
 
-    std::string BufferRegionError(const HazardResult& hazard, VkBuffer buffer, uint32_t region_index,
+    std::string BufferRegionError(const HazardResult& hazard, const std::string& resouce_description, uint32_t region_index,
                                   ResourceAccessRange region_range, const CommandBufferAccessContext& cb_context,
                                   const vvl::Func command) const;
 

--- a/layers/sync/sync_reporting.cpp
+++ b/layers/sync/sync_reporting.cpp
@@ -18,6 +18,24 @@
 #include "sync/sync_reporting.h"
 #include "sync/sync_image.h"
 #include "sync/sync_validation.h"
+#include "error_message/error_strings.h"
+
+void FormatVideoPictureResouce(const Logger &logger, const VkVideoPictureResourceInfoKHR &video_picture, std::stringstream &ss) {
+    ss << "{";
+    ss << logger.FormatHandle(video_picture.imageViewBinding);
+    ss << ", codedOffset (" << string_VkOffset2D(video_picture.codedOffset) << ")";
+    ss << ", codedExtent (" << string_VkExtent2D(video_picture.codedExtent) << ")";
+    ss << ", baseArrayLayer = " << video_picture.baseArrayLayer;
+    ss << "}";
+}
+
+void FormatVideoQuantizationMap(const Logger &logger, const VkVideoEncodeQuantizationMapInfoKHR &quantization_map,
+                                std::stringstream &ss) {
+    ss << "{";
+    ss << logger.FormatHandle(quantization_map.quantizationMap);
+    ss << ", quantizationMapExtent (" << string_VkExtent2D(quantization_map.quantizationMapExtent) << ")";
+    ss << "}";
+}
 
 SyncNodeFormatter::SyncNodeFormatter(const SyncValidator &sync_state, const vvl::CommandBuffer *cb_state)
     : debug_report(sync_state.debug_report), node(cb_state), label("command_buffer") {}

--- a/layers/sync/sync_reporting.h
+++ b/layers/sync/sync_reporting.h
@@ -26,10 +26,15 @@ class StateObject;
 class Image;
 class Queue;
 }  // namespace vvl
+class Logger;
 class DebugReport;
 class SyncValidator;
 struct DeviceFeatures;
 struct DeviceExtensions;
+
+void FormatVideoPictureResouce(const Logger &logger, const VkVideoPictureResourceInfoKHR &video_picture, std::stringstream &ss);
+void FormatVideoQuantizationMap(const Logger &logger, const VkVideoEncodeQuantizationMapInfoKHR &quantization_map,
+                                std::stringstream &ss);
 
 struct SyncNodeFormatter {
     const DebugReport *debug_report;

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -364,8 +364,8 @@ bool SyncValidator::PreCallValidateCmdCopyBuffer(VkCommandBuffer commandBuffer, 
             auto hazard = context->DetectHazard(*src_buffer, SYNC_COPY_TRANSFER_READ, src_range);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, srcBuffer);
-                const auto error = error_messages_.BufferRegionError(hazard, srcBuffer, region_index, src_range, *cb_context,
-                                                                     error_obj.location.function);
+                const auto error = error_messages_.BufferRegionError(hazard, FormatHandle(srcBuffer), region_index, src_range,
+                                                                     *cb_context, error_obj.location.function);
                 skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
             }
         }
@@ -374,8 +374,8 @@ bool SyncValidator::PreCallValidateCmdCopyBuffer(VkCommandBuffer commandBuffer, 
             auto hazard = context->DetectHazard(*dst_buffer, SYNC_COPY_TRANSFER_WRITE, dst_range);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, dstBuffer);
-                const auto error = error_messages_.BufferRegionError(hazard, dstBuffer, region_index, dst_range, *cb_context,
-                                                                     error_obj.location.function);
+                const auto error = error_messages_.BufferRegionError(hazard, FormatHandle(dstBuffer), region_index, dst_range,
+                                                                     *cb_context, error_obj.location.function);
                 skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
             }
         }
@@ -433,8 +433,8 @@ bool SyncValidator::PreCallValidateCmdCopyBuffer2(VkCommandBuffer commandBuffer,
                 // TODO -- add tag information to log msg when useful.
                 // TODO: there are no tests for this error
                 const LogObjectList objlist(commandBuffer, pCopyBufferInfo->srcBuffer);
-                const auto error = error_messages_.BufferRegionError(hazard, pCopyBufferInfo->srcBuffer, region_index, src_range,
-                                                                     *cb_context, error_obj.location.function);
+                const auto error = error_messages_.BufferRegionError(hazard, FormatHandle(pCopyBufferInfo->srcBuffer), region_index,
+                                                                     src_range, *cb_context, error_obj.location.function);
                 skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
             }
         }
@@ -444,8 +444,8 @@ bool SyncValidator::PreCallValidateCmdCopyBuffer2(VkCommandBuffer commandBuffer,
             if (hazard.IsHazard()) {
                 // TODO: there are no tests for this error
                 const LogObjectList objlist(commandBuffer, pCopyBufferInfo->dstBuffer);
-                const auto error = error_messages_.BufferRegionError(hazard, pCopyBufferInfo->dstBuffer, region_index, dst_range,
-                                                                     *cb_context, error_obj.location.function);
+                const auto error = error_messages_.BufferRegionError(hazard, FormatHandle(pCopyBufferInfo->dstBuffer), region_index,
+                                                                     dst_range, *cb_context, error_obj.location.function);
                 skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
             }
         }
@@ -1079,7 +1079,7 @@ bool SyncValidator::ValidateCmdCopyBufferToImage(VkCommandBuffer commandBuffer, 
                 if (hazard.IsHazard()) {
                     // PHASE1 TODO -- add tag information to log msg when useful.
                     const LogObjectList objlist(commandBuffer, srcBuffer);
-                    const auto error = error_messages_.BufferRegionError(hazard, srcBuffer, region_index, src_range,
+                    const auto error = error_messages_.BufferRegionError(hazard, FormatHandle(srcBuffer), region_index, src_range,
                                                                          *cb_access_context, loc.function);
                     skip |= SyncError(hazard.Hazard(), objlist, loc, error);
                 }
@@ -1215,7 +1215,7 @@ bool SyncValidator::ValidateCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, 
                 hazard = context->DetectHazard(*dst_buffer, SYNC_COPY_TRANSFER_WRITE, dst_range);
                 if (hazard.IsHazard()) {
                     const LogObjectList objlist(commandBuffer, dstBuffer);
-                    const auto error = error_messages_.BufferRegionError(hazard, dstBuffer, region_index, dst_range,
+                    const auto error = error_messages_.BufferRegionError(hazard, FormatHandle(dstBuffer), region_index, dst_range,
                                                                          *cb_access_context, loc.function);
                     skip |= SyncError(hazard.Hazard(), objlist, loc, error);
                 }


### PR DESCRIPTION
* Extracted formatting code that potentially can be used in many error messages.
* Update some of the video error messages to use this shared helper (video tests use the most general `ErrorMessages::Error` message type and it was the simplest place to start).

OLD:
> vkCmdEncodeVideoKHR(): pEncodeInfo->pSetupReferenceSlot->pPictureResource Hazard WRITE_AFTER_READ for reconstructed picture. Access info (usage: SYNC_VIDEO_ENCODE_VIDEO_ENCODE_WRITE, prior_usage: SYNC_VIDEO_ENCODE_VIDEO_ENCODE_READ, read_barriers: VkPipelineStageFlags2(0), command: vkCmdEncodeVideoKHR).

NEW:
> vkCmdEncodeVideoKHR(): WRITE_AFTER_READ hazard detected. vkCmdEncodeVideoKHR writes to reconstructed picture pEncodeInfo->pSetupReferenceSlot->pPictureResource {VkImageView 0xd5b26f0000000010[], codedOffset (x = 0, y = 0), codedExtent (width = 160, height = 64), baseArrayLayer = 0}, which was previously read by another vkCmdEncodeVideoKHR command. No sufficient synchronization is present to ensure that a write (VK_ACCESS_2_VIDEO_ENCODE_WRITE_BIT_KHR) at VK_PIPELINE_STAGE_2_VIDEO_ENCODE_BIT_KHR does not conflict with a prior read (VK_ACCESS_2_VIDEO_ENCODE_READ_BIT_KHR) at the same stage. An execution dependency is sufficient to prevent this hazard.

