### PR TITLE
gpuav: Fix crash when Binding LUT is null

### DIFF
--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
@@ -1189,8 +1189,11 @@ bool GpuShaderInstrumentor::InstrumentShader(const vvl::span<const uint32_t> &in
 
     bool modified = false;
 
+    // If there is no bindings found, can just ignore passes that use it
+    const bool has_bindings_layouts = !instrumentation_dsl.set_index_to_bindings_layout_lut.empty();
+
     // If descriptor indexing is enabled, enable length checks and updated descriptor checks
-    if (gpuav_settings.shader_instrumentation.descriptor_checks) {
+    if (gpuav_settings.shader_instrumentation.descriptor_checks && has_bindings_layouts) {
         // Will wrap descriptor indexing with if/else to prevent crashing if OOB
         spirv::DescriptorIndexingOOBPass oob_pass(module);
         modified |= oob_pass.Run();
@@ -1217,7 +1220,7 @@ bool GpuShaderInstrumentor::InstrumentShader(const vvl::span<const uint32_t> &in
 
     // Post Process instrumentation passes assume the things inside are valid, but putting at the end, things above will wrap checks
     // in a if/else, this means they will be gaurded as if they were inside the above passes
-    if (gpuav_settings.shader_instrumentation.post_process_descriptor_indexing) {
+    if (gpuav_settings.shader_instrumentation.post_process_descriptor_indexing && has_bindings_layouts) {
         spirv::PostProcessDescriptorIndexingPass pass(module);
         modified |= pass.Run();
     }


### PR DESCRIPTION
I couldn't get a shader saved that reproduced this, but sometimes my gfxrecon trace would crash in the instrumentation because the LUT was empty