### PR TITLE
gpuav: Remove Loc from Mapped Ptr

### DIFF
--- a/layers/gpuav/core/gpuav_setup.cpp
+++ b/layers/gpuav/core/gpuav_setup.cpp
@@ -307,7 +307,7 @@ void Validator::FinishDeviceSetup(const VkDeviceCreateInfo *pCreateInfo, const L
             return;
         }
 
-        auto indices_ptr = (uint32_t *)indices_buffer_.GetMappedPtr(loc);
+        auto indices_ptr = (uint32_t *)indices_buffer_.GetMappedPtr();
 
         for (uint32_t i = 0; i < buffer_info.size / sizeof(uint32_t); ++i) {
             indices_ptr[i] = i / (indices_buffer_alignment_ / sizeof(uint32_t));

--- a/layers/gpuav/debug_printf/debug_printf.cpp
+++ b/layers/gpuav/debug_printf/debug_printf.cpp
@@ -396,7 +396,7 @@ bool UpdateInstrumentationDescSet(Validator &gpuav, CommandBuffer &cb_state, VkD
     }
 
     // Clear the output block to zeros so that only printf values from the gpu will be present
-    auto printf_output_ptr = (uint32_t *)debug_printf_output_buffer.GetMappedPtr(loc);
+    auto printf_output_ptr = (uint32_t *)debug_printf_output_buffer.GetMappedPtr();
     memset(printf_output_ptr, 0, gpuav.gpuav_settings.debug_printf_buffer_size);
 
     VkDescriptorBufferInfo debug_printf_desc_buffer_info = {};

--- a/layers/gpuav/descriptor_validation/gpuav_descriptor_set.cpp
+++ b/layers/gpuav/descriptor_validation/gpuav_descriptor_set.cpp
@@ -219,7 +219,7 @@ VkDeviceAddress DescriptorSet::GetTypeAddress(Validator &gpuav, const Location &
         return 0;
     }
 
-    auto data = (glsl::DescriptorState *)input_buffer_.GetMappedPtr(loc);
+    auto data = (glsl::DescriptorState *)input_buffer_.GetMappedPtr();
 
     uint32_t index = 0;
     for (uint32_t i = 0; i < bindings_.size(); i++) {
@@ -296,7 +296,7 @@ VkDeviceAddress DescriptorSet::GetPostProcessBuffer(Validator &gpuav, const Loca
 
     VVL_TracyPlot("Post process buffer size (bytes)", int64_t(buffer_info.size));
 
-    void *data = post_process_buffer_.GetMappedPtr(loc);
+    void *data = post_process_buffer_.GetMappedPtr();
     memset(data, 0, static_cast<size_t>(buffer_info.size));
 
     post_process_buffer_.FlushAllocation(loc);
@@ -313,7 +313,7 @@ std::vector<DescriptorAccess> DescriptorSet::GetDescriptorAccesses(const Locatio
         return descriptor_accesses;
     }
 
-    auto slot_ptr = (glsl::PostProcessDescriptorIndexSlot *)post_process_buffer_.GetMappedPtr(loc);
+    auto slot_ptr = (glsl::PostProcessDescriptorIndexSlot *)post_process_buffer_.GetMappedPtr();
     post_process_buffer_.InvalidateAllocation(loc);
 
     for (uint32_t binding = 0; binding < binding_layouts_.size(); binding++) {
@@ -365,7 +365,7 @@ DescriptorHeap::DescriptorHeap(Validator &gpuav, uint32_t max_descriptors, const
         return;
     }
 
-    gpu_heap_state_ = (uint32_t *)buffer_.GetMappedPtr(loc);
+    gpu_heap_state_ = (uint32_t *)buffer_.GetMappedPtr();
     memset(gpu_heap_state_, 0, static_cast<size_t>(buffer_info.size));
 }
 

--- a/layers/gpuav/descriptor_validation/gpuav_descriptor_validation.cpp
+++ b/layers/gpuav/descriptor_validation/gpuav_descriptor_validation.cpp
@@ -91,7 +91,7 @@ void UpdateBoundDescriptorsPostProcess(Validator &gpuav, CommandBuffer &cb_state
         return;
     }
 
-    auto ssbo_buffer_ptr = (glsl::PostProcessSSBO *)descriptor_command_binding.post_process_ssbo_buffer.GetMappedPtr(loc);
+    auto ssbo_buffer_ptr = (glsl::PostProcessSSBO *)descriptor_command_binding.post_process_ssbo_buffer.GetMappedPtr();
     memset(ssbo_buffer_ptr, 0, sizeof(glsl::PostProcessSSBO));
 
     cb_state.post_process_buffer_lut = descriptor_command_binding.post_process_ssbo_buffer.VkHandle();
@@ -124,7 +124,7 @@ void UpdateBoundDescriptorsDescriptorChecks(Validator &gpuav, CommandBuffer &cb_
         return;
     }
 
-    auto ssbo_buffer_ptr = (glsl::DescriptorStateSSBO *)descriptor_command_binding.descritpor_state_ssbo_buffer.GetMappedPtr(loc);
+    auto ssbo_buffer_ptr = (glsl::DescriptorStateSSBO *)descriptor_command_binding.descritpor_state_ssbo_buffer.GetMappedPtr();
     memset(ssbo_buffer_ptr, 0, sizeof(glsl::DescriptorStateSSBO));
 
     cb_state.descriptor_indexing_buffer = descriptor_command_binding.descritpor_state_ssbo_buffer.VkHandle();
@@ -189,8 +189,7 @@ void UpdateBoundDescriptors(Validator &gpuav, CommandBuffer &cb_state, VkPipelin
     if (!need_descriptor_checks) return true;
 
     for (auto &descriptor_command_binding : cb_state.descriptor_command_bindings) {
-        auto ssbo_buffer_ptr =
-            (glsl::DescriptorStateSSBO *)descriptor_command_binding.descritpor_state_ssbo_buffer.GetMappedPtr(loc);
+        auto ssbo_buffer_ptr = (glsl::DescriptorStateSSBO *)descriptor_command_binding.descritpor_state_ssbo_buffer.GetMappedPtr();
         for (size_t i = 0; i < descriptor_command_binding.bound_descriptor_sets.size(); i++) {
             DescriptorSet &ds_state = *descriptor_command_binding.bound_descriptor_sets[i];
             ssbo_buffer_ptr->descriptor_set_types[i] = ds_state.GetTypeAddress(gpuav, loc);

--- a/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
@@ -382,7 +382,7 @@ void UpdateInstrumentationDescSet(Validator &gpuav, CommandBuffer &cb_state, VkD
 
         const auto [vertex_attribute_fetch_limit_vertex_input_rate, vertex_attribute_fetch_limit_instance_input_rate] =
             GetVertexAttributeFetchLimits(cb_state);
-        auto vertex_attribute_fetch_limits_buffer_ptr = (uint32_t *)vertex_attribute_fetch_limits_buffer.GetMappedPtr(loc);
+        auto vertex_attribute_fetch_limits_buffer_ptr = (uint32_t *)vertex_attribute_fetch_limits_buffer.GetMappedPtr();
         if (vertex_attribute_fetch_limit_vertex_input_rate.has_value()) {
             vertex_attribute_fetch_limits_buffer_ptr[0] = 1u;
             vertex_attribute_fetch_limits_buffer_ptr[1] =

--- a/layers/gpuav/resources/gpuav_state_trackers.cpp
+++ b/layers/gpuav/resources/gpuav_state_trackers.cpp
@@ -148,7 +148,7 @@ static bool AllocateErrorLogsBuffer(Validator &gpuav, VkCommandBuffer command_bu
         return false;
     }
 
-    auto output_buffer_ptr = (uint32_t *)error_output_buffer.GetMappedPtr(loc);
+    auto output_buffer_ptr = (uint32_t *)error_output_buffer.GetMappedPtr();
 
     memset(output_buffer_ptr, 0, glsl::kErrorBufferByteSize);
     if (gpuav.gpuav_settings.shader_instrumentation.descriptor_checks) {
@@ -310,7 +310,7 @@ bool CommandBuffer::UpdateBdaRangesBuffer(const Location &loc) {
 
     // Update buffer device address table
     // ---
-    auto bda_table_ptr = (VkDeviceAddress *)bda_ranges_snapshot_.GetMappedPtr(loc);
+    auto bda_table_ptr = (VkDeviceAddress *)bda_ranges_snapshot_.GetMappedPtr();
 
     // Buffer device address table layout
     // Ranges are sorted from low to high, and do not overlap
@@ -427,7 +427,7 @@ void CommandBuffer::ResetCBState(bool should_destroy) {
 }
 
 void CommandBuffer::ClearCmdErrorsCountsBuffer(const Location &loc) const {
-    auto cmd_errors_counts_buffer_ptr = (uint32_t *)cmd_errors_counts_buffer_.GetMappedPtr(loc);
+    auto cmd_errors_counts_buffer_ptr = (uint32_t *)cmd_errors_counts_buffer_.GetMappedPtr();
     std::memset(cmd_errors_counts_buffer_ptr, 0, static_cast<size_t>(GetCmdErrorsCountsBufferByteSize()));
 }
 
@@ -487,7 +487,7 @@ void CommandBuffer::PostProcess(VkQueue queue, const std::vector<std::string> &i
 
     // For the given command buffer, map its debug data buffers and read their contents for analysis.
     for (DebugPrintfBufferInfo &printf_buffer_info : debug_printf_buffer_infos) {
-        auto printf_output_ptr = (char *)printf_buffer_info.output_mem_buffer.GetMappedPtr(loc);
+        auto printf_output_ptr = (char *)printf_buffer_info.output_mem_buffer.GetMappedPtr();
         debug_printf::AnalyzeAndGenerateMessage(*gpuav, VkHandle(), queue, printf_buffer_info, (uint32_t *)printf_output_ptr, loc);
     }
 
@@ -500,7 +500,7 @@ void CommandBuffer::PostProcess(VkQueue queue, const std::vector<std::string> &i
 
     bool skip = false;
     {
-        auto error_output_buffer_ptr = (uint32_t *)error_output_buffer_.GetMappedPtr(loc);
+        auto error_output_buffer_ptr = (uint32_t *)error_output_buffer_.GetMappedPtr();
 
         // The second word in the debug output buffer is the number of words that would have
         // been written by the shader instrumentation, if there was enough room in the buffer we provided.

--- a/layers/gpuav/resources/gpuav_vulkan_objects.cpp
+++ b/layers/gpuav/resources/gpuav_vulkan_objects.cpp
@@ -145,7 +145,7 @@ void SharedResourcesCache::Clear() {
     shared_validation_resources_map_.clear();
 }
 
-void *Buffer::GetMappedPtr(const Location &loc) const { return mapped_ptr; }
+void *Buffer::GetMappedPtr() const { return mapped_ptr; }
 
 void Buffer::FlushAllocation(const Location &loc, VkDeviceSize offset, VkDeviceSize size) const {
     VkResult result = vmaFlushAllocation(gpuav.vma_allocator_, allocation, offset, size);

--- a/layers/gpuav/resources/gpuav_vulkan_objects.h
+++ b/layers/gpuav/resources/gpuav_vulkan_objects.h
@@ -60,7 +60,7 @@ class Buffer {
     // Warps VMA calls to simplify error reporting.
     // No error propagation, but if hitting a VMA error, GPU-AV is likely not going to recover anyway.
 
-    [[nodiscard]] void *GetMappedPtr(const Location &loc) const;
+    [[nodiscard]] void *GetMappedPtr() const;
     void FlushAllocation(const Location &loc, VkDeviceSize offset = 0, VkDeviceSize size = VK_WHOLE_SIZE) const;
     void InvalidateAllocation(const Location &loc, VkDeviceSize offset = 0, VkDeviceSize size = VK_WHOLE_SIZE) const;
 

--- a/layers/gpuav/validation_cmd/gpuav_copy_buffer_to_image.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_copy_buffer_to_image.cpp
@@ -201,7 +201,7 @@ void InsertCopyBufferToImageValidation(Validator &gpuav, const Location &loc, Co
             return;
         }
 
-        auto gpu_regions_u32_ptr = (uint32_t *)copy_src_regions_mem_buffer.GetMappedPtr(loc);
+        auto gpu_regions_u32_ptr = (uint32_t *)copy_src_regions_mem_buffer.GetMappedPtr();
 
         const uint32_t block_size = image_state->create_info.format == VK_FORMAT_D32_SFLOAT ? 4 : 5;
         uint32_t gpu_regions_count = 0;


### PR DESCRIPTION
Remove the `Loc` from `GetMappedPtr` as it is not actually needed