### PR TITLE
chassis: Shared state tracking

### DIFF
--- a/layers/best_practices/best_practices_utils.cpp
+++ b/layers/best_practices/best_practices_utils.cpp
@@ -51,16 +51,6 @@ WriteLockGuard BestPractices::WriteLock() {
     }
 }
 
-std::shared_ptr<vvl::CommandBuffer> BestPractices::CreateCmdBufferState(VkCommandBuffer handle,
-                                                                        const VkCommandBufferAllocateInfo* allocate_info,
-                                                                        const vvl::CommandPool* pool) {
-    auto cb = BaseClass::CreateCmdBufferState(handle, allocate_info, pool);
-    if (cb) {
-        cb->SetSubState(container_type, std::make_unique<bp_state::CommandBufferSubState>(*cb));
-    }
-    return cb;
-}
-
 bool bp_state::VendorCheckEnabled(const CHECK_ENABLED& enabled, BPVendorFlags vendors) {
     for (const auto& vendor : GetVendorInfo()) {
         if (vendors & vendor.first && enabled[vendor.second.vendor_id]) {

--- a/layers/best_practices/best_practices_validation.h
+++ b/layers/best_practices/best_practices_validation.h
@@ -189,8 +189,8 @@ const char* VendorSpecificTag(BPVendorFlags vendors);
 
 bool VendorCheckEnabled(const CHECK_ENABLED& enabled, BPVendorFlags vendors);
 
-class Instance : public vvl::Instance {
-    using BaseClass = vvl::Instance;
+class Instance : public vvl::InstanceState {
+    using BaseClass = vvl::InstanceState;
 
   public:
     using Func = vvl::Func;
@@ -243,8 +243,8 @@ class Instance : public vvl::Instance {
 };
 }  // namespace bp_state
 
-class BestPractices : public vvl::Device {
-    using BaseClass = vvl::Device;
+class BestPractices : public vvl::DeviceState {
+    using BaseClass = vvl::DeviceState;
 
   public:
     using Func = vvl::Func;

--- a/layers/best_practices/best_practices_validation.h
+++ b/layers/best_practices/best_practices_validation.h
@@ -189,8 +189,8 @@ const char* VendorSpecificTag(BPVendorFlags vendors);
 
 bool VendorCheckEnabled(const CHECK_ENABLED& enabled, BPVendorFlags vendors);
 
-class Instance : public vvl::InstanceState {
-    using BaseClass = vvl::InstanceState;
+class Instance : public vvl::InstanceProxy {
+    using BaseClass = vvl::InstanceProxy;
 
   public:
     using Func = vvl::Func;
@@ -243,8 +243,8 @@ class Instance : public vvl::InstanceState {
 };
 }  // namespace bp_state
 
-class BestPractices : public vvl::DeviceState {
-    using BaseClass = vvl::DeviceState;
+class BestPractices : public vvl::DeviceProxy {
+    using BaseClass = vvl::DeviceProxy;
 
   public:
     using Func = vvl::Func;
@@ -789,19 +789,10 @@ class BestPractices : public vvl::DeviceState {
                                                           const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos,
                                                           const ErrorObject& error_obj) const override;
 
+    void Created(vvl::CommandBuffer& cb_state) override;
+    void Created(vvl::Image& image_state) override;
 // Include code-generated functions
 #include "generated/best_practices_device_methods.h"
-  protected:
-    std::shared_ptr<vvl::CommandBuffer> CreateCmdBufferState(VkCommandBuffer handle,
-                                                             const VkCommandBufferAllocateInfo* allocate_info,
-                                                             const vvl::CommandPool* pool) final;
-
-    std::shared_ptr<vvl::Image> CreateImageState(VkImage handle, const VkImageCreateInfo* create_info,
-                                                 VkFormatFeatureFlags2 features) final;
-
-    std::shared_ptr<vvl::Image> CreateImageState(VkImage handle, const VkImageCreateInfo* create_info, VkSwapchainKHR swapchain,
-                                                 uint32_t swapchain_index, VkFormatFeatureFlags2 features) final;
-
   private:
     // CacheEntry and PostTransformLRUCacheModel are used on the stack
     struct CacheEntry {

--- a/layers/best_practices/bp_cmd_buffer.cpp
+++ b/layers/best_practices/bp_cmd_buffer.cpp
@@ -196,10 +196,10 @@ void BestPractices::PostCallRecordCmdSetDepthTestEnableEXT(VkCommandBuffer comma
 
 namespace {
 struct EventValidator {
-    const vvl::Device& state_tracker;
+    const Logger& log;
     vvl::unordered_map<VkEvent, bool> signaling_state;
 
-    EventValidator(const vvl::Device& state_tracker) : state_tracker(state_tracker) {}
+    EventValidator(const Logger& log_) : log(log_) {}
 
     bool ValidateSecondaryCbSignalingState(const bp_state::CommandBufferSubState& primary_cb,
                                            const bp_state::CommandBufferSubState& secondary_cb, const Location& secondary_cb_loc) {
@@ -218,12 +218,12 @@ struct EventValidator {
                     // the most recent state update was signal (signaled == true) and the secondary
                     // command buffer starts with a signal too (first_state_change_is_signal).
                     const LogObjectList objlist(primary_cb.VkHandle(), secondary_cb.VkHandle(), event);
-                    skip |= state_tracker.LogWarning(
+                    skip |= log.LogWarning(
                         "BestPractices-Event-SignalSignaledEvent", objlist, secondary_cb_loc,
                         "%s sets event %s which was already set (in the primary command buffer %s or in the executed secondary "
                         "command buffers). If this is not the desired behavior, the event must be reset before it is set again.",
-                        state_tracker.FormatHandle(secondary_cb.VkHandle()).c_str(), state_tracker.FormatHandle(event).c_str(),
-                        state_tracker.FormatHandle(primary_cb.VkHandle()).c_str());
+                        log.FormatHandle(secondary_cb.VkHandle()).c_str(), log.FormatHandle(event).c_str(),
+                        log.FormatHandle(primary_cb.VkHandle()).c_str());
                 }
             }
             signaling_state[event] = signaling_info.signaled;

--- a/layers/best_practices/bp_cmd_buffer.cpp
+++ b/layers/best_practices/bp_cmd_buffer.cpp
@@ -20,6 +20,10 @@
 #include "best_practices/best_practices_validation.h"
 #include "best_practices/bp_state.h"
 
+void BestPractices::Created(vvl::CommandBuffer& cb_state) {
+    cb_state.SetSubState(container_type, std::make_unique<bp_state::CommandBufferSubState>(cb_state));
+}
+
 bool BestPractices::PreCallValidateCreateCommandPool(VkDevice device, const VkCommandPoolCreateInfo* pCreateInfo,
                                                      const VkAllocationCallbacks* pAllocator, VkCommandPool* pCommandPool,
                                                      const ErrorObject& error_obj) const {

--- a/layers/best_practices/bp_image.cpp
+++ b/layers/best_practices/bp_image.cpp
@@ -295,21 +295,6 @@ void BestPractices::ValidateImageInQueue(const vvl::Queue& qs, const vvl::Comman
     }
 }
 
-std::shared_ptr<vvl::Image> BestPractices::CreateImageState(VkImage handle, const VkImageCreateInfo* create_info,
-                                                            VkFormatFeatureFlags2 features) {
-    auto image = BaseClass::CreateImageState(handle, create_info, features);
-    if (image) {
-        image->SetSubState(container_type, std::make_unique<bp_state::ImageSubState>(*image));
-    }
-    return image;
-}
-
-std::shared_ptr<vvl::Image> BestPractices::CreateImageState(VkImage handle, const VkImageCreateInfo* create_info,
-                                                            VkSwapchainKHR swapchain, uint32_t swapchain_index,
-                                                            VkFormatFeatureFlags2 features) {
-    auto image = BaseClass::CreateImageState(handle, create_info, swapchain, swapchain_index, features);
-    if (image) {
-        image->SetSubState(container_type, std::make_unique<bp_state::ImageSubState>(*image));
-    }
-    return image;
+void BestPractices::Created(vvl::Image& image_state) {
+    image_state.SetSubState(container_type, std::make_unique<bp_state::ImageSubState>(image_state));
 }

--- a/layers/chassis/chassis_manual.cpp
+++ b/layers/chassis/chassis_manual.cpp
@@ -450,7 +450,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateGraphicsPipelines(VkDevice device, VkPipeli
     bool skip = false;
     ErrorObject error_obj(vvl::Func::vkCreateGraphicsPipelines, VulkanTypedHandle(device, kVulkanObjectTypeDevice));
 
-    PipelineStates pipeline_states[LayerObjectTypeMaxEnum];
+    PipelineStates pipeline_states;
     chassis::CreateGraphicsPipelines chassis_state(pCreateInfos);
 
     {
@@ -461,8 +461,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateGraphicsPipelines(VkDevice device, VkPipeli
             }
             auto lock = vo->ReadLock();
             skip |= vo->PreCallValidateCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator,
-                                                               pPipelines, error_obj, pipeline_states[vo->container_type],
-                                                               chassis_state);
+                                                               pPipelines, error_obj, pipeline_states, chassis_state);
             if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
         }
     }
@@ -476,7 +475,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateGraphicsPipelines(VkDevice device, VkPipeli
             }
             auto lock = vo->WriteLock();
             vo->PreCallRecordCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines,
-                                                     record_obj, pipeline_states[vo->container_type], chassis_state);
+                                                     record_obj, pipeline_states, chassis_state);
         }
     }
 
@@ -503,7 +502,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateGraphicsPipelines(VkDevice device, VkPipeli
             }
             auto lock = vo->WriteLock();
             vo->PostCallRecordCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines,
-                                                      record_obj, pipeline_states[vo->container_type], chassis_state);
+                                                      record_obj, pipeline_states, chassis_state);
         }
     }
     return result;
@@ -519,7 +518,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateComputePipelines(VkDevice device, VkPipelin
     bool skip = false;
     ErrorObject error_obj(vvl::Func::vkCreateComputePipelines, VulkanTypedHandle(device, kVulkanObjectTypeDevice));
 
-    PipelineStates pipeline_states[LayerObjectTypeMaxEnum];
+    PipelineStates pipeline_states;
     chassis::CreateComputePipelines chassis_state(pCreateInfos);
 
     {
@@ -530,8 +529,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateComputePipelines(VkDevice device, VkPipelin
             }
             auto lock = vo->ReadLock();
             skip |= vo->PreCallValidateCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator,
-                                                              pPipelines, error_obj, pipeline_states[vo->container_type],
-                                                              chassis_state);
+                                                              pPipelines, error_obj, pipeline_states, chassis_state);
             if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
         }
     }
@@ -545,7 +543,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateComputePipelines(VkDevice device, VkPipelin
             }
             auto lock = vo->WriteLock();
             vo->PreCallRecordCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines,
-                                                    record_obj, pipeline_states[vo->container_type], chassis_state);
+                                                    record_obj, pipeline_states, chassis_state);
         }
     }
 
@@ -571,7 +569,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateComputePipelines(VkDevice device, VkPipelin
             }
             auto lock = vo->WriteLock();
             vo->PostCallRecordCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines,
-                                                     record_obj, pipeline_states[vo->container_type], chassis_state);
+                                                     record_obj, pipeline_states, chassis_state);
         }
     }
     return result;
@@ -584,7 +582,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesNV(VkDevice device, VkPi
     bool skip = false;
     ErrorObject error_obj(vvl::Func::vkCreateRayTracingPipelinesNV, VulkanTypedHandle(device, kVulkanObjectTypeDevice));
 
-    PipelineStates pipeline_states[LayerObjectTypeMaxEnum];
+    PipelineStates pipeline_states;
 
     for (const auto& vo : device_dispatch->object_dispatch) {
         if (!vo) {
@@ -592,7 +590,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesNV(VkDevice device, VkPi
         }
         auto lock = vo->ReadLock();
         skip |= vo->PreCallValidateCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator,
-                                                               pPipelines, error_obj, pipeline_states[vo->container_type]);
+                                                               pPipelines, error_obj, pipeline_states);
         if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
     }
 
@@ -603,7 +601,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesNV(VkDevice device, VkPi
         }
         auto lock = vo->WriteLock();
         vo->PreCallRecordCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines,
-                                                     record_obj, pipeline_states[vo->container_type]);
+                                                     record_obj, pipeline_states);
     }
 
     VkResult result;
@@ -617,7 +615,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesNV(VkDevice device, VkPi
         }
         auto lock = vo->WriteLock();
         vo->PostCallRecordCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines,
-                                                      record_obj, pipeline_states[vo->container_type]);
+                                                      record_obj, pipeline_states);
     }
     return result;
 }
@@ -632,7 +630,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesKHR(VkDevice device, VkD
     bool skip = false;
     ErrorObject error_obj(vvl::Func::vkCreateRayTracingPipelinesKHR, VulkanTypedHandle(device, kVulkanObjectTypeDevice));
 
-    PipelineStates pipeline_states[LayerObjectTypeMaxEnum];
+    PipelineStates pipeline_states;
     auto chassis_state = std::make_shared<chassis::CreateRayTracingPipelinesKHR>(pCreateInfos);
 
     {
@@ -644,7 +642,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesKHR(VkDevice device, VkD
             auto lock = vo->ReadLock();
             skip |= vo->PreCallValidateCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount,
                                                                     pCreateInfos, pAllocator, pPipelines, error_obj,
-                                                                    pipeline_states[vo->container_type], *chassis_state);
+                                                                    pipeline_states, *chassis_state);
             if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
         }
     }
@@ -658,8 +656,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesKHR(VkDevice device, VkD
             }
             auto lock = vo->WriteLock();
             vo->PreCallRecordCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos,
-                                                          pAllocator, pPipelines, record_obj, pipeline_states[vo->container_type],
-                                                          *chassis_state);
+                                                          pAllocator, pPipelines, record_obj, pipeline_states, *chassis_state);
         }
     }
 
@@ -687,8 +684,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesKHR(VkDevice device, VkD
             }
             auto lock = vo->WriteLock();
             vo->PostCallRecordCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos,
-                                                           pAllocator, pPipelines, record_obj, pipeline_states[vo->container_type],
-                                                           chassis_state);
+                                                           pAllocator, pPipelines, record_obj, pipeline_states, chassis_state);
         }
     }
     return result;
@@ -880,7 +876,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateDescriptorSets(VkDevice device, const VkD
     bool skip = false;
     ErrorObject error_obj(vvl::Func::vkAllocateDescriptorSets, VulkanTypedHandle(device, kVulkanObjectTypeDevice));
 
-    vvl::AllocateDescriptorSetsData ads_state[LayerObjectTypeMaxEnum];
+    vvl::AllocateDescriptorSetsData ads_state;
 
     {
         VVL_ZoneScopedN("PreCallValidate_AllocateDescriptorSets");
@@ -888,10 +884,9 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateDescriptorSets(VkDevice device, const VkD
             if (!vo) {
                 continue;
             }
-            ads_state[vo->container_type].Init(pAllocateInfo->descriptorSetCount);
+            ads_state.Init(pAllocateInfo->descriptorSetCount);
             auto lock = vo->ReadLock();
-            skip |= vo->PreCallValidateAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets, error_obj,
-                                                              ads_state[vo->container_type]);
+            skip |= vo->PreCallValidateAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets, error_obj, ads_state);
             if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
         }
     }
@@ -922,8 +917,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateDescriptorSets(VkDevice device, const VkD
                 continue;
             }
             auto lock = vo->WriteLock();
-            vo->PostCallRecordAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets, record_obj,
-                                                     ads_state[vo->container_type]);
+            vo->PostCallRecordAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets, record_obj, ads_state);
         }
     }
     return result;

--- a/layers/chassis/layer_object_id.h
+++ b/layers/chassis/layer_object_id.h
@@ -22,9 +22,10 @@
 #pragma once
 // Layer object type identifiers
 enum LayerObjectTypeId {
-    LayerObjectTypeThreading,            // Instance or device threading layer object
     LayerObjectTypeParameterValidation,  // Instance or device parameter validation layer object
+    LayerObjectTypeThreading,            // Instance or device threading layer object
     LayerObjectTypeObjectTracker,        // Instance or device object tracker layer object
+    LayerObjectTypeStateTracker,         // Shared state tracker
     LayerObjectTypeCoreValidation,       // Instance or device core validation layer object
     LayerObjectTypeBestPractices,        // Instance or device best practices layer object
     LayerObjectTypeGpuAssisted,          // Instance or device gpu assisted validation layer object

--- a/layers/core_checks/cc_android.cpp
+++ b/layers/core_checks/cc_android.cpp
@@ -494,7 +494,7 @@ bool CoreChecks::ValidateCreateImageANDROID(const VkImageCreateInfo &create_info
                              "(%" PRIu64 ") is non-zero, but layout is %s.", ext_fmt_android->externalFormat,
                              string_VkImageTiling(create_info.tiling));
         }
-        if (ahb_ext_formats_map.find(ext_fmt_android->externalFormat) == ahb_ext_formats_map.end()) {
+        if (device_state->ahb_ext_formats_map.find(ext_fmt_android->externalFormat) == device_state->ahb_ext_formats_map.end()) {
             skip |= LogError("VUID-VkExternalFormatANDROID-externalFormat-01894", device,
                              create_info_loc.pNext(Struct::VkExternalFormatANDROID, Field::externalFormat),
                              "(%" PRIu64 ") has not been previously retrieved by vkGetAndroidHardwareBufferPropertiesANDROID().",

--- a/layers/core_checks/cc_buffer.cpp
+++ b/layers/core_checks/cc_buffer.cpp
@@ -110,39 +110,39 @@ bool CoreChecks::ValidateCreateBufferDescriptorBuffer(const VkBufferCreateInfo &
     bool skip = false;
 
     if (usage & VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT) {
-        if (create_info.size + samplerDescriptorBufferAddressSpaceSize >
+        if (create_info.size + device_state->samplerDescriptorBufferAddressSpaceSize >
             phys_dev_ext_props.descriptor_buffer_props.samplerDescriptorBufferAddressSpaceSize) {
             skip |= LogError(
                 "VUID-VkBufferCreateInfo-usage-08097", device, create_info_loc.dot(Field::size),
                 "(%" PRIuLEAST64 ") + current total (%" PRIuLEAST64
                 ") is greater than specified in properties field samplerDescriptorBufferAddressSpaceSize (%" PRIuLEAST64 ").",
-                create_info.size, samplerDescriptorBufferAddressSpaceSize.load(),
+                create_info.size, device_state->samplerDescriptorBufferAddressSpaceSize.load(),
                 phys_dev_ext_props.descriptor_buffer_props.samplerDescriptorBufferAddressSpaceSize);
-        } else if (create_info.size + descriptorBufferAddressSpaceSize >
+        } else if (create_info.size + device_state->descriptorBufferAddressSpaceSize >
                    phys_dev_ext_props.descriptor_buffer_props.descriptorBufferAddressSpaceSize) {
             skip |= LogError("VUID-VkBufferCreateInfo-usage-08097", device, create_info_loc.dot(Field::size),
                              "(%" PRIuLEAST64 ") + current total (%" PRIuLEAST64
                              ") is greater than specified in properties field descriptorBufferAddressSpaceSize (%" PRIuLEAST64 ")",
-                             create_info.size, descriptorBufferAddressSpaceSize.load(),
+                             create_info.size, device_state->descriptorBufferAddressSpaceSize.load(),
                              phys_dev_ext_props.descriptor_buffer_props.descriptorBufferAddressSpaceSize);
         }
     }
 
     if (usage & VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT) {
-        if (create_info.size + resourceDescriptorBufferAddressSpaceSize >
+        if (create_info.size + device_state->resourceDescriptorBufferAddressSpaceSize >
             phys_dev_ext_props.descriptor_buffer_props.resourceDescriptorBufferAddressSpaceSize) {
             skip |= LogError(
                 "VUID-VkBufferCreateInfo-usage-08098", device, create_info_loc.dot(Field::size),
                 "(%" PRIuLEAST64 ") + current total (%" PRIuLEAST64
                 ") is greater than specified in properties field resourceDescriptorBufferAddressSpaceSize (%" PRIuLEAST64 ").",
-                create_info.size, resourceDescriptorBufferAddressSpaceSize.load(),
+                create_info.size, device_state->resourceDescriptorBufferAddressSpaceSize.load(),
                 phys_dev_ext_props.descriptor_buffer_props.resourceDescriptorBufferAddressSpaceSize);
-        } else if (create_info.size + descriptorBufferAddressSpaceSize >
+        } else if (create_info.size + device_state->descriptorBufferAddressSpaceSize >
                    phys_dev_ext_props.descriptor_buffer_props.descriptorBufferAddressSpaceSize) {
             skip |= LogError("VUID-VkBufferCreateInfo-usage-08098", device, create_info_loc.dot(Field::size),
                              "(%" PRIuLEAST64 ") + current total (%" PRIuLEAST64
                              ") is greater than specified in properties field descriptorBufferAddressSpaceSize (%" PRIuLEAST64 ").",
-                             create_info.size, descriptorBufferAddressSpaceSize.load(),
+                             create_info.size, device_state->descriptorBufferAddressSpaceSize.load(),
                              phys_dev_ext_props.descriptor_buffer_props.descriptorBufferAddressSpaceSize);
         }
     }

--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -930,7 +930,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
     const auto &cb_state = *GetRead<vvl::CommandBuffer>(commandBuffer);
     bool skip = false;
     vvl::unordered_set<const vvl::CommandBuffer *> linked_command_buffers;
-    ViewportScissorInheritanceTracker viewport_scissor_inheritance{*this};
+    ViewportScissorInheritanceTracker viewport_scissor_inheritance{*device_state};
 
     if (enabled_features.inheritedViewportScissor2D) {
         skip |= viewport_scissor_inheritance.VisitPrimary(cb_state);
@@ -1910,8 +1910,8 @@ bool CoreChecks::ValidateVkConvertCooperativeVectorMatrixInfoNV(const LogObjectL
         if (component_type == VK_COMPONENT_TYPE_FLOAT32_KHR) {
             return true;
         }
-        for (size_t i = 0; i < cooperative_vector_properties_nv.size(); ++i) {
-            if (cooperative_vector_properties_nv[i].matrixInterpretation == component_type) {
+        for (size_t i = 0; i < device_state->cooperative_vector_properties_nv.size(); ++i) {
+            if (device_state->cooperative_vector_properties_nv[i].matrixInterpretation == component_type) {
                 return true;
             }
         }

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -1449,7 +1449,7 @@ bool CoreChecks::ValidateUpdateDescriptorSets(uint32_t descriptorWriteCount, con
     return skip;
 }
 
-vvl::DecodedTemplateUpdate::DecodedTemplateUpdate(const vvl::Device &device_data, VkDescriptorSet descriptorSet,
+vvl::DecodedTemplateUpdate::DecodedTemplateUpdate(const vvl::DeviceState &device_data, VkDescriptorSet descriptorSet,
                                                   const vvl::DescriptorUpdateTemplate *template_state, const void *pData,
                                                   VkDescriptorSetLayout push_layout) {
     auto const &create_info = template_state->create_info;

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -2689,13 +2689,13 @@ bool CoreChecks::PreCallValidateGetBufferOpaqueCaptureDescriptorDataEXT(VkDevice
                          "descriptorBufferCaptureReplay feature was not enabled.");
     }
 
-    if (physical_device_count > 1 && !enabled_features.bufferDeviceAddressMultiDevice &&
+    if (device_state->physical_device_count > 1 && !enabled_features.bufferDeviceAddressMultiDevice &&
         !enabled_features.bufferDeviceAddressMultiDeviceEXT) {
         skip |= LogError("VUID-vkGetBufferOpaqueCaptureDescriptorDataEXT-device-08074", pInfo->buffer, error_obj.location,
                          "device was created with multiple physical devices (%" PRIu32
                          "), but the "
                          "bufferDeviceAddressMultiDevice feature was not enabled.",
-                         physical_device_count);
+                         device_state->physical_device_count);
     }
 
     if (auto buffer_state = Get<vvl::Buffer>(pInfo->buffer)) {
@@ -2719,13 +2719,13 @@ bool CoreChecks::PreCallValidateGetImageOpaqueCaptureDescriptorDataEXT(VkDevice 
                          "descriptorBufferCaptureReplay feature was not enabled.");
     }
 
-    if (physical_device_count > 1 && !enabled_features.bufferDeviceAddressMultiDevice &&
+    if (device_state->physical_device_count > 1 && !enabled_features.bufferDeviceAddressMultiDevice &&
         !enabled_features.bufferDeviceAddressMultiDeviceEXT) {
         skip |= LogError("VUID-vkGetImageOpaqueCaptureDescriptorDataEXT-device-08078", pInfo->image, error_obj.location,
                          "device was created with multiple physical devices (%" PRIu32
                          "), but the "
                          "bufferDeviceAddressMultiDevice feature was not enabled.",
-                         physical_device_count);
+                         device_state->physical_device_count);
     }
 
     if (auto image_state = Get<vvl::Image>(pInfo->image)) {
@@ -2749,13 +2749,13 @@ bool CoreChecks::PreCallValidateGetImageViewOpaqueCaptureDescriptorDataEXT(VkDev
                          "descriptorBufferCaptureReplay feature was not enabled.");
     }
 
-    if (physical_device_count > 1 && !enabled_features.bufferDeviceAddressMultiDevice &&
+    if (device_state->physical_device_count > 1 && !enabled_features.bufferDeviceAddressMultiDevice &&
         !enabled_features.bufferDeviceAddressMultiDeviceEXT) {
         skip |= LogError("VUID-vkGetImageViewOpaqueCaptureDescriptorDataEXT-device-08082", pInfo->imageView, error_obj.location,
                          "device was created with multiple physical devices (%" PRIu32
                          "), but the "
                          "bufferDeviceAddressMultiDevice feature was not enabled.",
-                         physical_device_count);
+                         device_state->physical_device_count);
     }
 
     if (auto image_view_state = Get<vvl::ImageView>(pInfo->imageView)) {
@@ -2779,13 +2779,13 @@ bool CoreChecks::PreCallValidateGetSamplerOpaqueCaptureDescriptorDataEXT(VkDevic
                          "descriptorBufferCaptureReplay feature was not enabled.");
     }
 
-    if (physical_device_count > 1 && !enabled_features.bufferDeviceAddressMultiDevice &&
+    if (device_state->physical_device_count > 1 && !enabled_features.bufferDeviceAddressMultiDevice &&
         !enabled_features.bufferDeviceAddressMultiDeviceEXT) {
         skip |= LogError("VUID-vkGetSamplerOpaqueCaptureDescriptorDataEXT-device-08086", pInfo->sampler, error_obj.location,
                          "device was created with multiple physical devices (%" PRIu32
                          "), but the "
                          "bufferDeviceAddressMultiDevice feature was not enabled.",
-                         physical_device_count);
+                         device_state->physical_device_count);
     }
 
     if (auto sampler_state = Get<vvl::Sampler>(pInfo->sampler)) {
@@ -2809,13 +2809,13 @@ bool CoreChecks::PreCallValidateGetAccelerationStructureOpaqueCaptureDescriptorD
                          "descriptorBufferCaptureReplay feature was not enabled.");
     }
 
-    if (physical_device_count > 1 && !enabled_features.bufferDeviceAddressMultiDevice &&
+    if (device_state->physical_device_count > 1 && !enabled_features.bufferDeviceAddressMultiDevice &&
         !enabled_features.bufferDeviceAddressMultiDeviceEXT) {
         skip |= LogError("VUID-vkGetAccelerationStructureOpaqueCaptureDescriptorDataEXT-device-08090", device, error_obj.location,
                          "device was created with multiple physical devices (%" PRIu32
                          "), but the "
                          "bufferDeviceAddressMultiDevice feature was not enabled.",
-                         physical_device_count);
+                         device_state->physical_device_count);
     }
 
     if (pInfo->accelerationStructure != VK_NULL_HANDLE) {
@@ -3568,7 +3568,7 @@ bool CoreChecks::ValidateCmdPushDescriptorSet(const vvl::CommandBuffer &cb_state
         // TODO move the validation (like this) that doesn't need descriptor set state to the DSL object so we
         // don't have to do this. Note we need to const_cast<>(this) because GPU-AV needs a non-const version of
         // the state tracker. The proxy here could get away with const.
-        vvl::DescriptorSet proxy_ds(VK_NULL_HANDLE, nullptr, dsl, 0, const_cast<CoreChecks *>(this));
+        vvl::DescriptorSet proxy_ds(VK_NULL_HANDLE, nullptr, dsl, 0, const_cast<vvl::DeviceState *>(device_state));
         vvl::DslErrorSource dsl_error_source(loc, layout, set);
         skip |= ValidatePushDescriptorsUpdate(proxy_ds, descriptorWriteCount, pDescriptorWrites, dsl_error_source, loc);
     }
@@ -3718,7 +3718,7 @@ bool CoreChecks::PreCallValidateUpdateDescriptorSetWithTemplate(VkDevice device,
     if (template_state->create_info.templateType == VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET) {
         // decode the templatized data and leverage the non-template UpdateDescriptor helper functions.
         // Translate the templated update into a normal update for validation...
-        vvl::DecodedTemplateUpdate decoded_update(*this, descriptorSet, template_state.get(), pData);
+        vvl::DecodedTemplateUpdate decoded_update(*device_state, descriptorSet, template_state.get(), pData);
         return ValidateUpdateDescriptorSets(static_cast<uint32_t>(decoded_update.desc_writes.size()),
                                             decoded_update.desc_writes.data(), 0, nullptr, error_obj.location);
     }
@@ -3812,9 +3812,9 @@ bool CoreChecks::ValidateCmdPushDescriptorSetWithTemplate(VkCommandBuffer comman
                          "VkDescriptorUpdateTemplateCreateInfo::descriptorSetLayout was accidentally destroy.");
     } else {
         // Create an empty proxy in order to use the existing descriptor set update validation
-        vvl::DescriptorSet proxy_ds(VK_NULL_HANDLE, nullptr, dsl, 0, const_cast<CoreChecks *>(this));
+        vvl::DescriptorSet proxy_ds(VK_NULL_HANDLE, nullptr, dsl, 0, const_cast<vvl::DeviceState *>(device_state));
         // Decode the template into a set of write updates
-        vvl::DecodedTemplateUpdate decoded_template(*this, VK_NULL_HANDLE, template_state.get(), pData, dsl->VkHandle());
+        vvl::DecodedTemplateUpdate decoded_template(*device_state, VK_NULL_HANDLE, template_state.get(), pData, dsl->VkHandle());
         // Validate the decoded update against the proxy_ds
         vvl::DslErrorSource dsl_error_source(loc, layout, set);
         skip |= ValidatePushDescriptorsUpdate(proxy_ds, static_cast<uint32_t>(decoded_template.desc_writes.size()),
@@ -4720,7 +4720,8 @@ bool CoreChecks::PreCallValidateCreateSampler(VkDevice device, const VkSamplerCr
 
     if (pCreateInfo->borderColor == VK_BORDER_COLOR_INT_CUSTOM_EXT ||
         pCreateInfo->borderColor == VK_BORDER_COLOR_FLOAT_CUSTOM_EXT) {
-        if (custom_border_color_sampler_count >= phys_dev_ext_props.custom_border_color_props.maxCustomBorderColorSamplers) {
+        if (device_state->custom_border_color_sampler_count >=
+            phys_dev_ext_props.custom_border_color_props.maxCustomBorderColorSamplers) {
             skip |= LogError("VUID-VkSamplerCreateInfo-None-04012", device, error_obj.location,
                              "Creating a sampler with a custom border color will exceed the "
                              "maxCustomBorderColorSamplers limit of %" PRIu32 ".",

--- a/layers/core_checks/cc_external_object.cpp
+++ b/layers/core_checks/cc_external_object.cpp
@@ -89,7 +89,7 @@ bool CoreChecks::PreCallValidateImportSemaphoreFdKHR(VkDevice device, const VkIm
     }
 
     if (pImportSemaphoreFdInfo->handleType == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT) {
-        if (const auto payload_info = GetOpaqueInfoFromFdHandle(pImportSemaphoreFdInfo->fd)) {
+        if (const auto payload_info = device_state->GetOpaqueInfoFromFdHandle(pImportSemaphoreFdInfo->fd)) {
             if (sem_state->flags != payload_info->semaphore_flags) {
                 // would use string_VkSemaphoreCreateFlags but no valid flags yet
                 skip |= LogError("VUID-VkImportSemaphoreFdInfoKHR-handleType-03263", device, info_loc.dot(Field::semaphore),

--- a/layers/core_checks/cc_pipeline.cpp
+++ b/layers/core_checks/cc_pipeline.cpp
@@ -121,14 +121,15 @@ bool CoreChecks::ValidatePipelineRobustnessCreateInfo(const vvl::Pipeline &pipel
     }
 
     // These validation depend if the features are exposed (not just enabled)
-    if (!has_robust_image_access && pipeline_robustness_info.images == VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS) {
+    if (!device_state->has_robust_image_access &&
+        pipeline_robustness_info.images == VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS) {
         skip |= LogError("VUID-VkPipelineRobustnessCreateInfo-robustImageAccess-06930", device,
                          loc.pNext(Struct::VkPipelineRobustnessCreateInfo, Field::images),
                          "is VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS "
                          "but robustImageAccess2 is not supported.");
     }
 
-    if (!has_robust_buffer_access2) {
+    if (!device_state->has_robust_buffer_access2) {
         if (pipeline_robustness_info.storageBuffers == VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2) {
             skip |= LogError(
                 "VUID-VkPipelineRobustnessCreateInfo-robustBufferAccess2-06931", device,
@@ -149,7 +150,7 @@ bool CoreChecks::ValidatePipelineRobustnessCreateInfo(const vvl::Pipeline &pipel
         }
     }
 
-    if (!has_robust_image_access2) {
+    if (!device_state->has_robust_image_access2) {
         if (pipeline_robustness_info.images == VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2) {
             skip |= LogError(
                 "VUID-VkPipelineRobustnessCreateInfo-robustImageAccess2-06934", device,

--- a/layers/core_checks/cc_query.cpp
+++ b/layers/core_checks/cc_query.cpp
@@ -268,7 +268,7 @@ bool CoreChecks::PreCallValidateCreateQueryPool(VkDevice device, const VkQueryPo
     switch (pCreateInfo->queryType) {
         case VK_QUERY_TYPE_PERFORMANCE_QUERY_KHR: {
             if (auto perf_ci = vku::FindStructInPNextChain<VkQueryPoolPerformanceCreateInfoKHR>(pCreateInfo->pNext)) {
-                auto *core_instance = static_cast<core::Instance *>(instance_state);
+                auto *core_instance = static_cast<core::Instance *>(instance_proxy);
                 skip |= core_instance->ValidateQueueFamilyIndex(
                     *physical_device_state, perf_ci->queueFamilyIndex,
                     "VUID-VkQueryPoolPerformanceCreateInfoKHR-queueFamilyIndex-03236",
@@ -566,7 +566,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
             break;
         }
         case VK_QUERY_TYPE_RESULT_STATUS_ONLY_KHR: {
-            const auto &qf_ext_props = queue_family_ext_props[cb_state.command_pool->queueFamilyIndex];
+            const auto &qf_ext_props = device_state->queue_family_ext_props[cb_state.command_pool->queueFamilyIndex];
             if (!qf_ext_props.query_result_status_props.queryResultStatusSupport) {
                 const char *vuid =
                     is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-07126" : "VUID-vkCmdBeginQuery-queryType-07126";
@@ -1543,7 +1543,7 @@ void CoreChecks::PostCallRecordGetQueryPoolResults(VkDevice device, VkQueryPool 
 bool CoreChecks::PreCallValidateReleaseProfilingLockKHR(VkDevice device, const ErrorObject &error_obj) const {
     bool skip = false;
 
-    if (!performance_lock_acquired) {
+    if (!device_state->performance_lock_acquired) {
         skip |= LogError("VUID-vkReleaseProfilingLockKHR-device-03235", device, error_obj.location,
                          "The profiling lock of device must have been held via a previous successful "
                          "call to vkAcquireProfilingLockKHR.");

--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -459,7 +459,7 @@ bool CoreChecks::PreCallValidateGetAccelerationStructureDeviceAddressKHR(VkDevic
         skip |= LogError("VUID-vkGetAccelerationStructureDeviceAddressKHR-accelerationStructure-08935", device, error_obj.location,
                          "accelerationStructure feature was not enabled.");
     }
-    if (physical_device_count > 1 && !enabled_features.bufferDeviceAddressMultiDevice &&
+    if (device_state->physical_device_count > 1 && !enabled_features.bufferDeviceAddressMultiDevice &&
         !enabled_features.bufferDeviceAddressMultiDeviceEXT) {
         skip |= LogError("VUID-vkGetAccelerationStructureDeviceAddressKHR-device-03504", device, error_obj.location,
                          "bufferDeviceAddressMultiDevice feature was not enabled.");
@@ -1543,9 +1543,11 @@ bool CoreChecks::PreCallValidateDestroyAccelerationStructureKHR(VkDevice device,
     return skip;
 }
 
-void CoreChecks::PostCallRecordCmdWriteAccelerationStructuresPropertiesKHR(
-    VkCommandBuffer commandBuffer, uint32_t accelerationStructureCount, const VkAccelerationStructureKHR *pAccelerationStructures,
-    VkQueryType queryType, VkQueryPool queryPool, uint32_t firstQuery, const RecordObject &record_obj) {
+void CoreChecks::PreCallRecordCmdWriteAccelerationStructuresPropertiesKHR(VkCommandBuffer commandBuffer,
+                                                                          uint32_t accelerationStructureCount,
+                                                                          const VkAccelerationStructureKHR *pAccelerationStructures,
+                                                                          VkQueryType queryType, VkQueryPool queryPool,
+                                                                          uint32_t firstQuery, const RecordObject &record_obj) {
     if (disabled[query_validation]) return;
     // Enqueue the submit time validation check here, before the submit time state update in BaseClass::PostCall...
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);

--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -425,8 +425,8 @@ bool CoreChecks::ValidateCooperativeMatrix(const spirv::Module &module_state, co
 
     auto print_properties = [this]() {
         std::ostringstream ss;
-        for (uint32_t i = 0; i < cooperative_matrix_properties_khr.size(); ++i) {
-            const auto &prop = cooperative_matrix_properties_khr[i];
+        for (uint32_t i = 0; i < device_state->cooperative_matrix_properties_khr.size(); ++i) {
+            const auto &prop = device_state->cooperative_matrix_properties_khr[i];
             ss << "[" << i << "] MSize = " << prop.MSize << " | NSize = " << prop.NSize << " | KSize = " << prop.KSize
                << " | AType = " << string_VkComponentTypeKHR(prop.AType) << " | BType = " << string_VkComponentTypeKHR(prop.BType)
                << " | CType = " << string_VkComponentTypeKHR(prop.CType)
@@ -438,8 +438,8 @@ bool CoreChecks::ValidateCooperativeMatrix(const spirv::Module &module_state, co
 
     auto print_flexible_properties = [this]() {
         std::ostringstream ss;
-        for (uint32_t i = 0; i < cooperative_matrix_flexible_dimensions_properties.size(); ++i) {
-            const auto &prop = cooperative_matrix_flexible_dimensions_properties[i];
+        for (uint32_t i = 0; i < device_state->cooperative_matrix_flexible_dimensions_properties.size(); ++i) {
+            const auto &prop = device_state->cooperative_matrix_flexible_dimensions_properties[i];
             ss << "[" << i << "] MGranularity = " << prop.MGranularity << " | NGranularity = " << prop.NGranularity
                << " | KGranularity = " << prop.KGranularity << " | AType = " << string_VkComponentTypeKHR(prop.AType)
                << " | BType = " << string_VkComponentTypeKHR(prop.BType) << " | CType = " << string_VkComponentTypeKHR(prop.CType)
@@ -491,8 +491,8 @@ bool CoreChecks::ValidateCooperativeMatrix(const spirv::Module &module_state, co
                 // Validate that the type parameters are all supported for one of the
                 // operands of a cooperative matrix khr property.
                 bool valid = false;
-                for (uint32_t i = 0; i < cooperative_matrix_properties_khr.size(); ++i) {
-                    const auto &property = cooperative_matrix_properties_khr[i];
+                for (uint32_t i = 0; i < device_state->cooperative_matrix_properties_khr.size(); ++i) {
+                    const auto &property = device_state->cooperative_matrix_properties_khr[i];
                     if (property.AType == m.component_type && property.MSize == m.rows && property.KSize == m.cols &&
                         property.scope == m.scope && m.use == spv::CooperativeMatrixUseMatrixAKHR) {
                         valid = true;
@@ -515,8 +515,8 @@ bool CoreChecks::ValidateCooperativeMatrix(const spirv::Module &module_state, co
                     }
                 }
                 if (enabled_features.cooperativeMatrixFlexibleDimensions) {
-                    for (uint32_t i = 0; i < cooperative_matrix_flexible_dimensions_properties.size(); ++i) {
-                        const auto &property = cooperative_matrix_flexible_dimensions_properties[i];
+                    for (uint32_t i = 0; i < device_state->cooperative_matrix_flexible_dimensions_properties.size(); ++i) {
+                        const auto &property = device_state->cooperative_matrix_flexible_dimensions_properties[i];
 
                         if (property.scope == VK_SCOPE_WORKGROUP_KHR && workgroup_size != property.workgroupInvocations) {
                             continue;
@@ -590,8 +590,8 @@ bool CoreChecks::ValidateCooperativeMatrix(const spirv::Module &module_state, co
                     // Validate that the type parameters are all supported for the same
                     // cooperative matrix property.
                     bool found_matching_prop = false;
-                    for (uint32_t i = 0; i < cooperative_matrix_properties_khr.size(); ++i) {
-                        const auto &property = cooperative_matrix_properties_khr[i];
+                    for (uint32_t i = 0; i < device_state->cooperative_matrix_properties_khr.size(); ++i) {
+                        const auto &property = device_state->cooperative_matrix_properties_khr[i];
 
                         bool valid = true;
                         valid &= property.AType == a.component_type && property.MSize == a.rows && property.KSize == a.cols &&
@@ -622,8 +622,8 @@ bool CoreChecks::ValidateCooperativeMatrix(const spirv::Module &module_state, co
                     }
                     bool found_matching_flexible_prop = false;
                     if (enabled_features.cooperativeMatrixFlexibleDimensions) {
-                        for (uint32_t i = 0; i < cooperative_matrix_flexible_dimensions_properties.size(); ++i) {
-                            const auto &property = cooperative_matrix_flexible_dimensions_properties[i];
+                        for (uint32_t i = 0; i < device_state->cooperative_matrix_flexible_dimensions_properties.size(); ++i) {
+                            const auto &property = device_state->cooperative_matrix_flexible_dimensions_properties[i];
 
                             bool valid = true;
                             valid &= property.AType == a.component_type && SafeModulo(a.rows, property.MGranularity) == 0 &&
@@ -690,8 +690,8 @@ bool CoreChecks::ValidateCooperativeMatrix(const spirv::Module &module_state, co
                 // Validate that the type parameters are all supported for one of the
                 // operands of a cooperative matrix property.
                 bool valid = false;
-                for (uint32_t i = 0; i < cooperative_matrix_properties_nv.size(); ++i) {
-                    const auto &property = cooperative_matrix_properties_nv[i];
+                for (uint32_t i = 0; i < device_state->cooperative_matrix_properties_nv.size(); ++i) {
+                    const auto &property = device_state->cooperative_matrix_properties_nv[i];
                     if (property.AType == m.component_type && property.MSize == m.rows && property.KSize == m.cols &&
                         property.scope == m.scope) {
                         valid = true;
@@ -734,8 +734,8 @@ bool CoreChecks::ValidateCooperativeMatrix(const spirv::Module &module_state, co
                     bool valid_b = false;
                     bool valid_c = false;
                     bool valid_d = false;
-                    for (uint32_t i = 0; i < cooperative_matrix_properties_nv.size(); ++i) {
-                        const auto &property = cooperative_matrix_properties_nv[i];
+                    for (uint32_t i = 0; i < device_state->cooperative_matrix_properties_nv.size(); ++i) {
+                        const auto &property = device_state->cooperative_matrix_properties_nv[i];
                         valid_a |= property.AType == a.component_type && property.MSize == a.rows && property.KSize == a.cols &&
                                    property.scope == a.scope;
                         valid_b |= property.BType == b.component_type && property.KSize == b.rows && property.NSize == b.cols &&
@@ -850,8 +850,8 @@ bool CoreChecks::ValidateCooperativeVector(const spirv::Module &module_state, co
                 }
 
                 bool found = false;
-                for (uint32_t i = 0; i < cooperative_vector_properties_nv.size(); ++i) {
-                    const auto &property = cooperative_vector_properties_nv[i];
+                for (uint32_t i = 0; i < device_state->cooperative_vector_properties_nv.size(); ++i) {
+                    const auto &property = device_state->cooperative_vector_properties_nv[i];
                     if (m.component_type == property.inputType || m.component_type == property.resultType) {
                         found = true;
                         break;
@@ -907,8 +907,8 @@ bool CoreChecks::ValidateCooperativeVector(const spirv::Module &module_state, co
                 }
 
                 bool found = false;
-                for (uint32_t i = 0; i < cooperative_vector_properties_nv.size(); ++i) {
-                    const auto &property = cooperative_vector_properties_nv[i];
+                for (uint32_t i = 0; i < device_state->cooperative_vector_properties_nv.size(); ++i) {
+                    const auto &property = device_state->cooperative_vector_properties_nv[i];
                     if (property.inputType == input_type && property.inputInterpretation == input_interpretation &&
                         property.matrixInterpretation == matrix_interpretation &&
                         (insn.Opcode() == spv::OpCooperativeVectorMatrixMulNV ||

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -1137,7 +1137,7 @@ bool CoreChecks::ValidateWaitEventsAtSubmit(vvl::Func command, const vvl::Comman
                                             size_t firstEventIndex, VkPipelineStageFlags2 sourceStageMask,
                                             const EventMap &local_event_signal_info, VkQueue waiting_queue, const Location &loc) {
     bool skip = false;
-    const vvl::Device &state_data = cb_state.dev_data;
+    const vvl::DeviceState &state_data = cb_state.dev_data;
     VkPipelineStageFlags2KHR stage_mask = 0;
     const auto max_event = std::min((firstEventIndex + eventCount), cb_state.events.size());
     for (size_t event_index = firstEventIndex; event_index < max_event; ++event_index) {
@@ -1923,7 +1923,7 @@ void CoreChecks::EnqueueSubmitTimeValidateImageBarrierAttachment(const Location 
     }
 }
 
-static bool IsQueueFamilyValid(const vvl::Device &device_data, uint32_t queue_family) {
+static bool IsQueueFamilyValid(const vvl::DeviceState &device_data, uint32_t queue_family) {
     return (queue_family < static_cast<uint32_t>(device_data.physical_device_state->queue_family_properties.size()));
 }
 
@@ -1931,7 +1931,7 @@ static bool IsQueueFamilySpecial(uint32_t queue_family) {
     return IsQueueFamilyExternal(queue_family) || (queue_family == VK_QUEUE_FAMILY_IGNORED);
 }
 
-static const char *GetFamilyAnnotation(const vvl::Device &device_data, uint32_t family) {
+static const char *GetFamilyAnnotation(const vvl::DeviceState &device_data, uint32_t family) {
     switch (family) {
         case VK_QUEUE_FAMILY_EXTERNAL:
             return " (VK_QUEUE_FAMILY_EXTERNAL)";

--- a/layers/core_checks/cc_wsi.cpp
+++ b/layers/core_checks/cc_wsi.cpp
@@ -654,7 +654,7 @@ bool CoreChecks::ValidateCreateSwapchain(const VkSwapchainCreateInfoKHR &create_
         }
     }
 
-    if ((create_info.flags & VK_SWAPCHAIN_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT_KHR) && physical_device_count == 1) {
+    if ((create_info.flags & VK_SWAPCHAIN_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT_KHR) && device_state->physical_device_count == 1) {
         if (LogError("VUID-VkSwapchainCreateInfoKHR-physicalDeviceCount-01429", device, create_info_loc.dot(Field::flags),
                      "containing VK_SWAPCHAIN_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT_KHR"
                      "but logical device was created with VkDeviceGroupDeviceCreateInfo::physicalDeviceCount equal to 1."
@@ -1471,15 +1471,15 @@ bool CoreChecks::PreCallValidateGetDeviceGroupSurfacePresentModes2EXT(VkDevice d
                                                                       const ErrorObject &error_obj) const {
     bool skip = false;
 
-    const auto *core_instance = reinterpret_cast<core::Instance *>(instance_state);
-    if (physical_device_count == 1) {
+    const auto *core_instance = reinterpret_cast<core::Instance *>(instance_proxy);
+    if (device_state->physical_device_count == 1) {
         skip |= core_instance->ValidatePhysicalDeviceSurfaceSupport(
             physical_device, pSurfaceInfo->surface, "VUID-vkGetDeviceGroupSurfacePresentModes2EXT-pSurfaceInfo-06213",
             error_obj.location);
     } else {
-        for (uint32_t i = 0; i < physical_device_count; ++i) {
+        for (uint32_t i = 0; i < device_state->physical_device_count; ++i) {
             skip |= core_instance->ValidatePhysicalDeviceSurfaceSupport(
-                device_group_create_info.pPhysicalDevices[i], pSurfaceInfo->surface,
+                device_state->device_group_create_info.pPhysicalDevices[i], pSurfaceInfo->surface,
                 "VUID-vkGetDeviceGroupSurfacePresentModes2EXT-pSurfaceInfo-06213", error_obj.location);
         }
     }
@@ -1508,14 +1508,14 @@ bool CoreChecks::PreCallValidateGetDeviceGroupSurfacePresentModesKHR(VkDevice de
                                                                      const ErrorObject &error_obj) const {
     bool skip = false;
     const auto *core_instance = reinterpret_cast<core::Instance *>(instance_state);
-    if (physical_device_count == 1) {
+    if (device_state->physical_device_count == 1) {
         skip |= core_instance->ValidatePhysicalDeviceSurfaceSupport(
             physical_device, surface, "VUID-vkGetDeviceGroupSurfacePresentModesKHR-surface-06212", error_obj.location);
     } else {
-        for (uint32_t i = 0; i < physical_device_count; ++i) {
-            skip |= core_instance->ValidatePhysicalDeviceSurfaceSupport(device_group_create_info.pPhysicalDevices[i], surface,
-                                                                        "VUID-vkGetDeviceGroupSurfacePresentModesKHR-surface-06212",
-                                                                        error_obj.location);
+        for (uint32_t i = 0; i < device_state->physical_device_count; ++i) {
+            skip |= core_instance->ValidatePhysicalDeviceSurfaceSupport(
+                device_state->device_group_create_info.pPhysicalDevices[i], surface,
+                "VUID-vkGetDeviceGroupSurfacePresentModesKHR-surface-06212", error_obj.location);
         }
     }
 

--- a/layers/core_checks/cc_ycbcr.cpp
+++ b/layers/core_checks/cc_ycbcr.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
+/* Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
  * Copyright (C) 2015-2023 Google Inc.
  * Modifications Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
@@ -62,8 +62,8 @@ bool CoreChecks::PreCallValidateCreateSamplerYcbcrConversion(VkDevice device, co
         // only check for external format inside VK_FORMAT_UNDEFINED check to prevent unnecessary extra errors from no format
         // features being supported
         if (external_format != 0) {
-            auto it = ahb_ext_formats_map.find(external_format);
-            if (it != ahb_ext_formats_map.end()) {
+            auto it = device_state->ahb_ext_formats_map.find(external_format);
+            if (it != device_state->ahb_ext_formats_map.end()) {
                 format_features = it->second;
             }
         }

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -47,8 +47,8 @@ struct DAGNode;
 struct SemaphoreSubmitState;
 
 namespace core {
-class Instance : public vvl::InstanceState {
-    using BaseClass = vvl::InstanceState;
+class Instance : public vvl::InstanceProxy {
+    using BaseClass = vvl::InstanceProxy;
 
   public:
     using Func = vvl::Func;
@@ -180,8 +180,8 @@ bool ValidateVideoProfileListInfo(const StateObject& state, const VkVideoProfile
                                   const char* missing_encode_profile_msg_code);
 }  // namespace core
 
-class CoreChecks : public vvl::DeviceState {
-    using BaseClass = vvl::DeviceState;
+class CoreChecks : public vvl::DeviceProxy {
+    using BaseClass = vvl::DeviceProxy;
 
   public:
     using Func = vvl::Func;
@@ -1911,11 +1911,11 @@ class CoreChecks : public vvl::DeviceState {
                                             uint32_t query, const RecordObject& record_obj) override;
     void PreCallRecordCmdWriteTimestamp2(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage, VkQueryPool queryPool,
                                          uint32_t query, const RecordObject& record_obj) override;
-    void PostCallRecordCmdWriteAccelerationStructuresPropertiesKHR(VkCommandBuffer commandBuffer,
-                                                                   uint32_t accelerationStructureCount,
-                                                                   const VkAccelerationStructureKHR* pAccelerationStructures,
-                                                                   VkQueryType queryType, VkQueryPool queryPool,
-                                                                   uint32_t firstQuery, const RecordObject& record_obj) override;
+    void PreCallRecordCmdWriteAccelerationStructuresPropertiesKHR(VkCommandBuffer commandBuffer,
+                                                                  uint32_t accelerationStructureCount,
+                                                                  const VkAccelerationStructureKHR* pAccelerationStructures,
+                                                                  VkQueryType queryType, VkQueryPool queryPool, uint32_t firstQuery,
+                                                                  const RecordObject& record_obj) override;
     bool ValidateFrameBufferAttachments(const VkFramebufferCreateInfo& create_info, const Location& create_info_loc,
                                         const vvl::RenderPass& rp_state, const VkRenderPassCreateInfo2& rpci) const;
     bool ValidateFrameBufferAttachmentsImageless(
@@ -1969,15 +1969,15 @@ class CoreChecks : public vvl::DeviceState {
     void PostCallRecordCmdNextSubpass2(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo* pSubpassBeginInfo,
                                        const VkSubpassEndInfo* pSubpassEndInfo, const RecordObject& record_obj) override;
     bool PreCallValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const ErrorObject& error_obj) const override;
-    void PostCallRecordCmdEndRenderPass(VkCommandBuffer commandBuffer, const RecordObject& record_obj) override;
+    void PreCallRecordCmdEndRenderPass(VkCommandBuffer commandBuffer, const RecordObject& record_obj) override;
     bool PreCallValidateCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo,
                                              const ErrorObject& error_obj) const override;
-    void PostCallRecordCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo,
-                                            const RecordObject& record_obj) override;
+    void PreCallRecordCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo,
+                                           const RecordObject& record_obj) override;
     bool PreCallValidateCmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo,
                                           const ErrorObject& error_obj) const override;
-    void PostCallRecordCmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo,
-                                         const RecordObject& record_obj) override;
+    void PreCallRecordCmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo,
+                                        const RecordObject& record_obj) override;
     bool ValidateFragmentDensityMapOffsetEnd(const vvl::CommandBuffer& cb_state, const vvl::RenderPass& rp_state,
                                              const VkSubpassFragmentDensityMapOffsetEndInfoQCOM& fdm_offset_end_info,
                                              const Location& end_info_loc) const;
@@ -2747,11 +2747,6 @@ class CoreChecks : public vvl::DeviceState {
                                                             const VkConvertCooperativeVectorMatrixInfoNV* pInfos,
                                                             const ErrorObject& error_obj) const override;
 
-    std::shared_ptr<vvl::CommandBuffer> CreateCmdBufferState(VkCommandBuffer handle,
-                                                             const VkCommandBufferAllocateInfo* pAllocateInfo,
-                                                             const vvl::CommandPool* pool) final;
-
-    std::shared_ptr<vvl::Queue> CreateQueue(VkQueue handle, uint32_t family_index, uint32_t queue_index,
-                                            VkDeviceQueueCreateFlags flags,
-                                            const VkQueueFamilyProperties& queue_family_properties) final;
+    void Created(vvl::CommandBuffer& cb) override;
+    void Created(vvl::Queue& queue) override;
 };  // Class CoreChecks

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -47,8 +47,8 @@ struct DAGNode;
 struct SemaphoreSubmitState;
 
 namespace core {
-class Instance : public vvl::Instance {
-    using BaseClass = vvl::Instance;
+class Instance : public vvl::InstanceState {
+    using BaseClass = vvl::InstanceState;
 
   public:
     using Func = vvl::Func;
@@ -180,8 +180,8 @@ bool ValidateVideoProfileListInfo(const StateObject& state, const VkVideoProfile
                                   const char* missing_encode_profile_msg_code);
 }  // namespace core
 
-class CoreChecks : public vvl::Device {
-    using BaseClass = vvl::Device;
+class CoreChecks : public vvl::DeviceState {
+    using BaseClass = vvl::DeviceState;
 
   public:
     using Func = vvl::Func;

--- a/layers/drawdispatch/descriptor_validator.cpp
+++ b/layers/drawdispatch/descriptor_validator.cpp
@@ -114,7 +114,7 @@ std::string DescriptorValidator::DescribeDescriptor(const spirv::ResourceInterfa
     return ss.str();
 }
 
-DescriptorValidator::DescriptorValidator(vvl::Device &dev, CommandBuffer &cb_state, DescriptorSet &descriptor_set,
+DescriptorValidator::DescriptorValidator(vvl::DeviceState &dev, CommandBuffer &cb_state, DescriptorSet &descriptor_set,
                                          uint32_t set_index, VkFramebuffer framebuffer, const VulkanTypedHandle *shader_handle,
                                          const Location &loc)
     : Logger(dev.debug_report),

--- a/layers/drawdispatch/descriptor_validator.h
+++ b/layers/drawdispatch/descriptor_validator.h
@@ -26,7 +26,7 @@ struct ResourceInterfaceVariable;
 namespace vvl {
 struct DrawDispatchVuid;
 class DescriptorBinding;
-class Device;
+class DeviceState;
 class BufferDescriptor;
 class ImageDescriptor;
 class ImageSamplerDescriptor;
@@ -39,7 +39,7 @@ class DescriptorSet;
 
 class DescriptorValidator : public Logger {
   public:
-    DescriptorValidator(Device& dev, vvl::CommandBuffer& cb_state, vvl::DescriptorSet& descriptor_set, uint32_t set_index,
+    DescriptorValidator(DeviceState& dev, vvl::CommandBuffer& cb_state, vvl::DescriptorSet& descriptor_set, uint32_t set_index,
                         VkFramebuffer framebuffer, const VulkanTypedHandle* shader_handle, const Location& loc);
 
     // Used with normal validation where we know which descriptors are accessed.
@@ -81,7 +81,7 @@ class DescriptorValidator : public Logger {
     std::string DescribeDescriptor(const spirv::ResourceInterfaceVariable& binding_info, uint32_t index,
                                    VkDescriptorType type) const;
 
-    vvl::Device& dev_state;
+    vvl::DeviceState& dev_state;
     vvl::CommandBuffer& cb_state;
     vvl::DescriptorSet& descriptor_set;
     const VkFramebuffer framebuffer;

--- a/layers/drawdispatch/descriptor_validator.h
+++ b/layers/drawdispatch/descriptor_validator.h
@@ -26,7 +26,7 @@ struct ResourceInterfaceVariable;
 namespace vvl {
 struct DrawDispatchVuid;
 class DescriptorBinding;
-class DeviceState;
+class DeviceProxy;
 class BufferDescriptor;
 class ImageDescriptor;
 class ImageSamplerDescriptor;
@@ -39,7 +39,7 @@ class DescriptorSet;
 
 class DescriptorValidator : public Logger {
   public:
-    DescriptorValidator(DeviceState& dev, vvl::CommandBuffer& cb_state, vvl::DescriptorSet& descriptor_set, uint32_t set_index,
+    DescriptorValidator(DeviceProxy& dev, vvl::CommandBuffer& cb_state, vvl::DescriptorSet& descriptor_set, uint32_t set_index,
                         VkFramebuffer framebuffer, const VulkanTypedHandle* shader_handle, const Location& loc);
 
     // Used with normal validation where we know which descriptors are accessed.
@@ -81,7 +81,7 @@ class DescriptorValidator : public Logger {
     std::string DescribeDescriptor(const spirv::ResourceInterfaceVariable& binding_info, uint32_t index,
                                    VkDescriptorType type) const;
 
-    vvl::DeviceState& dev_state;
+    vvl::DeviceProxy& dev_proxy;
     vvl::CommandBuffer& cb_state;
     vvl::DescriptorSet& descriptor_set;
     const VkFramebuffer framebuffer;

--- a/layers/gpuav/core/gpuav.h
+++ b/layers/gpuav/core/gpuav.h
@@ -35,8 +35,8 @@ class QueueSubState;
 
 namespace gpuav {
 
-class Instance : public vvl::Instance {
-    using BaseClass = vvl::Instance;
+class Instance : public vvl::InstanceState {
+    using BaseClass = vvl::InstanceState;
 
   public:
     Instance(vvl::dispatch::Instance* dispatch) : BaseClass(dispatch, LayerObjectTypeGpuAssisted) {}

--- a/layers/gpuav/core/gpuav.h
+++ b/layers/gpuav/core/gpuav.h
@@ -35,8 +35,8 @@ class QueueSubState;
 
 namespace gpuav {
 
-class Instance : public vvl::InstanceState {
-    using BaseClass = vvl::InstanceState;
+class Instance : public vvl::InstanceProxy {
+    using BaseClass = vvl::InstanceProxy;
 
   public:
     Instance(vvl::dispatch::Instance* dispatch) : BaseClass(dispatch, LayerObjectTypeGpuAssisted) {}
@@ -51,6 +51,7 @@ class Instance : public vvl::InstanceState {
     void PostCallRecordGetPhysicalDeviceProperties2(VkPhysicalDevice physicalDevice,
                                                     VkPhysicalDeviceProperties2* pPhysicalDeviceProperties2,
                                                     const RecordObject& record_obj) final;
+
     void InternalWarning(LogObjectList objlist, const Location& loc, const char* const specific_message) const;
     void AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceCreateInfo* modified_create_info, const Location& loc);
     bool timeline_khr_{false};
@@ -69,16 +70,6 @@ class Validator : public GpuShaderInstrumentor {
     // gpuav_setup.cpp
     // -------------
   public:
-    std::shared_ptr<vvl::CommandBuffer> CreateCmdBufferState(VkCommandBuffer handle,
-                                                             const VkCommandBufferAllocateInfo* allocate_info,
-                                                             const vvl::CommandPool* pool) final;
-    std::shared_ptr<vvl::DescriptorSet> CreateDescriptorSet(VkDescriptorSet handle, vvl::DescriptorPool* pool,
-                                                            const std::shared_ptr<vvl::DescriptorSetLayout const>& layout,
-                                                            uint32_t variable_count) final;
-    std::shared_ptr<vvl::Queue> CreateQueue(VkQueue handle, uint32_t family_index, uint32_t queue_index,
-                                            VkDeviceQueueCreateFlags flags,
-                                            const VkQueueFamilyProperties& queueFamilyProperties) override;
-
     void FinishDeviceSetup(const VkDeviceCreateInfo* pCreateInfo, const Location& loc) final;
 
     void InternalVmaError(LogObjectList objlist, const Location& loc, const char* const specific_message) const;
@@ -415,6 +406,10 @@ class Validator : public GpuShaderInstrumentor {
     bool VerifyImageLayout(const vvl::CommandBuffer& cb_state, const vvl::ImageView& image_view_state,
                            VkImageLayout explicit_layout, const Location& image_loc, const char* mismatch_layout_vuid,
                            bool* error) const final;
+
+    void Created(vvl::DescriptorSet& set) final;
+    void Created(vvl::CommandBuffer& cb_state) final;
+    void Created(vvl::Queue& queue) final;
 
   public:
     std::optional<DescriptorHeap> desc_heap_{};  // optional only to defer construction

--- a/layers/gpuav/core/gpuav_setup.cpp
+++ b/layers/gpuav/core/gpuav_setup.cpp
@@ -30,35 +30,15 @@
 #include "gpuav/shaders/gpuav_shaders_constants.h"
 namespace gpuav {
 
-std::shared_ptr<vvl::DescriptorSet> Validator::CreateDescriptorSet(VkDescriptorSet handle, vvl::DescriptorPool *pool,
-                                                                   const std::shared_ptr<vvl::DescriptorSetLayout const> &layout,
-                                                                   uint32_t variable_count) {
-    auto set = BaseClass::CreateDescriptorSet(handle, pool, layout, variable_count);
-    if (set) {
-        set->SetSubState(container_type, std::make_unique<DescriptorSetSubState>(*set, *this));
-    }
-    return set;
+void Validator::Created(vvl::DescriptorSet &set) {
+    set.SetSubState(container_type, std::make_unique<DescriptorSetSubState>(set, *this));
 }
 
-std::shared_ptr<vvl::CommandBuffer> Validator::CreateCmdBufferState(VkCommandBuffer handle,
-                                                                    const VkCommandBufferAllocateInfo *allocate_info,
-                                                                    const vvl::CommandPool *pool) {
-    auto cb = BaseClass::CreateCmdBufferState(handle, allocate_info, pool);
-    if (cb) {
-        cb->SetSubState(container_type, std::make_unique<CommandBufferSubState>(*this, *cb));
-    }
-    return cb;
+void Validator::Created(vvl::CommandBuffer &cb_state) {
+    cb_state.SetSubState(container_type, std::make_unique<CommandBufferSubState>(*this, cb_state));
 }
 
-std::shared_ptr<vvl::Queue> Validator::CreateQueue(VkQueue handle, uint32_t family_index, uint32_t queue_index,
-                                                   VkDeviceQueueCreateFlags flags,
-                                                   const VkQueueFamilyProperties &queueFamilyProperties) {
-    auto queue = BaseClass::CreateQueue(handle, family_index, queue_index, flags, queueFamilyProperties);
-    if (queue) {
-        queue->SetSubState(container_type, std::make_unique<QueueSubState>(*this, *queue));
-    }
-    return queue;
-}
+void Validator::Created(vvl::Queue &queue) { queue.SetSubState(container_type, std::make_unique<QueueSubState>(*this, queue)); }
 
 // Trampolines to make VMA call Dispatch for Vulkan calls
 static VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL gpuVkGetInstanceProcAddr(VkInstance inst, const char *name) {

--- a/layers/gpuav/descriptor_validation/gpuav_descriptor_validation.cpp
+++ b/layers/gpuav/descriptor_validation/gpuav_descriptor_validation.cpp
@@ -188,8 +188,8 @@ void UpdateBoundDescriptors(Validator &gpuav, CommandBufferSubState &cb_state, V
                 error << "In CommandBuffer::ValidateBindlessDescriptorSets, descriptor_command_binding.bound_descriptor_sets["
                       << set_index
                       << "].HasPostProcessBuffer() was false. This should not happen. GPU-AV is in a bad state, aborting.";
-                auto gpuav = static_cast<Validator *>(&base.dev_data);
-                gpuav->InternalError(gpuav->device, loc, error.str().c_str());
+
+                state_.InternalError(state_.device, loc, error.str().c_str());
                 return false;
             }
             validated_desc_sets.emplace(bound_descriptor_set->VkHandle());

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.h
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.h
@@ -65,11 +65,11 @@ struct InstrumentedShader {
 // We still keep this as encapsulates the complex code around shader instrumentation.
 // Handles shader instrumentation (reserve a descriptor slot, create descriptor
 // sets, pipeline layout, hook into pipeline creation, etc...)
-class GpuShaderInstrumentor : public vvl::DeviceState {
-    using BaseClass = vvl::DeviceState;
+class GpuShaderInstrumentor : public vvl::DeviceProxy {
+    using BaseClass = vvl::DeviceProxy;
 
   public:
-    GpuShaderInstrumentor(vvl::dispatch::Device *dev, vvl::InstanceState *instance, LayerObjectTypeId type)
+    GpuShaderInstrumentor(vvl::dispatch::Device *dev, vvl::InstanceProxy *instance, LayerObjectTypeId type)
         : BaseClass(dev, instance, type) {}
 
     ReadLockGuard ReadLock() const override;

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.h
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.h
@@ -65,11 +65,11 @@ struct InstrumentedShader {
 // We still keep this as encapsulates the complex code around shader instrumentation.
 // Handles shader instrumentation (reserve a descriptor slot, create descriptor
 // sets, pipeline layout, hook into pipeline creation, etc...)
-class GpuShaderInstrumentor : public vvl::Device {
-    using BaseClass = vvl::Device;
+class GpuShaderInstrumentor : public vvl::DeviceState {
+    using BaseClass = vvl::DeviceState;
 
   public:
-    GpuShaderInstrumentor(vvl::dispatch::Device *dev, vvl::Instance *instance, LayerObjectTypeId type)
+    GpuShaderInstrumentor(vvl::dispatch::Device *dev, vvl::InstanceState *instance, LayerObjectTypeId type)
         : BaseClass(dev, instance, type) {}
 
     ReadLockGuard ReadLock() const override;

--- a/layers/gpuav/resources/gpuav_state_trackers.cpp
+++ b/layers/gpuav/resources/gpuav_state_trackers.cpp
@@ -206,7 +206,7 @@ void CommandBufferSubState::AllocateResources(const Location &loc) {
 bool CommandBufferSubState::UpdateBdaRangesBuffer(const Location &loc) {
     // By supplying a "date"
     if (!state_.gpuav_settings.shader_instrumentation.buffer_device_address ||
-        bda_ranges_snapshot_version_ == state_.buffer_device_address_ranges_version) {
+        bda_ranges_snapshot_version_ == state_.device_state->buffer_device_address_ranges_version) {
         return true;
     }
 
@@ -229,7 +229,7 @@ bool CommandBufferSubState::UpdateBdaRangesBuffer(const Location &loc) {
         static_cast<size_t>((GetBdaRangesBufferByteSize() - sizeof(uint64_t)) / (2 * sizeof(VkDeviceAddress)));
     auto bda_ranges = reinterpret_cast<vvl::DeviceState::BufferAddressRange *>(bda_table_ptr + 2);
     const auto [ranges_to_update_count, total_address_ranges_count] =
-        state_.GetBufferAddressRanges(bda_ranges, max_recordable_ranges);
+        state_.device_state->GetBufferAddressRanges(bda_ranges, max_recordable_ranges);
     // Cast here instead of having to cast inside the shader
     bda_table_ptr[0] = static_cast<uint32_t>(ranges_to_update_count);
 
@@ -247,7 +247,7 @@ bool CommandBufferSubState::UpdateBdaRangesBuffer(const Location &loc) {
     // ---
     // Flush the BDA buffer before un-mapping so that the new state is visible to the GPU
     bda_ranges_snapshot_.FlushAllocation(loc);
-    bda_ranges_snapshot_version_ = state_.buffer_device_address_ranges_version;
+    bda_ranges_snapshot_version_ = state_.device_state->buffer_device_address_ranges_version;
 
     return true;
 }

--- a/layers/gpuav/resources/gpuav_state_trackers.cpp
+++ b/layers/gpuav/resources/gpuav_state_trackers.cpp
@@ -227,7 +227,7 @@ bool CommandBufferSubState::UpdateBdaRangesBuffer(const Location &loc) {
 
     const size_t max_recordable_ranges =
         static_cast<size_t>((GetBdaRangesBufferByteSize() - sizeof(uint64_t)) / (2 * sizeof(VkDeviceAddress)));
-    auto bda_ranges = reinterpret_cast<vvl::Device::BufferAddressRange *>(bda_table_ptr + 2);
+    auto bda_ranges = reinterpret_cast<vvl::DeviceState::BufferAddressRange *>(bda_table_ptr + 2);
     const auto [ranges_to_update_count, total_address_ranges_count] =
         state_.GetBufferAddressRanges(bda_ranges, max_recordable_ranges);
     // Cast here instead of having to cast inside the shader

--- a/layers/gpuav/resources/gpuav_vulkan_objects.cpp
+++ b/layers/gpuav/resources/gpuav_vulkan_objects.cpp
@@ -173,7 +173,7 @@ bool Buffer::Create(const Location &loc, const VkBufferCreateInfo *buffer_create
 
     if (buffer_create_info->usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT) {
         // After creating the buffer, get the address right away
-        device_address = gpuav.GetBufferDeviceAddressHelper(buffer, &gpuav.modified_extensions);
+        device_address = gpuav.device_state->GetBufferDeviceAddressHelper(buffer, &gpuav.modified_extensions);
         if (device_address == 0) {
             gpuav.InternalError(gpuav.device, loc, "Failed to get address with DispatchGetBufferDeviceAddress.");
             return false;

--- a/layers/gpuav/validation_cmd/gpuav_trace_rays.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_trace_rays.cpp
@@ -161,7 +161,8 @@ struct SharedTraceRaysValidationResources final {
         shader_group_handle_size_aligned = shader_group_size_aligned;
 
         // Retrieve SBT address
-        const VkDeviceAddress sbt_address = gpuav.GetBufferDeviceAddressHelper(sbt_buffer, &gpuav.modified_extensions);
+        const VkDeviceAddress sbt_address =
+            gpuav.device_state->GetBufferDeviceAddressHelper(sbt_buffer, &gpuav.modified_extensions);
         assert(sbt_address != 0);
         if (sbt_address == 0) {
             gpuav.InternalError(gpuav.device, loc, "Retrieved SBT buffer device address is null.");

--- a/layers/state_tracker/buffer_state.cpp
+++ b/layers/state_tracker/buffer_state.cpp
@@ -26,7 +26,7 @@ static VkExternalMemoryHandleTypeFlags GetExternalHandleTypes(const VkBufferCrea
     return external_memory_info ? external_memory_info->handleTypes : 0;
 }
 
-static VkMemoryRequirements GetMemoryRequirements(vvl::Device &dev_data, VkBuffer buffer) {
+static VkMemoryRequirements GetMemoryRequirements(vvl::DeviceState &dev_data, VkBuffer buffer) {
     VkMemoryRequirements result{};
     DispatchGetBufferMemoryRequirements(dev_data.device, buffer, &result);
     return result;
@@ -61,7 +61,7 @@ namespace vvl {
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 #endif
 
-Buffer::Buffer(Device &dev_data, VkBuffer handle, const VkBufferCreateInfo *pCreateInfo)
+Buffer::Buffer(DeviceState &dev_data, VkBuffer handle, const VkBufferCreateInfo *pCreateInfo)
     : Bindable(handle, kVulkanObjectTypeBuffer, (pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) != 0,
                (pCreateInfo->flags & VK_BUFFER_CREATE_PROTECTED_BIT) == 0, GetExternalHandleTypes(pCreateInfo)),
       safe_create_info(pCreateInfo),

--- a/layers/state_tracker/buffer_state.h
+++ b/layers/state_tracker/buffer_state.h
@@ -24,7 +24,7 @@
 
 namespace vvl {
 
-class Device;
+class DeviceState;
 class VideoProfileDesc;
 
 class Buffer : public Bindable {
@@ -39,7 +39,7 @@ class Buffer : public Bindable {
 
     unordered_set<std::shared_ptr<const VideoProfileDesc>> supported_video_profiles;
 
-    Buffer(Device &dev_data, VkBuffer handle, const VkBufferCreateInfo *pCreateInfo);
+    Buffer(DeviceState &dev_data, VkBuffer handle, const VkBufferCreateInfo *pCreateInfo);
 
     Buffer(Buffer const &rh_obj) = delete;
 

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -128,7 +128,7 @@ Event::Event(VkEvent handle, const VkEventCreateInfo *create_info)
 {
 }
 
-CommandPool::CommandPool(Device &dev, VkCommandPool handle, const VkCommandPoolCreateInfo *create_info, VkQueueFlags flags)
+CommandPool::CommandPool(DeviceState &dev, VkCommandPool handle, const VkCommandPoolCreateInfo *create_info, VkQueueFlags flags)
     : StateObject(handle, kVulkanObjectTypeCommandPool),
       dev_data(dev),
       createFlags(create_info->flags),
@@ -175,7 +175,7 @@ void CommandBuffer::SetActiveSubpass(uint32_t subpass) {
     active_subpass_sample_count_ = std::nullopt;
 }
 
-CommandBuffer::CommandBuffer(Device &dev, VkCommandBuffer handle, const VkCommandBufferAllocateInfo *allocate_info,
+CommandBuffer::CommandBuffer(DeviceState &dev, VkCommandBuffer handle, const VkCommandBufferAllocateInfo *allocate_info,
                              const vvl::CommandPool *pool)
     : RefcountedStateObject(handle, kVulkanObjectTypeCommandBuffer),
       allocate_info(*allocate_info),

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1198,7 +1198,7 @@ void CommandBuffer::PushDescriptorSetState(VkPipelineBindPoint pipelineBindPoint
     auto &push_descriptor_set = last_bound.push_descriptor_set;
     // If we are disturbing the current push_desriptor_set clear it
     if (!push_descriptor_set || !last_bound.IsBoundSetCompatible(set, pipeline_layout)) {
-        last_bound.UnbindAndResetPushDescriptorSet(dev_data.CreateDescriptorSet(VK_NULL_HANDLE, nullptr, dsl, 0));
+        last_bound.UnbindAndResetPushDescriptorSet(dev_data.CreatePushDescriptorSet(dsl));
     }
 
     UpdateLastBoundDescriptorSets(pipelineBindPoint, pipeline_layout, bound_command, set, 1, nullptr, push_descriptor_set, 0,

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -30,7 +30,7 @@ namespace vvl {
 class Bindable;
 class Buffer;
 class CommandBufferSubState;
-class Device;
+class DeviceState;
 class Framebuffer;
 class Queue;
 class RenderPass;
@@ -136,7 +136,7 @@ class Event : public StateObject {
 // Track command pools and their command buffers
 class CommandPool : public StateObject {
   public:
-    Device &dev_data;
+    DeviceState &dev_data;
     const VkCommandPoolCreateFlags createFlags;
     const uint32_t queueFamilyIndex;
     const VkQueueFlags queue_flags;
@@ -144,7 +144,7 @@ class CommandPool : public StateObject {
     // Cmd buffers allocated from this pool
     vvl::unordered_map<VkCommandBuffer, CommandBuffer *> commandBuffers;
 
-    CommandPool(Device &dev, VkCommandPool handle, const VkCommandPoolCreateInfo *create_info, VkQueueFlags flags);
+    CommandPool(DeviceState &dev, VkCommandPool handle, const VkCommandPoolCreateInfo *create_info, VkQueueFlags flags);
     virtual ~CommandPool() { Destroy(); }
 
     VkCommandPool VkHandle() const { return handle_.Cast<VkCommandPool>(); }
@@ -173,7 +173,7 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     VkCommandBufferInheritanceInfo inheritanceInfo;
     // since command buffers can only be destroyed by their command pool, this does not need to be a shared_ptr
     const vvl::CommandPool *command_pool;
-    Device &dev_data;
+    DeviceState &dev_data;
     bool unprotected;  // can't be used for protected memory
     bool hasRenderPassInstance;
     bool suspendsRenderPassInstance;
@@ -560,7 +560,7 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     ReadLockGuard ReadLock() const { return ReadLockGuard(lock); }
     WriteLockGuard WriteLock() { return WriteLockGuard(lock); }
 
-    CommandBuffer(Device &dev, VkCommandBuffer handle, const VkCommandBufferAllocateInfo *allocate_info,
+    CommandBuffer(DeviceState &dev, VkCommandBuffer handle, const VkCommandBufferAllocateInfo *allocate_info,
                   const vvl::CommandPool *cmd_pool);
 
     virtual ~CommandBuffer() { Destroy(); }

--- a/layers/state_tracker/device_generated_commands_state.cpp
+++ b/layers/state_tracker/device_generated_commands_state.cpp
@@ -19,7 +19,7 @@
 
 #include "state_tracker/device_generated_commands_state.h"
 
-vvl::IndirectExecutionSet::IndirectExecutionSet(vvl::Device &dev, VkIndirectExecutionSetEXT handle,
+vvl::IndirectExecutionSet::IndirectExecutionSet(vvl::DeviceState &dev, VkIndirectExecutionSetEXT handle,
                                                 const VkIndirectExecutionSetCreateInfoEXT *pCreateInfo)
     : StateObject(handle, kVulkanObjectTypeIndirectExecutionSetEXT),
       safe_create_info(pCreateInfo),
@@ -35,7 +35,7 @@ vvl::IndirectExecutionSet::IndirectExecutionSet(vvl::Device &dev, VkIndirectExec
     }
 }
 
-vvl::IndirectCommandsLayout::IndirectCommandsLayout(vvl::Device &dev, VkIndirectCommandsLayoutEXT handle,
+vvl::IndirectCommandsLayout::IndirectCommandsLayout(vvl::DeviceState &dev, VkIndirectCommandsLayoutEXT handle,
                                                     const VkIndirectCommandsLayoutCreateInfoEXT *pCreateInfo)
     : StateObject(handle, kVulkanObjectTypeIndirectCommandsLayoutEXT),
       safe_create_info(pCreateInfo),

--- a/layers/state_tracker/device_generated_commands_state.h
+++ b/layers/state_tracker/device_generated_commands_state.h
@@ -21,7 +21,7 @@
 #include <vulkan/utility/vk_safe_struct.hpp>
 
 namespace vvl {
-class Device;
+class DeviceState;
 class Pipeline;
 struct ShaderObject;
 
@@ -30,7 +30,8 @@ class IndirectExecutionSet : public StateObject {
     const vku::safe_VkIndirectExecutionSetCreateInfoEXT safe_create_info;
     const VkIndirectExecutionSetCreateInfoEXT &create_info;
 
-    IndirectExecutionSet(Device &dev, VkIndirectExecutionSetEXT handle, const VkIndirectExecutionSetCreateInfoEXT *pCreateInfo);
+    IndirectExecutionSet(DeviceState &dev, VkIndirectExecutionSetEXT handle,
+                         const VkIndirectExecutionSetCreateInfoEXT *pCreateInfo);
     VkIndirectExecutionSetEXT VkHandle() const { return handle_.Cast<VkIndirectExecutionSetEXT>(); }
 
     const bool is_pipeline;
@@ -52,7 +53,7 @@ class IndirectCommandsLayout : public StateObject {
     const vku::safe_VkIndirectCommandsLayoutCreateInfoEXT safe_create_info;
     const VkIndirectCommandsLayoutCreateInfoEXT &create_info;
 
-    IndirectCommandsLayout(Device &dev, VkIndirectCommandsLayoutEXT handle,
+    IndirectCommandsLayout(DeviceState &dev, VkIndirectCommandsLayoutEXT handle,
                            const VkIndirectCommandsLayoutCreateInfoEXT *pCreateInfo);
     VkIndirectCommandsLayoutEXT VkHandle() const { return handle_.Cast<VkIndirectCommandsLayoutEXT>(); }
 

--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -33,8 +33,8 @@ static VkSwapchainKHR GetSwapchain(const VkImageCreateInfo *pCreateInfo) {
     return swapchain_info ? swapchain_info->swapchain : VK_NULL_HANDLE;
 }
 
-static vvl::Image::MemoryReqs GetMemoryRequirements(const vvl::Device &dev_data, VkImage img, const VkImageCreateInfo *create_info,
-                                                    bool disjoint, bool is_external_ahb) {
+static vvl::Image::MemoryReqs GetMemoryRequirements(const vvl::DeviceState &dev_data, VkImage img,
+                                                    const VkImageCreateInfo *create_info, bool disjoint, bool is_external_ahb) {
     vvl::Image::MemoryReqs result{};
     // Record the memory requirements in case they won't be queried
     // External AHB memory can't be queried until after memory is bound
@@ -73,7 +73,7 @@ static vvl::Image::MemoryReqs GetMemoryRequirements(const vvl::Device &dev_data,
     return result;
 }
 
-static vvl::Image::SparseReqs GetSparseRequirements(const vvl::Device &dev_data, VkImage img, bool sparse_residency) {
+static vvl::Image::SparseReqs GetSparseRequirements(const vvl::DeviceState &dev_data, VkImage img, bool sparse_residency) {
     vvl::Image::SparseReqs result;
     if (sparse_residency) {
         uint32_t count = 0;
@@ -111,7 +111,7 @@ static bool GetMetalExport(const VkImageCreateInfo *info, VkExportMetalObjectTyp
 
 namespace vvl {
 
-Image::Image(const vvl::Device &dev_data, VkImage img, const VkImageCreateInfo *pCreateInfo, VkFormatFeatureFlags2KHR ff)
+Image::Image(const vvl::DeviceState &dev_data, VkImage img, const VkImageCreateInfo *pCreateInfo, VkFormatFeatureFlags2KHR ff)
     : Bindable(img, kVulkanObjectTypeImage, (pCreateInfo->flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT) != 0,
                (pCreateInfo->flags & VK_IMAGE_CREATE_PROTECTED_BIT) == 0, GetExternalHandleTypes(pCreateInfo)),
       safe_create_info(pCreateInfo),
@@ -152,7 +152,7 @@ Image::Image(const vvl::Device &dev_data, VkImage img, const VkImageCreateInfo *
     }
 }
 
-Image::Image(const vvl::Device &dev_data, VkImage img, const VkImageCreateInfo *pCreateInfo, VkSwapchainKHR swapchain,
+Image::Image(const vvl::DeviceState &dev_data, VkImage img, const VkImageCreateInfo *pCreateInfo, VkSwapchainKHR swapchain,
              uint32_t swapchain_index, VkFormatFeatureFlags2KHR ff)
     : Bindable(img, kVulkanObjectTypeImage, (pCreateInfo->flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT) != 0,
                (pCreateInfo->flags & VK_IMAGE_CREATE_PROTECTED_BIT) == 0, GetExternalHandleTypes(pCreateInfo)),
@@ -550,7 +550,7 @@ static vku::safe_VkImageCreateInfo GetImageCreateInfo(const VkSwapchainCreateInf
 
 namespace vvl {
 
-Swapchain::Swapchain(vvl::Device &dev_data_, const VkSwapchainCreateInfoKHR *pCreateInfo, VkSwapchainKHR handle)
+Swapchain::Swapchain(vvl::DeviceState &dev_data_, const VkSwapchainCreateInfoKHR *pCreateInfo, VkSwapchainKHR handle)
     : StateObject(handle, kVulkanObjectTypeSwapchainKHR),
       safe_create_info(pCreateInfo),
       create_info(*safe_create_info.ptr()),

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -28,7 +28,7 @@
 #include "containers/span.h"
 
 namespace vvl {
-class Device;
+class DeviceState;
 class Fence;
 class ImageSubState;
 class Semaphore;
@@ -127,8 +127,8 @@ class Image : public Bindable, public SubStateManager<ImageSubState> {
 
     vvl::unordered_set<std::shared_ptr<const vvl::VideoProfileDesc>> supported_video_profiles;
 
-    Image(const Device &dev_data, VkImage handle, const VkImageCreateInfo *pCreateInfo, VkFormatFeatureFlags2KHR features);
-    Image(const Device &dev_data, VkImage handle, const VkImageCreateInfo *pCreateInfo, VkSwapchainKHR swapchain,
+    Image(const DeviceState &dev_data, VkImage handle, const VkImageCreateInfo *pCreateInfo, VkFormatFeatureFlags2KHR features);
+    Image(const DeviceState &dev_data, VkImage handle, const VkImageCreateInfo *pCreateInfo, VkSwapchainKHR swapchain,
           uint32_t swapchain_index, VkFormatFeatureFlags2KHR features);
     Image(Image const &rh_obj) = delete;
     std::shared_ptr<const Image> shared_from_this() const { return SharedFromThisImpl(this); }
@@ -356,10 +356,10 @@ class Swapchain : public StateObject, public SubStateManager<SwapchainSubState> 
     const vku::safe_VkImageCreateInfo image_create_info;
 
     std::shared_ptr<vvl::Surface> surface;
-    Device &dev_data;
+    DeviceState &dev_data;
     uint32_t acquired_images = 0;
 
-    Swapchain(Device &dev_data, const VkSwapchainCreateInfoKHR *pCreateInfo, VkSwapchainKHR handle);
+    Swapchain(DeviceState &dev_data, const VkSwapchainCreateInfoKHR *pCreateInfo, VkSwapchainKHR handle);
 
     ~Swapchain() {
         if (!Destroyed()) {

--- a/layers/state_tracker/pipeline_layout_state.cpp
+++ b/layers/state_tracker/pipeline_layout_state.cpp
@@ -187,7 +187,7 @@ VkPipelineLayoutCreateFlags GetCreateFlags(const vvl::span<const vvl::PipelineLa
 
 namespace vvl {
 
-static PipelineLayout::SetLayoutVector GetSetLayouts(Device &dev_data, const VkPipelineLayoutCreateInfo *pCreateInfo) {
+static PipelineLayout::SetLayoutVector GetSetLayouts(DeviceState &dev_data, const VkPipelineLayoutCreateInfo *pCreateInfo) {
     PipelineLayout::SetLayoutVector set_layouts(pCreateInfo->setLayoutCount);
 
     for (uint32_t i = 0; i < pCreateInfo->setLayoutCount; ++i) {
@@ -232,7 +232,7 @@ static PipelineLayout::SetLayoutVector GetSetLayouts(const vvl::span<const Pipel
     return set_layouts;
 }
 
-PipelineLayout::PipelineLayout(Device &dev_data, VkPipelineLayout handle, const VkPipelineLayoutCreateInfo *pCreateInfo)
+PipelineLayout::PipelineLayout(DeviceState &dev_data, VkPipelineLayout handle, const VkPipelineLayoutCreateInfo *pCreateInfo)
     : StateObject(handle, kVulkanObjectTypePipelineLayout),
       set_layouts(GetSetLayouts(dev_data, pCreateInfo)),
       push_constant_ranges_layout(GetCanonicalId(pCreateInfo->pushConstantRangeCount, pCreateInfo->pPushConstantRanges)),

--- a/layers/state_tracker/pipeline_layout_state.h
+++ b/layers/state_tracker/pipeline_layout_state.h
@@ -28,7 +28,7 @@
 
 // Fwd declarations -- including descriptor_set.h creates an ugly include loop
 namespace vvl {
-class Device;
+class DeviceState;
 class DescriptorSetLayout;
 class DescriptorSetLayoutDef;
 }  // namespace vvl
@@ -80,7 +80,7 @@ class PipelineLayout : public StateObject {
     const std::vector<PipelineLayoutCompatId> set_compat_ids;
     VkPipelineLayoutCreateFlags create_flags;
 
-    PipelineLayout(Device &dev_data, VkPipelineLayout handle, const VkPipelineLayoutCreateInfo *pCreateInfo);
+    PipelineLayout(DeviceState &dev_data, VkPipelineLayout handle, const VkPipelineLayoutCreateInfo *pCreateInfo);
     // Merge 2 or more non-overlapping layouts
     PipelineLayout(const vvl::span<const PipelineLayout *const> &layouts);
     template <typename Container>

--- a/layers/state_tracker/pipeline_sub_state.cpp
+++ b/layers/state_tracker/pipeline_sub_state.cpp
@@ -61,7 +61,7 @@ VertexInputState::VertexInputState(const vvl::Pipeline &p, const vku::safe_VkGra
     }
 }
 
-PreRasterState::PreRasterState(const vvl::Pipeline &p, const vvl::Device &state_data,
+PreRasterState::PreRasterState(const vvl::Pipeline &p, const vvl::DeviceState &state_data,
                                const vku::safe_VkGraphicsPipelineCreateInfo &create_info, std::shared_ptr<const vvl::RenderPass> rp,
                                spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages])
     : PipelineSubState(p),
@@ -196,8 +196,8 @@ std::unique_ptr<const vku::safe_VkPipelineShaderStageCreateInfo> ToShaderStageCI
 }
 
 template <typename CreateInfo>
-void SetFragmentShaderInfoPrivate(const vvl::Pipeline &pipeline_state, FragmentShaderState &fs_state, const vvl::Device &state_data,
-                                  const CreateInfo &create_info,
+void SetFragmentShaderInfoPrivate(const vvl::Pipeline &pipeline_state, FragmentShaderState &fs_state,
+                                  const vvl::DeviceState &state_data, const CreateInfo &create_info,
                                   spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages]) {
     for (uint32_t i = 0; i < create_info.stageCount; ++i) {
         if (create_info.pStages[i].stage == VK_SHADER_STAGE_FRAGMENT_BIT) {
@@ -247,20 +247,20 @@ void SetFragmentShaderInfoPrivate(const vvl::Pipeline &pipeline_state, FragmentS
 
 // static
 void FragmentShaderState::SetFragmentShaderInfo(const vvl::Pipeline &pipeline_state, FragmentShaderState &fs_state,
-                                                const vvl::Device &state_data, const VkGraphicsPipelineCreateInfo &create_info,
+                                                const vvl::DeviceState &state_data, const VkGraphicsPipelineCreateInfo &create_info,
                                                 spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages]) {
     SetFragmentShaderInfoPrivate(pipeline_state, fs_state, state_data, create_info, stateless_data);
 }
 
 // static
 void FragmentShaderState::SetFragmentShaderInfo(const vvl::Pipeline &pipeline_state, FragmentShaderState &fs_state,
-                                                const vvl::Device &state_data,
+                                                const vvl::DeviceState &state_data,
                                                 const vku::safe_VkGraphicsPipelineCreateInfo &create_info,
                                                 spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages]) {
     SetFragmentShaderInfoPrivate(pipeline_state, fs_state, state_data, create_info, stateless_data);
 }
 
-FragmentShaderState::FragmentShaderState(const vvl::Pipeline &p, const vvl::Device &dev_data,
+FragmentShaderState::FragmentShaderState(const vvl::Pipeline &p, const vvl::DeviceState &dev_data,
                                          std::shared_ptr<const vvl::RenderPass> rp, uint32_t subp, VkPipelineLayout layout)
     : PipelineSubState(p), rp_state(rp), subpass(subp), pipeline_layout(dev_data.Get<vvl::PipelineLayout>(layout)) {}
 

--- a/layers/state_tracker/pipeline_sub_state.h
+++ b/layers/state_tracker/pipeline_sub_state.h
@@ -24,7 +24,7 @@
 // Graphics pipeline sub-state as defined by VK_KHR_graphics_pipeline_library
 
 namespace vvl {
-class Device;
+class DeviceState;
 class RenderPass;
 class Pipeline;
 class PipelineLayout;
@@ -93,13 +93,14 @@ struct VertexInputState : public PipelineSubState {
     // key is binding number
     vvl::unordered_map<uint32_t, VertexBindingState> bindings;
 
-    std::shared_ptr<VertexInputState> FromCreateInfo(const vvl::Device &state,
+    std::shared_ptr<VertexInputState> FromCreateInfo(const vvl::DeviceState &state,
                                                      const vku::safe_VkGraphicsPipelineCreateInfo &create_info);
 };
 
 struct PreRasterState : public PipelineSubState {
-    PreRasterState(const vvl::Pipeline &p, const vvl::Device &dev_data, const vku::safe_VkGraphicsPipelineCreateInfo &create_info,
-                   std::shared_ptr<const vvl::RenderPass> rp, spirv::StatelessData *stateless_data);
+    PreRasterState(const vvl::Pipeline &p, const vvl::DeviceState &dev_data,
+                   const vku::safe_VkGraphicsPipelineCreateInfo &create_info, std::shared_ptr<const vvl::RenderPass> rp,
+                   spirv::StatelessData *stateless_data);
 
     static inline VkShaderStageFlags ValidShaderStages() {
         return VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT | VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT |
@@ -141,11 +142,11 @@ std::unique_ptr<const vku::safe_VkPipelineShaderStageCreateInfo> ToShaderStageCI
 std::unique_ptr<const vku::safe_VkPipelineShaderStageCreateInfo> ToShaderStageCI(const VkPipelineShaderStageCreateInfo &cbs);
 
 struct FragmentShaderState : public PipelineSubState {
-    FragmentShaderState(const vvl::Pipeline &pipeline_state, const vvl::Device &dev_data, std::shared_ptr<const vvl::RenderPass> rp,
-                        uint32_t subpass, VkPipelineLayout layout);
+    FragmentShaderState(const vvl::Pipeline &pipeline_state, const vvl::DeviceState &dev_data,
+                        std::shared_ptr<const vvl::RenderPass> rp, uint32_t subpass, VkPipelineLayout layout);
 
     template <typename CreateInfo>
-    FragmentShaderState(const vvl::Pipeline &pipeline_state, const vvl::Device &dev_data, const CreateInfo &create_info,
+    FragmentShaderState(const vvl::Pipeline &pipeline_state, const vvl::DeviceState &dev_data, const CreateInfo &create_info,
                         std::shared_ptr<const vvl::RenderPass> rp, spirv::StatelessData *stateless_data)
         : FragmentShaderState(pipeline_state, dev_data, rp, create_info.subpass, create_info.layout) {
         if (create_info.pMultisampleState) {
@@ -173,10 +174,10 @@ struct FragmentShaderState : public PipelineSubState {
 
   private:
     static void SetFragmentShaderInfo(const vvl::Pipeline &pipeline_state, FragmentShaderState &fs_state,
-                                      const vvl::Device &state_data, const VkGraphicsPipelineCreateInfo &create_info,
+                                      const vvl::DeviceState &state_data, const VkGraphicsPipelineCreateInfo &create_info,
                                       spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages]);
     static void SetFragmentShaderInfo(const vvl::Pipeline &pipeline_state, FragmentShaderState &fs_state,
-                                      const vvl::Device &state_data, const vku::safe_VkGraphicsPipelineCreateInfo &create_info,
+                                      const vvl::DeviceState &state_data, const vku::safe_VkGraphicsPipelineCreateInfo &create_info,
                                       spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages]);
 };
 

--- a/layers/state_tracker/queue_state.h
+++ b/layers/state_tracker/queue_state.h
@@ -32,7 +32,7 @@
 namespace vvl {
 
 class CommandBuffer;
-class Device;
+class DeviceState;
 class Queue;
 class QueueSubState;
 
@@ -106,7 +106,7 @@ struct PreSubmitResult {
 
 class Queue : public StateObject, public SubStateManager<QueueSubState> {
   public:
-    Queue(Device &dev_data, VkQueue handle, uint32_t family_index, uint32_t queue_index, VkDeviceQueueCreateFlags flags,
+    Queue(DeviceState &dev_data, VkQueue handle, uint32_t family_index, uint32_t queue_index, VkDeviceQueueCreateFlags flags,
           const VkQueueFamilyProperties &queueFamilyProperties)
         : StateObject(handle, kVulkanObjectTypeQueue),
           queue_family_index(family_index),
@@ -178,7 +178,7 @@ class Queue : public StateObject, public SubStateManager<QueueSubState> {
     QueueSubmission *NextSubmission();
     LockGuard Lock() const { return LockGuard(lock_); }
 
-    Device &dev_data_;
+    DeviceState &dev_data_;
 
     // state related to submitting to the queue, all data members must
     // be accessed with lock_ held

--- a/layers/state_tracker/semaphore_state.cpp
+++ b/layers/state_tracker/semaphore_state.cpp
@@ -38,7 +38,7 @@ void vvl::Semaphore::TimePoint::Notify() const {
     signal_submit->queue->Notify(signal_submit->seq);
 }
 
-vvl::Semaphore::Semaphore(Device &dev, VkSemaphore handle, const VkSemaphoreTypeCreateInfo *type_create_info,
+vvl::Semaphore::Semaphore(DeviceState &dev, VkSemaphore handle, const VkSemaphoreTypeCreateInfo *type_create_info,
                           const VkSemaphoreCreateInfo *pCreateInfo)
     : RefcountedStateObject(handle, kVulkanObjectTypeSemaphore),
       type(type_create_info ? type_create_info->semaphoreType : VK_SEMAPHORE_TYPE_BINARY),

--- a/layers/state_tracker/semaphore_state.h
+++ b/layers/state_tracker/semaphore_state.h
@@ -27,7 +27,7 @@
 
 namespace vvl {
 
-class Device;
+class DeviceState;
 class Queue;
 class Semaphore;
 
@@ -76,7 +76,7 @@ class Semaphore : public RefcountedStateObject {
         void Notify() const;
     };
 
-    Semaphore(Device &dev, VkSemaphore handle, const VkSemaphoreCreateInfo *pCreateInfo)
+    Semaphore(DeviceState &dev, VkSemaphore handle, const VkSemaphoreCreateInfo *pCreateInfo)
         : Semaphore(dev, handle, vku::FindStructInPNextChain<VkSemaphoreTypeCreateInfo>(pCreateInfo->pNext), pCreateInfo) {}
 
     std::shared_ptr<const Semaphore> shared_from_this() const { return SharedFromThisImpl(this); }
@@ -140,7 +140,7 @@ class Semaphore : public RefcountedStateObject {
 #endif  // VK_USE_PLATFORM_METAL_EXT
 
   private:
-    Semaphore(Device &dev, VkSemaphore handle, const VkSemaphoreTypeCreateInfo *type_create_info,
+    Semaphore(DeviceState &dev, VkSemaphore handle, const VkSemaphoreTypeCreateInfo *type_create_info,
               const VkSemaphoreCreateInfo *pCreateInfo);
 
     ReadLockGuard ReadLock() const { return ReadLockGuard(lock_); }
@@ -172,7 +172,7 @@ class Semaphore : public RefcountedStateObject {
     // can use the same payload value.
     std::map<uint64_t, TimePoint> timeline_;
     mutable std::shared_mutex lock_;
-    Device &dev_data_;
+    DeviceState &dev_data_;
 };
 
 }  // namespace vvl

--- a/layers/state_tracker/shader_object_state.cpp
+++ b/layers/state_tracker/shader_object_state.cpp
@@ -19,7 +19,7 @@
 #include "state_tracker/state_tracker.h"
 
 namespace vvl {
-static ShaderObject::SetLayoutVector GetSetLayouts(Device &dev_data, const VkShaderCreateInfoEXT &pCreateInfo) {
+static ShaderObject::SetLayoutVector GetSetLayouts(DeviceState &dev_data, const VkShaderCreateInfoEXT &pCreateInfo) {
     ShaderObject::SetLayoutVector set_layouts(pCreateInfo.setLayoutCount);
 
     for (uint32_t i = 0; i < pCreateInfo.setLayoutCount; ++i) {
@@ -28,7 +28,7 @@ static ShaderObject::SetLayoutVector GetSetLayouts(Device &dev_data, const VkSha
     return set_layouts;
 }
 
-ShaderObject::ShaderObject(Device &dev_data, const VkShaderCreateInfoEXT &create_info_i, VkShaderEXT handle,
+ShaderObject::ShaderObject(DeviceState &dev_data, const VkShaderCreateInfoEXT &create_info_i, VkShaderEXT handle,
                            std::shared_ptr<spirv::Module> &spirv_module, uint32_t createInfoCount, VkShaderEXT *pShaders)
     : StateObject(handle, kVulkanObjectTypeShaderEXT),
       safe_create_info(&create_info_i),

--- a/layers/state_tracker/shader_object_state.h
+++ b/layers/state_tracker/shader_object_state.h
@@ -28,7 +28,7 @@
 namespace vvl {
 // Represents a VkShaderEXT (VK_EXT_shader_object) handle
 struct ShaderObject : public StateObject {
-    ShaderObject(Device &dev_data, const VkShaderCreateInfoEXT &create_info, VkShaderEXT shader_object,
+    ShaderObject(DeviceState &dev_data, const VkShaderCreateInfoEXT &create_info, VkShaderEXT shader_object,
                  std::shared_ptr<spirv::Module> &spirv_module, uint32_t createInfoCount, VkShaderEXT *pShaders);
 
     const vku::safe_VkShaderCreateInfoEXT safe_create_info;

--- a/layers/state_tracker/video_session_state.h
+++ b/layers/state_tracker/video_session_state.h
@@ -25,7 +25,7 @@
 #include <functional>
 
 namespace vvl {
-class Device;
+class DeviceState;
 class Image;
 class ImageView;
 class VideoSession;
@@ -288,7 +288,7 @@ class VideoPictureResource {
     VkExtent2D coded_extent;
 
     VideoPictureResource();
-    VideoPictureResource(const Device &dev_data, VkVideoPictureResourceInfoKHR const &res);
+    VideoPictureResource(const DeviceState &dev_data, VkVideoPictureResourceInfoKHR const &res);
 
     operator bool() const { return image_view_state != nullptr; }
 
@@ -378,7 +378,7 @@ struct VideoReferenceSlot {
 
     VideoReferenceSlot() : index(-1), picture_id(), resource() {}
 
-    VideoReferenceSlot(const Device &dev_data, VideoProfileDesc const &profile, VkVideoReferenceSlotInfoKHR const &slot,
+    VideoReferenceSlot(const DeviceState &dev_data, VideoProfileDesc const &profile, VkVideoReferenceSlotInfoKHR const &slot,
                        bool has_picture_id = true)
         : index(slot.slotIndex),
           picture_id(has_picture_id ? VideoPictureID(profile, slot) : VideoPictureID()),
@@ -527,7 +527,7 @@ class VideoSessionDeviceState {
         encode_.rate_control_state = rate_control_state;
     }
 
-    bool ValidateRateControlState(const Device &dev_data, const VideoSession *vs_state,
+    bool ValidateRateControlState(const Logger &log, const VideoSession *vs_state,
                                   const vku::safe_VkVideoBeginCodingInfoKHR &begin_info, const Location &loc) const;
 
   private:
@@ -566,7 +566,7 @@ class VideoSession : public StateObject {
         VideoSessionDeviceState &state_;
     };
 
-    VideoSession(const Device &dev_data, VkVideoSessionKHR handle, VkVideoSessionCreateInfoKHR const *pCreateInfo,
+    VideoSession(const DeviceState &dev_data, VkVideoSessionKHR handle, VkVideoSessionCreateInfoKHR const *pCreateInfo,
                  std::shared_ptr<const VideoProfileDesc> &&profile_desc);
 
     VkVideoSessionKHR VkHandle() const { return handle_.Cast<VkVideoSessionKHR>(); }
@@ -610,7 +610,7 @@ class VideoSession : public StateObject {
     bool ReferenceSetupRequested(VkVideoEncodeInfoKHR const &encode_info) const;
 
   private:
-    MemoryBindingMap GetMemoryBindings(const Device &dev_data, VkVideoSessionKHR vs);
+    MemoryBindingMap GetMemoryBindings(const DeviceState &dev_data, VkVideoSessionKHR vs);
 
     MemoryBindingMap memory_bindings_;
     uint32_t unbound_memory_binding_count_;

--- a/layers/state_tracker/video_session_state.h
+++ b/layers/state_tracker/video_session_state.h
@@ -26,6 +26,7 @@
 
 namespace vvl {
 class DeviceState;
+class DeviceProxy;
 class Image;
 class ImageView;
 class VideoSession;

--- a/layers/sync/sync_error_messages.cpp
+++ b/layers/sync/sync_error_messages.cpp
@@ -29,7 +29,7 @@
 
 namespace syncval {
 
-ErrorMessages::ErrorMessages(vvl::Device& validator) : validator_(validator) {}
+ErrorMessages::ErrorMessages(SyncValidator& validator) : validator_(validator) {}
 
 std::string ErrorMessages::Error(const HazardResult& hazard, const CommandExecutionContext& context, vvl::Func command,
                                  const std::string& resource_description, const char* message_type,

--- a/layers/sync/sync_error_messages.h
+++ b/layers/sync/sync_error_messages.h
@@ -27,10 +27,10 @@ class CommandExecutionContext;
 class HazardResult;
 class QueueBatchContext;
 struct SyncImageMemoryBarrier;
+class SyncValidator;
 
 namespace vvl {
 class DescriptorSet;
-class Device;
 class Pipeline;
 }  // namespace vvl
 
@@ -38,7 +38,7 @@ namespace syncval {
 
 class ErrorMessages {
   public:
-    explicit ErrorMessages(vvl::Device& validator);
+    explicit ErrorMessages(SyncValidator& validator);
 
     std::string Error(const HazardResult& hazard, const CommandExecutionContext& context, vvl::Func command,
                       const std::string& resource_description, const char* message_type,
@@ -134,7 +134,7 @@ class ErrorMessages {
                            const std::string& resource_description) const;
 
   private:
-    vvl::Device& validator_;
+    SyncValidator& validator_;
 };
 
 }  // namespace syncval

--- a/layers/sync/sync_image.cpp
+++ b/layers/sync/sync_image.cpp
@@ -23,7 +23,7 @@ bool syncval_state::ImageSubState::IsSimplyBound() const {
     return simple;
 }
 
-void syncval_state::ImageSubState::SetOpaqueBaseAddress(vvl::Device &dev_data) {
+void syncval_state::ImageSubState::SetOpaqueBaseAddress(vvl::DeviceState &dev_data) {
     // This is safe to call if already called to simplify caller logic
     // NOTE: Not asserting IsTiled, as there could in future be other reasons for opaque representations
     if (opaque_base_address_) return;

--- a/layers/sync/sync_image.h
+++ b/layers/sync/sync_image.h
@@ -29,7 +29,7 @@ class ImageSubState : public vvl::ImageSubState {
     bool IsTiled() const { return !IsLinear(); }
     bool IsSimplyBound() const;
 
-    void SetOpaqueBaseAddress(vvl::Device &dev_data);
+    void SetOpaqueBaseAddress(vvl::DeviceState &dev_data);
 
     VkDeviceSize GetOpaqueBaseAddress() const { return opaque_base_address_; }
     bool HasOpaqueMapping() const { return 0U != opaque_base_address_; }

--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -990,7 +990,7 @@ SyncOpBeginRenderPass::SyncOpBeginRenderPass(vvl::Func command, const SyncValida
         renderpass_begin_info_ = vku::safe_VkRenderPassBeginInfo(pRenderPassBegin);
         auto fb_state = sync_state.Get<vvl::Framebuffer>(pRenderPassBegin->framebuffer);
         if (fb_state) {
-            shared_attachments_ = sync_state.GetAttachmentViews(*renderpass_begin_info_.ptr(), *fb_state);
+            shared_attachments_ = sync_state.device_state->GetAttachmentViews(*renderpass_begin_info_.ptr(), *fb_state);
             // TODO: Revisit this when all attachment validation is through SyncOps to see if we can discard the plain pointer copy
             // Note that this a safe to presist as long as shared_attachments is not cleared
             attachments_.reserve(shared_attachments_.size());

--- a/layers/sync/sync_reporting.cpp
+++ b/layers/sync/sync_reporting.cpp
@@ -113,7 +113,7 @@ static std::string FormatAccessProperty(const SyncAccessInfo &access) {
     return ss.str();
 }
 
-static void GetAccessProperties(const HazardResult &hazard_result, const vvl::Device &device, VkQueueFlags allowed_queue_flags,
+static void GetAccessProperties(const HazardResult &hazard_result, const SyncValidator &device, VkQueueFlags allowed_queue_flags,
                                 ReportProperties &properties) {
     const HazardResult::HazardState &hazard = hazard_result.State();
     const SyncAccessInfo &access_info = GetSyncAccessInfos()[hazard.access_index];
@@ -196,7 +196,7 @@ static SyncAccessFlags FilterSyncAccessesByAllowedVkAccesses(const SyncAccessFla
 }
 
 static std::vector<std::pair<VkPipelineStageFlags2, VkAccessFlags2>> ConvertSyncAccessesToCompactVkForm(
-    const SyncAccessFlags &sync_accesses, const vvl::Device &device, VkQueueFlags allowed_queue_flags) {
+    const SyncAccessFlags &sync_accesses, const SyncValidator &device, VkQueueFlags allowed_queue_flags) {
     if (sync_accesses.none()) {
         return {};
     }
@@ -506,7 +506,7 @@ std::string FormatErrorMessage(const HazardResult &hazard, const CommandExecutio
     return ss.str();
 }
 
-std::string FormatSyncAccesses(const SyncAccessFlags &sync_accesses, const vvl::Device &device, VkQueueFlags allowed_queue_flags,
+std::string FormatSyncAccesses(const SyncAccessFlags &sync_accesses, const SyncValidator &device, VkQueueFlags allowed_queue_flags,
                                bool format_as_extra_property) {
     const auto report_accesses = ConvertSyncAccessesToCompactVkForm(sync_accesses, device, allowed_queue_flags);
     if (report_accesses.empty()) {

--- a/layers/sync/sync_reporting.h
+++ b/layers/sync/sync_reporting.h
@@ -21,13 +21,10 @@
 #include "generated/sync_validation_types.h"
 #include "generated/vk_object_types.h"
 
-namespace vvl {
-class Device;
-}  // namespace vvl
-
 class CommandExecutionContext;
 class HazardResult;
 class Logger;
+class SyncValidator;
 
 // Collection of named values that describe key information associated with an error message.
 // This can be useful to filter out messages or for quick inspection as a more structured (but lose)
@@ -70,7 +67,7 @@ ReportProperties GetErrorMessageProperties(const HazardResult &hazard, const Com
 std::string FormatErrorMessage(const HazardResult &hazard, const CommandExecutionContext &context, vvl::Func command,
                                const std::string &resouce_description, const AdditionalMessageInfo &additional_info);
 
-std::string FormatSyncAccesses(const SyncAccessFlags &sync_accesses, const vvl::Device &device, VkQueueFlags allowed_queue_flags,
+std::string FormatSyncAccesses(const SyncAccessFlags &sync_accesses, const SyncValidator &device, VkQueueFlags allowed_queue_flags,
                                bool format_as_extra_property);
 
 void FormatVideoPictureResouce(const Logger &logger, const VkVideoPictureResourceInfoKHR &video_picture, std::stringstream &ss);

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -3275,7 +3275,8 @@ bool SyncValidator::PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCou
     return ValidateQueueSubmit(queue, submitCount, submit_info.submit_infos2.data(), fence, error_obj);
 }
 
-static std::vector<CommandBufferConstPtr> GetCommandBuffers(const vvl::Device &state_tracker, const VkSubmitInfo2 &submit_info) {
+static std::vector<CommandBufferConstPtr> GetCommandBuffers(const vvl::DeviceState &state_tracker,
+                                                            const VkSubmitInfo2 &submit_info) {
     // Collected command buffers have the same indexing as in the input VkSubmitInfo2 for reporting purposes.
     // If Get query returns null, it is stored in the result array to keep original indexing.
     std::vector<CommandBufferConstPtr> command_buffers;
@@ -3664,7 +3665,7 @@ void SyncValidator::PostCallRecordGetSwapchainImagesKHR(VkDevice device, VkSwapc
 // Returns null when device address is asssociated with no buffers or more than one buffer.
 // Otherwise returns a valid buffer (device address is associated with a single buffer).
 // When syncval adds memory aliasing support the need of this function can be revisited.
-static const vvl::Buffer *GetSingleBufferFromDeviceAddress(const vvl::Device &device, VkDeviceAddress device_address) {
+static const vvl::Buffer *GetSingleBufferFromDeviceAddress(const vvl::DeviceState &device, VkDeviceAddress device_address) {
     vvl::span<vvl::Buffer *const> buffers = device.GetBuffersByAddress(device_address);
     if (buffers.empty()) {
         return nullptr;
@@ -3689,7 +3690,7 @@ struct AccelerationStructureGeometryInfo {
 };
 
 static std::optional<AccelerationStructureGeometryInfo> GetValidGeometryInfo(
-    const vvl::Device &device, const VkAccelerationStructureGeometryKHR &geometry,
+    const vvl::DeviceState &device, const VkAccelerationStructureGeometryKHR &geometry,
     const VkAccelerationStructureBuildRangeInfoKHR &range_info) {
     if (geometry.geometryType == VK_GEOMETRY_TYPE_TRIANGLES_KHR) {
         const VkAccelerationStructureGeometryTrianglesDataKHR &triangles = geometry.geometry.triangles;

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -30,14 +30,14 @@
 
 namespace syncval {
 // sync validation has no instance-level functionality
-class Instance : public vvl::Instance {
+class Instance : public vvl::InstanceState {
   public:
-    Instance(vvl::dispatch::Instance *dispatch) : vvl::Instance(dispatch, LayerObjectTypeSyncValidation) {}
+    Instance(vvl::dispatch::Instance *dispatch) : vvl::InstanceState(dispatch, LayerObjectTypeSyncValidation) {}
 };
 }  // namespace syncval
 
-class SyncValidator : public vvl::Device, public SyncStageAccess {
-    using BaseClass = vvl::Device;
+class SyncValidator : public vvl::DeviceState, public SyncStageAccess {
+    using BaseClass = vvl::DeviceState;
 
   public:
     using Func = vvl::Func;

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -30,14 +30,14 @@
 
 namespace syncval {
 // sync validation has no instance-level functionality
-class Instance : public vvl::InstanceState {
+class Instance : public vvl::InstanceProxy {
   public:
-    Instance(vvl::dispatch::Instance *dispatch) : vvl::InstanceState(dispatch, LayerObjectTypeSyncValidation) {}
+    Instance(vvl::dispatch::Instance *dispatch) : vvl::InstanceProxy(dispatch, LayerObjectTypeSyncValidation) {}
 };
 }  // namespace syncval
 
-class SyncValidator : public vvl::DeviceState, public SyncStageAccess {
-    using BaseClass = vvl::DeviceState;
+class SyncValidator : public vvl::DeviceProxy, public SyncStageAccess {
+    using BaseClass = vvl::DeviceProxy;
 
   public:
     using Func = vvl::Func;
@@ -124,15 +124,10 @@ class SyncValidator : public vvl::DeviceState, public SyncStageAccess {
     std::vector<QueueBatchContext::ConstPtr> GetLastPendingBatches(std::function<bool(const QueueBatchContext::ConstPtr &)> filter) const;
     void ClearPending() const;
 
-    std::shared_ptr<vvl::CommandBuffer> CreateCmdBufferState(VkCommandBuffer handle,
-                                                             const VkCommandBufferAllocateInfo *allocate_info,
-                                                             const vvl::CommandPool *cmd_pool) override;
-    std::shared_ptr<vvl::Swapchain> CreateSwapchainState(const VkSwapchainCreateInfoKHR *create_info,
-                                                         VkSwapchainKHR swapchain) final;
-    std::shared_ptr<vvl::Image> CreateImageState(VkImage handle, const VkImageCreateInfo *create_info,
-                                                 VkFormatFeatureFlags2 features) override;
-    std::shared_ptr<vvl::Image> CreateImageState(VkImage handle, const VkImageCreateInfo *create_info, VkSwapchainKHR swapchain,
-                                                 uint32_t swapchain_index, VkFormatFeatureFlags2 features) override;
+    void Created(vvl::CommandBuffer &cb_state) override;
+    void Created(vvl::Swapchain &swapchain_state) override;
+    void Created(vvl::Image &image_state) override;
+
     void PreCallRecordDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAllocationCallbacks *pAllocator,
                                     const RecordObject &record_obj) override;
     void PreCallRecordDestroyImage(VkDevice device, VkImage image, const VkAllocationCallbacks *pAllocator,

--- a/layers/vulkan/generated/dispatch_object.cpp
+++ b/layers/vulkan/generated/dispatch_object.cpp
@@ -31,6 +31,7 @@
 #include "thread_tracker/thread_safety_validation.h"
 #include "stateless/stateless_validation.h"
 #include "object_tracker/object_lifetime_validation.h"
+#include "state_tracker/state_tracker.h"
 #include "core_checks/core_validation.h"
 #include "best_practices/best_practices_validation.h"
 #include "gpuav/core/gpuav.h"
@@ -52,6 +53,10 @@ void Instance::InitValidationObjects() {
     }
     if (!settings.disabled[object_tracking]) {
         object_dispatch.emplace_back(new object_lifetimes::Instance(this));
+    }
+    if (!settings.disabled[core_checks] || settings.enabled[best_practices] || settings.enabled[gpu_validation] ||
+        settings.enabled[debug_printf_validation] || settings.enabled[sync_validation]) {
+        object_dispatch.emplace_back(new vvl::InstanceState(this));
     }
     if (!settings.disabled[core_checks]) {
         object_dispatch.emplace_back(new core::Instance(this));
@@ -81,6 +86,11 @@ void Device::InitValidationObjects() {
     if (!settings.disabled[object_tracking]) {
         object_dispatch.emplace_back(new object_lifetimes::Device(
             this, static_cast<object_lifetimes::Instance*>(dispatch_instance->GetValidationObject(LayerObjectTypeObjectTracker))));
+    }
+    if (!settings.disabled[core_checks] || settings.enabled[best_practices] || settings.enabled[gpu_validation] ||
+        settings.enabled[debug_printf_validation] || settings.enabled[sync_validation]) {
+        object_dispatch.emplace_back(new vvl::DeviceState(
+            this, static_cast<vvl::InstanceState*>(dispatch_instance->GetValidationObject(LayerObjectTypeStateTracker))));
     }
     if (!settings.disabled[core_checks]) {
         object_dispatch.emplace_back(new CoreChecks(

--- a/layers/vulkan/generated/dispatch_vector.cpp
+++ b/layers/vulkan/generated/dispatch_vector.cpp
@@ -32,13 +32,10 @@
 
 #include "generated/dispatch_vector.h"
 #include "chassis/dispatch_object.h"
-
-// Include layer validation object definitions
-#include "generated/dispatch_vector.h"
-#include "chassis/dispatch_object.h"
 #include "thread_tracker/thread_safety_validation.h"
 #include "stateless/stateless_validation.h"
 #include "object_tracker/object_lifetime_validation.h"
+#include "state_tracker/state_tracker.h"
 #include "core_checks/core_validation.h"
 #include "best_practices/best_practices_validation.h"
 #include "gpuav/core/gpuav.h"
@@ -51,44 +48,74 @@ void Device::InitObjectDispatchVectors() {
 #define BUILD_DISPATCH_VECTOR(name)                                                                                       \
     init_object_dispatch_vector(InterceptId##name, typeid(&vvl::base::Device::name), typeid(&threadsafety::Device::name), \
                                 typeid(&stateless::Device::name), typeid(&object_lifetimes::Device::name),                \
-                                typeid(&CoreChecks::name), typeid(&BestPractices::name), typeid(&gpuav::Validator::name), \
-                                typeid(&SyncValidator::name));
+                                typeid(&vvl::DeviceState::name), typeid(&CoreChecks::name), typeid(&BestPractices::name), \
+                                typeid(&gpuav::Validator::name), typeid(&SyncValidator::name), false);
+#define BUILD_DESTROY_DISPATCH_VECTOR(name)                                                                               \
+    init_object_dispatch_vector(InterceptId##name, typeid(&vvl::base::Device::name), typeid(&threadsafety::Device::name), \
+                                typeid(&stateless::Device::name), typeid(&object_lifetimes::Device::name),                \
+                                typeid(&vvl::DeviceState::name), typeid(&CoreChecks::name), typeid(&BestPractices::name), \
+                                typeid(&gpuav::Validator::name), typeid(&SyncValidator::name), true);
 
-    auto init_object_dispatch_vector = [this](InterceptId id, const std::type_info& vo_typeid, const std::type_info& tt_typeid,
-                                              const std::type_info& tpv_typeid, const std::type_info& tot_typeid,
-                                              const std::type_info& tcv_typeid, const std::type_info& tbp_typeid,
-                                              const std::type_info& tga_typeid, const std::type_info& tsv_typeid) {
-        for (auto& vo : this->object_dispatch) {
-            auto* item = vo.get();
-            auto intercept_vector = &this->intercept_vectors[id];
-            switch (item->container_type) {
-                case LayerObjectTypeThreading:
-                    if (tt_typeid != vo_typeid) intercept_vector->push_back(item);
-                    break;
-                case LayerObjectTypeParameterValidation:
-                    if (tpv_typeid != vo_typeid) intercept_vector->push_back(item);
-                    break;
-                case LayerObjectTypeObjectTracker:
-                    if (tot_typeid != vo_typeid) intercept_vector->push_back(item);
-                    break;
-                case LayerObjectTypeCoreValidation:
-                    if (tcv_typeid != vo_typeid) intercept_vector->push_back(item);
-                    break;
-                case LayerObjectTypeBestPractices:
-                    if (tbp_typeid != vo_typeid) intercept_vector->push_back(item);
-                    break;
-                case LayerObjectTypeGpuAssisted:
-                    if (tga_typeid != vo_typeid) intercept_vector->push_back(item);
-                    break;
-                case LayerObjectTypeSyncValidation:
-                    if (tsv_typeid != vo_typeid) intercept_vector->push_back(item);
-                    break;
-                default:
-                    /* Chassis codegen needs to be updated for unknown validation object type */
-                    assert(0);
+    auto init_object_dispatch_vector =
+        [this](InterceptId id, const std::type_info& vo_typeid, const std::type_info& t_typeid, const std::type_info& pv_typeid,
+               const std::type_info& ot_typeid, const std::type_info& st_typeid, const std::type_info& cv_typeid,
+               const std::type_info& bp_typeid, const std::type_info& ga_typeid, const std::type_info& sv_typeid, bool is_destroy) {
+            vvl::base::Device* state_tracker = nullptr;
+            auto* intercept_vector = &this->intercept_vectors[id];
+            for (auto& vo : this->object_dispatch) {
+                auto* item = vo.get();
+                switch (item->container_type) {
+                    case LayerObjectTypeThreading:
+                        if (t_typeid != vo_typeid) intercept_vector->push_back(item);
+                        break;
+
+                    case LayerObjectTypeParameterValidation:
+                        if (pv_typeid != vo_typeid) intercept_vector->push_back(item);
+                        break;
+
+                    case LayerObjectTypeObjectTracker:
+                        if (ot_typeid != vo_typeid) intercept_vector->push_back(item);
+                        break;
+
+                    case LayerObjectTypeStateTracker:
+                        if (st_typeid != vo_typeid) {
+                            // For destroy/free commands, the state tracker must run last so that
+                            // other validation objects can still access the state object which
+                            // is being destroyed.
+                            if (is_destroy) {
+                                state_tracker = item;
+                            } else {
+                                intercept_vector->push_back(item);
+                            }
+                        }
+                        break;
+
+                    case LayerObjectTypeCoreValidation:
+                        if (cv_typeid != vo_typeid) intercept_vector->push_back(item);
+                        break;
+
+                    case LayerObjectTypeBestPractices:
+                        if (bp_typeid != vo_typeid) intercept_vector->push_back(item);
+                        break;
+
+                    case LayerObjectTypeGpuAssisted:
+                        if (ga_typeid != vo_typeid) intercept_vector->push_back(item);
+                        break;
+
+                    case LayerObjectTypeSyncValidation:
+                        if (sv_typeid != vo_typeid) intercept_vector->push_back(item);
+                        break;
+
+                    case LayerObjectTypeMaxEnum:
+                        /* Chassis codegen needs to be updated for unknown validation object type */
+                        assert(0);
+                        break;
+                }
             }
-        }
-    };
+            if (state_tracker) {
+                intercept_vector->push_back(state_tracker);
+            }
+        };
 
     intercept_vectors.resize(InterceptIdCount);
     BUILD_DISPATCH_VECTOR(PreCallValidateGetDeviceQueue);
@@ -106,9 +133,9 @@ void Device::InitObjectDispatchVectors() {
     BUILD_DISPATCH_VECTOR(PreCallValidateAllocateMemory);
     BUILD_DISPATCH_VECTOR(PreCallRecordAllocateMemory);
     BUILD_DISPATCH_VECTOR(PostCallRecordAllocateMemory);
-    BUILD_DISPATCH_VECTOR(PreCallValidateFreeMemory);
-    BUILD_DISPATCH_VECTOR(PreCallRecordFreeMemory);
-    BUILD_DISPATCH_VECTOR(PostCallRecordFreeMemory);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateFreeMemory);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordFreeMemory);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordFreeMemory);
     BUILD_DISPATCH_VECTOR(PreCallValidateMapMemory);
     BUILD_DISPATCH_VECTOR(PreCallRecordMapMemory);
     BUILD_DISPATCH_VECTOR(PostCallRecordMapMemory);
@@ -145,9 +172,9 @@ void Device::InitObjectDispatchVectors() {
     BUILD_DISPATCH_VECTOR(PreCallValidateCreateFence);
     BUILD_DISPATCH_VECTOR(PreCallRecordCreateFence);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreateFence);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyFence);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyFence);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyFence);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyFence);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyFence);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyFence);
     BUILD_DISPATCH_VECTOR(PreCallValidateResetFences);
     BUILD_DISPATCH_VECTOR(PreCallRecordResetFences);
     BUILD_DISPATCH_VECTOR(PostCallRecordResetFences);
@@ -160,15 +187,15 @@ void Device::InitObjectDispatchVectors() {
     BUILD_DISPATCH_VECTOR(PreCallValidateCreateSemaphore);
     BUILD_DISPATCH_VECTOR(PreCallRecordCreateSemaphore);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreateSemaphore);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroySemaphore);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroySemaphore);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroySemaphore);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroySemaphore);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroySemaphore);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroySemaphore);
     BUILD_DISPATCH_VECTOR(PreCallValidateCreateEvent);
     BUILD_DISPATCH_VECTOR(PreCallRecordCreateEvent);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreateEvent);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyEvent);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyEvent);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyEvent);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyEvent);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyEvent);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyEvent);
     BUILD_DISPATCH_VECTOR(PreCallValidateGetEventStatus);
     BUILD_DISPATCH_VECTOR(PreCallRecordGetEventStatus);
     BUILD_DISPATCH_VECTOR(PostCallRecordGetEventStatus);
@@ -181,119 +208,119 @@ void Device::InitObjectDispatchVectors() {
     BUILD_DISPATCH_VECTOR(PreCallValidateCreateQueryPool);
     BUILD_DISPATCH_VECTOR(PreCallRecordCreateQueryPool);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreateQueryPool);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyQueryPool);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyQueryPool);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyQueryPool);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyQueryPool);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyQueryPool);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyQueryPool);
     BUILD_DISPATCH_VECTOR(PreCallValidateGetQueryPoolResults);
     BUILD_DISPATCH_VECTOR(PreCallRecordGetQueryPoolResults);
     BUILD_DISPATCH_VECTOR(PostCallRecordGetQueryPoolResults);
     BUILD_DISPATCH_VECTOR(PreCallValidateCreateBuffer);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreateBuffer);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyBuffer);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyBuffer);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyBuffer);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyBuffer);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyBuffer);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyBuffer);
     BUILD_DISPATCH_VECTOR(PreCallValidateCreateBufferView);
     BUILD_DISPATCH_VECTOR(PreCallRecordCreateBufferView);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreateBufferView);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyBufferView);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyBufferView);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyBufferView);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyBufferView);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyBufferView);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyBufferView);
     BUILD_DISPATCH_VECTOR(PreCallValidateCreateImage);
     BUILD_DISPATCH_VECTOR(PreCallRecordCreateImage);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreateImage);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyImage);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyImage);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyImage);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyImage);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyImage);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyImage);
     BUILD_DISPATCH_VECTOR(PreCallValidateGetImageSubresourceLayout);
     BUILD_DISPATCH_VECTOR(PreCallRecordGetImageSubresourceLayout);
     BUILD_DISPATCH_VECTOR(PostCallRecordGetImageSubresourceLayout);
     BUILD_DISPATCH_VECTOR(PreCallValidateCreateImageView);
     BUILD_DISPATCH_VECTOR(PreCallRecordCreateImageView);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreateImageView);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyImageView);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyImageView);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyImageView);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyShaderModule);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyShaderModule);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyShaderModule);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyImageView);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyImageView);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyImageView);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyShaderModule);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyShaderModule);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyShaderModule);
     BUILD_DISPATCH_VECTOR(PreCallValidateCreatePipelineCache);
     BUILD_DISPATCH_VECTOR(PreCallRecordCreatePipelineCache);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreatePipelineCache);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyPipelineCache);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyPipelineCache);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyPipelineCache);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyPipelineCache);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyPipelineCache);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyPipelineCache);
     BUILD_DISPATCH_VECTOR(PreCallValidateGetPipelineCacheData);
     BUILD_DISPATCH_VECTOR(PreCallRecordGetPipelineCacheData);
     BUILD_DISPATCH_VECTOR(PostCallRecordGetPipelineCacheData);
     BUILD_DISPATCH_VECTOR(PreCallValidateMergePipelineCaches);
     BUILD_DISPATCH_VECTOR(PreCallRecordMergePipelineCaches);
     BUILD_DISPATCH_VECTOR(PostCallRecordMergePipelineCaches);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyPipeline);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyPipeline);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyPipeline);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyPipeline);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyPipeline);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyPipeline);
     BUILD_DISPATCH_VECTOR(PreCallValidateCreatePipelineLayout);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreatePipelineLayout);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyPipelineLayout);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyPipelineLayout);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyPipelineLayout);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyPipelineLayout);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyPipelineLayout);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyPipelineLayout);
     BUILD_DISPATCH_VECTOR(PreCallValidateCreateSampler);
     BUILD_DISPATCH_VECTOR(PreCallRecordCreateSampler);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreateSampler);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroySampler);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroySampler);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroySampler);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroySampler);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroySampler);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroySampler);
     BUILD_DISPATCH_VECTOR(PreCallValidateCreateDescriptorSetLayout);
     BUILD_DISPATCH_VECTOR(PreCallRecordCreateDescriptorSetLayout);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreateDescriptorSetLayout);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyDescriptorSetLayout);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyDescriptorSetLayout);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyDescriptorSetLayout);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyDescriptorSetLayout);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyDescriptorSetLayout);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyDescriptorSetLayout);
     BUILD_DISPATCH_VECTOR(PreCallValidateCreateDescriptorPool);
     BUILD_DISPATCH_VECTOR(PreCallRecordCreateDescriptorPool);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreateDescriptorPool);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyDescriptorPool);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyDescriptorPool);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyDescriptorPool);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyDescriptorPool);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyDescriptorPool);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyDescriptorPool);
     BUILD_DISPATCH_VECTOR(PreCallValidateResetDescriptorPool);
     BUILD_DISPATCH_VECTOR(PreCallRecordResetDescriptorPool);
     BUILD_DISPATCH_VECTOR(PostCallRecordResetDescriptorPool);
     BUILD_DISPATCH_VECTOR(PreCallRecordAllocateDescriptorSets);
-    BUILD_DISPATCH_VECTOR(PreCallValidateFreeDescriptorSets);
-    BUILD_DISPATCH_VECTOR(PreCallRecordFreeDescriptorSets);
-    BUILD_DISPATCH_VECTOR(PostCallRecordFreeDescriptorSets);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateFreeDescriptorSets);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordFreeDescriptorSets);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordFreeDescriptorSets);
     BUILD_DISPATCH_VECTOR(PreCallValidateUpdateDescriptorSets);
     BUILD_DISPATCH_VECTOR(PreCallRecordUpdateDescriptorSets);
     BUILD_DISPATCH_VECTOR(PostCallRecordUpdateDescriptorSets);
     BUILD_DISPATCH_VECTOR(PreCallValidateCreateFramebuffer);
     BUILD_DISPATCH_VECTOR(PreCallRecordCreateFramebuffer);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreateFramebuffer);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyFramebuffer);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyFramebuffer);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyFramebuffer);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyFramebuffer);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyFramebuffer);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyFramebuffer);
     BUILD_DISPATCH_VECTOR(PreCallValidateCreateRenderPass);
     BUILD_DISPATCH_VECTOR(PreCallRecordCreateRenderPass);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreateRenderPass);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyRenderPass);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyRenderPass);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyRenderPass);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyRenderPass);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyRenderPass);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyRenderPass);
     BUILD_DISPATCH_VECTOR(PreCallValidateGetRenderAreaGranularity);
     BUILD_DISPATCH_VECTOR(PreCallRecordGetRenderAreaGranularity);
     BUILD_DISPATCH_VECTOR(PostCallRecordGetRenderAreaGranularity);
     BUILD_DISPATCH_VECTOR(PreCallValidateCreateCommandPool);
     BUILD_DISPATCH_VECTOR(PreCallRecordCreateCommandPool);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreateCommandPool);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyCommandPool);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyCommandPool);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyCommandPool);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyCommandPool);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyCommandPool);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyCommandPool);
     BUILD_DISPATCH_VECTOR(PreCallValidateResetCommandPool);
     BUILD_DISPATCH_VECTOR(PreCallRecordResetCommandPool);
     BUILD_DISPATCH_VECTOR(PostCallRecordResetCommandPool);
     BUILD_DISPATCH_VECTOR(PreCallValidateAllocateCommandBuffers);
     BUILD_DISPATCH_VECTOR(PreCallRecordAllocateCommandBuffers);
     BUILD_DISPATCH_VECTOR(PostCallRecordAllocateCommandBuffers);
-    BUILD_DISPATCH_VECTOR(PreCallValidateFreeCommandBuffers);
-    BUILD_DISPATCH_VECTOR(PreCallRecordFreeCommandBuffers);
-    BUILD_DISPATCH_VECTOR(PostCallRecordFreeCommandBuffers);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateFreeCommandBuffers);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordFreeCommandBuffers);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordFreeCommandBuffers);
     BUILD_DISPATCH_VECTOR(PreCallValidateBeginCommandBuffer);
     BUILD_DISPATCH_VECTOR(PreCallRecordBeginCommandBuffer);
     BUILD_DISPATCH_VECTOR(PostCallRecordBeginCommandBuffer);
@@ -468,15 +495,15 @@ void Device::InitObjectDispatchVectors() {
     BUILD_DISPATCH_VECTOR(PreCallValidateCreateSamplerYcbcrConversion);
     BUILD_DISPATCH_VECTOR(PreCallRecordCreateSamplerYcbcrConversion);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreateSamplerYcbcrConversion);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroySamplerYcbcrConversion);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroySamplerYcbcrConversion);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroySamplerYcbcrConversion);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroySamplerYcbcrConversion);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroySamplerYcbcrConversion);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroySamplerYcbcrConversion);
     BUILD_DISPATCH_VECTOR(PreCallValidateCreateDescriptorUpdateTemplate);
     BUILD_DISPATCH_VECTOR(PreCallRecordCreateDescriptorUpdateTemplate);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreateDescriptorUpdateTemplate);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyDescriptorUpdateTemplate);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyDescriptorUpdateTemplate);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyDescriptorUpdateTemplate);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyDescriptorUpdateTemplate);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyDescriptorUpdateTemplate);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyDescriptorUpdateTemplate);
     BUILD_DISPATCH_VECTOR(PreCallValidateUpdateDescriptorSetWithTemplate);
     BUILD_DISPATCH_VECTOR(PreCallRecordUpdateDescriptorSetWithTemplate);
     BUILD_DISPATCH_VECTOR(PostCallRecordUpdateDescriptorSetWithTemplate);
@@ -525,9 +552,9 @@ void Device::InitObjectDispatchVectors() {
     BUILD_DISPATCH_VECTOR(PreCallValidateCreatePrivateDataSlot);
     BUILD_DISPATCH_VECTOR(PreCallRecordCreatePrivateDataSlot);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreatePrivateDataSlot);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyPrivateDataSlot);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyPrivateDataSlot);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyPrivateDataSlot);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyPrivateDataSlot);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyPrivateDataSlot);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyPrivateDataSlot);
     BUILD_DISPATCH_VECTOR(PreCallValidateSetPrivateData);
     BUILD_DISPATCH_VECTOR(PreCallRecordSetPrivateData);
     BUILD_DISPATCH_VECTOR(PostCallRecordSetPrivateData);
@@ -690,9 +717,9 @@ void Device::InitObjectDispatchVectors() {
     BUILD_DISPATCH_VECTOR(PreCallValidateCreateSwapchainKHR);
     BUILD_DISPATCH_VECTOR(PreCallRecordCreateSwapchainKHR);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreateSwapchainKHR);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroySwapchainKHR);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroySwapchainKHR);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroySwapchainKHR);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroySwapchainKHR);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroySwapchainKHR);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroySwapchainKHR);
     BUILD_DISPATCH_VECTOR(PreCallValidateGetSwapchainImagesKHR);
     BUILD_DISPATCH_VECTOR(PreCallRecordGetSwapchainImagesKHR);
     BUILD_DISPATCH_VECTOR(PostCallRecordGetSwapchainImagesKHR);
@@ -717,9 +744,9 @@ void Device::InitObjectDispatchVectors() {
     BUILD_DISPATCH_VECTOR(PreCallValidateCreateVideoSessionKHR);
     BUILD_DISPATCH_VECTOR(PreCallRecordCreateVideoSessionKHR);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreateVideoSessionKHR);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyVideoSessionKHR);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyVideoSessionKHR);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyVideoSessionKHR);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyVideoSessionKHR);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyVideoSessionKHR);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyVideoSessionKHR);
     BUILD_DISPATCH_VECTOR(PreCallValidateGetVideoSessionMemoryRequirementsKHR);
     BUILD_DISPATCH_VECTOR(PreCallRecordGetVideoSessionMemoryRequirementsKHR);
     BUILD_DISPATCH_VECTOR(PostCallRecordGetVideoSessionMemoryRequirementsKHR);
@@ -732,9 +759,9 @@ void Device::InitObjectDispatchVectors() {
     BUILD_DISPATCH_VECTOR(PreCallValidateUpdateVideoSessionParametersKHR);
     BUILD_DISPATCH_VECTOR(PreCallRecordUpdateVideoSessionParametersKHR);
     BUILD_DISPATCH_VECTOR(PostCallRecordUpdateVideoSessionParametersKHR);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyVideoSessionParametersKHR);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyVideoSessionParametersKHR);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyVideoSessionParametersKHR);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyVideoSessionParametersKHR);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyVideoSessionParametersKHR);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyVideoSessionParametersKHR);
     BUILD_DISPATCH_VECTOR(PreCallValidateCmdBeginVideoCodingKHR);
     BUILD_DISPATCH_VECTOR(PreCallRecordCmdBeginVideoCodingKHR);
     BUILD_DISPATCH_VECTOR(PostCallRecordCmdBeginVideoCodingKHR);
@@ -802,9 +829,9 @@ void Device::InitObjectDispatchVectors() {
     BUILD_DISPATCH_VECTOR(PreCallValidateCreateDescriptorUpdateTemplateKHR);
     BUILD_DISPATCH_VECTOR(PreCallRecordCreateDescriptorUpdateTemplateKHR);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreateDescriptorUpdateTemplateKHR);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyDescriptorUpdateTemplateKHR);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyDescriptorUpdateTemplateKHR);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyDescriptorUpdateTemplateKHR);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyDescriptorUpdateTemplateKHR);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyDescriptorUpdateTemplateKHR);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyDescriptorUpdateTemplateKHR);
     BUILD_DISPATCH_VECTOR(PreCallValidateUpdateDescriptorSetWithTemplateKHR);
     BUILD_DISPATCH_VECTOR(PreCallRecordUpdateDescriptorSetWithTemplateKHR);
     BUILD_DISPATCH_VECTOR(PostCallRecordUpdateDescriptorSetWithTemplateKHR);
@@ -855,9 +882,9 @@ void Device::InitObjectDispatchVectors() {
     BUILD_DISPATCH_VECTOR(PreCallValidateCreateSamplerYcbcrConversionKHR);
     BUILD_DISPATCH_VECTOR(PreCallRecordCreateSamplerYcbcrConversionKHR);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreateSamplerYcbcrConversionKHR);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroySamplerYcbcrConversionKHR);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroySamplerYcbcrConversionKHR);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroySamplerYcbcrConversionKHR);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroySamplerYcbcrConversionKHR);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroySamplerYcbcrConversionKHR);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroySamplerYcbcrConversionKHR);
     BUILD_DISPATCH_VECTOR(PreCallValidateBindBufferMemory2KHR);
     BUILD_DISPATCH_VECTOR(PreCallRecordBindBufferMemory2KHR);
     BUILD_DISPATCH_VECTOR(PostCallRecordBindBufferMemory2KHR);
@@ -906,9 +933,9 @@ void Device::InitObjectDispatchVectors() {
     BUILD_DISPATCH_VECTOR(PreCallValidateCreateDeferredOperationKHR);
     BUILD_DISPATCH_VECTOR(PreCallRecordCreateDeferredOperationKHR);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreateDeferredOperationKHR);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyDeferredOperationKHR);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyDeferredOperationKHR);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyDeferredOperationKHR);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyDeferredOperationKHR);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyDeferredOperationKHR);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyDeferredOperationKHR);
     BUILD_DISPATCH_VECTOR(PreCallValidateGetDeferredOperationMaxConcurrencyKHR);
     BUILD_DISPATCH_VECTOR(PreCallRecordGetDeferredOperationMaxConcurrencyKHR);
     BUILD_DISPATCH_VECTOR(PostCallRecordGetDeferredOperationMaxConcurrencyKHR);
@@ -1002,9 +1029,9 @@ void Device::InitObjectDispatchVectors() {
     BUILD_DISPATCH_VECTOR(PreCallValidateCreatePipelineBinariesKHR);
     BUILD_DISPATCH_VECTOR(PreCallRecordCreatePipelineBinariesKHR);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreatePipelineBinariesKHR);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyPipelineBinaryKHR);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyPipelineBinaryKHR);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyPipelineBinaryKHR);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyPipelineBinaryKHR);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyPipelineBinaryKHR);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyPipelineBinaryKHR);
     BUILD_DISPATCH_VECTOR(PreCallValidateGetPipelineKeyKHR);
     BUILD_DISPATCH_VECTOR(PreCallRecordGetPipelineKeyKHR);
     BUILD_DISPATCH_VECTOR(PostCallRecordGetPipelineKeyKHR);
@@ -1077,12 +1104,12 @@ void Device::InitObjectDispatchVectors() {
     BUILD_DISPATCH_VECTOR(PreCallValidateCreateCuFunctionNVX);
     BUILD_DISPATCH_VECTOR(PreCallRecordCreateCuFunctionNVX);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreateCuFunctionNVX);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyCuModuleNVX);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyCuModuleNVX);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyCuModuleNVX);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyCuFunctionNVX);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyCuFunctionNVX);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyCuFunctionNVX);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyCuModuleNVX);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyCuModuleNVX);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyCuModuleNVX);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyCuFunctionNVX);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyCuFunctionNVX);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyCuFunctionNVX);
     BUILD_DISPATCH_VECTOR(PreCallValidateCmdCuLaunchKernelNVX);
     BUILD_DISPATCH_VECTOR(PreCallRecordCmdCuLaunchKernelNVX);
     BUILD_DISPATCH_VECTOR(PostCallRecordCmdCuLaunchKernelNVX);
@@ -1221,9 +1248,9 @@ void Device::InitObjectDispatchVectors() {
     BUILD_DISPATCH_VECTOR(PreCallValidateCreateAccelerationStructureNV);
     BUILD_DISPATCH_VECTOR(PreCallRecordCreateAccelerationStructureNV);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreateAccelerationStructureNV);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyAccelerationStructureNV);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyAccelerationStructureNV);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyAccelerationStructureNV);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyAccelerationStructureNV);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyAccelerationStructureNV);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyAccelerationStructureNV);
     BUILD_DISPATCH_VECTOR(PreCallValidateGetAccelerationStructureMemoryRequirementsNV);
     BUILD_DISPATCH_VECTOR(PreCallRecordGetAccelerationStructureMemoryRequirementsNV);
     BUILD_DISPATCH_VECTOR(PostCallRecordGetAccelerationStructureMemoryRequirementsNV);
@@ -1409,18 +1436,18 @@ void Device::InitObjectDispatchVectors() {
     BUILD_DISPATCH_VECTOR(PreCallValidateCreateIndirectCommandsLayoutNV);
     BUILD_DISPATCH_VECTOR(PreCallRecordCreateIndirectCommandsLayoutNV);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreateIndirectCommandsLayoutNV);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyIndirectCommandsLayoutNV);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyIndirectCommandsLayoutNV);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyIndirectCommandsLayoutNV);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyIndirectCommandsLayoutNV);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyIndirectCommandsLayoutNV);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyIndirectCommandsLayoutNV);
     BUILD_DISPATCH_VECTOR(PreCallValidateCmdSetDepthBias2EXT);
     BUILD_DISPATCH_VECTOR(PreCallRecordCmdSetDepthBias2EXT);
     BUILD_DISPATCH_VECTOR(PostCallRecordCmdSetDepthBias2EXT);
     BUILD_DISPATCH_VECTOR(PreCallValidateCreatePrivateDataSlotEXT);
     BUILD_DISPATCH_VECTOR(PreCallRecordCreatePrivateDataSlotEXT);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreatePrivateDataSlotEXT);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyPrivateDataSlotEXT);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyPrivateDataSlotEXT);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyPrivateDataSlotEXT);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyPrivateDataSlotEXT);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyPrivateDataSlotEXT);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyPrivateDataSlotEXT);
     BUILD_DISPATCH_VECTOR(PreCallValidateSetPrivateDataEXT);
     BUILD_DISPATCH_VECTOR(PreCallRecordSetPrivateDataEXT);
     BUILD_DISPATCH_VECTOR(PostCallRecordSetPrivateDataEXT);
@@ -1437,12 +1464,12 @@ void Device::InitObjectDispatchVectors() {
     BUILD_DISPATCH_VECTOR(PreCallValidateCreateCudaFunctionNV);
     BUILD_DISPATCH_VECTOR(PreCallRecordCreateCudaFunctionNV);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreateCudaFunctionNV);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyCudaModuleNV);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyCudaModuleNV);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyCudaModuleNV);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyCudaFunctionNV);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyCudaFunctionNV);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyCudaFunctionNV);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyCudaModuleNV);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyCudaModuleNV);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyCudaModuleNV);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyCudaFunctionNV);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyCudaFunctionNV);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyCudaFunctionNV);
     BUILD_DISPATCH_VECTOR(PreCallValidateCmdCudaLaunchKernelNV);
     BUILD_DISPATCH_VECTOR(PreCallRecordCmdCudaLaunchKernelNV);
     BUILD_DISPATCH_VECTOR(PostCallRecordCmdCudaLaunchKernelNV);
@@ -1516,9 +1543,9 @@ void Device::InitObjectDispatchVectors() {
     BUILD_DISPATCH_VECTOR(PreCallValidateSetBufferCollectionBufferConstraintsFUCHSIA);
     BUILD_DISPATCH_VECTOR(PreCallRecordSetBufferCollectionBufferConstraintsFUCHSIA);
     BUILD_DISPATCH_VECTOR(PostCallRecordSetBufferCollectionBufferConstraintsFUCHSIA);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyBufferCollectionFUCHSIA);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyBufferCollectionFUCHSIA);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyBufferCollectionFUCHSIA);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyBufferCollectionFUCHSIA);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyBufferCollectionFUCHSIA);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyBufferCollectionFUCHSIA);
     BUILD_DISPATCH_VECTOR(PreCallValidateGetBufferCollectionPropertiesFUCHSIA);
     BUILD_DISPATCH_VECTOR(PreCallRecordGetBufferCollectionPropertiesFUCHSIA);
     BUILD_DISPATCH_VECTOR(PostCallRecordGetBufferCollectionPropertiesFUCHSIA);
@@ -1565,9 +1592,9 @@ void Device::InitObjectDispatchVectors() {
     BUILD_DISPATCH_VECTOR(PreCallValidateCreateMicromapEXT);
     BUILD_DISPATCH_VECTOR(PreCallRecordCreateMicromapEXT);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreateMicromapEXT);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyMicromapEXT);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyMicromapEXT);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyMicromapEXT);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyMicromapEXT);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyMicromapEXT);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyMicromapEXT);
     BUILD_DISPATCH_VECTOR(PreCallValidateCmdBuildMicromapsEXT);
     BUILD_DISPATCH_VECTOR(PreCallRecordCmdBuildMicromapsEXT);
     BUILD_DISPATCH_VECTOR(PostCallRecordCmdBuildMicromapsEXT);
@@ -1742,9 +1769,9 @@ void Device::InitObjectDispatchVectors() {
     BUILD_DISPATCH_VECTOR(PreCallValidateCreateOpticalFlowSessionNV);
     BUILD_DISPATCH_VECTOR(PreCallRecordCreateOpticalFlowSessionNV);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreateOpticalFlowSessionNV);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyOpticalFlowSessionNV);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyOpticalFlowSessionNV);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyOpticalFlowSessionNV);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyOpticalFlowSessionNV);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyOpticalFlowSessionNV);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyOpticalFlowSessionNV);
     BUILD_DISPATCH_VECTOR(PreCallValidateBindOpticalFlowSessionImageNV);
     BUILD_DISPATCH_VECTOR(PreCallRecordBindOpticalFlowSessionImageNV);
     BUILD_DISPATCH_VECTOR(PostCallRecordBindOpticalFlowSessionImageNV);
@@ -1754,9 +1781,9 @@ void Device::InitObjectDispatchVectors() {
     BUILD_DISPATCH_VECTOR(PreCallValidateAntiLagUpdateAMD);
     BUILD_DISPATCH_VECTOR(PreCallRecordAntiLagUpdateAMD);
     BUILD_DISPATCH_VECTOR(PostCallRecordAntiLagUpdateAMD);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyShaderEXT);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyShaderEXT);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyShaderEXT);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyShaderEXT);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyShaderEXT);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyShaderEXT);
     BUILD_DISPATCH_VECTOR(PreCallValidateGetShaderBinaryDataEXT);
     BUILD_DISPATCH_VECTOR(PreCallRecordGetShaderBinaryDataEXT);
     BUILD_DISPATCH_VECTOR(PostCallRecordGetShaderBinaryDataEXT);
@@ -1825,15 +1852,15 @@ void Device::InitObjectDispatchVectors() {
     BUILD_DISPATCH_VECTOR(PreCallValidateCreateIndirectCommandsLayoutEXT);
     BUILD_DISPATCH_VECTOR(PreCallRecordCreateIndirectCommandsLayoutEXT);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreateIndirectCommandsLayoutEXT);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyIndirectCommandsLayoutEXT);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyIndirectCommandsLayoutEXT);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyIndirectCommandsLayoutEXT);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyIndirectCommandsLayoutEXT);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyIndirectCommandsLayoutEXT);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyIndirectCommandsLayoutEXT);
     BUILD_DISPATCH_VECTOR(PreCallValidateCreateIndirectExecutionSetEXT);
     BUILD_DISPATCH_VECTOR(PreCallRecordCreateIndirectExecutionSetEXT);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreateIndirectExecutionSetEXT);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyIndirectExecutionSetEXT);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyIndirectExecutionSetEXT);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyIndirectExecutionSetEXT);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyIndirectExecutionSetEXT);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyIndirectExecutionSetEXT);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyIndirectExecutionSetEXT);
     BUILD_DISPATCH_VECTOR(PreCallValidateUpdateIndirectExecutionSetPipelineEXT);
     BUILD_DISPATCH_VECTOR(PreCallRecordUpdateIndirectExecutionSetPipelineEXT);
     BUILD_DISPATCH_VECTOR(PostCallRecordUpdateIndirectExecutionSetPipelineEXT);
@@ -1854,9 +1881,9 @@ void Device::InitObjectDispatchVectors() {
     BUILD_DISPATCH_VECTOR(PreCallValidateCreateAccelerationStructureKHR);
     BUILD_DISPATCH_VECTOR(PreCallRecordCreateAccelerationStructureKHR);
     BUILD_DISPATCH_VECTOR(PostCallRecordCreateAccelerationStructureKHR);
-    BUILD_DISPATCH_VECTOR(PreCallValidateDestroyAccelerationStructureKHR);
-    BUILD_DISPATCH_VECTOR(PreCallRecordDestroyAccelerationStructureKHR);
-    BUILD_DISPATCH_VECTOR(PostCallRecordDestroyAccelerationStructureKHR);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallValidateDestroyAccelerationStructureKHR);
+    BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyAccelerationStructureKHR);
+    BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyAccelerationStructureKHR);
     BUILD_DISPATCH_VECTOR(PreCallValidateCmdBuildAccelerationStructuresKHR);
     BUILD_DISPATCH_VECTOR(PreCallRecordCmdBuildAccelerationStructuresKHR);
     BUILD_DISPATCH_VECTOR(PostCallRecordCmdBuildAccelerationStructuresKHR);

--- a/scripts/generators/dispatch_object_generator.py
+++ b/scripts/generators/dispatch_object_generator.py
@@ -60,6 +60,19 @@ class APISpecific:
                         'enabled': '!settings.disabled[object_tracking]'
                     },
                     {
+                        'include': 'state_tracker/state_tracker.h',
+                        'device': 'vvl::DeviceState',
+                        'instance': 'vvl::InstanceState',
+                        'type': 'LayerObjectTypeStateTracker',
+                        'enabled': '''
+                            !settings.disabled[core_checks] ||
+                            settings.enabled[best_practices] ||
+                            settings.enabled[gpu_validation] ||
+                            settings.enabled[debug_printf_validation] ||
+                            settings.enabled[sync_validation]
+                        '''
+                    },
+                    {
                         'include': 'core_checks/core_validation.h',
                         'device': 'CoreChecks',
                         'instance': 'core::Instance',

--- a/scripts/generators/dispatch_vector_generator.py
+++ b/scripts/generators/dispatch_vector_generator.py
@@ -25,92 +25,7 @@ import os
 from vulkan_object import Command
 from base_generator import BaseGenerator
 from generators.generator_utils import PlatformGuardHelper
-
-# This class is a container for any source code, data, or other behavior that is necessary to
-# customize the generator script for a specific target API variant (e.g. Vulkan SC). As such,
-# all of these API-specific interfaces and their use in the generator script are part of the
-# contract between this repository and its downstream users. Changing or removing any of these
-# interfaces or their use in the generator script will have downstream effects and thus
-# should be avoided unless absolutely necessary.
-class APISpecific:
-    # Generates source code for InitObjectDispatchVector
-    @staticmethod
-    def genInitObjectDispatchVectorSource(targetApiName: str) -> str:
-        match targetApiName:
-
-            # Vulkan specific InitObjectDispatchVector
-            case 'vulkan':
-                return '''
-// Include layer validation object definitions
-#include "generated/dispatch_vector.h"
-#include "chassis/dispatch_object.h"
-#include "thread_tracker/thread_safety_validation.h"
-#include "stateless/stateless_validation.h"
-#include "object_tracker/object_lifetime_validation.h"
-#include "core_checks/core_validation.h"
-#include "best_practices/best_practices_validation.h"
-#include "gpuav/core/gpuav.h"
-#include "sync/sync_validation.h"
-
-namespace vvl {
-namespace dispatch {
-
-void Device::InitObjectDispatchVectors() {
-
-#define BUILD_DISPATCH_VECTOR(name) \\
-    init_object_dispatch_vector(InterceptId ## name, \\
-                                typeid(&vvl::base::Device::name), \\
-                                typeid(&threadsafety::Device::name), \\
-                                typeid(&stateless::Device::name), \\
-                                typeid(&object_lifetimes::Device::name), \\
-                                typeid(&CoreChecks::name), \\
-                                typeid(&BestPractices::name), \\
-                                typeid(&gpuav::Validator::name), \\
-                                typeid(&SyncValidator::name));
-
-    auto init_object_dispatch_vector = [this](InterceptId id,
-                                              const std::type_info& vo_typeid,
-                                              const std::type_info& tt_typeid,
-                                              const std::type_info& tpv_typeid,
-                                              const std::type_info& tot_typeid,
-                                              const std::type_info& tcv_typeid,
-                                              const std::type_info& tbp_typeid,
-                                              const std::type_info& tga_typeid,
-                                              const std::type_info& tsv_typeid) {
-        for (auto& vo: this->object_dispatch) {
-            auto *item = vo.get();
-            auto intercept_vector = &this->intercept_vectors[id];
-            switch (item->container_type) {
-            case LayerObjectTypeThreading:
-                if (tt_typeid != vo_typeid) intercept_vector->push_back(item);
-                break;
-            case LayerObjectTypeParameterValidation:
-                if (tpv_typeid != vo_typeid) intercept_vector->push_back(item);
-                break;
-            case LayerObjectTypeObjectTracker:
-                if (tot_typeid != vo_typeid) intercept_vector->push_back(item);
-                break;
-            case LayerObjectTypeCoreValidation:
-                if (tcv_typeid != vo_typeid) intercept_vector->push_back(item);
-                break;
-            case LayerObjectTypeBestPractices:
-                if (tbp_typeid != vo_typeid) intercept_vector->push_back(item);
-                break;
-            case LayerObjectTypeGpuAssisted:
-                if (tga_typeid != vo_typeid) intercept_vector->push_back(item);
-                break;
-            case LayerObjectTypeSyncValidation:
-                if (tsv_typeid != vo_typeid) intercept_vector->push_back(item);
-                break;
-            default:
-                /* Chassis codegen needs to be updated for unknown validation object type */
-                assert(0);
-            }
-        }
-    };
-
-    intercept_vectors.resize(InterceptIdCount);
-'''
+from generators.dispatch_object_generator import APISpecific
 
 class DispatchVectorGenerator(BaseGenerator):
     # will skip all 3 functions
@@ -219,17 +134,97 @@ class DispatchVectorGenerator(BaseGenerator):
             #include "chassis/dispatch_object.h"
             ''')
 
-        out.append(APISpecific.genInitObjectDispatchVectorSource(self.targetApiName))
+        layer_list = APISpecific.getValidationLayerList(self.targetApiName)
+        for layer in layer_list:
+            include = layer['include']
+            out.append(f'#include "{include}"\n')
+
+        out.append('''
+namespace vvl {
+namespace dispatch {
+
+void Device::InitObjectDispatchVectors() {
+
+#define BUILD_DISPATCH_VECTOR(name) \\
+    init_object_dispatch_vector(InterceptId ## name, \\
+                                typeid(&vvl::base::Device::name), \\
+        ''')
+        params = [f'typeid(&{layer["device"]}::name)' for layer in layer_list]
+        out.append(',\\\n'.join(params))
+        out.append(', false);')
+        out.append('''
+#define BUILD_DESTROY_DISPATCH_VECTOR(name) \\
+    init_object_dispatch_vector(InterceptId ## name, \\
+                                typeid(&vvl::base::Device::name), \\
+        ''')
+        out.append(',\\\n'.join(params))
+        out.append(', true);\n')
+        out.append('''
+    auto init_object_dispatch_vector = [this](InterceptId id,
+                                              const std::type_info& vo_typeid,
+        ''')
+        for i in range(len(layer_list)):
+            type_name = layer_list[i]['type'].replace('LayerObjectType', '')
+            lambda_param = ''.join([c for c in type_name if c.isupper()]).lower() + '_typeid'
+            layer_list[i]['lambda_param'] = lambda_param
+            out.append(f'const std::type_info& {lambda_param},\n')
+
+        out.append('bool is_destroy) {\n')
+        out.append('''
+        vvl::base::Device *state_tracker = nullptr;
+        auto *intercept_vector = &this->intercept_vectors[id];
+        for (auto& vo: this->object_dispatch) {
+            auto *item = vo.get();
+            switch (item->container_type) {
+        ''')
+        for layer in layer_list:
+            if layer['type'] == 'LayerObjectTypeStateTracker':
+               out.append(f'''
+                   case {layer['type']}:
+                       if ({layer['lambda_param']} != vo_typeid) {{
+                           // For destroy/free commands, the state tracker must run last so that
+                           // other validation objects can still access the state object which
+                           // is being destroyed.
+                           if (is_destroy) {{
+                               state_tracker = item;
+                           }} else {{
+                               intercept_vector->push_back(item);
+                           }}
+                       }}
+                       break;
+                   ''')
+            else:
+               out.append(f'''
+                   case {layer['type']}:
+                       if ({layer['lambda_param']} != vo_typeid) intercept_vector->push_back(item);
+                       break;
+                   ''')
+        out.append('''
+            case LayerObjectTypeMaxEnum:
+                /* Chassis codegen needs to be updated for unknown validation object type */
+                assert(0);
+                break;
+            }
+        }
+        if (state_tracker) {
+            intercept_vector->push_back(state_tracker);
+        }
+    };
+
+    intercept_vectors.resize(InterceptIdCount);
+    ''')
+
 
         guard_helper = PlatformGuardHelper()
         for command in [x for x in self.vk.commands.values() if not x.instance and x.name not in self.skip_intercept_id_functions]:
             out.extend(guard_helper.add_guard(command.protect))
+            macro = 'BUILD_DESTROY_DISPATCH_VECTOR' if ('Destroy' in command.name or 'Free' in command.name) else 'BUILD_DISPATCH_VECTOR'
             if command.name not in self.skip_intercept_id_pre_validate:
-                out.append(f'    BUILD_DISPATCH_VECTOR(PreCallValidate{command.name[2:]});\n')
+                out.append(f'    {macro}(PreCallValidate{command.name[2:]});\n')
             if command.name not in self.skip_intercept_id_pre_record:
-                out.append(f'    BUILD_DISPATCH_VECTOR(PreCallRecord{command.name[2:]});\n')
+                out.append(f'    {macro}(PreCallRecord{command.name[2:]});\n')
             if command.name not in self.skip_intercept_id_post_record:
-                out.append(f'    BUILD_DISPATCH_VECTOR(PostCallRecord{command.name[2:]});\n')
+                out.append(f'    {macro}(PostCallRecord{command.name[2:]});\n')
         out.extend(guard_helper.add_guard(None))
         out.append('}\n')
         out.append('} // namespace dispatch\n')


### PR DESCRIPTION
Rather than each type of validation (eg. core checks, gpu-av) having its own state tracking via inheritance, they now share
a single state tracker, which is now dispatched separately just like all the other validation types. Validation that needs state
tracking now inherits from vvl::InstanceProxy and vvl::DeviceProxy, which provide the same interface for the most commonly used functionality like the Get methods.

The order in which the state tracker runs is important. For most commands, it runs before any validation types that use it. However, for Destroy and Free commands, it runs last so that the state object being destroyed still exists until the other active validation types run. This is implemented by changing the order in the dispatch vector, see dispatch_vector_generator.py and dispatch_vector.cpp.

The first commit in this PR renames vvl::Device to vvl::DeviceState for clarity and its best to review the 2 commits separately.