### PR TITLE
layers: Add initial JSON error message option

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@ This directory contains more detailed information about how each part of the Val
 
 - [VK_LAYER_KHRONOS_validation overview](./khronos_validation_layer.md)
     - [Core Validation Checks](./core_checks.md)
+    - [Error Message Overview](./error_messages.md)
     - [Best Practices Validation](./best_practices.md)
     - [Error Object (information used to print better error messages)](./error_object.md)
     - [Shader Debug Printf](./debug_printf.md)

--- a/docs/error_messages.md
+++ b/docs/error_messages.md
@@ -1,0 +1,115 @@
+# Error Message Overview
+
+> Note: This is written for the 1.4.309 SDK and afterwards, the older versions of the Validation Layers will be slightly different
+
+When an error message is found, the Validation Layers use the "debug callback" mechanism to report the error message.
+
+By default, the Validation Layers will format the message, but it is possible for the user to provide their own `PFN_vkDebugUtilsMessengerCallbackEXT` and parse the string in `VkDebugUtilsMessengerCallbackDataEXT::pMessage` ([working example using vk-bootstrap](https://github.com/charles-lunarg/vk-bootstrap/blob/main/example/custom_debug_callback.cpp#L9-L20)).
+
+The default error message will look like:
+
+> Validation Error: [ VUID-vkCmdSetScissor-x-00595 ] Objects: VkCommandBuffer 0x639cdf870510[command_buffer_name] | MessageID = 0xa54a6ff8
+>
+> vkCmdSetScissor(): pScissors[0].offset.x (-1) is negative.
+>
+> The Vulkan spec states: The x and y members of offset member of any element of pScissors must be greater than or equal to 0 (https://docs.vulkan.org/spec/latest/chapters/fragops.html#VUID-vkCmdSetScissor-x-00595)
+
+Here we see a few things, listed in the order they appear
+
+1. The message severity
+    - (error, warning, etc)
+2. The [VUID](https://github.com/KhronosGroup/Vulkan-Guide/blob/main/chapters/validation_overview.adoc#valid-usage-id-vuid)
+3. List of Objects
+    - Contain handle type, hex value, and optional debug util name
+4. Message ID
+    - This is just a hash of the VUID used internally to detect if the message duplication rate was hit
+5. Which function the error occured at
+6. The faulty parameter / struct member
+    - Helps if there is an array to know which index it is in
+7. The "main message"
+    - This is normally hand written by the Validation Layer developer
+8. The Vulkan spec langague for this VUID
+9. Link to the VUID
+
+# Message Formatting Options
+
+There are a few ways to adjust the message format.
+
+## Verbose
+
+By default, the error messages are verbose, but if you turn off the setting the new error messages will look like
+
+> [ VUID-vkCmdSetScissor-x-00595 ] vkCmdSetScissor(): pScissors[0].offset.x (-1) is negative.
+>
+> The Vulkan spec states: The x and y members of offset member of any element of pScissors must be greater than or equal to 0
+
+To try it out, use `vkconfig` or turn off verbose with
+
+```bash
+# Windows
+set VK_LAYER_MESSAGE_FORMAT_VERBOSE=0
+
+# Linux
+export VK_LAYER_MESSAGE_FORMAT_VERBOSE=0
+
+# Android
+adb setprop debug.vulkan.khronos_validation.message_format_verbose=0
+```
+
+## JSON
+
+There is a way to print the error message as JSON to be machine readable, here we document the schema used:
+
+> All fields are always printed, an empty string will be given if no value is provided
+
+```json
+{
+	"Severity" : "string",
+	"VUID" : "string",
+	"Objects" : [
+		{"type" : "string", "handle" : "string", "name" : "string"},
+		...
+	],
+	"MessageID" : "string",
+	"Function" : "string",
+	"Location" : "string",
+	"MainMessage" : "string", // Newline '\n' will be inlined here
+	"DebugRegion" : "string",
+	"SpecText" : "string",
+	"SpecUrl" : "string"
+}
+```
+
+Here is an example of what it looks like
+
+```json
+{
+	"Severity" : "Error",
+	"VUID" : "VUID-vkCmdSetScissor-x-00595",
+	"Objects" : [
+		{"type" : "VkCommandBuffer", "handle" : "0x618497491590", "name" : "command_buffer_name"},
+	],
+	"MessageID" : "0xa54a6ff8",
+	"Function" : "vkCmdSetScissor",
+	"Location" : "pScissors[0].offset.x",
+	"MainMessage" : "(-1) is negative.",
+	"DebugRegion" : "",
+	"SpecText" : "The x and y members of offset member of any element of pScissors must be greater than or equal to 0",
+	"SpecUrl" : "https://docs.vulkan.org/spec/latest/chapters/fragops.html#VUID-vkCmdSetScissor-x-00595"
+}
+```
+
+> On Android, we will print it all in a single line to work better with `logcat`.
+
+To try it out, use `vkconfig` or set with
+
+```bash
+# Windows
+set VK_LAYER_MESSAGE_FORMAT_JSON=1
+
+# Linux
+export VK_LAYER_MESSAGE_FORMAT_JSON=1
+
+# Android
+adb setprop debug.vulkan.khronos_validation.message_format_json=1
+```

--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -1157,9 +1157,17 @@
                         {
                             "key": "message_format_verbose",
                             "label": "Verbose",
-                            "description": "Display Validation Type, Object Handles, Message ID, Spec Link",
+                            "description": "Display Validation Type, Object Handles, Message ID, Spec Link. (Ignored if using JSON)",
                             "type": "BOOL",
                             "default": true,
+                            "platforms": [ "WINDOWS", "LINUX", "MACOS", "ANDROID" ]
+                        },
+                        {
+                            "key": "message_format_json",
+                            "label": "JSON",
+                            "description": "Display Validation as JSON (VkDebugUtilsMessengerCallbackDataEXT::pMessage will contain JSON)",
+                            "type": "BOOL",
+                            "default": false,
                             "platforms": [ "WINDOWS", "LINUX", "MACOS", "ANDROID" ]
                         },
                         {

--- a/layers/error_message/logging.h
+++ b/layers/error_message/logging.h
@@ -174,7 +174,8 @@ class TypedHandleWrapper {
 struct Location;
 
 struct MessageFormatSettings {
-    bool verbose = true;
+    bool json = false;
+    bool verbose = true;  // ignored if JSON is used
     bool display_application_name = false;
     std::string application_name;
 };
@@ -245,6 +246,9 @@ class DebugReport {
     bool LogMsgEnabled(uint32_t vuid_hash, VkDebugUtilsMessageSeverityFlagsEXT msg_severity,
                        VkDebugUtilsMessageTypeFlagsEXT msg_type);
     std::string CreateMessageText(VkFlags msg_flags, const Location &loc,
+                                  const std::vector<VkDebugUtilsObjectNameInfoEXT> &object_name_infos, const uint32_t vuid_hash,
+                                  std::string_view vuid_text, const std::string &main_message);
+    std::string CreateMessageJson(VkFlags msg_flags, const Location &loc,
                                   const std::vector<VkDebugUtilsObjectNameInfoEXT> &object_name_infos, const uint32_t vuid_hash,
                                   std::string_view vuid_text, const std::string &main_message);
 

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -227,6 +227,7 @@ const char *VK_LAYER_SYNCVAL_MESSAGE_EXTRA_PROPERTIES_PRETTY_PRINT = "syncval_me
 // Message Formatting
 // ---
 const char *VK_LAYER_MESSAGE_FORMAT_VERBOSE = "message_format_verbose";
+const char *VK_LAYER_MESSAGE_FORMAT_JSON = "message_format_json";
 const char *VK_LAYER_MESSAGE_FORMAT_DISPLAY_APPLICATION_NAME = "message_format_display_application_name";
 // Until post 1.3.290 SDK release, these were not possible to set via environment variables
 const char *VK_LAYER_LOG_FILENAME = "log_filename";
@@ -632,6 +633,8 @@ static void ValidateLayerSettingsProvided(const VkLayerSettingsCreateInfoEXT *la
             required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
         } else if (strcmp(VK_LAYER_MESSAGE_FORMAT_VERBOSE, setting.pSettingName) == 0) {
             required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
+        } else if (strcmp(VK_LAYER_MESSAGE_FORMAT_JSON, setting.pSettingName) == 0) {
+            required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
         } else if (strcmp(VK_LAYER_MESSAGE_FORMAT_DISPLAY_APPLICATION_NAME, setting.pSettingName) == 0) {
             required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
         } else if (strcmp(VK_LAYER_LOG_FILENAME, setting.pSettingName) == 0) {
@@ -769,6 +772,10 @@ static void ProcessDebugReportSettings(ConfigAndEnvSettings *settings_data, VkuL
 
     if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_MESSAGE_FORMAT_VERBOSE)) {
         vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_MESSAGE_FORMAT_VERBOSE, debug_report->message_format_settings.verbose);
+    }
+
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_MESSAGE_FORMAT_JSON)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_MESSAGE_FORMAT_JSON, debug_report->message_format_settings.json);
     }
 
     if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_MESSAGE_FORMAT_DISPLAY_APPLICATION_NAME)) {

--- a/layers/vk_layer_settings.txt
+++ b/layers/vk_layer_settings.txt
@@ -159,6 +159,11 @@ khronos_validation.fine_grained_locking = true
 # Display Validation Type, Object Handles, Message ID, Spec Link
 #khronos_validation.message_format_verbose = true
 
+# Display as JSON
+# =====================
+# Display Validation as JSON
+#khronos_validation.message_format_json = false
+
 # Display Application Name
 # =====================
 # Useful when running multiple instances to know which instance the message is from

--- a/tests/unit/layer_settings_positive.cpp
+++ b/tests/unit/layer_settings_positive.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2024 The Khronos Group Inc.
- * Copyright (c) 2024 Valve Corporation
- * Copyright (c) 2024 LunarG, Inc.
+ * Copyright (c) 2024-2025 The Khronos Group Inc.
+ * Copyright (c) 2024-2025 Valve Corporation
+ * Copyright (c) 2024-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,6 +77,8 @@ TEST_F(PositiveLayerSettings, AllSettings) {
         {OBJECT_LAYER_NAME, "syncval_message_extra_properties", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable},
         {OBJECT_LAYER_NAME, "syncval_message_extra_properties_pretty_print", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable},
         {OBJECT_LAYER_NAME, "message_format_display_application_name", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable},
+        {OBJECT_LAYER_NAME, "message_format_verbose", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable},
+        {OBJECT_LAYER_NAME, "message_format_json", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable},
         {OBJECT_LAYER_NAME, "debug_action", VK_LAYER_SETTING_TYPE_STRING_EXT, 1, &action_ignore},
         {OBJECT_LAYER_NAME, "report_flags", VK_LAYER_SETTING_TYPE_STRING_EXT, 1, &warning},
     }};


### PR DESCRIPTION
First attempt to add JSON output and an optional setting

As people try using it, we might still tweak things, but this is the initial start

```json
{
	"Severity" : "Error",
	"VUID" : "VUID-vkBindBufferMemory-buffer-07459",
	"Objects" : [
		{"type" : "VkDeviceMemory", "handle" : "0xe7f79a0000000005", "name" : "memory_name"},
		{"type" : "VkBuffer", "handle" : "0xfa21a40000000003", "name" : ""},
		{"type" : "VkDeviceMemory", "handle" : "0xf56c9b0000000004", "name" : ""}
	],
	"MessageID" : "0x5001937c",
	"Function" : "vkBindBufferMemory",
	"Location" : "",
	"MainMessage" : "attempting to bind VkDeviceMemory 0xe7f79a0000000005[memory_name] to VkBuffer 0xfa21a40000000003 which has already been bound to VkDeviceMemory 0xf56c9b0000000004.",
	"DebugRegion" : "",
	"SpecText" : "buffer must not have been bound to a memory object",
	"SpecUrl" : "https://docs.vulkan.org/spec/latest/chapters/resources.html#VUID-vkBindBufferMemory-buffer-07459"
}

{
	"Severity" : "Error",
	"VUID" : "VUID-vkCmdSetScissor-x-00595",
	"Objects" : [
		{"type" : "VkCommandBuffer", "handle" : "0x57b2d5611570", "name" : "command_buffer_name"}
	],
	"MessageID" : "0xa54a6ff8",
	"Function" : "vkCmdSetScissor",
	"Location" : "pScissors[0].offset.x",
	"MainMessage" : "(-1) is negative.",
	"DebugRegion" : "",
	"SpecText" : "The x and y members of offset member of any element of pScissors must be greater than or equal to 0",
	"SpecUrl" : "https://docs.vulkan.org/spec/latest/chapters/fragops.html#VUID-vkCmdSetScissor-x-00595"
}
```