### PR TITLE
sync: Validate destination acceleration structure build

### DIFF
--- a/layers/sync/sync_error_messages.cpp
+++ b/layers/sync/sync_error_messages.cpp
@@ -109,11 +109,15 @@ static void FormatCommonMessage(const HazardResult& hazard, const std::string& r
     const bool missing_synchronization = (hazard_info.IsPriorWrite() && write_barriers.none()) ||
                                          (hazard_info.IsPriorRead() && read_barriers == VK_PIPELINE_STAGE_2_NONE);
 
+    // TODO: collect more use cases and generalize if needed
+    bool use_and_conjunction = command == vvl::Func::vkCmdBuildAccelerationStructuresKHR;
+
     // Brief description of what happened
     ss << string_SyncHazard(hazard_type) << " hazard detected. ";
     ss << vvl::String(command);
     ss << (hazard_info.IsWrite() ? " writes to " : " reads ") << resouce_description;
-    ss << (hazard_info.IsRacingHazard() ? ", which is being " : ", which was previously ");
+    ss << (use_and_conjunction ? " and " : ", which ");
+    ss << (hazard_info.IsRacingHazard() ? "is being " : "was previously ");
     ss << (hazard_info.IsPriorWrite() ? "written by " : "read by ");
     if (usage_info.command == command) {
         ss << "another " << vvl::String(usage_info.command) << " command";

--- a/tests/framework/ray_tracing_objects.cpp
+++ b/tests/framework/ray_tracing_objects.cpp
@@ -334,7 +334,7 @@ void AccelerationStructureKHR::Build() {
         VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
         alloc_flags.flags = buffer_memory_allocate_flags_;
         VkBufferCreateInfo ci = vku::InitStructHelper();
-        ci.size = vk_info_.size;
+        ci.size = vk_info_.offset + vk_info_.size;
         ci.usage = buffer_usage_flags_;
         if (buffer_init_no_mem_) {
             device_buffer_.InitNoMemory(*device_, ci);

--- a/tests/unit/sync_val_ray_tracing_positive.cpp
+++ b/tests/unit/sync_val_ray_tracing_positive.cpp
@@ -30,3 +30,55 @@ TEST_F(PositiveSyncValRayTracing, BuildAccelerationStructure) {
     blas.BuildCmdBuffer(m_command_buffer);
     m_command_buffer.End();
 }
+
+TEST_F(PositiveSyncValRayTracing, WriteToAccelerationStructureBuffer) {
+    TEST_DESCRIPTION("Write to a vacant region of acceleration structure buffer during acceleration structure build");
+    RETURN_IF_SKIP(InitRayTracing());
+
+    vkt::as::BuildGeometryInfoKHR blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
+    blas.GetDstAS()->SetBufferUsageFlags(VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR | VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+    // Reserve initial buffer region for non-acceleration-structure business.
+    // Acceleration structure contents start after it.
+    blas.GetDstAS()->SetOffset(256);
+    blas.SetupBuild(true);
+    const vkt::Buffer& accel_buffer = blas.GetDstAS()->GetBuffer();
+
+    m_command_buffer.Begin();
+    blas.VkCmdBuildAccelerationStructuresKHR(m_command_buffer);
+    // Write the answer into the first 4 bytes.
+    // This should not interfere with acceleration structure build accesses
+    vk::CmdFillBuffer(m_command_buffer, accel_buffer, 0, 4, 0x42);
+    m_command_buffer.End();
+}
+
+TEST_F(PositiveSyncValRayTracing, BuildAccelerationStructureThenBarrier) {
+    TEST_DESCRIPTION("Use barrier to wait for acceleration structure accesses");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(InitRayTracing());
+
+    vkt::as::BuildGeometryInfoKHR blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
+    blas.GetDstAS()->SetBufferUsageFlags(VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR | VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+    blas.SetupBuild(true);
+
+    const vkt::Buffer& accel_buffer = blas.GetDstAS()->GetBuffer();
+
+    VkBufferMemoryBarrier2 barrier = vku::InitStructHelper();
+    barrier.srcStageMask = VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR;
+    barrier.srcAccessMask = VK_ACCESS_2_ACCELERATION_STRUCTURE_READ_BIT_KHR | VK_ACCESS_2_ACCELERATION_STRUCTURE_WRITE_BIT_KHR;
+    barrier.dstStageMask = VK_PIPELINE_STAGE_2_CLEAR_BIT;
+    barrier.dstAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
+    barrier.buffer = accel_buffer;
+    barrier.offset = 0;
+    barrier.size = 4;
+
+    VkDependencyInfo dep_info = vku::InitStructHelper();
+    dep_info.bufferMemoryBarrierCount = 1;
+    dep_info.pBufferMemoryBarriers = &barrier;
+
+    m_command_buffer.Begin();
+    blas.VkCmdBuildAccelerationStructuresKHR(m_command_buffer);
+    vk::CmdPipelineBarrier2(m_command_buffer, &dep_info);
+    vk::CmdFillBuffer(m_command_buffer, accel_buffer, 0, 4, 0x80386);
+    m_command_buffer.End();
+}


### PR DESCRIPTION
> vkCmdBuildAccelerationStructuresKHR(): WRITE_AFTER_READ hazard detected. vkCmdBuildAccelerationStructuresKHR writes to VkBuffer 0xcfef35000000000a[], which backs VkAccelerationStructureKHR 0xe88693000000000c[] and was previously read by vkCmdCopyBuffer. No sufficient synchronization is present to ensure that a write (VK_ACCESS_2_ACCELERATION_STRUCTURE_WRITE_BIT_KHR) at VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR does not conflict with a prior read (VK_ACCESS_2_TRANSFER_READ_BIT) at VK_PIPELINE_STAGE_2_COPY_BIT. An execution dependency is sufficient to prevent this hazard. Buffer access region: (offset = 0, size = 2304).