### PR TITLE
sync: Fix getting SyncAccessFlags from VkAccessFlags2

### DIFF
--- a/layers/sync/sync_utils.cpp
+++ b/layers/sync/sync_utils.cpp
@@ -62,6 +62,9 @@ VkPipelineStageFlags2 DisabledPipelineStages(const DeviceFeatures &features, con
     if (!features.rayTracingMaintenance1) {
         result |= VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR;
     }
+    if (!features.micromap) {
+        result |= VK_PIPELINE_STAGE_2_MICROMAP_BUILD_BIT_EXT;
+    }
     return result;
 }
 

--- a/tests/unit/sync_object_positive.cpp
+++ b/tests/unit/sync_object_positive.cpp
@@ -1785,6 +1785,7 @@ TEST_F(PositiveSyncObject, BarrierAccessSyncMicroMap) {
     AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_OPACITY_MICROMAP_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::synchronization2);
+    AddRequiredFeature(vkt::Feature::micromap);
     RETURN_IF_SKIP(Init());
 
     VkMemoryBarrier2 mem_barrier = vku::InitStructHelper();


### PR DESCRIPTION
Fixes major gap in syncval ray tracing testing, where simple scenario did not work at all