### PR TITLE
sync: More cleanup of reporting code

### DIFF
--- a/layers/sync/sync_commandbuffer.h
+++ b/layers/sync/sync_commandbuffer.h
@@ -20,7 +20,7 @@
 #include "sync/sync_reporting.h"
 #include "state_tracker/cmd_buffer_state.h"
 
-struct ReportKeyValues;
+struct ReportProperties;
 class SyncValidator;
 
 namespace syncval {
@@ -150,7 +150,7 @@ class CommandExecutionContext {
     virtual ReportUsageInfo GetReportUsageInfo(ResourceUsageTagEx tag_ex) const = 0;
     virtual std::string GetDebugRegionName(ResourceUsageTagEx tag_ex) const = 0;
 
-    virtual void AddUsageRecordProperties(ResourceUsageTag tag, ReportKeyValues &properties) const = 0;
+    virtual void AddUsageRecordProperties(ResourceUsageTag tag, ReportProperties &properties) const = 0;
 
     bool ValidForSyncOps() const;
     const SyncValidator &GetSyncState() const { return sync_state_; }
@@ -203,7 +203,7 @@ class CommandBufferAccessContext : public CommandExecutionContext, DebugNameProv
 
     ReportUsageInfo GetReportUsageInfo(ResourceUsageTagEx tag_ex) const override;
     std::string GetDebugRegionName(ResourceUsageTagEx tag_ex) const override;
-    void AddUsageRecordProperties(ResourceUsageTag tag, ReportKeyValues &properties) const override;
+    void AddUsageRecordProperties(ResourceUsageTag tag, ReportProperties &properties) const override;
     AccessContext *GetCurrentAccessContext() override { return current_context_; }
     SyncEventsContext *GetCurrentEventsContext() override { return &events_context_; }
     const AccessContext *GetCurrentAccessContext() const override { return current_context_; }

--- a/layers/sync/sync_commandbuffer.h
+++ b/layers/sync/sync_commandbuffer.h
@@ -127,6 +127,16 @@ struct ResourceUsageRecord : public ResourceCmdUsageRecord {
     ResourceUsageRecord &operator=(const ResourceUsageRecord &other) = default;
 };
 
+struct ResourceUsageInfo {
+    vvl::Func command = vvl::Func::Empty;
+    VulkanTypedHandle resource_handle;
+    std::string debug_region_name;
+    const vvl::CommandBuffer *cb = nullptr;
+    const vvl::Queue *queue = nullptr;
+    uint64_t submit_index = 0;
+    uint32_t batch_index = 0;
+};
+
 // Provides debug region name for the specified access log command.
 // If empty name is returned it means the command is not inside debug region.
 struct DebugNameProvider {
@@ -147,9 +157,7 @@ class CommandExecutionContext {
     virtual const SyncEventsContext *GetCurrentEventsContext() const = 0;
     virtual QueueId GetQueueId() const = 0;
     virtual VulkanTypedHandle Handle() const = 0;
-    virtual ReportUsageInfo GetReportUsageInfo(ResourceUsageTagEx tag_ex) const = 0;
-    virtual std::string GetDebugRegionName(ResourceUsageTagEx tag_ex) const = 0;
-
+    virtual ResourceUsageInfo GetResourceUsageInfo(ResourceUsageTagEx tag_ex) const = 0;
     virtual void AddUsageRecordProperties(ResourceUsageTag tag, ReportProperties &properties) const = 0;
 
     bool ValidForSyncOps() const;
@@ -201,8 +209,7 @@ class CommandBufferAccessContext : public CommandExecutionContext, DebugNameProv
 
     void Reset();
 
-    ReportUsageInfo GetReportUsageInfo(ResourceUsageTagEx tag_ex) const override;
-    std::string GetDebugRegionName(ResourceUsageTagEx tag_ex) const override;
+    ResourceUsageInfo GetResourceUsageInfo(ResourceUsageTagEx tag_ex) const override;
     void AddUsageRecordProperties(ResourceUsageTag tag, ReportProperties &properties) const override;
     AccessContext *GetCurrentAccessContext() override { return current_context_; }
     SyncEventsContext *GetCurrentEventsContext() override { return &events_context_; }

--- a/layers/sync/sync_common.h
+++ b/layers/sync/sync_common.h
@@ -45,8 +45,11 @@ constexpr static QueueId kQueueIdInvalid = QueueId(vvl::kU32Max);
 constexpr static QueueId kQueueAny = kQueueIdInvalid - 1;
 
 using ResourceUsageTag = size_t;
-constexpr static ResourceUsageTag kMaxIndex = std::numeric_limits<ResourceUsageTag>::max();
-constexpr static ResourceUsageTag kInvalidTag = kMaxIndex;
+
+// TODO: in the current implementation invalid tag is used not only as initial value
+// but also in some other scenarios (e.g. error reporting classifies layout transition
+// based on tag validity). Clarify when tag can be invalid and document this.
+constexpr static ResourceUsageTag kInvalidTag = std::numeric_limits<ResourceUsageTag>::max();
 
 using ResourceUsageRange = vvl::range<ResourceUsageTag>;
 using ResourceAddress = VkDeviceSize;

--- a/layers/sync/sync_error_messages.h
+++ b/layers/sync/sync_error_messages.h
@@ -17,16 +17,16 @@
 
 #pragma once
 
-#include "sync/sync_renderpass.h"  // DynamicRenderingInfo::Attachment
+#include "sync/sync_common.h"
 #include "sync/sync_reporting.h"
-
 #include <vulkan/vulkan.h>
 #include <string>
 
 class CommandBufferAccessContext;
+class CommandExecutionContext;
 class HazardResult;
-struct ReportKeyValues;
 class QueueBatchContext;
+struct SyncImageMemoryBarrier;
 
 namespace vvl {
 class DescriptorSet;
@@ -37,7 +37,7 @@ class Pipeline;
 namespace syncval {
 
 struct AdditionalMessageInfo {
-    ReportKeyValues properties;
+    ReportProperties properties;
 
     // When we need something more complex than vvl::Func
     std::string access_initiator;

--- a/layers/sync/sync_error_messages.h
+++ b/layers/sync/sync_error_messages.h
@@ -36,28 +36,12 @@ class Pipeline;
 
 namespace syncval {
 
-struct AdditionalMessageInfo {
-    ReportProperties properties;
-
-    // When we need something more complex than vvl::Func
-    std::string access_initiator;
-
-    // Replaces standard "writes to"/"reads" access wording.
-    // For example, "clears" for a clear operation might be more specific than a write
-    std::string access_action;
-
-    std::string hazard_overview;
-    std::string brief_description_end_text;
-    std::string pre_synchronization_text;
-    std::string message_end_text;
-};
-
 class ErrorMessages {
   public:
     explicit ErrorMessages(vvl::Device& validator);
 
     std::string Error(const HazardResult& hazard, const CommandExecutionContext& context, vvl::Func command,
-                      const std::string& resouce_description, const char* message_type,
+                      const std::string& resource_description, const char* message_type,
                       const AdditionalMessageInfo& additional_info = {}) const;
 
     std::string BufferError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context, vvl::Func command,
@@ -121,7 +105,6 @@ class ErrorMessages {
     std::string RenderPassStoreOpError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context, vvl::Func command,
                                        const std::string& resource_description, VkAttachmentStoreOp store_op) const;
 
-
     std::string RenderPassLayoutTransitionError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
                                                 vvl::Func command, const std::string& resource_description,
                                                 VkImageLayout old_layout, VkImageLayout new_layout) const;
@@ -152,8 +135,6 @@ class ErrorMessages {
 
   private:
     vvl::Device& validator_;
-    const bool& extra_properties_;
-    const bool& pretty_print_extra_;
 };
 
 }  // namespace syncval

--- a/layers/sync/sync_reporting.h
+++ b/layers/sync/sync_reporting.h
@@ -29,18 +29,17 @@ class Queue;
 class HazardResult;
 class Logger;
 
-struct ReportKeyValues {
-    struct KeyValue {
-        std::string key;
+struct ReportProperties {
+    struct NameValue {
+        std::string name;
         std::string value;
     };
-    std::vector<KeyValue> key_values;
+    std::vector<NameValue> name_values;
 
-    void Add(std::string_view key, std::string_view value);
-    void Add(std::string_view key, uint64_t value);
-
+    void Add(std::string_view property_name, std::string_view value);
+    void Add(std::string_view property_name, uint64_t value);
+    const std::string *FindProperty(std::string_view property_name) const;
     std::string GetExtraPropertiesSection(bool pretty_print) const;
-    const std::string *FindProperty(const std::string &key) const;
 };
 
 struct ReportUsageInfo {
@@ -54,7 +53,7 @@ struct ReportUsageInfo {
 };
 
 void GetAccessProperties(const HazardResult &hazard, const vvl::Device &device, VkQueueFlags allowed_queue_flags,
-                         ReportKeyValues &key_values);
+                         ReportProperties &properties);
 
 std::vector<std::pair<VkPipelineStageFlags2, VkAccessFlags2>> ConvertSyncAccessesToCompactVkForm(
     const SyncAccessFlags &sync_accesses, const vvl::Device &device, VkQueueFlags allowed_queue_flags);

--- a/layers/sync/sync_submit.h
+++ b/layers/sync/sync_submit.h
@@ -293,8 +293,7 @@ class QueueBatchContext : public CommandExecutionContext, public std::enable_sha
     ~QueueBatchContext();
     void Trim();
 
-    ReportUsageInfo GetReportUsageInfo(ResourceUsageTagEx tag_ex) const override;
-    std::string GetDebugRegionName(ResourceUsageTagEx tag_ex) const override;
+    ResourceUsageInfo GetResourceUsageInfo(ResourceUsageTagEx tag_ex) const override;
     void AddUsageRecordProperties(ResourceUsageTag tag, ReportProperties &properties) const override;
     AccessContext *GetCurrentAccessContext() override { return current_access_context_; }
     const AccessContext *GetCurrentAccessContext() const override { return current_access_context_; }

--- a/layers/sync/sync_submit.h
+++ b/layers/sync/sync_submit.h
@@ -295,7 +295,7 @@ class QueueBatchContext : public CommandExecutionContext, public std::enable_sha
 
     ReportUsageInfo GetReportUsageInfo(ResourceUsageTagEx tag_ex) const override;
     std::string GetDebugRegionName(ResourceUsageTagEx tag_ex) const override;
-    void AddUsageRecordProperties(ResourceUsageTag tag, ReportKeyValues &properties) const override;
+    void AddUsageRecordProperties(ResourceUsageTag tag, ReportProperties &properties) const override;
     AccessContext *GetCurrentAccessContext() override { return current_access_context_; }
     const AccessContext *GetCurrentAccessContext() const override { return current_access_context_; }
     SyncEventsContext *GetCurrentEventsContext() override { return &events_context_; }

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -3799,7 +3799,7 @@ bool SyncValidator::PreCallValidateCmdBuildAccelerationStructuresKHR(
                 ss << " (" << Location(vvl::Func::Empty, vvl::Field::srcAccelerationStructure).Fields() << ")";
                 const std::string resource_description = ss.str();
 
-                syncval::AdditionalMessageInfo additional_info;
+                AdditionalMessageInfo additional_info;
                 additional_info.pre_synchronization_text = "The buffer backs " + FormatHandle(info.srcAccelerationStructure) + ". ";
 
                 const auto error = error_messages_.BufferError(hazard, cb_context, error_obj.location.function,
@@ -3819,7 +3819,7 @@ bool SyncValidator::PreCallValidateCmdBuildAccelerationStructuresKHR(
                 ss << " (" << Location(vvl::Func::Empty, vvl::Field::dstAccelerationStructure).Fields() << ")";
                 const std::string resource_description = ss.str();
 
-                syncval::AdditionalMessageInfo additional_info;
+                AdditionalMessageInfo additional_info;
                 additional_info.pre_synchronization_text = "The buffer backs " + FormatHandle(info.dstAccelerationStructure) + ". ";
 
                 const auto error = error_messages_.BufferError(hazard, cb_context, error_obj.location.function,


### PR DESCRIPTION
Update naming and interfaces cleanup.

Move code to proper locations:
sync_reporting - logic and helpers to generate error messages
sync_error_messages - use that logic to construct specific messages