### PR TITLE
settings: Simplify extra properties label

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -426,7 +426,7 @@
                                     "settings": [
                                         {
                                             "key": "syncval_message_extra_properties",
-                                            "label": "Extra key-value properties",
+                                            "label": "Extra properties",
                                             "description": "Append a section of key-value properties to the error message. Useful for filtering errors.",
                                             "type": "BOOL",
                                             "default": false,


### PR DESCRIPTION
The "key-value" clarification looks like an unnecessary detail in the high-level description. The popup description contains this information.