### PR TITLE
layers: Use Logger in class DescriptorValidator

### DIFF
--- a/layers/drawdispatch/descriptor_validator.h
+++ b/layers/drawdispatch/descriptor_validator.h
@@ -37,53 +37,52 @@ class CommandBuffer;
 class Sampler;
 class DescriptorSet;
 
-class DescriptorValidator {
- public:
-   DescriptorValidator(Device& dev, vvl::CommandBuffer& cb_state, vvl::DescriptorSet& descriptor_set, uint32_t set_index,
-                       VkFramebuffer framebuffer, const VulkanTypedHandle& shader_handle, const Location& loc);
+class DescriptorValidator : public Logger {
+  public:
+    DescriptorValidator(Device& dev, vvl::CommandBuffer& cb_state, vvl::DescriptorSet& descriptor_set, uint32_t set_index,
+                        VkFramebuffer framebuffer, const VulkanTypedHandle& shader_handle, const Location& loc);
 
-   // Used with normal validation where we know which descriptors are accessed.
-   bool ValidateBindingStatic(const spirv::ResourceInterfaceVariable& binding_info, const vvl::DescriptorBinding& binding) const;
-   // Used with GPU-AV when we need to run the GPU to know which descriptors are accessed.
-   // The main reason we can't combine is one function needs to be const and the other is non-const.
-   bool ValidateBindingDynamic(const spirv::ResourceInterfaceVariable& binding_info, DescriptorBinding& binding,
-                               const uint32_t index);
+    // Used with normal validation where we know which descriptors are accessed.
+    bool ValidateBindingStatic(const spirv::ResourceInterfaceVariable& binding_info, const vvl::DescriptorBinding& binding) const;
+    // Used with GPU-AV when we need to run the GPU to know which descriptors are accessed.
+    // The main reason we can't combine is one function needs to be const and the other is non-const.
+    bool ValidateBindingDynamic(const spirv::ResourceInterfaceVariable& binding_info, DescriptorBinding& binding,
+                                const uint32_t index);
 
- private:
-   template <typename T>
-   bool ValidateDescriptorsStatic(const spirv::ResourceInterfaceVariable& binding_info, const T& binding) const;
+  private:
+    template <typename T>
+    bool ValidateDescriptorsStatic(const spirv::ResourceInterfaceVariable& binding_info, const T& binding) const;
 
-   template <typename T>
-   bool ValidateDescriptorsDynamic(const spirv::ResourceInterfaceVariable& binding_info, const T& binding, const uint32_t index);
+    template <typename T>
+    bool ValidateDescriptorsDynamic(const spirv::ResourceInterfaceVariable& binding_info, const T& binding, const uint32_t index);
 
-   bool ValidateDescriptor(const spirv::ResourceInterfaceVariable& binding_info, const uint32_t index,
-                           VkDescriptorType descriptor_type, const vvl::BufferDescriptor& descriptor) const;
-   bool ValidateDescriptor(const spirv::ResourceInterfaceVariable& binding_info, const uint32_t index,
-                           VkDescriptorType descriptor_type, const vvl::ImageDescriptor& descriptor) const;
-   bool ValidateDescriptor(const spirv::ResourceInterfaceVariable& binding_info, const uint32_t index,
-                           VkDescriptorType descriptor_type, const vvl::ImageSamplerDescriptor& descriptor) const;
-   bool ValidateDescriptor(const spirv::ResourceInterfaceVariable& binding_info, const uint32_t index,
-                           VkDescriptorType descriptor_type, const vvl::TexelDescriptor& descriptor) const;
-   bool ValidateDescriptor(const spirv::ResourceInterfaceVariable& binding_info, const uint32_t index,
-                           VkDescriptorType descriptor_type, const vvl::AccelerationStructureDescriptor& descriptor) const;
-   bool ValidateDescriptor(const spirv::ResourceInterfaceVariable& binding_info, const uint32_t index,
-                           VkDescriptorType descriptor_type, const vvl::SamplerDescriptor& descriptor) const;
+    bool ValidateDescriptor(const spirv::ResourceInterfaceVariable& binding_info, const uint32_t index,
+                            VkDescriptorType descriptor_type, const vvl::BufferDescriptor& descriptor) const;
+    bool ValidateDescriptor(const spirv::ResourceInterfaceVariable& binding_info, const uint32_t index,
+                            VkDescriptorType descriptor_type, const vvl::ImageDescriptor& descriptor) const;
+    bool ValidateDescriptor(const spirv::ResourceInterfaceVariable& binding_info, const uint32_t index,
+                            VkDescriptorType descriptor_type, const vvl::ImageSamplerDescriptor& descriptor) const;
+    bool ValidateDescriptor(const spirv::ResourceInterfaceVariable& binding_info, const uint32_t index,
+                            VkDescriptorType descriptor_type, const vvl::TexelDescriptor& descriptor) const;
+    bool ValidateDescriptor(const spirv::ResourceInterfaceVariable& binding_info, const uint32_t index,
+                            VkDescriptorType descriptor_type, const vvl::AccelerationStructureDescriptor& descriptor) const;
+    bool ValidateDescriptor(const spirv::ResourceInterfaceVariable& binding_info, const uint32_t index,
+                            VkDescriptorType descriptor_type, const vvl::SamplerDescriptor& descriptor) const;
 
-   // helper for the common parts of ImageSamplerDescriptor and SamplerDescriptor validation
-   bool ValidateSamplerDescriptor(const spirv::ResourceInterfaceVariable& binding_info, uint32_t index, VkSampler sampler,
-                                  bool is_immutable, const vvl::Sampler* sampler_state) const;
+    // helper for the common parts of ImageSamplerDescriptor and SamplerDescriptor validation
+    bool ValidateSamplerDescriptor(const spirv::ResourceInterfaceVariable& binding_info, uint32_t index, VkSampler sampler,
+                                   bool is_immutable, const vvl::Sampler* sampler_state) const;
 
-   std::string DescribeDescriptor(const spirv::ResourceInterfaceVariable& binding_info, uint32_t index,
-                                  VkDescriptorType type) const;
+    std::string DescribeDescriptor(const spirv::ResourceInterfaceVariable& binding_info, uint32_t index,
+                                   VkDescriptorType type) const;
 
-   vvl::Device& dev_state;
-   vvl::CommandBuffer& cb_state;
-   vvl::DescriptorSet& descriptor_set;
-   const uint32_t set_index;
-   const VkFramebuffer framebuffer;
-   const VulkanTypedHandle& shader_handle;  // VkPipeline or VkShaderObject
-   const Location& loc;
-   const DrawDispatchVuid& vuids;
-
+    vvl::Device& dev_state;
+    vvl::CommandBuffer& cb_state;
+    vvl::DescriptorSet& descriptor_set;
+    const uint32_t set_index;
+    const VkFramebuffer framebuffer;
+    const VulkanTypedHandle& shader_handle;  // VkPipeline or VkShaderObject
+    const Location& loc;
+    const DrawDispatchVuid& vuids;
 };
 }  // namespace vvl


### PR DESCRIPTION
This thing is like 90% log messages so not having to dereference something is nice. Also the header was formatted very poorly and clang-format decided to redo it all.