### PR TITLE
sync: Reuse image barrier message for event validation

### DIFF
--- a/layers/sync/sync_commandbuffer.h
+++ b/layers/sync/sync_commandbuffer.h
@@ -213,12 +213,14 @@ class CommandExecutionContext {
     virtual const SyncEventsContext *GetCurrentEventsContext() const = 0;
     virtual QueueId GetQueueId() const = 0;
     virtual VulkanTypedHandle Handle() const = 0;
+    virtual ReportUsageInfo GetReportUsageInfo(ResourceUsageTagEx tag_ex) const = 0;
     virtual std::string FormatUsage(ResourceUsageTagEx tag_ex, ReportKeyValues &extra_properties) const = 0;
     virtual void AddUsageRecordExtraProperties(ResourceUsageTag tag, ReportKeyValues &extra_properties) const = 0;
 
     std::string FormatHazard(const HazardResult &hazard, ReportKeyValues &key_values) const;
     bool ValidForSyncOps() const;
     const SyncValidator &GetSyncState() const { return sync_state_; }
+    VkQueueFlags GetQueueFlags() const { return queue_flags_; }
 
   protected:
     const SyncValidator &sync_state_;
@@ -265,7 +267,7 @@ class CommandBufferAccessContext : public CommandExecutionContext, DebugNameProv
 
     void Reset();
 
-    ReportUsageInfo GetReportUsageInfo(ResourceUsageTagEx tag_ex) const;
+    ReportUsageInfo GetReportUsageInfo(ResourceUsageTagEx tag_ex) const override;
     std::string FormatUsage(ResourceUsageTagEx tag_ex, ReportKeyValues &extra_properties) const override;
     void AddUsageRecordExtraProperties(ResourceUsageTag tag, ReportKeyValues &extra_properties) const override;
     std::string FormatUsage(const char *usage_string, const ResourceFirstAccess &access,
@@ -305,9 +307,6 @@ class CommandBufferAccessContext : public CommandExecutionContext, DebugNameProv
 
     void RecordExecutedCommandBuffer(const CommandBufferAccessContext &recorded_context);
     void ResolveExecutedCommandBuffer(const AccessContext &recorded_context, ResourceUsageTag offset);
-
-    // TODO: what about using queue_flags directly from base class?
-    VkQueueFlags GetQueueFlags() const { return cb_state_ ? cb_state_->GetQueueFlags() : 0; }
 
     ExecutionType Type() const override { return kExecuted; }
     size_t GetTagCount() const { return access_log_->size(); }

--- a/layers/sync/sync_error_messages.h
+++ b/layers/sync/sync_error_messages.h
@@ -56,7 +56,7 @@ class ErrorMessages {
   public:
     explicit ErrorMessages(vvl::Device& validator);
 
-    std::string Error(const HazardResult& hazard, const CommandBufferAccessContext& cb_context, vvl::Func command,
+    std::string Error(const HazardResult& hazard, const CommandExecutionContext& context, vvl::Func command,
                       const std::string& resouce_description, const AdditionalMessageInfo& additional_info = {}) const;
 
     std::string BufferError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context, vvl::Func command,
@@ -131,12 +131,8 @@ class ErrorMessages {
                                                                      VkImageLayout old_layout, VkImageLayout new_layout,
                                                                      uint32_t store_resolve_subpass) const;
 
-    std::string ImagePipelineBarrierError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
-                                          vvl::Func command, const std::string& resource_description,
-                                          const SyncImageMemoryBarrier& barrier) const;
-
-    std::string WaitEventsError(const HazardResult& hazard, const CommandExecutionContext& exec_context,
-                                uint32_t image_barrier_index, const vvl::Image& image, vvl::Func command) const;
+    std::string ImageBarrierError(const HazardResult& hazard, const CommandExecutionContext& context, vvl::Func command,
+                                  const std::string& resource_description, const SyncImageMemoryBarrier& barrier) const;
 
     std::string FirstUseError(const HazardResult& hazard, const CommandExecutionContext& exec_context,
                               const CommandBufferAccessContext& recorded_context, uint32_t command_buffer_index,
@@ -145,10 +141,6 @@ class ErrorMessages {
     std::string PresentError(const HazardResult& hazard, const QueueBatchContext& batch_context, uint32_t present_index,
                              const VulkanTypedHandle& swapchain_handle, uint32_t image_index, const VulkanTypedHandle& image_handle,
                              vvl::Func command) const;
-
-  private:
-    void AddCbContextExtraProperties(const CommandBufferAccessContext& cb_context, ResourceUsageTag tag,
-                                     ReportKeyValues& key_values) const;
 
   private:
     vvl::Device& validator_;

--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -405,10 +405,10 @@ bool SyncOpPipelineBarrier::Validate(const CommandBufferAccessContext &cb_contex
         if (hazard.IsHazard()) {
             LogObjectList objlist(cb_context.GetCBState().Handle(), image_state.Handle());
             const Location loc(command_);
-            const auto &sync_state = cb_context.GetSyncState();
+            const SyncValidator &sync_state = cb_context.GetSyncState();
             const std::string resource_description = sync_state.FormatHandle(image_state.Handle());
-            const std::string error = sync_state.error_messages_.ImagePipelineBarrierError(hazard, cb_context, command_,
-                                                                                           resource_description, image_barrier);
+            const std::string error =
+                sync_state.error_messages_.ImageBarrierError(hazard, cb_context, command_, resource_description, image_barrier);
             skip |= sync_state.SyncError(hazard.Hazard(), objlist, loc, error);
         }
     }
@@ -639,8 +639,10 @@ bool SyncOpWaitEvents::DoValidate(const CommandExecutionContext &exec_context, c
                     *image_state, subresource_range, sync_event->scope.exec_scope, src_access_scope, queue_id,
                     sync_event->FirstScope(), sync_event->first_scope_tag, AccessContext::DetectOptions::kDetectAll);
                 if (hazard.IsHazard()) {
-                    const auto error = sync_state.error_messages_.WaitEventsError(
-                        hazard, exec_context, image_memory_barrier.barrier_index, *image_state, command_);
+                    LogObjectList objlist(exec_context.Handle(), image_state->Handle());
+                    const std::string resource_description = sync_state.FormatHandle(image_state->Handle());
+                    const std::string error = sync_state.error_messages_.ImageBarrierError(
+                        hazard, exec_context, command_, resource_description, image_memory_barrier);
                     skip |= sync_state.SyncError(hazard.Hazard(), image_state->Handle(), loc, error);
                     break;
                 }

--- a/layers/sync/sync_reporting.cpp
+++ b/layers/sync/sync_reporting.cpp
@@ -479,6 +479,21 @@ void CommandBufferAccessContext::AddUsageRecordExtraProperties(ResourceUsageTag 
     extra_properties.Add(kPropertyResetNo, record.reset_count);
 }
 
+ReportUsageInfo QueueBatchContext::GetReportUsageInfo(ResourceUsageTagEx tag_ex) const {
+    BatchAccessLog::AccessRecord access = batch_log_.GetAccessRecord(tag_ex.tag);
+    if (!access.IsValid()) {
+        return {};
+    }
+    const ResourceUsageRecord &record = *access.record;
+    ReportUsageInfo info;
+    if (record.alt_usage) {
+        info.command = record.alt_usage.GetCommand();
+    } else {
+        info.command = record.command;
+    }
+    return info;
+}
+
 std::string QueueBatchContext::FormatUsage(ResourceUsageTagEx tag_ex, ReportKeyValues &extra_properties) const {
     std::stringstream out;
     BatchAccessLog::AccessRecord access = batch_log_.GetAccessRecord(tag_ex.tag);

--- a/layers/sync/sync_submit.h
+++ b/layers/sync/sync_submit.h
@@ -295,6 +295,7 @@ class QueueBatchContext : public CommandExecutionContext, public std::enable_sha
     ~QueueBatchContext();
     void Trim();
 
+    ReportUsageInfo GetReportUsageInfo(ResourceUsageTagEx tag_ex) const override;
     std::string FormatUsage(ResourceUsageTagEx tag_ex, ReportKeyValues &extra_properties) const override;
     void AddUsageRecordExtraProperties(ResourceUsageTag tag, ReportKeyValues &extra_properties) const override;
     AccessContext *GetCurrentAccessContext() override { return current_access_context_; }


### PR DESCRIPTION
Both pipeline barrier and event code detect image barrier hazard. Made corresponding code shared. Refactored implementation to be able to use reporting code also during submit time (event code runs both during recording and queue submit time).
