### PR TITLE
layers: Extract stateless device data initialization

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -205,9 +205,7 @@ class CoreChecks : public vvl::Device {
 
     CoreChecks(vvl::dispatch::Device* dev, core::Instance* instance_vo)
         : BaseClass(dev, instance_vo, LayerObjectTypeCoreValidation),
-          stateless_spirv_validator(dev->debug_report, api_version, extensions, phys_dev_props, phys_dev_props_core11,
-                                    phys_dev_props_core12, phys_dev_props_core13, phys_dev_props_core14, phys_dev_ext_props,
-                                    enabled_features, has_format_feature2) {}
+          stateless_spirv_validator(dev->debug_report, dev->stateless_device_data) {}
 
     ReadLockGuard ReadLock() const override;
     WriteLockGuard WriteLock() override;

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -725,44 +725,6 @@ void Device::FinishDeviceSetup(const VkDeviceCreateInfo *pCreateInfo, const Loca
         physical_device_count = 1;
     }
 
-    {
-        uint32_t n_props = 0;
-        std::vector<VkExtensionProperties> props;
-        DispatchEnumerateDeviceExtensionProperties(physical_device, NULL, &n_props, NULL);
-        props.resize(n_props);
-        DispatchEnumerateDeviceExtensionProperties(physical_device, NULL, &n_props, props.data());
-
-        unordered_set<Extension> phys_dev_extensions;
-        for (const auto &ext_prop : props) {
-            phys_dev_extensions.insert(GetExtension(ext_prop.extensionName));
-        }
-
-        // Even if VK_KHR_format_feature_flags2 is available, we need to have
-        // a path to grab that information from the physical device. This
-        // requires to have VK_KHR_get_physical_device_properties2 enabled or
-        // Vulkan 1.1 (which made this core).
-        has_format_feature2 =
-            (api_version >= VK_API_VERSION_1_1 || IsExtEnabled(extensions.vk_khr_get_physical_device_properties2)) &&
-            phys_dev_extensions.find(Extension::_VK_KHR_format_feature_flags2) != phys_dev_extensions.end();
-
-        // feature is required if 1.3 or extension is supported
-        has_robust_image_access =
-            (api_version >= VK_API_VERSION_1_3 || IsExtEnabled(extensions.vk_khr_get_physical_device_properties2)) &&
-            phys_dev_extensions.find(Extension::_VK_EXT_image_robustness) != phys_dev_extensions.end();
-
-        if (IsExtEnabled(extensions.vk_khr_get_physical_device_properties2) &&
-            phys_dev_extensions.find(Extension::_VK_EXT_robustness2) != phys_dev_extensions.end()) {
-            VkPhysicalDeviceRobustness2FeaturesEXT robustness_2_features = vku::InitStructHelper();
-            VkPhysicalDeviceFeatures2 features2 = vku::InitStructHelper(&robustness_2_features);
-            DispatchGetPhysicalDeviceFeatures2Helper(api_version, physical_device, &features2);
-            has_robust_image_access2 = robustness_2_features.robustImageAccess2;
-            has_robust_buffer_access2 = robustness_2_features.robustBufferAccess2;
-        } else {
-            has_robust_image_access2 = false;
-            has_robust_buffer_access2 = false;
-        }
-    }
-
     // Store queue family data
     if (pCreateInfo->pQueueCreateInfos != nullptr) {
         uint32_t num_queue_families = 0;

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -472,7 +472,12 @@ class Device : public vvl::base::Device {
 
   public:
     Device(vvl::dispatch::Device* dev, Instance* instance, LayerObjectTypeId type)
-        : BaseClass(dev, instance, type), instance_state(instance) {
+        : BaseClass(dev, instance, type),
+          instance_state(instance),
+          has_format_feature2(dev->stateless_device_data.has_format_feature2),
+          has_robust_image_access(dev->stateless_device_data.has_robust_image_access),
+          has_robust_image_access2(dev->stateless_device_data.has_robust_image_access2),
+          has_robust_buffer_access2(dev->stateless_device_data.has_robust_buffer_access2) {
         physical_device_state = instance_state->Get<vvl::PhysicalDevice>(physical_device).get();
     }
     ~Device();
@@ -1872,15 +1877,15 @@ class Device : public vvl::base::Device {
 
     // Some extensions/features changes the behavior of the app/layers/spec if present.
     // So it needs its own special boolean unlike the enabled_fatures.
-    bool has_format_feature2;  // VK_KHR_format_feature_flags2
+    const bool has_format_feature2;  // VK_KHR_format_feature_flags2
     // VK_EXT_pipeline_robustness was designed to be a subset of robustness extensions
     // Enabling the other robustness features can reduce performance on GPU, so just the
     // support is needed to check
-    bool has_robust_image_access;  // VK_EXT_image_robustness
+    const bool has_robust_image_access;  // VK_EXT_image_robustness
     // Validation requires special handling for VkPhysicalDeviceRobustness2FeaturesEXT, because for some cases robustness features
     // // need to only be supported, not enabled
-    bool has_robust_image_access2;   // VK_EXT_robustness2
-    bool has_robust_buffer_access2;  // VK_EXT_robustness2
+    const bool has_robust_image_access2;   // VK_EXT_robustness2
+    const bool has_robust_buffer_access2;  // VK_EXT_robustness2
 
     std::vector<VkCooperativeMatrixPropertiesNV> cooperative_matrix_properties_nv;
     std::vector<VkCooperativeMatrixPropertiesKHR> cooperative_matrix_properties_khr;

--- a/layers/stateless/sl_spirv.h
+++ b/layers/stateless/sl_spirv.h
@@ -33,25 +33,18 @@ namespace stateless {
 
 class SpirvValidator : public Logger {
   public:
-    SpirvValidator(DebugReport* debug_report, const APIVersion& api_version_ref, const DeviceExtensions& extensions_ref,
-                   const VkPhysicalDeviceProperties& phys_dev_props_ref,
-                   const VkPhysicalDeviceVulkan11Properties& phys_dev_props_core11_ref,
-                   const VkPhysicalDeviceVulkan12Properties& phys_dev_props_core12_ref,
-                   const VkPhysicalDeviceVulkan13Properties& phys_dev_props_core13_ref,
-                   const VkPhysicalDeviceVulkan14Properties& phys_dev_props_core14_ref,
-                   const vvl::DeviceExtensionProperties& phys_dev_ext_props_ref, const DeviceFeatures& enabled_features_ref,
-                   const bool& has_format_feature2_ref)
+    SpirvValidator(DebugReport* debug_report, const vvl::StatelessDeviceData& stateless_device_data)
         : Logger(debug_report),
-          api_version(api_version_ref),
-          extensions(extensions_ref),
-          phys_dev_props(phys_dev_props_ref),
-          phys_dev_props_core11(phys_dev_props_core11_ref),
-          phys_dev_props_core12(phys_dev_props_core12_ref),
-          phys_dev_props_core13(phys_dev_props_core13_ref),
-          phys_dev_props_core14(phys_dev_props_core14_ref),
-          phys_dev_ext_props(phys_dev_ext_props_ref),
-          enabled_features(enabled_features_ref),
-          has_format_feature2(has_format_feature2_ref) {}
+          api_version(stateless_device_data.api_version),
+          extensions(stateless_device_data.extensions),
+          phys_dev_props(stateless_device_data.phys_dev_props),
+          phys_dev_props_core11(stateless_device_data.phys_dev_props_core11),
+          phys_dev_props_core12(stateless_device_data.phys_dev_props_core12),
+          phys_dev_props_core13(stateless_device_data.phys_dev_props_core13),
+          phys_dev_props_core14(stateless_device_data.phys_dev_props_core14),
+          phys_dev_ext_props(stateless_device_data.phys_dev_ext_props),
+          enabled_features(stateless_device_data.enabled_features),
+          has_format_feature2(stateless_device_data.has_format_feature2) {}
 
     bool Validate(const spirv::Module& module_state, const spirv::StatelessData& stateless_data, const Location& loc) const;
 
@@ -64,7 +57,7 @@ class SpirvValidator : public Logger {
     const VkPhysicalDeviceVulkan14Properties& phys_dev_props_core14;
     const vvl::DeviceExtensionProperties& phys_dev_ext_props;
     const DeviceFeatures& enabled_features;
-    const bool& has_format_feature2;
+    const bool has_format_feature2;
 
   private:
     bool ValidateShaderClock(const spirv::Module& module_state, const spirv::StatelessData& stateless_data,


### PR DESCRIPTION
Here's the promised follow-up refactoring extracting the stateless device data into its own atomically initialized class.

Unfortunately, I had to keep `extensions` and `enabled_features` mutable, because there's some patching done in the chassis of `CreateDevice`.