### PR TITLE
gpuav: Add a Clear to vbo::Buffer

### DIFF
--- a/layers/gpuav/debug_printf/debug_printf.cpp
+++ b/layers/gpuav/debug_printf/debug_printf.cpp
@@ -396,8 +396,7 @@ bool UpdateInstrumentationDescSet(Validator &gpuav, CommandBuffer &cb_state, VkD
     }
 
     // Clear the output block to zeros so that only printf values from the gpu will be present
-    auto printf_output_ptr = (uint32_t *)debug_printf_output_buffer.GetMappedPtr();
-    memset(printf_output_ptr, 0, gpuav.gpuav_settings.debug_printf_buffer_size);
+    debug_printf_output_buffer.Clear();
 
     VkDescriptorBufferInfo debug_printf_desc_buffer_info = {};
     debug_printf_desc_buffer_info.range = gpuav.gpuav_settings.debug_printf_buffer_size;

--- a/layers/gpuav/descriptor_validation/gpuav_descriptor_set.cpp
+++ b/layers/gpuav/descriptor_validation/gpuav_descriptor_set.cpp
@@ -296,9 +296,7 @@ VkDeviceAddress DescriptorSet::GetPostProcessBuffer(Validator &gpuav, const Loca
 
     VVL_TracyPlot("Post process buffer size (bytes)", int64_t(buffer_info.size));
 
-    void *data = post_process_buffer_.GetMappedPtr();
-    memset(data, 0, static_cast<size_t>(buffer_info.size));
-
+    post_process_buffer_.Clear();
     post_process_buffer_.FlushAllocation(loc);
 
     return post_process_buffer_.Address();

--- a/layers/gpuav/descriptor_validation/gpuav_descriptor_validation.cpp
+++ b/layers/gpuav/descriptor_validation/gpuav_descriptor_validation.cpp
@@ -91,8 +91,8 @@ void UpdateBoundDescriptorsPostProcess(Validator &gpuav, CommandBuffer &cb_state
         return;
     }
 
+    descriptor_command_binding.post_process_ssbo_buffer.Clear();
     auto ssbo_buffer_ptr = (glsl::PostProcessSSBO *)descriptor_command_binding.post_process_ssbo_buffer.GetMappedPtr();
-    memset(ssbo_buffer_ptr, 0, sizeof(glsl::PostProcessSSBO));
 
     cb_state.post_process_buffer_lut = descriptor_command_binding.post_process_ssbo_buffer.VkHandle();
 

--- a/layers/gpuav/resources/gpuav_state_trackers.cpp
+++ b/layers/gpuav/resources/gpuav_state_trackers.cpp
@@ -147,10 +147,8 @@ static bool AllocateErrorLogsBuffer(Validator &gpuav, VkCommandBuffer command_bu
     if (!success) {
         return false;
     }
-
+    error_output_buffer.Clear();
     auto output_buffer_ptr = (uint32_t *)error_output_buffer.GetMappedPtr();
-
-    memset(output_buffer_ptr, 0, glsl::kErrorBufferByteSize);
     if (gpuav.gpuav_settings.shader_instrumentation.descriptor_checks) {
         output_buffer_ptr[cst::stream_output_flags_offset] = cst::inst_buffer_oob_enabled;
     }
@@ -195,7 +193,7 @@ void CommandBuffer::AllocateResources(const Location &loc) {
             return;
         }
 
-        ClearCmdErrorsCountsBuffer(loc);
+        cmd_errors_counts_buffer_.Clear();
         if (gpuav->aborted_) return;
     }
 
@@ -426,11 +424,6 @@ void CommandBuffer::ResetCBState(bool should_destroy) {
     action_command_count = 0;
 }
 
-void CommandBuffer::ClearCmdErrorsCountsBuffer(const Location &loc) const {
-    auto cmd_errors_counts_buffer_ptr = (uint32_t *)cmd_errors_counts_buffer_.GetMappedPtr();
-    std::memset(cmd_errors_counts_buffer_ptr, 0, static_cast<size_t>(GetCmdErrorsCountsBufferByteSize()));
-}
-
 void CommandBuffer::IncrementCommandCount(VkPipelineBindPoint bind_point) {
     action_command_count++;
     if (bind_point == VK_PIPELINE_BIND_POINT_GRAPHICS) {
@@ -542,7 +535,7 @@ void CommandBuffer::PostProcess(VkQueue queue, const std::vector<std::string> &i
         error_output_buffer_ptr[cst::stream_output_size_offset] = 0;
     }
 
-    ClearCmdErrorsCountsBuffer(loc);
+    cmd_errors_counts_buffer_.Clear();
     if (gpuav->aborted_) return;
 
     // If instrumentation found an error, skip post processing. Errors detected by instrumentation are usually

--- a/layers/gpuav/resources/gpuav_state_trackers.h
+++ b/layers/gpuav/resources/gpuav_state_trackers.h
@@ -112,7 +112,6 @@ class CommandBuffer : public vvl::CommandBuffer {
 
     const vko::Buffer &GetBdaRangesSnapshot() const { return bda_ranges_snapshot_; }
 
-    void ClearCmdErrorsCountsBuffer(const Location &loc) const;
     void IncrementCommandCount(VkPipelineBindPoint bind_point);
 
     std::string GetDebugLabelRegion(uint32_t label_command_i, const std::vector<std::string> &initial_label_stack) const;

--- a/layers/gpuav/resources/gpuav_vulkan_objects.cpp
+++ b/layers/gpuav/resources/gpuav_vulkan_objects.cpp
@@ -169,6 +169,7 @@ bool Buffer::Create(const Location &loc, const VkBufferCreateInfo *buffer_create
         gpuav.InternalVmaError(gpuav.device, loc, "Unable to allocate device memory for internal buffer.");
         return false;
     }
+    size = buffer_create_info->size;
 
     if (buffer_create_info->usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT) {
         // After creating the buffer, get the address right away
@@ -199,6 +200,12 @@ void Buffer::Destroy() {
         allocation = VK_NULL_HANDLE;
         device_address = 0;
     }
+}
+
+void Buffer::Clear() const {
+    // Caller is in charge of calling Flush/Invalidate as needed
+    assert(mapped_ptr);
+    memset((uint8_t *)mapped_ptr, 0, static_cast<size_t>(size));
 }
 
 VkDescriptorSet GpuResourcesManager::GetManagedDescriptorSet(VkDescriptorSetLayout desc_set_layout) {

--- a/layers/gpuav/resources/gpuav_vulkan_objects.h
+++ b/layers/gpuav/resources/gpuav_vulkan_objects.h
@@ -72,6 +72,7 @@ class Buffer {
     const VkBuffer &VkHandle() const { return buffer; }
     const VmaAllocation &Allocation() const { return allocation; }
     VkDeviceAddress Address() const { return device_address; };
+    void Clear() const;
 
   private:
     const Validator &gpuav;
@@ -79,6 +80,7 @@ class Buffer {
     VmaAllocation allocation = VK_NULL_HANDLE;
     // If buffer was not created with VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT then this will not be zero
     VkDeviceAddress device_address = 0;
+    VkDeviceSize size = 0;
     void *mapped_ptr = nullptr;
 };
 


### PR DESCRIPTION
All our `memset` in GPU-AV are just to clear the size of the buffer and we have to try and keep track of the size when it can be just done in `vko::Buffer`