### PR TITLE
layers: Fix semaphore handling for Fuchsia

### DIFF
--- a/layers/core_checks/cc_external_object.cpp
+++ b/layers/core_checks/cc_external_object.cpp
@@ -320,7 +320,8 @@ void CoreChecks::PostCallRecordGetSemaphoreZirconHandleFUCHSIA(VkDevice device,
                                                                const VkSemaphoreGetZirconHandleInfoFUCHSIA *pGetZirconHandleInfo,
                                                                zx_handle_t *pZirconHandle, const RecordObject &record_obj) {
     if (VK_SUCCESS != record_obj.result) return;
-    RecordGetExternalSemaphoreState(pGetZirconHandleInfo->semaphore, pGetZirconHandleInfo->handleType);
+    auto semaphore_state = Get<vvl::Semaphore>(pGetZirconHandleInfo->semaphore);
+    RecordGetExternalSemaphoreState(*semaphore_state, pGetZirconHandleInfo->handleType);
 }
 #endif
 


### PR DESCRIPTION
This applies changes in #6910 to Fuchsia-specific code for VkSemaphoreGetZirconHandleInfoFUCHSIA.

Test: Vulkan-ValidationLayer v1.4.304.1 with this patch builds on Fuchsia tip-of-tree.
Bug: https://g-issues.fuchsia.dev/issues/378964821
