### PR TITLE
sync: Update barrier messages

### DIFF
--- a/layers/sync/sync_error_messages.h
+++ b/layers/sync/sync_error_messages.h
@@ -131,8 +131,9 @@ class ErrorMessages {
                                                                      VkImageLayout old_layout, VkImageLayout new_layout,
                                                                      uint32_t store_resolve_subpass) const;
 
-    std::string PipelineBarrierError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
-                                     uint32_t image_barrier_index, const vvl::Image& image, vvl::Func command) const;
+    std::string ImagePipelineBarrierError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
+                                          vvl::Func command, const std::string& resource_description,
+                                          const SyncImageMemoryBarrier& barrier) const;
 
     std::string WaitEventsError(const HazardResult& hazard, const CommandExecutionContext& exec_context,
                                 uint32_t image_barrier_index, const vvl::Image& image, vvl::Func command) const;

--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -403,12 +403,13 @@ bool SyncOpPipelineBarrier::Validate(const CommandBufferAccessContext &cb_contex
                                                               image_barrier.barrier.src_access_scope,
                                                               image_barrier.subresource_range, AccessContext::kDetectAll);
         if (hazard.IsHazard()) {
-            // PHASE1 TODO -- add tag information to log msg when useful.
+            LogObjectList objlist(cb_context.GetCBState().Handle(), image_state.Handle());
             const Location loc(command_);
             const auto &sync_state = cb_context.GetSyncState();
-            const auto error = sync_state.error_messages_.PipelineBarrierError(hazard, cb_context, image_barrier.barrier_index,
-                                                                               image_state, command_);
-            skip |= sync_state.SyncError(hazard.Hazard(), image_state.Handle(), loc, error);
+            const std::string resource_description = sync_state.FormatHandle(image_state.Handle());
+            const std::string error = sync_state.error_messages_.ImagePipelineBarrierError(hazard, cb_context, command_,
+                                                                                           resource_description, image_barrier);
+            skip |= sync_state.SyncError(hazard.Hazard(), objlist, loc, error);
         }
     }
     return skip;

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -4867,9 +4867,9 @@ TEST_F(NegativeSyncVal, AvailabilityWithoutVisibilityForBuffer) {
 }
 
 TEST_F(NegativeSyncVal, ImageCopyHazardsLayoutTransition) {
-    TEST_DESCRIPTION("Copy to image and then start image layout transition without waiting for copy to end.");
-    RETURN_IF_SKIP(InitSyncValFramework());
-    RETURN_IF_SKIP(InitState());
+    TEST_DESCRIPTION("Copy to image and then start image layout transition without making copy accesses visible");
+    RETURN_IF_SKIP(InitSyncVal());
+
     vkt::Buffer buffer(*m_device, 64 * 64 * 4, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
 
     const VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
@@ -5482,7 +5482,7 @@ TEST_F(NegativeSyncVal, RenderPassStoreOpNone) {
     m_command_buffer.EndRenderPass();
 
     // SYNC-HAZARD-WRITE-AFTER-READ hazard: transition should synchronize with draw command
-    m_errorMonitor->SetDesiredError("SYNC_FRAGMENT_SHADER_INPUT_ATTACHMENT_READ");
+    m_errorMonitor->SetDesiredError("(VK_ACCESS_2_INPUT_ATTACHMENT_READ_BIT) at VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT");
     vk::CmdPipelineBarrier2(m_command_buffer, &dep_info);
     m_errorMonitor->VerifyFound();
     m_command_buffer.End();


### PR DESCRIPTION
Temporary contains commits from https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/9543

OLD:
> vkCmdPipelineBarrier(): Hazard WRITE_AFTER_WRITE for image barrier 0 VkImage 0xf443490000000006. Access info (usage: SYNC_IMAGE_LAYOUT_TRANSITION, prior_usage: SYNC_COPY_TRANSFER_WRITE, write_barriers: 0, command: vkCmdCopyBufferToImage, resource: VkImage 0xf443490000000006).


NEW:
> vkCmdPipelineBarrier(): WRITE_AFTER_WRITE hazard detected. vkCmdPipelineBarrier performs image layout transition on the VkImage 0xf443490000000006, which was previously written by vkCmdCopyBufferToImage.
No sufficient synchronization is present to ensure that a layout transition does not conflict with a prior write (VK_ACCESS_2_TRANSFER_WRITE_BIT) at VK_PIPELINE_STAGE_2_COPY_BIT.
Image barrier: {
  barrier index = 0,
  src access = 0,
  dst access = 0,
  srcStageMask = VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT,
  dstStageMask = VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT,
}