### PR TITLE
layers: Add more deprecated VUIDs

### DIFF
--- a/layers/error_message/unimplementable_validation.h
+++ b/layers/error_message/unimplementable_validation.h
@@ -538,7 +538,7 @@ const char* unimplementable_validation[] = {
     "VUID-VkVideoEncodeAV1SessionParametersCreateInfoKHR-pStdDecoderModelInfo-parameter",
     "VUID-VkVideoEncodeAV1SessionParametersCreateInfoKHR-pStdOperatingPoints-parameter",
 
-    // Acceleration structure replay related, 
+    // Acceleration structure replay related,
     // but VVL has no way of tracking needed info (typically stored offline)
     "VUID-VkAccelerationStructureCreateInfoKHR-deviceAddress-09488"
     "VUID-VkAccelerationStructureCreateInfoKHR-deviceAddress-09489"
@@ -560,6 +560,28 @@ const char* deprecated_validation[] = {
     "VUID-VkAccelerationStructureTrianglesDisplacementMicromapNV-micromap-parameter",
     "VUID-VkBindIndexBufferIndirectCommandNV-indexType-parameter",
     "VUID-VkAccelerationStructureMotionInstanceNV-srtMotionInstance-parameter",
+    "VUID-RuntimeSpirv-OpTraceRayKHR-06360",
+    "VUID-RuntimeSpirv-OpRayQueryGenerateIntersectionKHR-06354",
+    "VUID-RuntimeSpirv-OpTraceRayMotionNV-06361",
+    "VUID-RuntimeSpirv-OpTraceRayMotionNV-06362",
+    "VUID-RuntimeSpirv-OpTraceRayMotionNV-06363",
+    "VUID-RuntimeSpirv-OpTraceRayMotionNV-06364",
+    "VUID-RuntimeSpirv-OpTraceRayMotionNV-06365",
+    "VUID-RuntimeSpirv-OpTraceRayMotionNV-06366",
+    "VUID-RuntimeSpirv-OpTraceRayMotionNV-06367",
+    "VUID-RuntimeSpirv-OpHitObjectTraceRayMotionNV-07704",
+    "VUID-RuntimeSpirv-OpHitObjectTraceRayNV-07705",
+    "VUID-RuntimeSpirv-OpHitObjectTraceRayNV-07706",
+    "VUID-RuntimeSpirv-OpHitObjectTraceRayNV-07707",
+    "VUID-RuntimeSpirv-OpHitObjectTraceRayNV-07708",
+    "VUID-RuntimeSpirv-OpHitObjectTraceRayMotionNV-07709",
+    "VUID-RuntimeSpirv-OpHitObjectTraceRayNV-07710",
+    "VUID-RuntimeSpirv-OpHitObjectTraceRayMotionNV-07711",
+    "VUID-RuntimeSpirv-OpHitObjectTraceRayNV-07712",
+    "VUID-RuntimeSpirv-OpHitObjectTraceRayNV-07713",
+    "VUID-RuntimeSpirv-OpHitObjectTraceRayNV-07714",
+    "VUID-RuntimeSpirv-OpHitObjectTraceRayNV-07715",
+    "VUID-RuntimeSpirv-OpHitObjectTraceRayNV-07716",
 };
 
 // clang-format on


### PR DESCRIPTION
Some `RuntimeSpirv` VUs that are not going to be added