### PR TITLE
layers: Handle yet-another ignored pointer

### DIFF
--- a/tests/unit/graphics_library_positive.cpp
+++ b/tests/unit/graphics_library_positive.cpp
@@ -937,6 +937,22 @@ TEST_F(PositiveGraphicsLibrary, FSIgnoredPointerGPLDynamicRendering) {
     ASSERT_TRUE(exe_pipe.initialized());
 }
 
+TEST_F(PositiveGraphicsLibrary, FSIgnoredPointerGPLDynamicRendering2) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9527");
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    RETURN_IF_SKIP(InitBasicGraphicsLibrary());
+
+    VkPipelineRenderingCreateInfo pipeline_rendering_info = vku::InitStructHelper();
+    pipeline_rendering_info.pColorAttachmentFormats = reinterpret_cast<VkFormat*>(static_cast<uintptr_t>(0xffffdead));
+    pipeline_rendering_info.colorAttachmentCount = 2;
+
+    CreatePipelineHelper vi_lib(*this);
+    vi_lib.InitVertexInputLibInfo(&pipeline_rendering_info);
+    vi_lib.CreateGraphicsPipeline();
+}
+
 TEST_F(PositiveGraphicsLibrary, GPLDynamicRenderingWithDepthDraw) {
     TEST_DESCRIPTION("Check ignored pointers with dynamics rendering and GPL");
     SetTargetApiVersion(VK_API_VERSION_1_2);


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9527

We ignored when `VkPipelineRenderingCreateInfo::pColorAttachmentFormats` is garbage in like 3 out of 4 cases, we missed one, this just brings the big hammer and nulls the pointer for the user if they are supplying it with garbage (we tried to not do this before and it worked well for the non-pNext structs, but this one is harder because its in the pNext)