### PR TITLE
layers: Fix warning for Storage Image

### DIFF
--- a/layers/vulkan/generated/spirv_validation_helper.cpp
+++ b/layers/vulkan/generated/spirv_validation_helper.cpp
@@ -882,6 +882,95 @@ VkFormat CompatibleSpirvImageFormat(uint32_t spirv_image_format) {
     };
 }
 
+const char *string_SpirvImageFormat(VkFormat format) {
+    switch (format) {
+        case VK_FORMAT_R8_UNORM:
+            return "R8";
+        case VK_FORMAT_R8_SNORM:
+            return "R8Snorm";
+        case VK_FORMAT_R8_UINT:
+            return "R8ui";
+        case VK_FORMAT_R8_SINT:
+            return "R8i";
+        case VK_FORMAT_R8G8_UNORM:
+            return "Rg8";
+        case VK_FORMAT_R8G8_SNORM:
+            return "Rg8Snorm";
+        case VK_FORMAT_R8G8_UINT:
+            return "Rg8ui";
+        case VK_FORMAT_R8G8_SINT:
+            return "Rg8i";
+        case VK_FORMAT_R8G8B8A8_UNORM:
+            return "Rgba8";
+        case VK_FORMAT_R8G8B8A8_SNORM:
+            return "Rgba8Snorm";
+        case VK_FORMAT_R8G8B8A8_UINT:
+            return "Rgba8ui";
+        case VK_FORMAT_R8G8B8A8_SINT:
+            return "Rgba8i";
+        case VK_FORMAT_A2B10G10R10_UNORM_PACK32:
+            return "Rgb10A2";
+        case VK_FORMAT_A2B10G10R10_UINT_PACK32:
+            return "Rgb10a2ui";
+        case VK_FORMAT_R16_UNORM:
+            return "R16";
+        case VK_FORMAT_R16_SNORM:
+            return "R16Snorm";
+        case VK_FORMAT_R16_UINT:
+            return "R16ui";
+        case VK_FORMAT_R16_SINT:
+            return "R16i";
+        case VK_FORMAT_R16_SFLOAT:
+            return "R16f";
+        case VK_FORMAT_R16G16_UNORM:
+            return "Rg16";
+        case VK_FORMAT_R16G16_SNORM:
+            return "Rg16Snorm";
+        case VK_FORMAT_R16G16_UINT:
+            return "Rg16ui";
+        case VK_FORMAT_R16G16_SINT:
+            return "Rg16i";
+        case VK_FORMAT_R16G16_SFLOAT:
+            return "Rg16f";
+        case VK_FORMAT_R16G16B16A16_UNORM:
+            return "Rgba16";
+        case VK_FORMAT_R16G16B16A16_SNORM:
+            return "Rgba16Snorm";
+        case VK_FORMAT_R16G16B16A16_UINT:
+            return "Rgba16ui";
+        case VK_FORMAT_R16G16B16A16_SINT:
+            return "Rgba16i";
+        case VK_FORMAT_R16G16B16A16_SFLOAT:
+            return "Rgba16f";
+        case VK_FORMAT_R32_UINT:
+            return "R32ui";
+        case VK_FORMAT_R32_SINT:
+            return "R32i";
+        case VK_FORMAT_R32_SFLOAT:
+            return "R32f";
+        case VK_FORMAT_R32G32_UINT:
+            return "Rg32ui";
+        case VK_FORMAT_R32G32_SINT:
+            return "Rg32i";
+        case VK_FORMAT_R32G32_SFLOAT:
+            return "Rg32f";
+        case VK_FORMAT_R32G32B32A32_UINT:
+            return "Rgba32ui";
+        case VK_FORMAT_R32G32B32A32_SINT:
+            return "Rgba32i";
+        case VK_FORMAT_R32G32B32A32_SFLOAT:
+            return "Rgba32f";
+        case VK_FORMAT_R64_UINT:
+            return "R64ui";
+        case VK_FORMAT_R64_SINT:
+            return "R64i";
+        case VK_FORMAT_B10G11R11_UFLOAT_PACK32:
+            return "R11fG11fB10f";
+        default:
+            return "Unknown SPIR-V Format";
+    };
+}
+
 // clang-format off
 static inline const char* SpvCapabilityRequirements(uint32_t capability) {
     static const vvl::unordered_map<uint32_t, std::string_view> table {

--- a/layers/vulkan/generated/spirv_validation_helper.h
+++ b/layers/vulkan/generated/spirv_validation_helper.h
@@ -29,5 +29,8 @@
 
 // This is the one function that requires mapping SPIR-V enums to Vulkan enums
 VkFormat CompatibleSpirvImageFormat(uint32_t spirv_image_format);
+// Since we keep things in VkFormat for checking, we need a way to get the original SPIR-V
+// Format name for any error message
+const char* string_SpirvImageFormat(VkFormat format);
 
 // NOLINTEND

--- a/scripts/generators/spirv_validation_generator.py
+++ b/scripts/generators/spirv_validation_generator.py
@@ -158,6 +158,9 @@ class SpirvValidationHelperOutputGenerator(BaseGenerator):
 
             // This is the one function that requires mapping SPIR-V enums to Vulkan enums
             VkFormat CompatibleSpirvImageFormat(uint32_t spirv_image_format);
+            // Since we keep things in VkFormat for checking, we need a way to get the original SPIR-V
+            // Format name for any error message
+            const char* string_SpirvImageFormat(VkFormat format);
         ''')
 
         self.write("".join(out))
@@ -270,6 +273,17 @@ class SpirvValidationHelperOutputGenerator(BaseGenerator):
         out.append('    };\n')
         out.append('}\n')
 
+        out.append('''
+            const char* string_SpirvImageFormat(VkFormat format) {
+                switch (format) {
+            ''')
+        for format in [x for x in self.vk.formats.values() if x.spirvImageFormat]:
+            out.append(f'        case {format.name}:\n')
+            out.append(f'            return \"{format.spirvImageFormat}\";\n')
+        out.append('        default:\n')
+        out.append('            return "Unknown SPIR-V Format";\n')
+        out.append('    };\n')
+        out.append('}\n')
 
         out.append('''
 // clang-format off

--- a/tests/unit/shader_storage_image.cpp
+++ b/tests/unit/shader_storage_image.cpp
@@ -911,7 +911,7 @@ void NegativeShaderStorageImage::FormatComponentMismatchTest(std::string spirv_f
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
 
-    m_errorMonitor->SetDesiredWarning("Undefined-Value-StorageImage-FormatMismatch");
+    m_errorMonitor->SetDesiredWarning("Undefined-Value-StorageImage-FormatMismatch-ImageView");
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
     m_errorMonitor->VerifyFound();
     m_command_buffer.End();
@@ -923,6 +923,8 @@ TEST_F(NegativeShaderStorageImage, FormatComponentTypeMismatch) {
 
 TEST_F(NegativeShaderStorageImage, FormatComponentSizeMismatch) { FormatComponentMismatchTest("Rgba8", VK_FORMAT_R8_UNORM); }
 
-TEST_F(NegativeShaderStorageImage, FormatComponentNumericMismatch) {
-    FormatComponentMismatchTest("Rgba8", VK_FORMAT_R8G8B8A8_SNORM);
+TEST_F(NegativeShaderStorageImage, FormatComponentWidthMismatch) {
+    FormatComponentMismatchTest("Rgba8", VK_FORMAT_R32G32B32A32_SFLOAT);
 }
+
+TEST_F(NegativeShaderStorageImage, FormatCompatibleMismatch) { FormatComponentMismatchTest("Rgba8", VK_FORMAT_B8G8R8A8_UNORM); }

--- a/tests/unit/shader_storage_texel.cpp
+++ b/tests/unit/shader_storage_texel.cpp
@@ -235,7 +235,7 @@ TEST_F(NegativeShaderStorageTexel, FormatComponentTypeMismatch) {
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout, 0, 1,
                               &descriptor_set.set_, 0, nullptr);
-    m_errorMonitor->SetDesiredWarning("Undefined-Value-StorageImage-FormatMismatch");
+    m_errorMonitor->SetDesiredWarning("Undefined-Value-StorageImage-FormatMismatch-BufferView");
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
     m_errorMonitor->VerifyFound();
     m_command_buffer.End();


### PR DESCRIPTION
Fixes issue with warning, the user might use `Rgba8` in their shader which maps to `VK_FORMAT_R8G8B8A8_UNORM` but the user can still use `VK_FORMAT_B8G8R8A8_UNORM` (basically was doing exact format check instead of using `vkuFormatCompatibilityClass`