### PR TITLE
gpuav: Make Module Setting fields not be repeated

### DIFF
--- a/layers/gpuav/spirv/descriptor_class_general_buffer_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_class_general_buffer_pass.cpp
@@ -185,7 +185,8 @@ bool DescriptorClassGeneralBufferPass::Instrument() {
                 // Every instruction is analyzed by the specific pass and lets us know if we need to inject a function or not
                 if (!RequiresInstrumentation(*function, *(inst_it->get()))) continue;
 
-                if (module_.max_instrumentations_count_ != 0 && instrumentations_count_ >= module_.max_instrumentations_count_) {
+                if (module_.settings_.max_instrumentations_count != 0 &&
+                    instrumentations_count_ >= module_.settings_.max_instrumentations_count) {
                     return true;  // hit limit
                 }
                 instrumentations_count_++;

--- a/layers/gpuav/spirv/descriptor_class_texel_buffer_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_class_texel_buffer_pass.cpp
@@ -192,7 +192,8 @@ bool DescriptorClassTexelBufferPass::Instrument() {
                 // Every instruction is analyzed by the specific pass and lets us know if we need to inject a function or not
                 if (!RequiresInstrumentation(*function, *(inst_it->get()))) continue;
 
-                if (module_.max_instrumentations_count_ != 0 && instrumentations_count_ >= module_.max_instrumentations_count_) {
+                if (module_.settings_.max_instrumentations_count != 0 &&
+                    instrumentations_count_ >= module_.settings_.max_instrumentations_count) {
                     return true;  // hit limit
                 }
                 instrumentations_count_++;

--- a/layers/gpuav/spirv/inject_conditional_function_pass.cpp
+++ b/layers/gpuav/spirv/inject_conditional_function_pass.cpp
@@ -146,7 +146,8 @@ bool InjectConditionalFunctionPass::Instrument() {
                     continue;
                 }
 
-                if (module_.max_instrumentations_count_ != 0 && instrumentations_count_ >= module_.max_instrumentations_count_) {
+                if (module_.settings_.max_instrumentations_count != 0 &&
+                    instrumentations_count_ >= module_.settings_.max_instrumentations_count) {
                     return true;  // hit limit
                 }
                 instrumentations_count_++;

--- a/layers/gpuav/spirv/inject_function_pass.cpp
+++ b/layers/gpuav/spirv/inject_function_pass.cpp
@@ -34,7 +34,8 @@ bool InjectFunctionPass::Instrument() {
                 // Every instruction is analyzed by the specific pass and lets us know if we need to inject a function or not
                 if (!RequiresInstrumentation(*function, *(inst_it->get()))) continue;
 
-                if (module_.max_instrumentations_count_ != 0 && instrumentations_count_ >= module_.max_instrumentations_count_) {
+                if (module_.settings_.max_instrumentations_count != 0 &&
+                    instrumentations_count_ >= module_.settings_.max_instrumentations_count) {
                     return true;  // hit limit
                 }
                 instrumentations_count_++;

--- a/layers/gpuav/spirv/module.cpp
+++ b/layers/gpuav/spirv/module.cpp
@@ -32,13 +32,9 @@ Module::Module(vvl::span<const uint32_t> words, DebugReport* debug_report, const
                const DeviceFeatures& enabled_features,
                const std::vector<std::vector<BindingLayout>>& set_index_to_bindings_layout_lut)
     : type_manager_(*this),
-      max_instrumentations_count_(settings.max_instrumentations_count),
-      shader_id_(settings.shader_id),
-      output_buffer_descriptor_set_(settings.output_buffer_descriptor_set),
-      support_non_semantic_info_(settings.support_non_semantic_info),
+      settings_(settings),
       enabled_features_(enabled_features),
       has_bindless_descriptors_(settings.has_bindless_descriptors),
-      print_debug_info_(settings.print_debug_info),
       debug_report_(debug_report),
       set_index_to_bindings_layout_lut_(set_index_to_bindings_layout_lut) {
     uint32_t instruction_count = 0;
@@ -499,7 +495,7 @@ void Module::LinkFunction(const LinkInfo& info) {
 
                 // Replace LinkConstants
                 if (constant_value == glsl::kLinkShaderId) {
-                    new_inst->UpdateWord(3, shader_id_);
+                    new_inst->UpdateWord(3, settings_.shader_id);
                 }
             }
 
@@ -633,7 +629,7 @@ void Module::LinkFunction(const LinkInfo& info) {
             continue;  // remove linkage info
         } else if (decoration->Word(2) == spv::DecorationDescriptorSet) {
             // only should be one DescriptorSet to update
-            decoration->UpdateWord(3, output_buffer_descriptor_set_);
+            decoration->UpdateWord(3, settings_.output_buffer_descriptor_set);
         }
 
         decoration->ReplaceLinkedId(id_swap_map);

--- a/layers/gpuav/spirv/module.h
+++ b/layers/gpuav/spirv/module.h
@@ -37,9 +37,14 @@ struct ModuleHeader {
 };
 
 struct Settings {
+    // provides a way to map back and know which original SPIR-V this was from
     uint32_t shader_id;
+    // Will replace the "OpDecorate DescriptorSet" for the output buffer in the incoming linked module
+    // This allows anything to be set in the GLSL for the set value, as we change it at runtime
     uint32_t output_buffer_descriptor_set;
+    // Used to help debug
     bool print_debug_info;
+    // zero is same as "unlimited"
     uint32_t max_instrumentations_count;
     bool support_non_semantic_info;
     bool has_bindless_descriptors;
@@ -94,15 +99,10 @@ class Module {
     void AddDecoration(uint32_t target_id, spv::Decoration decoration, const std::vector<uint32_t>& operands);
     void AddMemberDecoration(uint32_t target_id, uint32_t index, spv::Decoration decoration, const std::vector<uint32_t>& operands);
 
-    const uint32_t max_instrumentations_count_ = 0;  // zero is same as "unlimited"
-    bool use_bda_ = false;
-    // provides a way to map back and know which original SPIR-V this was from
-    const uint32_t shader_id_;
-    // Will replace the "OpDecorate DescriptorSet" for the output buffer in the incoming linked module
-    // This allows anything to be set in the GLSL for the set value, as we change it at runtime
-    const uint32_t output_buffer_descriptor_set_;
+    const Settings& settings_;
 
-    const bool support_non_semantic_info_;
+    bool use_bda_ = false;
+
     const DeviceFeatures& enabled_features_;
 
     // TODO - To make things simple to start, decide if the whole shader has anything bindless or not. The next step will be a
@@ -110,9 +110,6 @@ class Module {
     // descriptors. This will require special consideration as it will break a simple way to test standalone version of the
     // instrumentation
     bool has_bindless_descriptors_ = false;
-
-    // Used to help debug
-    const bool print_debug_info_;
 
     // To keep the GPU Shader Instrumentation a standalone sub-project, the runtime version needs to pass in info to allow for
     // warnings/errors to be piped into the normal callback (otherwise will be sent to stdout)

--- a/layers/gpuav/spirv/pass.cpp
+++ b/layers/gpuav/spirv/pass.cpp
@@ -26,7 +26,7 @@ namespace spirv {
 
 bool Pass::Run() {
     const bool modified = Instrument();
-    if (module_.print_debug_info_) {
+    if (module_.settings_.print_debug_info) {
         PrintDebugInfo();
     }
     return modified;

--- a/layers/gpuav/spirv/post_process_descriptor_indexing_pass.cpp
+++ b/layers/gpuav/spirv/post_process_descriptor_indexing_pass.cpp
@@ -179,7 +179,8 @@ bool PostProcessDescriptorIndexingPass::Instrument() {
             for (auto inst_it = block_instructions.begin(); inst_it != block_instructions.end(); ++inst_it) {
                 if (!RequiresInstrumentation(*function, *(inst_it->get()))) continue;
 
-                if (module_.max_instrumentations_count_ != 0 && instrumentations_count_ >= module_.max_instrumentations_count_) {
+                if (module_.settings_.max_instrumentations_count != 0 &&
+                    instrumentations_count_ >= module_.settings_.max_instrumentations_count) {
                     return true;  // hit limit
                 }
                 instrumentations_count_++;


### PR DESCRIPTION
Noticed while doing https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/9471

We have this `Settings` struct, but were still duplicating everything inside another private field member of `Module`