### PR TITLE
layers: Remove Device arg from various submit-time callbacks

### DIFF
--- a/layers/best_practices/bp_image.cpp
+++ b/layers/best_practices/bp_image.cpp
@@ -173,11 +173,11 @@ void BestPractices::QueueValidateImage(QueueCallbacks& funcs, Func command, std:
 
 void BestPractices::QueueValidateImage(QueueCallbacks& funcs, Func command, std::shared_ptr<bp_state::Image>& state,
                                        IMAGE_SUBRESOURCE_USAGE_BP usage, uint32_t array_layer, uint32_t mip_level) {
-    funcs.emplace_back([this, command, state, usage, array_layer, mip_level](const vvl::Device& vst, const vvl::Queue& qs,
-                                                                             const vvl::CommandBuffer& cbs) -> bool {
-        ValidateImageInQueue(qs, cbs, command, *state, usage, array_layer, mip_level);
-        return false;
-    });
+    funcs.emplace_back(
+        [this, command, state, usage, array_layer, mip_level](const vvl::Queue& qs, const vvl::CommandBuffer& cbs) -> bool {
+            ValidateImageInQueue(qs, cbs, command, *state, usage, array_layer, mip_level);
+            return false;
+        });
 }
 
 void BestPractices::ValidateImageInQueueArmImg(Func command, const bp_state::Image& image, IMAGE_SUBRESOURCE_USAGE_BP last_usage,

--- a/layers/best_practices/bp_instance_device.cpp
+++ b/layers/best_practices/bp_instance_device.cpp
@@ -327,7 +327,7 @@ void BestPractices::PreCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount
         for (uint32_t cb_index = 0; cb_index < submit_info.commandBufferCount; cb_index++) {
             auto cb = GetWrite<bp_state::CommandBuffer>(submit_info.pCommandBuffers[cb_index]);
             for (auto& func : cb->queue_submit_functions) {
-                func(*this, *queue_state, *cb);
+                func(*queue_state, *cb);
             }
             cb->num_submits++;
         }

--- a/layers/best_practices/bp_synchronization.cpp
+++ b/layers/best_practices/bp_synchronization.cpp
@@ -470,7 +470,7 @@ void BestPractices::RecordCmdPipelineBarrierImageBarrier(VkCommandBuffer command
         auto image = Get<bp_state::Image>(barrier.image);
         ASSERT_AND_RETURN(image);
         auto subresource_range = barrier.subresourceRange;
-        cb_state->queue_submit_functions.emplace_back([image, subresource_range](const vvl::Device& vst, const vvl::Queue& qs,
+        cb_state->queue_submit_functions.emplace_back([image, subresource_range](const vvl::Queue& qs,
                                                                                  const vvl::CommandBuffer& cbs) -> bool {
             ForEachSubresource(*image, subresource_range, [&](uint32_t layer, uint32_t level) {
                 // Update queue family index without changing usage, signifying a correct queue family transfer

--- a/layers/core_checks/cc_copy_blit_resolve.cpp
+++ b/layers/core_checks/cc_copy_blit_resolve.cpp
@@ -2003,8 +2003,7 @@ void CoreChecks::RecordCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer src
 
         auto queue_submit_validation = [this, commandBuffer, src_buffer_state, dst_buffer_state, src_ranges = std::move(src_ranges),
                                         dst_ranges = std::move(dst_ranges), src_ranges_bounds, dst_ranges_bounds, loc,
-                                        vuid](const vvl::Device &device_data, const class vvl::Queue &queue_state,
-                                              const vvl::CommandBuffer &cb_state) -> bool {
+                                        vuid](const class vvl::Queue &queue_state, const vvl::CommandBuffer &cb_state) -> bool {
             bool skip = false;
 
             auto src_vk_memory_to_ranges_map = src_buffer_state->GetBoundRanges(src_ranges_bounds, src_ranges);

--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
+/* Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
  * Copyright (C) 2015-2024 Google Inc.
  * Modifications Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
  *
@@ -74,7 +74,7 @@ struct CommandBufferSubmitState {
 
         // Call submit-time functions to validate or update local mirrors of state (to preserve const-ness at validate time)
         for (auto &function : cb_state.queue_submit_functions) {
-            skip |= function(core, queue_state, cb_state);
+            skip |= function(queue_state, cb_state);
         }
         for (auto &function : cb_state.event_updates) {
             skip |= function(const_cast<vvl::CommandBuffer &>(cb_state), /*do_validate*/ true, local_event_signal_info,
@@ -93,7 +93,7 @@ struct CommandBufferSubmitState {
                 local_state_it = local_video_session_state.insert({it.first, video_session_state->DeviceStateCopy()}).first;
             }
             for (const auto &function : it.second) {
-                skip |= function(core, video_session_state.get(), local_state_it->second, /*do_validate*/ true);
+                skip |= function(video_session_state.get(), local_state_it->second, /*do_validate*/ true);
             }
         }
         return skip;

--- a/layers/core_checks/cc_video.cpp
+++ b/layers/core_checks/cc_video.cpp
@@ -119,12 +119,11 @@ bool CoreChecks::IsImageCompatibleWithVideoSession(const vvl::Image &image_state
 void CoreChecks::EnqueueVerifyVideoSessionInitialized(vvl::CommandBuffer &cb_state, vvl::VideoSession &vs_state,
                                                       const Location &loc, const char *vuid) {
     cb_state.video_session_updates[vs_state.VkHandle()].emplace_back(
-        [loc, vuid](const vvl::Device &dev_data, const vvl::VideoSession *vs_state, vvl::VideoSessionDeviceState &dev_state,
-                    bool do_validate) {
+        [this, loc, vuid](const vvl::VideoSession *vs_state, vvl::VideoSessionDeviceState &dev_state, bool do_validate) {
             bool skip = false;
             if (!dev_state.IsInitialized()) {
-                skip |= dev_data.LogError(vuid, vs_state->Handle(), loc, "Bound video session %s is uninitialized.",
-                                          dev_data.FormatHandle(*vs_state).c_str());
+                skip |= this->LogError(vuid, vs_state->Handle(), loc, "Bound video session %s is uninitialized.",
+                                       this->FormatHandle(*vs_state).c_str());
             }
             return skip;
         });
@@ -4800,24 +4799,24 @@ void CoreChecks::PreCallRecordCmdBeginVideoCodingKHR(VkCommandBuffer commandBuff
 
         // Enqueue submission time validation of DPB slots
         cb_state->video_session_updates[vs_state->VkHandle()].emplace_back(
-            [expected_slots, loc](const vvl::Device &dev_data, const vvl::VideoSession *vs_state,
-                                  vvl::VideoSessionDeviceState &dev_state, bool do_validate) {
+            [this, expected_slots, loc](const vvl::VideoSession *vs_state, vvl::VideoSessionDeviceState &dev_state,
+                                        bool do_validate) {
                 if (!do_validate) return false;
                 bool skip = false;
                 for (const auto &slot : expected_slots) {
                     if (!dev_state.IsSlotActive(slot.index)) {
-                        skip |= dev_data.LogError("VUID-vkCmdBeginVideoCodingKHR-slotIndex-07239", vs_state->Handle(), loc,
-                                                  "DPB slot index %d is not active in %s.", slot.index,
-                                                  dev_data.FormatHandle(*vs_state).c_str());
+                        skip |= this->LogError("VUID-vkCmdBeginVideoCodingKHR-slotIndex-07239", vs_state->Handle(), loc,
+                                               "DPB slot index %d is not active in %s.", slot.index,
+                                               this->FormatHandle(*vs_state).c_str());
                     } else if (slot.resource && !dev_state.IsSlotPicture(slot.index, slot.resource)) {
-                        skip |= dev_data.LogError("VUID-vkCmdBeginVideoCodingKHR-pPictureResource-07265", vs_state->Handle(), loc,
-                                                  "DPB slot index %d of %s is not currently associated with the specified "
-                                                  "video picture resource: %s, layer %u, offset (%s), extent (%s).",
-                                                  slot.index, dev_data.FormatHandle(*vs_state).c_str(),
-                                                  dev_data.FormatHandle(slot.resource.image_state->Handle()).c_str(),
-                                                  slot.resource.range.baseArrayLayer,
-                                                  string_VkOffset2D(slot.resource.coded_offset).c_str(),
-                                                  string_VkExtent2D(slot.resource.coded_extent).c_str());
+                        skip |= this->LogError("VUID-vkCmdBeginVideoCodingKHR-pPictureResource-07265", vs_state->Handle(), loc,
+                                               "DPB slot index %d of %s is not currently associated with the specified "
+                                               "video picture resource: %s, layer %u, offset (%s), extent (%s).",
+                                               slot.index, this->FormatHandle(*vs_state).c_str(),
+                                               this->FormatHandle(slot.resource.image_state->Handle()).c_str(),
+                                               slot.resource.range.baseArrayLayer,
+                                               string_VkOffset2D(slot.resource.coded_offset).c_str(),
+                                               string_VkExtent2D(slot.resource.coded_extent).c_str());
                     }
                 }
                 return skip;
@@ -4829,10 +4828,9 @@ void CoreChecks::PreCallRecordCmdBeginVideoCodingKHR(VkCommandBuffer commandBuff
 
         // Enqueue submission time validation of rate control state
         cb_state->video_session_updates[vs_state->VkHandle()].emplace_back(
-            [begin_info, loc](const vvl::Device &dev_data, const vvl::VideoSession *vs_state,
-                              vvl::VideoSessionDeviceState &dev_state, bool do_validate) {
+            [this, begin_info, loc](const vvl::VideoSession *vs_state, vvl::VideoSessionDeviceState &dev_state, bool do_validate) {
                 if (!do_validate) return false;
-                return dev_state.ValidateRateControlState(dev_data, vs_state, begin_info, loc);
+                return dev_state.ValidateRateControlState(*this, vs_state, begin_info, loc);
             });
     }
 }
@@ -5304,20 +5302,19 @@ void CoreChecks::PreCallRecordCmdDecodeVideoKHR(VkCommandBuffer commandBuffer, c
 
         // Enqueue submission time validation of picture kind (frame, top field, bottom field) for H.264
         cb_state->video_session_updates[vs_state->VkHandle()].emplace_back(
-            [reference_slots, loc](const vvl::Device &dev_data, const vvl::VideoSession *vs_state,
-                                   vvl::VideoSessionDeviceState &dev_state, bool do_validate) {
+            [this, reference_slots, loc](const vvl::VideoSession *vs_state, vvl::VideoSessionDeviceState &dev_state,
+                                         bool do_validate) {
                 if (!do_validate) return false;
                 bool skip = false;
                 const auto log_picture_kind_error = [&](const vvl::VideoReferenceSlot &slot, const char *vuid,
                                                         const char *picture_kind) -> bool {
-                    return dev_data.LogError(vuid, vs_state->Handle(), loc,
-                                             "DPB slot index %d of %s does not currently contain a %s with the specified "
-                                             "video picture resource: %s, layer %u, offset (%s), extent (%s).",
-                                             slot.index, dev_data.FormatHandle(*vs_state).c_str(), picture_kind,
-                                             dev_data.FormatHandle(slot.resource.image_state->Handle()).c_str(),
-                                             slot.resource.range.baseArrayLayer,
-                                             string_VkOffset2D(slot.resource.coded_offset).c_str(),
-                                             string_VkExtent2D(slot.resource.coded_extent).c_str());
+                    return this->LogError(vuid, vs_state->Handle(), loc,
+                                          "DPB slot index %d of %s does not currently contain a %s with the specified "
+                                          "video picture resource: %s, layer %u, offset (%s), extent (%s).",
+                                          slot.index, this->FormatHandle(*vs_state).c_str(), picture_kind,
+                                          this->FormatHandle(slot.resource.image_state->Handle()).c_str(),
+                                          slot.resource.range.baseArrayLayer, string_VkOffset2D(slot.resource.coded_offset).c_str(),
+                                          string_VkExtent2D(slot.resource.coded_extent).c_str());
                 };
                 for (const auto &slot : reference_slots) {
                     if (slot.picture_id.IsFrame() &&
@@ -5799,18 +5796,17 @@ void CoreChecks::PreCallRecordCmdEncodeVideoKHR(VkCommandBuffer commandBuffer, c
             // time, because it was set in this command buffer, then that was already checked outside
             // so we only have to do submit-time validation if that's not the case
             cb_state->video_session_updates[vs_state->VkHandle()].emplace_back(
-                [vsp_state = cb_state->bound_video_session_parameters, loc](
-                    const vvl::Device &dev_data, const vvl::VideoSession *vs_state, vvl::VideoSessionDeviceState &dev_state,
-                    bool do_validate) {
+                [this, vsp_state = cb_state->bound_video_session_parameters, loc](
+                    const vvl::VideoSession *vs_state, vvl::VideoSessionDeviceState &dev_state, bool do_validate) {
                     if (!do_validate) return false;
                     bool skip = false;
                     if (vsp_state->GetEncodeQualityLevel() != dev_state.GetEncodeQualityLevel()) {
                         const LogObjectList objlist(vs_state->Handle(), vsp_state->Handle());
-                        skip |= dev_data.LogError("VUID-vkCmdEncodeVideoKHR-None-08318", objlist, loc,
-                                                  "The currently configured encode quality level (%u) for %s "
-                                                  "does not match the encode quality level (%u) %s was created with.",
-                                                  dev_state.GetEncodeQualityLevel(), dev_data.FormatHandle(*vs_state).c_str(),
-                                                  vsp_state->GetEncodeQualityLevel(), dev_data.FormatHandle(*vsp_state).c_str());
+                        skip |= this->LogError("VUID-vkCmdEncodeVideoKHR-None-08318", objlist, loc,
+                                               "The currently configured encode quality level (%u) for %s "
+                                               "does not match the encode quality level (%u) %s was created with.",
+                                               dev_state.GetEncodeQualityLevel(), this->FormatHandle(*vs_state).c_str(),
+                                               vsp_state->GetEncodeQualityLevel(), this->FormatHandle(*vsp_state).c_str());
                     }
                     return skip;
                 });

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -495,8 +495,7 @@ class CommandBuffer : public RefcountedStateObject {
     // If primary, the secondary command buffers we will call.
     vvl::unordered_set<CommandBuffer *> linkedCommandBuffers;
     // Validation functions run at primary CB queue submit time
-    using QueueCallback =
-        std::function<bool(const Device &device_data, const class vvl::Queue &queue_state, const CommandBuffer &cb_state)>;
+    using QueueCallback = std::function<bool(const class vvl::Queue &queue_state, const CommandBuffer &cb_state)>;
     std::vector<QueueCallback> queue_submit_functions;
     // Used by some layers to defer actions until vkCmdEndRenderPass time.
     // Layers using this are responsible for inserting the callbacks into queue_submit_functions.

--- a/layers/state_tracker/video_session_state.h
+++ b/layers/state_tracker/video_session_state.h
@@ -786,8 +786,8 @@ class VideoSessionParameters : public StateObject {
     void AddEncodeH265(VkVideoEncodeH265SessionParametersAddInfoKHR const *info);
 };
 
-using VideoSessionUpdateList = std::vector<std::function<bool(const Device &dev_data, const VideoSession *vs_state,
-                                                              VideoSessionDeviceState &dev_state, bool do_validate)>>;
+using VideoSessionUpdateList =
+    std::vector<std::function<bool(const VideoSession *vs_state, VideoSessionDeviceState &dev_state, bool do_validate)>>;
 using VideoSessionUpdateMap = unordered_map<VkVideoSessionKHR, VideoSessionUpdateList>;
 
 }  // namespace vvl


### PR DESCRIPTION
Many of the callbacks don't use it. Those that do should just capture the device in their lambda. Eventually the way these callbacks get run will change and so that they'll be run by the state tracker on behalf of each validation object so the device arg will be wrong.