### PR TITLE
tests: Improve Simple Test creation helpers

### DIFF
--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -246,56 +246,34 @@ VkFormat FindFormatWithoutFeatures2(VkPhysicalDevice gpu, VkImageTiling tiling, 
     return return_format;
 }
 
-void CreateSamplerTest(VkLayerTest &test, const VkSamplerCreateInfo *create_info, const std::string &code) {
-    if (code.length()) {
-        test.Monitor().SetDesiredError(code.c_str());
-    }
-
-    vkt::Sampler sampler(*test.DeviceObj(), *create_info);
-
-    if (code.length()) {
-        test.Monitor().VerifyFound();
-    }
+void VkLayerTest::CreateSamplerTest(const VkSamplerCreateInfo &create_info, const char *vuid) {
+    Monitor().SetDesiredError(vuid);
+    vkt::Sampler sampler(*m_device, create_info);
+    Monitor().VerifyFound();
 }
 
-void CreateBufferTest(VkLayerTest &test, const VkBufferCreateInfo *create_info, const std::string &code) {
-    if (code.length()) {
-        test.Monitor().SetDesiredError(code.c_str());
-    }
-    vkt::Buffer buffer(*test.DeviceObj(), *create_info, vkt::no_mem);
-    if (code.length()) {
-        test.Monitor().VerifyFound();
-    }
+void VkLayerTest::CreateBufferTest(const VkBufferCreateInfo &create_info, const char *vuid) {
+    Monitor().SetDesiredError(vuid);
+    vkt::Buffer buffer(*m_device, create_info, vkt::no_mem);
+    Monitor().VerifyFound();
 }
 
-void CreateImageTest(VkLayerTest &test, const VkImageCreateInfo *create_info, const std::string &code) {
-    if (code.length()) {
-        test.Monitor().SetDesiredError(code.c_str());
-    }
-    vkt::Image image(*test.DeviceObj(), *create_info, vkt::no_mem);
-    if (code.length()) {
-        test.Monitor().VerifyFound();
-    }
+void VkLayerTest::CreateImageTest(const VkImageCreateInfo &create_info, const char *vuid) {
+    Monitor().SetDesiredError(vuid);
+    vkt::Image image(*m_device, create_info, vkt::no_mem);
+    Monitor().VerifyFound();
 }
 
-void CreateBufferViewTest(VkLayerTest &test, const VkBufferViewCreateInfo *create_info, const std::vector<std::string> &codes) {
-    if (codes.size()) {
-        std::for_each(codes.begin(), codes.end(), [&](const std::string &s) { test.Monitor().SetDesiredError(s.c_str()); });
-    }
-    vkt::BufferView view(*test.DeviceObj(), *create_info);
-    if (codes.size()) {
-        test.Monitor().VerifyFound();
-    }
+void VkLayerTest::CreateBufferViewTest(const VkBufferViewCreateInfo &create_info, const char *vuid) {
+    Monitor().SetDesiredError(vuid);
+    vkt::BufferView view(*m_device, create_info);
+    Monitor().VerifyFound();
 }
 
-void CreateImageViewTest(VkLayerTest &test, const VkImageViewCreateInfo *create_info, const std::string &code) {
-    if (code.length()) {
-        test.Monitor().SetDesiredError(code.c_str());
-    }
-    vkt::ImageView view(*test.DeviceObj(), *create_info);
-    if (code.length()) {
-        test.Monitor().VerifyFound();
-    }
+void VkLayerTest::CreateImageViewTest(const VkImageViewCreateInfo &create_info, const char *vuid) {
+    Monitor().SetDesiredError(vuid);
+    vkt::ImageView view(*m_device, create_info);
+    Monitor().VerifyFound();
 }
 
 VkSamplerCreateInfo SafeSaneSamplerCreateInfo() {

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -201,6 +201,13 @@ class VkLayerTest : public VkLayerTestBase {
     }
     APIVersion DeviceValidationVersion() const;
 
+    // Helpers to quickly create a Handle and check it gives a certain VU error
+    void CreateSamplerTest(const VkSamplerCreateInfo &create_info, const char *vuid);
+    void CreateBufferTest(const VkBufferCreateInfo &create_info, const char *vuid);
+    void CreateImageTest(const VkImageCreateInfo &create_info, const char *vuid);
+    void CreateBufferViewTest(const VkBufferViewCreateInfo &create_info, const char *vuid);
+    void CreateImageViewTest(const VkImageViewCreateInfo &create_info, const char *vuid);
+
   protected:
     void SetTargetApiVersion(APIVersion target_api_version);
     bool LoadDeviceProfileLayer(
@@ -459,15 +466,5 @@ VkFormat FindFormatWithoutFeatures(VkPhysicalDevice gpu, VkImageTiling tiling,
                                    VkFormatFeatureFlags undesired_features = vvl::kU32Max);
 
 VkFormat FindFormatWithoutFeatures2(VkPhysicalDevice gpu, VkImageTiling tiling, VkFormatFeatureFlags2 undesired_features);
-
-void CreateSamplerTest(VkLayerTest &test, const VkSamplerCreateInfo *pCreateInfo, const std::string &code = "");
-
-void CreateBufferTest(VkLayerTest &test, const VkBufferCreateInfo *pCreateInfo, const std::string &code = "");
-
-void CreateImageTest(VkLayerTest &test, const VkImageCreateInfo *pCreateInfo, const std::string &code = "");
-
-void CreateBufferViewTest(VkLayerTest &test, const VkBufferViewCreateInfo *pCreateInfo, const std::vector<std::string> &codes);
-
-void CreateImageViewTest(VkLayerTest &test, const VkImageViewCreateInfo *pCreateInfo, const std::string &code = "");
 
 void PrintAndroid(const char *c);

--- a/tests/unit/buffer_positive.cpp
+++ b/tests/unit/buffer_positive.cpp
@@ -83,7 +83,7 @@ TEST_F(PositiveBuffer, TexelBufferAlignmentIn13) {
     buff_view_ci.range = VK_WHOLE_SIZE;
     buff_view_ci.buffer = buffer.handle();
     buff_view_ci.offset = minTexelBufferOffsetAlignment + block_size;
-    CreateBufferViewTest(*this, &buff_view_ci, {});
+    vkt::BufferView buffer_view(*m_device, buff_view_ci);
 }
 
 // The two PerfGetBufferAddress tests are intended to be used locally to monitor performance of the internal address -> buffer map
@@ -220,7 +220,7 @@ TEST_F(PositiveBuffer, BufferViewUsageBasic) {
     buffer_view_ci.format = VK_FORMAT_R8G8B8A8_UNORM;
     buffer_view_ci.range = VK_WHOLE_SIZE;
     buffer_view_ci.buffer = buffer.handle();
-    CreateBufferViewTest(*this, &buffer_view_ci, {});
+    vkt::BufferView buffer_view(*m_device, buffer_view_ci);
 }
 
 TEST_F(PositiveBuffer, BufferUsageFlags2Subset) {
@@ -239,7 +239,7 @@ TEST_F(PositiveBuffer, BufferUsageFlags2Subset) {
     buffer_view_ci.format = VK_FORMAT_R8G8B8A8_UNORM;
     buffer_view_ci.range = VK_WHOLE_SIZE;
     buffer_view_ci.buffer = buffer.handle();
-    CreateBufferViewTest(*this, &buffer_view_ci, {});
+    vkt::BufferView buffer_view(*m_device, buffer_view_ci);
 }
 
 TEST_F(PositiveBuffer, BufferUsageFlags2Ignore) {
@@ -255,11 +255,11 @@ TEST_F(PositiveBuffer, BufferUsageFlags2Ignore) {
     VkBufferCreateInfo buffer_ci = vku::InitStructHelper(&buffer_usage_flags);
     buffer_ci.size = 32;
     buffer_ci.usage = VK_BUFFER_USAGE_PUSH_DESCRIPTORS_DESCRIPTOR_BUFFER_BIT_EXT;
-    CreateBufferTest(*this, &buffer_ci, {});
+    vkt::Buffer buffer(*m_device, buffer_ci, vkt::no_mem);
 
     buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR | VK_BUFFER_USAGE_VIDEO_DECODE_DST_BIT_KHR |
                       VK_BUFFER_USAGE_MICROMAP_BUILD_INPUT_READ_ONLY_BIT_EXT;
-    CreateBufferTest(*this, &buffer_ci, {});
+    vkt::Buffer buffer2(*m_device, buffer_ci, vkt::no_mem);
 }
 
 TEST_F(PositiveBuffer, BufferUsageFlags2Usage) {
@@ -275,8 +275,8 @@ TEST_F(PositiveBuffer, BufferUsageFlags2Usage) {
     VkBufferCreateInfo buffer_ci = vku::InitStructHelper(&buffer_usage_flags);
     buffer_ci.size = 32;
     buffer_ci.usage = 0;
-    CreateBufferTest(*this, &buffer_ci, {});
+    vkt::Buffer buffer(*m_device, buffer_ci, vkt::no_mem);
 
     buffer_ci.usage = 0xBAD0000;
-    CreateBufferTest(*this, &buffer_ci, {});
+    vkt::Buffer buffer2(*m_device, buffer_ci, vkt::no_mem);
 }

--- a/tests/unit/descriptor_buffer.cpp
+++ b/tests/unit/descriptor_buffer.cpp
@@ -415,7 +415,7 @@ TEST_F(NegativeDescriptorBuffer, NotEnabledDescriptorBufferCaptureReplay) {
         buffer_ci.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
 
         buffer_ci.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
-        CreateBufferTest(*this, &buffer_ci, "VUID-VkBufferCreateInfo-flags-08099");
+        CreateBufferTest(buffer_ci, "VUID-VkBufferCreateInfo-flags-08099");
 
         buffer_ci.flags = 0;
 
@@ -424,11 +424,11 @@ TEST_F(NegativeDescriptorBuffer, NotEnabledDescriptorBufferCaptureReplay) {
         }
         buffer_ci.usage =
             VK_BUFFER_USAGE_PUSH_DESCRIPTORS_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
-        CreateBufferTest(*this, &buffer_ci, "VUID-VkBufferCreateInfo-usage-08101");
+        CreateBufferTest(buffer_ci, "VUID-VkBufferCreateInfo-usage-08101");
 
         buffer_ci.pNext = &ocddci;
         buffer_ci.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
-        CreateBufferTest(*this, &buffer_ci, "VUID-VkBufferCreateInfo-pNext-08100");
+        CreateBufferTest(buffer_ci, "VUID-VkBufferCreateInfo-pNext-08100");
     }
 
     {
@@ -445,11 +445,11 @@ TEST_F(NegativeDescriptorBuffer, NotEnabledDescriptorBufferCaptureReplay) {
         image_create_info.format = VK_FORMAT_D32_SFLOAT;
         image_create_info.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
         image_create_info.pNext = &ocddci;
-        CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-flags-08104");
+        CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-flags-08104");
 
         image_create_info.pNext = &ocddci;
         image_create_info.flags &= ~VK_IMAGE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
-        CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-pNext-08105");
+        CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-pNext-08105");
     }
 
     {
@@ -464,22 +464,22 @@ TEST_F(NegativeDescriptorBuffer, NotEnabledDescriptorBufferCaptureReplay) {
         dsvci.subresourceRange.baseMipLevel = 0;
         dsvci.subresourceRange.levelCount = 1;
         dsvci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
-        CreateImageViewTest(*this, &dsvci, "VUID-VkImageViewCreateInfo-flags-08106");
+        CreateImageViewTest(dsvci, "VUID-VkImageViewCreateInfo-flags-08106");
 
         dsvci.pNext = &ocddci;
         dsvci.flags &= ~VK_IMAGE_VIEW_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
-        CreateImageViewTest(*this, &dsvci, "VUID-VkImageViewCreateInfo-pNext-08107");
+        CreateImageViewTest(dsvci, "VUID-VkImageViewCreateInfo-pNext-08107");
     }
 
     {
         auto sampler_ci = SafeSaneSamplerCreateInfo();
         sampler_ci.flags |= VK_SAMPLER_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
 
-        CreateSamplerTest(*this, &sampler_ci, "VUID-VkSamplerCreateInfo-flags-08110");
+        CreateSamplerTest(sampler_ci, "VUID-VkSamplerCreateInfo-flags-08110");
 
         sampler_ci.pNext = &ocddci;
         sampler_ci.flags &= ~VK_SAMPLER_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
-        CreateSamplerTest(*this, &sampler_ci, "VUID-VkSamplerCreateInfo-pNext-08111");
+        CreateSamplerTest(sampler_ci, "VUID-VkSamplerCreateInfo-pNext-08111");
     }
 }
 
@@ -1491,15 +1491,15 @@ TEST_F(NegativeDescriptorBuffer, SetBufferAddressSpaceLimits) {
     buffer_ci.size = descriptor_buffer_properties.descriptorBufferAddressSpaceSize + 1;
 
     buffer_ci.usage = VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT;
-    CreateBufferTest(*this, &buffer_ci, "VUID-VkBufferCreateInfo-usage-08097");
+    CreateBufferTest(buffer_ci, "VUID-VkBufferCreateInfo-usage-08097");
 
     buffer_ci.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
-    CreateBufferTest(*this, &buffer_ci, "VUID-VkBufferCreateInfo-usage-08098");
+    CreateBufferTest(buffer_ci, "VUID-VkBufferCreateInfo-usage-08098");
 
     m_errorMonitor->SetDesiredError("VUID-VkBufferCreateInfo-usage-08097");
     buffer_ci.usage = VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT |
                       VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT;
-    CreateBufferTest(*this, &buffer_ci, "VUID-VkBufferCreateInfo-usage-08098");
+    CreateBufferTest(buffer_ci, "VUID-VkBufferCreateInfo-usage-08098");
 }
 
 // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5826

--- a/tests/unit/device_queue.cpp
+++ b/tests/unit/device_queue.cpp
@@ -55,34 +55,34 @@ TEST_F(NegativeDeviceQueue, FamilyIndexUsage) {
     all_queue_count_ = true;
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
-    VkBufferCreateInfo buffCI = vku::InitStructHelper();
-    buffCI.size = 1024;
-    buffCI.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
-    buffCI.queueFamilyIndexCount = 2;
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
+    buffer_ci.size = 1024;
+    buffer_ci.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+    buffer_ci.queueFamilyIndexCount = 2;
     // Introduce failure by specifying invalid queue_family_index
     uint32_t qfi[2];
     qfi[0] = 777;
     qfi[1] = 0;
 
-    buffCI.pQueueFamilyIndices = qfi;
-    buffCI.sharingMode = VK_SHARING_MODE_CONCURRENT;  // qfi only matters in CONCURRENT mode
+    buffer_ci.pQueueFamilyIndices = qfi;
+    buffer_ci.sharingMode = VK_SHARING_MODE_CONCURRENT;  // qfi only matters in CONCURRENT mode
 
     // Test for queue family index out of range
-    CreateBufferTest(*this, &buffCI, "VUID-VkBufferCreateInfo-sharingMode-01419");
+    CreateBufferTest(buffer_ci, "VUID-VkBufferCreateInfo-sharingMode-01419");
 
     // Test for non-unique QFI in array
     qfi[0] = 0;
-    CreateBufferTest(*this, &buffCI, "VUID-VkBufferCreateInfo-sharingMode-01419");
+    CreateBufferTest(buffer_ci, "VUID-VkBufferCreateInfo-sharingMode-01419");
 
     if (m_device->Physical().queue_properties_.size() > 2) {
         m_errorMonitor->SetDesiredError("VUID-vkQueueSubmit-pSubmits-04626");
 
         // Create buffer shared to queue families 1 and 2, but submitted on queue family 0
-        buffCI.queueFamilyIndexCount = 2;
+        buffer_ci.queueFamilyIndexCount = 2;
         qfi[0] = 1;
         qfi[1] = 2;
         vkt::Buffer ib;
-        ib.init(*m_device, buffCI);
+        ib.init(*m_device, buffer_ci);
 
         m_command_buffer.Begin();
         vk::CmdFillBuffer(m_command_buffer.handle(), ib.handle(), 0, 16, 5);
@@ -120,10 +120,10 @@ TEST_F(NegativeDeviceQueue, FamilyIndexUsage) {
     ASSERT_EQ(VK_SUCCESS, vk::CreateDevice(Gpu(), &dev_info, nullptr, &second_device));
 
     // Select Queue family for CONCURRENT buffer that is not owned by device
-    buffCI.queueFamilyIndexCount = 2;
+    buffer_ci.queueFamilyIndexCount = 2;
     qfi[1] = 2;
     VkBuffer buffer = VK_NULL_HANDLE;
-    vk::CreateBuffer(second_device, &buffCI, NULL, &buffer);
+    vk::CreateBuffer(second_device, &buffer_ci, NULL, &buffer);
     vk::DestroyBuffer(second_device, buffer, nullptr);
     vk::DestroyDevice(second_device, nullptr);
 }

--- a/tests/unit/dynamic_state.cpp
+++ b/tests/unit/dynamic_state.cpp
@@ -3119,7 +3119,7 @@ TEST_F(NegativeDynamicState, SampleLocations) {
     if ((format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT) != 0) {
         image_create_info.flags = VK_IMAGE_CREATE_SAMPLE_LOCATIONS_COMPATIBLE_DEPTH_BIT_EXT;
         image_create_info.format = VK_FORMAT_S8_UINT;
-        CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-flags-01533");
+        CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-flags-01533");
     }
 
     const VkFormat depth_format = FindSupportedDepthStencilFormat(Gpu());

--- a/tests/unit/external_memory_sync.cpp
+++ b/tests/unit/external_memory_sync.cpp
@@ -35,7 +35,7 @@ TEST_F(NegativeExternalMemorySync, CreateBufferIncompatibleHandleTypes) {
     VkBufferCreateInfo buffer_create_info = vku::InitStructHelper(&external_memory_info);
     buffer_create_info.size = 1024;
     buffer_create_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
-    CreateBufferTest(*this, &buffer_create_info, "VUID-VkBufferCreateInfo-pNext-00920");
+    CreateBufferTest(buffer_create_info, "VUID-VkBufferCreateInfo-pNext-00920");
 
     IgnoreHandleTypeError(m_errorMonitor);
     // Get all exportable handle types supported by the platform.
@@ -58,7 +58,7 @@ TEST_F(NegativeExternalMemorySync, CreateBufferIncompatibleHandleTypes) {
     // Main test case. Handle types are supported but not compatible with each other
     if ((supported_handle_types & any_compatible_group) != supported_handle_types) {
         external_memory_info.handleTypes = supported_handle_types;
-        CreateBufferTest(*this, &buffer_create_info, "VUID-VkBufferCreateInfo-pNext-00920");
+        CreateBufferTest(buffer_create_info, "VUID-VkBufferCreateInfo-pNext-00920");
     }
 }
 
@@ -83,7 +83,7 @@ TEST_F(NegativeExternalMemorySync, CreateImageIncompatibleHandleTypes) {
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-pNext-00990");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-pNext-00990");
 
     // Get all exportable handle types supported by the platform.
     VkExternalMemoryHandleTypeFlags supported_handle_types = 0;
@@ -114,7 +114,7 @@ TEST_F(NegativeExternalMemorySync, CreateImageIncompatibleHandleTypes) {
     // Main test case. Handle types are supported but not compatible with each other
     if ((supported_handle_types & any_compatible_group) != supported_handle_types) {
         external_memory_info.handleTypes = supported_handle_types;
-        CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-pNext-00990");
+        CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-pNext-00990");
     }
 }
 
@@ -159,7 +159,7 @@ TEST_F(NegativeExternalMemorySync, CreateImageIncompatibleHandleTypesNV) {
     // Main test case. Handle types are supported but not compatible with each other
     if ((supported_handle_types & any_compatible_group) != supported_handle_types) {
         external_memory_info.handleTypes = supported_handle_types;
-        CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-pNext-00991");
+        CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-pNext-00991");
     }
 }
 
@@ -1542,7 +1542,7 @@ TEST_F(NegativeExternalMemorySync, MemoryAndMemoryNV) {
     }
     external_mem_nv.handleTypes = LeastSignificantFlag<VkExternalMemoryFeatureFlagBitsNV>(supported_types_nv);
     external_mem.handleTypes = LeastSignificantFlag<VkExternalMemoryHandleTypeFlagBits>(supported_types);
-    CreateImageTest(*this, &ici, "VUID-VkImageCreateInfo-pNext-00988");
+    CreateImageTest(ici, "VUID-VkImageCreateInfo-pNext-00988");
 }
 
 TEST_F(NegativeExternalMemorySync, MemoryImageLayout) {
@@ -1570,7 +1570,7 @@ TEST_F(NegativeExternalMemorySync, MemoryImageLayout) {
     const auto supported_types = FindSupportedExternalMemoryHandleTypes(Gpu(), ici, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT);
     if (supported_types) {
         external_mem.handleTypes = LeastSignificantFlag<VkExternalMemoryHandleTypeFlagBits>(supported_types);
-        CreateImageTest(*this, &ici, "VUID-VkImageCreateInfo-pNext-01443");
+        CreateImageTest(ici, "VUID-VkImageCreateInfo-pNext-01443");
     }
     if (IsExtensionsEnabled(VK_NV_EXTERNAL_MEMORY_EXTENSION_NAME)) {
         VkExternalMemoryImageCreateInfoNV external_mem_nv = vku::InitStructHelper();
@@ -1579,7 +1579,7 @@ TEST_F(NegativeExternalMemorySync, MemoryImageLayout) {
         if (supported_types_nv) {
             external_mem_nv.handleTypes = LeastSignificantFlag<VkExternalMemoryHandleTypeFlagBitsNV>(supported_types_nv);
             ici.pNext = &external_mem_nv;
-            CreateImageTest(*this, &ici, "VUID-VkImageCreateInfo-pNext-01443");
+            CreateImageTest(ici, "VUID-VkImageCreateInfo-pNext-01443");
         }
     }
 }
@@ -2777,21 +2777,21 @@ TEST_F(NegativeExternalMemorySync, ExportMetalObjects) {
     ici.tiling = VK_IMAGE_TILING_LINEAR;
     ici.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     ici.pNext = &metal_object_create_info;
-    CreateImageTest(*this, &ici, "VUID-VkImageCreateInfo-pNext-06783");
+    CreateImageTest(ici, "VUID-VkImageCreateInfo-pNext-06783");
 
     VkImportMetalTextureInfoEXT import_metal_texture_info = vku::InitStructHelper();
     import_metal_texture_info.plane = VK_IMAGE_ASPECT_COLOR_BIT;
     ici.pNext = &import_metal_texture_info;
     ici.format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;
-    CreateImageTest(*this, &ici, "VUID-VkImageCreateInfo-pNext-06784");
+    CreateImageTest(ici, "VUID-VkImageCreateInfo-pNext-06784");
 
     ici.format = VK_FORMAT_B8G8R8A8_UNORM;
     import_metal_texture_info.plane = VK_IMAGE_ASPECT_PLANE_1_BIT;
-    CreateImageTest(*this, &ici, "VUID-VkImageCreateInfo-pNext-06785");
+    CreateImageTest(ici, "VUID-VkImageCreateInfo-pNext-06785");
 
     ici.format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;
     import_metal_texture_info.plane = VK_IMAGE_ASPECT_PLANE_2_BIT;
-    CreateImageTest(*this, &ici, "VUID-VkImageCreateInfo-pNext-06786");
+    CreateImageTest(ici, "VUID-VkImageCreateInfo-pNext-06786");
 
     VkBufferCreateInfo buffer_create_info = vku::InitStructHelper();
     buffer_create_info.size = 1024;
@@ -2803,7 +2803,7 @@ TEST_F(NegativeExternalMemorySync, ExportMetalObjects) {
     buff_view_ci.format = VK_FORMAT_B8G8R8A8_UNORM;
     buff_view_ci.range = VK_WHOLE_SIZE;
     buff_view_ci.pNext = &metal_object_create_info;
-    CreateBufferViewTest(*this, &buff_view_ci, {"VUID-VkBufferViewCreateInfo-pNext-06782"});
+    CreateBufferViewTest(buff_view_ci, "VUID-VkBufferViewCreateInfo-pNext-06782");
 
     vkt::Image image_obj(*m_device, 256, 256, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_STORAGE_BIT);
     VkImageViewCreateInfo ivci = vku::InitStructHelper();
@@ -2815,7 +2815,7 @@ TEST_F(NegativeExternalMemorySync, ExportMetalObjects) {
     ivci.subresourceRange.levelCount = 1;
     ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     ivci.pNext = &metal_object_create_info;
-    CreateImageViewTest(*this, &ivci, "VUID-VkImageViewCreateInfo-pNext-06787");
+    CreateImageViewTest(ivci, "VUID-VkImageViewCreateInfo-pNext-06787");
 
     VkSemaphoreCreateInfo sem_info = vku::InitStructHelper();
     sem_info.pNext = &metal_object_create_info;

--- a/tests/unit/fragment_shading_rate.cpp
+++ b/tests/unit/fragment_shading_rate.cpp
@@ -502,45 +502,45 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapEnabled) {
     // min max filters must match
     sampler_info.minFilter = VK_FILTER_LINEAR;
     sampler_info.magFilter = VK_FILTER_NEAREST;
-    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-flags-02574");
+    CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-flags-02574");
     sampler_info.minFilter = sampler_info_ref.minFilter;
     sampler_info.magFilter = sampler_info_ref.magFilter;
 
     // mipmapMode must be SAMPLER_MIPMAP_MODE_NEAREST
     sampler_info.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
-    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-flags-02575");
+    CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-flags-02575");
     sampler_info.mipmapMode = sampler_info_ref.mipmapMode;
 
     // minLod and maxLod must be 0.0
     sampler_info.minLod = 1.0;
     sampler_info.maxLod = 1.0;
-    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-flags-02576");
+    CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-flags-02576");
     sampler_info.minLod = sampler_info_ref.minLod;
     sampler_info.maxLod = sampler_info_ref.maxLod;
 
     // addressMode must be CLAMP_TO_EDGE or CLAMP_TO_BORDER
     sampler_info.addressModeU = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-flags-02577");
+    CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-flags-02577");
     sampler_info.addressModeU = sampler_info_ref.addressModeU;
 
     sampler_info.addressModeV = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-flags-02577");
+    CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-flags-02577");
     sampler_info.addressModeV = sampler_info_ref.addressModeV;
 
     // some features cannot be enabled for subsampled samplers
     if (features2.features.samplerAnisotropy == VK_TRUE) {
         sampler_info.anisotropyEnable = VK_TRUE;
-        CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-flags-02578");
+        CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-flags-02578");
         sampler_info.anisotropyEnable = sampler_info_ref.anisotropyEnable;
         sampler_info.anisotropyEnable = VK_FALSE;
     }
 
     sampler_info.compareEnable = VK_TRUE;
-    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-flags-02579");
+    CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-flags-02579");
     sampler_info.compareEnable = sampler_info_ref.compareEnable;
 
     sampler_info.unnormalizedCoordinates = VK_TRUE;
-    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-flags-02580");
+    CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-flags-02580");
     sampler_info.unnormalizedCoordinates = sampler_info_ref.unnormalizedCoordinates;
 
     // Test image parameters
@@ -561,37 +561,37 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapEnabled) {
     // only VK_IMAGE_TYPE_2D is supported
     image_create_info.imageType = VK_IMAGE_TYPE_1D;
     image_create_info.extent.height = 1;
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-flags-02557");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-flags-02557");
 
     // only VK_SAMPLE_COUNT_1_BIT is supported
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.samples = VK_SAMPLE_COUNT_4_BIT;
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-samples-02558");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-samples-02558");
 
     // tiling must be VK_IMAGE_TILING_OPTIMAL
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     image_create_info.flags = VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT;
     image_create_info.tiling = VK_IMAGE_TILING_LINEAR;
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-flags-02565");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-flags-02565");
 
     // only 2D
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.imageType = VK_IMAGE_TYPE_1D;
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-flags-02566");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-flags-02566");
 
     // no cube maps
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.extent.height = 64;
     image_create_info.arrayLayers = 6;
     image_create_info.flags |= VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT;
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-flags-02567");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-flags-02567");
 
     // mipLevels must be 1
     image_create_info.flags = VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT;
     image_create_info.arrayLayers = 1;
     image_create_info.mipLevels = 2;
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-flags-02568");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-flags-02568");
 
     // Test image view parameters
 
@@ -618,19 +618,19 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapEnabled) {
         vkt::Image image(*m_device, image_create_info, vkt::no_mem);
 
         ivci.image = image.handle();
-        CreateImageViewTest(*this, &ivci, "VUID-VkImageViewCreateInfo-flags-04116");
+        CreateImageViewTest(ivci, "VUID-VkImageViewCreateInfo-flags-04116");
     }
 
     if (fdm2Supported) {
         if (!density_map2_features.fragmentDensityMapDeferred) {
             ivci.flags = VK_IMAGE_VIEW_CREATE_FRAGMENT_DENSITY_MAP_DEFERRED_BIT_EXT;
             ivci.image = densityImage.handle();
-            CreateImageViewTest(*this, &ivci, "VUID-VkImageViewCreateInfo-flags-03567");
+            CreateImageViewTest(ivci, "VUID-VkImageViewCreateInfo-flags-03567");
         } else {
             ivci.flags = VK_IMAGE_VIEW_CREATE_FRAGMENT_DENSITY_MAP_DEFERRED_BIT_EXT;
             ivci.flags |= VK_IMAGE_VIEW_CREATE_FRAGMENT_DENSITY_MAP_DYNAMIC_BIT_EXT;
             ivci.image = densityImage.handle();
-            CreateImageViewTest(*this, &ivci, "VUID-VkImageViewCreateInfo-flags-03568");
+            CreateImageViewTest(ivci, "VUID-VkImageViewCreateInfo-flags-03568");
         }
         if (density_map2_properties.maxSubsampledArrayLayers < properties2.properties.limits.maxImageArrayLayers) {
             image_create_info.flags = VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT;
@@ -641,7 +641,7 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapEnabled) {
             ivci.flags = 0;
             ivci.subresourceRange.layerCount = density_map2_properties.maxSubsampledArrayLayers + 1;
             m_errorMonitor->SetUnexpectedError("VUID-VkImageViewCreateInfo-imageViewType-04973");
-            CreateImageViewTest(*this, &ivci, "VUID-VkImageViewCreateInfo-image-03569");
+            CreateImageViewTest(ivci, "VUID-VkImageViewCreateInfo-image-03569");
         }
     }
 }
@@ -679,7 +679,7 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapDisabled) {
 
     // Flags must not be set if the feature is not enabled
     ivci.flags = VK_IMAGE_VIEW_CREATE_FRAGMENT_DENSITY_MAP_DYNAMIC_BIT_EXT;
-    CreateImageViewTest(*this, &ivci, "VUID-VkImageViewCreateInfo-flags-02572");
+    CreateImageViewTest(ivci, "VUID-VkImageViewCreateInfo-flags-02572");
 }
 
 TEST_F(NegativeFragmentShadingRate, FragmentDensityMapReferenceAttachment) {
@@ -1208,7 +1208,7 @@ TEST_F(NegativeFragmentShadingRate, ShadingRateUsage) {
     }
 
     // Create a view with the fragment shading rate attachment usage, but that doesn't support it
-    CreateImageViewTest(*this, &createinfo, "VUID-VkImageViewCreateInfo-usage-04550");
+    CreateImageViewTest(createinfo, "VUID-VkImageViewCreateInfo-usage-04550");
 
     VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsrProperties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(fsrProperties);
@@ -1227,7 +1227,7 @@ TEST_F(NegativeFragmentShadingRate, ShadingRateUsage) {
             createinfo.format = VK_FORMAT_R8_UINT;
             createinfo.subresourceRange.layerCount = 2;
             createinfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-            CreateImageViewTest(*this, &createinfo, "VUID-VkImageViewCreateInfo-usage-04551");
+            CreateImageViewTest(createinfo, "VUID-VkImageViewCreateInfo-usage-04551");
         }
     }
 }
@@ -2424,20 +2424,20 @@ TEST_F(NegativeFragmentShadingRate, ShadingRateImageNV) {
 
     // image type must be 2D
     image_create_info.imageType = VK_IMAGE_TYPE_3D;
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-imageType-02082");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-imageType-02082");
 
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.arrayLayers = 6;
 
     // must be single sample
     image_create_info.samples = VK_SAMPLE_COUNT_2_BIT;
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-samples-02083");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-samples-02083");
 
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
 
     // tiling must be optimal
     image_create_info.tiling = VK_IMAGE_TILING_LINEAR;
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-shadingRateImage-07727");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-shadingRateImage-07727");
 
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     vkt::Image image(*m_device, image_create_info, vkt::set_layout);
@@ -2779,13 +2779,13 @@ TEST_F(NegativeFragmentShadingRate, ImageMaxLimitsQCOM) {
     if (dev_limits.maxFramebufferWidth + 1 > img_limits.maxExtent.width) {
         m_errorMonitor->SetDesiredError("VUID-VkImageCreateInfo-extent-02252");
     }
-    CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-fragmentDensityMapOffset-06514");
+    CreateImageTest(image_ci, "VUID-VkImageCreateInfo-fragmentDensityMapOffset-06514");
 
     image_ci.extent = {64, dev_limits.maxFramebufferHeight + 1, 1};
     if (dev_limits.maxFramebufferHeight + 1 > img_limits.maxExtent.height) {
         m_errorMonitor->SetDesiredError("VUID-VkImageCreateInfo-extent-02253");
     }
-    CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-fragmentDensityMapOffset-06515");
+    CreateImageTest(image_ci, "VUID-VkImageCreateInfo-fragmentDensityMapOffset-06515");
 }
 
 TEST_F(NegativeFragmentShadingRate, Framebuffer) {

--- a/tests/unit/image.cpp
+++ b/tests/unit/image.cpp
@@ -45,7 +45,7 @@ TEST_F(NegativeImage, UsageBits) {
     dsvci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
 
     // Create a view with depth / stencil aspect for image with different usage
-    CreateImageViewTest(*this, &dsvci, "VUID-VkImageViewCreateInfo-image-04441");
+    CreateImageViewTest(dsvci, "VUID-VkImageViewCreateInfo-image-04441");
 
     // Initialize buffer with TRANSFER_DST usage
     vkt::Buffer buffer(*m_device, 128 * 128, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
@@ -962,7 +962,7 @@ TEST_F(NegativeImage, Array2DImageType) {
     // Trigger check by setting imagecreateflags to 2d_array_compat and imageType to 2D
     auto image_ci = vkt::Image::ImageCreateInfo2D(32, 32, 1, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
     image_ci.flags = VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT;
-    CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-flags-00950");
+    CreateImageTest(image_ci, "VUID-VkImageCreateInfo-flags-00950");
 }
 
 TEST_F(NegativeImage, View2DImageType) {
@@ -974,7 +974,7 @@ TEST_F(NegativeImage, View2DImageType) {
     // Trigger check by setting imagecreateflags to 2d_array_compat and imageType to 2D
     auto image_ci = vkt::Image::ImageCreateInfo2D(32, 32, 1, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
     image_ci.flags = VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT;
-    CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-flags-07755");
+    CreateImageTest(image_ci, "VUID-VkImageCreateInfo-flags-07755");
 }
 
 TEST_F(NegativeImage, ImageViewBreaksParameterCompatibilityRequirements) {
@@ -1009,7 +1009,7 @@ TEST_F(NegativeImage, ImageViewBreaksParameterCompatibilityRequirements) {
     ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 
     // Test for error message
-    CreateImageViewTest(*this, &ivci, "VUID-VkImageViewCreateInfo-subResourceRange-01021");
+    CreateImageViewTest(ivci, "VUID-VkImageViewCreateInfo-subResourceRange-01021");
 
     // Test mismatch detection for image of type VK_IMAGE_TYPE_2D
     image_ci.imageType = VK_IMAGE_TYPE_2D;
@@ -1028,14 +1028,14 @@ TEST_F(NegativeImage, ImageViewBreaksParameterCompatibilityRequirements) {
     ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 
     // Test for error message
-    CreateImageViewTest(*this, &ivci, "VUID-VkImageViewCreateInfo-subResourceRange-01021");
+    CreateImageViewTest(ivci, "VUID-VkImageViewCreateInfo-subResourceRange-01021");
 
     // Change VkImageViewCreateInfo to different mismatched viewType
     ivci.viewType = VK_IMAGE_VIEW_TYPE_CUBE;
     ivci.subresourceRange.layerCount = 6;
 
     // Test for error message
-    CreateImageViewTest(*this, &ivci, "VUID-VkImageViewCreateInfo-image-01003");
+    CreateImageViewTest(ivci, "VUID-VkImageViewCreateInfo-image-01003");
 
     // Test mismatch detection for image of type VK_IMAGE_TYPE_3D
     image_ci.imageType = VK_IMAGE_TYPE_3D;
@@ -1054,16 +1054,16 @@ TEST_F(NegativeImage, ImageViewBreaksParameterCompatibilityRequirements) {
     ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 
     // Test for error message
-    CreateImageViewTest(*this, &ivci, "VUID-VkImageViewCreateInfo-subResourceRange-01021");
+    CreateImageViewTest(ivci, "VUID-VkImageViewCreateInfo-subResourceRange-01021");
 
     // Change VkImageViewCreateInfo to different mismatched viewType
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
 
     // Test for error message
     if (maintenance1_support) {
-        CreateImageViewTest(*this, &ivci, "VUID-VkImageViewCreateInfo-image-06728");
+        CreateImageViewTest(ivci, "VUID-VkImageViewCreateInfo-image-06728");
     } else {
-        CreateImageViewTest(*this, &ivci, "VUID-VkImageViewCreateInfo-subResourceRange-01021");
+        CreateImageViewTest(ivci, "VUID-VkImageViewCreateInfo-subResourceRange-01021");
     }
 
     // Check if the device can make the image required for this test case.
@@ -1162,7 +1162,7 @@ TEST_F(NegativeImage, ImageViewFormatFeatureMismatch) {
         ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 
         // Test for error message
-        CreateImageViewTest(*this, &ivci, optimal_error_codes[i]);
+        CreateImageViewTest(ivci, optimal_error_codes[i].c_str());
     }
 
     // Test for VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT.  Needs special formats
@@ -1205,7 +1205,7 @@ TEST_F(NegativeImage, ImageViewFormatFeatureMismatch) {
     // This extra VU checked is because depth formats are only compatible with themselves
     m_errorMonitor->SetDesiredError("VUID-VkImageViewCreateInfo-image-01761");
     // Test for error message
-    CreateImageViewTest(*this, &ivci, optimal_error_codes[i]);
+    CreateImageViewTest(ivci, optimal_error_codes[i].c_str());
 }
 
 TEST_F(NegativeImage, ImageViewUsageCreateInfo) {
@@ -1252,7 +1252,7 @@ TEST_F(NegativeImage, ImageViewUsageCreateInfo) {
     ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 
     // ImageView creation should fail because view format doesn't support all the underlying image's usages
-    CreateImageViewTest(*this, &ivci, "VUID-VkImageViewCreateInfo-usage-02275");
+    CreateImageViewTest(ivci, "VUID-VkImageViewCreateInfo-usage-02275");
 
     // Add a chained VkImageViewUsageCreateInfo to override original image usage bits, removing storage
     VkImageViewUsageCreateInfo usage_ci = vku::InitStructHelper();
@@ -1261,15 +1261,15 @@ TEST_F(NegativeImage, ImageViewUsageCreateInfo) {
     ivci.pNext = &usage_ci;
 
     // ImageView should now succeed without error
-    CreateImageViewTest(*this, &ivci);
+    vkt::ImageView image_view(*m_device, ivci);
 
     // Try a zero usage field
     usage_ci.usage = 0;
-    CreateImageViewTest(*this, &ivci, "VUID-VkImageViewUsageCreateInfo-usage-requiredbitmask");
+    CreateImageViewTest(ivci, "VUID-VkImageViewUsageCreateInfo-usage-requiredbitmask");
 
     // Try an illegal bit in usage field
     usage_ci.usage = 0x10000000 | VK_IMAGE_USAGE_SAMPLED_BIT;
-    CreateImageViewTest(*this, &ivci, "VUID-VkImageViewUsageCreateInfo-usage-parameter");
+    CreateImageViewTest(ivci, "VUID-VkImageViewUsageCreateInfo-usage-parameter");
 }
 
 TEST_F(NegativeImage, ImageViewNoSeparateStencilUsage) {
@@ -1313,7 +1313,7 @@ TEST_F(NegativeImage, ImageViewNoSeparateStencilUsage) {
     image_view_usage_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;  // Extra flag
 
     // VkImageViewUsageCreateInfo::usage must not include any bits that were not set in VkImageCreateInfo::usage
-    CreateImageViewTest(*this, &image_view_create_info, "VUID-VkImageViewCreateInfo-pNext-02662");
+    CreateImageViewTest(image_view_create_info, "VUID-VkImageViewCreateInfo-pNext-02662");
 }
 
 TEST_F(NegativeImage, ImageViewStencilUsageCreateInfo) {
@@ -1359,7 +1359,7 @@ TEST_F(NegativeImage, ImageViewStencilUsageCreateInfo) {
     image_view_usage_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;  // Extra flag
 
     // VkImageViewUsageCreateInfo::usage must not include any bits that were not set in VkImageCreateInfo::usage
-    CreateImageViewTest(*this, &image_view_create_info, "VUID-VkImageViewCreateInfo-pNext-02662");
+    CreateImageViewTest(image_view_create_info, "VUID-VkImageViewCreateInfo-pNext-02662");
 
     VkImageStencilUsageCreateInfo image_stencil_create_info = vku::InitStructHelper();
     image_stencil_create_info.stencilUsage = VK_IMAGE_USAGE_SAMPLED_BIT;
@@ -1419,7 +1419,7 @@ TEST_F(NegativeImage, ImageViewNoMemoryBoundToImage) {
     image_view_create_info.subresourceRange.levelCount = 1;
     image_view_create_info.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 
-    CreateImageViewTest(*this, &image_view_create_info,
+    CreateImageViewTest(image_view_create_info,
                         " used with no memory bound. Memory should be bound by calling vkBindImageMemory().");
     vk::DestroyImage(device(), image, NULL);
 }
@@ -1442,7 +1442,7 @@ TEST_F(NegativeImage, ImageViewAspect) {
     // Cause an error by setting an invalid image aspect
     image_view_create_info.subresourceRange.aspectMask = VK_IMAGE_ASPECT_METADATA_BIT;
 
-    CreateImageViewTest(*this, &image_view_create_info, "VUID-VkImageViewCreateInfo-subresourceRange-09594");
+    CreateImageViewTest(image_view_create_info, "VUID-VkImageViewCreateInfo-subresourceRange-09594");
 }
 
 TEST_F(NegativeImage, GetImageSubresourceLayout) {
@@ -1676,7 +1676,7 @@ TEST_F(NegativeImage, UndefinedFormat) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
 
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-pNext-01975");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-pNext-01975");
 }
 
 TEST_F(NegativeImage, ImageViewFormatMismatchUnrelated) {
@@ -1709,7 +1709,7 @@ TEST_F(NegativeImage, ImageViewFormatMismatchUnrelated) {
     imgViewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 
     // Can't use depth format for view into color image - Expect INVALID_FORMAT
-    CreateImageViewTest(*this, &imgViewInfo,
+    CreateImageViewTest(imgViewInfo,
                         "Formats MUST be IDENTICAL unless VK_IMAGE_CREATE_MUTABLE_FORMAT BIT was set on image creation.");
 }
 
@@ -1742,7 +1742,7 @@ TEST_F(NegativeImage, ImageViewNoMutableFormatBit) {
 
     // Same compatibility class but no MUTABLE_FORMAT bit - Expect
     // VIEW_CREATE_ERROR
-    CreateImageViewTest(*this, &imgViewInfo, "VUID-VkImageViewCreateInfo-image-01762");
+    CreateImageViewTest(imgViewInfo, "VUID-VkImageViewCreateInfo-image-01762");
 }
 
 TEST_F(NegativeImage, ImageViewDifferentClass) {
@@ -1766,7 +1766,7 @@ TEST_F(NegativeImage, ImageViewDifferentClass) {
     imgViewInfo.subresourceRange.levelCount = 1;
     imgViewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     imgViewInfo.image = mutImage.handle();
-    CreateImageViewTest(*this, &imgViewInfo, "VUID-VkImageViewCreateInfo-image-01761");
+    CreateImageViewTest(imgViewInfo, "VUID-VkImageViewCreateInfo-image-01761");
 
     // Use CUBE_ARRAY without feature enabled
     {
@@ -1778,7 +1778,7 @@ TEST_F(NegativeImage, ImageViewDifferentClass) {
         imgViewInfo.format = VK_FORMAT_R8_UINT;  // compatiable format
         imgViewInfo.image = cubeImage.handle();
         m_errorMonitor->SetDesiredError("VUID-VkImageViewCreateInfo-viewType-02961");
-        CreateImageViewTest(*this, &imgViewInfo, "VUID-VkImageViewCreateInfo-viewType-01004");
+        CreateImageViewTest(imgViewInfo, "VUID-VkImageViewCreateInfo-viewType-01004");
     }
 }
 
@@ -1804,7 +1804,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRange) {
         const VkImageSubresourceRange range = {VK_IMAGE_ASPECT_COLOR_BIT, 1, VK_REMAINING_MIP_LEVELS, 0, 1};
         VkImageViewCreateInfo img_view_info = img_view_info_template;
         img_view_info.subresourceRange = range;
-        CreateImageViewTest(*this, &img_view_info, "VUID-VkImageViewCreateInfo-subresourceRange-01478");
+        CreateImageViewTest(img_view_info, "VUID-VkImageViewCreateInfo-subresourceRange-01478");
     }
 
     // Try baseMipLevel >= image.mipLevels without VK_REMAINING_MIP_LEVELS
@@ -1813,7 +1813,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRange) {
         VkImageViewCreateInfo img_view_info = img_view_info_template;
         img_view_info.subresourceRange = range;
         m_errorMonitor->SetDesiredError("VUID-VkImageViewCreateInfo-subresourceRange-01718");
-        CreateImageViewTest(*this, &img_view_info, "VUID-VkImageViewCreateInfo-subresourceRange-01478");
+        CreateImageViewTest(img_view_info, "VUID-VkImageViewCreateInfo-subresourceRange-01478");
     }
 
     // Try levelCount = 0
@@ -1821,7 +1821,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRange) {
         const VkImageSubresourceRange range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 0, 1};
         VkImageViewCreateInfo img_view_info = img_view_info_template;
         img_view_info.subresourceRange = range;
-        CreateImageViewTest(*this, &img_view_info, "VUID-VkImageSubresourceRange-levelCount-01720");
+        CreateImageViewTest(img_view_info, "VUID-VkImageSubresourceRange-levelCount-01720");
     }
 
     // Try baseMipLevel + levelCount > image.mipLevels
@@ -1829,7 +1829,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRange) {
         const VkImageSubresourceRange range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 2, 0, 1};
         VkImageViewCreateInfo img_view_info = img_view_info_template;
         img_view_info.subresourceRange = range;
-        CreateImageViewTest(*this, &img_view_info, "VUID-VkImageViewCreateInfo-subresourceRange-01718");
+        CreateImageViewTest(img_view_info, "VUID-VkImageViewCreateInfo-subresourceRange-01718");
     }
 
     // Try baseArrayLayer >= image.arrayLayers with VK_REMAINING_ARRAY_LAYERS
@@ -1837,7 +1837,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRange) {
         const VkImageSubresourceRange range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 1, VK_REMAINING_ARRAY_LAYERS};
         VkImageViewCreateInfo img_view_info = img_view_info_template;
         img_view_info.subresourceRange = range;
-        CreateImageViewTest(*this, &img_view_info, "VUID-VkImageViewCreateInfo-image-06724");
+        CreateImageViewTest(img_view_info, "VUID-VkImageViewCreateInfo-image-06724");
     }
 
     // Try baseArrayLayer >= image.arrayLayers without VK_REMAINING_ARRAY_LAYERS
@@ -1846,7 +1846,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRange) {
         VkImageViewCreateInfo img_view_info = img_view_info_template;
         img_view_info.subresourceRange = range;
         m_errorMonitor->SetDesiredError("VUID-VkImageViewCreateInfo-subresourceRange-06725");
-        CreateImageViewTest(*this, &img_view_info, "VUID-VkImageViewCreateInfo-image-06724");
+        CreateImageViewTest(img_view_info, "VUID-VkImageViewCreateInfo-image-06724");
     }
 
     // Try layerCount = 0
@@ -1854,7 +1854,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRange) {
         const VkImageSubresourceRange range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 0};
         VkImageViewCreateInfo img_view_info = img_view_info_template;
         img_view_info.subresourceRange = range;
-        CreateImageViewTest(*this, &img_view_info, "VUID-VkImageSubresourceRange-layerCount-01721");
+        CreateImageViewTest(img_view_info, "VUID-VkImageSubresourceRange-layerCount-01721");
     }
 
     // Try baseArrayLayer + layerCount > image.arrayLayers
@@ -1862,7 +1862,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRange) {
         const VkImageSubresourceRange range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 2};
         VkImageViewCreateInfo img_view_info = img_view_info_template;
         img_view_info.subresourceRange = range;
-        CreateImageViewTest(*this, &img_view_info, "VUID-VkImageViewCreateInfo-subresourceRange-06725");
+        CreateImageViewTest(img_view_info, "VUID-VkImageViewCreateInfo-subresourceRange-06725");
     }
 }
 
@@ -1898,25 +1898,25 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRangeCubeArray) {
         const VkImageSubresourceRange range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 6};
         VkImageViewCreateInfo img_view_info = cube_img_view_info_template;
         img_view_info.subresourceRange = range;
-        CreateImageViewTest(*this, &img_view_info);
+        vkt::ImageView view(*m_device, img_view_info);
     }
     {
         const VkImageSubresourceRange range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 5};
         VkImageViewCreateInfo img_view_info = cube_img_view_info_template;
         img_view_info.subresourceRange = range;
-        CreateImageViewTest(*this, &img_view_info, "VUID-VkImageViewCreateInfo-viewType-02960");
+        CreateImageViewTest(img_view_info, "VUID-VkImageViewCreateInfo-viewType-02960");
     }
     {
         const VkImageSubresourceRange range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 12, VK_REMAINING_ARRAY_LAYERS};
         VkImageViewCreateInfo img_view_info = cube_img_view_info_template;
         img_view_info.subresourceRange = range;
-        CreateImageViewTest(*this, &img_view_info);
+        vkt::ImageView view(*m_device, img_view_info);
     }
     {
         const VkImageSubresourceRange range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 6, VK_REMAINING_ARRAY_LAYERS};
         VkImageViewCreateInfo img_view_info = cube_img_view_info_template;
         img_view_info.subresourceRange = range;
-        CreateImageViewTest(*this, &img_view_info, "VUID-VkImageViewCreateInfo-viewType-02962");
+        CreateImageViewTest(img_view_info, "VUID-VkImageViewCreateInfo-viewType-02962");
     }
 
     {
@@ -1924,28 +1924,28 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRangeCubeArray) {
         VkImageViewCreateInfo img_view_info = cube_img_view_info_template;
         img_view_info.viewType = VK_IMAGE_VIEW_TYPE_CUBE_ARRAY;
         img_view_info.subresourceRange = range;
-        CreateImageViewTest(*this, &img_view_info);
+        vkt::ImageView view(*m_device, img_view_info);
     }
     {
         const VkImageSubresourceRange range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 13};
         VkImageViewCreateInfo img_view_info = cube_img_view_info_template;
         img_view_info.viewType = VK_IMAGE_VIEW_TYPE_CUBE_ARRAY;
         img_view_info.subresourceRange = range;
-        CreateImageViewTest(*this, &img_view_info, "VUID-VkImageViewCreateInfo-viewType-02961");
+        CreateImageViewTest(img_view_info, "VUID-VkImageViewCreateInfo-viewType-02961");
     }
     {
         const VkImageSubresourceRange range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 6, VK_REMAINING_ARRAY_LAYERS};
         VkImageViewCreateInfo img_view_info = cube_img_view_info_template;
         img_view_info.viewType = VK_IMAGE_VIEW_TYPE_CUBE_ARRAY;
         img_view_info.subresourceRange = range;
-        CreateImageViewTest(*this, &img_view_info);
+        vkt::ImageView view(*m_device, img_view_info);
     }
     {
         const VkImageSubresourceRange range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 11, VK_REMAINING_ARRAY_LAYERS};
         VkImageViewCreateInfo img_view_info = cube_img_view_info_template;
         img_view_info.viewType = VK_IMAGE_VIEW_TYPE_CUBE_ARRAY;
         img_view_info.subresourceRange = range;
-        CreateImageViewTest(*this, &img_view_info, "VUID-VkImageViewCreateInfo-viewType-02963");
+        CreateImageViewTest(img_view_info, "VUID-VkImageViewCreateInfo-viewType-02963");
     }
 }
 
@@ -1978,7 +1978,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRangeMaintenance1) {
         VkImageViewCreateInfo img_view_info = volume_img_view_info_template;
         img_view_info.viewType = VK_IMAGE_VIEW_TYPE_3D;
         img_view_info.subresourceRange = range;
-        CreateImageViewTest(*this, &img_view_info);
+        vkt::ImageView view(*m_device, img_view_info);
     }
     // all mips
     {
@@ -1986,7 +1986,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRangeMaintenance1) {
         VkImageViewCreateInfo img_view_info = volume_img_view_info_template;
         img_view_info.viewType = VK_IMAGE_VIEW_TYPE_3D;
         img_view_info.subresourceRange = range;
-        CreateImageViewTest(*this, &img_view_info);
+        vkt::ImageView view(*m_device, img_view_info);
     }
     // too many mips
     {
@@ -1994,7 +1994,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRangeMaintenance1) {
         VkImageViewCreateInfo img_view_info = volume_img_view_info_template;
         img_view_info.viewType = VK_IMAGE_VIEW_TYPE_3D;
         img_view_info.subresourceRange = range;
-        CreateImageViewTest(*this, &img_view_info, "VUID-VkImageViewCreateInfo-subresourceRange-01718");
+        CreateImageViewTest(img_view_info, "VUID-VkImageViewCreateInfo-subresourceRange-01718");
     }
     // invalid base mip
     {
@@ -2003,7 +2003,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRangeMaintenance1) {
         img_view_info.viewType = VK_IMAGE_VIEW_TYPE_3D;
         img_view_info.subresourceRange = range;
         m_errorMonitor->SetDesiredError("VUID-VkImageViewCreateInfo-subresourceRange-01718");
-        CreateImageViewTest(*this, &img_view_info, "VUID-VkImageViewCreateInfo-subresourceRange-01478");
+        CreateImageViewTest(img_view_info, "VUID-VkImageViewCreateInfo-subresourceRange-01478");
     }
     // too many layers
     {
@@ -2012,7 +2012,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRangeMaintenance1) {
         img_view_info.viewType = VK_IMAGE_VIEW_TYPE_3D;
         img_view_info.subresourceRange = range;
         m_errorMonitor->SetDesiredError("VUID-VkImageViewCreateInfo-imageViewType-04973");
-        CreateImageViewTest(*this, &img_view_info, "VUID-VkImageViewCreateInfo-subresourceRange-06725");
+        CreateImageViewTest(img_view_info, "VUID-VkImageViewCreateInfo-subresourceRange-06725");
     }
     // invalid base layer
     {
@@ -2021,7 +2021,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRangeMaintenance1) {
         img_view_info.viewType = VK_IMAGE_VIEW_TYPE_3D;
         img_view_info.subresourceRange = range;
         m_errorMonitor->SetDesiredError("VUID-VkImageViewCreateInfo-subresourceRange-06725");
-        CreateImageViewTest(*this, &img_view_info, "VUID-VkImageViewCreateInfo-image-06724");
+        CreateImageViewTest(img_view_info, "VUID-VkImageViewCreateInfo-image-06724");
     }
     // 2D views
     // first mip, first layer
@@ -2030,7 +2030,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRangeMaintenance1) {
         VkImageViewCreateInfo img_view_info = volume_img_view_info_template;
         img_view_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
         img_view_info.subresourceRange = range;
-        CreateImageViewTest(*this, &img_view_info);
+        vkt::ImageView view(*m_device, img_view_info);
     }
     // all mips, first layer (invalid)
     {
@@ -2038,7 +2038,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRangeMaintenance1) {
         VkImageViewCreateInfo img_view_info = volume_img_view_info_template;
         img_view_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
         img_view_info.subresourceRange = range;
-        CreateImageViewTest(*this, &img_view_info, "VUID-VkImageViewCreateInfo-image-04970");
+        CreateImageViewTest(img_view_info, "VUID-VkImageViewCreateInfo-image-04970");
     }
     // first mip, all layers (invalid)
     {
@@ -2046,7 +2046,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRangeMaintenance1) {
         VkImageViewCreateInfo img_view_info = volume_img_view_info_template;
         img_view_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
         img_view_info.subresourceRange = range;
-        CreateImageViewTest(*this, &img_view_info, "VUID-VkImageViewCreateInfo-imageViewType-04973");
+        CreateImageViewTest(img_view_info, "VUID-VkImageViewCreateInfo-imageViewType-04973");
     }
     // mip 3, 8 layers (invalid)
     {
@@ -2055,7 +2055,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRangeMaintenance1) {
         img_view_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
         img_view_info.subresourceRange = range;
         m_errorMonitor->SetDesiredError("VUID-VkImageViewCreateInfo-imageViewType-04973");
-        CreateImageViewTest(*this, &img_view_info, "VUID-VkImageViewCreateInfo-subresourceRange-02725");
+        CreateImageViewTest(img_view_info, "VUID-VkImageViewCreateInfo-subresourceRange-02725");
     }
     // mip 3, layer 7 (invalid)
     {
@@ -2064,7 +2064,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRangeMaintenance1) {
         img_view_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
         img_view_info.subresourceRange = range;
         m_errorMonitor->SetDesiredError("VUID-VkImageViewCreateInfo-image-02724");
-        CreateImageViewTest(*this, &img_view_info, "VUID-VkImageViewCreateInfo-subresourceRange-02725");
+        CreateImageViewTest(img_view_info, "VUID-VkImageViewCreateInfo-subresourceRange-02725");
     }
     // 2D array views
     // first mip, first layer
@@ -2073,7 +2073,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRangeMaintenance1) {
         VkImageViewCreateInfo img_view_info = volume_img_view_info_template;
         img_view_info.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
         img_view_info.subresourceRange = range;
-        CreateImageViewTest(*this, &img_view_info);
+        vkt::ImageView view(*m_device, img_view_info);
     }
     // all mips, first layer (invalid)
     {
@@ -2081,7 +2081,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRangeMaintenance1) {
         VkImageViewCreateInfo img_view_info = volume_img_view_info_template;
         img_view_info.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
         img_view_info.subresourceRange = range;
-        CreateImageViewTest(*this, &img_view_info, "VUID-VkImageViewCreateInfo-image-04970");
+        CreateImageViewTest(img_view_info, "VUID-VkImageViewCreateInfo-image-04970");
     }
     // first mip, all layers
     {
@@ -2089,7 +2089,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRangeMaintenance1) {
         VkImageViewCreateInfo img_view_info = volume_img_view_info_template;
         img_view_info.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
         img_view_info.subresourceRange = range;
-        CreateImageViewTest(*this, &img_view_info);
+        vkt::ImageView view(*m_device, img_view_info);
     }
     // mip 3, layer 0
     {
@@ -2097,7 +2097,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRangeMaintenance1) {
         VkImageViewCreateInfo img_view_info = volume_img_view_info_template;
         img_view_info.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
         img_view_info.subresourceRange = range;
-        CreateImageViewTest(*this, &img_view_info);
+        vkt::ImageView view(*m_device, img_view_info);
     }
     // mip 3, 8 layers (invalid)
     {
@@ -2105,7 +2105,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRangeMaintenance1) {
         VkImageViewCreateInfo img_view_info = volume_img_view_info_template;
         img_view_info.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
         img_view_info.subresourceRange = range;
-        CreateImageViewTest(*this, &img_view_info, "VUID-VkImageViewCreateInfo-subresourceRange-02725");
+        CreateImageViewTest(img_view_info, "VUID-VkImageViewCreateInfo-subresourceRange-02725");
     }
     // mip 3, layer 7 (invalid)
     {
@@ -2114,7 +2114,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRangeMaintenance1) {
         img_view_info.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
         img_view_info.subresourceRange = range;
         m_errorMonitor->SetDesiredError("VUID-VkImageViewCreateInfo-image-02724");
-        CreateImageViewTest(*this, &img_view_info, "VUID-VkImageViewCreateInfo-subresourceRange-02725");
+        CreateImageViewTest(img_view_info, "VUID-VkImageViewCreateInfo-subresourceRange-02725");
     }
 
     // Checking sparse flags are not set
@@ -2171,53 +2171,6 @@ TEST_F(NegativeImage, ImageViewLayerCount) {
     image_view_ci.subresourceRange.levelCount = 1;
     image_view_ci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 
-    // Sanity checks
-    {
-        image_view_ci.subresourceRange.baseArrayLayer = 0;
-        image_view_ci.subresourceRange.layerCount = 1;
-
-        image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_1D;
-        image_view_ci.image = image_1d_array.handle();
-        CreateImageViewTest(*this, &image_view_ci);
-        image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D;
-        image_view_ci.image = image_2d_array.handle();
-        CreateImageViewTest(*this, &image_view_ci);
-        if (image_3d_array.handle() != VK_NULL_HANDLE) {
-            image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_3D;
-            image_view_ci.image = image_3d_array.handle();
-            CreateImageViewTest(*this, &image_view_ci);
-        }
-
-        image_view_ci.subresourceRange.baseArrayLayer = 1;
-        image_view_ci.subresourceRange.layerCount = VK_REMAINING_ARRAY_LAYERS;
-
-        image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_1D;
-        image_view_ci.image = image_1d_array.handle();
-        CreateImageViewTest(*this, &image_view_ci);
-        image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D;
-        image_view_ci.image = image_2d_array.handle();
-        CreateImageViewTest(*this, &image_view_ci);
-        if (image_3d_array.handle() != VK_NULL_HANDLE) {
-            image_view_ci.subresourceRange.baseArrayLayer = 0;
-            image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_3D;
-            image_view_ci.image = image_3d_array.handle();
-            CreateImageViewTest(*this, &image_view_ci);
-        }
-
-        image_view_ci.subresourceRange.baseArrayLayer = 0;
-        image_view_ci.subresourceRange.layerCount = VK_REMAINING_ARRAY_LAYERS;
-
-        image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_1D;
-        image_view_ci.image = image_1d.handle();
-        CreateImageViewTest(*this, &image_view_ci);
-        image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D;
-        image_view_ci.image = image_2d.handle();
-        CreateImageViewTest(*this, &image_view_ci);
-        image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_3D;
-        image_view_ci.image = image_3d.handle();
-        CreateImageViewTest(*this, &image_view_ci);
-    }
-
     // layerCount is not 1 as imageView is not an array type
     {
         image_view_ci.subresourceRange.baseArrayLayer = 0;
@@ -2225,17 +2178,17 @@ TEST_F(NegativeImage, ImageViewLayerCount) {
 
         image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_1D;
         image_view_ci.image = image_1d_array.handle();
-        CreateImageViewTest(*this, &image_view_ci, "VUID-VkImageViewCreateInfo-imageViewType-04973");
+        CreateImageViewTest(image_view_ci, "VUID-VkImageViewCreateInfo-imageViewType-04973");
 
         image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D;
         image_view_ci.image = image_2d_array.handle();
-        CreateImageViewTest(*this, &image_view_ci, "VUID-VkImageViewCreateInfo-imageViewType-04973");
+        CreateImageViewTest(image_view_ci, "VUID-VkImageViewCreateInfo-imageViewType-04973");
 
         if (image_3d_array.handle() != VK_NULL_HANDLE) {
             image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_3D;
             image_view_ci.image = image_3d_array.handle();
             m_errorMonitor->SetDesiredError("VUID-VkImageViewCreateInfo-subresourceRange-06725");
-            CreateImageViewTest(*this, &image_view_ci, "VUID-VkImageViewCreateInfo-imageViewType-04973");
+            CreateImageViewTest(image_view_ci, "VUID-VkImageViewCreateInfo-imageViewType-04973");
         }
     }
 
@@ -2246,11 +2199,11 @@ TEST_F(NegativeImage, ImageViewLayerCount) {
 
         image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_1D;
         image_view_ci.image = image_1d_array.handle();
-        CreateImageViewTest(*this, &image_view_ci, "VUID-VkImageViewCreateInfo-imageViewType-04974");
+        CreateImageViewTest(image_view_ci, "VUID-VkImageViewCreateInfo-imageViewType-04974");
 
         image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D;
         image_view_ci.image = image_2d_array.handle();
-        CreateImageViewTest(*this, &image_view_ci, "VUID-VkImageViewCreateInfo-imageViewType-04974");
+        CreateImageViewTest(image_view_ci, "VUID-VkImageViewCreateInfo-imageViewType-04974");
     }
 }
 
@@ -2270,33 +2223,33 @@ TEST_F(NegativeImage, ImageMisc) {
         image_ci.samples = VK_SAMPLE_COUNT_4_BIT;
         image_ci.imageType = VK_IMAGE_TYPE_3D;
         image_ci.extent = {4, 4, 4};
-        CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-samples-02257");
+        CreateImageTest(image_ci, "VUID-VkImageCreateInfo-samples-02257");
 
         image_ci = safe_image_ci;
         image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;  // always has 4 samples support
         image_ci.samples = VK_SAMPLE_COUNT_4_BIT;
         image_ci.flags = VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT;
         image_ci.arrayLayers = 6;
-        CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-samples-02257");
+        CreateImageTest(image_ci, "VUID-VkImageCreateInfo-samples-02257");
 
         image_ci = safe_image_ci;
         image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;  // always has 4 samples support
         image_ci.samples = VK_SAMPLE_COUNT_4_BIT;
         image_ci.tiling = VK_IMAGE_TILING_LINEAR;
-        CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-samples-02257");
+        CreateImageTest(image_ci, "VUID-VkImageCreateInfo-samples-02257");
 
         image_ci = safe_image_ci;
         image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;  // always has 4 samples support
         image_ci.samples = VK_SAMPLE_COUNT_4_BIT;
         image_ci.mipLevels = 2;
-        CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-samples-02257");
+        CreateImageTest(image_ci, "VUID-VkImageCreateInfo-samples-02257");
 
         image_ci = safe_image_ci;
         image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
         image_ci.samples = VK_SAMPLE_COUNT_4_BIT;
         image_ci.mipLevels = 1;
         image_ci.tiling = VK_IMAGE_TILING_LINEAR;
-        CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-samples-02257");
+        CreateImageTest(image_ci, "VUID-VkImageCreateInfo-samples-02257");
 
         image_ci = safe_image_ci;
         image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
@@ -2304,7 +2257,7 @@ TEST_F(NegativeImage, ImageMisc) {
         image_ci.mipLevels = 2;
         image_ci.flags = VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT;
         m_errorMonitor->SetAllowedFailureMsg("VUID-VkImageCreateInfo-flags-parameter");
-        CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-flags-02259");
+        CreateImageTest(image_ci, "VUID-VkImageCreateInfo-flags-02259");
 
         image_ci = safe_image_ci;
         image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
@@ -2313,35 +2266,35 @@ TEST_F(NegativeImage, ImageMisc) {
         image_ci.flags = VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT;
         image_ci.tiling = VK_IMAGE_TILING_LINEAR;
         m_errorMonitor->SetAllowedFailureMsg("VUID-VkImageCreateInfo-flags-parameter");
-        CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-flags-02259");
+        CreateImageTest(image_ci, "VUID-VkImageCreateInfo-flags-02259");
     }
 
     {
         VkImageCreateInfo image_ci = safe_image_ci;
         image_ci.usage = VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
         image_ci.usage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-        CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-usage-00963");
+        CreateImageTest(image_ci, "VUID-VkImageCreateInfo-usage-00963");
 
         image_ci.usage = VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT;
-        CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-usage-00966");
+        CreateImageTest(image_ci, "VUID-VkImageCreateInfo-usage-00966");
 
         image_ci.usage = VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT;
         image_ci.usage |= VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
         m_errorMonitor->SetDesiredError("VUID-VkImageCreateInfo-usage-00963");
-        CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-usage-00966");
+        CreateImageTest(image_ci, "VUID-VkImageCreateInfo-usage-00966");
     }
 
     {
         VkImageCreateInfo image_ci = safe_image_ci;
         image_ci.flags = VK_IMAGE_CREATE_SPARSE_BINDING_BIT;
-        CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-flags-00969");
+        CreateImageTest(image_ci, "VUID-VkImageCreateInfo-flags-00969");
     }
 
     // InitialLayout not VK_IMAGE_LAYOUT_UNDEFINED or VK_IMAGE_LAYOUT_PREDEFINED
     {
         VkImageCreateInfo image_ci = safe_image_ci;
         image_ci.initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-        CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-initialLayout-00993");
+        CreateImageTest(image_ci, "VUID-VkImageCreateInfo-initialLayout-00993");
     }
 
     // Storage usage can't be multisample if feature not set
@@ -2351,7 +2304,7 @@ TEST_F(NegativeImage, ImageMisc) {
         VkImageCreateInfo image_ci = safe_image_ci;
         image_ci.usage = VK_IMAGE_USAGE_STORAGE_BIT;
         image_ci.samples = VK_SAMPLE_COUNT_2_BIT;
-        CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-usage-00968");
+        CreateImageTest(image_ci, "VUID-VkImageCreateInfo-usage-00968");
     }
 }
 
@@ -2400,52 +2353,52 @@ TEST_F(NegativeImage, ImageMinLimits) {
     {
         VkImageCreateInfo bad_image_ci = safe_image_ci;
         bad_image_ci.mipLevels = 0;
-        CreateImageTest(*this, &bad_image_ci, "VUID-VkImageCreateInfo-mipLevels-00947");
+        CreateImageTest(bad_image_ci, "VUID-VkImageCreateInfo-mipLevels-00947");
     }
 
     {
         VkImageCreateInfo bad_image_ci = safe_image_ci;
         bad_image_ci.arrayLayers = 0;
-        CreateImageTest(*this, &bad_image_ci, "VUID-VkImageCreateInfo-arrayLayers-00948");
+        CreateImageTest(bad_image_ci, "VUID-VkImageCreateInfo-arrayLayers-00948");
     }
 
     {
         VkImageCreateInfo bad_image_ci = safe_image_ci;
         bad_image_ci.flags = VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT;
         bad_image_ci.arrayLayers = 5;  // arrayLayers must be greater than or equal to 6
-        CreateImageTest(*this, &bad_image_ci, "VUID-VkImageCreateInfo-flags-08866");
+        CreateImageTest(bad_image_ci, "VUID-VkImageCreateInfo-flags-08866");
 
         bad_image_ci.arrayLayers = 6;
         bad_image_ci.extent = {64, 63, 1};  // extent.width and extent.height must be equal
-        CreateImageTest(*this, &bad_image_ci, "VUID-VkImageCreateInfo-flags-08865");
+        CreateImageTest(bad_image_ci, "VUID-VkImageCreateInfo-flags-08865");
     }
 
     {
         VkImageCreateInfo bad_image_ci = safe_image_ci;
         bad_image_ci.imageType = VK_IMAGE_TYPE_1D;
         bad_image_ci.extent = {64, 2, 1};
-        CreateImageTest(*this, &bad_image_ci, "VUID-VkImageCreateInfo-imageType-00956");
+        CreateImageTest(bad_image_ci, "VUID-VkImageCreateInfo-imageType-00956");
 
         bad_image_ci.imageType = VK_IMAGE_TYPE_1D;
         bad_image_ci.extent = {64, 1, 2};
-        CreateImageTest(*this, &bad_image_ci, "VUID-VkImageCreateInfo-imageType-00956");
+        CreateImageTest(bad_image_ci, "VUID-VkImageCreateInfo-imageType-00956");
 
         bad_image_ci.imageType = VK_IMAGE_TYPE_2D;
         bad_image_ci.extent = {64, 64, 2};
-        CreateImageTest(*this, &bad_image_ci, "VUID-VkImageCreateInfo-imageType-00957");
+        CreateImageTest(bad_image_ci, "VUID-VkImageCreateInfo-imageType-00957");
 
         bad_image_ci.imageType = VK_IMAGE_TYPE_2D;
         bad_image_ci.flags = VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT;
         bad_image_ci.arrayLayers = 6;
         bad_image_ci.extent = {64, 64, 2};
-        CreateImageTest(*this, &bad_image_ci, "VUID-VkImageCreateInfo-imageType-00957");
+        CreateImageTest(bad_image_ci, "VUID-VkImageCreateInfo-imageType-00957");
     }
 
     {
         VkImageCreateInfo bad_image_ci = safe_image_ci;
         bad_image_ci.imageType = VK_IMAGE_TYPE_3D;
         bad_image_ci.arrayLayers = 2;
-        CreateImageTest(*this, &bad_image_ci, "VUID-VkImageCreateInfo-imageType-00961");
+        CreateImageTest(bad_image_ci, "VUID-VkImageCreateInfo-imageType-00961");
     }
 }
 
@@ -2455,11 +2408,11 @@ TEST_F(NegativeImage, MaxLimitsMipLevelsAndExtent) {
     VkImageCreateInfo image_ci = DefaultImageInfo();
     image_ci.extent = {8, 8, 1};
     image_ci.mipLevels = 4 + 1;  // 4 = log2(8) + 1
-    CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-mipLevels-00958");
+    CreateImageTest(image_ci, "VUID-VkImageCreateInfo-mipLevels-00958");
 
     image_ci.extent = {8, 15, 1};
     image_ci.mipLevels = 4 + 1;  // 4 = floor(log2(15)) + 1
-    CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-mipLevels-00958");
+    CreateImageTest(image_ci, "VUID-VkImageCreateInfo-mipLevels-00958");
 }
 
 TEST_F(NegativeImage, MaxLimitsMipLevels) {
@@ -2478,7 +2431,7 @@ TEST_F(NegativeImage, MaxLimitsMipLevels) {
 
         VkImageFormatProperties img_limits;
         if (VK_SUCCESS == GPDIFPHelper(Gpu(), &image_ci, &img_limits) && img_limits.maxMipLevels == 1) {
-            CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-mipLevels-02255");
+            CreateImageTest(image_ci, "VUID-VkImageCreateInfo-mipLevels-02255");
             return;  // end test
         }
     }
@@ -2498,7 +2451,7 @@ TEST_F(NegativeImage, MaxLimitsArrayLayers) {
         GTEST_SKIP() << "VkImageFormatProperties::maxArrayLayers is already UINT32_MAX; skipping part of test";
     }
     image_ci.arrayLayers = img_limits.maxArrayLayers + 1;
-    CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-arrayLayers-02256");
+    CreateImageTest(image_ci, "VUID-VkImageCreateInfo-arrayLayers-02256");
 }
 
 TEST_F(NegativeImage, MaxLimitsSamples) {
@@ -2515,7 +2468,7 @@ TEST_F(NegativeImage, MaxLimitsSamples) {
             image_ci.samples = samples;
             VkImageFormatProperties img_limits;
             if (VK_SUCCESS == GPDIFPHelper(Gpu(), &image_ci, &img_limits) && !(img_limits.sampleCounts & samples)) {
-                CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-samples-02258");
+                CreateImageTest(image_ci, "VUID-VkImageCreateInfo-samples-02258");
                 return;  // end test
             }
         }
@@ -2534,13 +2487,13 @@ TEST_F(NegativeImage, MaxLimitsExtent) {
     ASSERT_EQ(VK_SUCCESS, GPDIFPHelper(Gpu(), &image_ci, &img_limits));
 
     image_ci.extent = {img_limits.maxExtent.width + 1, 1, 1};
-    CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-extent-02252");
+    CreateImageTest(image_ci, "VUID-VkImageCreateInfo-extent-02252");
 
     image_ci.extent = {1, img_limits.maxExtent.height + 1, 1};
-    CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-extent-02253");
+    CreateImageTest(image_ci, "VUID-VkImageCreateInfo-extent-02253");
 
     image_ci.extent = {1, 1, img_limits.maxExtent.depth + 1};
-    CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-extent-02254");
+    CreateImageTest(image_ci, "VUID-VkImageCreateInfo-extent-02254");
 }
 
 TEST_F(NegativeImage, MaxLimitsFramebufferWidth) {
@@ -2561,7 +2514,7 @@ TEST_F(NegativeImage, MaxLimitsFramebufferWidth) {
     if (dev_limits.maxFramebufferWidth + 1 > img_limits.maxExtent.width) {
         m_errorMonitor->SetDesiredError("VUID-VkImageCreateInfo-extent-02252");
     }
-    CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-usage-00964");
+    CreateImageTest(image_ci, "VUID-VkImageCreateInfo-usage-00964");
 }
 
 TEST_F(NegativeImage, MaxLimitsFramebufferHeight) {
@@ -2583,7 +2536,7 @@ TEST_F(NegativeImage, MaxLimitsFramebufferHeight) {
     if (dev_limits.maxFramebufferHeight + 1 > img_limits.maxExtent.height) {
         m_errorMonitor->SetDesiredError("VUID-VkImageCreateInfo-extent-02253");
     }
-    CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-usage-00965");
+    CreateImageTest(image_ci, "VUID-VkImageCreateInfo-usage-00965");
 }
 
 TEST_F(NegativeImage, DepthStencilImageViewWithColorAspectBit) {
@@ -2629,7 +2582,7 @@ TEST_F(NegativeImage, DepthStencilImageViewWithColorAspectBit) {
     image_view_create_info.subresourceRange.layerCount = 1;
     image_view_create_info.subresourceRange.levelCount = 1;
     image_view_create_info.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT | VK_IMAGE_ASPECT_DEPTH_BIT;
-    CreateImageViewTest(*this, &image_view_create_info, "VUID-VkImageViewCreateInfo-subresourceRange-09594");
+    CreateImageViewTest(image_view_create_info, "VUID-VkImageViewCreateInfo-subresourceRange-09594");
 }
 
 TEST_F(NegativeImage, CornerSampledImageNV) {
@@ -2652,45 +2605,31 @@ TEST_F(NegativeImage, CornerSampledImageNV) {
     image_create_info.flags = VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV;
 
     // image type must be 2D or 3D
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-flags-02050");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-flags-02050");
 
     // cube/depth not supported
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.extent.height = 2;
     image_create_info.format = VK_FORMAT_D24_UNORM_S8_UINT;
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-flags-02051");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-flags-02051");
 
     image_create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
 
     // 2D width/height must be > 1
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.extent.height = 1;
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-flags-02052");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-flags-02052");
 
     // 3D width/height/depth must be > 1
     image_create_info.imageType = VK_IMAGE_TYPE_3D;
     image_create_info.extent.height = 2;
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-flags-02053");
-
-    image_create_info.imageType = VK_IMAGE_TYPE_2D;
-
-    // Valid # of mip levels
-    image_create_info.extent = {7, 7, 1};
-    image_create_info.mipLevels = 3;  // 3 = ceil(log2(7))
-    CreateImageTest(*this, &image_create_info);
-
-    image_create_info.extent = {8, 8, 1};
-    image_create_info.mipLevels = 3;  // 3 = ceil(log2(8))
-    CreateImageTest(*this, &image_create_info);
-
-    image_create_info.extent = {9, 9, 1};
-    image_create_info.mipLevels = 3;  // 4 = ceil(log2(9))
-    CreateImageTest(*this, &image_create_info);
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-flags-02053");
 
     // Invalid # of mip levels
+    image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.extent = {8, 8, 1};
     image_create_info.mipLevels = 4;  // 3 = ceil(log2(8))
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-mipLevels-00958");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-mipLevels-00958");
 }
 
 TEST_F(NegativeImage, Stencil) {
@@ -2733,7 +2672,7 @@ TEST_F(NegativeImage, Stencil) {
     vk::GetPhysicalDeviceImageFormatProperties2KHR(m_device->Physical().handle(), &image_format_info2, &image_format_properties2);
     m_errorMonitor->VerifyFound();
     // test vkCreateImage as well for this case
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageStencilUsageCreateInfo-stencilUsage-02539");
+    CreateImageTest(image_create_info, "VUID-VkImageStencilUsageCreateInfo-stencilUsage-02539");
 
     // depth-stencil format image with VkImageStencilUsageCreateInfo with
     // VK_IMAGE_USAGE_STORAGE_BIT and the multisampled storage images feature
@@ -2742,7 +2681,7 @@ TEST_F(NegativeImage, Stencil) {
     image_create_info.extent = {64, 64, 1};
     image_create_info.samples = VK_SAMPLE_COUNT_2_BIT;
     image_stencil_create_info.stencilUsage = VK_IMAGE_USAGE_STORAGE_BIT;
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-format-02538");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-format-02538");
 
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
 
@@ -2750,28 +2689,28 @@ TEST_F(NegativeImage, Stencil) {
     // VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, so VkImageStencilUsageCreateInfo::stencilUsage
     // must also include VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT
     image_create_info.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-format-02795");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-format-02795");
 
     // depth-stencil format image with VkImageStencilUsageCreateInfo, usage does not include
     // VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, so VkImageStencilUsageCreateInfo::stencilUsage
     // must also not include VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     image_stencil_create_info.stencilUsage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-format-02796");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-format-02796");
 
     // depth-stencil format image with VkImageStencilUsageCreateInfo, usage includes
     // VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT, so VkImageStencilUsageCreateInfo::stencilUsage
     // must also include VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT
     image_create_info.usage = VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT;
     image_stencil_create_info.stencilUsage = VK_IMAGE_USAGE_STORAGE_BIT;
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-format-02797");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-format-02797");
 
     // depth-stencil format image with VkImageStencilUsageCreateInfo, usage does not include
     // VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT, so VkImageStencilUsageCreateInfo::stencilUsage
     // must also not include VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     image_stencil_create_info.stencilUsage = VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT;
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-format-02798");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-format-02798");
 }
 
 TEST_F(NegativeImage, StencilLimits) {
@@ -2804,14 +2743,14 @@ TEST_F(NegativeImage, StencilLimits) {
     image_create_info.format = VK_FORMAT_D32_SFLOAT_S8_UINT;
     image_create_info.extent = {dev_limits.maxFramebufferWidth + 1, 64, 1};
     image_stencil_create_info.stencilUsage = VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT;
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-Format-02536");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-Format-02536");
 
     // depth-stencil format image with VkImageStencilUsageCreateInfo with
     // VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT set cannot have image height exceeding device maximum
     image_create_info.format = VK_FORMAT_D32_SFLOAT_S8_UINT;
     image_create_info.extent = {64, dev_limits.maxFramebufferHeight + 1, 1};
     image_stencil_create_info.stencilUsage = VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT;
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-format-02537");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-format-02537");
 }
 
 TEST_F(NegativeImage, AstcDecodeMode) {
@@ -2841,17 +2780,17 @@ TEST_F(NegativeImage, AstcDecodeMode) {
 
     // image view format is not ASTC
 
-    CreateImageViewTest(*this, &image_view_create_info, "VUID-VkImageViewASTCDecodeModeEXT-format-04084");
+    CreateImageViewTest(image_view_create_info, "VUID-VkImageViewASTCDecodeModeEXT-format-04084");
 
     // Non-valid decodeMode
     image_view_create_info.image = astc_image.handle();
     image_view_create_info.format = ldr_format;
     astc_decode_mode.decodeMode = ldr_format;
-    CreateImageViewTest(*this, &image_view_create_info, "VUID-VkImageViewASTCDecodeModeEXT-decodeMode-02230");
+    CreateImageViewTest(image_view_create_info, "VUID-VkImageViewASTCDecodeModeEXT-decodeMode-02230");
 
     // decodeModeSharedExponent not enabled
     astc_decode_mode.decodeMode = VK_FORMAT_E5B9G9R9_UFLOAT_PACK32;
-    CreateImageViewTest(*this, &image_view_create_info, "VUID-VkImageViewASTCDecodeModeEXT-decodeMode-02231");
+    CreateImageViewTest(image_view_create_info, "VUID-VkImageViewASTCDecodeModeEXT-decodeMode-02231");
 }
 
 TEST_F(NegativeImage, ImageViewIncompatibleFormat) {
@@ -2875,17 +2814,7 @@ TEST_F(NegativeImage, ImageViewIncompatibleFormat) {
     // The Image's format is non-planar and incompatible with the ImageView's format, which should trigger
     // VUID-VkImageViewCreateInfo-image-01761
     imgViewInfo.format = VK_FORMAT_B8G8R8A8_UNORM;
-    CreateImageViewTest(*this, &imgViewInfo, "VUID-VkImageViewCreateInfo-image-01761");
-
-    // With a identical format, there should be no error
-    imgViewInfo.format = image_ci.format;
-    CreateImageViewTest(*this, &imgViewInfo, {});
-
-    vkt::Image mut_compat_image(*m_device, image_ci);
-
-    imgViewInfo.image = mut_compat_image.handle();
-    imgViewInfo.format = VK_FORMAT_R8_SINT;  // different, but size compatible
-    CreateImageViewTest(*this, &imgViewInfo, {});
+    CreateImageViewTest(imgViewInfo, "VUID-VkImageViewCreateInfo-image-01761");
 }
 
 TEST_F(NegativeImage, ImageViewIncompatibleDepthFormat) {
@@ -2909,7 +2838,7 @@ TEST_F(NegativeImage, ImageViewIncompatibleDepthFormat) {
     imgViewInfo.image = mutImage.handle();
     // "Each depth/stencil format is only compatible with itself."
     imgViewInfo.format = depthOnlyFormat;
-    CreateImageViewTest(*this, &imgViewInfo, "VUID-VkImageViewCreateInfo-image-01761");
+    CreateImageViewTest(imgViewInfo, "VUID-VkImageViewCreateInfo-image-01761");
 }
 
 TEST_F(NegativeImage, ImageViewMissingYcbcrConversion) {
@@ -2930,7 +2859,7 @@ TEST_F(NegativeImage, ImageViewMissingYcbcrConversion) {
     view_info.subresourceRange.levelCount = 1;
     view_info.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 
-    CreateImageViewTest(*this, &view_info, "VUID-VkImageViewCreateInfo-format-06415");
+    CreateImageViewTest(view_info, "VUID-VkImageViewCreateInfo-format-06415");
 }
 
 TEST_F(NegativeImage, ImageFormatList) {
@@ -2951,7 +2880,7 @@ TEST_F(NegativeImage, ImageFormatList) {
     image_ci.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
 
     // Not all 4 formats are compatible
-    CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-pNext-06722");
+    CreateImageTest(image_ci, "VUID-VkImageCreateInfo-pNext-06722");
 
     // Should work with only first 3 in array
     formatList.viewFormatCount = 3;
@@ -2968,7 +2897,7 @@ TEST_F(NegativeImage, ImageFormatList) {
 
     // Can't use 2 or higher formats if no mutable flag
     image_ci.flags = 0;
-    CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-flags-04738");
+    CreateImageTest(image_ci, "VUID-VkImageCreateInfo-flags-04738");
 
     // Make sure no error if 1 format
     formatList.viewFormatCount = 1;
@@ -2986,14 +2915,14 @@ TEST_F(NegativeImage, ImageFormatList) {
     // Not in format list
     imageViewInfo.format = VK_FORMAT_R8_SNORM;
     m_errorMonitor->SetUnexpectedError("VUID-VkImageViewCreateInfo-image-01761");
-    CreateImageViewTest(*this, &imageViewInfo, "VUID-VkImageViewCreateInfo-pNext-01585");
+    CreateImageViewTest(imageViewInfo, "VUID-VkImageViewCreateInfo-pNext-01585");
 
     imageViewInfo.format = VK_FORMAT_R8G8B8A8_SNORM;
-    CreateImageViewTest(*this, &imageViewInfo, {});
+    vkt::ImageView image_view(*m_device, imageViewInfo);
 
     // If viewFormatCount is zero should not hit VUID 01585
     imageViewInfo.image = mutableImageZero.handle();
-    CreateImageViewTest(*this, &imageViewInfo, {});
+    vkt::ImageView image_view2(*m_device, imageViewInfo);
 }
 
 TEST_F(NegativeImage, ImageFormatListEnum) {
@@ -3008,7 +2937,7 @@ TEST_F(NegativeImage, ImageFormatListEnum) {
     image_ci.pNext = &formatList;
     image_ci.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
 
-    CreateImageTest(*this, &image_ci, "VUID-VkImageFormatListCreateInfo-pViewFormats-parameter");
+    CreateImageTest(image_ci, "VUID-VkImageFormatListCreateInfo-pViewFormats-parameter");
 }
 
 TEST_F(NegativeImage, ImageFormatListFormat) {
@@ -3023,7 +2952,7 @@ TEST_F(NegativeImage, ImageFormatListFormat) {
     image_ci.pNext = &formatList;
     image_ci.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
 
-    CreateImageTest(*this, &image_ci, "VUID-VkImageFormatListCreateInfo-viewFormatCount-09540");
+    CreateImageTest(image_ci, "VUID-VkImageFormatListCreateInfo-viewFormatCount-09540");
 }
 
 TEST_F(NegativeImage, ImageFormatListSizeCompatible) {
@@ -3052,7 +2981,7 @@ TEST_F(NegativeImage, ImageFormatListSizeCompatible) {
 
     // The second image in the list should NOT be size-compatible (64-bit)
     formatList.viewFormatCount = 2;
-    CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-pNext-06722");
+    CreateImageTest(image_ci, "VUID-VkImageCreateInfo-pNext-06722");
 }
 
 TEST_F(NegativeImage, BlockTextImageViewCompatibleFormat) {
@@ -3070,7 +2999,7 @@ TEST_F(NegativeImage, BlockTextImageViewCompatibleFormat) {
         GTEST_SKIP() << "Image format not valid for format, type, tiling, usage and flags combination.";
     }
 
-    CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-flags-01572");
+    CreateImageTest(image_ci, "VUID-VkImageCreateInfo-flags-01572");
 }
 
 TEST_F(NegativeImage, BlockTextImageViewCompatibleFlag) {
@@ -3088,7 +3017,7 @@ TEST_F(NegativeImage, BlockTextImageViewCompatibleFlag) {
         GTEST_SKIP() << "Image format not valid for format, type, tiling, usage and flags combination.";
     }
 
-    CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-flags-01573");
+    CreateImageTest(image_ci, "VUID-VkImageCreateInfo-flags-01573");
 }
 
 TEST_F(NegativeImage, SparseResidencyAliased) {
@@ -3100,7 +3029,7 @@ TEST_F(NegativeImage, SparseResidencyAliased) {
     VkImageCreateInfo image_ci = DefaultImageInfo();
     image_ci.flags = VK_IMAGE_CREATE_SPARSE_ALIASED_BIT | VK_IMAGE_CREATE_SPARSE_BINDING_BIT;
     m_errorMonitor->SetDesiredError("VUID-VkImageCreateInfo-flags-00969");
-    CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-flags-01924");
+    CreateImageTest(image_ci, "VUID-VkImageCreateInfo-flags-01924");
 }
 
 TEST_F(NegativeImage, SparseResidencyLinear) {
@@ -3112,7 +3041,7 @@ TEST_F(NegativeImage, SparseResidencyLinear) {
     VkImageCreateInfo image_ci = DefaultImageInfo();
     image_ci.tiling = VK_IMAGE_TILING_LINEAR;
     image_ci.flags = VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT | VK_IMAGE_CREATE_SPARSE_BINDING_BIT;
-    CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-tiling-04121");
+    CreateImageTest(image_ci, "VUID-VkImageCreateInfo-tiling-04121");
 }
 
 TEST_F(NegativeImage, DisjointWithoutAlias) {
@@ -3123,7 +3052,7 @@ TEST_F(NegativeImage, DisjointWithoutAlias) {
     image_ci.flags = VK_IMAGE_CREATE_DISJOINT_BIT;
     // some devices fail query on this image
     m_errorMonitor->SetUnexpectedError("VUID-VkImageCreateInfo-imageCreateMaxMipLevels-02251");
-    CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-format-01577");
+    CreateImageTest(image_ci, "VUID-VkImageCreateInfo-format-01577");
 }
 
 TEST_F(NegativeImage, ImageSplitInstanceBindRegionCount) {
@@ -3296,15 +3225,15 @@ TEST_F(NegativeImage, BlockTexelViewLevelOrLayerCount) {
 
     ivci.subresourceRange.layerCount = 1;
     ivci.subresourceRange.levelCount = 4;
-    CreateImageViewTest(*this, &ivci, "VUID-VkImageViewCreateInfo-image-07072");
+    CreateImageViewTest(ivci, "VUID-VkImageViewCreateInfo-image-07072");
 
     ivci.subresourceRange.levelCount = VK_REMAINING_MIP_LEVELS;
-    CreateImageViewTest(*this, &ivci, "VUID-VkImageViewCreateInfo-image-07072");
+    CreateImageViewTest(ivci, "VUID-VkImageViewCreateInfo-image-07072");
 
     // Test for error message
     ivci.subresourceRange.layerCount = 2;
     ivci.subresourceRange.levelCount = 1;
-    CreateImageViewTest(*this, &ivci, "VUID-VkImageViewCreateInfo-image-09487");
+    CreateImageViewTest(ivci, "VUID-VkImageViewCreateInfo-image-09487");
 }
 
 TEST_F(NegativeImage, BlockTexelViewCompatibleMultipleLayers) {
@@ -3347,7 +3276,7 @@ TEST_F(NegativeImage, BlockTexelViewCompatibleMultipleLayers) {
     ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     ivci.subresourceRange.levelCount = 1;
     ivci.subresourceRange.layerCount = 2;
-    CreateImageViewTest(*this, &ivci, "VUID-VkImageViewCreateInfo-image-09487");
+    CreateImageViewTest(ivci, "VUID-VkImageViewCreateInfo-image-09487");
 }
 
 TEST_F(NegativeImage, BindIMageMemoryDeviceGroupInfo) {
@@ -3437,45 +3366,6 @@ TEST_F(NegativeImage, BindIMageMemoryDeviceGroupInfo) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeImage, BlockTexelViewType) {
-    TEST_DESCRIPTION(
-        "Create Image with VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT and non-compressed format and ImageView with view type "
-        "VK_IMAGE_VIEW_TYPE_3D.");
-
-    AddRequiredExtensions(VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
-    RETURN_IF_SKIP(Init());
-    VkImageCreateInfo image_create_info = vku::InitStructHelper();
-    image_create_info.flags = VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT | VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
-    image_create_info.imageType = VK_IMAGE_TYPE_3D;
-    image_create_info.format = VK_FORMAT_BC1_RGBA_SRGB_BLOCK;
-    image_create_info.extent = {32, 32, 1};
-    image_create_info.mipLevels = 1;
-    image_create_info.arrayLayers = 1;
-    image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
-    image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
-    image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-
-    VkFormatProperties image_fmt;
-    vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), image_create_info.format, &image_fmt);
-    if (!vkt::Image::IsCompatible(*m_device, image_create_info.usage, image_fmt.optimalTilingFeatures)) {
-        GTEST_SKIP() << "Image usage and format not compatible on device";
-    }
-    vkt::Image image(*m_device, image_create_info, vkt::set_layout);
-
-    VkImageViewCreateInfo ivci = vku::InitStructHelper();
-    ivci.image = image.handle();
-    ivci.viewType = VK_IMAGE_VIEW_TYPE_3D;
-    ivci.format = VK_FORMAT_R16G16B16A16_UNORM;
-    ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    ivci.subresourceRange.baseMipLevel = 0;
-    ivci.subresourceRange.layerCount = 1;
-    ivci.subresourceRange.baseArrayLayer = 0;
-    ivci.subresourceRange.levelCount = 1;
-
-    // Test for no error message, as VUID was removed
-    CreateImageViewTest(*this, &ivci);
-}
-
 TEST_F(NegativeImage, BlockTexelViewFormat) {
     TEST_DESCRIPTION("Create Image with VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT with non compatible formats.");
 
@@ -3509,13 +3399,13 @@ TEST_F(NegativeImage, BlockTexelViewFormat) {
     ivci.subresourceRange.levelCount = 1;
 
     ivci.format = VK_FORMAT_R8G8B8A8_UNORM;  // 32-bit block size
-    CreateImageViewTest(*this, &ivci, "VUID-VkImageViewCreateInfo-image-01583");
+    CreateImageViewTest(ivci, "VUID-VkImageViewCreateInfo-image-01583");
 
     ivci.format = VK_FORMAT_BC1_RGB_SRGB_BLOCK;  // 64-bit block size, but not same format class
-    CreateImageViewTest(*this, &ivci, "VUID-VkImageViewCreateInfo-image-01583");
+    CreateImageViewTest(ivci, "VUID-VkImageViewCreateInfo-image-01583");
 
     ivci.format = VK_FORMAT_BC1_RGBA_UNORM_BLOCK;  // 64-bit block size, and same format class
-    CreateImageViewTest(*this, &ivci);
+    vkt::ImageView image_view(*m_device, ivci);
 }
 
 TEST_F(NegativeImage, ImageSubresourceRangeAspectMask) {
@@ -3568,7 +3458,7 @@ TEST_F(NegativeImage, ImageSubresourceRangeAspectMask) {
     ivci.subresourceRange.baseArrayLayer = 0;
     ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT | VK_IMAGE_ASPECT_PLANE_0_BIT;
 
-    CreateImageViewTest(*this, &ivci, "VUID-VkImageSubresourceRange-aspectMask-01670");
+    CreateImageViewTest(ivci, "VUID-VkImageSubresourceRange-aspectMask-01670");
 }
 
 TEST_F(NegativeImage, CreateImageSharingModeConcurrentQueueFamilies) {
@@ -3597,7 +3487,7 @@ TEST_F(NegativeImage, CreateImageSharingModeConcurrentQueueFamilies) {
     {
         ci.queueFamilyIndexCount = 2;
         ci.pQueueFamilyIndices = nullptr;
-        CreateImageTest(*this, &ci, "VUID-VkImageCreateInfo-sharingMode-00941");
+        CreateImageTest(ci, "VUID-VkImageCreateInfo-sharingMode-00941");
     }
 
     // queueFamilyIndexCount must be greater than 1
@@ -3605,7 +3495,7 @@ TEST_F(NegativeImage, CreateImageSharingModeConcurrentQueueFamilies) {
         ci.queueFamilyIndexCount = 1;
         const uint32_t queue_family = 0;
         ci.pQueueFamilyIndices = &queue_family;
-        CreateImageTest(*this, &ci, "VUID-VkImageCreateInfo-sharingMode-00942");
+        CreateImageTest(ci, "VUID-VkImageCreateInfo-sharingMode-00942");
     }
 
     // Each element of pQueueFamilyIndices must be unique
@@ -3613,7 +3503,7 @@ TEST_F(NegativeImage, CreateImageSharingModeConcurrentQueueFamilies) {
         const std::array queue_families = {0U, 0U};
         ci.queueFamilyIndexCount = size32(queue_families);
         ci.pQueueFamilyIndices = queue_families.data();
-        CreateImageTest(*this, &ci, "VUID-VkImageCreateInfo-sharingMode-01420");
+        CreateImageTest(ci, "VUID-VkImageCreateInfo-sharingMode-01420");
     }
 
     // Each element of pQueueFamilyIndices must be less than pQueueFamilyPropertyCount returned by either
@@ -3626,7 +3516,7 @@ TEST_F(NegativeImage, CreateImageSharingModeConcurrentQueueFamilies) {
         ci.queueFamilyIndexCount = size32(queue_families);
         ci.pQueueFamilyIndices = queue_families.data();
 
-        CreateImageTest(*this, &ci, "VUID-VkImageCreateInfo-sharingMode-01420");
+        CreateImageTest(ci, "VUID-VkImageCreateInfo-sharingMode-01420");
     }
 }
 
@@ -3727,7 +3617,7 @@ TEST_F(NegativeImage, Image2DViewOf3D) {
     image_ci.flags = 0;
     vkt::Image image_3d_no_flag(*m_device, image_ci, vkt::set_layout);
     view_ci.image = image_3d_no_flag.handle();
-    CreateImageViewTest(*this, &view_ci, "VUID-VkImageViewCreateInfo-image-06728");
+    CreateImageViewTest(view_ci, "VUID-VkImageViewCreateInfo-image-06728");
 
     const VkImageSubresourceRange range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 1, 1};
     view_ci.subresourceRange = range;
@@ -3735,7 +3625,7 @@ TEST_F(NegativeImage, Image2DViewOf3D) {
     view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
     m_errorMonitor->SetDesiredError("VUID-VkImageViewCreateInfo-image-06723");
     m_errorMonitor->SetDesiredError("VUID-VkImageViewCreateInfo-image-06724");
-    CreateImageViewTest(*this, &view_ci, "VUID-VkImageViewCreateInfo-subresourceRange-06725");
+    CreateImageViewTest(view_ci, "VUID-VkImageViewCreateInfo-subresourceRange-06725");
 }
 
 TEST_F(NegativeImage, Image2DViewOf3DFeature) {
@@ -3819,7 +3709,7 @@ TEST_F(NegativeImage, ImageViewMinLod) {
     ivml.minLod = 4.0;
     ivci.pNext = &ivml;
 
-    CreateImageViewTest(*this, &ivci, "VUID-VkImageViewMinLodCreateInfoEXT-minLod-06456");
+    CreateImageViewTest(ivci, "VUID-VkImageViewMinLodCreateInfoEXT-minLod-06456");
     ivml.minLod = 1.0;
     vkt::ImageView image_view(*m_device, ivci);
 
@@ -3853,7 +3743,7 @@ TEST_F(NegativeImage, ImageViewMinLodFeature) {
     ivml.minLod = 1.0;
     ivci.pNext = &ivml;
 
-    CreateImageViewTest(*this, &ivci, "VUID-VkImageViewMinLodCreateInfoEXT-minLod-06455");
+    CreateImageViewTest(ivci, "VUID-VkImageViewMinLodCreateInfoEXT-minLod-06455");
 }
 
 TEST_F(NegativeImage, ColorWthDepthAspect) {
@@ -3895,7 +3785,7 @@ TEST_F(NegativeImage, ImageCompressionControl) {
                                                                VK_IMAGE_USAGE_TRANSFER_DST_BIT, VK_IMAGE_TILING_LINEAR);
         image_create_info.pNext = &compression_control;
 
-        CreateImageTest(*this, &image_create_info, "VUID-VkImageCompressionControlEXT-flags-06747");
+        CreateImageTest(image_create_info, "VUID-VkImageCompressionControlEXT-flags-06747");
     }
 
     // Explicit Fixed Rate
@@ -3908,7 +3798,7 @@ TEST_F(NegativeImage, ImageCompressionControl) {
                                                                VK_IMAGE_USAGE_TRANSFER_SRC_BIT, VK_IMAGE_TILING_LINEAR);
         image_create_info.pNext = &compression_control;
 
-        CreateImageTest(*this, &image_create_info, "VUID-VkImageCompressionControlEXT-flags-06748");
+        CreateImageTest(image_create_info, "VUID-VkImageCompressionControlEXT-flags-06748");
     }
 
     // Image creation lambda
@@ -4515,32 +4405,32 @@ TEST_F(NegativeImage, ImageViewTextureSampleWeighted) {
     sci.flags = VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM;
 
     // vkCreateSampler - expect success
-    CreateSamplerTest(*this, &sci, "");
+    vkt::Sampler good_sampler(*m_device, sci);
     auto sci_bad = sci;
 
     // vkCreateSampler - expect failure
     sci_bad.minFilter = VK_FILTER_LINEAR;  // disallowed
-    CreateSamplerTest(*this, &sci_bad, "VUID-VkSamplerCreateInfo-flags-06964");
+    CreateSamplerTest(sci_bad, "VUID-VkSamplerCreateInfo-flags-06964");
     sci_bad.minFilter = sci.minFilter;
 
     sci_bad.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;  // disallowed
-    CreateSamplerTest(*this, &sci_bad, "VUID-VkSamplerCreateInfo-flags-06965");
+    CreateSamplerTest(sci_bad, "VUID-VkSamplerCreateInfo-flags-06965");
     sci_bad.mipmapMode = sci.mipmapMode;
 
     sci_bad.maxLod = 1.0f;  // disallowed
-    CreateSamplerTest(*this, &sci_bad, "VUID-VkSamplerCreateInfo-flags-06966");
+    CreateSamplerTest(sci_bad, "VUID-VkSamplerCreateInfo-flags-06966");
     sci_bad.maxLod = sci.maxLod;
 
     sci_bad.addressModeU = VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT;  // disallowed
-    CreateSamplerTest(*this, &sci_bad, "VUID-VkSamplerCreateInfo-flags-06967");
+    CreateSamplerTest(sci_bad, "VUID-VkSamplerCreateInfo-flags-06967");
     sci_bad.addressModeU = sci.addressModeU;
 
     sci_bad.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_WHITE;  // disallowed
-    CreateSamplerTest(*this, &sci_bad, "VUID-VkSamplerCreateInfo-flags-06968");
+    CreateSamplerTest(sci_bad, "VUID-VkSamplerCreateInfo-flags-06968");
     sci_bad.borderColor = sci.borderColor;
 
     sci_bad.compareEnable = VK_TRUE;  // disallowed
-    CreateSamplerTest(*this, &sci_bad, "VUID-VkSamplerCreateInfo-flags-06970");
+    CreateSamplerTest(sci_bad, "VUID-VkSamplerCreateInfo-flags-06970");
     sci_bad.compareEnable = sci.compareEnable;
 
     vkt::Sampler sampler(*m_device, sci);
@@ -4598,25 +4488,25 @@ TEST_F(NegativeImage, ImageViewTextureSampleWeighted) {
     // vkCreateImage - expect failure
     m_errorMonitor->SetDesiredError("VUID-VkImageViewCreateInfo-pNext-06956 ");
     m_errorMonitor->SetDesiredError("VUID-VkImageViewCreateInfo-pNext-06957 ");
-    CreateImageViewTest(*this, &ivci_bad, "VUID-VkImageViewSampleWeightCreateInfoQCOM-filterSize-06959");
+    CreateImageViewTest(ivci_bad, "VUID-VkImageViewSampleWeightCreateInfoQCOM-filterSize-06959");
     ivswci_bad.filterSize.height = ivswci.filterSize.height;
 
     ivswci_bad.filterSize.width = image_proc_properties.maxWeightFilterDimension.width + 1;
     m_errorMonitor->SetDesiredError("VUID-VkImageViewCreateInfo-pNext-06955");
-    CreateImageViewTest(*this, &ivci_bad, "VUID-VkImageViewSampleWeightCreateInfoQCOM-filterSize-06958");
+    CreateImageViewTest(ivci_bad, "VUID-VkImageViewSampleWeightCreateInfoQCOM-filterSize-06958");
     ivswci_bad.filterSize.width = ivswci.filterSize.width;
 
     ivswci_bad.filterCenter.x = ivswci.filterSize.width;
     ivswci_bad.filterCenter.y = ivswci.filterSize.height;
     m_errorMonitor->SetDesiredError("VUID-VkImageViewSampleWeightCreateInfoQCOM-filterCenter-06960");
-    CreateImageViewTest(*this, &ivci_bad, "VUID-VkImageViewSampleWeightCreateInfoQCOM-filterCenter-06961");
+    CreateImageViewTest(ivci_bad, "VUID-VkImageViewSampleWeightCreateInfoQCOM-filterCenter-06961");
     ivswci_bad.filterCenter.x = ivswci.filterCenter.x;
     ivswci_bad.filterCenter.y = ivswci.filterCenter.y;
 
     ivswci_bad.numPhases = image_proc_properties.maxWeightFilterPhases + 1;
     m_errorMonitor->SetDesiredError("VUID-VkImageViewSampleWeightCreateInfoQCOM-numPhases-06962");
     m_errorMonitor->SetDesiredError("VUID-VkImageViewCreateInfo-pNext-06954");
-    CreateImageViewTest(*this, &ivci_bad, "VUID-VkImageViewSampleWeightCreateInfoQCOM-numPhases-06963");
+    CreateImageViewTest(ivci_bad, "VUID-VkImageViewSampleWeightCreateInfoQCOM-numPhases-06963");
     ivswci_bad.filterSize.width = ivswci.filterSize.width;
 
     vkt::ImageView weight_image_view(*m_device, ivci);
@@ -4676,11 +4566,11 @@ TEST_F(NegativeImage, CubeCompatibleMustBeImageType2D) {
     ci.extent.width = 1;
     ci.extent.height = 1;
     m_errorMonitor->SetUnexpectedError("VUID-VkImageCreateInfo-flags-08866");
-    CreateImageTest(*this, &ci, "VUID-VkImageCreateInfo-flags-00949");
+    CreateImageTest(ci, "VUID-VkImageCreateInfo-flags-00949");
 
     ci.imageType = VK_IMAGE_TYPE_3D;
     m_errorMonitor->SetUnexpectedError("VUID-VkImageCreateInfo-flags-08866");
-    CreateImageTest(*this, &ci, "VUID-VkImageCreateInfo-flags-00949");
+    CreateImageTest(ci, "VUID-VkImageCreateInfo-flags-00949");
 }
 
 TEST_F(NegativeImage, GetPhysicalDeviceImageFormatProperties) {

--- a/tests/unit/image_drm.cpp
+++ b/tests/unit/image_drm.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (c) 2015-2024 Google, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2025 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ TEST_F(NegativeImageDrm, Basic) {
     drm_format_mod_explicit.pPlaneLayouts = &fake_plane_layout;
 
     // No pNext
-    CreateImageTest(*this, &image_info, "VUID-VkImageCreateInfo-tiling-02261");
+    CreateImageTest(image_info, "VUID-VkImageCreateInfo-tiling-02261");
 
     // Having wrong size, arrayPitch and depthPitch in VkSubresourceLayout
     fake_plane_layout.size = 1;
@@ -71,7 +71,7 @@ TEST_F(NegativeImageDrm, Basic) {
     image_info.pNext = (void *)&drm_format_mod_explicit;
     m_errorMonitor->SetDesiredError("VUID-VkImageDrmFormatModifierExplicitCreateInfoEXT-size-02267");
     m_errorMonitor->SetDesiredError("VUID-VkImageDrmFormatModifierExplicitCreateInfoEXT-arrayPitch-02268");
-    CreateImageTest(*this, &image_info, "VUID-VkImageDrmFormatModifierExplicitCreateInfoEXT-depthPitch-02269");
+    CreateImageTest(image_info, "VUID-VkImageDrmFormatModifierExplicitCreateInfoEXT-depthPitch-02269");
 }
 
 TEST_F(NegativeImageDrm, Basic2) {
@@ -136,12 +136,12 @@ TEST_F(NegativeImageDrm, Basic2) {
 
     // Having both in pNext
     drm_format_mod_explicit.pNext = (void *)&drm_format_mod_list;
-    CreateImageTest(*this, &image_info, "VUID-VkImageCreateInfo-tiling-02261");
+    CreateImageTest(image_info, "VUID-VkImageCreateInfo-tiling-02261");
 
     // Only 1 pNext but wrong tiling
     image_info.pNext = (void *)&drm_format_mod_list;
     image_info.tiling = VK_IMAGE_TILING_LINEAR;
-    CreateImageTest(*this, &image_info, "VUID-VkImageCreateInfo-pNext-02262");
+    CreateImageTest(image_info, "VUID-VkImageCreateInfo-pNext-02262");
 }
 
 TEST_F(NegativeImageDrm, ImageFormatInfo) {
@@ -289,7 +289,7 @@ TEST_F(NegativeImageDrm, ImageSubresourceRangeAspectMask) {
     ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_MEMORY_PLANE_0_BIT_EXT;
 
     m_errorMonitor->SetUnexpectedError("VUID-VkImageViewCreateInfo-subresourceRange-09594");
-    CreateImageViewTest(*this, &ivci, "VUID-VkImageSubresourceRange-aspectMask-02278");
+    CreateImageViewTest(ivci, "VUID-VkImageSubresourceRange-aspectMask-02278");
 }
 
 TEST_F(NegativeImageDrm, MutableFormat) {
@@ -316,12 +316,12 @@ TEST_F(NegativeImageDrm, MutableFormat) {
     image_info.samples = VK_SAMPLE_COUNT_1_BIT;
     image_info.tiling = VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT;
     image_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    CreateImageTest(*this, &image_info, "VUID-VkImageCreateInfo-tiling-02353");
+    CreateImageTest(image_info, "VUID-VkImageCreateInfo-tiling-02353");
 
     VkImageFormatListCreateInfo format_list = vku::InitStructHelper();
     format_list.viewFormatCount = 0;
     mod_list.pNext = &format_list;
-    CreateImageTest(*this, &image_info, "VUID-VkImageCreateInfo-tiling-02353");
+    CreateImageTest(image_info, "VUID-VkImageCreateInfo-tiling-02353");
 }
 
 TEST_F(NegativeImageDrm, CompressionControl) {
@@ -349,7 +349,7 @@ TEST_F(NegativeImageDrm, CompressionControl) {
     image_info.samples = VK_SAMPLE_COUNT_1_BIT;
     image_info.tiling = VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT;
     image_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    CreateImageTest(*this, &image_info, "VUID-VkImageCreateInfo-pNext-06746");
+    CreateImageTest(image_info, "VUID-VkImageCreateInfo-pNext-06746");
 }
 
 TEST_F(NegativeImageDrm, GetImageDrmFormatModifierProperties) {

--- a/tests/unit/memory.cpp
+++ b/tests/unit/memory.cpp
@@ -1494,13 +1494,13 @@ TEST_F(NegativeMemory, BufferDeviceAddressEXT) {
     buffer_create_info.size = sizeof(uint32_t);
     buffer_create_info.usage = VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
     buffer_create_info.flags = VK_BUFFER_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT;
-    CreateBufferTest(*this, &buffer_create_info, "VUID-VkBufferCreateInfo-flags-03338");
+    CreateBufferTest(buffer_create_info, "VUID-VkBufferCreateInfo-flags-03338");
 
     buffer_create_info.flags = 0;
     VkBufferDeviceAddressCreateInfoEXT addr_ci = vku::InitStructHelper();
     addr_ci.deviceAddress = 1;
     buffer_create_info.pNext = &addr_ci;
-    CreateBufferTest(*this, &buffer_create_info, "VUID-VkBufferCreateInfo-deviceAddress-02604");
+    CreateBufferTest(buffer_create_info, "VUID-VkBufferCreateInfo-deviceAddress-02604");
 
     buffer_create_info.pNext = nullptr;
     vkt::Buffer buffer(*m_device, buffer_create_info, vkt::no_mem);
@@ -1561,13 +1561,13 @@ TEST_F(NegativeMemory, BufferDeviceAddressKHR) {
     buffer_create_info.size = sizeof(uint32_t);
     buffer_create_info.usage = VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
     buffer_create_info.flags = VK_BUFFER_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT;
-    CreateBufferTest(*this, &buffer_create_info, "VUID-VkBufferCreateInfo-flags-03338");
+    CreateBufferTest(buffer_create_info, "VUID-VkBufferCreateInfo-flags-03338");
 
     buffer_create_info.flags = 0;
     VkBufferOpaqueCaptureAddressCreateInfo addr_ci = vku::InitStructHelper();
     addr_ci.opaqueCaptureAddress = 1;
     buffer_create_info.pNext = &addr_ci;
-    CreateBufferTest(*this, &buffer_create_info, "VUID-VkBufferCreateInfo-opaqueCaptureAddress-03337");
+    CreateBufferTest(buffer_create_info, "VUID-VkBufferCreateInfo-opaqueCaptureAddress-03337");
 
     buffer_create_info.pNext = nullptr;
     vkt::Buffer buffer(*m_device, buffer_create_info, vkt::no_mem);

--- a/tests/unit/others.cpp
+++ b/tests/unit/others.cpp
@@ -486,7 +486,7 @@ TEST_F(VkLayerTest, UnrecognizedValueBadBool) {
 
     // Not VK_TRUE or VK_FALSE
     sampler_info.anisotropyEnable = 3;
-    CreateSamplerTest(*this, &sampler_info, "UNASSIGNED-GeneralParameterError-UnrecognizedBool32");
+    CreateSamplerTest(sampler_info, "UNASSIGNED-GeneralParameterError-UnrecognizedBool32");
 }
 
 TEST_F(VkLayerTest, UnrecognizedValueMaxEnum) {
@@ -816,7 +816,7 @@ TEST_F(VkLayerTest, InvalidImageCreateFlagWithPhysicalDeviceCount) {
         GTEST_SKIP() << "image format is not supported";
     }
 
-    CreateImageTest(*this, &ici, "VUID-VkImageCreateInfo-physicalDeviceCount-01421");
+    CreateImageTest(ici, "VUID-VkImageCreateInfo-physicalDeviceCount-01421");
 }
 
 TEST_F(VkLayerTest, ZeroBitmask) {

--- a/tests/unit/portability_subset.cpp
+++ b/tests/unit/portability_subset.cpp
@@ -95,13 +95,13 @@ TEST_F(NegativePortabilitySubset, Image) {
     ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     ci.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     ci.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
-    CreateImageTest(*this, &ci, "VUID-VkImageCreateInfo-imageView2DOn3DImage-04459");
+    CreateImageTest(ci, "VUID-VkImageCreateInfo-imageView2DOn3DImage-04459");
 
     ci.imageType = VK_IMAGE_TYPE_2D;
     ci.flags = 0;
     ci.samples = VK_SAMPLE_COUNT_2_BIT;
     ci.arrayLayers = 2;
-    CreateImageTest(*this, &ci, "VUID-VkImageCreateInfo-multisampleArrayImage-04460");
+    CreateImageTest(ci, "VUID-VkImageCreateInfo-multisampleArrayImage-04460");
 }
 
 TEST_F(NegativePortabilitySubset, ImageViewFormatSwizzle) {
@@ -141,14 +141,14 @@ TEST_F(NegativePortabilitySubset, ImageViewFormatSwizzle) {
     ci.components.b = VK_COMPONENT_SWIZZLE_R;
     ci.components.a = VK_COMPONENT_SWIZZLE_IDENTITY;
     ci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-    CreateImageViewTest(*this, &ci, "VUID-VkImageViewCreateInfo-imageViewFormatSwizzle-04465");
+    CreateImageViewTest(ci, "VUID-VkImageViewCreateInfo-imageViewFormatSwizzle-04465");
 
     // Verify using VK_COMPONENT_SWIZZLE_R/G/B/A works when imageViewFormatSwizzle == VK_FALSE
     ci.components.r = VK_COMPONENT_SWIZZLE_R;
     ci.components.g = VK_COMPONENT_SWIZZLE_G;
     ci.components.b = VK_COMPONENT_SWIZZLE_B;
     ci.components.a = VK_COMPONENT_SWIZZLE_A;
-    CreateImageViewTest(*this, &ci);
+    vkt::ImageView image_view(*m_device, ci);
 }
 
 TEST_F(NegativePortabilitySubset, ImageViewFormatReinterpretationComponentCount) {
@@ -191,7 +191,7 @@ TEST_F(NegativePortabilitySubset, ImageViewFormatReinterpretationComponentCount)
     // Format might not be supported
     // TODO - Need to figure out which format is supported that hits 04466
     m_errorMonitor->SetUnexpectedError("VUID-VkImageViewCreateInfo-None-02273");
-    CreateImageViewTest(*this, &ci, "VUID-VkImageViewCreateInfo-imageViewFormatReinterpretation-04466");
+    CreateImageViewTest(ci, "VUID-VkImageViewCreateInfo-imageViewFormatReinterpretation-04466");
 }
 
 TEST_F(NegativePortabilitySubset, Sampler) {
@@ -208,7 +208,7 @@ TEST_F(NegativePortabilitySubset, Sampler) {
 
     VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
     sampler_info.mipLodBias = 1.0f;
-    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-samplerMipLodBias-04467");
+    CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-samplerMipLodBias-04467");
 }
 
 TEST_F(NegativePortabilitySubset, TriangleFans) {

--- a/tests/unit/protected_memory.cpp
+++ b/tests/unit/protected_memory.cpp
@@ -94,7 +94,7 @@ TEST_F(NegativeProtectedMemory, Submit) {
     buffer_create_info.flags = VK_BUFFER_CREATE_PROTECTED_BIT;
     buffer_create_info.size = 4096;
     buffer_create_info.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
-    CreateBufferTest(*this, &buffer_create_info, "VUID-VkBufferCreateInfo-flags-01887");
+    CreateBufferTest(buffer_create_info, "VUID-VkBufferCreateInfo-flags-01887");
 
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.flags = VK_IMAGE_CREATE_PROTECTED_BIT;
@@ -106,7 +106,7 @@ TEST_F(NegativeProtectedMemory, Submit) {
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
     image_create_info.arrayLayers = 1;
     image_create_info.mipLevels = 1;
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-flags-01890");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-flags-01890");
 
     // Try to find memory with protected bit in it at all
     VkDeviceMemory memory_protected = VK_NULL_HANDLE;
@@ -161,7 +161,7 @@ TEST_F(NegativeProtectedMemory, Memory) {
     buffer_create_info.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
 
     if (sparse_support == true) {
-        CreateBufferTest(*this, &buffer_create_info, "VUID-VkBufferCreateInfo-None-01888");
+        CreateBufferTest(buffer_create_info, "VUID-VkBufferCreateInfo-None-01888");
     }
 
     // Create actual protected and unprotected buffers
@@ -183,7 +183,7 @@ TEST_F(NegativeProtectedMemory, Memory) {
     image_create_info.mipLevels = 1;
 
     if (sparse_support == true) {
-        CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-None-01891");
+        CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-None-01891");
     }
 
     // Create actual protected and unprotected images
@@ -1164,7 +1164,7 @@ TEST_F(NegativeProtectedMemory, Usage) {
     buffer_create_info.flags = VK_BUFFER_CREATE_PROTECTED_BIT;
     buffer_create_info.size = 4096;
     buffer_create_info.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT;
-    CreateBufferTest(*this, &buffer_create_info, "VUID-VkBufferCreateInfo-flags-09641");
+    CreateBufferTest(buffer_create_info, "VUID-VkBufferCreateInfo-flags-09641");
 }
 
 TEST_F(NegativeProtectedMemory, WriteToProtectedStorageBuffer) {

--- a/tests/unit/sampler.cpp
+++ b/tests/unit/sampler.cpp
@@ -28,7 +28,7 @@ TEST_F(NegativeSampler, MirrorClampToEdgeNotEnabled) {
     // Set the modes to cause the error
     sampler_info.addressModeU = VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE;
     // Prior to 1.2 we get the implicit VU
-    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-addressModeU-parameter");
+    CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-addressModeU-parameter");
 }
 
 TEST_F(NegativeSampler, MirrorClampToEdgeNotEnabled12) {
@@ -39,7 +39,7 @@ TEST_F(NegativeSampler, MirrorClampToEdgeNotEnabled12) {
 
     VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
     sampler_info.addressModeU = VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE;
-    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-addressModeU-01079");
+    CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-addressModeU-01079");
 }
 
 TEST_F(NegativeSampler, AnisotropyFeatureDisabled) {
@@ -65,12 +65,12 @@ TEST_F(NegativeSampler, AnisotropyFeatureEnabled) {
 
     // maxAnisotropy out-of-bounds low.
     sampler_info.maxAnisotropy = NearestSmaller(1.0F);
-    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-anisotropyEnable-01071");
+    CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-anisotropyEnable-01071");
     sampler_info.maxAnisotropy = sampler_info_ref.maxAnisotropy;
 
     // maxAnisotropy out-of-bounds high.
     sampler_info.maxAnisotropy = NearestGreater(m_device->Physical().limits_.maxSamplerAnisotropy);
-    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-anisotropyEnable-01071");
+    CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-anisotropyEnable-01071");
     sampler_info.maxAnisotropy = sampler_info_ref.maxAnisotropy;
 
     // Both anisotropy and unnormalized coords enabled
@@ -78,7 +78,7 @@ TEST_F(NegativeSampler, AnisotropyFeatureEnabled) {
     // If unnormalizedCoordinates is VK_TRUE, minLod and maxLod must be zero
     sampler_info.minLod = 0;
     sampler_info.maxLod = 0;
-    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01076");
+    CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01076");
     sampler_info.unnormalizedCoordinates = sampler_info_ref.unnormalizedCoordinates;
 }
 
@@ -95,11 +95,11 @@ TEST_F(NegativeSampler, AnisotropyFeatureEnabledCubic) {
 
     sampler_info.minFilter = VK_FILTER_CUBIC_IMG;
     sampler_info.magFilter = VK_FILTER_NEAREST;
-    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-magFilter-01081");
+    CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-magFilter-01081");
 
     sampler_info.minFilter = VK_FILTER_NEAREST;
     sampler_info.magFilter = VK_FILTER_CUBIC_IMG;
-    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-magFilter-01081");
+    CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-magFilter-01081");
 }
 
 TEST_F(NegativeSampler, UnnormalizedCoordinatesEnabled) {
@@ -115,21 +115,21 @@ TEST_F(NegativeSampler, UnnormalizedCoordinatesEnabled) {
     // min and mag filters must be the same
     sampler_info.minFilter = VK_FILTER_NEAREST;
     sampler_info.magFilter = VK_FILTER_LINEAR;
-    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01072");
+    CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01072");
     std::swap(sampler_info.minFilter, sampler_info.magFilter);
-    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01072");
+    CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01072");
     sampler_info = sampler_info_ref;
 
     // mipmapMode must be NEAREST
     sampler_info.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
-    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01073");
+    CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01073");
     sampler_info = sampler_info_ref;
 
     // minlod and maxlod must be zero
     sampler_info.maxLod = 3.14159f;
-    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01074");
+    CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01074");
     sampler_info.minLod = 2.71828f;
-    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01074");
+    CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01074");
     sampler_info = sampler_info_ref;
 
     // addressModeU and addressModeV must both be CLAMP_TO_EDGE or CLAMP_TO_BORDER
@@ -146,7 +146,7 @@ TEST_F(NegativeSampler, UnnormalizedCoordinatesEnabled) {
                 (vmode != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE && vmode != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER)) {
                 sampler_info.addressModeU = umode;
                 sampler_info.addressModeV = vmode;
-                CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01075");
+                CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01075");
             }
         }
     }
@@ -158,7 +158,7 @@ TEST_F(NegativeSampler, UnnormalizedCoordinatesEnabled) {
 
     // compareEnable must be VK_FALSE
     sampler_info.compareEnable = VK_TRUE;
-    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01077");
+    CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-unnormalizedCoordinates-01077");
     sampler_info = sampler_info_ref;
 }
 
@@ -173,13 +173,13 @@ TEST_F(NegativeSampler, BasicUsage) {
     // Mix up Lod values
     sampler_info.minLod = 4.0f;
     sampler_info.maxLod = 1.0f;
-    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-maxLod-01973");
+    CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-maxLod-01973");
     sampler_info.minLod = sampler_info_ref.minLod;
     sampler_info.maxLod = sampler_info_ref.maxLod;
 
     // Larger mipLodBias than max limit
     sampler_info.mipLodBias = NearestGreater(m_device->Physical().limits_.maxSamplerLodBias);
-    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-mipLodBias-01069");
+    CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-mipLodBias-01069");
     sampler_info.mipLodBias = sampler_info_ref.mipLodBias;
 }
 
@@ -754,12 +754,12 @@ TEST_F(NegativeSampler, FilterMinmax) {
 
     // Wrong mode with a YCbCr Conversion used
     reduction_info.pNext = &ycbcr_info;
-    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-None-01647");
+    CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-None-01647");
 
     // Wrong mode with compareEnable
     reduction_info.pNext = nullptr;
     sampler_info.compareEnable = VK_TRUE;
-    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-compareEnable-01423");
+    CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-compareEnable-01423");
 
     vk::DestroySamplerYcbcrConversionKHR(m_device->handle(), conversion, nullptr);
 }
@@ -774,17 +774,17 @@ TEST_F(NegativeSampler, CustomBorderColor) {
     VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
     sampler_info.borderColor = VK_BORDER_COLOR_INT_CUSTOM_EXT;
     // No SCBCCreateInfo in pNext
-    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-borderColor-04011");
+    CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-borderColor-04011");
 
     VkSamplerCustomBorderColorCreateInfoEXT custom_color_cinfo = vku::InitStructHelper();
     custom_color_cinfo.format = VK_FORMAT_R32_SFLOAT;
     sampler_info.pNext = &custom_color_cinfo;
     // Format mismatch
-    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCustomBorderColorCreateInfoEXT-format-07605");
+    CreateSamplerTest(sampler_info, "VUID-VkSamplerCustomBorderColorCreateInfoEXT-format-07605");
 
     custom_color_cinfo.format = VK_FORMAT_UNDEFINED;
     // Format undefined with no customBorderColorWithoutFormat
-    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCustomBorderColorCreateInfoEXT-format-04014");
+    CreateSamplerTest(sampler_info, "VUID-VkSamplerCustomBorderColorCreateInfoEXT-format-04014");
 
     custom_color_cinfo.format = VK_FORMAT_R8G8B8A8_UINT;
     vkt::Sampler sampler(*m_device, sampler_info);
@@ -1733,7 +1733,7 @@ TEST_F(NegativeSampler, ReductionModeFeature) {
 
     auto sampler_ci = SafeSaneSamplerCreateInfo();
     sampler_ci.pNext = &sampler_reduction_mode_ci;
-    CreateSamplerTest(*this, &sampler_ci, "VUID-VkSamplerCreateInfo-pNext-06726");
+    CreateSamplerTest(sampler_ci, "VUID-VkSamplerCreateInfo-pNext-06726");
 }
 
 TEST_F(NegativeSampler, ReductionModeCubicIMG) {
@@ -1746,7 +1746,7 @@ TEST_F(NegativeSampler, ReductionModeCubicIMG) {
     sampler_reduction_mode_ci.reductionMode = VK_SAMPLER_REDUCTION_MODE_MAX;
     VkSamplerCreateInfo sampler_ci = vku::InitStructHelper(&sampler_reduction_mode_ci);
     sampler_ci.magFilter = VK_FILTER_CUBIC_EXT;
-    CreateSamplerTest(*this, &sampler_ci, "VUID-VkSamplerCreateInfo-magFilter-07911");
+    CreateSamplerTest(sampler_ci, "VUID-VkSamplerCreateInfo-magFilter-07911");
 }
 
 TEST_F(NegativeSampler, NonSeamlessCubeMapNotEnabled) {
@@ -1759,7 +1759,7 @@ TEST_F(NegativeSampler, NonSeamlessCubeMapNotEnabled) {
 
     VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
     sampler_info.flags = VK_SAMPLER_CREATE_NON_SEAMLESS_CUBE_MAP_BIT_EXT;
-    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-nonSeamlessCubeMap-06788");
+    CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-nonSeamlessCubeMap-06788");
 }
 
 TEST_F(NegativeSampler, BorderColorSwizzle) {
@@ -1787,7 +1787,7 @@ TEST_F(NegativeSampler, BorderColorValue) {
     VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
     sampler_info.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER;
     sampler_info.borderColor = static_cast<VkBorderColor>(0xFFFFBAD0);
-    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-addressModeU-01078");
+    CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-addressModeU-01078");
 }
 
 TEST_F(NegativeSampler, CompareOpValue) {
@@ -1796,7 +1796,7 @@ TEST_F(NegativeSampler, CompareOpValue) {
     VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
     sampler_info.compareEnable = VK_TRUE;
     sampler_info.compareOp = static_cast<VkCompareOp>(0xFFFFBAD0);
-    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-compareEnable-01080");
+    CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-compareEnable-01080");
 }
 
 TEST_F(NegativeSampler, CustomBorderColorsFeature) {

--- a/tests/unit/sparse_buffer.cpp
+++ b/tests/unit/sparse_buffer.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (c) 2015-2024 Google, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2025 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -606,15 +606,15 @@ TEST_F(NegativeSparseBuffer, BufferFlagsFeature) {
     buffer_create_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
 
     buffer_create_info.flags = VK_BUFFER_CREATE_SPARSE_BINDING_BIT;
-    CreateBufferTest(*this, &buffer_create_info, "VUID-VkBufferCreateInfo-flags-00915");
+    CreateBufferTest(buffer_create_info, "VUID-VkBufferCreateInfo-flags-00915");
 
     buffer_create_info.flags = VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT;
     m_errorMonitor->SetDesiredError("VUID-VkBufferCreateInfo-flags-00916");
-    CreateBufferTest(*this, &buffer_create_info, "VUID-VkBufferCreateInfo-flags-00918");
+    CreateBufferTest(buffer_create_info, "VUID-VkBufferCreateInfo-flags-00918");
 
     buffer_create_info.flags = VK_BUFFER_CREATE_SPARSE_ALIASED_BIT;
     m_errorMonitor->SetDesiredError("VUID-VkBufferCreateInfo-flags-00917");
-    CreateBufferTest(*this, &buffer_create_info, "VUID-VkBufferCreateInfo-flags-00918");
+    CreateBufferTest(buffer_create_info, "VUID-VkBufferCreateInfo-flags-00918");
 }
 
 TEST_F(NegativeSparseBuffer, VkSparseMemoryBindMemory) {

--- a/tests/unit/sparse_image.cpp
+++ b/tests/unit/sparse_image.cpp
@@ -25,20 +25,20 @@ TEST_F(NegativeSparseImage, BindingImageBufferCreate) {
     AddRequiredFeature(vkt::Feature::sparseResidencyImage2D);
     RETURN_IF_SKIP(Init());
 
-    VkBufferCreateInfo buf_info = vku::InitStructHelper();
-    buf_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
-    buf_info.size = 2048;
+    VkBufferCreateInfo buffer_create_info = vku::InitStructHelper();
+    buffer_create_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+    buffer_create_info.size = 2048;
 
     if (m_device->Physical().Features().sparseResidencyBuffer) {
-        buf_info.flags = VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT;
-        CreateBufferTest(*this, &buf_info, "VUID-VkBufferCreateInfo-flags-00918");
+        buffer_create_info.flags = VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT;
+        CreateBufferTest(buffer_create_info, "VUID-VkBufferCreateInfo-flags-00918");
     } else {
         GTEST_SKIP() << "Test requires unsupported sparseResidencyBuffer feature";
     }
 
     if (m_device->Physical().Features().sparseResidencyAliased) {
-        buf_info.flags = VK_BUFFER_CREATE_SPARSE_ALIASED_BIT;
-        CreateBufferTest(*this, &buf_info, "VUID-VkBufferCreateInfo-flags-00918");
+        buffer_create_info.flags = VK_BUFFER_CREATE_SPARSE_ALIASED_BIT;
+        CreateBufferTest(buffer_create_info, "VUID-VkBufferCreateInfo-flags-00918");
     } else {
         GTEST_SKIP() << "Test requires unsupported sparseResidencyAliased feature";
     }
@@ -58,14 +58,14 @@ TEST_F(NegativeSparseImage, BindingImageBufferCreate) {
 
     if (m_device->Physical().Features().sparseResidencyImage2D) {
         image_create_info.flags = VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT;
-        CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-flags-00987");
+        CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-flags-00987");
     } else {
         GTEST_SKIP() << "Test requires unsupported sparseResidencyImage2D feature";
     }
 
     if (m_device->Physical().Features().sparseResidencyAliased) {
         image_create_info.flags = VK_IMAGE_CREATE_SPARSE_ALIASED_BIT;
-        CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-flags-00987");
+        CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-flags-00987");
     } else {
         GTEST_SKIP() << "Test requires unsupported sparseResidencyAliased feature";
     }
@@ -93,17 +93,17 @@ TEST_F(NegativeSparseImage, ResidencyImageCreateUnsupportedTypes) {
     image_create_info.flags = VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT | VK_IMAGE_CREATE_SPARSE_BINDING_BIT;
 
     // 1D image w/ sparse residency is an error
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-imageType-00970");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-imageType-00970");
 
     // 2D image w/ sparse residency when feature isn't available
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.extent.height = 64;
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-imageType-00971");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-imageType-00971");
 
     // 3D image w/ sparse residency when feature isn't available
     image_create_info.imageType = VK_IMAGE_TYPE_3D;
     image_create_info.extent.depth = 8;
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-imageType-00972");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-imageType-00972");
 }
 
 TEST_F(NegativeSparseImage, ResidencyImageCreateUnsupportedSamples) {
@@ -128,21 +128,21 @@ TEST_F(NegativeSparseImage, ResidencyImageCreateUnsupportedSamples) {
     image_create_info.flags = VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT | VK_IMAGE_CREATE_SPARSE_BINDING_BIT;
 
     // 2D image w/ sparse residency and linear tiling is an error
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-tiling-04121");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-tiling-04121");
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
 
     // Multi-sample image w/ sparse residency when feature isn't available (4 flavors)
     image_create_info.samples = VK_SAMPLE_COUNT_2_BIT;
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-imageType-00973");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-imageType-00973");
 
     image_create_info.samples = VK_SAMPLE_COUNT_4_BIT;
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-imageType-00974");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-imageType-00974");
 
     image_create_info.samples = VK_SAMPLE_COUNT_8_BIT;
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-imageType-00975");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-imageType-00975");
 
     image_create_info.samples = VK_SAMPLE_COUNT_16_BIT;
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-imageType-00976");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-imageType-00976");
 }
 
 TEST_F(NegativeSparseImage, ResidencyFlag) {
@@ -206,7 +206,7 @@ TEST_F(NegativeSparseImage, ImageUsageBits) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
     image_create_info.usage = VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-None-01925");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-None-01925");
 }
 
 TEST_F(NegativeSparseImage, MemoryBindOffset) {

--- a/tests/unit/wsi.cpp
+++ b/tests/unit/wsi.cpp
@@ -222,33 +222,33 @@ TEST_F(NegativeWsi, SwapchainImage) {
     // imageType
     image_create_info = good_create_info;
     image_create_info.imageType = VK_IMAGE_TYPE_3D;
-    CreateImageTest(*this, &image_create_info, vuid);
+    CreateImageTest(image_create_info, vuid);
 
     // mipLevels
     image_create_info = good_create_info;
     image_create_info.mipLevels = 2;
-    CreateImageTest(*this, &image_create_info, vuid);
+    CreateImageTest(image_create_info, vuid);
 
     // samples
     image_create_info = good_create_info;
     image_create_info.samples = VK_SAMPLE_COUNT_4_BIT;
-    CreateImageTest(*this, &image_create_info, vuid);
+    CreateImageTest(image_create_info, vuid);
 
     // tiling
     image_create_info = good_create_info;
     image_create_info.tiling = VK_IMAGE_TILING_LINEAR;
-    CreateImageTest(*this, &image_create_info, vuid);
+    CreateImageTest(image_create_info, vuid);
 
     // initialLayout
     image_create_info = good_create_info;
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
-    CreateImageTest(*this, &image_create_info, vuid);
+    CreateImageTest(image_create_info, vuid);
 
     // flags
     if (m_device->Physical().Features().sparseBinding) {
         image_create_info = good_create_info;
         image_create_info.flags = VK_IMAGE_CREATE_SPARSE_BINDING_BIT;
-        CreateImageTest(*this, &image_create_info, vuid);
+        CreateImageTest(image_create_info, vuid);
     }
 }
 

--- a/tests/unit/ycbcr.cpp
+++ b/tests/unit/ycbcr.cpp
@@ -120,11 +120,11 @@ TEST_F(NegativeYcbcr, Sampler) {
     sampler_info.minFilter = VK_FILTER_NEAREST;  // Different than chromaFilter
     sampler_info.magFilter = VK_FILTER_LINEAR;
     sampler_info.pNext = (void *)&sampler_ycbcr_info;
-    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-minFilter-01645");
+    CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-minFilter-01645");
 
     sampler_info.magFilter = VK_FILTER_NEAREST;
     sampler_info.minFilter = VK_FILTER_LINEAR;
-    CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-minFilter-01645");
+    CreateSamplerTest(sampler_info, "VUID-VkSamplerCreateInfo-minFilter-01645");
 }
 
 TEST_F(NegativeYcbcr, Swizzle) {
@@ -272,7 +272,7 @@ TEST_F(NegativeYcbcr, Swizzle) {
     image_view_create_info.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     image_view_create_info.components = identity;
     image_view_create_info.components.r = VK_COMPONENT_SWIZZLE_B;
-    CreateImageViewTest(*this, &image_view_create_info, "VUID-VkImageViewCreateInfo-pNext-01970");
+    CreateImageViewTest(image_view_create_info, "VUID-VkImageViewCreateInfo-pNext-01970");
 }
 
 TEST_F(NegativeYcbcr, Formats) {
@@ -322,17 +322,17 @@ TEST_F(NegativeYcbcr, Formats) {
     if ((image_format_props.sampleCounts & VK_SAMPLE_COUNT_4_BIT) == 0) {
         m_errorMonitor->SetDesiredError("VUID-VkImageCreateInfo-samples-02258");
     }
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-format-06411");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-format-06411");
     image_create_info = reset_create_info;
 
     // invalid width
     image_create_info.extent.width = 31;
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-format-04712");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-format-04712");
     image_create_info = reset_create_info;
 
     // invalid height (since 420 format)
     image_create_info.extent.height = 31;
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-format-04713");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-format-04713");
     image_create_info = reset_create_info;
 
     // invalid imageType
@@ -344,13 +344,13 @@ TEST_F(NegativeYcbcr, Formats) {
         // Can't just set height to 1 as stateless validation will hit 04713 first
         m_errorMonitor->SetUnexpectedError("VUID-VkImageCreateInfo-imageType-00956");
         m_errorMonitor->SetUnexpectedError("VUID-VkImageCreateInfo-extent-02253");
-        CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-format-06412");
+        CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-format-06412");
     }
     image_create_info = reset_create_info;
 
     // Test using a format that doesn't support disjoint
     image_create_info.flags = VK_IMAGE_CREATE_DISJOINT_BIT;
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-imageCreateFormatFeatures-02260");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-imageCreateFormatFeatures-02260");
     image_create_info = reset_create_info;
 }
 
@@ -401,7 +401,7 @@ TEST_F(NegativeYcbcr, FormatsLimits) {
     // if more then 2 the VU since its larger the (depth^2 + 1)
     // if up the depth the VU for IMAGE_TYPE_2D and depth != 1 hits
     image_create_info.mipLevels = 2;
-    CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-format-06410");
+    CreateImageTest(image_create_info, "VUID-VkImageCreateInfo-format-06410");
 }
 
 TEST_F(NegativeYcbcr, ImageViewFormat) {
@@ -1313,7 +1313,7 @@ TEST_F(NegativeYcbcr, MismatchedImageViewAndSamplerFormat) {
     view_info.subresourceRange.levelCount = 1;
     view_info.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 
-    CreateImageViewTest(*this, &view_info, "VUID-VkImageViewCreateInfo-pNext-06658");
+    CreateImageViewTest(view_info, "VUID-VkImageViewCreateInfo-pNext-06658");
 }
 
 TEST_F(NegativeYcbcr, MultiplaneIncompatibleViewFormat3Plane) {
@@ -1356,20 +1356,20 @@ TEST_F(NegativeYcbcr, MultiplaneIncompatibleViewFormat3Plane) {
     ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_PLANE_1_BIT;
 
     // Incompatible format error
-    CreateImageViewTest(*this, &ivci, "VUID-VkImageViewCreateInfo-image-01586");
+    CreateImageViewTest(ivci, "VUID-VkImageViewCreateInfo-image-01586");
 
     // Correct format succeeds
     ivci.format = VK_FORMAT_R8_UNORM;
-    CreateImageViewTest(*this, &ivci);
+    vkt::ImageView image_view(*m_device, ivci);
 
     // R8_SNORM is compatible with R8_UNORM
     ivci.format = VK_FORMAT_R8_SNORM;
-    CreateImageViewTest(*this, &ivci);
+    vkt::ImageView image_view2(*m_device, ivci);
 
     // Try a multiplane imageview
     ivci.format = VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM;
     ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    CreateImageViewTest(*this, &ivci, "VUID-VkImageViewCreateInfo-format-06415");
+    CreateImageViewTest(ivci, "VUID-VkImageViewCreateInfo-format-06415");
 }
 
 TEST_F(NegativeYcbcr, MultiplaneIncompatibleViewFormat2Plane) {
@@ -1417,20 +1417,20 @@ TEST_F(NegativeYcbcr, MultiplaneIncompatibleViewFormat2Plane) {
     // Correct format succeeds
     ivci.format = VK_FORMAT_R8_UNORM;
     ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_PLANE_0_BIT;
-    CreateImageViewTest(*this, &ivci);
+    vkt::ImageView image_view(*m_device, ivci);
 
     ivci.format = VK_FORMAT_R8G8_UNORM;
     ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_PLANE_1_BIT;
-    CreateImageViewTest(*this, &ivci);
+    vkt::ImageView image_view2(*m_device, ivci);
 
     // Incompatible format error
     ivci.format = VK_FORMAT_R8_UNORM;
     ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_PLANE_1_BIT;
-    CreateImageViewTest(*this, &ivci, "VUID-VkImageViewCreateInfo-image-01586");
+    CreateImageViewTest(ivci, "VUID-VkImageViewCreateInfo-image-01586");
 
     ivci.format = VK_FORMAT_R8G8_UNORM;
     ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_PLANE_0_BIT;
-    CreateImageViewTest(*this, &ivci, "VUID-VkImageViewCreateInfo-image-01586");
+    CreateImageViewTest(ivci, "VUID-VkImageViewCreateInfo-image-01586");
 }
 
 TEST_F(NegativeYcbcr, MultiplaneImageViewAspectMasks) {
@@ -1473,7 +1473,7 @@ TEST_F(NegativeYcbcr, MultiplaneImageViewAspectMasks) {
         ivci.format = VK_FORMAT_R8_UNORM;
         ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_PLANE_0_BIT | VK_IMAGE_ASPECT_PLANE_1_BIT;
 
-        CreateImageViewTest(*this, &ivci, "VUID-VkImageViewCreateInfo-subresourceRange-07818");
+        CreateImageViewTest(ivci, "VUID-VkImageViewCreateInfo-subresourceRange-07818");
     }
 
     // Without Mutable format
@@ -1500,7 +1500,7 @@ TEST_F(NegativeYcbcr, MultiplaneImageViewAspectMasks) {
         ivci.format = mp_format;
         ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_PLANE_0_BIT | VK_IMAGE_ASPECT_PLANE_1_BIT;
         ivci.pNext = &ycbcr_info;
-        CreateImageViewTest(*this, &ivci, "VUID-VkImageViewCreateInfo-subresourceRange-07818");
+        CreateImageViewTest(ivci, "VUID-VkImageViewCreateInfo-subresourceRange-07818");
     }
 }
 


### PR DESCRIPTION
Things like `CreateSamplerTest` and `CreateBufferTest` were a little more clunky then needed to

1. Moved to inside `VkLayerTest` (so don't need to pass it in as a first argument)
2. Remove default string being null (Positive tests can just use `vkt::`)
3. Pass by reference