### PR TITLE
layers: Check if pSetupReferenceSlot is NULL for 0752.

### DIFF
--- a/layers/core_checks/cc_video.cpp
+++ b/layers/core_checks/cc_video.cpp
@@ -5111,7 +5111,7 @@ bool CoreChecks::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuffer,
                              FormatHandle(dst_resource.image_state->Handle()).c_str(), FormatHandle(*vs_state).c_str());
         }
 
-        bool dst_same_as_setup = (setup_resource == dst_resource);
+        bool dst_same_as_setup = (setup_resource == dst_resource) || !setup_resource;
 
         VkImageLayout expected_layout =
             dst_same_as_setup ? VK_IMAGE_LAYOUT_VIDEO_DECODE_DPB_KHR : VK_IMAGE_LAYOUT_VIDEO_DECODE_DST_KHR;


### PR DESCRIPTION
The Spec says:

 ```
 If pDecodeInfo->pSetupReferenceSlot is NULL or pDecodeInfo->pSetupReferenceSlot->pPictureResource 
does not refer to the same image subresource as pDecodeInfo->dstPictureResource, then the image subresource
referred to by pDecodeInfo->dstPictureResource must be in the VK_IMAGE_LAYOUT_VIDEO_DECODE_DST_KHR layout
at the time the video decode operation is executed on the device 
(https://docs.vulkan.org/spec/latest/chapters/videocoding.html#VUID-vkCmdDecodeVideoKHR-pDecodeInfo-07252)

```

I found when testing ANV.
This causes a false alarm on ANV, which supports VK_VIDEO_DECODE_CAPABILITY_DPB_AND_OUTPUT_COINCIDE_BIT_KHR.