### PR TITLE
settings: Make warnings on by default

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -86,7 +86,7 @@
                         { "key": "printf_enable", "value": false },
                         { "key": "gpuav_enable", "value": false },
                         { "key": "validate_best_practices", "value": false },
-                        { "key": "report_flags", "value": [ "error" ] },
+                        { "key": "report_flags", "value": [ "error", "warn" ] },
                         { "key": "debug_action", "value": [ "VK_DBG_LAYER_ACTION_LOG_MSG" ] },
                         { "key": "enable_message_limit", "value": true }
                     ]

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -818,7 +818,7 @@ static void ProcessDebugReportSettings(ConfigAndEnvSettings *settings_data, VkuL
         }
     }
 
-    std::vector<std::string> report_flags_list = {"error"};  // Default
+    std::vector<std::string> report_flags_list = {"error", "warn"};  // Default
     if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_REPORT_FLAGS)) {
         vkuGetLayerSettingValues(layer_setting_set, VK_LAYER_REPORT_FLAGS, report_flags_list);
     }


### PR DESCRIPTION
So this has been a long time coming ...

Originally there were only errors, then many warnings snuck their way into Core Checks, eventually we decided create Best Practices to hold them, then we slowly moved all the warning from Core Checks to there. In the process we found that some things are actually "warnings" people care about and then become `LogUndefinedValue` in the code (https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/6707).

So as of today, if you are just using the normal/standard Core Validation the non-errors we have are

- Warning if you try setting a device extension at instance time (and vice versa)
- `vkGetDeviceProcAddr` trying to grab an instance level function
- Failing vkAllocateDescriptorSets because they are using a type not supported (details https://gitlab.khronos.org/vulkan/vulkan/-/issues/3347)
- Trying to create an image larger than `maxResourceSize` limit
- if spirv-val returns a warning (which it currently does in 2 obscure spots)
- A warning until https://github.com/KhronosGroup/SPIRV-Tools/pull/6000 lands

On top of this we have a few spots (and plan to add more) where users have "Undefined Value" (not Undefined Behavior) 
These have been shown to more useful to report then hide from people. Those who are elite and don't want those warnings can simply either

1. VUID Mute them
2. Disable Warning from VkConfig
3. turn off warnings and only have errors with

```bash
# Windows
set VK_LAYER_REPORT_FLAGS=error
# Linux
export VK_LAYER_REPORT_FLAGS=error
# Android
adb setprop debug.vulkan.khronos_validation.report_flags=error
```