### PR TITLE
tests: Fix image CreateInfo incorrect use

### DIFF
--- a/tests/framework/binding.cpp
+++ b/tests/framework/binding.cpp
@@ -1312,7 +1312,7 @@ bool Image::IsCompatible(const Device &dev, const VkImageUsageFlags usages, cons
 VkImageCreateInfo Image::ImageCreateInfo2D(uint32_t const width, uint32_t const height, uint32_t const mip_levels,
                                            uint32_t const layers, VkFormat const format, VkFlags const usage,
                                            VkImageTiling const requested_tiling, const vvl::span<uint32_t> &queue_families) {
-    VkImageCreateInfo imageCreateInfo = CreateInfo();
+    VkImageCreateInfo imageCreateInfo = DefaultCreateInfo();
     imageCreateInfo.imageType = VK_IMAGE_TYPE_2D;
     imageCreateInfo.format = format;
     imageCreateInfo.extent.width = width;

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -796,7 +796,8 @@ class Image : public internal::NonDispHandle<VkImage> {
                             VkPipelineStageFlags src_stages = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
                             VkPipelineStageFlags dest_stages = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
 
-    static VkImageCreateInfo CreateInfo();
+    const VkImageCreateInfo &CreateInfo() const { return create_info_; }
+    static VkImageCreateInfo DefaultCreateInfo();
 
     VkImageSubresourceRange SubresourceRange(VkImageAspectFlags aspect_mask) {
         return VkImageSubresourceRange{aspect_mask, 0, create_info_.mipLevels, 0, create_info_.arrayLayers};
@@ -1291,14 +1292,15 @@ inline VkQueryPoolCreateInfo QueryPool::CreateInfo(VkQueryType type, uint32_t sl
     return info;
 }
 
-inline VkImageCreateInfo Image::CreateInfo() {
+inline VkImageCreateInfo Image::DefaultCreateInfo() {
     VkImageCreateInfo info = vku::InitStructHelper();
-    info.extent.width = 1;
-    info.extent.height = 1;
-    info.extent.depth = 1;
+    info.imageType = VK_IMAGE_TYPE_2D;
+    info.extent = {1, 1, 1};
     info.mipLevels = 1;
     info.arrayLayers = 1;
     info.samples = VK_SAMPLE_COUNT_1_BIT;
+    info.tiling = VK_IMAGE_TILING_OPTIMAL;
+    info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     return info;
 }
 

--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -2509,15 +2509,11 @@ TEST_F(NegativeCommand, ImageFilterCubicSamplerInCmdDraw) {
 
     VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
     VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
-    auto image_ci = vkt::Image::CreateInfo();
+    auto image_ci = vkt::Image::DefaultCreateInfo();
     image_ci.imageType = VK_IMAGE_TYPE_3D;
     image_ci.format = format;
     image_ci.extent.width = 128;
     image_ci.extent.height = 128;
-    image_ci.mipLevels = 1;
-    image_ci.arrayLayers = 1;
-    image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
-    image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     image_ci.usage = usage;
     VkImageViewType imageViewType = VK_IMAGE_VIEW_TYPE_3D;
 
@@ -3294,12 +3290,10 @@ TEST_F(NegativeCommand, ClearDepthStencilImage) {
     auto depth_format = FindSupportedDepthStencilFormat(Gpu());
 
     VkClearDepthStencilValue clear_value = {0};
-    VkImageCreateInfo image_create_info = vkt::Image::CreateInfo();
-    image_create_info.imageType = VK_IMAGE_TYPE_2D;
+    VkImageCreateInfo image_create_info = vkt::Image::DefaultCreateInfo();
     image_create_info.format = depth_format;
     image_create_info.extent.width = 64;
     image_create_info.extent.height = 64;
-    image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     // Error here is that VK_IMAGE_USAGE_TRANSFER_DST_BIT is excluded for DS image that we'll call Clear on below
     image_create_info.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
     vkt::Image dst_image_bad_usage(*m_device, image_create_info, vkt::set_layout);

--- a/tests/unit/external_memory_sync.cpp
+++ b/tests/unit/external_memory_sync.cpp
@@ -1869,11 +1869,9 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFromWin32Handle) {
     {
         VkExternalMemoryImageCreateInfo external_info = vku::InitStructHelper();
         external_info.handleTypes = handle_type;
-        auto create_info = vkt::Image::CreateInfo();
+        auto create_info = vkt::Image::DefaultCreateInfo();
         create_info.pNext = &external_info;
-        create_info.imageType = VK_IMAGE_TYPE_2D;
         create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
-        create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
         create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
         image.InitNoMemory(*m_device, create_info);
     }
@@ -2564,7 +2562,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFdImageSupport) {
     RETURN_IF_SKIP(Init());
     IgnoreHandleTypeError(m_errorMonitor);
 
-    auto image_info = vkt::Image::CreateInfo();
+    auto image_info = vkt::Image::DefaultCreateInfo();
     image_info.extent.width = 1024;
     image_info.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     image_info.format = VK_FORMAT_R8G8B8A8_UNORM;

--- a/tests/unit/image.cpp
+++ b/tests/unit/image.cpp
@@ -1848,14 +1848,11 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRangeCubeArray) {
 
     vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
 
-    auto image_ci = vkt::Image::CreateInfo();
+    auto image_ci = vkt::Image::DefaultCreateInfo();
     image_ci.arrayLayers = 18;
     image_ci.flags = VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT;
-    image_ci.imageType = VK_IMAGE_TYPE_2D;
     image_ci.format = VK_FORMAT_R8G8B8A8_UNORM;
-    image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
-    image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     vkt::Image cubeArrayImg(*m_device, image_ci, vkt::set_layout);
 
     VkImageViewCreateInfo cube_img_view_info_template = vku::InitStructHelper();
@@ -1931,15 +1928,13 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRangeMaintenance1) {
     AddRequiredFeature(vkt::Feature::sparseResidencyImage3D);
     RETURN_IF_SKIP(Init());
 
-    auto image_ci = vkt::Image::CreateInfo();
+    auto image_ci = vkt::Image::DefaultCreateInfo();
     image_ci.flags = VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT;
     image_ci.imageType = VK_IMAGE_TYPE_3D;
     image_ci.format = VK_FORMAT_R8G8B8A8_UNORM;
     image_ci.extent = {8, 8, 8};
     image_ci.mipLevels = 4;
-    image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
-    image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     vkt::Image volumeImage(*m_device, image_ci, vkt::set_layout);
 
     VkImageViewCreateInfo volume_img_view_info_template = vku::InitStructHelper();
@@ -4011,7 +4006,7 @@ TEST_F(NegativeImage, TransitionNonSparseImageLayoutWithoutBoundMemory) {
 
     RETURN_IF_SKIP(Init());
 
-    VkImageCreateInfo info = vkt::Image::CreateInfo();
+    VkImageCreateInfo info = vkt::Image::DefaultCreateInfo();
     info.format = VK_FORMAT_B8G8R8A8_UNORM;
     info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
     vkt::Image image(*m_device, info, vkt::no_mem);
@@ -4028,7 +4023,7 @@ TEST_F(NegativeImage, AttachmentFeedbackLoopLayoutFeature) {
     AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(Init());
 
-    VkImageCreateInfo info = vkt::Image::CreateInfo();
+    VkImageCreateInfo info = vkt::Image::DefaultCreateInfo();
     info.format = VK_FORMAT_B8G8R8A8_UNORM;
     info.usage =
         VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT | VK_IMAGE_USAGE_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT;
@@ -4603,17 +4598,12 @@ TEST_F(NegativeImage, ResolveDepthImage) {
 
     auto depth_format = FindSupportedDepthStencilFormat(Gpu());
 
-    VkImageCreateInfo image_ci = vkt::Image::CreateInfo();
-    image_ci.imageType = VK_IMAGE_TYPE_2D;
+    VkImageCreateInfo image_ci = vkt::Image::DefaultCreateInfo();
     image_ci.format = depth_format;
     image_ci.extent.width = 32u;
     image_ci.extent.height = 32u;
-    image_ci.mipLevels = 1u;
-    image_ci.arrayLayers = 1u;
     image_ci.samples = VK_SAMPLE_COUNT_2_BIT;
-    image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-    image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
     VkImageFormatProperties image_format_properties;
     vk::GetPhysicalDeviceImageFormatProperties(Gpu(), image_ci.format, image_ci.imageType, image_ci.tiling, image_ci.usage,

--- a/tests/unit/image_layout_positive.cpp
+++ b/tests/unit/image_layout_positive.cpp
@@ -202,14 +202,12 @@ TEST_F(PositiveImageLayout, ImagelessTracking) {
 TEST_F(PositiveImageLayout, Subresource) {
     RETURN_IF_SKIP(Init());
 
-    auto image_ci = vkt::Image::CreateInfo();
-    image_ci.imageType = VK_IMAGE_TYPE_2D;
+    auto image_ci = vkt::Image::DefaultCreateInfo();
     image_ci.extent.width = 64;
     image_ci.extent.height = 64;
     image_ci.mipLevels = 7;
     image_ci.arrayLayers = 6;
     image_ci.format = VK_FORMAT_R8_UINT;
-    image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     vkt::Image image(*m_device, image_ci);
 

--- a/tests/unit/image_positive.cpp
+++ b/tests/unit/image_positive.cpp
@@ -322,8 +322,7 @@ TEST_F(PositiveImage, ImageCompressionControl) {
 
     vk::GetPhysicalDeviceImageFormatProperties2(Gpu(), &image_format_info, &image_format_properties);
 
-    auto image_ci = vkt::Image::CreateInfo();
-    image_ci.imageType = VK_IMAGE_TYPE_2D;
+    auto image_ci = vkt::Image::DefaultCreateInfo();
     image_ci.format = VK_FORMAT_R8G8B8A8_UNORM;
     image_ci.tiling = VK_IMAGE_TILING_LINEAR;
     image_ci.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;

--- a/tests/unit/memory.cpp
+++ b/tests/unit/memory.cpp
@@ -555,12 +555,10 @@ TEST_F(NegativeMemory, QueryMemoryCommitmentWithoutLazyProperty) {
     TEST_DESCRIPTION("Attempt to query memory commitment on memory without lazy allocation");
     RETURN_IF_SKIP(Init());
 
-    auto image_ci = vkt::Image::CreateInfo();
-    image_ci.imageType = VK_IMAGE_TYPE_2D;
+    auto image_ci = vkt::Image::DefaultCreateInfo();
     image_ci.format = VK_FORMAT_B8G8R8A8_UNORM;
     image_ci.extent.width = 32;
     image_ci.extent.height = 32;
-    image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     vkt::Image image(*m_device, image_ci, vkt::no_mem);
 
@@ -1384,7 +1382,7 @@ TEST_F(NegativeMemory, DedicatedAllocationBinding) {
     vk::BindBufferMemory(m_device->handle(), buffer.handle(), dedicated_buffer_memory.handle(), 0);
 
     // And for images...
-    auto image_info = vkt::Image::CreateInfo();
+    auto image_info = vkt::Image::DefaultCreateInfo();
     image_info.extent.width = resource_size;
     image_info.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     image_info.format = VK_FORMAT_R8G8B8A8_UNORM;
@@ -1423,7 +1421,7 @@ TEST_F(NegativeMemory, DedicatedAllocationImageAliasing) {
     VkMemoryPropertyFlags mem_flags = 0;
     const VkDeviceSize resource_size = 1024;
 
-    auto image_info = vkt::Image::CreateInfo();
+    auto image_info = vkt::Image::DefaultCreateInfo();
     image_info.extent.width = resource_size;
     image_info.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     image_info.format = VK_FORMAT_R8G8B8A8_UNORM;
@@ -1441,7 +1439,7 @@ TEST_F(NegativeMemory, DedicatedAllocationImageAliasing) {
     // Bind with different but identical image
     vk::BindImageMemory(m_device->handle(), identical_image.handle(), dedicated_image_memory.handle(), 0);
 
-    image_info = vkt::Image::CreateInfo();
+    image_info = vkt::Image::DefaultCreateInfo();
     image_info.extent.width = resource_size - 1;
     image_info.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     image_info.format = VK_FORMAT_R8G8B8A8_UNORM;
@@ -1450,7 +1448,7 @@ TEST_F(NegativeMemory, DedicatedAllocationImageAliasing) {
     // Bind with a smaller image
     vk::BindImageMemory(m_device->handle(), smaller_image.handle(), dedicated_image_memory.handle(), 0);
 
-    image_info = vkt::Image::CreateInfo();
+    image_info = vkt::Image::DefaultCreateInfo();
     image_info.extent.width = resource_size + 1;
     image_info.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     image_info.format = VK_FORMAT_R8G8B8A8_UNORM;
@@ -2251,12 +2249,10 @@ TEST_F(NegativeMemory, BadMemoryBindMemory2) {
     AddRequiredExtensions(VK_KHR_BIND_MEMORY_2_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    auto image_ci = vkt::Image::CreateInfo();
-    image_ci.imageType = VK_IMAGE_TYPE_2D;
+    auto image_ci = vkt::Image::DefaultCreateInfo();
     image_ci.extent.width = 32;
     image_ci.extent.height = 32;
     image_ci.format = VK_FORMAT_R8G8B8A8_UNORM;
-    image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     vkt::Image image(*m_device, image_ci, vkt::no_mem);
 

--- a/tests/unit/memory_positive.cpp
+++ b/tests/unit/memory_positive.cpp
@@ -178,12 +178,10 @@ TEST_F(PositiveMemory, GetMemoryRequirements2) {
     vk::BindBufferMemory(device(), buffer.handle(), buffer_memory.handle(), 0);
 
     // Create a test image
-    auto image_ci = vkt::Image::CreateInfo();
-    image_ci.imageType = VK_IMAGE_TYPE_2D;
+    auto image_ci = vkt::Image::DefaultCreateInfo();
     image_ci.extent.width = 32;
     image_ci.extent.height = 32;
     image_ci.format = VK_FORMAT_R8G8B8A8_UNORM;
-    image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     vkt::Image image(*m_device, image_ci, vkt::no_mem);
 
@@ -238,12 +236,10 @@ TEST_F(PositiveMemory, BindMemory2) {
     vk::BindBufferMemory2KHR(device(), 1, &buffer_bind_info);
 
     // Create a test image
-    auto image_ci = vkt::Image::CreateInfo();
-    image_ci.imageType = VK_IMAGE_TYPE_2D;
+    auto image_ci = vkt::Image::DefaultCreateInfo();
     image_ci.extent.width = 32;
     image_ci.extent.height = 32;
     image_ci.format = VK_FORMAT_R8G8B8A8_UNORM;
-    image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     vkt::Image image(*m_device, image_ci, vkt::no_mem);
 

--- a/tests/unit/render_pass_positive.cpp
+++ b/tests/unit/render_pass_positive.cpp
@@ -893,7 +893,7 @@ TEST_F(PositiveRenderPass, SeparateDepthStencilSubresourceLayout) {
         ASSERT_TRUE((props.optimalTilingFeatures & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT) != 0);
     }
 
-    auto image_ci = vkt::Image::CreateInfo();
+    auto image_ci = vkt::Image::DefaultCreateInfo();
     image_ci.imageType = VK_IMAGE_TYPE_2D;
     image_ci.extent.width = 64;
     image_ci.extent.height = 64;

--- a/tests/unit/sampler.cpp
+++ b/tests/unit/sampler.cpp
@@ -501,7 +501,7 @@ TEST_F(NegativeSampler, AddressModeWithCornerSampledNV) {
     RETURN_IF_SKIP(InitState(nullptr, nullptr, 0));
     InitRenderTarget();
 
-    VkImageCreateInfo image_info = vkt::Image::CreateInfo();
+    VkImageCreateInfo image_info = vkt::Image::DefaultCreateInfo();
     image_info.flags = VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV;
     image_info.format = VK_FORMAT_R8G8B8A8_UNORM;
     image_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
@@ -511,8 +511,6 @@ TEST_F(NegativeSampler, AddressModeWithCornerSampledNV) {
     // If flags contains VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV and imageType is VK_IMAGE_TYPE_2D,
     // extent.width and extent.height must be greater than 1.
     image_info.extent = {2, 2, 1};
-    image_info.tiling = VK_IMAGE_TILING_OPTIMAL;
-    image_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
     vkt::Image test_image(*m_device, image_info, vkt::set_layout);
 

--- a/tests/unit/sparse_image.cpp
+++ b/tests/unit/sparse_image.cpp
@@ -976,7 +976,7 @@ TEST_F(NegativeSparseImage, ImageMemoryBind) {
         GTEST_SKIP() << "Required SPARSE_BINDING queue families not present";
     }
 
-    VkImageCreateInfo create_info = vkt::Image::CreateInfo();
+    VkImageCreateInfo create_info = vkt::Image::DefaultCreateInfo();
     create_info.flags = VK_IMAGE_CREATE_SPARSE_BINDING_BIT | VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT;
     create_info.imageType = VK_IMAGE_TYPE_3D;
     create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
@@ -984,7 +984,6 @@ TEST_F(NegativeSparseImage, ImageMemoryBind) {
     create_info.extent.width = 1024;
     create_info.extent.height = 1024;
     create_info.extent.depth = 1;
-    create_info.arrayLayers = 1;
     vkt::Image image(*m_device, create_info, vkt::no_mem);
 
     VkMemoryRequirements image_mem_reqs;
@@ -1097,7 +1096,7 @@ TEST_F(NegativeSparseImage, ImageMemoryBindInvalidMemory) {
         GTEST_SKIP() << "Required SPARSE_BINDING queue families not present";
     }
 
-    VkImageCreateInfo create_info = vkt::Image::CreateInfo();
+    VkImageCreateInfo create_info = vkt::Image::DefaultCreateInfo();
     create_info.flags = VK_IMAGE_CREATE_SPARSE_BINDING_BIT | VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT;
     create_info.imageType = VK_IMAGE_TYPE_3D;
     create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
@@ -1105,7 +1104,6 @@ TEST_F(NegativeSparseImage, ImageMemoryBindInvalidMemory) {
     create_info.extent.width = 1024;
     create_info.extent.height = 1024;
     create_info.extent.depth = 1;
-    create_info.arrayLayers = 1;
     vkt::Image image(*m_device, create_info, vkt::no_mem);
 
     VkMemoryRequirements image_mem_reqs;
@@ -1182,7 +1180,7 @@ TEST_F(NegativeSparseImage, ImageMemoryBindInvalidAlignment) {
         GTEST_SKIP() << "Required SPARSE_BINDING queue families not present";
     }
 
-    VkImageCreateInfo create_info = vkt::Image::CreateInfo();
+    VkImageCreateInfo create_info = vkt::Image::DefaultCreateInfo();
     create_info.flags = VK_IMAGE_CREATE_SPARSE_BINDING_BIT | VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT;
     create_info.imageType = VK_IMAGE_TYPE_3D;
     create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
@@ -1190,7 +1188,6 @@ TEST_F(NegativeSparseImage, ImageMemoryBindInvalidAlignment) {
     create_info.extent.width = 1024;
     create_info.extent.height = 1024;
     create_info.extent.depth = 1;
-    create_info.arrayLayers = 1;
     vkt::Image image(*m_device, create_info, vkt::no_mem);
 
     VkMemoryRequirements image_mem_reqs;
@@ -1273,7 +1270,7 @@ TEST_F(NegativeSparseImage, ImageMemoryBindInvalidExtent) {
         GTEST_SKIP() << "Required SPARSE_BINDING queue families not present";
     }
 
-    VkImageCreateInfo create_info = vkt::Image::CreateInfo();
+    VkImageCreateInfo create_info = vkt::Image::DefaultCreateInfo();
     create_info.flags = VK_IMAGE_CREATE_SPARSE_BINDING_BIT | VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT;
     create_info.imageType = VK_IMAGE_TYPE_3D;
     create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
@@ -1281,7 +1278,6 @@ TEST_F(NegativeSparseImage, ImageMemoryBindInvalidExtent) {
     create_info.extent.width = 1024;
     create_info.extent.height = 1024;
     create_info.extent.depth = 1;
-    create_info.arrayLayers = 1;
     vkt::Image image(*m_device, create_info, vkt::no_mem);
 
     VkMemoryRequirements image_mem_reqs;

--- a/tests/unit/sync_object.cpp
+++ b/tests/unit/sync_object.cpp
@@ -2276,7 +2276,7 @@ TEST_F(NegativeSyncObject, Sync2LayoutFeature) {
 
     RETURN_IF_SKIP(Init());
 
-    VkImageCreateInfo info = vkt::Image::CreateInfo();
+    VkImageCreateInfo info = vkt::Image::DefaultCreateInfo();
     info.format = VK_FORMAT_B8G8R8A8_UNORM;
     info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     vkt::Image image(*m_device, info, vkt::set_layout);


### PR DESCRIPTION
Sometimes the code assumed that `CreateInfo()` returns the image's `create_info_`, but in reality, it returns default create info structure.

Rename `CreateInfo()` to `DefaultCreateInfo()` to avoid confusion, and reintroduce `CreateInfo()`, which now returns the actual image create info.
