### PR TITLE
sync: Update renderpass layout transition messages

### DIFF
--- a/layers/sync/sync_error_messages.h
+++ b/layers/sync/sync_error_messages.h
@@ -47,6 +47,7 @@ struct AdditionalMessageInfo {
     std::string access_action;
 
     std::string hazard_overview;
+    std::string brief_description_end_text;
     std::string pre_synchronization_text;
     std::string message_end_text;
 };
@@ -110,6 +111,23 @@ class ErrorMessages {
     std::string RenderPassStoreOpError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context, vvl::Func command,
                                        const std::string& resource_description, VkAttachmentStoreOp store_op) const;
 
+
+    std::string RenderPassLayoutTransitionError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
+                                                vvl::Func command, const std::string& resource_description,
+                                                VkImageLayout old_layout, VkImageLayout new_layout) const;
+    std::string RenderPassLayoutTransitionVsStoreOrResolveError(const HazardResult& hazard,
+                                                                const CommandBufferAccessContext& cb_context, vvl::Func command,
+                                                                const std::string& resource_description, VkImageLayout old_layout,
+                                                                VkImageLayout new_layout, uint32_t store_resolve_subpass) const;
+    std::string RenderPassFinalLayoutTransitionError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
+                                                     vvl::Func command, const std::string& resource_description,
+                                                     VkImageLayout old_layout, VkImageLayout new_layout) const;
+    std::string RenderPassFinalLayoutTransitionVsStoreOrResolveError(const HazardResult& hazard,
+                                                                     const CommandBufferAccessContext& cb_context,
+                                                                     vvl::Func command, const std::string& resource_description,
+                                                                     VkImageLayout old_layout, VkImageLayout new_layout,
+                                                                     uint32_t store_resolve_subpass) const;
+
     std::string PipelineBarrierError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
                                      uint32_t image_barrier_index, const vvl::Image& image, vvl::Func command) const;
 
@@ -120,29 +138,11 @@ class ErrorMessages {
                               const CommandBufferAccessContext& recorded_context, uint32_t command_buffer_index,
                               VkCommandBuffer recorded_handle, vvl::Func command) const;
 
-    std::string RenderPassLayoutTransitionVsStoreOrResolveError(const HazardResult& hazard, uint32_t subpass, uint32_t attachment,
-                                                                VkImageLayout old_layout, VkImageLayout new_layout,
-                                                                uint32_t store_resolve_subpass, vvl::Func command) const;
-
-    std::string RenderPassLayoutTransitionError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
-                                                uint32_t subpass, uint32_t attachment, VkImageLayout old_layout,
-                                                VkImageLayout new_layout, vvl::Func command) const;
-
-
     std::string RenderPassColorAttachmentError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
                                                const vvl::ImageView& view, uint32_t attachment, vvl::Func command) const;
 
     std::string RenderPassDepthStencilAttachmentError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
                                                       const vvl::ImageView& view, bool is_depth, vvl::Func command) const;
-
-    std::string RenderPassFinalLayoutTransitionVsStoreOrResolveError(const HazardResult& hazard,
-                                                                     const CommandBufferAccessContext& cb_context, uint32_t subpass,
-                                                                     uint32_t attachment, VkImageLayout old_layout,
-                                                                     VkImageLayout new_layout, vvl::Func command) const;
-
-    std::string RenderPassFinalLayoutTransitionError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
-                                                     uint32_t subpass, uint32_t attachment, VkImageLayout old_layout,
-                                                     VkImageLayout new_layout, vvl::Func command) const;
 
     std::string PresentError(const HazardResult& hazard, const QueueBatchContext& batch_context, uint32_t present_index,
                              const VulkanTypedHandle& swapchain_handle, uint32_t image_index, const VulkanTypedHandle& image_handle,


### PR DESCRIPTION
> vkCmdBeginRenderPass(): WRITE_AFTER_READ hazard detected. vkCmdBeginRenderPass performs image layout transition in subpass 0 on attachment 0 (VkImageView 0xcfef35000000000a, VkImage 0xf56c9b0000000004, oldLayout VK_IMAGE_LAYOUT_UNDEFINED, newLayout VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL), which was previously read by vkCmdCopyImage.
No sufficient synchronization is present to ensure that a layout transition does not conflict with a prior read (VK_ACCESS_2_TRANSFER_READ_BIT) at VK_PIPELINE_STAGE_2_COPY_BIT. An execution dependency is sufficient to prevent this hazard.
