### PR TITLE
layers: Account for Variable Descriptor Count

### DIFF
--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -619,9 +619,10 @@ bool CoreChecks::ValidateDescriptorSetLayoutBindingFlags(const VkDescriptorSetLa
         if (flags_info->pBindingFlags[i] & VK_DESCRIPTOR_BINDING_VARIABLE_DESCRIPTOR_COUNT_BIT) {
             if (binding_info.binding != max_binding) {
                 skip |= LogError("VUID-VkDescriptorSetLayoutBindingFlagsCreateInfo-pBindingFlags-03004", device, binding_flags_loc,
-                                 "includes VK_DESCRIPTOR_BINDING_VARIABLE_DESCRIPTOR_COUNT_BIT "
-                                 "but %" PRIu32 " is the largest value of all the bindings.",
-                                 binding_info.binding);
+                                 "(binding %" PRIu32
+                                 ") includes VK_DESCRIPTOR_BINDING_VARIABLE_DESCRIPTOR_COUNT_BIT "
+                                 "but can only be on the last binding element (binding %" PRIu32 ").",
+                                 binding_info.binding, max_binding);
             }
 
             if (!enabled_features.descriptorBindingVariableDescriptorCount) {

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -4381,8 +4381,12 @@ void Device::UpdateAllocateDescriptorSetsData(const VkDescriptorSetAllocateInfo 
                 uint32_t type_index = static_cast<uint32_t>(binding_layout->descriptorType);
                 uint32_t descriptor_count = binding_layout->descriptorCount;
                 if (count_allocate_info && i < count_allocate_info->descriptorSetCount) {
-                    descriptor_count = count_allocate_info->pDescriptorCounts[i];
+                    // Only binding will have this flag
+                    if (layout->GetDescriptorBindingFlagsFromIndex(j) & VK_DESCRIPTOR_BINDING_VARIABLE_DESCRIPTOR_COUNT_BIT) {
+                        descriptor_count = count_allocate_info->pDescriptorCounts[i];
+                    }
                 }
+
                 ds_data.required_descriptors_by_type[type_index] += descriptor_count;
             }
         }


### PR DESCRIPTION
This was giving a false positive for the `WARNING-VkDescriptorSetAllocateInfo-descriptorCount` warning due to not accounting correctly for `VK_DESCRIPTOR_BINDING_VARIABLE_DESCRIPTOR_COUNT_BIT`