### PR TITLE
layers: Enhanced error message format

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -1155,6 +1155,14 @@
                     "expanded": true,
                     "settings": [
                         {
+                            "key": "message_format_verbose",
+                            "label": "Verbose",
+                            "description": "Display Validation Type, Object Handles, Message ID, Spec Link",
+                            "type": "BOOL",
+                            "default": true,
+                            "platforms": [ "WINDOWS", "LINUX", "MACOS", "ANDROID" ]
+                        },
+                        {
                             "key": "message_format_display_application_name",
                             "label": "Display Application Name",
                             "description": "Useful when running multiple instances to know which instance the message is from.",

--- a/layers/error_message/logging.cpp
+++ b/layers/error_message/logging.cpp
@@ -210,26 +210,31 @@ bool DebugReport::DebugLogMsg(VkFlags msg_flags, const LogObjectList &objects, c
     }
 
     if (text_vuid != nullptr) {
-        oss << "[ " << text_vuid << " ] ";
+        oss << "[ " << text_vuid << " ]";
     }
-    uint32_t index = 0;
-    for (const auto &src_object : object_name_infos) {
+
+    if (!object_name_infos.empty()) {
+        oss << " Objects: ";
+    }
+    for (uint32_t i = 0; i < object_name_infos.size(); i++) {
+        const VkDebugUtilsObjectNameInfoEXT &src_object = object_name_infos[i];
         if (0 != src_object.objectHandle) {
-            oss << "Object " << index++ << ": ";
+            oss << string_VkObjectTypeHandleName(src_object.objectType) << " ";
             if (!debug_stable_messages) {
-                oss << "handle = 0x" << std::hex << src_object.objectHandle << ", ";
+                oss << "0x" << std::hex << src_object.objectHandle;
             }
             if (src_object.pObjectName) {
-                oss << "name = " << src_object.pObjectName << ", type = ";
-            } else {
-                oss << "type = ";
+                oss << "[" << src_object.pObjectName << "]";
             }
-            oss << string_VkObjectType(src_object.objectType) << "; ";
         } else {
-            oss << "Object " << index++ << ": VK_NULL_HANDLE, type = " << string_VkObjectType(src_object.objectType) << "; ";
+            oss << string_VkObjectTypeHandleName(src_object.objectType) << " VK_NULL_HANDLE";
+        }
+
+        if (i + 1 != object_name_infos.size()) {
+            oss << "; ";
         }
     }
-    oss << "| MessageID = 0x" << std::hex << message_id_number << " | " << msg;
+    oss << " | MessageID = 0x" << std::hex << message_id_number << "\n" << msg;
     std::string composite = oss.str();
 
     const auto callback_list = &debug_callback_list;
@@ -340,7 +345,9 @@ std::string DebugReport::FormatHandle(const char *handle_type_name, uint64_t han
     if (print_handle) {
         str << "0x" << std::hex << handle;
     }
-    str << "[" << handle_name.c_str() << "]";
+    if (!handle_name.empty()) {
+        str << "[" << handle_name.c_str() << "]";
+    }
     return str.str();
 }
 

--- a/layers/error_message/logging.h
+++ b/layers/error_message/logging.h
@@ -174,6 +174,7 @@ class TypedHandleWrapper {
 struct Location;
 
 struct MessageFormatSettings {
+    bool verbose = true;
     bool display_application_name = false;
     std::string application_name;
 };

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -226,6 +226,7 @@ const char *VK_LAYER_SYNCVAL_MESSAGE_EXTRA_PROPERTIES_PRETTY_PRINT = "syncval_me
 
 // Message Formatting
 // ---
+const char *VK_LAYER_MESSAGE_FORMAT_VERBOSE = "message_format_verbose";
 const char *VK_LAYER_MESSAGE_FORMAT_DISPLAY_APPLICATION_NAME = "message_format_display_application_name";
 // Until post 1.3.290 SDK release, these were not possible to set via environment variables
 const char *VK_LAYER_LOG_FILENAME = "log_filename";
@@ -629,6 +630,8 @@ static void ValidateLayerSettingsProvided(const VkLayerSettingsCreateInfoEXT *la
             required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
         } else if (strcmp(VK_LAYER_SYNCVAL_MESSAGE_EXTRA_PROPERTIES_PRETTY_PRINT, setting.pSettingName) == 0) {
             required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
+        } else if (strcmp(VK_LAYER_MESSAGE_FORMAT_VERBOSE, setting.pSettingName) == 0) {
+            required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
         } else if (strcmp(VK_LAYER_MESSAGE_FORMAT_DISPLAY_APPLICATION_NAME, setting.pSettingName) == 0) {
             required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
         } else if (strcmp(VK_LAYER_LOG_FILENAME, setting.pSettingName) == 0) {
@@ -763,6 +766,10 @@ static void ProcessDebugReportSettings(ConfigAndEnvSettings *settings_data, VkuL
         duplicate_message_limit = 0;
     }
     debug_report->duplicate_message_limit = duplicate_message_limit;
+
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_MESSAGE_FORMAT_VERBOSE)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_MESSAGE_FORMAT_VERBOSE, debug_report->message_format_settings.verbose);
+    }
 
     if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_MESSAGE_FORMAT_DISPLAY_APPLICATION_NAME)) {
         vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_MESSAGE_FORMAT_DISPLAY_APPLICATION_NAME,

--- a/layers/vk_layer_settings.txt
+++ b/layers/vk_layer_settings.txt
@@ -154,6 +154,11 @@ khronos_validation.enables =
 # performance in multithreaded applications.
 khronos_validation.fine_grained_locking = true
 
+# Verbose error messages
+# =====================
+# Display Validation Type, Object Handles, Message ID, Spec Link
+#khronos_validation.message_format_verbose = true
+
 # Display Application Name
 # =====================
 # Useful when running multiple instances to know which instance the message is from

--- a/layers/vulkan/generated/vk_object_types.cpp
+++ b/layers/vulkan/generated/vk_object_types.cpp
@@ -3,10 +3,10 @@
 
 /***************************************************************************
  *
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (c) 2015-2024 Google Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2025 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -145,5 +145,9 @@ static const char* const kVulkanObjectTypeStrings[kVulkanObjectTypeMax] = {
 VkDebugReportObjectTypeEXT GetDebugReport(VulkanObjectType type) { return kDebugReportLookup[type]; }
 
 const char* string_VulkanObjectType(VulkanObjectType type) { return kVulkanObjectTypeStrings[type]; }
+
+const char* string_VkObjectTypeHandleName(VkObjectType type) {
+    return string_VulkanObjectType(ConvertCoreObjectToVulkanObject(type));
+}
 
 // NOLINTEND

--- a/layers/vulkan/generated/vk_object_types.h
+++ b/layers/vulkan/generated/vk_object_types.h
@@ -3,10 +3,10 @@
 
 /***************************************************************************
  *
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (c) 2015-2024 Google Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2025 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,6 +87,7 @@ typedef enum VulkanObjectType {
 
 VkDebugReportObjectTypeEXT GetDebugReport(VulkanObjectType type);
 const char* string_VulkanObjectType(VulkanObjectType type);
+const char* string_VkObjectTypeHandleName(VkObjectType type);
 
 // Helper function to get Official Vulkan VkObjectType enum from the internal layers version
 static constexpr VkObjectType ConvertVulkanObjectToCoreObject(VulkanObjectType internal_type) {

--- a/scripts/generators/object_types_generator.py
+++ b/scripts/generators/object_types_generator.py
@@ -1,10 +1,10 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2015-2024 The Khronos Group Inc.
-# Copyright (c) 2015-2024 Valve Corporation
-# Copyright (c) 2015-2024 LunarG, Inc.
-# Copyright (c) 2015-2024 Google Inc.
-# Copyright (c) 2023-2024 RasterGrid Kft.
+# Copyright (c) 2015-2025 The Khronos Group Inc.
+# Copyright (c) 2015-2025 Valve Corporation
+# Copyright (c) 2015-2025 LunarG, Inc.
+# Copyright (c) 2015-2025 Google Inc.
+# Copyright (c) 2023-2025 RasterGrid Kft.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,10 +43,10 @@ class ObjectTypesOutputGenerator(BaseGenerator):
 
             /***************************************************************************
             *
-            * Copyright (c) 2015-2024 The Khronos Group Inc.
-            * Copyright (c) 2015-2024 Valve Corporation
-            * Copyright (c) 2015-2024 LunarG, Inc.
-            * Copyright (c) 2015-2024 Google Inc.
+            * Copyright (c) 2015-2025 The Khronos Group Inc.
+            * Copyright (c) 2015-2025 Valve Corporation
+            * Copyright (c) 2015-2025 LunarG, Inc.
+            * Copyright (c) 2015-2025 Google Inc.
             *
             * Licensed under the Apache License, Version 2.0 (the "License");
             * you may not use this file except in compliance with the License.
@@ -92,6 +92,7 @@ class ObjectTypesOutputGenerator(BaseGenerator):
 
         out.append('VkDebugReportObjectTypeEXT GetDebugReport(VulkanObjectType type);\n')
         out.append('const char* string_VulkanObjectType(VulkanObjectType type);\n')
+        out.append('const char* string_VkObjectTypeHandleName(VkObjectType type);\n')
 
         out.append('''
             // Helper function to get Official Vulkan VkObjectType enum from the internal layers version
@@ -272,6 +273,10 @@ class ObjectTypesOutputGenerator(BaseGenerator):
 
             const char* string_VulkanObjectType(VulkanObjectType type) {
                 return kVulkanObjectTypeStrings[type];
+            }
+
+            const char* string_VkObjectTypeHandleName(VkObjectType type) {
+                return string_VulkanObjectType(ConvertCoreObjectToVulkanObject(type));
             }
             ''')
         self.write("".join(out))

--- a/tests/unit/layer_settings.cpp
+++ b/tests/unit/layer_settings.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2024 The Khronos Group Inc.
- * Copyright (c) 2024 Valve Corporation
- * Copyright (c) 2024 LunarG, Inc.
+ * Copyright (c) 2024-2025 The Khronos Group Inc.
+ * Copyright (c) 2024-2025 Valve Corporation
+ * Copyright (c) 2024-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -452,7 +452,7 @@ TEST_F(NegativeLayerSettings, WrongSettingType) {
     VkLayerSettingsCreateInfoEXT create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1, &setting};
     Monitor().ExpectSuccess(kErrorBit | kWarningBit);
     Monitor().SetDesiredWarning(
-        " The setting enable_message_limit in VkLayerSettingsCreateInfoEXT was set to type VK_LAYER_SETTING_TYPE_UINT32_EXT but "
+        "The setting enable_message_limit in VkLayerSettingsCreateInfoEXT was set to type VK_LAYER_SETTING_TYPE_UINT32_EXT but "
         "requires type VK_LAYER_SETTING_TYPE_BOOL32_EXT and the value may be parsed incorrectly.");
     RETURN_IF_SKIP(InitFramework(&create_info));
     RETURN_IF_SKIP(InitState());
@@ -466,7 +466,7 @@ TEST_F(NegativeLayerSettings, WrongSettingType2) {
     VkLayerSettingsCreateInfoEXT create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1, &setting};
     Monitor().ExpectSuccess(kErrorBit | kWarningBit);
     Monitor().SetDesiredWarning(
-        " The setting thread_safety in VkLayerSettingsCreateInfoEXT was set to type VK_LAYER_SETTING_TYPE_UINT32_EXT but requires "
+        "The setting thread_safety in VkLayerSettingsCreateInfoEXT was set to type VK_LAYER_SETTING_TYPE_UINT32_EXT but requires "
         "type VK_LAYER_SETTING_TYPE_BOOL32_EXT and the value may be parsed incorrectly.");
     RETURN_IF_SKIP(InitFramework(&create_info));
     RETURN_IF_SKIP(InitState());
@@ -487,4 +487,23 @@ TEST_F(NegativeLayerSettings, DuplicateSettings) {
     RETURN_IF_SKIP(InitFramework(&create_info));
     RETURN_IF_SKIP(InitState());
     Monitor().VerifyFound();
+}
+
+TEST_F(NegativeLayerSettings, MessageFormatVerbose) {
+    VkBool32 disable = VK_FALSE;
+    const VkLayerSettingEXT setting[] = {
+        {OBJECT_LAYER_NAME, "message_format_verbose", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable}};
+    VkLayerSettingsCreateInfoEXT layer_setting_create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1,
+                                                              setting};
+    RETURN_IF_SKIP(InitFramework(&layer_setting_create_info));
+    RETURN_IF_SKIP(InitState());
+
+    VkBufferCreateInfo info = vku::InitStructHelper();
+    info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+    info.size = 0;
+    m_errorMonitor->SetDesiredError(
+        "[ VUID-VkBufferCreateInfo-size-00912 ] vkCreateBuffer(): pCreateInfo->size is zero.\nThe Vulkan spec states: size must be "
+        "greater than 0");
+    vkt::Buffer buffer(*m_device, info, vkt::no_mem);
+    m_errorMonitor->VerifyFound();
 }


### PR DESCRIPTION
Before

```
Validation Error: [ VUID-vkBindBufferMemory-buffer-07459 ] Object 0: handle = 0xe7f79a0000000005, name = memory_name, type = VK_OBJECT_TYPE_DEVICE_MEMORY; Object 1: handle = 0xfa21a40000000003, type = VK_OBJECT_TYPE_BUFFER; Object 2: handle = 0xf56c9b0000000004, type = VK_OBJECT_TYPE_DEVICE_MEMORY; | MessageID = 0x5001937c | vkBindBufferMemory(): attempting to bind VkDeviceMemory 0xe7f79a0000000005[memory_name] to VkBuffer 0xfa21a40000000003 which has already been bound to VkDeviceMemory 0xf56c9b0000000004.
```

now

```
Validation Error: [ VUID-vkBindBufferMemory-buffer-07459 ] Objects: VkDeviceMemory 0xe7f79a0000000005[memory_name]; VkBuffer 0xfa21a40000000003; VkDeviceMemory 0xf56c9b0000000004 | MessageID = 0x5001937c
vkBindBufferMemory(): attempting to bind VkDeviceMemory 0xe7f79a0000000005[memory_name] to VkBuffer 0xfa21a40000000003 which has already been bound to VkDeviceMemory 0xf56c9b0000000004.
```

- Use same formatting of handle (`VkHandleType 0x0000000000[optional_name]`)
- New line before actual error message (people can now even strip everything before the first `\n` if they want themselves)
- Remove counting the objects, the index provided no useful information