### PR TITLE
printf: Extra testing and error message fix

### DIFF
--- a/layers/gpuav/spirv/debug_printf_pass.cpp
+++ b/layers/gpuav/spirv/debug_printf_pass.cpp
@@ -19,6 +19,7 @@
 #include <spirv/unified1/NonSemanticDebugPrintf.h>
 #include <cstring>
 #include <iostream>
+#include <string>
 
 #include "generated/device_features.h"
 
@@ -698,8 +699,14 @@ bool DebugPrintfPass::Validate(const Function& current_function) {
                     break;
                 }
                 default:
-                    std::string err_msg = "OpString \"" + print_op_string() + "\" contains a \"" + modifier +
+                    // Need to escape, other error makes no sense
+                    std::string err_modifier = (modifier == '\n') ? "\\n" : (modifier == '\t') ? "\\t" : std::to_string(modifier);
+                    std::string err_msg = "OpString \"" + print_op_string() + "\" contains a \"" + err_modifier +
                                           "\" modifier which is an unknown modifier.";
+                    if (param_info.vector_size > 0) {
+                        // Help explain our custom vector format rules
+                        err_msg += " (for vectors you need something like %v3f which is just %f with a special v3 prefix)";
+                    }
                     module_.InternalError(tag, err_msg);
                     valid = false;
                     break;  // unknown

--- a/tests/unit/gpu_av_positive.cpp
+++ b/tests/unit/gpu_av_positive.cpp
@@ -1983,3 +1983,59 @@ TEST_F(PositiveGpuAV, DISABLED_DeviceGeneratedCommandsIES) {
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }
+
+TEST_F(PositiveGpuAV, BasicMeshShader) {
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::meshShader);
+    AddRequiredExtensions(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
+    RETURN_IF_SKIP(InitGpuAvFramework());
+    RETURN_IF_SKIP(InitState());
+    InitRenderTarget();
+
+    const char *mesh_source = R"glsl(
+    #version 450
+    #extension GL_EXT_mesh_shader : require
+
+    layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+    layout(triangles, max_vertices = 3, max_primitives = 1) out;
+
+    const vec4[3] positions = {
+        vec4( 0.0, -1.0, 0.0, 1.0),
+        vec4(-1.0,  1.0, 0.0, 1.0),
+        vec4( 1.0,  1.0, 0.0, 1.0)
+    };
+
+    const vec4[3] colors = {
+        vec4(0.0, 1.0, 0.0, 1.0),
+        vec4(0.0, 0.0, 1.0, 1.0),
+        vec4(1.0, 0.0, 0.0, 1.0)
+    };
+
+    void main() {
+        vec4 offset = vec4(0.0, 0.0, gl_GlobalInvocationID.x, 0.0);
+        SetMeshOutputsEXT(3, 1);
+        gl_MeshVerticesEXT[0].gl_Position = (positions[0] + offset);
+        gl_MeshVerticesEXT[1].gl_Position = (positions[1] + offset);
+        gl_MeshVerticesEXT[2].gl_Position = (positions[2] + offset);
+        gl_PrimitiveTriangleIndicesEXT[gl_LocalInvocationIndex] =  uvec3(0, 1, 2);
+    }
+    )glsl";
+
+    VkShaderObj ms(this, mesh_source, VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_2);
+    VkShaderObj fs(this, kFragmentMinimalGlsl, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_2);
+
+    CreatePipelineHelper pipe(*this);
+    pipe.shader_stages_ = {ms.GetStageCreateInfo(), fs.GetStageCreateInfo()};
+    pipe.CreateGraphicsPipeline();
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
+    vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
+    vk::CmdDrawMeshTasksEXT(m_command_buffer.handle(), 1, 1, 1);
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+
+    m_default_queue->Submit(m_command_buffer);
+    m_default_queue->Wait();
+}


### PR DESCRIPTION
1. Add some basic Mesh/Task tests for Printf/GPU-AV
2. Fix how we report error for `printf` when user messes up our `%v3f` style syntax 