### PR TITLE
vvl: Rework accel structs mem aliasing validation

### DIFF
--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -29,6 +29,7 @@
 #include "error_message/error_strings.h"
 
 #include <algorithm>
+#include <iostream>
 
 bool CoreChecks::ValidateInsertAccelerationStructureMemoryRange(VkAccelerationStructureNV as, const vvl::DeviceMemory &mem_info,
                                                                 VkDeviceSize mem_offset, const Location &loc) const {
@@ -270,6 +271,8 @@ bool CoreChecks::ValidateAccelerationStructuresDeviceScratchBufferMemoryAliasing
             src_as_state && info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR) {
             const vvl::range<VkDeviceAddress> src_as_range = src_as_state->GetDeviceAddressRange();
 
+            std::cout << "pInfos[" << info_i << "].src_as addr range: " << string_range_hex(src_as_range) << std::endl;
+
             if (dst_as_state && dst_as_state->VkHandle() != src_as_state->VkHandle()) {
                 const vvl::range<VkDeviceAddress> dst_as_range = dst_as_state->GetDeviceAddressRange();
 
@@ -327,6 +330,10 @@ bool CoreChecks::ValidateAccelerationStructuresDeviceScratchBufferMemoryAliasing
         if (dst_as_state) {
             const AddressRange dst_as_address_range = {dst_as_state->GetDeviceAddressRange(), info_i,
                                                        AddressRangeOrigin::DstAccelStruct};
+
+            std::cout << "pInfos[" << info_i << "].dst_as addr range: " << string_range_hex(dst_as_address_range.range)
+                      << std::endl;
+
             const std::optional<AddressRange> overlapped_address_range = insert_address(address_ranges, dst_as_address_range);
             if (overlapped_address_range.has_value()) {
                 switch (overlapped_address_range->origin) {
@@ -387,6 +394,9 @@ bool CoreChecks::ValidateAccelerationStructuresDeviceScratchBufferMemoryAliasing
                                                                info.scratchData.deviceAddress + assumed_scratch_size};
 
             const AddressRange scratch_address_range = {scratch_range, info_i, AddressRangeOrigin::Scratch};
+
+            std::cout << "pInfos[" << info_i << "].scratch addr range: " << string_range_hex(scratch_range) << std::endl;
+
             const std::optional<AddressRange> overlapped_address_range = insert_address(address_ranges, scratch_address_range);
             if (overlapped_address_range.has_value()) {
                 switch (overlapped_address_range->origin) {

--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -28,6 +28,8 @@
 #include "state_tracker/ray_tracing_state.h"
 #include "error_message/error_strings.h"
 
+#include <algorithm>
+
 bool CoreChecks::ValidateInsertAccelerationStructureMemoryRange(VkAccelerationStructureNV as, const vvl::DeviceMemory &mem_info,
                                                                 VkDeviceSize mem_offset, const Location &loc) const {
     return ValidateInsertMemoryRange(VulkanTypedHandle(as, kVulkanObjectTypeAccelerationStructureNV), mem_info, mem_offset, loc);
@@ -215,67 +217,223 @@ bool CoreChecks::ValidateAccelerationStructuresMemoryAlisasing(const LogObjectLi
     return skip;
 }
 
-bool CoreChecks::ValidateAccelerationStructuresDeviceScratchBufferMemoryAlisasing(
-    const LogObjectList &objlist, uint32_t info_count, const VkAccelerationStructureBuildGeometryInfoKHR *p_infos, uint32_t info_i,
+bool CoreChecks::ValidateAccelerationStructuresDeviceScratchBufferMemoryAliasing(
+    VkCommandBuffer cmd_buffer, uint32_t info_count, const VkAccelerationStructureBuildGeometryInfoKHR *p_infos,
     const VkAccelerationStructureBuildRangeInfoKHR *const *pp_range_infos, const ErrorObject &error_obj) const {
-    using vvl::range;
-
     bool skip = false;
-    const VkAccelerationStructureBuildGeometryInfoKHR &info = p_infos[info_i];
-    const Location info_i_loc = error_obj.location.dot(Field::pInfos, info_i);
-    const auto src_as_state = Get<vvl::AccelerationStructureKHR>(info.srcAccelerationStructure);
-    const auto dst_as_state = Get<vvl::AccelerationStructureKHR>(info.dstAccelerationStructure);
-    const rt::BuildType rt_build_type =
-        error_obj.location.function == Func::vkBuildAccelerationStructuresKHR ? rt::BuildType::Host : rt::BuildType::Device;
 
-    const bool info_in_mode_update = info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR;
+    enum class AddressRangeOrigin : uint8_t { Undefined, SrcAccelStruct, DstAccelStruct, Scratch };
+    struct AddressRange {
+        vvl::range<VkDeviceAddress> range = {};
+        uint32_t info_i = 0;
+        AddressRangeOrigin origin = AddressRangeOrigin::Undefined;
+    };
+    // Gather all address ranges  from source acceleration structtures, destination acceleration structures
+    // and scratch buffers in a single sorted vector, to more rapidly lookup overlaps
+    std::vector<AddressRange> address_ranges;
+    address_ranges.reserve(3 * info_count);
 
-    // Cannot compute scratch buffer size from the CPU with indirect calls,
-    // so cannot perform validation
-    vvl::span<vvl::Buffer *const> info_scratches = GetBuffersByAddress(info.scratchData.deviceAddress);
-    const VkDeviceSize assumed_scratch_size = rt::ComputeScratchSize(rt_build_type, device, info, pp_range_infos[info_i]);
+    const auto insert_address = [](std::vector<AddressRange> &address_ranges, const AddressRange address_range) {
+        std::optional<AddressRange> overlapped_range = std::nullopt;
+        auto insert_pos = std::lower_bound(
+            address_ranges.begin(), address_ranges.end(), address_range,
+            [&overlapped_range](const AddressRange iter, const AddressRange new_elt) -> bool {
+                const vvl::range<VkDeviceAddress> intersection = iter.range & new_elt.range;
+                if (intersection.non_empty()) {
+                    const bool both_src_as_ranges =
+                        iter.origin == AddressRangeOrigin::SrcAccelStruct && new_elt.origin == AddressRangeOrigin::SrcAccelStruct;
+                    // #ARNO_TODO make sure VUID 03668 is correctly handled
+                    const bool as_update =
+                        iter.info_i == new_elt.info_i && ((iter.origin == AddressRangeOrigin::SrcAccelStruct &&
+                                                           new_elt.origin == AddressRangeOrigin::DstAccelStruct) ||
+                                                          (new_elt.origin == AddressRangeOrigin::SrcAccelStruct &&
+                                                           iter.origin == AddressRangeOrigin::DstAccelStruct));
 
-    if (dst_as_state) {
-        vvl::span<vvl::Buffer *const> dummy(nullptr, 0);
-        skip |= ValidateScratchMemoryNoOverlap(error_obj.location, objlist, info_scratches, info.scratchData.deviceAddress,
-                                               assumed_scratch_size, info_i_loc.dot(Field::scratchData).dot(Field::deviceAddress),
-                                               info_in_mode_update ? src_as_state.get() : nullptr,
-                                               info_i_loc.dot(Field::srcAccelerationStructure), *dst_as_state,
-                                               info_i_loc.dot(Field::dstAccelerationStructure), dummy, 0, 0, nullptr);
-    }
+                    if (!both_src_as_ranges && !as_update) {
+                        overlapped_range = iter;
+                    }
+                }
 
-    // Loop on other acceleration structure builds info.
-    // Given that comparisons are commutative, only need to consider elements after info_i
-    assert(info_count > info_i);
-    for (uint32_t other_info_j = info_i + 1; other_info_j < info_count; ++other_info_j) {
-        // Validate that scratch buffer's memory does not overlap destination acceleration structure's memory, or source
-        // acceleration structure's memory if build mode is update, or other scratch buffers' memory.
-        // Here validation is pessimistic: if one buffer associated to pInfos[other_info_j].scratchData.deviceAddress has an
-        // overlap, an error will be logged.
+                return iter.range < new_elt.range;
+            });
 
-        const VkAccelerationStructureBuildGeometryInfoKHR &other_info = p_infos[other_info_j];
-        const Location other_info_j_loc = error_obj.location.dot(Field::pInfos, other_info_j);
+        address_ranges.insert(insert_pos, address_range);
+        return overlapped_range;
+    };
 
-        const auto other_dst_as_state = Get<vvl::AccelerationStructureKHR>(other_info.dstAccelerationStructure);
-        const auto other_src_as_state = Get<vvl::AccelerationStructureKHR>(other_info.srcAccelerationStructure);
+    for (const auto [info_i, info] : vvl::enumerate(p_infos, info_count)) {
+        const Location info_i_loc = error_obj.location.dot(Field::pInfos, info_i);
 
-        const bool other_info_in_update_mode = other_info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR;
+        const auto dst_as_state = Get<vvl::AccelerationStructureKHR>(info.dstAccelerationStructure);
 
-        if (other_dst_as_state) {
-            auto other_info_scratches = GetBuffersByAddress(other_info.scratchData.deviceAddress);
-            const VkDeviceSize assumed_other_scratch_size =
-                rt::ComputeScratchSize(rt_build_type, device, other_info, pp_range_infos[other_info_j]);
+        if (const auto src_as_state = Get<vvl::AccelerationStructureKHR>(info.srcAccelerationStructure);
+            src_as_state && info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR) {
+            const vvl::range<VkDeviceAddress> src_as_range = src_as_state->GetDeviceAddressRange();
 
-            const Location other_scratch_loc = other_info_j_loc.dot(Field::scratchData);
-            const Location other_scratch_address_loc = other_scratch_loc.dot(Field::deviceAddress);
+            if (dst_as_state && dst_as_state->VkHandle() != src_as_state->VkHandle()) {
+                const vvl::range<VkDeviceAddress> dst_as_range = dst_as_state->GetDeviceAddressRange();
 
-            skip |= ValidateScratchMemoryNoOverlap(
-                error_obj.location, objlist, info_scratches, info.scratchData.deviceAddress, assumed_scratch_size,
-                info_i_loc.dot(Field::scratchData).dot(Field::deviceAddress),
-                other_info_in_update_mode ? other_src_as_state.get() : nullptr,
-                other_info_j_loc.dot(Field::srcAccelerationStructure), *other_dst_as_state,
-                other_info_j_loc.dot(Field::dstAccelerationStructure), other_info_scratches, other_info.scratchData.deviceAddress,
-                assumed_other_scratch_size, &other_scratch_address_loc);
+                if (const vvl::range<VkDeviceAddress> dst_as_src_as_intersection = dst_as_range & src_as_range;
+                    dst_as_src_as_intersection.non_empty()) {
+                    skip |= LogError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03668",
+                                     LogObjectList(cmd_buffer, src_as_state->VkHandle(), dst_as_state->VkHandle()),
+                                     info_i_loc.dot(Field::dstAccelerationStructure),
+                                     "overlaps with srcAccelerationStructure, which is in update mode, on device address range %s.",
+                                     string_range_hex(dst_as_src_as_intersection).c_str());
+                }
+            }
+
+            const AddressRange src_as_address_range = {src_as_range, info_i, AddressRangeOrigin::SrcAccelStruct};
+            const std::optional<AddressRange> overlapped_address_range = insert_address(address_ranges, src_as_address_range);
+            if (overlapped_address_range.has_value()) {
+                switch (overlapped_address_range->origin) {
+                    case AddressRangeOrigin::SrcAccelStruct: {
+                        // Valid overlap, source acceleration structures being read only
+                        break;
+                    }
+                    case AddressRangeOrigin::DstAccelStruct: {
+                        if (const auto other_dst_as_state = Get<vvl::AccelerationStructureKHR>(
+                                p_infos[overlapped_address_range->info_i].dstAccelerationStructure)) {
+                            const vvl::range<VkDeviceAddress> src_as_other_dst_as_intersection =
+                                src_as_address_range.range & overlapped_address_range->range;
+
+                            skip |= LogError("VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03701",
+                                             LogObjectList(cmd_buffer, src_as_state->VkHandle(), other_dst_as_state->VkHandle()),
+                                             info_i_loc.dot(Field::srcAccelerationStructure),
+                                             ", in update mode, overlaps with dstAccelerationStructure of pInfos[%" PRIu32
+                                             "], on device address range %s.",
+                                             overlapped_address_range->info_i,
+                                             string_range_hex(src_as_other_dst_as_intersection).c_str());
+                        }
+                        break;
+                    }
+                    case AddressRangeOrigin::Scratch: {
+                        const vvl::range<VkDeviceAddress> src_as_other_scratch_intersection =
+                            src_as_address_range.range & overlapped_address_range->range;
+                        skip |= LogError(
+                            "VUID-vkCmdBuildAccelerationStructuresKHR-scratchData-03705",
+                            LogObjectList(cmd_buffer, src_as_state->VkHandle()), info_i_loc.dot(Field::srcAccelerationStructure),
+                            "overlaps with scratch buffer of pInfos[%" PRIu32 "] on device address range %s.",
+                            overlapped_address_range->info_i, string_range_hex(src_as_other_scratch_intersection).c_str());
+                        break;
+                    }
+                    default:
+                        assert(false);
+                        break;
+                }
+            }
+        }
+
+        if (dst_as_state) {
+            const AddressRange dst_as_address_range = {dst_as_state->GetDeviceAddressRange(), info_i,
+                                                       AddressRangeOrigin::DstAccelStruct};
+            const std::optional<AddressRange> overlapped_address_range = insert_address(address_ranges, dst_as_address_range);
+            if (overlapped_address_range.has_value()) {
+                switch (overlapped_address_range->origin) {
+                    case AddressRangeOrigin::SrcAccelStruct: {
+                        if (const auto other_src_as_state = Get<vvl::AccelerationStructureKHR>(
+                                p_infos[overlapped_address_range->info_i].srcAccelerationStructure)) {
+                            const vvl::range<VkDeviceAddress> dst_as_other_src_as_intersection =
+                                dst_as_address_range.range & overlapped_address_range->range;
+
+                            skip |= LogError("VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03701",
+                                             LogObjectList(cmd_buffer, dst_as_state->VkHandle(), other_src_as_state->VkHandle()),
+                                             info_i_loc.dot(Field::dstAccelerationStructure),
+                                             ", overlaps with srcAccelerationStructure of pInfos[%" PRIu32
+                                             "], which is in update mode, on device address range %s.",
+                                             overlapped_address_range->info_i,
+                                             string_range_hex(dst_as_other_src_as_intersection).c_str());
+                        }
+                        break;
+                    }
+                    case AddressRangeOrigin::DstAccelStruct: {
+                        if (const auto other_dst_as_state = Get<vvl::AccelerationStructureKHR>(
+                                p_infos[overlapped_address_range->info_i].dstAccelerationStructure)) {
+                            const vvl::range<VkDeviceAddress> dst_as_other_dst_as_intersection =
+                                dst_as_address_range.range & overlapped_address_range->range;
+
+                            skip |= LogError(
+                                "VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03702",
+                                LogObjectList(cmd_buffer, dst_as_state->VkHandle(), other_dst_as_state->VkHandle()),
+                                info_i_loc.dot(Field::dstAccelerationStructure),
+                                "overlaps with dstAccelerationStructure of pInfos[%" PRIu32 "], on device address range %s.",
+                                overlapped_address_range->info_i, string_range_hex(dst_as_other_dst_as_intersection).c_str());
+                        }
+                        break;
+                    }
+                    case AddressRangeOrigin::Scratch: {
+                        const vvl::range<VkDeviceAddress> src_as_other_scratch_intersection =
+                            dst_as_address_range.range & overlapped_address_range->range;
+                        skip |= LogError(
+                            "VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03703",
+                            LogObjectList(cmd_buffer, dst_as_state->VkHandle()), info_i_loc.dot(Field::dstAccelerationStructure),
+                            "overlaps with scratch buffer of pInfos[%" PRIu32 "] on device address range %s.",
+                            overlapped_address_range->info_i, string_range_hex(src_as_other_scratch_intersection).c_str());
+                        break;
+                    }
+                    default:
+                        assert(false);
+                        break;
+                }
+            }
+        }
+
+        {
+            assert(error_obj.location.function != Func::vkBuildAccelerationStructuresKHR);
+            const VkDeviceSize assumed_scratch_size =
+                rt::ComputeScratchSize(rt::BuildType::Device, device, info, pp_range_infos[info_i]);
+
+            const vvl::range<VkDeviceAddress> scratch_range = {info.scratchData.deviceAddress,
+                                                               info.scratchData.deviceAddress + assumed_scratch_size};
+
+            const AddressRange scratch_address_range = {scratch_range, info_i, AddressRangeOrigin::Scratch};
+            const std::optional<AddressRange> overlapped_address_range = insert_address(address_ranges, scratch_address_range);
+            if (overlapped_address_range.has_value()) {
+                switch (overlapped_address_range->origin) {
+                    case AddressRangeOrigin::SrcAccelStruct: {
+                        if (const auto other_src_as_state = Get<vvl::AccelerationStructureKHR>(
+                                p_infos[overlapped_address_range->info_i].srcAccelerationStructure)) {
+                            const vvl::range<VkDeviceAddress> scratch_other_src_as_intersection =
+                                scratch_address_range.range & overlapped_address_range->range;
+
+                            skip |= LogError(
+                                "VUID-vkCmdBuildAccelerationStructuresKHR-scratchData-03705",
+                                LogObjectList(cmd_buffer, other_src_as_state->VkHandle()), info_i_loc.dot(Field::scratchData),
+                                ", overlaps with srcAccelerationStructure of pInfos[%" PRIu32
+                                "], which is in update mode, on device address range %s.",
+                                overlapped_address_range->info_i, string_range_hex(scratch_other_src_as_intersection).c_str());
+                        }
+                        break;
+                    }
+                    case AddressRangeOrigin::DstAccelStruct: {
+                        if (const auto other_dst_as_state = Get<vvl::AccelerationStructureKHR>(
+                                p_infos[overlapped_address_range->info_i].dstAccelerationStructure)) {
+                            const vvl::range<VkDeviceAddress> dst_as_other_dst_as_intersection =
+                                scratch_address_range.range & overlapped_address_range->range;
+
+                            skip |= LogError(
+                                "VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03703",
+                                LogObjectList(cmd_buffer, other_dst_as_state->VkHandle()), info_i_loc.dot(Field::scratchData),
+                                "overlaps with dstAccelerationStructure of pInfos[%" PRIu32 "], on device address range %s.",
+                                overlapped_address_range->info_i, string_range_hex(dst_as_other_dst_as_intersection).c_str());
+                        }
+                        break;
+                    }
+                    case AddressRangeOrigin::Scratch: {
+                        const vvl::range<VkDeviceAddress> src_as_other_scratch_intersection =
+                            scratch_address_range.range & overlapped_address_range->range;
+                        skip |=
+                            LogError("VUID-vkCmdBuildAccelerationStructuresKHR-scratchData-03704", LogObjectList(cmd_buffer),
+                                     info_i_loc.dot(Field::scratchData),
+                                     "overlaps with scratch buffer of pInfos[%" PRIu32 "] on device address range %s.",
+                                     overlapped_address_range->info_i, string_range_hex(src_as_other_scratch_intersection).c_str());
+                        break;
+                    }
+                    default:
+                        assert(false);
+                        break;
+                }
+            }
         }
     }
 
@@ -906,12 +1064,10 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresKHR(
         skip |= CommonBuildAccelerationStructureValidation(info, info_loc, commandBuffer);
 
         skip |= ValidateAccelerationBuffers(commandBuffer, info_i, info, ppBuildRangeInfos[info_i], info_loc);
-
-        skip |= ValidateAccelerationStructuresMemoryAlisasing(commandBuffer, infoCount, pInfos, info_i, error_obj);
-
-        skip |= ValidateAccelerationStructuresDeviceScratchBufferMemoryAlisasing(commandBuffer, infoCount, pInfos, info_i,
-                                                                                 ppBuildRangeInfos, error_obj);
     }
+
+    skip |= ValidateAccelerationStructuresDeviceScratchBufferMemoryAliasing(commandBuffer, infoCount, pInfos, ppBuildRangeInfos,
+                                                                            error_obj);
 
     return skip;
 }

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1689,9 +1689,9 @@ class CoreChecks : public vvl::Device {
     bool ValidateAccelerationStructuresMemoryAlisasing(const LogObjectList& objlist, uint32_t infoCount,
                                                        const VkAccelerationStructureBuildGeometryInfoKHR* pInfos, uint32_t info_i,
                                                        const ErrorObject& error_obj) const;
-    bool ValidateAccelerationStructuresDeviceScratchBufferMemoryAlisasing(
-        const LogObjectList& objlist, uint32_t info_count, const VkAccelerationStructureBuildGeometryInfoKHR* p_infos,
-        uint32_t info_i, const VkAccelerationStructureBuildRangeInfoKHR* const* pp_range_infos, const ErrorObject& error_obj) const;
+    bool ValidateAccelerationStructuresDeviceScratchBufferMemoryAliasing(
+        VkCommandBuffer cmd_buffer, uint32_t info_count, const VkAccelerationStructureBuildGeometryInfoKHR* p_infos,
+        const VkAccelerationStructureBuildRangeInfoKHR* const* pp_range_infos, const ErrorObject& error_obj) const;
     bool PreCallValidateCmdBuildAccelerationStructuresKHR(VkCommandBuffer commandBuffer, uint32_t infoCount,
                                                           const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
                                                           const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos,

--- a/layers/gpuav/core/gpuav_setup.cpp
+++ b/layers/gpuav/core/gpuav_setup.cpp
@@ -53,7 +53,7 @@ std::shared_ptr<vvl::Sampler> Validator::CreateSamplerState(VkSampler handle, co
 std::shared_ptr<vvl::AccelerationStructureKHR> Validator::CreateAccelerationStructureState(
     VkAccelerationStructureKHR handle, const VkAccelerationStructureCreateInfoKHR *create_info,
     std::shared_ptr<vvl::Buffer> &&buf_state) {
-    return std::make_shared<AccelerationStructureKHR>(handle, create_info, std::move(buf_state), *desc_heap_);
+    return std::make_shared<AccelerationStructureKHR>(api_version, device, handle, create_info, std::move(buf_state), *desc_heap_);
 }
 
 std::shared_ptr<vvl::DescriptorSet> Validator::CreateDescriptorSet(VkDescriptorSet handle, vvl::DescriptorPool *pool,

--- a/layers/gpuav/resources/gpuav_state_trackers.cpp
+++ b/layers/gpuav/resources/gpuav_state_trackers.cpp
@@ -90,9 +90,10 @@ void Sampler::NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) {
     vvl::Sampler::NotifyInvalidate(invalid_nodes, unlink);
 }
 
-AccelerationStructureKHR::AccelerationStructureKHR(VkAccelerationStructureKHR as, const VkAccelerationStructureCreateInfoKHR *ci,
+AccelerationStructureKHR::AccelerationStructureKHR(APIVersion api_version, VkDevice device, VkAccelerationStructureKHR as,
+                                                   const VkAccelerationStructureCreateInfoKHR *ci,
                                                    std::shared_ptr<vvl::Buffer> &&buf_state, DescriptorHeap &desc_heap_)
-    : vvl::AccelerationStructureKHR(as, ci, std::move(buf_state)),
+    : vvl::AccelerationStructureKHR(api_version, device, as, ci, std::move(buf_state)),
       desc_heap(desc_heap_),
       id(desc_heap.NextId(VulkanTypedHandle(as, kVulkanObjectTypeAccelerationStructureKHR))) {}
 

--- a/layers/gpuav/resources/gpuav_state_trackers.h
+++ b/layers/gpuav/resources/gpuav_state_trackers.h
@@ -229,8 +229,9 @@ class Sampler : public vvl::Sampler {
 
 class AccelerationStructureKHR : public vvl::AccelerationStructureKHR {
   public:
-    AccelerationStructureKHR(VkAccelerationStructureKHR as, const VkAccelerationStructureCreateInfoKHR *ci,
-                             std::shared_ptr<vvl::Buffer> &&buf_state, DescriptorHeap &desc_heap_);
+    AccelerationStructureKHR(APIVersion api_version, VkDevice device, VkAccelerationStructureKHR as,
+                             const VkAccelerationStructureCreateInfoKHR *ci, std::shared_ptr<vvl::Buffer> &&buf_state,
+                             DescriptorHeap &desc_heap_);
 
     void Destroy() final;
     void NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) final;

--- a/layers/state_tracker/ray_tracing_state.h
+++ b/layers/state_tracker/ray_tracing_state.h
@@ -75,12 +75,27 @@ class AccelerationStructureNV : public Bindable {
 
 class AccelerationStructureKHR : public StateObject {
   public:
-    AccelerationStructureKHR(VkAccelerationStructureKHR handle, const VkAccelerationStructureCreateInfoKHR *pCreateInfo,
-                             std::shared_ptr<Buffer> &&buf_state)
+    AccelerationStructureKHR(APIVersion api_version, VkDevice device, VkAccelerationStructureKHR handle,
+                             const VkAccelerationStructureCreateInfoKHR *pCreateInfo, std::shared_ptr<Buffer> &&buf_state)
         : StateObject(handle, kVulkanObjectTypeAccelerationStructureKHR),
           safe_create_info(pCreateInfo),
           create_info(*safe_create_info.ptr()),
-          buffer_state(buf_state) {}
+          buffer_state(buf_state) {
+        // If the buffer's device address has not been queried,
+        // get it here. Since it is used for the purpose of
+        // validation, do not try to update buffer_state, since
+        // it only tracks application state.
+        if (buffer_state && buffer_state->deviceAddress == 0) {
+            VkBufferDeviceAddressInfo address_info = vku::InitStructHelper();
+            address_info.buffer = buffer_state->VkHandle();
+
+            if (api_version >= VK_API_VERSION_1_2) {
+                buffer_device_address = DispatchGetBufferDeviceAddress(device, &address_info);
+            } else {
+                buffer_device_address = DispatchGetBufferDeviceAddressKHR(device, &address_info);
+            }
+        }
+    }
     AccelerationStructureKHR(const AccelerationStructureKHR &rh_obj) = delete;
 
     virtual ~AccelerationStructureKHR() {
@@ -120,11 +135,30 @@ class AccelerationStructureKHR : public StateObject {
         }
     }
 
+    // Returns the device address range effectively occupied by the acceleration structure,
+    // as defined by its creation info.
+    // It does NOT take into account the acceleration structure address as returned by
+    // vkGetAccelerationStructureDeviceAddress, this address may be at an offset
+    // of the buffer range backing the acceleration structure
+    vvl::range<VkDeviceAddress> GetDeviceAddressRange() const {
+        if (!buffer_state) {
+            return {};
+        }
+        if (buffer_state->deviceAddress != 0) {
+            return {buffer_state->deviceAddress + safe_create_info.offset,
+                    buffer_state->deviceAddress + safe_create_info.offset + safe_create_info.size};
+        }
+        return {buffer_device_address + safe_create_info.offset,
+                buffer_device_address + safe_create_info.offset + safe_create_info.size};
+    }
+
     const vku::safe_VkAccelerationStructureCreateInfoKHR safe_create_info;
     const VkAccelerationStructureCreateInfoKHR &create_info;
 
     uint64_t opaque_handle = 0;
     std::shared_ptr<vvl::Buffer> buffer_state{};
+    VkDeviceAddress buffer_device_address =
+        0;  // Used in case buffer_state->deviceAddress is 0 (happens if app never queried address)
     std::optional<vku::safe_VkAccelerationStructureBuildGeometryInfoKHR> build_info_khr{};
     std::vector<VkAccelerationStructureBuildRangeInfoKHR> build_range_infos{};
     // You can't have is_built == false and a build_info_khr, but you can have is_built == true and no build_info_khr,

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -368,6 +368,21 @@ std::shared_ptr<Buffer> Device::CreateBufferState(VkBuffer handle, const VkBuffe
     return std::make_shared<Buffer>(*this, handle, create_info);
 }
 
+void Device::PreCallRecordCreateBuffer(VkDevice device, const VkBufferCreateInfo *pCreateInfo,
+                                       const VkAllocationCallbacks *pAllocator, VkBuffer *pBuffer, const RecordObject &record_obj,
+                                       chassis::CreateBuffer &chassis_state) {
+    if (pCreateInfo->usage & VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR) {
+        // When it comes to validation acceleration memory overlaps, it is much faster to
+        // work on device address ranges directly, but for that to be possible,
+        // buffers used to back acceleration structures must have been created with the
+        // VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT usage flag
+        // => Enforce it.
+        // Doing so will not modify VVL state tracking, and if the application forgot to set
+        // this flag, it will still be detected.
+        chassis_state.modified_create_info.usage |= VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
+    }
+}
+
 void Device::PostCallRecordCreateBuffer(VkDevice device, const VkBufferCreateInfo *pCreateInfo,
                                         const VkAllocationCallbacks *pAllocator, VkBuffer *pBuffer,
                                         const RecordObject &record_obj) {
@@ -2233,7 +2248,7 @@ void Device::PostCallRecordCreateAccelerationStructureNV(VkDevice device, const 
 std::shared_ptr<AccelerationStructureKHR> Device::CreateAccelerationStructureState(
     VkAccelerationStructureKHR handle, const VkAccelerationStructureCreateInfoKHR *create_info,
     std::shared_ptr<Buffer> &&buf_state) {
-    return std::make_shared<AccelerationStructureKHR>(handle, create_info, std::move(buf_state));
+    return std::make_shared<AccelerationStructureKHR>(api_version, device, handle, create_info, std::move(buf_state));
 }
 
 void Device::PostCallRecordCreateAccelerationStructureKHR(VkDevice device, const VkAccelerationStructureCreateInfoKHR *pCreateInfo,

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -788,6 +788,9 @@ class Device : public vvl::base::Device {
                                                       const RecordObject& record_obj) override;
 
     virtual std::shared_ptr<vvl::Buffer> CreateBufferState(VkBuffer handle, const VkBufferCreateInfo* create_info);
+    void PreCallRecordCreateBuffer(VkDevice device, const VkBufferCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
+                                   VkBuffer* pBuffer, const RecordObject& record_obj,
+                                   chassis::CreateBuffer& chassis_state) override;
     void PostCallRecordCreateBuffer(VkDevice device, const VkBufferCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                     VkBuffer* pBuffer, const RecordObject& record_obj) override;
     void PreCallRecordDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAllocationCallbacks* pAllocator,

--- a/tests/icd/test_icd.cpp
+++ b/tests/icd/test_icd.cpp
@@ -1696,8 +1696,7 @@ static VKAPI_ATTR void VKAPI_CALL GetShaderModuleIdentifierEXT(VkDevice device, 
 
 static VKAPI_ATTR VkDeviceAddress VKAPI_CALL
 GetAccelerationStructureDeviceAddressKHR(VkDevice device, const VkAccelerationStructureDeviceAddressInfoKHR* pInfo) {
-    // arbitrary - need to be aligned to 256 bytes
-    return 0x262144;
+    return VkDeviceAddress(pInfo->accelerationStructure) << 8u;
 }
 
 static VKAPI_ATTR void VKAPI_CALL GetAccelerationStructureBuildSizesKHR(

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -1834,6 +1834,11 @@ TEST_F(NegativeRayTracing, AccelerationStructuresOverlappingMemory) {
     RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
     RETURN_IF_SKIP(InitState());
 
+    if (IsPlatformMockICD()) {
+        GTEST_SKIP()
+            << "Test needs acceleration structures addresses to be related to the buffer backing them, mock ICD does not do that";
+    }
+
     constexpr size_t build_info_count = 3;
 
     // All buffers used to back source/destination acceleration structures will be bound to this memory chunk
@@ -1861,11 +1866,11 @@ TEST_F(NegativeRayTracing, AccelerationStructuresOverlappingMemory) {
             build_infos.emplace_back(std::move(blas));
         }
 
-        // Since all the destination acceleration structures are bound to the same memory, 03702 will be triggered for each pair of
-        // elements in `build_infos`
-        for (size_t i = 0; i < binom<size_t>(build_info_count, 2); ++i) {
-            m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03702");
-        }
+        // Since all the destination acceleration structures are bound to the same memory, 03702 should be triggered for each pair
+        // of elements in `build_infos`
+        // => due to validation code optimisations, not *all* overlaps will be detected,
+        // but if there is *at least one*, it will *always+ be detected.
+        m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03702", 2);
         m_command_buffer.Begin();
         vkt::as::BuildAccelerationStructuresKHR(m_command_buffer.handle(), build_infos);
         m_command_buffer.End();
@@ -1910,12 +1915,13 @@ TEST_F(NegativeRayTracing, AccelerationStructuresOverlappingMemory) {
             blas_vec.emplace_back(std::move(blas));
         }
 
-        // Since all the source and destination acceleration structures are bound to the same memory, 03701 and 03702 will be
+        // Since all the source and destination acceleration structures are bound to the same memory, 03701 and 03702 should be
         // triggered for each pair of elements in `build_infos`, and 03668 for each element
-        for (size_t i = 0; i < binom<size_t>(build_info_count, 2); ++i) {
-            m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03701");
-            m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03702");
-        }
+        // => due to validation code optimisations, not *all* overlaps described by 03701 and 03702 will be detected,
+        // but if there is *at least one*, it will *always+ be detected.
+        m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03701", 2);
+        m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03702", 2);
+
         for (size_t i = 0; i < build_info_count; ++i) {
             m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03668");
         }
@@ -1976,9 +1982,9 @@ TEST_F(NegativeRayTracing, AccelerationStructuresOverlappingMemory2) {
 
         // Since all the scratch buffers are bound to the same memory, 03704 will be triggered for each pair of elements in
         // `build_infos`
-        for (size_t i = 0; i < binom<size_t>(build_info_count, 2); ++i) {
-            m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-scratchData-03704");
-        }
+        // => due to validation code optimisations, not *all* overlaps will be detected,
+        // but if there is *at least one*, it will *always+ be detected.
+        m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-scratchData-03704", 2);
         m_command_buffer.Begin();
         vkt::as::BuildAccelerationStructuresKHR(m_command_buffer.handle(), build_infos);
         m_command_buffer.End();
@@ -2044,15 +2050,12 @@ TEST_F(NegativeRayTracing, AccelerationStructuresOverlappingMemory3) {
         }
 
         // Since all the destination acceleration structures and scratch buffers are bound to the same memory, 03702, 03703 and
-        // 03704 will be triggered for each pair of elements in `build_infos`. 03703 will also be triggered for individual elements.
-        for (size_t i = 0; i < binom<size_t>(build_info_count, 2); ++i) {
-            m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03702");
-            m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03703");
-            m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-scratchData-03704");
-        }
-        for (size_t i = 0; i < build_info_count; ++i) {
-            m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03703");
-        }
+        // 03704 *should* be triggered for each pair of elements in `build_infos`. 03703 *should* also be triggered for individual
+        // elements.
+        // => due to validation code optimisations, not *all* overlaps will be detected,
+        // but if there is *at least one*, it will *always+ be detected.
+        m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03703", 3);
+        m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-scratchData-03704", 2);
         m_command_buffer.Begin();
         vkt::as::BuildAccelerationStructuresKHR(m_command_buffer.handle(), blas_vec);
         m_command_buffer.End();
@@ -2134,15 +2137,12 @@ TEST_F(NegativeRayTracing, AccelerationStructuresOverlappingMemory4) {
             blas_vec.emplace_back(std::move(blas));
         }
 
-        // Since all the source and destination acceleration structures are bound to the same memory, 03704 and 03705 will be
-        // triggered for each pair of elements in `build_infos`. 03705 will also be triggered for individual elements.
-        for (size_t i = 0; i < binom<size_t>(build_info_count, 2); ++i) {
-            m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-scratchData-03704");
-            m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-scratchData-03705");
-        }
-        for (size_t i = 0; i < build_info_count; ++i) {
-            m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-scratchData-03705");
-        }
+        // Since all the source and destination acceleration structures are bound to the same memory, 03704 and 03705 *should* be
+        // triggered for each pair of elements in `build_infos`. 03705 *should* also be triggered for individual elements.
+        // => due to validation code optimisations, not *all* overlaps will be detected,
+        // but if there is *at least one*, it will *always+ be detected.
+        m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-scratchData-03704", 2);
+        m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-scratchData-03705", 3);
 
         m_command_buffer.Begin();
         vkt::as::BuildAccelerationStructuresKHR(m_command_buffer.handle(), blas_vec);


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9428

In acceleration structures build commands, when looking for overlaps between source acceleration structures, destination acceleration structures, and scratch buffers, do it using device address ranges instead of relying on the device memory objects, and sort device address ranges.
=> Since overlap detection is done when a new device address range is inserted among the previously seen ones, and insertion is done using dichotomy (faster and ok since address ranges are sorted), not all overlap will be detected, but if there is any, it will be detected.
For instance, if all ranges are equal, inserting yet another equal range will likely result in it being directly placed at the beginning or end of the list, with only one overlap detected with first of last element.
Given the performance gains, and the fact that most calls done by apps to `vkCmdBuildAccelerationStructuresKHR` are expected to be valid so no memory overlaps will be detected, this compromise is well worth it.

Doing some stress test, where I build 8000 acceleration structures in one go, `PreCallValidateCmdBuildAccelerationStructuresKHR` went from ~4 minutes down to ~200 ms, and the overlap validation itself is about ~100 ms

Still need to do the same change at other spots, but this one in particular was the issue, so let's get this in first
