### PR TITLE
layers: Fix BDA being viewed as 1 byte

### DIFF
--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -2253,7 +2253,7 @@ uint32_t Module::GetTypeBitsSize(const Instruction* insn) const {
         if (insn->StorageClass() == spv::StorageClassPhysicalStorageBuffer) {
             // All PhysicalStorageBuffer are just 64-bit pointers
             // We don't need to go chasing it to find the size, as it is not calculated for any VUs
-            bit_size = 8;
+            bit_size = 64;
         } else {
             const Instruction* type = FindDef(insn->Word(3));
             bit_size = GetTypeBitsSize(type);


### PR DESCRIPTION
There are not many places that care about the struct size in SPIR-V, but Push Constants do. The struct

```
        layout(push_constant) uniform Uniforms {
            BDA ptr0;
            BDA ptr1;
        };
```

is 16 bytes (2 pointers), but was being counted as 9 due to this bug