### PR TITLE
layers: Fix typo enabling wrong feature

### DIFF
--- a/layers/gpuav/core/gpuav_features.cpp
+++ b/layers/gpuav/core/gpuav_features.cpp
@@ -93,7 +93,7 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
             if (gpuav_settings.force_on_robustness && supported_features.robustBufferAccess &&
                 !modified_features->robustBufferAccess) {
                 InternalWarning(instance, loc, "Forcing robustBufferAccess to VK_TRUE");
-                modified_features->shaderInt64 = VK_TRUE;
+                modified_features->robustBufferAccess = VK_TRUE;
             }
         }
     }


### PR DESCRIPTION
Simple typo, setting was not working, not sure how I got this messed up (as it was working when I first was testing it)