### PR TITLE
sync: Fix separator in access string

### DIFF
--- a/layers/sync/sync_reporting.cpp
+++ b/layers/sync/sync_reporting.cpp
@@ -372,7 +372,7 @@ std::string FormatSyncAccesses(const SyncAccessFlags &sync_accesses, VkQueueFlag
     bool first = true;
     for (const auto &[stages, accesses] : report_accesses) {
         if (!first) {
-            out << ":";
+            out << (format_as_extra_property ? ":" : ", ");
         }
         if (format_as_extra_property) {
             if (accesses == sync_utils::kAllAccesses) {


### PR DESCRIPTION
The separator is used when the barrier protects accesses on multiple stages.

The ":" separator is used in the extra properties format (no spaces), but for regular message it should be a user-friendly separator (comma).

Regular message (fixed by this PR):
`ACCESS_SHADER_READ|ACCESS_SHADER_WRITE` accesses at `STAGE_VERTEX_SHADER`, `ACCESS_TRANFER_WRITE` accesses at `STAGE_COPY`

Property:
`STAGE_VERTEX_SHADER(ACCESS_SHADER_READ|ACCESS_SHADER_WRITE):STAGE_COPY(ACCESS_TRANFER_WRITE)`

Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9432


