### PR TITLE
state: Support VkSemaphores imported with Zircon handles

### DIFF
--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -3385,6 +3385,25 @@ void Device::PostCallRecordGetFenceWin32HandleKHR(VkDevice device, const VkFence
 }
 #endif
 
+#ifdef VK_USE_PLATFORM_FUCHSIA
+void Device::PostCallRecordImportSemaphoreZirconHandleFUCHSIA(
+    VkDevice device, const VkImportSemaphoreZirconHandleInfoFUCHSIA *pImportSemaphoreZirconHandleInfo,
+    const RecordObject &record_obj) {
+    if (VK_SUCCESS != record_obj.result) return;
+    RecordImportSemaphoreState(pImportSemaphoreZirconHandleInfo->semaphore, pImportSemaphoreZirconHandleInfo->handleType,
+                               pImportSemaphoreZirconHandleInfo->flags);
+}
+
+void Device::PostCallRecordGetSemaphoreZirconHandleFUCHSIA(VkDevice device,
+                                                           const VkSemaphoreGetZirconHandleInfoFUCHSIA *pGetZirconHandleInfo,
+                                                           zx_handle_t *pZirconHandle, const RecordObject &record_obj) {
+    if (VK_SUCCESS != record_obj.result) return;
+    if (auto semaphore_state = Get<vvl::Semaphore>(pGetZirconHandleInfo->semaphore)) {
+        RecordGetExternalSemaphoreState(*semaphore_state, pGetZirconHandleInfo->handleType);
+    }
+}
+#endif  // VK_USE_PLATFORM_FUCHSIA
+
 void Device::PostCallRecordGetSemaphoreFdKHR(VkDevice device, const VkSemaphoreGetFdInfoKHR *pGetFdInfo, int *pFd,
                                              const RecordObject &record_obj) {
     if (VK_SUCCESS != record_obj.result) return;

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -688,6 +688,11 @@ class Device : public vvl::base::Device {
     void PostCallRecordGetSemaphoreWin32HandleKHR(VkDevice device, const VkSemaphoreGetWin32HandleInfoKHR* pGetWin32HandleInfo,
                                                   HANDLE* pHandle, const RecordObject& record_obj) override;
 #endif  // VK_USE_PLATFORM_WIN32_KHR
+#ifdef VK_USE_PLATFORM_FUCHSIA
+    void PostCallRecordGetSemaphoreZirconHandleFUCHSIA(VkDevice device,
+                                                       const VkSemaphoreGetZirconHandleInfoFUCHSIA* pGetZirconHandleInfo,
+                                                       zx_handle_t* pZirconHandle, const RecordObject& record_obj) override;
+#endif  // VK_USE_PLATFORM_FUCHSIA
 #ifdef VK_USE_PLATFORM_WIN32_KHR
     void PostCallRecordGetMemoryWin32HandleKHR(VkDevice device, const VkMemoryGetWin32HandleInfoKHR* pGetWin32HandleInfo,
                                                HANDLE* pHandle, const RecordObject& record_obj) override;
@@ -708,6 +713,11 @@ class Device : public vvl::base::Device {
                                                      const VkImportSemaphoreWin32HandleInfoKHR* pImportSemaphoreWin32HandleInfo,
                                                      const RecordObject& record_obj) override;
 #endif  // VK_USE_PLATFORM_WIN32_KHR
+#ifdef VK_USE_PLATFORM_FUCHSIA
+    void PostCallRecordImportSemaphoreZirconHandleFUCHSIA(
+        VkDevice device, const VkImportSemaphoreZirconHandleInfoFUCHSIA* pImportSemaphoreZirconHandleInfo,
+        const RecordObject& record_obj) override;
+#endif  // VK_USE_PLATFORM_FUCHSIA
     void PreCallRecordSignalSemaphoreKHR(VkDevice device, const VkSemaphoreSignalInfo* pSignalInfo,
                                          const RecordObject& record_obj) override;
     void PreCallRecordSignalSemaphore(VkDevice device, const VkSemaphoreSignalInfo* pSignalInfo,


### PR DESCRIPTION
This adds support for vkImportSemaphoreZirconHandleFUCHSIA() and vkGetSemaphoreZirconHandleFUCHSIA() to state_tracker. The logic is similar to fd and win32 handles.

Bug: https://fxbug.dev/379153784
Test: Fuchsia image-pipe-swapchain-test [1] passed with Vulkan- ValidationLayers vulkan-sdk-1.4.304.1 patched with this change.

[1] https://cs.opensource.google/fuchsia/fuchsia/+/main:src/lib/vulkan/tests/test_swapchain.cc
