### PR TITLE
layers: Add comment why we use small_vector

### DIFF
--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -761,6 +761,8 @@ class DescriptorBindingImpl : public DescriptorBinding {
         }
     }
 
+    // Most descriptor bindings will only have a single descriptor, so want to assume that
+    // If they don't have 1, we will resize on construction (and never resize again) to the exact size with small_vector
     small_vector<T, 1, uint32_t> descriptors;
 };
 


### PR DESCRIPTION
Thought I hit a bug here (couldn't reproduce) but wanted to leave a comment as I was at first confused why we had a `small_vector` that was a 1 million items big, but learned it was the app that had literally a `descriptorCount` value of `1,000,000` and this is perfectly resized and should stay (and wanted to explain this)