### PR TITLE
gpuav: Hash Post Processing once per block

### DIFF
--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -2006,7 +2006,7 @@ bool CoreChecks::RunSpirvValidation(spv_const_binary_t &binary, const Location &
 
     uint32_t hash = 0;
     if (cache) {
-        hash = hash_util::ShaderHash((void *)binary.code, binary.wordCount * sizeof(uint32_t));
+        hash = hash_util::Hash32((void *)binary.code, binary.wordCount * sizeof(uint32_t));
         if (cache->Contains(hash)) {
             return skip;
         }

--- a/layers/gpuav/spirv/post_process_descriptor_indexing_pass.h
+++ b/layers/gpuav/spirv/post_process_descriptor_indexing_pass.h
@@ -40,7 +40,8 @@ class PostProcessDescriptorIndexingPass : public Pass {
         uint32_t variable_id = 0;
     };
 
-    bool RequiresInstrumentation(const Function& function, const Instruction& inst, InstructionMeta& meta);
+    bool RequiresInstrumentation(const Function& function, const Instruction& inst, InstructionMeta& meta,
+                                 vvl::unordered_set<uint32_t>& found_in_block_set);
     void CreateFunctionCall(BasicBlockIt block_it, InstructionIt* inst_it, const InstructionMeta& meta);
 
     uint32_t link_function_id = 0;

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -2114,7 +2114,7 @@ ResourceInterfaceVariable::ResourceInterfaceVariable(const Module& module_state,
     }
 
     info.access_mask = access_mask;
-    descriptor_hash = hash_util::DescriptorVariableHash(&info, sizeof(info));
+    descriptor_hash = hash_util::Hash64(&info, sizeof(info));
 }
 
 PushConstantVariable::PushConstantVariable(const Module& module_state, const Instruction& insn, VkShaderStageFlagBits stage,

--- a/layers/utils/hash_util.cpp
+++ b/layers/utils/hash_util.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2023-2024 The Khronos Group Inc.
- * Copyright (c) 2023-2024 Valve Corporation
- * Copyright (c) 2023-2024 LunarG, Inc.
+/* Copyright (c) 2023-2025 The Khronos Group Inc.
+ * Copyright (c) 2023-2025 Valve Corporation
+ * Copyright (c) 2023-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,12 +37,12 @@ uint32_t VuidHash(std::string_view vuid) {
     return XXH32(vuid.data(), vuid.size(), seed);
 }
 
-uint32_t ShaderHash(const void *pCode, const size_t codeSize) {
+uint32_t Hash32(const void *info, const size_t info_size) {
     constexpr uint32_t seed = 0;
-    return XXH32(pCode, codeSize, seed);
+    return XXH32(info, info_size, seed);
 }
 
-uint64_t DescriptorVariableHash(const void *info, const size_t info_size) {
+uint64_t Hash64(const void *info, const size_t info_size) {
     constexpr uint64_t seed = 0;
     return XXH64(info, info_size, seed);
 }

--- a/layers/utils/hash_util.h
+++ b/layers/utils/hash_util.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (C) 2015-2024 Google Inc.
+/* Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (C) 2015-2025 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -160,8 +160,8 @@ class Dictionary {
 
 uint32_t VuidHash(std::string_view vuid);
 
-uint32_t ShaderHash(const void *pCode, const size_t codeSize);
+uint32_t Hash32(const void *info, const size_t info_size);
 
-uint64_t DescriptorVariableHash(const void *info, const size_t info_size);
+uint64_t Hash64(const void *info, const size_t info_size);
 
 }  // namespace hash_util

--- a/layers/utils/shader_utils.cpp
+++ b/layers/utils/shader_utils.cpp
@@ -182,7 +182,7 @@ void AdjustValidatorOptions(const DeviceExtensions &device_extensions, const Dev
 
     // The spv_validator_options_t in libspirv.h is hidden so we can't just hash that struct, so instead need to create our own.
     if (out_hash) {
-        *out_hash = hash_util::ShaderHash(&settings, sizeof(Settings));
+        *out_hash = hash_util::Hash32(&settings, sizeof(Settings));
     }
 }
 


### PR DESCRIPTION
While looking at traces, found one where we could reduce almost half the post processing instrumentation just doing a simple hash lookup on the 4 variables we were going to pass into the function (as it means they are all going to mark the same things)

**Before**
Vert Shader - PostProcessDescriptorIndexingPass instrumentation count: **127**
Geom Shader - PostProcessDescriptorIndexingPass instrumentation count: **8**
Frag Shader - PostProcessDescriptorIndexingPass instrumentation count: **57**

**After**
Vert Shader - PostProcessDescriptorIndexingPass instrumentation count: **78**
Geom Shader - PostProcessDescriptorIndexingPass instrumentation count: **2**
Frag Shader - PostProcessDescriptorIndexingPass instrumentation count: **30**
