### PR TITLE
gpuav: Add an EarlySkip option in the pass

### DIFF
--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
@@ -1204,11 +1204,8 @@ bool GpuShaderInstrumentor::InstrumentShader(const vvl::span<const uint32_t> &in
 
     bool modified = false;
 
-    // If there is no bindings found, can just ignore passes that use it
-    const bool has_bindings_layouts = !instrumentation_dsl.set_index_to_bindings_layout_lut.empty();
-
     // If descriptor indexing is enabled, enable length checks and updated descriptor checks
-    if (gpuav_settings.shader_instrumentation.descriptor_checks && has_bindings_layouts) {
+    if (gpuav_settings.shader_instrumentation.descriptor_checks) {
         // Will wrap descriptor indexing with if/else to prevent crashing if OOB
         spirv::DescriptorIndexingOOBPass oob_pass(module);
         modified |= oob_pass.Run();
@@ -1238,7 +1235,7 @@ bool GpuShaderInstrumentor::InstrumentShader(const vvl::span<const uint32_t> &in
 
     // Post Process instrumentation passes assume the things inside are valid, but putting at the end, things above will wrap checks
     // in a if/else, this means they will be gaurded as if they were inside the above passes
-    if (gpuav_settings.shader_instrumentation.post_process_descriptor_indexing && has_bindings_layouts) {
+    if (gpuav_settings.shader_instrumentation.post_process_descriptor_indexing) {
         spirv::PostProcessDescriptorIndexingPass pass(module);
         modified |= pass.Run();
     }

--- a/layers/gpuav/spirv/descriptor_class_general_buffer_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_class_general_buffer_pass.cpp
@@ -315,6 +315,13 @@ bool DescriptorClassGeneralBufferPass::RequiresInstrumentation(const Function& f
     return true;
 }
 
+bool DescriptorClassGeneralBufferPass::EarlySkip() const {
+    if (module_.set_index_to_bindings_layout_lut_.empty()) {
+        return true;  // If there is no bindings, nothing to instrument
+    }
+    return false;
+}
+
 void DescriptorClassGeneralBufferPass::PrintDebugInfo() const {
     std::cout << "DescriptorClassGeneralBufferPass instrumentation count: " << instrumentations_count_ << '\n';
 }

--- a/layers/gpuav/spirv/descriptor_class_general_buffer_pass.h
+++ b/layers/gpuav/spirv/descriptor_class_general_buffer_pass.h
@@ -29,6 +29,7 @@ class DescriptorClassGeneralBufferPass : public Pass {
     const char* Name() const final { return "DescriptorClassGeneralBufferPass"; }
 
     bool Instrument() final;
+    bool EarlySkip() const final;
     void PrintDebugInfo() const final;
 
   private:

--- a/layers/gpuav/spirv/descriptor_class_texel_buffer_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_class_texel_buffer_pass.cpp
@@ -165,6 +165,13 @@ bool DescriptorClassTexelBufferPass::RequiresInstrumentation(const Function& fun
     return true;
 }
 
+bool DescriptorClassTexelBufferPass::EarlySkip() const {
+    if (module_.set_index_to_bindings_layout_lut_.empty()) {
+        return true;  // If there is no bindings, nothing to instrument
+    }
+    return false;
+}
+
 void DescriptorClassTexelBufferPass::PrintDebugInfo() const {
     std::cout << "DescriptorClassTexelBufferPass instrumentation count: " << instrumentations_count_ << '\n';
 }

--- a/layers/gpuav/spirv/descriptor_class_texel_buffer_pass.h
+++ b/layers/gpuav/spirv/descriptor_class_texel_buffer_pass.h
@@ -28,6 +28,7 @@ class DescriptorClassTexelBufferPass : public Pass {
     const char* Name() const final { return "DescriptorClassTexelBufferPass"; }
 
     bool Instrument() final;
+    bool EarlySkip() const final;
     void PrintDebugInfo() const final;
 
   private:

--- a/layers/gpuav/spirv/descriptor_indexing_oob_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_indexing_oob_pass.cpp
@@ -151,6 +151,13 @@ uint32_t DescriptorIndexingOOBPass::CreateFunctionCall(BasicBlock& block, Instru
     return function_result;
 }
 
+bool DescriptorIndexingOOBPass::EarlySkip() const {
+    if (module_.set_index_to_bindings_layout_lut_.empty()) {
+        return true;  // If there is no bindings, nothing to instrument
+    }
+    return false;
+}
+
 void DescriptorIndexingOOBPass::NewBlock(const BasicBlock&, bool is_original_new_block) {
     // Don't clear if the new block occurs from control flow breaking one up
     if (is_original_new_block) {

--- a/layers/gpuav/spirv/descriptor_indexing_oob_pass.h
+++ b/layers/gpuav/spirv/descriptor_indexing_oob_pass.h
@@ -27,6 +27,7 @@ class DescriptorIndexingOOBPass : public InjectConditionalFunctionPass {
   public:
     DescriptorIndexingOOBPass(Module& module) : InjectConditionalFunctionPass(module) {}
     const char* Name() const final { return "DescriptorIndexingOOBPass"; }
+    bool EarlySkip() const final;
     void PrintDebugInfo() const final;
 
     void NewBlock(const BasicBlock& block, bool is_original_new_block) override;

--- a/layers/gpuav/spirv/pass.cpp
+++ b/layers/gpuav/spirv/pass.cpp
@@ -25,7 +25,13 @@ namespace gpuav {
 namespace spirv {
 
 bool Pass::Run() {
-    const bool modified = Instrument();
+    bool modified = false;
+    if (EarlySkip()) {
+        return modified;
+    }
+
+    modified = Instrument();
+
     if (module_.settings_.print_debug_info) {
         PrintDebugInfo();
     }

--- a/layers/gpuav/spirv/pass.h
+++ b/layers/gpuav/spirv/pass.h
@@ -40,6 +40,9 @@ class Pass {
     virtual const char* Name() const = 0;
     // Return true if code was instrumented/modified in anyway
     virtual bool Instrument() = 0;
+    // Optional time before the pass to decide to skip or not.
+    // This is for things that can change between shaders
+    virtual bool EarlySkip() const { return false; };
     // Requiring because this becomes important/helpful while debugging
     virtual void PrintDebugInfo() const = 0;
     // Wrapper that each pass can use to start

--- a/layers/gpuav/spirv/post_process_descriptor_indexing_pass.cpp
+++ b/layers/gpuav/spirv/post_process_descriptor_indexing_pass.cpp
@@ -200,6 +200,13 @@ bool PostProcessDescriptorIndexingPass::Instrument() {
     return (instrumentations_count_ != 0);
 }
 
+bool PostProcessDescriptorIndexingPass::EarlySkip() const {
+    if (module_.set_index_to_bindings_layout_lut_.empty()) {
+        return true;  // If there is no bindings, nothing to instrument
+    }
+    return false;
+}
+
 void PostProcessDescriptorIndexingPass::PrintDebugInfo() const {
     std::cout << "PostProcessDescriptorIndexingPass instrumentation count: " << instrumentations_count_ << '\n';
 }

--- a/layers/gpuav/spirv/post_process_descriptor_indexing_pass.h
+++ b/layers/gpuav/spirv/post_process_descriptor_indexing_pass.h
@@ -28,6 +28,7 @@ class PostProcessDescriptorIndexingPass : public Pass {
     const char* Name() const final { return "PostProcessDescriptorIndexingPass"; }
 
     bool Instrument() final;
+    bool EarlySkip() const final;
     void PrintDebugInfo() const final;
 
   private:


### PR DESCRIPTION
Talking with @arno-lunarg about how to streamline the Passes, I wanted to move this check inside the pass as it might change between shaders, but also not tied to the SPIR-V itself and falls into this strange grey area

This just adds an option so each pass (which actually knows what it does) is in charge of deciding to early return, not the "chassis" calling it