### PR TITLE
sync: Remove old formating code

### DIFF
--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -1147,8 +1147,12 @@ uint32_t CommandBufferAccessContext::AddHandle(const VulkanTypedHandle &typed_ha
     return handle_index;
 }
 
-ResourceUsageTagEx CommandBufferAccessContext::AddCommandHandle(ResourceUsageTag tag, const VulkanTypedHandle &typed_handle,
-                                                                uint32_t index) {
+ResourceUsageTagEx CommandBufferAccessContext::AddCommandHandle(ResourceUsageTag tag, const VulkanTypedHandle &typed_handle) {
+    return AddCommandHandleIndexed(tag, typed_handle, vvl::kNoIndex32);
+}
+
+ResourceUsageTagEx CommandBufferAccessContext::AddCommandHandleIndexed(ResourceUsageTag tag, const VulkanTypedHandle &typed_handle,
+                                                                       uint32_t index) {
     assert(tag < access_log_->size());
     const uint32_t handle_index = AddHandle(typed_handle, index);
     // TODO: the following range check is not needed. Test and remove.
@@ -1166,7 +1170,8 @@ ResourceUsageTagEx CommandBufferAccessContext::AddCommandHandle(ResourceUsageTag
     return {tag, handle_index};
 }
 
-void CommandBufferAccessContext::AddSubcommandHandle(ResourceUsageTag tag, const VulkanTypedHandle &typed_handle, uint32_t index) {
+void CommandBufferAccessContext::AddSubcommandHandleIndexed(ResourceUsageTag tag, const VulkanTypedHandle &typed_handle,
+                                                            uint32_t index) {
     assert(tag < access_log_->size());
     const uint32_t handle_index = AddHandle(typed_handle, index);
     // TODO: the following range check is not needed. Test and remove.

--- a/layers/sync/sync_common.h
+++ b/layers/sync/sync_common.h
@@ -75,12 +75,8 @@ constexpr VkImageAspectFlags kDepthStencilAspects = VK_IMAGE_ASPECT_DEPTH_BIT | 
 
 // Useful Utilites for manipulating StageAccess parameters, suitable as base class to save typing
 struct SyncStageAccess {
-    static inline const SyncAccessInfo &AccessInfo(SyncAccessIndex access_index) {
-        return syncAccessInfoByAccessIndex()[access_index];
-    }
-    static inline SyncAccessFlags FlagBit(SyncAccessIndex stage_access) {
-        return syncAccessInfoByAccessIndex()[stage_access].access_bit;
-    }
+    static const SyncAccessInfo &AccessInfo(SyncAccessIndex access_index) { return GetSyncAccessInfos()[access_index]; }
+    static SyncAccessFlags FlagBit(SyncAccessIndex stage_access) { return GetSyncAccessInfos()[stage_access].access_bit; }
 
     static bool IsRead(SyncAccessIndex access_index) { return syncAccessReadMask[access_index]; }
     static bool IsRead(const SyncAccessInfo &info) { return IsRead(info.access_index); }
@@ -88,7 +84,7 @@ struct SyncStageAccess {
     static bool IsWrite(const SyncAccessInfo &info) { return IsWrite(info.access_index); }
 
     static VkPipelineStageFlags2 PipelineStageBit(SyncAccessIndex access_index) {
-        return syncAccessInfoByAccessIndex()[access_index].stage_mask;
+        return GetSyncAccessInfos()[access_index].stage_mask;
     }
     static SyncAccessFlags AccessScopeByStage(VkPipelineStageFlags2 stages);
     static SyncAccessFlags AccessScopeByAccess(VkAccessFlags2 access);

--- a/layers/sync/sync_error_messages.cpp
+++ b/layers/sync/sync_error_messages.cpp
@@ -98,8 +98,8 @@ static void FormatCommonMessage(const HazardResult& hazard, const std::string& r
     const SyncHazard hazard_type = hazard.Hazard();
     const SyncHazardInfo hazard_info = GetSyncHazardInfo(hazard_type);
 
-    const SyncAccessInfo& access = syncAccessInfoByAccessIndex()[hazard.State().access_index];
-    const SyncAccessInfo& prior_access = syncAccessInfoByAccessIndex()[hazard.State().prior_access_index];
+    const SyncAccessInfo& access = GetSyncAccessInfos()[hazard.State().access_index];
+    const SyncAccessInfo& prior_access = GetSyncAccessInfos()[hazard.State().prior_access_index];
 
     const SyncAccessFlags write_barriers = hazard.State().access_state->GetWriteBarriers();
     const VkPipelineStageFlags2 read_barriers = hazard.State().access_state->GetReadBarriers(hazard.State().prior_access_index);

--- a/layers/sync/sync_reporting.h
+++ b/layers/sync/sync_reporting.h
@@ -36,19 +36,6 @@ struct DeviceExtensions;
 void FormatVideoPictureResouce(const Logger &logger, const VkVideoPictureResourceInfoKHR &video_picture, std::stringstream &ss);
 void FormatVideoQuantizationMap(const Logger &logger, const VkVideoEncodeQuantizationMapInfoKHR &quantization_map,
                                 std::stringstream &ss);
-
-struct SyncNodeFormatter {
-    const DebugReport *debug_report;
-    const vvl::StateObject *node;
-    const char *label;
-
-    SyncNodeFormatter(const SyncValidator &sync_state, const vvl::CommandBuffer *cb_state);
-    SyncNodeFormatter(const SyncValidator &sync_state, const vvl::Image *image);
-    SyncNodeFormatter(const SyncValidator &sync_state, const vvl::Queue *q_state);
-    SyncNodeFormatter(const SyncValidator &sync_state, const vvl::StateObject *state_object, const char *label_ = nullptr);
-};
-std::string FormatStateObject(const SyncNodeFormatter &formatter);
-
 struct ReportKeyValues {
     struct KeyValue {
         std::string key;

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -648,29 +648,9 @@ bool QueueBatchContext::ValidateSubmit(const std::vector<CommandBufferConstPtr>&
 QueueBatchContext::PresentResourceRecord::Base_::Record QueueBatchContext::PresentResourceRecord::MakeRecord() const {
     return std::make_unique<PresentResourceRecord>(presented_);
 }
-std::ostream& QueueBatchContext::PresentResourceRecord::Format(std::ostream& out, const SyncValidator& sync_state) const {
-    out << "vkQueuePresentKHR ";
-    out << "present_tag:" << presented_.tag;
-    out << ", pSwapchains[" << presented_.present_index << "]";
-    out << ": " << FormatStateObject(SyncNodeFormatter(sync_state, presented_.swapchain_state.lock().get()));
-    out << ", image_index: " << presented_.image_index;
-    out << FormatStateObject(SyncNodeFormatter(sync_state, presented_.image.get()));
-
-    return out;
-}
 
 QueueBatchContext::AcquireResourceRecord::Base_::Record QueueBatchContext::AcquireResourceRecord::MakeRecord() const {
     return std::make_unique<AcquireResourceRecord>(presented_, acquire_tag_, command_);
-}
-
-std::ostream& QueueBatchContext::AcquireResourceRecord::Format(std::ostream& out, const SyncValidator& sync_state) const {
-    out << vvl::String(command_) << " ";
-    out << "aquire_tag:" << acquire_tag_;
-    out << ": " << FormatStateObject(SyncNodeFormatter(sync_state, presented_.swapchain_state.lock().get()));
-    out << ", image_index: " << presented_.image_index;
-    out << FormatStateObject(SyncNodeFormatter(sync_state, presented_.image.get()));
-
-    return out;
 }
 
 std::vector<QueueBatchContext::ConstPtr> SyncValidator::GetLastBatches(

--- a/layers/sync/sync_submit.h
+++ b/layers/sync/sync_submit.h
@@ -264,7 +264,6 @@ class QueueBatchContext : public CommandExecutionContext, public std::enable_sha
         Base_::Record MakeRecord() const override;
         ~PresentResourceRecord() override {}
         PresentResourceRecord(const PresentedImageRecord &presented) : presented_(presented) {}
-        std::ostream &Format(std::ostream &out, const SyncValidator &sync_state) const override;
         vvl::Func GetCommand() const override { return vvl::Func::vkQueuePresentKHR; }
 
       private:
@@ -277,7 +276,6 @@ class QueueBatchContext : public CommandExecutionContext, public std::enable_sha
         Base_::Record MakeRecord() const override;
         AcquireResourceRecord(const PresentedImageRecord &presented, ResourceUsageTag tag, vvl::Func command)
             : presented_(presented), acquire_tag_(tag), command_(command) {}
-        std::ostream &Format(std::ostream &out, const SyncValidator &sync_state) const override;
         vvl::Func GetCommand() const override { return command_; }
 
       private:
@@ -296,7 +294,7 @@ class QueueBatchContext : public CommandExecutionContext, public std::enable_sha
     void Trim();
 
     ReportUsageInfo GetReportUsageInfo(ResourceUsageTagEx tag_ex) const override;
-    std::string FormatUsage(ResourceUsageTagEx tag_ex, ReportKeyValues &extra_properties) const override;
+    void FormatUsage(ResourceUsageTagEx tag_ex, ReportKeyValues &extra_properties) const override;
     void AddUsageRecordExtraProperties(ResourceUsageTag tag, ReportKeyValues &extra_properties) const override;
     AccessContext *GetCurrentAccessContext() override { return current_access_context_; }
     const AccessContext *GetCurrentAccessContext() const override { return current_access_context_; }

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -3024,10 +3024,10 @@ void SyncValidator::PreCallRecordCmdExecuteCommands(VkCommandBuffer commandBuffe
             const auto subcommand = ResourceUsageRecord::SubcommandType::kIndex;
             if (cb_index == 0) {
                 ResourceUsageTag cb_tag = cb_context->NextCommandTag(record_obj.location.function, subcommand);
-                cb_context->AddCommandHandle(cb_tag, recorded_cb->Handle(), cb_index);
+                cb_context->AddCommandHandleIndexed(cb_tag, recorded_cb->Handle(), cb_index);
             } else {
                 ResourceUsageTag cb_tag = cb_context->NextSubcommandTag(record_obj.location.function, subcommand);
-                cb_context->AddSubcommandHandle(cb_tag, recorded_cb->Handle(), cb_index);
+                cb_context->AddSubcommandHandleIndexed(cb_tag, recorded_cb->Handle(), cb_index);
             }
             cb_context->RecordExecutedCommandBuffer(recorded_cb->access_context);
         }

--- a/layers/vulkan/generated/sync_validation_types.cpp
+++ b/layers/vulkan/generated/sync_validation_types.cpp
@@ -23,7 +23,7 @@
 
 #include "sync_validation_types.h"
 // clang-format off
-const std::array<SyncAccessInfo, 139>& syncAccessInfoByAccessIndex() {
+const std::array<SyncAccessInfo, 139>& GetSyncAccessInfos() {
 static const std::array<SyncAccessInfo, 139> variable = { {
     {
         "SYNC_ACCESS_INDEX_NONE",

--- a/layers/vulkan/generated/sync_validation_types.h
+++ b/layers/vulkan/generated/sync_validation_types.h
@@ -331,7 +331,7 @@ struct SyncAccessInfo {
 };
 
 // Array of text names and component masks for each stage/access index
-const std::array<SyncAccessInfo, 139>& syncAccessInfoByAccessIndex();
+const std::array<SyncAccessInfo, 139>& GetSyncAccessInfos();
 
 // Constants defining the mask of all read and write access states
 static const SyncAccessFlags syncAccessReadMask = ( //  Mask of all read accesses

--- a/scripts/generators/sync_validation_generator.py
+++ b/scripts/generators/sync_validation_generator.py
@@ -204,7 +204,7 @@ struct SyncAccessInfo {{
 }};
 
 // Array of text names and component masks for each stage/access index
-const std::array<SyncAccessInfo, {len(self.stageAccessCombo)}>& syncAccessInfoByAccessIndex();
+const std::array<SyncAccessInfo, {len(self.stageAccessCombo)}>& GetSyncAccessInfos();
 
 ''')
 
@@ -251,9 +251,9 @@ const vvl::unordered_map<VkPipelineStageFlagBits2, VkPipelineStageFlags2>& syncL
             #include "sync_validation_types.h"
             ''')
 
-        # syncAccessInfoByAccessIndex
+        # GetSyncAccessInfos
         out.append('// clang-format off\n')
-        out.append(f'const std::array<SyncAccessInfo, {len(self.stageAccessCombo)}>& syncAccessInfoByAccessIndex() {{\n')
+        out.append(f'const std::array<SyncAccessInfo, {len(self.stageAccessCombo)}>& GetSyncAccessInfos() {{\n')
         out.append(f'static const std::array<SyncAccessInfo, {len(self.stageAccessCombo)}> variable = {{ {{\n')
         for stageAccess in self.stageAccessCombo:
             out.append(f'''    {{


### PR DESCRIPTION
Starting removing old error reporting functionality and cleanup new functionality. There will be more follow up PRs.
