### PR TITLE
layers: Use normal skip in ValidateDescriptor

### DIFF
--- a/tests/unit/descriptors.cpp
+++ b/tests/unit/descriptors.cpp
@@ -4208,7 +4208,8 @@ TEST_F(NegativeDescriptors, DescriptorWriteFromReadAttachment) {
                               &descriptor_set_storage_image.set_, 0, nullptr);
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 1, 1,
                               &descriptor_set_input_attachment.set_, 0, nullptr);
-    m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-06539");
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-06537");  // write
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-06539");  // read
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();

--- a/tests/unit/shader_storage_texel.cpp
+++ b/tests/unit/shader_storage_texel.cpp
@@ -142,7 +142,7 @@ TEST_F(NegativeShaderStorageTexel, UnknownWriteLessComponent) {
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &ds.set_, 0, nullptr);
-    m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-OpImageWrite-04469");
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-OpImageWrite-04469", 2);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
     m_errorMonitor->VerifyFound();
     m_command_buffer.End();


### PR DESCRIPTION
follow up to https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/9487

Removes the early `return` in `ValidateDescriptor`

I assume they were there because the first check does need to return early (if the descriptor is not valid) but otherwise there was no good reason