### PR TITLE
tests: Fix broken test on RADV

### DIFF
--- a/tests/unit/gpu_av_buffer_device_address_positive.cpp
+++ b/tests/unit/gpu_av_buffer_device_address_positive.cpp
@@ -969,7 +969,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, LoadStoreStruct) {
           vec2 uv;
         };
 
-        layout(std430, buffer_reference) readonly buffer VertexBuffer {
+        layout(std430, buffer_reference) buffer VertexBuffer {
           Vertex vertices[];
         };
 


### PR DESCRIPTION
Found from https://gitlab.freedesktop.org/mesa/mesa/-/issues/12819 that this was an uncaught issue and this is why the test was failing on CI

tracking new issue at https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9664