### PR TITLE
gpuav: Remove VMA pool

### DIFF
--- a/layers/gpuav/core/gpuav.h
+++ b/layers/gpuav/core/gpuav.h
@@ -444,7 +444,6 @@ class Validator : public GpuShaderInstrumentor {
     PFN_vkSetDeviceLoaderData vk_set_device_loader_data_;
 
     VmaAllocator vma_allocator_ = {};
-    VmaPool output_buffer_pool_ = VK_NULL_HANDLE;
     std::unique_ptr<vko::DescriptorSetManager> desc_set_manager_;
 
     vko::Buffer indices_buffer_;

--- a/layers/gpuav/core/gpuav_record.cpp
+++ b/layers/gpuav/core/gpuav_record.cpp
@@ -128,10 +128,6 @@ void Validator::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCa
     BaseClass::PreCallRecordDestroyDevice(device, pAllocator, record_obj);
 
     // State Tracker (BaseClass) can end up making vma calls through callbacks - so destroy allocator last
-    if (output_buffer_pool_ != VK_NULL_HANDLE) {
-        vmaDestroyPool(vma_allocator_, output_buffer_pool_);
-        output_buffer_pool_ = VK_NULL_HANDLE;
-    }
     if (vma_allocator_) {
         vmaDestroyAllocator(vma_allocator_);
     }

--- a/layers/gpuav/core/gpuav_setup.cpp
+++ b/layers/gpuav/core/gpuav_setup.cpp
@@ -279,18 +279,6 @@ void Validator::FinishDeviceSetup(const VkDeviceCreateInfo *pCreateInfo, const L
             InternalVmaError(device, loc, "Unable to find memory type index.");
             return;
         }
-        VmaPoolCreateInfo vma_pool_ci = {};
-        vma_pool_ci.memoryTypeIndex = mem_type_index;
-        vma_pool_ci.blockSize = 0;
-        vma_pool_ci.maxBlockCount = 0;
-        if (gpuav_settings.vma_linear_output) {
-            vma_pool_ci.flags = VMA_POOL_CREATE_LINEAR_ALGORITHM_BIT;
-        }
-        result = vmaCreatePool(vma_allocator_, &vma_pool_ci, &output_buffer_pool_);
-        if (result != VK_SUCCESS) {
-            InternalVmaError(device, loc, "Unable to create VMA memory pool.");
-            return;
-        }
     }
 
     // Create command indices buffer
@@ -300,8 +288,6 @@ void Validator::FinishDeviceSetup(const VkDeviceCreateInfo *pCreateInfo, const L
         buffer_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
         buffer_info.size = cst::indices_count * indices_buffer_alignment_;
         VmaAllocationCreateInfo alloc_info = {};
-        assert(output_buffer_pool_);
-        alloc_info.pool = output_buffer_pool_;
         alloc_info.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
         alloc_info.preferredFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
         const bool success = indices_buffer_.Create(loc, &buffer_info, &alloc_info);

--- a/layers/gpuav/debug_printf/debug_printf.cpp
+++ b/layers/gpuav/debug_printf/debug_printf.cpp
@@ -385,7 +385,6 @@ bool UpdateInstrumentationDescSet(Validator &gpuav, CommandBuffer &cb_state, VkD
     VmaAllocationCreateInfo alloc_info = {};
     alloc_info.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
     alloc_info.preferredFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
-    alloc_info.pool = gpuav.output_buffer_pool_;
     const bool success = debug_printf_output_buffer.Create(loc, &buffer_info, &alloc_info);
     if (!success) {
         return false;

--- a/layers/gpuav/resources/gpuav_state_trackers.cpp
+++ b/layers/gpuav/resources/gpuav_state_trackers.cpp
@@ -142,7 +142,6 @@ static bool AllocateErrorLogsBuffer(Validator &gpuav, VkCommandBuffer command_bu
     VmaAllocationCreateInfo alloc_info = {};
     alloc_info.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
     alloc_info.preferredFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
-    alloc_info.pool = gpuav.output_buffer_pool_;
     const bool success = error_output_buffer.Create(loc, &buffer_info, &alloc_info);
     if (!success) {
         return false;
@@ -191,7 +190,6 @@ void CommandBuffer::AllocateResources(const Location &loc) {
         VmaAllocationCreateInfo alloc_info = {};
         alloc_info.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
         alloc_info.preferredFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
-        alloc_info.pool = gpuav->output_buffer_pool_;
         const bool success = cmd_errors_counts_buffer_.Create(loc, &buffer_info, &alloc_info);
         if (!success) {
             return;


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9499

Went down the "Do not use VMA pools" route.
Still need to investigate our VMA usage further. 
Ideally our buffers should always use device local memory, otherwise perf can get stupid.
Buffers need to be cached rather than created/destroyed at will, it can happen a lot during a frame, so much so that in games like Doom Eternal it can become the bottleneck 