### PR TITLE
layers: Remove VK_EXT_validation_features VU

### DIFF
--- a/layers/error_message/unimplementable_validation.h
+++ b/layers/error_message/unimplementable_validation.h
@@ -54,6 +54,16 @@ const char* unimplementable_validation[] = {
     "VUID-vkGetPrivateData-device-parameter",
     "VUID-vkSetPrivateData-device-parameter",
 
+    // These were added for "completeness" (by us!) and serve no real purpose.
+    // 1. VK_EXT_validation_features/VK_EXT_validation_flags are implemented by us and we don't even care
+    //    if the extension name is enabled or not
+    // 2. It would crazy for a layer to suddenly not have VK_EXT_layer_settings work if the extension name is not provided
+    //
+    // Until there is a real world usecase where these are needed, we are just going to defer validating them.
+    "VUID-VkInstanceCreateInfo-pNext-10242",
+    "VUID-VkInstanceCreateInfo-pNext-10243",
+    "VUID-VkInstanceCreateInfo-pNext-10244",
+
     // These ask if pData is a certain size, but no way to validate a pointer to memory is a certain size.
     // There is already another implicit VU checking if pData is not null.
     "VUID-vkGetBufferOpaqueCaptureDescriptorDataEXT-pData-08073",

--- a/layers/stateless/sl_instance_device.cpp
+++ b/layers/stateless/sl_instance_device.cpp
@@ -226,13 +226,7 @@ bool Instance::PreCallValidateCreateInstance(const VkInstanceCreateInfo *pCreate
         return skip;
     }
 
-    const auto *validation_features = vku::FindStructInPNextChain<VkValidationFeaturesEXT>(pCreateInfo->pNext);
-    if (validation_features && !instance_extensions.vk_ext_validation_features) {
-        skip |= LogError("VUID-VkInstanceCreateInfo-pNext-10243", instance, create_info_loc.dot(Field::ppEnabledExtensionNames),
-                         "does not include VK_EXT_validation_features, but the pNext chain includes VkValidationFeaturesEXT");
-        return skip;
-    }
-    if (validation_features) {
+    if (const auto *validation_features = vku::FindStructInPNextChain<VkValidationFeaturesEXT>(pCreateInfo->pNext)) {
         bool debug_printf = false;
         bool gpu_assisted = false;
         bool reserve_slot = false;

--- a/tests/unit/instanceless.cpp
+++ b/tests/unit/instanceless.cpp
@@ -338,13 +338,6 @@ TEST_F(NegativeInstanceless, ExtensionStructsWithoutExtensions) {
     vk::CreateInstance(&ici, nullptr, &instance);
     m_errorMonitor->VerifyFound();
 
-    VkValidationFeaturesEXT features = vku::InitStructHelper();
-    features.pNext = m_errorMonitor->GetDebugCreateInfo();
-    ici.pNext = &features;
-    m_errorMonitor->SetDesiredError("VUID-VkInstanceCreateInfo-pNext-10243");
-    vk::CreateInstance(&ici, nullptr, &instance);
-    m_errorMonitor->VerifyFound();
-
     // This must be last because it messes up the extension list
     VkDebugUtilsMessengerCreateInfoEXT debug_utils_messenger = vku::InitStructHelper();
     debug_utils_messenger.pNext = m_errorMonitor->GetDebugCreateInfo();


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9479

I am the one who brought these 3 VUs on the world, I feel the need to amend my mistake before more and more developers waste time on this