### PR TITLE
gpuav: Skip State Tracking Image Layout when off

### DIFF
--- a/layers/drawdispatch/descriptor_validator.cpp
+++ b/layers/drawdispatch/descriptor_validator.cpp
@@ -202,16 +202,20 @@ bool DescriptorValidator::ValidateBindingDynamic(const spirv::ResourceInterfaceV
             skip |= ValidateDescriptorsDynamic(resource_variable, static_cast<const BufferBinding &>(binding), index);
             break;
         case DescriptorClass::ImageSampler: {
-            auto &imgs_binding = static_cast<ImageSamplerBinding &>(binding);
-            auto &descriptor = imgs_binding.descriptors[index];
-            descriptor.UpdateDrawState(cb_state);
-            skip |= ValidateDescriptorsDynamic(resource_variable, imgs_binding, index);
+            auto &img_sampler_binding = static_cast<ImageSamplerBinding &>(binding);
+            if (dev_state.gpuav_settings.validate_image_layout) {
+                auto &descriptor = img_sampler_binding.descriptors[index];
+                descriptor.UpdateImageLayoutDrawState(cb_state);
+            }
+            skip |= ValidateDescriptorsDynamic(resource_variable, img_sampler_binding, index);
             break;
         }
         case DescriptorClass::Image: {
             auto &img_binding = static_cast<ImageBinding &>(binding);
-            auto &descriptor = img_binding.descriptors[index];
-            descriptor.UpdateDrawState(cb_state);
+            if (dev_state.gpuav_settings.validate_image_layout) {
+                auto &descriptor = img_binding.descriptors[index];
+                descriptor.UpdateImageLayoutDrawState(cb_state);
+            }
             skip |= ValidateDescriptorsDynamic(resource_variable, img_binding, index);
             break;
         }

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1266,7 +1266,7 @@ void CommandBuffer::UpdatePipelineState(Func command, const VkPipelineBindPoint 
                 }
 
                 // Bind this set and its active descriptor resources to the command buffer
-                descriptor_set->UpdateDrawStates(&dev_data, *this, binding_req_map);
+                descriptor_set->UpdateImageLayoutDrawStates(&dev_data, *this, binding_req_map);
 
                 ds_slot.validated_set = descriptor_set.get();
                 ds_slot.validated_set_change_count = descriptor_set->GetChangeCount();

--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -415,7 +415,7 @@ class Descriptor {
     virtual bool AddParent(StateObject *state_object) { return false; }
     virtual void RemoveParent(StateObject *state_object) {}
 
-    virtual void UpdateDrawState(vvl::CommandBuffer &cb_state) {}
+    virtual void UpdateImageLayoutDrawState(vvl::CommandBuffer &cb_state) {}
 
     // return true if resources used by this descriptor are destroyed or otherwise missing
     virtual bool Invalid() const { return false; }
@@ -468,7 +468,7 @@ class ImageDescriptor : public Descriptor {
                      bool is_bindless) override;
     void CopyUpdate(DescriptorSet &set_state, const Device &dev_data, const Descriptor &, bool is_bindless,
                     VkDescriptorType type) override;
-    void UpdateDrawState(vvl::CommandBuffer &cb_state) override;
+    void UpdateImageLayoutDrawState(vvl::CommandBuffer &cb_state) override;
     VkImageView GetImageView() const;
     const vvl::ImageView *GetImageViewState() const { return image_view_state_.get(); }
     vvl::ImageView *GetImageViewState() { return image_view_state_.get(); }
@@ -632,7 +632,7 @@ class MutableDescriptor : public Descriptor {
         return acc_khr != VK_NULL_HANDLE;
     }
 
-    void UpdateDrawState(vvl::CommandBuffer &cb_state) override;
+    void UpdateImageLayoutDrawState(vvl::CommandBuffer &cb_state) override;
 
     bool AddParent(StateObject *state_object) override;
     void RemoveParent(StateObject *state_object) override;
@@ -841,7 +841,7 @@ class DescriptorSet : public StateObject {
     VkDescriptorSet VkHandle() const { return handle_.Cast<VkDescriptorSet>(); };
     // Bind given cmd_buffer to this descriptor set and
     // update CB image layout map with image/imagesampler descriptor image layouts
-    void UpdateDrawStates(Device *, vvl::CommandBuffer &cb_state, const BindingVariableMap &);
+    void UpdateImageLayoutDrawStates(Device *, vvl::CommandBuffer &cb_state, const BindingVariableMap &);
 
     // For a particular binding, get the global index
     const IndexRange GetGlobalIndexRangeFromBinding(const uint32_t binding, bool actual_length = false) const {

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -688,7 +688,7 @@ struct LastBound {
         std::vector<uint32_t> dynamic_offsets;
         PipelineLayoutCompatId compat_id_for_set{0};
 
-        // Cache most recently validated descriptor state for ValidateActionState/UpdateDrawState
+        // Cache most recently validated descriptor state for ValidateActionState/UpdateImageLayoutDrawState
         const vvl::DescriptorSet *validated_set{nullptr};
         uint64_t validated_set_change_count{~0ULL};
         uint64_t validated_set_image_layout_change_count{~0ULL};


### PR DESCRIPTION
@arno-lunarg showed we were spending a lot of time in `UpdateDrawState` in GPU-AV even when Image Layout validation is off

1. Check if setting is off and skip work
2. Rename function to be clear this is only updating Image Layout state