### PR TITLE
sync: Update clear attachment messages

### DIFF
--- a/layers/error_message/error_strings.h
+++ b/layers/error_message/error_strings.h
@@ -54,8 +54,8 @@
 
 [[maybe_unused]] static std::string string_VkRect2D(VkRect2D rect) {
     std::stringstream ss;
-    ss << "offset.x = " << rect.offset.x << ", offset.y = " << rect.offset.y << ", extent.width = " << rect.extent.width
-       << ", extent.height = " << rect.extent.height;
+    ss << "offset = {" << rect.offset.x << ", " << rect.offset.y << "}, extent = {" << rect.extent.width << ", "
+       << rect.extent.height << "}";
     return ss.str();
 }
 

--- a/layers/sync/sync_commandbuffer.h
+++ b/layers/sync/sync_commandbuffer.h
@@ -295,8 +295,9 @@ class CommandBufferAccessContext : public CommandExecutionContext, DebugNameProv
     bool ValidateDrawDynamicRenderingAttachment(const Location &loc) const;
     void RecordDrawAttachment(ResourceUsageTag tag);
     void RecordDrawDynamicRenderingAttachment(ResourceUsageTag tag);
-    bool ValidateClearAttachment(const Location &loc, const VkClearAttachment &clear_attachment, const VkClearRect &rect) const;
-    void RecordClearAttachment(ResourceUsageTag tag, const VkClearAttachment &clear_attachment, const VkClearRect &rect);
+    bool ValidateClearAttachment(const Location &loc, const VkClearAttachment &clear_attachment, uint32_t clear_rect_index,
+                                 const VkClearRect &clear_rect) const;
+    void RecordClearAttachment(ResourceUsageTag tag, const VkClearAttachment &clear_attachment, const VkClearRect &clear_rect);
 
     ResourceUsageTag RecordNextSubpass(vvl::Func command);
     ResourceUsageTag RecordEndRenderPass(vvl::Func command);

--- a/layers/sync/sync_error_messages.h
+++ b/layers/sync/sync_error_messages.h
@@ -38,7 +38,14 @@ namespace syncval {
 
 struct AdditionalMessageInfo {
     ReportKeyValues properties;
-    std::string access_initiator;  // when we need something more complex than vvl::Func
+
+    // When we need something more complex than vvl::Func
+    std::string access_initiator;
+
+    // Replaces standard "writes to"/"reads" access wording.
+    // For example, "clears" for a clear operation might be more specific than a write
+    std::string access_action;
+
     std::string pre_synchronization_text;
     std::string message_end_text;
 };
@@ -79,6 +86,10 @@ class ErrorMessages {
                                      uint32_t descriptor_binding, uint32_t descriptor_array_element,
                                      VkShaderStageFlagBits shader_stage, VkImageLayout image_layout) const;
 
+    std::string ClearAttachmentError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context, vvl::Func command,
+                                     const std::string& resource_description, VkImageAspectFlagBits aspect,
+                                     uint32_t clear_rect_index, const VkClearRect& clear_rect) const;
+
     std::string BeginRenderingError(const HazardResult& hazard, const syncval_state::DynamicRenderingInfo::Attachment& attachment,
                                     const CommandBufferAccessContext& cb_context, vvl::Func command) const;
 
@@ -89,13 +100,6 @@ class ErrorMessages {
     std::string EndRenderingStoreError(const HazardResult& hazard, const VulkanTypedHandle& image_view_handle,
                                        VkAttachmentStoreOp store_op, const CommandBufferAccessContext& cb_context,
                                        vvl::Func command) const;
-
-    std::string ClearColorAttachmentError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
-                                          const std::string& subpass_attachment_info, vvl::Func command) const;
-
-    std::string ClearDepthStencilAttachmentError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
-                                                 const std::string& subpass_attachment_info, VkImageAspectFlagBits aspect,
-                                                 vvl::Func command) const;
 
     std::string PipelineBarrierError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
                                      uint32_t image_barrier_index, const vvl::Image& image, vvl::Func command) const;

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -2001,16 +2001,12 @@ bool SyncValidator::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBu
                                                        const VkClearAttachment *pAttachments, uint32_t rectCount,
                                                        const VkClearRect *pRects, const ErrorObject &error_obj) const {
     bool skip = false;
-
     const auto cb_state = Get<syncval_state::CommandBuffer>(commandBuffer);
-    assert(cb_state);
-    if (!cb_state) return skip;
+    ASSERT_AND_RETURN_SKIP(cb_state);
 
-    for (const auto [attachment_index, attachment] : vvl::enumerate(pAttachments, attachmentCount)) {
-        Location attachment_loc = error_obj.location.dot(Field::pAttachments, attachment_index);
+    for (const VkClearAttachment &attachment : vvl::make_span(pAttachments, attachmentCount)) {
         for (const auto [rect_index, rect] : vvl::enumerate(pRects, rectCount)) {
-            Location rect_loc = attachment_loc.dot(Field::pRects, rect_index);
-            skip |= cb_state->access_context.ValidateClearAttachment(rect_loc, attachment, rect);
+            skip |= cb_state->access_context.ValidateClearAttachment(error_obj.location, attachment, rect_index, rect);
         }
     }
     return skip;


### PR DESCRIPTION
> WRITE_AFTER_WRITE hazard detected. vkCmdClearAttachments clears VK_IMAGE_ASPECT_COLOR_BIT aspect of color attachment 0 (VkImageView 0xcad092000000000d[]) in subpass 0, which was previously written by vkCmdCopyImage.
No sufficient synchronization is present to ensure that a write (VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT) at VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT does not conflict with a prior write (VK_ACCESS_2_TRANSFER_WRITE_BIT) at VK_PIPELINE_STAGE_2_COPY_BIT.
Clear region: {
  region_index = 0,
  rect = {offset = {0, 0}, extent = {128, 64}},
  baseArrayLayer = 0,
  layerCount = 1
}
