### PR TITLE
gpuav: Fix unsafe mode for Descriptor Indexing

### DIFF
--- a/layers/gpuav/spirv/descriptor_indexing_oob_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_indexing_oob_pass.cpp
@@ -151,7 +151,12 @@ uint32_t DescriptorIndexingOOBPass::CreateFunctionCall(BasicBlock& block, Instru
     return function_result;
 }
 
-void DescriptorIndexingOOBPass::NewBlock(const BasicBlock&) { block_instrumented_table_.clear(); }
+void DescriptorIndexingOOBPass::NewBlock(const BasicBlock&, bool is_original_new_block) {
+    // Don't clear if the new block occurs from control flow breaking one up
+    if (is_original_new_block) {
+        block_instrumented_table_.clear();
+    }
+}
 
 bool DescriptorIndexingOOBPass::RequiresInstrumentation(const Function& function, const Instruction& inst, InstructionMeta& meta) {
     const uint32_t opcode = inst.Opcode();

--- a/layers/gpuav/spirv/descriptor_indexing_oob_pass.h
+++ b/layers/gpuav/spirv/descriptor_indexing_oob_pass.h
@@ -29,7 +29,7 @@ class DescriptorIndexingOOBPass : public InjectConditionalFunctionPass {
     const char* Name() const final { return "DescriptorIndexingOOBPass"; }
     void PrintDebugInfo() const final;
 
-    void NewBlock(const BasicBlock& block) override;
+    void NewBlock(const BasicBlock& block, bool is_original_new_block) override;
 
   private:
     bool RequiresInstrumentation(const Function& function, const Instruction& inst, InstructionMeta& meta) final;

--- a/layers/gpuav/spirv/inject_conditional_function_pass.h
+++ b/layers/gpuav/spirv/inject_conditional_function_pass.h
@@ -90,7 +90,7 @@ class InjectConditionalFunctionPass : public Pass {
                                         const InstructionMeta& meta) = 0;
 
     // Optional notification that a new block is being passed
-    virtual void NewBlock(const BasicBlock&){};
+    virtual void NewBlock(const BasicBlock&, bool) {};
 };
 
 }  // namespace spirv


### PR DESCRIPTION
Unsafe mode wasn't working because when we split up the Block for the `if / else` control flow we "create a new block" but the idea of the unsafe is we don't want to clear the LUT yet