### PR TITLE
layers: Remove Queue Transfer Ownership warnings

### DIFF
--- a/layers/containers/qfo_transfer.h
+++ b/layers/containers/qfo_transfer.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (C) 2015-2022 Google Inc.
+/* Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (C) 2015-2025 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +18,7 @@
  */
 #pragma once
 #include "custom_containers.h"
+#include "generated/error_location_helper.h"
 #include "sync/sync_utils.h"
 #include "utils/hash_util.h"
 
@@ -79,15 +80,7 @@ struct QFOImageTransferBarrier : public QFOTransferBarrierBase<VkImage> {
         // Ignoring layout w.r.t. equality. See comment in hash above.
         return (static_cast<BaseType>(*this) == static_cast<BaseType>(rhs)) && (subresourceRange == rhs.subresourceRange);
     }
-    // TODO: codegen a comprehensive complie time type -> string (and or other traits) template family
-    static const char *BarrierName() { return "VkImageMemoryBarrier"; }
-    static const char *HandleName() { return "VkImage"; }
-    // QFO transfer image barrier must not duplicate QFO recorded in command buffer
-    static const char *DuplicateQFOInCB() { return "WARNING-VkImageMemoryBarrier-image-00001"; }
-    // QFO transfer image barrier must not duplicate QFO submitted in batch
-    static const char *DuplicateQFOInSubmit() { return "WARNING-VkImageMemoryBarrier-image-00002"; }
-    // QFO transfer image barrier must not duplicate QFO submitted previously
-    static const char *DuplicateQFOSubmitted() { return "WARNING-VkImageMemoryBarrier-image-00003"; }
+    static vvl::Struct BarrierName() { return vvl::Struct::VkImageMemoryBarrier; }
 };
 
 // Buffer barrier specific implementation
@@ -108,14 +101,7 @@ struct QFOBufferTransferBarrier : public QFOTransferBarrierBase<VkBuffer> {
     bool operator==(const QFOBufferTransferBarrier &rhs) const {
         return (static_cast<BaseType>(*this) == static_cast<BaseType>(rhs)) && (offset == rhs.offset) && (size == rhs.size);
     }
-    static const char *BarrierName() { return "VkBufferMemoryBarrier"; }
-    static const char *HandleName() { return "VkBuffer"; }
-    // QFO transfer buffer barrier must not duplicate QFO recorded in command buffer
-    static const char *DuplicateQFOInCB() { return "WARNING-VkBufferMemoryBarrier-buffer-00001"; }
-    // QFO transfer buffer barrier must not duplicate QFO submitted in batch
-    static const char *DuplicateQFOInSubmit() { return "WARNING-VkBufferMemoryBarrier-buffer-00002"; }
-    // QFO transfer buffer barrier must not duplicate QFO submitted previously
-    static const char *DuplicateQFOSubmitted() { return "WARNING-VkBufferMemoryBarrier-buffer-00003"; }
+    static vvl::Struct BarrierName() { return vvl::Struct::VkBufferMemoryBarrier; }
 };
 
 template <typename TransferBarrier>

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -633,19 +633,10 @@ class CoreChecks : public vvl::Device {
                                     QFOTransferCBScoreboards<QFOBufferTransferBarrier>* qfo_buffer_scoreboards,
                                     const Location& loc) const;
 
-    template <typename Barrier, typename Scoreboard>
-    bool ValidateAndUpdateQFOScoreboard(const vvl::CommandBuffer& cb_state, const char* operation, const Barrier& barrier,
-                                        Scoreboard* scoreboard, const Location& loc) const;
-
     void RecordBarrierValidationInfo(const Location& loc, vvl::CommandBuffer& cb_state, const BufferBarrier& barrier,
                                      QFOTransferBarrierSets<QFOBufferTransferBarrier>& barrier_sets);
     void RecordBarrierValidationInfo(const Location& loc, vvl::CommandBuffer& cb_state, const ImageBarrier& barrier,
                                      QFOTransferBarrierSets<QFOImageTransferBarrier>& barrier_sets);
-
-    template <typename Barrier, typename TransferBarrier>
-    bool ValidateQFOTransferBarrierUniqueness(const Location& barrier_loc, const vvl::CommandBuffer& cb_state,
-                                              const Barrier& barrier,
-                                              const QFOTransferBarrierSets<TransferBarrier>& barrier_sets) const;
 
     bool ValidatePrimaryCommandBufferState(const Location& loc, const vvl::CommandBuffer& cb_state, uint32_t current_submit_count,
                                            QFOTransferCBScoreboards<QFOImageTransferBarrier>* qfo_image_scoreboards,

--- a/tests/unit/sync_object_positive.cpp
+++ b/tests/unit/sync_object_positive.cpp
@@ -103,6 +103,39 @@ TEST_F(PositiveSyncObject, Sync2OwnershipTranfersBuffer) {
     ValidOwnershipTransfer(m_errorMonitor, no_gfx_queue, no_gfx_cb, m_default_queue, m_command_buffer, &buffer_barrier, nullptr);
 }
 
+TEST_F(PositiveSyncObject, BarrierQueueFamily2) {
+    TEST_DESCRIPTION("Create and submit barriers with invalid queue families");
+    SetTargetApiVersion(VK_API_VERSION_1_0);
+    RETURN_IF_SKIP(Init());
+
+    // Find queues of two families
+    const uint32_t submit_family = m_device->graphics_queue_node_index_;
+    const uint32_t queue_family_count = static_cast<uint32_t>(m_device->Physical().queue_properties_.size());
+    const uint32_t other_family = submit_family != 0 ? 0 : 1;
+    const bool only_one_family = (queue_family_count == 1) ||
+                                 (m_device->Physical().queue_properties_[other_family].queueCount == 0) ||
+                                 ((m_device->Physical().queue_properties_[other_family].queueFlags & VK_QUEUE_TRANSFER_BIT) == 0);
+
+    if (only_one_family) {
+        GTEST_SKIP() << "Single queue family found";
+    }
+    std::vector<uint32_t> qf_indices{{submit_family, other_family}};
+    BarrierQueueFamilyTestHelper::Context test_context(this, qf_indices);
+
+    BarrierQueueFamilyTestHelper excl_test(&test_context);
+    excl_test.Init(nullptr);
+
+    // Although other_family does not match submit_family, because the barrier families are
+    // equal here, no ownership transfer actually happens, and this barrier is valid by the spec.
+    excl_test(other_family, other_family, submit_family);
+
+    // positive test (testing both the index logic and the QFO transfer tracking.
+    excl_test(submit_family, other_family, submit_family);
+    excl_test(submit_family, other_family, other_family);
+    excl_test(other_family, submit_family, other_family);
+    excl_test(other_family, submit_family, submit_family);
+}
+
 TEST_F(PositiveSyncObject, LayoutFromPresentWithoutAccessMemoryRead) {
     // Transition an image away from PRESENT_SRC_KHR without ACCESS_MEMORY_READ
     // in srcAccessMask.


### PR DESCRIPTION
We have had these warnings in forever and they should just be part of best practice, but at this point, they are so baked into the QFOScoreboard logic, that rather just remove

If someone finds these warnings **so** important, we can change course, but this just smells like "we didn't touch because we think there might be a use case"

but no warnings allowed in Core Validation without a valid comment above explaining the rational