### PR TITLE
sync: Replace VideoReferencePictureError with general Error

### DIFF
--- a/layers/sync/sync_error_messages.cpp
+++ b/layers/sync/sync_error_messages.cpp
@@ -837,22 +837,4 @@ std::string ErrorMessages::PresentError(const HazardResult& hazard, const QueueB
     return message;
 }
 
-std::string ErrorMessages::VideoReferencePictureError(const HazardResult& hazard, uint32_t reference_picture_index,
-                                                      const CommandBufferAccessContext& cb_context, vvl::Func command) const {
-    const auto format = "Hazard %s for reference picture #%u. Access info %s.";
-    ReportKeyValues key_values;
-
-    const std::string access_info = cb_context.FormatHazard(hazard, key_values);
-    std::string message = Format(format, string_SyncHazard(hazard.Hazard()), reference_picture_index, access_info.c_str());
-
-    if (extra_properties_) {
-        key_values.Add(kPropertyMessageType, "VideoReferencePictureError");
-        key_values.Add(kPropertyHazardType, string_SyncHazard(hazard.Hazard()));
-        key_values.Add(kPropertyCommand, vvl::String(command));
-        AddCbContextExtraProperties(cb_context, hazard.Tag(), key_values);
-        message += key_values.GetExtraPropertiesSection(pretty_print_extra_);
-    }
-    return message;
-}
-
 }  // namespace syncval

--- a/layers/sync/sync_error_messages.h
+++ b/layers/sync/sync_error_messages.h
@@ -151,9 +151,6 @@ class ErrorMessages {
                              const VulkanTypedHandle& swapchain_handle, uint32_t image_index, const VulkanTypedHandle& image_handle,
                              vvl::Func command) const;
 
-    std::string VideoReferencePictureError(const HazardResult& hazard, uint32_t reference_picture_index,
-                                           const CommandBufferAccessContext& cb_context, vvl::Func command) const;
-
   private:
     void AddCbContextExtraProperties(const CommandBufferAccessContext& cb_context, ResourceUsageTag tag,
                                      ReportKeyValues& key_values) const;


### PR DESCRIPTION
Initial categorization of message types was done based on pattern matching message code. Now, going over errors one by one, some things can be unified further.