### PR TITLE
build: Use Custom hash build name

### DIFF
--- a/.github/workflows/vvl.yml
+++ b/.github/workflows/vvl.yml
@@ -52,22 +52,22 @@ jobs:
   linux:
     needs: check_vvl
     runs-on: ubuntu-24.04
-    name: "linux (address sanitizer, ${{matrix.config}}, robinhood ${{matrix.robin_hood}} )"
+    name: "linux (address sanitizer, ${{matrix.config}}, custom_hash_map ${{matrix.custom_hash_map}} )"
     strategy:
       fail-fast: false
       matrix:
         config: [ release ]
         # Test with Robin Hood disabled
         # Chromium build, and some package managers don't use it.
-        robin_hood: [ "ON", "OFF" ]
+        custom_hash_map: [ "ON", "OFF" ]
     steps:
       - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
       - uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: ${{ matrix.config }}-address-${{matrix.robin_hood}}
+          key: ${{ matrix.config }}-address-${{matrix.custom_hash_map}}
       - run: sudo apt-get -qq update && sudo apt-get install -y libwayland-dev xorg-dev
-      - run: python scripts/tests.py --build --config ${{ matrix.config }} --cmake='-DUSE_ROBIN_HOOD_HASHING=${{matrix.robin_hood}}'
+      - run: python scripts/tests.py --build --config ${{ matrix.config }} --cmake='-DUSE_CUSTOM_HASH_MAP=${{matrix.custom_hash_map}}'
         env:
           CFLAGS: -fsanitize=address
           CXXFLAGS: -fsanitize=address
@@ -90,22 +90,22 @@ jobs:
   linux-tsan:
     needs: check_vvl
     runs-on: ubuntu-24.04
-    name: "linux (thread sanitizer, ${{matrix.config}}, robinhood ${{matrix.robin_hood}} )"
+    name: "linux (thread sanitizer, ${{matrix.config}}, custom_hash_map ${{matrix.custom_hash_map}} )"
     strategy:
       fail-fast: false
       matrix:
         # Have found over time debug finds nothing extra, while taking the longest and using the most CI minutes.
         config: [ release ]
-        robin_hood: [ "ON" ]
+        custom_hash_map: [ "ON" ]
 
     steps:
       - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
       - uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: ${{ matrix.config }}-thread-${{matrix.robin_hood}}
+          key: ${{ matrix.config }}-thread-${{matrix.custom_hash_map}}
       - run: sudo apt-get -qq update && sudo apt-get install -y libwayland-dev xorg-dev
-      - run: python scripts/tests.py --build --config ${{ matrix.config }} --cmake='-DUSE_ROBIN_HOOD_HASHING=${{matrix.robin_hood}}'
+      - run: python scripts/tests.py --build --config ${{ matrix.config }} --cmake='-DUSE_CUSTOM_HASH_MAP=${{matrix.custom_hash_map}}'
         env:
           CFLAGS: -fsanitize=thread
           CXXFLAGS: -fsanitize=thread

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -88,11 +88,19 @@ target_link_libraries(VkLayer_utils PUBLIC
 target_include_directories(VkLayer_utils SYSTEM PRIVATE external)
 target_include_directories(VkLayer_utils PUBLIC . ${API_TYPE})
 
+option(USE_CUSTOM_HASH_MAP "Use a custom hashing library that is faster than std::unordered_map and std::unordered_set (default: ON)" ON)
+
 find_package(robin_hood CONFIG)
+
+# Keep this option as legacy for people to turn off custom hashing
 option(USE_ROBIN_HOOD_HASHING "robin_hood provides faster versions of std::unordered_map and std::unordered_set" ${robin_hood_FOUND})
-if (USE_ROBIN_HOOD_HASHING)
+if (NOT USE_ROBIN_HOOD_HASHING)
+    set(USE_CUSTOM_HASH_MAP OFF CACHE BOOL "Disable custom hash map" FORCE)
+endif()
+
+if (USE_CUSTOM_HASH_MAP)
     target_link_libraries(VkLayer_utils PUBLIC robin_hood::robin_hood)
-    target_compile_definitions(VkLayer_utils PUBLIC USE_ROBIN_HOOD_HASHING)
+    target_compile_definitions(VkLayer_utils PUBLIC USE_CUSTOM_HASH_MAP)
 endif()
 
 # Using mimalloc on non-Windows OSes currently results in unit test instability with some

--- a/layers/containers/custom_containers.h
+++ b/layers/containers/custom_containers.h
@@ -25,7 +25,7 @@
 #include <iterator>
 #include <utility>
 
-#ifdef USE_ROBIN_HOOD_HASHING
+#ifdef USE_CUSTOM_HASH_MAP
 #include "robin_hood.h"
 #else
 #include <map>
@@ -39,7 +39,7 @@
 // namespace aliases to allow map and set implementations to easily be swapped out
 namespace vvl {
 
-#ifdef USE_ROBIN_HOOD_HASHING
+#ifdef USE_CUSTOM_HASH_MAP
 template <typename T>
 using hash = robin_hood::hash<T>;
 


### PR DESCRIPTION
taking idea from https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/7558

This change the cmake flag from `USE_ROBIN_HOOD_HASHING` to `USE_CUSTOM_HASH_MAP` for when we try and use something other than robin hood

Note that this will still allow `-D DUSE_ROBIN_HOOD_HASHING=OFF` to turn it off to not break any tooling that was doing that while we get them to swap