### PR TITLE
layers: Refresh of messages for callbacks

### DIFF
--- a/docs/error_messages.md
+++ b/docs/error_messages.md
@@ -2,63 +2,54 @@
 
 > Note: This is written for the 1.4.309 SDK and afterwards, the older versions of the Validation Layers will be slightly different
 
-When an error message is found, the Validation Layers use the "debug callback" mechanism to report the error message.
+When an error message is found, the Validation Layers use the "debug callback" mechanism (`PFN_vkDebugUtilsMessengerCallbackEXT`) to report the error message.
 
-By default, the Validation Layers will format the message, but it is possible for the user to provide their own `PFN_vkDebugUtilsMessengerCallbackEXT` and parse the string in `VkDebugUtilsMessengerCallbackDataEXT::pMessage` ([working example using vk-bootstrap](https://github.com/charles-lunarg/vk-bootstrap/blob/main/example/custom_debug_callback.cpp#L9-L20)).
+There are 2 options
+
+1. Use the default callback (provided by the validation layers)
+2. Use a custom callback (more details below)
+
+By default, the Validation Layers will format the message for you, but it is possible for the user to provide their own `PFN_vkDebugUtilsMessengerCallbackEXT` and parse the data from `VkDebugUtilsMessengerCallbackDataEXT` in a way they prefer.
 
 The default error message will look like:
 
-> Validation Error: [ VUID-vkCmdSetScissor-x-00595 ] Objects: VkCommandBuffer 0x639cdf870510[command_buffer_name] | MessageID = 0xa54a6ff8
+> Validation Error: [ VUID-vkCmdSetScissor-firstScissor-00593 ] | MessageID = 0x603fac6b
 >
-> vkCmdSetScissor(): pScissors[0].offset.x (-1) is negative.
+> vkCmdSetScissor(): firstScissor is 1 but the multiViewport feature was not enabled.
 >
-> The Vulkan spec states: The x and y members of offset member of any element of pScissors must be greater than or equal to 0 (https://docs.vulkan.org/spec/latest/chapters/fragops.html#VUID-vkCmdSetScissor-x-00595)
+> The Vulkan spec states: If the multiViewport feature is not enabled, firstScissor must be 0 (https://docs.vulkan.org/spec/latest/chapters/fragops.html#VUID-vkCmdSetScissor-firstScissor-00593)
+>
+>     Objects: 1
+>         [0] VkCommandBuffer 0x5c11921d2d10
+>
+> (new line)
+
 
 Here we see a few things, listed in the order they appear
 
 1. The message severity
     - (error, warning, etc)
 2. The [VUID](https://github.com/KhronosGroup/Vulkan-Guide/blob/main/chapters/validation_overview.adoc#valid-usage-id-vuid)
-3. List of Objects
-    - Contain handle type, hex value, and optional debug util name
-4. Message ID
+3. Message ID
     - This is just a hash of the VUID used internally to detect if the message duplication rate was hit
-5. Which function the error occured at
-6. The faulty parameter / struct member
+4. Which function the error occured at
+5. The faulty parameter / struct member
     - Helps if there is an array to know which index it is in
-7. The "main message"
+6. The "main message"
     - This is normally hand written by the Validation Layer developer
-8. The Vulkan spec langague for this VUID
-9. Link to the VUID
+7. The Vulkan spec langague for this VUID
+8. Link to the VUID
+9. List of Objects
+    - Contain handle type, hex value, and optional debug util name
+10. There is a new line under to allow for easy seperation of multiple error messages
 
-# Message Formatting Options
+# JSON Error Format
 
-There are a few ways to adjust the message format.
+For those who want something more machine readable, or don't want to deal with regex parsing, there is an option to output the error in JSON.
 
-## Verbose
+The string returned in `VkDebugUtilsMessengerCallbackDataEXT::pMessage` will be a valid JSON object.
 
-By default, the error messages are verbose, but if you turn off the setting the new error messages will look like
-
-> [ VUID-vkCmdSetScissor-x-00595 ] vkCmdSetScissor(): pScissors[0].offset.x (-1) is negative.
->
-> The Vulkan spec states: The x and y members of offset member of any element of pScissors must be greater than or equal to 0
-
-To try it out, use `vkconfig` or turn off verbose with
-
-```bash
-# Windows
-set VK_LAYER_MESSAGE_FORMAT_VERBOSE=0
-
-# Linux
-export VK_LAYER_MESSAGE_FORMAT_VERBOSE=0
-
-# Android
-adb setprop debug.vulkan.khronos_validation.message_format_verbose=0
-```
-
-## JSON
-
-There is a way to print the error message as JSON to be machine readable, here we document the schema used:
+The JSON schema:
 
 > All fields are always printed, an empty string will be given if no value is provided
 
@@ -112,4 +103,78 @@ export VK_LAYER_MESSAGE_FORMAT_JSON=1
 
 # Android
 adb setprop debug.vulkan.khronos_validation.message_format_json=1
+```
+
+# Custom Callback
+
+For those who want to handle the callback to format the message the way they want, here is how the `VkDebugUtilsMessengerCallbackDataEXT` is laid out
+
+```c++
+// VkDebugUtilsMessengerCallbackDataEXT
+const char*                           pMessageIdName;  // VUID
+int32_t                               messageIdNumber; // Hash of the VUID
+const char*                           pMessage;        // The "main message" (includes the spec text on seperate line)
+
+// Debug Objects that Validaiton will print for you in a default callback
+uint32_t                              queueLabelCount;
+const VkDebugUtilsLabelEXT*           pQueueLabels;
+uint32_t                              cmdBufLabelCount;
+const VkDebugUtilsLabelEXT*           pCmdBufLabels;
+uint32_t                              objectCount;
+const VkDebugUtilsObjectNameInfoEXT*  pObjects;
+```
+
+The following is an example of how one could do their custom callback
+
+```c++
+VkBool32 DebugCallback(VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,
+                       VkDebugUtilsMessageTypeFlagsEXT,
+                       const VkDebugUtilsMessengerCallbackDataEXT *callback_data) {
+    // Only report Errors and Warnings
+    bool is_error = messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+    bool is_warning = messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT;
+    if (is_error || is_warning) {
+        std::cout << "Validation " << (is_error ? "Error:" : "Warning:");
+        std::cout << " [ " << pCallbackData->pMessageIdName << " ]\n";
+        std::cout << pCallbackData->pMessage;
+
+        for (uint32_t i = 0; i < pCallbackData->objectCount; i++) {
+            std::cout << '\n';
+            if (pCallbackData->pObjects[i].objectHandle) {
+                std::cout << "    Object Handle [" << i << "] = " << " 0x" << std::hex << pCallbackData->pObjects[i].objectHandle;
+            }
+            if (pCallbackData->pObjects[i].pObjectName) {
+                std::cout << "[" << pCallbackData->pObjects[i].pObjectName << "]";
+            }
+        }
+    }
+    std::cout << '\n';
+
+    // Return false to move on and still call the function to the driver
+    return VK_FALSE;
+    // Return true to have validation skip passing down the call to the driver
+    return VK_TRUE;
+};
+```
+
+# Logging to a file
+
+By default the validation layers will try to print the error message out to `OutputDebugString` on Windows, `logcat` on Android, and `stdout` for Linux/MacOS.
+
+You have the option to have the files write out to a file as well.
+
+To try it out, use `vkconfig` or set with
+
+```bash
+# Windows
+set VK_LAYER_DEBUG_ACTION=VK_DBG_LAYER_ACTION_LOG_MSG
+set VK_LAYER_LOG_FILENAME=C:\vvl_errors.txt
+
+# Linux
+export VK_LAYER_DEBUG_ACTION=VK_DBG_LAYER_ACTION_LOG_MSG
+export VK_LAYER_LOG_FILENAME=/tmp/vvl_errors.txt
+
+# Android
+adb setprop debug.vulkan.khronos_validation.debug_action=VK_DBG_LAYER_ACTION_LOG_MSG
+adb setprop debug.vulkan.khronos_validation.log_filename=/data/local/tmp/vvl_errors.txt
 ```

--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -1155,14 +1155,6 @@
                     "expanded": true,
                     "settings": [
                         {
-                            "key": "message_format_verbose",
-                            "label": "Verbose",
-                            "description": "Display Validation Type, Object Handles, Message ID, Spec Link. (Ignored if using JSON)",
-                            "type": "BOOL",
-                            "default": true,
-                            "platforms": [ "WINDOWS", "LINUX", "MACOS", "ANDROID" ]
-                        },
-                        {
                             "key": "message_format_json",
                             "label": "JSON",
                             "description": "Display Validation as JSON (VkDebugUtilsMessengerCallbackDataEXT::pMessage will contain JSON)",

--- a/layers/error_message/logging.h
+++ b/layers/error_message/logging.h
@@ -175,7 +175,6 @@ struct Location;
 
 struct MessageFormatSettings {
     bool json = false;
-    bool verbose = true;  // ignored if JSON is used
     bool display_application_name = false;
     std::string application_name;
 };
@@ -245,9 +244,7 @@ class DebugReport {
     bool UpdateLogMsgCounts(int32_t vuid_hash) const;
     bool LogMsgEnabled(uint32_t vuid_hash, VkDebugUtilsMessageSeverityFlagsEXT msg_severity,
                        VkDebugUtilsMessageTypeFlagsEXT msg_type);
-    std::string CreateMessageText(VkFlags msg_flags, const Location &loc,
-                                  const std::vector<VkDebugUtilsObjectNameInfoEXT> &object_name_infos, const uint32_t vuid_hash,
-                                  std::string_view vuid_text, const std::string &main_message);
+    std::string CreateMessageText(const Location &loc, std::string_view vuid_text, const std::string &main_message);
     std::string CreateMessageJson(VkFlags msg_flags, const Location &loc,
                                   const std::vector<VkDebugUtilsObjectNameInfoEXT> &object_name_infos, const uint32_t vuid_hash,
                                   std::string_view vuid_text, const std::string &main_message);

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -226,7 +226,6 @@ const char *VK_LAYER_SYNCVAL_MESSAGE_EXTRA_PROPERTIES_PRETTY_PRINT = "syncval_me
 
 // Message Formatting
 // ---
-const char *VK_LAYER_MESSAGE_FORMAT_VERBOSE = "message_format_verbose";
 const char *VK_LAYER_MESSAGE_FORMAT_JSON = "message_format_json";
 const char *VK_LAYER_MESSAGE_FORMAT_DISPLAY_APPLICATION_NAME = "message_format_display_application_name";
 // Until post 1.3.290 SDK release, these were not possible to set via environment variables
@@ -631,8 +630,6 @@ static void ValidateLayerSettingsProvided(const VkLayerSettingsCreateInfoEXT *la
             required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
         } else if (strcmp(VK_LAYER_SYNCVAL_MESSAGE_EXTRA_PROPERTIES_PRETTY_PRINT, setting.pSettingName) == 0) {
             required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
-        } else if (strcmp(VK_LAYER_MESSAGE_FORMAT_VERBOSE, setting.pSettingName) == 0) {
-            required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
         } else if (strcmp(VK_LAYER_MESSAGE_FORMAT_JSON, setting.pSettingName) == 0) {
             required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
         } else if (strcmp(VK_LAYER_MESSAGE_FORMAT_DISPLAY_APPLICATION_NAME, setting.pSettingName) == 0) {
@@ -769,10 +766,6 @@ static void ProcessDebugReportSettings(ConfigAndEnvSettings *settings_data, VkuL
         duplicate_message_limit = 0;
     }
     debug_report->duplicate_message_limit = duplicate_message_limit;
-
-    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_MESSAGE_FORMAT_VERBOSE)) {
-        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_MESSAGE_FORMAT_VERBOSE, debug_report->message_format_settings.verbose);
-    }
 
     if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_MESSAGE_FORMAT_JSON)) {
         vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_MESSAGE_FORMAT_JSON, debug_report->message_format_settings.json);

--- a/layers/object_tracker/object_tracker_utils.cpp
+++ b/layers/object_tracker/object_tracker_utils.cpp
@@ -399,8 +399,8 @@ bool Instance::ReportLeakedObjects(VulkanObjectType object_type, const std::stri
     for (const auto &item : snapshot) {
         const auto object_info = item.second;
         const LogObjectList objlist(instance, ObjTrackStateTypedHandle(*object_info));
-        skip |= LogError(error_code, objlist, loc, "OBJ ERROR : For %s, %s has not been destroyed.", FormatHandle(instance).c_str(),
-                         FormatHandle(ObjTrackStateTypedHandle(*object_info)).c_str());
+        skip |= LogError(error_code, objlist, loc, "Object Tracking - For %s, %s has not been destroyed.",
+                         FormatHandle(instance).c_str(), FormatHandle(ObjTrackStateTypedHandle(*object_info)).c_str());
     }
     return skip;
 }
@@ -413,8 +413,8 @@ bool Device::ReportLeakedObjects(VulkanObjectType object_type, const std::string
     for (const auto &item : snapshot) {
         const auto object_info = item.second;
         const LogObjectList objlist(device, ObjTrackStateTypedHandle(*object_info));
-        skip |= LogError(error_code, objlist, loc, "OBJ ERROR : For %s, %s has not been destroyed.", FormatHandle(device).c_str(),
-                         FormatHandle(ObjTrackStateTypedHandle(*object_info)).c_str());
+        skip |= LogError(error_code, objlist, loc, "Object Tracking - For %s, %s has not been destroyed.",
+                         FormatHandle(device).c_str(), FormatHandle(ObjTrackStateTypedHandle(*object_info)).c_str());
     }
     return skip;
 }

--- a/layers/vk_layer_settings.txt
+++ b/layers/vk_layer_settings.txt
@@ -154,11 +154,6 @@ khronos_validation.enables =
 # performance in multithreaded applications.
 khronos_validation.fine_grained_locking = true
 
-# Verbose error messages
-# =====================
-# Display Validation Type, Object Handles, Message ID, Spec Link
-#khronos_validation.message_format_verbose = true
-
 # Display as JSON
 # =====================
 # Display Validation as JSON

--- a/tests/framework/error_monitor.h
+++ b/tests/framework/error_monitor.h
@@ -112,13 +112,8 @@ class ErrorMonitor {
     void MonitorReset();
     std::unique_lock<std::mutex> Lock() const { return std::unique_lock<std::mutex>(mutex_); }
 
-#if !defined(VK_USE_PLATFORM_ANDROID_KHR)
     VkDebugUtilsMessengerEXT debug_obj_ = VK_NULL_HANDLE;
     VkDebugUtilsMessengerCreateInfoEXT debug_create_info_{};
-#else
-    VkDebugReportCallbackEXT debug_obj_ = VK_NULL_HANDLE;
-    VkDebugReportCallbackCreateInfoEXT debug_create_info_{};
-#endif
 
     VkFlags message_flags_{};
     std::vector<std::string> failure_message_strings_;

--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -303,12 +303,7 @@ void VkLayerTest::Init(VkPhysicalDeviceFeatures *features, VkPhysicalDeviceFeatu
 }
 
 VkLayerTest::VkLayerTest() {
-#if !defined(VK_USE_PLATFORM_ANDROID_KHR)
     m_instance_extension_names.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
-#else
-    m_instance_extension_names.push_back(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
-#endif
-
     instance_layers_.push_back(kValidationLayerName);
 
     if (InstanceLayerSupported("VK_LAYER_LUNARG_device_profile_api")) {

--- a/tests/unit/debug_extensions.cpp
+++ b/tests/unit/debug_extensions.cpp
@@ -610,8 +610,7 @@ TEST_F(NegativeDebugExtensions, MultiObjectBindImage) {
 
     // Introduce validation failure, try to bind a different memory object to
     // the same image object
-    m_errorMonitor->SetDesiredErrorRegex("VUID-vkBindImageMemory-image-07460",
-                                         "Objects: VkDeviceMemory 0x[a-f0-9]+, VkImage 0x[a-f0-9]+, VkDeviceMemory 0x[a-f0-9]+");
+    m_errorMonitor->SetDesiredErrorRegex("VUID-vkBindImageMemory-image-07460", "Objects: 3");
     vk::BindImageMemory(device(), image, mem2, 0);
     m_errorMonitor->VerifyFound();
 }

--- a/tests/unit/layer_settings.cpp
+++ b/tests/unit/layer_settings.cpp
@@ -488,22 +488,3 @@ TEST_F(NegativeLayerSettings, DuplicateSettings) {
     RETURN_IF_SKIP(InitState());
     Monitor().VerifyFound();
 }
-
-TEST_F(NegativeLayerSettings, MessageFormatVerbose) {
-    VkBool32 disable = VK_FALSE;
-    const VkLayerSettingEXT setting[] = {
-        {OBJECT_LAYER_NAME, "message_format_verbose", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable}};
-    VkLayerSettingsCreateInfoEXT layer_setting_create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1,
-                                                              setting};
-    RETURN_IF_SKIP(InitFramework(&layer_setting_create_info));
-    RETURN_IF_SKIP(InitState());
-
-    VkBufferCreateInfo info = vku::InitStructHelper();
-    info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
-    info.size = 0;
-    m_errorMonitor->SetDesiredError(
-        "[ VUID-VkBufferCreateInfo-size-00912 ] vkCreateBuffer(): pCreateInfo->size is zero.\nThe Vulkan spec states: size must be "
-        "greater than 0");
-    vkt::Buffer buffer(*m_device, info, vkt::no_mem);
-    m_errorMonitor->VerifyFound();
-}

--- a/tests/unit/layer_settings_positive.cpp
+++ b/tests/unit/layer_settings_positive.cpp
@@ -77,7 +77,6 @@ TEST_F(PositiveLayerSettings, AllSettings) {
         {OBJECT_LAYER_NAME, "syncval_message_extra_properties", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable},
         {OBJECT_LAYER_NAME, "syncval_message_extra_properties_pretty_print", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable},
         {OBJECT_LAYER_NAME, "message_format_display_application_name", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable},
-        {OBJECT_LAYER_NAME, "message_format_verbose", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable},
         {OBJECT_LAYER_NAME, "message_format_json", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable},
         {OBJECT_LAYER_NAME, "debug_action", VK_LAYER_SETTING_TYPE_STRING_EXT, 1, &action_ignore},
         {OBJECT_LAYER_NAME, "report_flags", VK_LAYER_SETTING_TYPE_STRING_EXT, 1, &warning},


### PR DESCRIPTION
tl;dr - This **finally** makes messages look nice by default

```
Validation Error: [ VUID-vkCmdCopyImage-srcImage-01548 ] | MessageID = 0x1c1c4e09
vkCmdCopyImage(): srcImage format (VK_FORMAT_R8G8B8A8_UNORM) is not size-compatible with dstImage format (VK_FORMAT_D32_SFLOAT). VK_FORMAT_R8G8B8A8_UNORM is a color and VK_FORMAT_D32_SFLOAT is depth/stencil (this is only allowed with a certain set of formats during image copy with VK_KHR_maintenance8).
The Vulkan spec states: If the VkFormat of each of srcImage and dstImage is not a multi-planar format, the VkFormat of each of srcImage and dstImage must be size-compatible (https://docs.vulkan.org/spec/latest/chapters/copies.html#VUID-vkCmdCopyImage-srcImage-01548)
    Objects: 3
        [0] VkCommandBuffer 0x607a385f8e50[myCommandBuffer]
        [1] VkImage 0xf56c9b0000000004[image_a]
        [2] VkImage 0xf443490000000006
```

Long - We have been forever (mainly due to VK_EXT_debug_report legacy it seems) been overloading the `VkDebugUtilsMessengerCallbackDataEXT::pMessage` with information that can be found elsewhere in `VkDebugUtilsMessengerCallbackDataEXT` leading to duplication and a LOT of noise in the error message

Now the `pMessage` only contains the "main" error message with the spec text. The VUID, error vs warning, object list, etc is now done for you in the default callback