### PR TITLE
layers: Warn if using VK_KHR_maintenance5 flags2

### DIFF
--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -209,6 +209,7 @@ class Context {
                                             bool is_const_param = true) const;
     bool ValidatePnextStructContents(const Location &loc, const VkBaseOutStructure *header, const char *pnext_vuid,
                                      bool is_const_param = true) const;
+    bool ValidatePnextStructExtension(const Location &loc, const VkBaseOutStructure *header) const;
 
     bool ValidateStructPnext(const Location &loc, const void *next, size_t allowed_type_count, const VkStructureType *allowed_types,
                              uint32_t header_version, const char *pnext_vuid, const char *stype_vuid,

--- a/tests/unit/others.cpp
+++ b/tests/unit/others.cpp
@@ -1424,3 +1424,47 @@ TEST_F(VkLayerTest, UnrecognizedEnumExtension) {
     vkt::Image image(*m_device, 4, 4, 1, VK_FORMAT_A4B4G4R4_UNORM_PACK16, VK_IMAGE_USAGE_SAMPLED_BIT);
     m_errorMonitor->VerifyFound();
 }
+
+TEST_F(VkLayerTest, MissingExtensionBufferUsageFlags2CreateInfo) {
+    TEST_DESCRIPTION("Use VkBufferUsageFlags2CreateInfo without the extension");
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    RETURN_IF_SKIP(Init());
+
+    // added in VK_KHR_maintenance5
+    VkBufferUsageFlags2CreateInfo buffer_usage_flags = vku::InitStructHelper();
+    buffer_usage_flags.usage = VK_BUFFER_USAGE_2_UNIFORM_TEXEL_BUFFER_BIT;
+
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper(&buffer_usage_flags);
+    buffer_ci.usage = VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT;
+    buffer_ci.size = 64;
+    {
+        m_errorMonitor->SetDesiredWarning("WARNING-VkBufferUsageFlags2CreateInfo-Extension");
+        vkt::Buffer buffer(*m_device, buffer_ci, vkt::no_mem);
+        m_errorMonitor->VerifyFound();
+    }
+
+    buffer_ci.pNext = nullptr;
+    vkt::Buffer good_buffer(*m_device, buffer_ci, vkt::no_mem);
+    VkBufferViewCreateInfo buffer_view_ci = vku::InitStructHelper(&buffer_usage_flags);
+    buffer_view_ci.format = VK_FORMAT_R8G8B8A8_UNORM;
+    buffer_view_ci.range = VK_WHOLE_SIZE;
+    buffer_view_ci.buffer = good_buffer;
+    m_errorMonitor->SetDesiredWarning("WARNING-VkBufferUsageFlags2CreateInfo-Extension");
+    vkt::BufferView view(*m_device, buffer_view_ci);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(VkLayerTest, MissingExtensionPipelineCreateFlags2) {
+    TEST_DESCRIPTION("Use VkPipelineCreateFlags2 without the extension");
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    RETURN_IF_SKIP(Init());
+
+    // added in VK_KHR_maintenance5
+    VkPipelineCreateFlags2CreateInfo flags2 = vku::InitStructHelper();
+    flags2.flags = VK_PIPELINE_CREATE_2_DISABLE_OPTIMIZATION_BIT;
+
+    CreateComputePipelineHelper pipe(*this, &flags2);
+    m_errorMonitor->SetDesiredWarning("WARNING-VkPipelineCreateFlags2CreateInfo-Extension");
+    pipe.CreateComputePipeline();
+    m_errorMonitor->VerifyFound();
+}


### PR DESCRIPTION
Follow up of https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/9578 

After looking, honestly just the VK_KHR_maintenance5 structs I feel are worth giving a warning about. Things like `VkAccessFlags2` you need to use the Sync2 structs. `VK_KHR_format_feature_flags2` is a special case as you don't enable it, we check if it is supported or not

Basically here is a valid spot to give a warning IMO, everything else I think is better that we got rid of

cc @jeremyg-lunarg @aqnuep 