### PR TITLE
sync: Update buffer/image descriptor error messages

### DIFF
--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -371,10 +371,11 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
                         }
 
                         if (hazard.IsHazard() && !sync_state_.SupressedBoundDescriptorWAW(hazard)) {
-                            const auto error = error_messages_.DrawDispatchImageError(
-                                hazard, *this, *img_view_state, *pipe, *descriptor_set, descriptor_type, image_layout,
-                                variable.decorations.binding, index, loc.function);
-                            skip |= sync_state_.SyncError(hazard.Hazard(), img_view_state->Handle(), loc, error);
+                            LogObjectList objlist(cb_state_->Handle(), img_view_state->Handle(), pipe->Handle());
+                            const auto error = error_messages_.ImageDescriptorError(
+                                hazard, *this, loc.function, sync_state_.FormatHandle(*img_view_state), *pipe, *descriptor_set,
+                                descriptor_type, variable.decorations.binding, index, stage_state.GetStage(), image_layout);
+                            skip |= sync_state_.SyncError(hazard.Hazard(), objlist, loc, error);
                         }
                         break;
                     }
@@ -388,10 +389,11 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
                         const ResourceAccessRange range = MakeRange(*buf_view_state);
                         auto hazard = current_context_->DetectHazard(*buf_state, sync_index, range);
                         if (hazard.IsHazard() && !sync_state_.SupressedBoundDescriptorWAW(hazard)) {
-                            const auto error = error_messages_.DrawDispatchTexelBufferError(
-                                hazard, *this, *buf_view_state, *pipe, *descriptor_set, descriptor_type,
-                                variable.decorations.binding, index, loc.function);
-                            skip |= sync_state_.SyncError(hazard.Hazard(), buf_view_state->Handle(), loc, error);
+                            LogObjectList objlist(cb_state_->Handle(), buf_view_state->Handle(), pipe->Handle());
+                            const auto error = error_messages_.BufferDescriptorError(
+                                hazard, *this, loc.function, sync_state_.FormatHandle(*buf_view_state), *pipe, *descriptor_set,
+                                descriptor_type, variable.decorations.binding, index, stage_state.GetStage());
+                            skip |= sync_state_.SyncError(hazard.Hazard(), objlist, loc, error);
                         }
                         break;
                     }
@@ -413,10 +415,11 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
                         const ResourceAccessRange range = MakeRange(*buf_state, offset, buffer_descriptor->GetRange());
                         auto hazard = current_context_->DetectHazard(*buf_state, sync_index, range);
                         if (hazard.IsHazard() && !sync_state_.SupressedBoundDescriptorWAW(hazard)) {
-                            const auto error = error_messages_.DrawDispatchBufferError(
-                                hazard, *this, *buf_state, *pipe, *descriptor_set, descriptor_type, variable.decorations.binding,
-                                index, loc.function);
-                            skip |= sync_state_.SyncError(hazard.Hazard(), buf_state->Handle(), loc, error);
+                            LogObjectList objlist(cb_state_->Handle(), buf_state->Handle(), pipe->Handle());
+                            const auto error = error_messages_.BufferDescriptorError(
+                                hazard, *this, loc.function, sync_state_.FormatHandle(*buf_state), *pipe, *descriptor_set,
+                                descriptor_type, variable.decorations.binding, index, stage_state.GetStage());
+                            skip |= sync_state_.SyncError(hazard.Hazard(), objlist, loc, error);
                         }
                         break;
                     }

--- a/layers/sync/sync_error_messages.h
+++ b/layers/sync/sync_error_messages.h
@@ -38,6 +38,7 @@ namespace syncval {
 
 struct AdditionalMessageInfo {
     ReportKeyValues properties;
+    std::string access_initiator;  // when we need something more complex than vvl::Func
     std::string pre_synchronization_text;
     std::string message_end_text;
 };
@@ -66,6 +67,27 @@ class ErrorMessages {
                                            uint32_t subresource_range_index,
                                            const VkImageSubresourceRange& subresource_range) const;
 
+    std::string BufferDescriptorError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context, vvl::Func command,
+                                      const std::string& resource_description, const vvl::Pipeline& pipeline,
+                                      const vvl::DescriptorSet& descriptor_set, VkDescriptorType descriptor_type,
+                                      uint32_t descriptor_binding, uint32_t descriptor_array_element,
+                                      VkShaderStageFlagBits shader_stage) const;
+
+    std::string ImageDescriptorError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context, vvl::Func command,
+                                     const std::string& resource_description, const vvl::Pipeline& pipeline,
+                                     const vvl::DescriptorSet& descriptor_set, VkDescriptorType descriptor_type,
+                                     uint32_t descriptor_binding, uint32_t descriptor_array_element,
+                                     VkShaderStageFlagBits shader_stage, VkImageLayout image_layout) const;
+
+    std::string DrawVertexBufferError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
+                                      const vvl::Buffer& vertex_buffer, vvl::Func command) const;
+
+    std::string DrawIndexBufferError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
+                                     const vvl::Buffer& index_buffer, vvl::Func command) const;
+
+    std::string DrawAttachmentError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
+                                    const vvl::ImageView& attachment_view, vvl::Func command) const;
+
     std::string BeginRenderingError(const HazardResult& hazard, const syncval_state::DynamicRenderingInfo::Attachment& attachment,
                                     const CommandBufferAccessContext& cb_context, vvl::Func command) const;
 
@@ -76,31 +98,6 @@ class ErrorMessages {
     std::string EndRenderingStoreError(const HazardResult& hazard, const VulkanTypedHandle& image_view_handle,
                                        VkAttachmentStoreOp store_op, const CommandBufferAccessContext& cb_context,
                                        vvl::Func command) const;
-
-    std::string DrawDispatchImageError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
-                                       const vvl::ImageView& image_view, const vvl::Pipeline& pipeline,
-                                       const vvl::DescriptorSet& descriptor_set, VkDescriptorType descriptor_type,
-                                       VkImageLayout image_layout, uint32_t descriptor_binding, uint32_t binding_index,
-                                       vvl::Func command) const;
-
-    std::string DrawDispatchTexelBufferError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
-                                             const vvl::BufferView& buffer_view, const vvl::Pipeline& pipeline,
-                                             const vvl::DescriptorSet& descriptor_set, VkDescriptorType descriptor_type,
-                                             uint32_t descriptor_binding, uint32_t binding_index, vvl::Func command) const;
-
-    std::string DrawDispatchBufferError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
-                                        const vvl::Buffer& buffer, const vvl::Pipeline& pipeline,
-                                        const vvl::DescriptorSet& descriptor_set, VkDescriptorType descriptor_type,
-                                        uint32_t descriptor_binding, uint32_t binding_index, vvl::Func command) const;
-
-    std::string DrawVertexBufferError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
-                                      const vvl::Buffer& vertex_buffer, vvl::Func command) const;
-
-    std::string DrawIndexBufferError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
-                                     const vvl::Buffer& index_buffer, vvl::Func command) const;
-
-    std::string DrawAttachmentError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
-                                    const vvl::ImageView& attachment_view, vvl::Func command) const;
 
     std::string ClearColorAttachmentError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
                                           const std::string& subpass_attachment_info, vvl::Func command) const;

--- a/layers/sync/sync_reporting.h
+++ b/layers/sync/sync_reporting.h
@@ -90,6 +90,8 @@ inline constexpr const char *kPropertyResolveMode = "resolve_mode";
 inline constexpr const char *kPropertyOldLayout = "old_layout";
 inline constexpr const char *kPropertyNewLayout = "new_layout";
 inline constexpr const char *kPropertyDescriptorType = "descriptor_type";
+inline constexpr const char *kPropertyDescriptorBinding = "descriptor_binding";
+inline constexpr const char *kPropertyDescriptorArrayElement = "descriptor_array_element";
 inline constexpr const char *kPropertyImageLayout = "image_layout";
 inline constexpr const char *kPropertyImageAspect = "image_aspect";
 

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -1631,7 +1631,7 @@ TEST_F(NegativeSyncVal, UniformBufferDescriptorHazard) {
                                        {
                                            {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
                                        });
-    descriptor_set.WriteDescriptorBufferInfo(0, buffer, 0, 2048);
+    descriptor_set.WriteDescriptorBufferInfo(0, buffer, 0, 2048, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
     const char* cs_source = R"glsl(


### PR DESCRIPTION
OLD:
> Hazard READ_AFTER_WRITE for VkImageView 0xcb3ee80000000007[], in VkCommandBuffer [], and VkPipeline 0xd175b40000000013[], VkDescriptorSet 0x967dd1000000000e[], type: VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, imageLayout: VK_IMAGE_LAYOUT_GENERAL, binding #0, index 0. Access info (usage: SYNC_COMPUTE_SHADER_SHADER_SAMPLED_READ, prior_usage: SYNC_COPY_TRANSFER_WRITE, write_barriers: 0, command: vkCmdCopyImage, resource: VkImage 0xf56c9b0000000004[]).

NEW:
> READ_AFTER_WRITE hazard detected. Shader stage VK_SHADER_STAGE_COMPUTE_BIT reads VkImageView 0xcb3ee80000000007[], which was previously written by vkCmdCopyImage.
The image is referenced by a VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER descriptor in VkDescriptorSet 0x967dd1000000000e[], binding 0, image layout VK_IMAGE_LAYOUT_GENERAL, VkPipeline 0xd175b40000000013[].
No sufficient synchronization is present to ensure that a read (VK_ACCESS_2_SHADER_SAMPLED_READ_BIT) at VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT does not conflict with a prior write (VK_ACCESS_2_TRANSFER_WRITE_BIT) at VK_PIPELINE_STAGE_2_COPY_BIT.

Also adds new lines (less visible in markdown quote formatting)

