### PR TITLE
layers: Remove Robinhood for spirv parsing

### DIFF
--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -338,7 +338,7 @@ static uint32_t ExecutionModelToShaderStageFlagBits(uint32_t mode) {
 
 // TODO: The set of interesting opcodes here was determined by eyeballing the SPIRV spec. It might be worth
 // converting parts of this to be generated from the machine-readable spec instead.
-static void FindPointersAndObjects(const Instruction& insn, vvl::unordered_set<uint32_t>& result) {
+static void FindPointersAndObjects(const Instruction& insn, std::unordered_set<uint32_t>& result) {
     switch (insn.Opcode()) {
         case spv::OpLoad:
             result.insert(insn.Word(3));  // ptr
@@ -471,12 +471,12 @@ bool EntryPoint::HasBuiltIn(spv::BuiltIn built_in) const {
     return false;
 }
 
-vvl::unordered_set<uint32_t> EntryPoint::GetAccessibleIds(const Module& module_state, EntryPoint& entrypoint) {
-    vvl::unordered_set<uint32_t> result_ids;
+std::unordered_set<uint32_t> EntryPoint::GetAccessibleIds(const Module& module_state, EntryPoint& entrypoint) {
+    std::unordered_set<uint32_t> result_ids;
 
     // For some analyses, we need to know about all ids referenced by the static call tree of a particular entrypoint.
     // This is important for identifying the set of shader resources actually used by an entrypoint.
-    vvl::unordered_set<uint32_t> worklist;
+    std::unordered_set<uint32_t> worklist;
     worklist.insert(entrypoint.id);
 
     while (!worklist.empty()) {

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -22,6 +22,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <vector>
+#include <unordered_set>
 
 #include "state_tracker/shader_instruction.h"
 #include "state_tracker/state_object.h"
@@ -496,7 +497,9 @@ struct EntryPoint {
 
     // All ids that can be accessed from the entry point
     // being accessed doesn't guarantee it is statically used
-    const vvl::unordered_set<uint32_t> accessible_ids;
+    // From https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8501 we found that using robin hood here will produce
+    // overflows, this shouldn't be a perf critical section that it is ok using STL
+    const std::unordered_set<uint32_t> accessible_ids;
 
     // only one Push Constant block is allowed per entry point
     std::shared_ptr<const PushConstantVariable> push_constant_variable;
@@ -541,7 +544,7 @@ struct EntryPoint {
     bool HasBuiltIn(spv::BuiltIn built_in) const;
 
   protected:
-    static vvl::unordered_set<uint32_t> GetAccessibleIds(const Module &module_state, EntryPoint &entrypoint);
+    static std::unordered_set<uint32_t> GetAccessibleIds(const Module &module_state, EntryPoint &entrypoint);
     static std::vector<StageInterfaceVariable> GetStageInterfaceVariables(const Module &module_state, const EntryPoint &entrypoint,
                                                                           const VariableAccessMap &variable_access_map,
                                                                           const DebugNameMap &debug_name_map);


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8501