### PR TITLE
scripts: Move CompatibleSpirvImageFormat out of core checks

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -415,6 +415,7 @@ vvl_sources = [
   "layers/vulkan/generated/spirv_grammar_helper.h",
   "layers/vulkan/generated/spirv_tools_commit_id.h",
   "layers/vulkan/generated/spirv_validation_helper.cpp",
+  "layers/vulkan/generated/spirv_validation_helper.h",
   "layers/vulkan/generated/stateless_device_methods.h",
   "layers/vulkan/generated/stateless_instance_methods.h",
   "layers/vulkan/generated/stateless_validation_helper.cpp",

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -217,6 +217,7 @@ target_sources(vvl PRIVATE
     ${API_TYPE}/generated/object_tracker_instance_methods.h
     ${API_TYPE}/generated/spirv_grammar_helper.cpp
     ${API_TYPE}/generated/spirv_validation_helper.cpp
+    ${API_TYPE}/generated/spirv_validation_helper.h
     ${API_TYPE}/generated/stateless_device_methods.h
     ${API_TYPE}/generated/stateless_instance_methods.h
     ${API_TYPE}/generated/stateless_validation_helper.cpp

--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -29,6 +29,7 @@
 #include "core_checks/cc_vuid_maps.h"
 #include "core_validation.h"
 #include "generated/spirv_grammar_helper.h"
+#include "generated/spirv_validation_helper.h"
 #include "state_tracker/shader_instruction.h"
 #include "state_tracker/shader_stage_state.h"
 #include "utils/hash_util.h"

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -857,7 +857,6 @@ class CoreChecks : public vvl::Device {
 
     // Auto-generated helper functions
     bool ValidateShaderCapabilitiesAndExtensions(const spirv::Instruction& insn, const Location& loc) const;
-    VkFormat CompatibleSpirvImageFormat(uint32_t spirv_image_format) const;
 
     bool ValidateShaderStageInputOutputLimits(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
                                               const spirv::StatelessData& stateless_data, const Location& loc) const;

--- a/layers/vulkan/generated/spirv_validation_helper.cpp
+++ b/layers/vulkan/generated/spirv_validation_helper.cpp
@@ -3,7 +3,7 @@
 
 /***************************************************************************
  *
- * Copyright (c) 2020-2024 The Khronos Group Inc.
+ * Copyright (c) 2020-2025 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,9 @@
  * to SPIR-V. Anything related to the SPIR-V grammar belongs in spirv_grammar_helper
  *
  ****************************************************************************/
+
 // NOLINTBEGIN
+
 #include <string>
 #include <string_view>
 #include <functional>
@@ -787,10 +789,10 @@ static inline const char *string_SpvCapability(uint32_t input_value) {
 }
 
 // Will return the Vulkan format for a given SPIR-V image format value
-// Note: will return VK_FORMAT_UNDEFINED if non valid input
+// Note: will return VK_FORMAT_UNDEFINED if non valid input (or if ImageFormatUnknown)
 // This was in vk_format_utils but the SPIR-V Header dependency was an issue
 //   see https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/4647
-VkFormat CoreChecks::CompatibleSpirvImageFormat(uint32_t spirv_image_format) const {
+VkFormat CompatibleSpirvImageFormat(uint32_t spirv_image_format) {
     switch (spirv_image_format) {
         case spv::ImageFormatR8:
             return VK_FORMAT_R8_UNORM;
@@ -1324,4 +1326,5 @@ bool CoreChecks::ValidateShaderCapabilitiesAndExtensions(const spirv::Instructio
     }  // spv::OpExtension
     return skip;
 }
+
 // NOLINTEND

--- a/layers/vulkan/generated/spirv_validation_helper.h
+++ b/layers/vulkan/generated/spirv_validation_helper.h
@@ -1,0 +1,33 @@
+// *** THIS FILE IS GENERATED - DO NOT EDIT ***
+// See spirv_validation_generator.py for modifications
+
+/***************************************************************************
+ *
+ * Copyright (c) 2020-2025 The Khronos Group Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This file is related to anything that is found in the Vulkan XML related
+ * to SPIR-V. Anything related to the SPIR-V grammar belongs in spirv_grammar_helper
+ *
+ ****************************************************************************/
+
+// NOLINTBEGIN
+
+#pragma once
+#include <vulkan/vulkan_core.h>
+
+// This is the one function that requires mapping SPIR-V enums to Vulkan enums
+VkFormat CompatibleSpirvImageFormat(uint32_t spirv_image_format);
+
+// NOLINTEND

--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -265,6 +265,11 @@ def RunGenerators(api: str, registry: str, grammar: str, directory: str, styleFi
             'genCombined': True,
             'regenerate' : True
         },
+        'spirv_validation_helper.h' : {
+            'generator' : SpirvValidationHelperOutputGenerator,
+            'genCombined': False,
+            'options' : [grammar],
+        },
         'spirv_validation_helper.cpp' : {
             'generator' : SpirvValidationHelperOutputGenerator,
             'genCombined': False,

--- a/scripts/generators/spirv_validation_generator.py
+++ b/scripts/generators/spirv_validation_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2020-2024 The Khronos Group Inc.
+# Copyright (c) 2020-2025 The Khronos Group Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -115,13 +115,12 @@ class SpirvValidationHelperOutputGenerator(BaseGenerator):
         return "".join(out)
 
     def generate(self):
-        out = []
-        out.append(f'''// *** THIS FILE IS GENERATED - DO NOT EDIT ***
+        self.write(f'''// *** THIS FILE IS GENERATED - DO NOT EDIT ***
             // See {os.path.basename(__file__)} for modifications
 
             /***************************************************************************
             *
-            * Copyright (c) 2020-2024 The Khronos Group Inc.
+            * Copyright (c) 2020-2025 The Khronos Group Inc.
             *
             * Licensed under the Apache License, Version 2.0 (the "License");
             * you may not use this file except in compliance with the License.
@@ -140,7 +139,31 @@ class SpirvValidationHelperOutputGenerator(BaseGenerator):
             *
             ****************************************************************************/
             ''')
-        out.append('// NOLINTBEGIN') # Wrap for clang-tidy to ignore
+        self.write('// NOLINTBEGIN') # Wrap for clang-tidy to ignore
+
+        if self.filename == 'spirv_validation_helper.h':
+            self.generateHeader()
+        elif self.filename == 'spirv_validation_helper.cpp':
+            self.generateSource()
+        else:
+            self.write(f'\nFile name {self.filename} has no code to generate\n')
+
+        self.write('// NOLINTEND') # Wrap for clang-tidy to ignore
+
+    def generateHeader(self):
+        out = []
+        out.append('''
+            #pragma once
+            #include <vulkan/vulkan_core.h>
+
+            // This is the one function that requires mapping SPIR-V enums to Vulkan enums
+            VkFormat CompatibleSpirvImageFormat(uint32_t spirv_image_format);
+        ''')
+
+        self.write("".join(out))
+
+    def generateSource(self):
+        out = []
         out.append('''
             #include <string>
             #include <string_view>
@@ -233,10 +256,10 @@ class SpirvValidationHelperOutputGenerator(BaseGenerator):
         # Creates SPIR-V image format helper
         out.append('''
             // Will return the Vulkan format for a given SPIR-V image format value
-            // Note: will return VK_FORMAT_UNDEFINED if non valid input
+            // Note: will return VK_FORMAT_UNDEFINED if non valid input (or if ImageFormatUnknown)
             // This was in vk_format_utils but the SPIR-V Header dependency was an issue
             //   see https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/4647
-            VkFormat CoreChecks::CompatibleSpirvImageFormat(uint32_t spirv_image_format) const {
+            VkFormat CompatibleSpirvImageFormat(uint32_t spirv_image_format) {
                 switch (spirv_image_format) {
             ''')
         for format in [x for x in self.vk.formats.values() if x.spirvImageFormat]:
@@ -442,5 +465,4 @@ static inline std::string SpvExtensionRequirments(std::string_view extension) {
             return skip;
             }
             ''')
-        out.append('// NOLINTEND') # Wrap for clang-tidy to ignore
         self.write("".join(out))


### PR DESCRIPTION
Need for future to fix https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9129

Someone **not** in CoreChecks is going to need this