### PR TITLE
sync: Cleanup ResourceUsageRecord and corresponding properties

### DIFF
--- a/layers/sync/sync_error_messages.cpp
+++ b/layers/sync/sync_error_messages.cpp
@@ -417,8 +417,6 @@ std::string ErrorMessages::FirstUseError(const HazardResult& hazard, const Comma
         ss << " (from " << validator_.FormatHandle(recorded_context.Handle());
         ss << " submitted on the current ";
         ss << validator_.FormatHandle(exec_usage_info.queue->Handle()) << ")";
-        additional_info.properties.Add(kPropertySubmitIndex, exec_usage_info.submit_index);
-        additional_info.properties.Add(kPropertyBatchIndex, exec_usage_info.batch_index);
     } else {
         ss << " (from the secondary " << validator_.FormatHandle(recorded_context.Handle()) << ")";
     }

--- a/layers/sync/sync_reporting.h
+++ b/layers/sync/sync_reporting.h
@@ -108,6 +108,5 @@ inline constexpr const char *kPropertySwapchainIndex = "swapchain_index";
 
 // Debug properties
 inline constexpr const char *kPropertySeqNo = "seq_no";
-inline constexpr const char *kPropertySubCmd = "subcmd";
 inline constexpr const char *kPropertyResetNo = "reset_no";
 inline constexpr const char *kPropertyBatchTag = "batch_tag";

--- a/layers/sync/sync_submit.h
+++ b/layers/sync/sync_submit.h
@@ -294,7 +294,6 @@ class QueueBatchContext : public CommandExecutionContext, public std::enable_sha
     void Trim();
 
     ResourceUsageInfo GetResourceUsageInfo(ResourceUsageTagEx tag_ex) const override;
-    void AddUsageRecordProperties(ResourceUsageTag tag, ReportProperties &properties) const override;
     AccessContext *GetCurrentAccessContext() override { return current_access_context_; }
     const AccessContext *GetCurrentAccessContext() const override { return current_access_context_; }
     SyncEventsContext *GetCurrentEventsContext() override { return &events_context_; }


### PR DESCRIPTION
This cleanups the code that reports the properties derived from `ResourceUsageRecord`.
