### PR TITLE
utils: Move math utils to dedicated file

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -341,6 +341,7 @@ vvl_sources = [
   "layers/utils/hash_vk_types.h",
   "layers/utils/image_layout_utils.cpp",
   "layers/utils/image_layout_utils.h",
+  "layers/utils/math_utils.h",
   "layers/utils/ray_tracing_utils.cpp",
   "layers/utils/ray_tracing_utils.h",
   "layers/utils/shader_utils.cpp",

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -57,6 +57,7 @@ target_sources(VkLayer_utils PRIVATE
     utils/hash_vk_types.h
     utils/image_layout_utils.h
     utils/image_layout_utils.cpp
+    utils/math_utils.h
     utils/vk_layer_extension_utils.cpp
     utils/vk_layer_extension_utils.h
     utils/ray_tracing_utils.cpp

--- a/layers/core_checks/cc_copy_blit_resolve.cpp
+++ b/layers/core_checks/cc_copy_blit_resolve.cpp
@@ -31,7 +31,7 @@
 #include "state_tracker/buffer_state.h"
 #include "state_tracker/device_state.h"
 #include "generated/dispatch_functions.h"
-#include "utils/vk_layer_utils.h"
+#include "utils/math_utils.h"
 
 struct ImageRegionIntersection {
     VkImageSubresourceLayers subresource = {};

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -33,7 +33,7 @@
 #include "state_tracker/sampler_state.h"
 #include "state_tracker/render_pass_state.h"
 #include "sync/sync_vuid_maps.h"
-#include "utils/vk_layer_utils.h"
+#include "utils/math_utils.h"
 
 bool CoreChecks::ValidateImageFormatFeatures(const VkImageCreateInfo &create_info, const Location &loc) const {
     bool skip = false;

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -23,7 +23,7 @@
 #include <vector>
 
 #include <vulkan/vk_enum_string_helper.h>
-#include "utils/vk_layer_utils.h"
+#include "utils/math_utils.h"
 #include "utils/vk_struct_compare.h"
 #include "core_validation.h"
 #include "generated/enum_flag_bits.h"

--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -29,7 +29,7 @@
 #include "error_message/error_strings.h"
 #include "state_tracker/image_state.h"
 #include "state_tracker/render_pass_state.h"
-#include "utils/vk_layer_utils.h"
+#include "utils/math_utils.h"
 
 bool CoreChecks::ValidateAttachmentCompatibility(const VulkanTypedHandle &rp1_object, const vvl::RenderPass &rp1_state,
                                                  const VulkanTypedHandle &rp2_object, const vvl::RenderPass &rp2_state,

--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -37,7 +37,7 @@
 #include "state_tracker/descriptor_sets.h"
 #include "state_tracker/render_pass_state.h"
 #include "spirv-tools/optimizer.hpp"
-#include "utils/vk_layer_utils.h"
+#include "utils/math_utils.h"
 
 // Validate use of input attachments against subpass structure
 bool CoreChecks::ValidateShaderInputAttachment(const spirv::Module &module_state, const vvl::Pipeline &pipeline,

--- a/layers/gpuav/spirv/buffer_device_address_pass.cpp
+++ b/layers/gpuav/spirv/buffer_device_address_pass.cpp
@@ -17,6 +17,7 @@
 #include "module.h"
 #include <spirv/unified1/spirv.hpp>
 #include <iostream>
+#include "utils/math_utils.h"
 
 #include "generated/instrumentation_buffer_device_address_comp.h"
 
@@ -68,8 +69,6 @@ void BufferDeviceAddressPass::Reset() {
     alignment_literal_ = 0;
     type_length_ = 0;
 }
-
-constexpr bool IsPowerOfTwo(uint32_t x) { return x && !(x & (x - 1)); }
 
 bool BufferDeviceAddressPass::RequiresInstrumentation(const Function& function, const Instruction& inst) {
     const uint32_t opcode = inst.Opcode();

--- a/layers/stateless/sl_image.cpp
+++ b/layers/stateless/sl_image.cpp
@@ -21,7 +21,7 @@
 #include "error_message/error_strings.h"
 #include "stateless/stateless_validation.h"
 #include "generated/enum_flag_bits.h"
-#include "utils/vk_layer_utils.h"
+#include "utils/math_utils.h"
 
 namespace stateless {
 

--- a/layers/utils/math_utils.h
+++ b/layers/utils/math_utils.h
@@ -1,0 +1,106 @@
+/* Copyright (c) 2015-2017, 2019-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2017, 2019-2025 Valve Corporation
+ * Copyright (c) 2015-2017, 2019-2025 LunarG, Inc.
+ * Modifications Copyright (C) 2022 RasterGrid Kft.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <bitset>
+#include <cassert>
+#include <cctype>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <type_traits>
+
+#ifdef WIN32
+#include <intrin.h>  // For __lzcnt()
+#else
+#include <strings.h>  // For ffs()
+#endif
+
+template <typename T>
+constexpr bool IsPowerOfTwo(T x) {
+    static_assert(std::is_integral_v<T> && std::is_unsigned_v<T>, "Unsigned integer required");
+    return x && !(x & (x - 1));
+}
+
+template <typename T>
+constexpr uint32_t GetBitSetCount(T value) {
+    static_assert(std::is_integral_v<T> && std::is_unsigned_v<T>, "Unsigned integer required");
+    static_assert(sizeof(T) == 4 || sizeof(T) == 8, "32 or 64 bit value is expected");
+    return static_cast<uint32_t>(std::bitset<sizeof(T) * 8>(value).count());
+}
+
+template <typename T>
+constexpr bool IsSingleBitSet(T flags) {
+    static_assert(std::is_integral_v<T> && std::is_unsigned_v<T>, "Unsigned integer required");
+    return IsPowerOfTwo(flags);
+}
+
+// Returns the 0-based index of the MSB, like the x86 bit scan reverse (bsr) instruction
+// Note: an input mask of 0 yields -1
+[[maybe_unused]] static inline int MostSignificantBit(uint32_t mask) {
+#if defined __GNUC__
+    return mask ? __builtin_clz(mask) ^ 31 : -1;
+#elif defined _MSC_VER
+    unsigned long bit_pos;
+    return _BitScanReverse(&bit_pos, mask) ? int(bit_pos) : -1;
+#else
+    for (int k = 31; k >= 0; --k) {
+        if (((mask >> k) & 1) != 0) {
+            return k;
+        }
+    }
+    return -1;
+#endif
+}
+
+static inline int u_ffs(int val) {
+#ifdef WIN32
+    unsigned long bit_pos = 0;
+    if (_BitScanForward(&bit_pos, val) != 0) {
+        bit_pos += 1;
+    }
+    return bit_pos;
+
+#elif defined __GNUC__
+    return __builtin_ffs(val);
+#else
+    return ffs(val);
+#endif
+}
+
+// Given p2 a power of two, returns smallest multiple of p2 greater than or equal to x
+// Different than std::align in that it simply aligns an unsigned integer, when std::align aligns a virtual address and does the
+// necessary bookkeeping to be able to correctly free memory at the new address
+template <typename T>
+constexpr T Align(T x, T p2) {
+    static_assert(std::numeric_limits<T>::is_integer, "Unsigned integer required.");
+    static_assert(std::is_unsigned<T>::value, "Unsigned integer required.");
+    assert(IsPowerOfTwo(p2));
+    return (x + p2 - 1) & ~(p2 - 1);
+}
+
+// Returns the 0-based index of the LSB. An input mask of 0 yields -1
+static inline int LeastSignificantBit(uint32_t mask) { return u_ffs(static_cast<int>(mask)) - 1; }
+
+template <typename FlagBits, typename Flags>
+FlagBits LeastSignificantFlag(Flags flags) {
+    const int bit_shift = LeastSignificantBit(flags);
+    assert(bit_shift != -1);
+    return static_cast<FlagBits>(1ull << bit_shift);
+}

--- a/layers/utils/vk_layer_utils.h
+++ b/layers/utils/vk_layer_utils.h
@@ -20,30 +20,22 @@
 
 #include <algorithm>
 #include <atomic>
-#include <bitset>
 #include <cassert>
 #include <cctype>
 #include <cmath>
 #include <cstring>
 #include <memory>
-#include <optional>
 #include <shared_mutex>
 #include <string>
-#include <type_traits>
 #include <vector>
 
 #include <vulkan/utility/vk_format_utils.h>
 #include <vulkan/utility/vk_concurrent_unordered_map.hpp>
 #include <vulkan/utility/vk_struct_helper.hpp>
 #include "vulkan/vk_layer.h"
+#include "utils/math_utils.h"
 
 #include "generated/vk_layer_dispatch_table.h"
-
-#ifndef WIN32
-#include <strings.h>  // For ffs()
-#else
-#include <intrin.h>  // For __lzcnt()
-#endif
 
 #define STRINGIFY(s) STRINGIFY_HELPER(s)
 #define STRINGIFY_HELPER(s) #s
@@ -102,76 +94,6 @@ static inline dispatch_key GetDispatchKey(const void *object) { return (dispatch
 
 VkLayerInstanceCreateInfo *GetChainInfo(const VkInstanceCreateInfo *pCreateInfo, VkLayerFunction func);
 VkLayerDeviceCreateInfo *GetChainInfo(const VkDeviceCreateInfo *pCreateInfo, VkLayerFunction func);
-
-template <typename T>
-constexpr bool IsPowerOfTwo(T x) {
-    static_assert(std::is_integral_v<T> && std::is_unsigned_v<T>, "Unsigned integer required");
-    return x && !(x & (x - 1));
-}
-
-template <typename T>
-constexpr uint32_t GetBitSetCount(T value) {
-    static_assert(std::is_integral_v<T> && std::is_unsigned_v<T>, "Unsigned integer required");
-    static_assert(sizeof(T) == 4 || sizeof(T) == 8, "32 or 64 bit value is expected");
-    return static_cast<uint32_t>(std::bitset<sizeof(T) * 8>(value).count());
-}
-
-template <typename T>
-constexpr bool IsSingleBitSet(T flags) {
-    static_assert(std::is_integral_v<T> && std::is_unsigned_v<T>, "Unsigned integer required");
-    return IsPowerOfTwo(flags);
-}
-
-// Returns the 0-based index of the MSB, like the x86 bit scan reverse (bsr) instruction
-// Note: an input mask of 0 yields -1
-static inline int MostSignificantBit(uint32_t mask) {
-#if defined __GNUC__
-    return mask ? __builtin_clz(mask) ^ 31 : -1;
-#elif defined _MSC_VER
-    unsigned long bit_pos;
-    return _BitScanReverse(&bit_pos, mask) ? int(bit_pos) : -1;
-#else
-    for (int k = 31; k >= 0; --k) {
-        if (((mask >> k) & 1) != 0) {
-            return k;
-        }
-    }
-    return -1;
-#endif
-}
-
-static inline int u_ffs(int val) {
-#ifdef WIN32
-    unsigned long bit_pos = 0;
-    if (_BitScanForward(&bit_pos, val) != 0) {
-        bit_pos += 1;
-    }
-    return bit_pos;
-#else
-    return ffs(val);
-#endif
-}
-
-// Given p2 a power of two, returns smallest multiple of p2 greater than or equal to x
-// Different than std::align in that it simply aligns an unsigned integer, when std::align aligns a virtual address and does the
-// necessary bookkeeping to be able to correctly free memory at the new address
-template <typename T>
-constexpr T Align(T x, T p2) {
-    static_assert(std::numeric_limits<T>::is_integer, "Unsigned integer required.");
-    static_assert(std::is_unsigned<T>::value, "Unsigned integer required.");
-    assert(IsPowerOfTwo(p2));
-    return (x + p2 - 1) & ~(p2 - 1);
-}
-
-// Returns the 0-based index of the LSB. An input mask of 0 yields -1
-static inline int LeastSignificantBit(uint32_t mask) { return u_ffs(static_cast<int>(mask)) - 1; }
-
-template <typename FlagBits, typename Flags>
-FlagBits LeastSignificantFlag(Flags flags) {
-    const int bit_shift = LeastSignificantBit(flags);
-    assert(bit_shift != -1);
-    return static_cast<FlagBits>(1ull << bit_shift);
-}
 
 // Iterates over all set bits and calls the callback with a bit mask corresponding to each flag.
 // FlagBits and Flags follow Vulkan naming convensions for flag types.

--- a/tests/unit/external_memory_metal.cpp
+++ b/tests/unit/external_memory_metal.cpp
@@ -11,11 +11,11 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#ifdef VK_USE_PLATFORM_METAL_EXT
 #include "utils/vk_layer_utils.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/external_memory_sync.h"
 
-#ifdef VK_USE_PLATFORM_METAL_EXT
 // We need these instead of using FindSupportedExternalMemoryHandleTypes because otherwise we'll get
 // VUID-VkPhysicalDeviceExternalImageFormatInfo-handleType-parameter due to sending flags that are not supported due to extensions
 // not being present

--- a/tests/unit/external_memory_sync_positive.cpp
+++ b/tests/unit/external_memory_sync_positive.cpp
@@ -13,7 +13,7 @@
 
 #include "../framework/layer_validation_tests.h"
 #include "../framework/external_memory_sync.h"
-#include "utils/vk_layer_utils.h"
+#include "utils/math_utils.h"
 #include "generated/enum_flag_bits.h"
 
 class PositiveExternalMemorySync : public ExternalMemorySyncTest {};

--- a/tests/unit/gpu_av_descriptor_buffer_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_buffer_positive.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2024 Valve Corporation
- * Copyright (c) 2024 LunarG, Inc.
+ * Copyright (c) 2024-2025 Valve Corporation
+ * Copyright (c) 2024-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
 
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
-#include "utils/vk_layer_utils.h"
+#include "utils/math_utils.h"
 
 class PositiveGpuAVDescriptorBuffer : public GpuAVTest {};
 

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -16,7 +16,7 @@
 #include "../framework/ray_tracing_objects.h"
 #include "../framework/descriptor_helper.h"
 #include "../framework/shader_helper.h"
-#include "../layers/utils/vk_layer_utils.h"
+#include "../layers/utils/math_utils.h"
 
 // Compute a binomial coefficient
 template <typename T>

--- a/tests/unit/sparse_image.cpp
+++ b/tests/unit/sparse_image.cpp
@@ -12,7 +12,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#include "utils/vk_layer_utils.h"
+#include "utils/math_utils.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/external_memory_sync.h"
 

--- a/tests/unit/video.cpp
+++ b/tests/unit/video.cpp
@@ -11,7 +11,7 @@
  */
 
 #include "../framework/video_objects.h"
-#include "utils/vk_layer_utils.h"
+#include "utils/math_utils.h"
 
 class NegativeVideo : public VkVideoLayerTest {};
 


### PR DESCRIPTION
Creates a dedicated `utils/math_utils.h` file to help reduce the "everything that doesn't fit" bin of `vk_layer_utils.h`

There were a few files that really just needed these non-Vulkan helpers