### PR TITLE
layers: Fix present semaphore in use error after acquire fence wait

### DIFF
--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -315,10 +315,9 @@ struct SwapchainImage {
     std::shared_ptr<vvl::Semaphore> acquire_semaphore;
     std::shared_ptr<vvl::Fence> acquire_fence;
 
-    // Each swapchain image keeps information about submissions associated with current present.
-    // When the image is re-acquired later this information can be used to synchronize with
-    // these submissions by using acquire fence.
-    AcquireFenceSync acquire_fence_sync;
+    // Queue location (seq) for present operation that presented this image.
+    // When this image is reacquired, the acquire fence can synchronize with this location.
+    std::optional<SubmissionReference> present_submission_ref;
 };
 
 // State for VkSwapchainKHR objects.
@@ -352,7 +351,7 @@ class Swapchain : public StateObject {
 
     VkSwapchainKHR VkHandle() const { return handle_.Cast<VkSwapchainKHR>(); }
 
-    void PresentImage(uint32_t image_index, uint64_t present_id, const AcquireFenceSync &acquire_fence_sync);
+    void PresentImage(uint32_t image_index, uint64_t present_id, const SubmissionReference &present_submission_ref);
 
     void ReleaseImage(uint32_t image_index);
 

--- a/layers/state_tracker/queue_state.cpp
+++ b/layers/state_tracker/queue_state.cpp
@@ -70,6 +70,7 @@ vvl::PreSubmitResult vvl::Queue::PreSubmit(std::vector<vvl::QueueSubmission> &&s
         // Note that this relies on the external synchonization requirements for the
         // VkQueue
         submission.seq = ++seq_;
+        result.submission_seq = submission.seq;
         submission.BeginUse();
         for (SemaphoreInfo &wait : submission.wait_semaphores) {
             wait.semaphore->EnqueueWait(SubmissionReference(this, submission.seq), wait.payload);
@@ -83,7 +84,6 @@ vvl::PreSubmitResult vvl::Queue::PreSubmit(std::vector<vvl::QueueSubmission> &&s
         if (submission.fence) {
             if (submission.fence->EnqueueSignal(this, submission.seq)) {
                 result.has_external_fence = true;
-                result.submission_with_external_fence_seq = submission.seq;
             }
         }
         {

--- a/layers/state_tracker/queue_state.h
+++ b/layers/state_tracker/queue_state.h
@@ -99,7 +99,7 @@ struct PreSubmitResult {
     uint64_t last_submission_seq = 0;
 
     bool has_external_fence = false;
-    uint64_t submission_with_external_fence_seq = 0;
+    uint64_t submission_seq = 0;
 };
 
 class Queue : public StateObject {

--- a/layers/state_tracker/semaphore_state.cpp
+++ b/layers/state_tracker/semaphore_state.cpp
@@ -185,22 +185,6 @@ std::optional<vvl::Semaphore::SemOp> vvl::Semaphore::LastOp(const std::function<
     return result;
 }
 
-std::optional<vvl::SubmissionReference> vvl::Semaphore::GetPendingBinarySignalSubmission() const {
-    assert(type == VK_SEMAPHORE_TYPE_BINARY);
-    auto guard = ReadLock();
-    if (timeline_.empty()) {
-        return {};
-    }
-    const auto &timepoint = timeline_.rbegin()->second;
-    const auto &signal_submit = timepoint.signal_submit;
-
-    // Skip signals that are not associated with a queue
-    if (signal_submit.has_value() && signal_submit->queue == nullptr) {
-        return {};
-    }
-    return signal_submit;
-}
-
 std::optional<vvl::SubmissionReference> vvl::Semaphore::GetPendingBinaryWaitSubmission() const {
     assert(type == VK_SEMAPHORE_TYPE_BINARY);
     auto guard = ReadLock();

--- a/layers/state_tracker/semaphore_state.h
+++ b/layers/state_tracker/semaphore_state.h
@@ -106,9 +106,6 @@ class Semaphore : public RefcountedStateObject {
     // Look for most recent / highest payload operation that matches
     std::optional<SemOp> LastOp(const std::function<bool(OpType op_type, uint64_t payload, bool is_pending)> &filter) const;
 
-    // Returns pending queue submission that signals this binary semaphore.
-    std::optional<SubmissionReference> GetPendingBinarySignalSubmission() const;
-
     // Returns pending queue submission that waits on this binary semaphore.
     std::optional<SubmissionReference> GetPendingBinaryWaitSubmission() const;
 


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9587

This adds one more use case of synchronization and simplifies implementation a bit. The new use case helped to realize it's possible to use simpler implementation that unifies both previous and new sync scenario  (assuming no regression, which is hard to guarantee for such code). Some code simplifications:
* Remove `AcquireFenceSync` type. Now it can be replaced with a single instance of `SubmissionReference`
* Remove `Semaphore::GetPendingBinaryWaitSubmission`