### PR TITLE
tests: Add missing feature to GPU-AV CooperativeVector

### DIFF
--- a/tests/unit/gpu_av_cooperative_vector_positive.cpp
+++ b/tests/unit/gpu_av_cooperative_vector_positive.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2020-2024 The Khronos Group Inc.
- * Copyright (c) 2020-2024 Valve Corporation
- * Copyright (c) 2020-2024 LunarG, Inc.
+ * Copyright (c) 2020-2025 The Khronos Group Inc.
+ * Copyright (c) 2020-2025 Valve Corporation
+ * Copyright (c) 2020-2025 LunarG, Inc.
  * Copyright (c) 2020-2024 Google, Inc.
  * Copyright (c) 2023-2025 NVIDIA Corporation
  *
@@ -33,6 +33,7 @@ TEST_F(PositiveGpuAVCooperativeVector, CooperativeVector) {
     AddRequiredFeature(vkt::Feature::shaderReplicatedComposites);
     AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
     AddRequiredFeature(vkt::Feature::cooperativeVector);
+    AddRequiredFeature(vkt::Feature::vulkanMemoryModel);
     RETURN_IF_SKIP(InitState());
 
     vkt::Buffer buffer(*m_device, 4096, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);


### PR DESCRIPTION
This is related to #9599 but the CI driver isn't new enough to support this test.