### PR TITLE
gpuav: Force on Robustness 2 as well

### DIFF
--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.h
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.h
@@ -229,8 +229,8 @@ class GpuShaderInstrumentor : public vvl::Device {
 
     std::vector<spirv::InternalOnlyDebugPrintf> intenral_only_debug_printf_;
 
-    // Keep track of changes made to the enabled extensions and features separately so
-    // that they don't influence other parts of validation.
+    // These are the same as enabled_features, but may have been altered at setup time. This should be use for any feature GPU-AV
+    // might force on. We need to track these changes separately so that they don't influence non-GPU-AV parts of validation.
     DeviceExtensions modified_extensions;
     DeviceFeatures modified_features;
 

--- a/layers/gpuav/spirv/descriptor_class_general_buffer_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_class_general_buffer_pass.cpp
@@ -30,9 +30,7 @@ namespace gpuav {
 namespace spirv {
 
 DescriptorClassGeneralBufferPass::DescriptorClassGeneralBufferPass(Module& module)
-    : Pass(module),
-      // robustBufferAccess safety to got into unsafe mode to improve performance
-      unsafe_mode_(module.settings_.unsafe_mode || module.enabled_features_.robustBufferAccess) {
+    : Pass(module), unsafe_mode_(module.settings_.unsafe_mode) {
     module.use_bda_ = true;
 }
 

--- a/layers/gpuav/validation_cmd/gpuav_draw.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_draw.cpp
@@ -845,7 +845,7 @@ void DrawIndexedIndirectIndexBuffer(Validator &gpuav, CommandBuffer &cb_state, c
         return;
     }
 
-    if (gpuav.enabled_features.robustBufferAccess2) {
+    if (gpuav.modified_features.robustBufferAccess2) {
         return;
     }
 


### PR DESCRIPTION
For those using `VK_LAYER_GPUAV_FORCE_ON_ROBUSTNESS` this will now also turn on `robustBufferAccess2` and `robustImageAccess2` as well