### PR TITLE
gn: Remove unsupported files for Fuchsia

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -443,6 +443,16 @@ vvl_sources = [
   "layers/vulkan/generated/vk_validation_error_messages.h",
 ]
 
+if (is_fuchsia) {
+  # TODO(https://fxbug.dev/396761837): vk_function_pointers is not yet
+  # supported on Fuchsia. We can skip building it as it is only used
+  # in tests.
+  vvl_sources -= [
+    "layers/vulkan/generated/vk_function_pointers.cpp",
+    "layers/vulkan/generated/vk_function_pointers.h",
+  ]
+}
+
 layers = [ [
       "khronos_validation",
       vvl_sources,


### PR DESCRIPTION
vk_function_pointers.{cpp,h} is not supported on Fuchsia yet. Since this is only used in tests and we don't yet build Validation Layers tests on Fuchsia, it's okay to skip these files when building the validation layer library.

Test: Vulkan-ValidationLayers v1.4.304.1 with this change builds on Fuchsia tip-of-tree.

Bug: https://fxbug.dev/378964821
