### PR TITLE
sync: Validate source acceleration structure

### DIFF
--- a/layers/sync/sync_error_messages.h
+++ b/layers/sync/sync_error_messages.h
@@ -36,16 +36,22 @@ class Pipeline;
 
 namespace syncval {
 
+struct AdditionalMessageInfo {
+    ReportKeyValues properties;
+    std::string pre_synchronization_text;
+    std::string message_end_text;
+};
+
 class ErrorMessages {
   public:
     explicit ErrorMessages(vvl::Device& validator);
 
     std::string Error(const HazardResult& hazard, const CommandBufferAccessContext& cb_context, vvl::Func command,
-                      const std::string& resouce_description, const std::string& additional_information = {},
-                      const ReportKeyValues& additional_properties = {}) const;
+                      const std::string& resouce_description, const AdditionalMessageInfo& additional_info = {}) const;
 
     std::string BufferError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context, vvl::Func command,
-                            const std::string& resource_description, const ResourceAccessRange range) const;
+                            const std::string& resource_description, const ResourceAccessRange range,
+                            AdditionalMessageInfo additional_info = {}) const;
 
     std::string BufferRegionError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context, const vvl::Func command,
                                   const std::string& resouce_description, uint32_t region_index,


### PR DESCRIPTION
Some improvements to sync messages plus validation of *source* acceleration structure in the acceleration structure update operation. Complains like this:
> vkCmdBuildAccelerationStructuresKHR(): READ_AFTER_WRITE hazard detected. vkCmdBuildAccelerationStructuresKHR reads VkBuffer 0xcfef35000000000a[] (srcAccelerationStructure), which was previously written by another vkCmdBuildAccelerationStructuresKHR command. The buffer backs VkAccelerationStructureKHR 0xe88693000000000c[]. No sufficient synchronization is present to ensure that a read (VK_ACCESS_2_ACCELERATION_STRUCTURE_READ_BIT_KHR) at VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR does not conflict with a prior write (VK_ACCESS_2_ACCELERATION_STRUCTURE_WRITE_BIT_KHR) at the same stage. Buffer access region: (offset = 0, size = 2944).
