### PR TITLE
layers: Add Descriptor Allocate Warning

### DIFF
--- a/layers/best_practices/bp_device_memory.cpp
+++ b/layers/best_practices/bp_device_memory.cpp
@@ -167,7 +167,7 @@ bool BestPractices::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory mem
                                       "Trying to bind %s to a memory block which is fully consumed by the buffer. "
                                       "The required size of the allocation is %" PRIu64
                                       ", but smaller buffers like this should be sub-allocated from "
-                                      "larger memory blocks. (Current threshold is %" PRIu64 " bytes.)",
+                                      "larger memory blocks. (Current threshold is %" PRIu64 " bytes)",
                                       FormatHandle(buffer).c_str(), memory_state->allocate_info.allocationSize,
                                       kMinDedicatedAllocationSize);
     }
@@ -215,7 +215,7 @@ bool BestPractices::ValidateBindImageMemory(VkImage image, VkDeviceMemory memory
                                       "Trying to bind %s to a memory block which is fully consumed by the image. "
                                       "The required size of the allocation is %" PRIu64
                                       ", but smaller images like this should be sub-allocated from "
-                                      "larger memory blocks. (Current threshold is %" PRIu64 " bytes.)",
+                                      "larger memory blocks. (Current threshold is %" PRIu64 " bytes)",
                                       FormatHandle(image).c_str(), memory_state->allocate_info.allocationSize,
                                       kMinDedicatedAllocationSize);
     }

--- a/layers/state_tracker/descriptor_sets.cpp
+++ b/layers/state_tracker/descriptor_sets.cpp
@@ -43,9 +43,9 @@ vvl::DescriptorPool::DescriptorPool(vvl::Device &dev, const VkDescriptorPool han
       safe_create_info(pCreateInfo),
       create_info(*safe_create_info.ptr()),
       maxSets(pCreateInfo->maxSets),
-      maxDescriptorTypeCount(GetMaxTypeCounts(pCreateInfo)),
+      max_descriptor_type_count(GetMaxTypeCounts(pCreateInfo)),
       available_sets_(pCreateInfo->maxSets),
-      available_counts_(maxDescriptorTypeCount),
+      available_counts_(max_descriptor_type_count),
       dev_data_(dev) {}
 
 void vvl::DescriptorPool::Allocate(const VkDescriptorSetAllocateInfo *alloc_info, const VkDescriptorSet *descriptor_sets,
@@ -113,7 +113,7 @@ void vvl::DescriptorPool::Reset() {
     }
     sets_.clear();
     // Reset available count for each type and available sets for this pool
-    available_counts_ = maxDescriptorTypeCount;
+    available_counts_ = max_descriptor_type_count;
     available_sets_ = maxSets;
 }
 

--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -88,7 +88,7 @@ class DescriptorPool : public StateObject {
 
     const uint32_t maxSets;  // Max descriptor sets allowed in this pool
     using TypeCountMap = vvl::unordered_map<uint32_t, uint32_t>;
-    const TypeCountMap maxDescriptorTypeCount;  // Max # of descriptors of each type in this pool
+    const TypeCountMap max_descriptor_type_count;  // Max # of descriptors of each type in this pool
 
     uint32_t GetFreedCount() const {
         auto guard = ReadLock();

--- a/tests/unit/best_practices.cpp
+++ b/tests/unit/best_practices.cpp
@@ -1284,11 +1284,11 @@ TEST_F(VkBestPracticesLayerTest, OverAllocateFromDescriptorPool) {
 
     VkDescriptorPoolSize ds_type_count = {};
     ds_type_count.type = VK_DESCRIPTOR_TYPE_SAMPLER;
-    ds_type_count.descriptorCount = 2;
+    ds_type_count.descriptorCount = 8;
 
     VkDescriptorPoolCreateInfo ds_pool_ci = vku::InitStructHelper();
     ds_pool_ci.flags = 0;
-    ds_pool_ci.maxSets = 1;
+    ds_pool_ci.maxSets = 3;
     ds_pool_ci.poolSizeCount = 1;
     ds_pool_ci.pPoolSizes = &ds_type_count;
 
@@ -1304,14 +1304,15 @@ TEST_F(VkBestPracticesLayerTest, OverAllocateFromDescriptorPool) {
     const vkt::DescriptorSetLayout ds_layout_samp(*m_device, {dsl_binding_samp});
 
     // Try to allocate 2 sets when pool only has 1 set
-    VkDescriptorSet descriptor_sets[2];
+    VkDescriptorSet descriptor_sets[4];
     VkDescriptorSetLayout set_layouts[2] = {ds_layout_samp.handle(), ds_layout_samp.handle()};
     VkDescriptorSetAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.descriptorSetCount = 2;
     alloc_info.descriptorPool = ds_pool.handle();
     alloc_info.pSetLayouts = set_layouts;
+    vk::AllocateDescriptorSets(device(), &alloc_info, &descriptor_sets[0]);
     m_errorMonitor->SetDesiredWarning("BestPractices-vkAllocateDescriptorSets-EmptyDescriptorPool");
-    vk::AllocateDescriptorSets(device(), &alloc_info, descriptor_sets);
+    vk::AllocateDescriptorSets(device(), &alloc_info, &descriptor_sets[2]);
     m_errorMonitor->VerifyFound();
 }
 
@@ -1325,11 +1326,11 @@ TEST_F(VkBestPracticesLayerTest, OverAllocateTypeFromDescriptorPool) {
 
     VkDescriptorPoolSize ds_type_count = {};
     ds_type_count.type = VK_DESCRIPTOR_TYPE_SAMPLER;
-    ds_type_count.descriptorCount = 1;
+    ds_type_count.descriptorCount = 3;
 
     VkDescriptorPoolCreateInfo ds_pool_ci = vku::InitStructHelper();
     ds_pool_ci.flags = 0;
-    ds_pool_ci.maxSets = 2;
+    ds_pool_ci.maxSets = 4;
     ds_pool_ci.poolSizeCount = 1;
     ds_pool_ci.pPoolSizes = &ds_type_count;
 
@@ -1345,14 +1346,15 @@ TEST_F(VkBestPracticesLayerTest, OverAllocateTypeFromDescriptorPool) {
     const vkt::DescriptorSetLayout ds_layout_samp(*m_device, {dsl_binding_samp});
 
     // Try to allocate 2 sets when pool only has 1 set
-    VkDescriptorSet descriptor_sets[2];
+    VkDescriptorSet descriptor_sets[4];
     VkDescriptorSetLayout set_layouts[2] = {ds_layout_samp.handle(), ds_layout_samp.handle()};
     VkDescriptorSetAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.descriptorSetCount = 2;
     alloc_info.descriptorPool = ds_pool.handle();
     alloc_info.pSetLayouts = set_layouts;
+    vk::AllocateDescriptorSets(device(), &alloc_info, &descriptor_sets[0]);
     m_errorMonitor->SetDesiredWarning("BestPractices-vkAllocateDescriptorSets-EmptyDescriptorPoolType");
-    vk::AllocateDescriptorSets(device(), &alloc_info, descriptor_sets);
+    vk::AllocateDescriptorSets(device(), &alloc_info, &descriptor_sets[2]);
     m_errorMonitor->VerifyFound();
 }
 


### PR DESCRIPTION
This will warn people without `VK_KHR_maintenance1` that they are possibly over-allocating their descriptor sets

This is a bit more conservative than the Best Practice version (because that is more of expected usage), but is a good first step to help people doing something nonsensical

closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9500