### PR TITLE
gpuav: Introduce unsafe mode

### DIFF
--- a/docs/gpu_av_shader_instrumentation.md
+++ b/docs/gpu_av_shader_instrumentation.md
@@ -147,3 +147,21 @@ OpBranchConditional %compare %L2 %L3
 %L3 = OpLabel
 OpReturn
 ```
+
+## Unsafe Mode
+
+The `Unsafe Mode` was designed as a way to improve performance. Every time we instrument a shader, if the driver doesn't support the SPIR-V `DontInline` (which there is not way to test), it gets exponentially slower to compile.
+
+To illustrate the idea, take the simple shader
+
+```glsl
+layout (set = 0, binding = 0) uniform sampler2D imageArray[];
+
+sample(imageArray[8], a);  // access 1
+sample(imageArray[8], b);  // access 2
+sample(imageArray[8], c);  // access 3
+```
+
+Here we normally check all 3 access for being valid and safely wrap it in a `if` statement so the application will not crash. With `unsafe mode` we will only check the first access to `imageArray[8]` because it is valid, it will save the exponential cost of compiling to check the rest.
+
+The goal with `unsafe mode` is to help people get going with GPU-AV and if they are finding a crash, it is hopefully isolated that they can turn off `unsafe mode` to do the full validaiton without crashing. A future extension will hopefully provide another mechanism to stop the shader upon the first invalid access.

--- a/docs/gpu_av_shader_instrumentation.md
+++ b/docs/gpu_av_shader_instrumentation.md
@@ -150,7 +150,7 @@ OpReturn
 
 ## Unsafe Mode
 
-The `Unsafe Mode` was designed as a way to improve performance. Every time we instrument a shader, if the driver doesn't support the SPIR-V `DontInline` (which there is not way to test), it gets exponentially slower to compile.
+The `Unsafe Mode` was designed as a way to improve performance. Every time we instrument a shader, if the driver doesn't support the SPIR-V `DontInline` (which there is no way to test), it gets exponentially slower to compile.
 
 To illustrate the idea, take the simple shader
 
@@ -164,4 +164,4 @@ sample(imageArray[8], c);  // access 3
 
 Here we normally check all 3 access for being valid and safely wrap it in a `if` statement so the application will not crash. With `unsafe mode` we will only check the first access to `imageArray[8]` because it is valid, it will save the exponential cost of compiling to check the rest.
 
-The goal with `unsafe mode` is to help people get going with GPU-AV and if they are finding a crash, it is hopefully isolated that they can turn off `unsafe mode` to do the full validaiton without crashing. A future extension will hopefully provide another mechanism to stop the shader upon the first invalid access.
+The goal with `unsafe mode` is to help people get going with GPU-AV by making it faster, If they are still finding a crash with `unsafe mode`, it hopefully can be isolated so they can then turn off `unsafe mode` to do the full validaition without crashing. A future extension will hopefully provide another mechanism to stop the shader upon the first invalid access.

--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -569,7 +569,7 @@
                                 {
                                     "key": "gpuav_unsafe_mode",
                                     "label": "Unsafe Mode",
-                                    "description": "Normally GPU-AV will try and prevent crashing, but with unsafe mode, it will be much faster to validate, but might not stop a crash",
+                                    "description": "Normally GPU-AV will try to prevent crashes, but with unsafe mode, it will be much faster to validate, but might not stop a crash",
                                     "type": "BOOL",
                                     "default": false,
                                     "platforms": [ "WINDOWS", "LINUX" ],

--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -567,6 +567,20 @@
                             "platforms": [ "WINDOWS", "LINUX" ],
                             "settings": [
                                 {
+                                    "key": "gpuav_unsafe_mode",
+                                    "label": "Unsafe Mode",
+                                    "description": "Normally GPU-AV will try and prevent crashing, but with unsafe mode, it will be much faster to validate, but might not stop a crash",
+                                    "type": "BOOL",
+                                    "default": false,
+                                    "platforms": [ "WINDOWS", "LINUX" ],
+                                    "dependence": {
+                                        "mode": "ALL",
+                                        "settings": [
+                                            { "key": "gpuav_enable", "value": true }
+                                        ]
+                                    }
+                                },
+                                {
                                     "key": "gpuav_shader_instrumentation",
                                     "label": "Shader instrumentation",
                                     "description": "Instrument shaders to validate descriptors, descriptor indexing, buffer device addresses and ray queries. Warning: will considerably slow down shader executions.",

--- a/layers/gpuav/core/gpuav_settings.h
+++ b/layers/gpuav/core/gpuav_settings.h
@@ -20,6 +20,8 @@
 // Default values for those settings should match layers/VkLayer_khronos_validation.json.in
 
 struct GpuAVSettings {
+    bool unsafe_mode = false;
+
     bool warn_on_robust_oob = true;
     uint32_t max_bda_in_use = 10000;
     bool select_instrumented_shaders = false;

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
@@ -1174,6 +1174,7 @@ bool GpuShaderInstrumentor::InstrumentShader(const vvl::span<const uint32_t> &in
     // Use the unique_shader_id as a shader ID so we can look up its handle later in the shader_map.
     module_settings.shader_id = unique_shader_id;
     module_settings.output_buffer_descriptor_set = instrumentation_desc_set_bind_index_;
+    module_settings.unsafe_mode = gpuav_settings.unsafe_mode;
     module_settings.print_debug_info = gpuav_settings.debug_print_instrumentation_info;
     module_settings.max_instrumentations_count = gpuav_settings.debug_max_instrumentations_count;
     module_settings.support_non_semantic_info = IsExtEnabled(extensions.vk_khr_shader_non_semantic_info);

--- a/layers/gpuav/spirv/descriptor_class_general_buffer_pass.h
+++ b/layers/gpuav/spirv/descriptor_class_general_buffer_pass.h
@@ -40,8 +40,8 @@ class DescriptorClassGeneralBufferPass : public Pass {
     uint32_t GetLinkFunctionId();
 
     // Finds the offset into the SSBO/UBO
-    uint32_t GetOffsetByAccessChain(uint32_t descriptor_id, bool is_descriptor_array,
-                                    std::vector<const Instruction*>& access_chain_insts) const;
+    uint32_t FindLastByteOffset(uint32_t descriptor_id, bool is_descriptor_array,
+                                const std::vector<const Instruction*>& access_chain_insts) const;
 
     // List of OpAccessChains fom the Store/Load down to the OpVariable
     // The front() will be closet to the exact spot accesssed
@@ -66,7 +66,7 @@ class DescriptorClassGeneralBufferPass : public Pass {
     //        ssbo.data[8] = 0;
     // We don't know which will actually execute, but by definition a Block must execute from start to finish
     //
-    // < Descriptor SSA ID, Highest offset >
+    // < Descriptor SSA ID, Highest offset byte that will be accessed >
     vvl::unordered_map<uint32_t, uint32_t> block_highest_offset_map_;
 };
 

--- a/layers/gpuav/spirv/descriptor_indexing_oob_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_indexing_oob_pass.cpp
@@ -123,6 +123,8 @@ uint32_t DescriptorIndexingOOBPass::CreateFunctionCall(BasicBlock& block, Instru
     return function_result;
 }
 
+void DescriptorIndexingOOBPass::NewBlock(const BasicBlock&) { block_instrumented_table_.clear(); }
+
 void DescriptorIndexingOOBPass::Reset() {
     var_inst_ = nullptr;
     sampler_var_inst_ = nullptr;

--- a/layers/gpuav/spirv/descriptor_indexing_oob_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_indexing_oob_pass.cpp
@@ -299,9 +299,9 @@ bool DescriptorIndexingOOBPass::RequiresInstrumentation(const Function& function
     }
 
     if (module_.settings_.unsafe_mode) {
-        auto variable_found_it = instrumented_table_.find(variable_id);
-        if (variable_found_it == instrumented_table_.end()) {
-            instrumented_table_[variable_id] = {descriptor_index_id_};
+        auto variable_found_it = block_instrumented_table_.find(variable_id);
+        if (variable_found_it == block_instrumented_table_.end()) {
+            block_instrumented_table_[variable_id] = {descriptor_index_id_};
         } else {
             vvl::unordered_set<uint32_t>& descriptor_index_set = variable_found_it->second;
             if (descriptor_index_set.find(descriptor_index_id_) != descriptor_index_set.end()) {

--- a/layers/gpuav/spirv/descriptor_indexing_oob_pass.h
+++ b/layers/gpuav/spirv/descriptor_indexing_oob_pass.h
@@ -30,6 +30,8 @@ class DescriptorIndexingOOBPass : public InjectConditionalFunctionPass {
     const char* Name() const final { return "DescriptorIndexingOOBPass"; }
     void PrintDebugInfo() const final;
 
+    void NewBlock(const BasicBlock& block) override;
+
   private:
     bool RequiresInstrumentation(const Function& function, const Instruction& inst) final;
     uint32_t CreateFunctionCall(BasicBlock& block, InstructionIt* inst_it, const InjectionData& injection_data) final;
@@ -53,6 +55,11 @@ class DescriptorIndexingOOBPass : public InjectConditionalFunctionPass {
 
     // < original ID, new CopyObject ID >
     vvl::unordered_map<uint32_t, uint32_t> copy_object_map_;
+
+    // If the shader has a 'imageArray[]' the OpVariable will point to 'imageArray' then we only need to check (in unsafe mode) each
+    // index into it once to see if the descriptor is valid or not . We marks which variables were already instrumented
+    // < Variable ID, [descriptor index IDs accessed with this variable >
+    vvl::unordered_map<uint32_t, vvl::unordered_set<uint32_t>> block_instrumented_table_;
 };
 
 }  // namespace spirv

--- a/layers/gpuav/spirv/descriptor_indexing_oob_pass.h
+++ b/layers/gpuav/spirv/descriptor_indexing_oob_pass.h
@@ -51,11 +51,6 @@ class DescriptorIndexingOOBPass : public InjectConditionalFunctionPass {
     uint32_t sampler_descriptor_binding_ = 0;
     uint32_t sampler_descriptor_index_id_ = 0;
 
-    // If the shader has a 'imageArray[]' the OpVariable will point to 'imageArray' then we only need to check (in unsafe mode) each
-    // index into it once to see if the descriptor is valid or not . We marks which variables were already instrumented
-    // < Variable ID, [descriptor index IDs accessed with this variable >
-    vvl::unordered_map<uint32_t, vvl::unordered_set<uint32_t>> instrumented_table_;
-
     // < original ID, new CopyObject ID >
     vvl::unordered_map<uint32_t, uint32_t> copy_object_map_;
 };

--- a/layers/gpuav/spirv/descriptor_indexing_oob_pass.h
+++ b/layers/gpuav/spirv/descriptor_indexing_oob_pass.h
@@ -15,6 +15,8 @@
 #pragma once
 
 #include <stdint.h>
+#include <vector>
+#include "containers/custom_containers.h"
 #include "inject_conditional_function_pass.h"
 
 namespace gpuav {
@@ -48,6 +50,11 @@ class DescriptorIndexingOOBPass : public InjectConditionalFunctionPass {
     uint32_t sampler_descriptor_set_ = 0;
     uint32_t sampler_descriptor_binding_ = 0;
     uint32_t sampler_descriptor_index_id_ = 0;
+
+    // If the shader has a 'imageArray[]' the OpVariable will point to 'imageArray' then we only need to check (in unsafe mode) each
+    // index into it once to see if the descriptor is valid or not < Variable ID, [descriptor index IDs accessed with this variable]
+    // > Marks which variables were already instrumented
+    vvl::unordered_map<uint32_t, vvl::unordered_set<uint32_t>> instrumented_table_;
 
     // < original ID, new CopyObject ID >
     vvl::unordered_map<uint32_t, uint32_t> copy_object_map_;

--- a/layers/gpuav/spirv/descriptor_indexing_oob_pass.h
+++ b/layers/gpuav/spirv/descriptor_indexing_oob_pass.h
@@ -52,8 +52,8 @@ class DescriptorIndexingOOBPass : public InjectConditionalFunctionPass {
     uint32_t sampler_descriptor_index_id_ = 0;
 
     // If the shader has a 'imageArray[]' the OpVariable will point to 'imageArray' then we only need to check (in unsafe mode) each
-    // index into it once to see if the descriptor is valid or not < Variable ID, [descriptor index IDs accessed with this variable]
-    // > Marks which variables were already instrumented
+    // index into it once to see if the descriptor is valid or not . We marks which variables were already instrumented
+    // < Variable ID, [descriptor index IDs accessed with this variable >
     vvl::unordered_map<uint32_t, vvl::unordered_set<uint32_t>> instrumented_table_;
 
     // < original ID, new CopyObject ID >

--- a/layers/gpuav/spirv/inject_conditional_function_pass.cpp
+++ b/layers/gpuav/spirv/inject_conditional_function_pass.cpp
@@ -123,6 +123,9 @@ bool InjectConditionalFunctionPass::Instrument() {
                 continue;  // Currently can't properly handle injecting CFG logic into a loop header block
             }
             auto& block_instructions = (*block_it)->instructions_;
+
+            block_instrumented_table_.clear();
+
             for (auto inst_it = block_instructions.begin(); inst_it != block_instructions.end(); ++inst_it) {
                 // Every instruction is analyzed by the specific pass and lets us know if we need to inject a function or not
                 if (!RequiresInstrumentation(*function, *(inst_it->get()))) {

--- a/layers/gpuav/spirv/inject_conditional_function_pass.cpp
+++ b/layers/gpuav/spirv/inject_conditional_function_pass.cpp
@@ -123,8 +123,7 @@ bool InjectConditionalFunctionPass::Instrument() {
                 continue;  // Currently can't properly handle injecting CFG logic into a loop header block
             }
             auto& block_instructions = (*block_it)->instructions_;
-
-            block_instrumented_table_.clear();
+            NewBlock(**block_it);
 
             for (auto inst_it = block_instructions.begin(); inst_it != block_instructions.end(); ++inst_it) {
                 // Every instruction is analyzed by the specific pass and lets us know if we need to inject a function or not

--- a/layers/gpuav/spirv/inject_conditional_function_pass.h
+++ b/layers/gpuav/spirv/inject_conditional_function_pass.h
@@ -60,6 +60,11 @@ class InjectConditionalFunctionPass : public Pass {
     // Each pass creates a OpFunctionCall and returns its result id.
     // If |inst_it| is not null, it will update it to instruction post OpFunctionCall
     virtual uint32_t CreateFunctionCall(BasicBlock& block, InstructionIt* inst_it, const InjectionData& injection_data) = 0;
+
+    // If the shader has a 'imageArray[]' the OpVariable will point to 'imageArray' then we only need to check (in unsafe mode) each
+    // index into it once to see if the descriptor is valid or not . We marks which variables were already instrumented
+    // < Variable ID, [descriptor index IDs accessed with this variable >
+    vvl::unordered_map<uint32_t, vvl::unordered_set<uint32_t>> block_instrumented_table_;
 };
 
 }  // namespace spirv

--- a/layers/gpuav/spirv/inject_conditional_function_pass.h
+++ b/layers/gpuav/spirv/inject_conditional_function_pass.h
@@ -61,10 +61,8 @@ class InjectConditionalFunctionPass : public Pass {
     // If |inst_it| is not null, it will update it to instruction post OpFunctionCall
     virtual uint32_t CreateFunctionCall(BasicBlock& block, InstructionIt* inst_it, const InjectionData& injection_data) = 0;
 
-    // If the shader has a 'imageArray[]' the OpVariable will point to 'imageArray' then we only need to check (in unsafe mode) each
-    // index into it once to see if the descriptor is valid or not . We marks which variables were already instrumented
-    // < Variable ID, [descriptor index IDs accessed with this variable >
-    vvl::unordered_map<uint32_t, vvl::unordered_set<uint32_t>> block_instrumented_table_;
+    // Optional notification that a new block is being passed
+    virtual void NewBlock(const BasicBlock&){};
 };
 
 }  // namespace spirv

--- a/layers/gpuav/spirv/module.h
+++ b/layers/gpuav/spirv/module.h
@@ -43,6 +43,7 @@ struct Settings {
     // This allows anything to be set in the GLSL for the set value, as we change it at runtime
     uint32_t output_buffer_descriptor_set;
     // Reduce amount of work so compiling the pipeline/shader is quicker
+    // This is a global setting for all passes
     bool unsafe_mode;
     // Used to help debug
     bool print_debug_info;

--- a/layers/gpuav/spirv/module.h
+++ b/layers/gpuav/spirv/module.h
@@ -42,6 +42,8 @@ struct Settings {
     // Will replace the "OpDecorate DescriptorSet" for the output buffer in the incoming linked module
     // This allows anything to be set in the GLSL for the set value, as we change it at runtime
     uint32_t output_buffer_descriptor_set;
+    // Reduce amount of work so compiling the pipeline/shader is quicker
+    bool unsafe_mode;
     // Used to help debug
     bool print_debug_info;
     // zero is same as "unlimited"

--- a/layers/gpuav/spirv/pass.cpp
+++ b/layers/gpuav/spirv/pass.cpp
@@ -311,8 +311,8 @@ uint32_t Pass::FindTypeByteSize(uint32_t type_id, uint32_t matrix_stride, bool c
 // Find outermost buffer type and its access chain index.
 // Because access chains indexes can be runtime values, we need to build arithmetic logic in the SPIR-V to get the runtime value of
 // the indexing
-uint32_t Pass::GetLastByte(const Type& descriptor_type, std::vector<const Instruction*>& access_chain_insts, BasicBlock& block,
-                           InstructionIt* inst_it) {
+uint32_t Pass::GetLastByte(const Type& descriptor_type, const std::vector<const Instruction*>& access_chain_insts,
+                           BasicBlock& block, InstructionIt* inst_it) {
     assert(!access_chain_insts.empty());
     uint32_t current_type_id = 0;
     const uint32_t reset_ac_word = 4;  // points to first "Index" operand of an OpAccessChain

--- a/layers/gpuav/spirv/pass.cpp
+++ b/layers/gpuav/spirv/pass.cpp
@@ -197,7 +197,7 @@ uint32_t Pass::GetStageInfo(Function& function, BasicBlockIt target_block_it, In
     return function.stage_info_id_;
 }
 
-const Instruction* Pass::GetDecoration(uint32_t id, spv::Decoration decoration) {
+const Instruction* Pass::GetDecoration(uint32_t id, spv::Decoration decoration) const {
     for (const auto& annotation : module_.annotations_) {
         if (annotation->Opcode() == spv::OpDecorate && annotation->Word(1) == id &&
             spv::Decoration(annotation->Word(2)) == decoration) {
@@ -207,7 +207,7 @@ const Instruction* Pass::GetDecoration(uint32_t id, spv::Decoration decoration) 
     return nullptr;
 }
 
-const Instruction* Pass::GetMemberDecoration(uint32_t id, uint32_t member_index, spv::Decoration decoration) {
+const Instruction* Pass::GetMemberDecoration(uint32_t id, uint32_t member_index, spv::Decoration decoration) const {
     for (const auto& annotation : module_.annotations_) {
         if (annotation->Opcode() == spv::OpMemberDecorate && annotation->Word(1) == id && annotation->Word(2) == member_index &&
             spv::Decoration(annotation->Word(3)) == decoration) {
@@ -220,7 +220,7 @@ const Instruction* Pass::GetMemberDecoration(uint32_t id, uint32_t member_index,
 // In an ideal world, this would be baked into the Type class when we construct it. The core issue is OpTypeMatrix size can be
 // different depending where it is used. Because of this, we need to have a higher level view what is going on in order to correctly
 // figure out the size of a given type.
-uint32_t Pass::FindTypeByteSize(uint32_t type_id, uint32_t matrix_stride, bool col_major, bool in_matrix) {
+uint32_t Pass::FindTypeByteSize(uint32_t type_id, uint32_t matrix_stride, bool col_major, bool in_matrix) const {
     const Type& type = *module_.type_manager_.FindTypeById(type_id);
     switch (type.spv_type_) {
         case SpvType::kPointer:

--- a/layers/gpuav/spirv/pass.h
+++ b/layers/gpuav/spirv/pass.h
@@ -55,7 +55,7 @@ class Pass {
     const Instruction* GetMemberDecoration(uint32_t id, uint32_t member_index, spv::Decoration decoration) const;
 
     uint32_t FindTypeByteSize(uint32_t type_id, uint32_t matrix_stride = 0, bool col_major = false, bool in_matrix = false) const;
-    uint32_t GetLastByte(const Type& descriptor_type, std::vector<const Instruction*>& access_chain_insts, BasicBlock& block,
+    uint32_t GetLastByte(const Type& descriptor_type, const std::vector<const Instruction*>& access_chain_insts, BasicBlock& block,
                          InstructionIt* inst_it);
     // Generate SPIR-V needed to help convert things to be uniformly uint32_t
     // If no inst_it is passed in, any new instructions will be added to end of the Block

--- a/layers/gpuav/spirv/pass.h
+++ b/layers/gpuav/spirv/pass.h
@@ -51,10 +51,10 @@ class Pass {
     // Returns the ID for OpCompositeConstruct it creates
     uint32_t GetStageInfo(Function& function, BasicBlockIt target_block_it, InstructionIt& target_inst_it);
 
-    const Instruction* GetDecoration(uint32_t id, spv::Decoration decoration);
-    const Instruction* GetMemberDecoration(uint32_t id, uint32_t member_index, spv::Decoration decoration);
+    const Instruction* GetDecoration(uint32_t id, spv::Decoration decoration) const;
+    const Instruction* GetMemberDecoration(uint32_t id, uint32_t member_index, spv::Decoration decoration) const;
 
-    uint32_t FindTypeByteSize(uint32_t type_id, uint32_t matrix_stride = 0, bool col_major = false, bool in_matrix = false);
+    uint32_t FindTypeByteSize(uint32_t type_id, uint32_t matrix_stride = 0, bool col_major = false, bool in_matrix = false) const;
     uint32_t GetLastByte(const Type& descriptor_type, std::vector<const Instruction*>& access_chain_insts, BasicBlock& block,
                          InstructionIt* inst_it);
     // Generate SPIR-V needed to help convert things to be uniformly uint32_t

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -188,6 +188,7 @@ const char *VK_LAYER_PRINTF_BUFFER_SIZE = "printf_buffer_size";
 // GPU-AV
 // ---
 const char *VK_LAYER_GPUAV_ENABLE = "gpuav_enable";
+const char *VK_LAYER_GPUAV_UNSAFE_MODE = "gpuav_unsafe_mode";
 const char *VK_LAYER_GPUAV_SHADER_INSTRUMENTATION = "gpuav_shader_instrumentation";
 const char *VK_LAYER_GPUAV_DESCRIPTOR_CHECKS = "gpuav_descriptor_checks";
 const char *VK_LAYER_GPUAV_WARN_ON_ROBUST_OOB = "gpuav_warn_on_robust_oob";
@@ -587,6 +588,8 @@ static void ValidateLayerSettingsProvided(const VkLayerSettingsCreateInfoEXT *la
         } else if (strcmp(VK_LAYER_GPUAV_ENABLE, setting.pSettingName) == 0) {
             required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
         } else if (strcmp(DEPRECATED_VK_LAYER_VALIDATE_GPU_BASED, setting.pSettingName) == 0) {
+            required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
+        } else if (strcmp(VK_LAYER_GPUAV_UNSAFE_MODE, setting.pSettingName) == 0) {
             required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
         } else if (strcmp(VK_LAYER_GPUAV_SHADER_INSTRUMENTATION, setting.pSettingName) == 0) {
             required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
@@ -1036,6 +1039,10 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
     }
 
     GpuAVSettings &gpuav_settings = *settings_data->gpuav_settings;
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_UNSAFE_MODE)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_UNSAFE_MODE, gpuav_settings.unsafe_mode);
+    }
+
     bool shader_instrumentation_enabled = true;
     if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_SHADER_INSTRUMENTATION)) {
         vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_SHADER_INSTRUMENTATION, shader_instrumentation_enabled);

--- a/layers/vk_layer_settings.txt
+++ b/layers/vk_layer_settings.txt
@@ -65,7 +65,7 @@ khronos_validation.enables =
 
 # Shader instrumentation
 # =====================
-# Normally GPU-AV will try and prevent crashing, but with unsafe mode, it will be much faster to validate, but might not stop a crash
+# Normally GPU-AV will try to prevent crashes, but with unsafe mode, it will be much faster to validate, but might not stop a crash
 #khronos_validation.gpuav_unsafe_mode = true
 
 # Shader instrumentation

--- a/layers/vk_layer_settings.txt
+++ b/layers/vk_layer_settings.txt
@@ -65,6 +65,11 @@ khronos_validation.enables =
 
 # Shader instrumentation
 # =====================
+# Normally GPU-AV will try and prevent crashing, but with unsafe mode, it will be much faster to validate, but might not stop a crash
+#khronos_validation.gpuav_unsafe_mode = true
+
+# Shader instrumentation
+# =====================
 # Instrument shaders to validate descriptors, descriptor indexing, buffer device addresses and ray queries.
 # Warning: will considerably slow down shader executions
 #khronos_validation.gpuav_shader_instrumentation = true


### PR DESCRIPTION
By not preventing crashing, we can take things that took 20 seconds to compile down to a 2 to 3ms overhead. Many more things I can take advantage of `unsafe mode` but wanted to add it as a nice single first change

Some numbers

- [**BASE LINE**] PositiveGpuAVDescriptorIndexing.Stress
    - 150 ms
- [**BASE LINE**] PositiveGpuAVDescriptorIndexing.Stress2 
    - 30 ms
- [**SAFE** MODE] PositiveGpuAVDescriptorIndexing.Stress
    - 2150 ms
    - DescriptorIndexingOOBPass instrumentation count: 47 (Bindless version)
- [**SAFE** MODE] PositiveGpuAVDescriptorIndexing.Stress2
    - 19417 ms (!!!)
    - DescriptorIndexingOOBPass instrumentation count: 201 (Bindless version)
- [**UNSAFE** MODE] PositiveGpuAVDescriptorIndexing.Stress
    - 1400 ms
    - DescriptorIndexingOOBPass instrumentation count: 31 (Bindless version)
- [**UNSAFE** MODE] PositiveGpuAVDescriptorIndexing.Stress2
    - 35 ms
    - DescriptorIndexingOOBPass instrumentation count: 1 (Bindless version)
