### PR TITLE
layers: Improve small_vector initialization for better memory handling

### DIFF
--- a/layers/containers/custom_containers.h
+++ b/layers/containers/custom_containers.h
@@ -160,13 +160,14 @@ class small_vector {
     }
 
     small_vector(size_type size, const value_type &value = value_type()) : size_(0), capacity_(N), working_store_(GetSmallStore()) {
-        reserve(size);
-        auto dest = GetWorkingStore();
-        for (size_type i = 0; i < size; i++) {
-            new (dest) value_type(value);
-            ++dest;
+        if (size > 0) {
+            reserve(size);
+            auto dest = GetWorkingStore();
+            for (size_type i = 0; i < size; i++) {
+                new (&dest[i]) value_type(value);
+            }
+            size_ = size;
         }
-        size_ = size;
     }
 
     ~small_vector() { clear(); }


### PR DESCRIPTION
This pull request includes an update to the `small_vector` class in the `layers/containers/custom_containers.h` file to improve the initialization process and ensure proper memory allocation. Fixes an issue where ninja would fail to compile the x64 windows release triplet.

Changes to `small_vector` class:

* Added a check to ensure the `reserve` method is called only if the size is greater than zero, preventing unnecessary memory allocation.
* Fixed the initialization loop to correctly construct elements in the allocated memory using the `placement new` operator.