### PR TITLE
gpuav: Remove NV RTX for KHR RTX

### DIFF
--- a/layers/chassis/chassis_manual.cpp
+++ b/layers/chassis/chassis_manual.cpp
@@ -583,7 +583,6 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesNV(VkDevice device, VkPi
     ErrorObject error_obj(vvl::Func::vkCreateRayTracingPipelinesNV, VulkanTypedHandle(device, kVulkanObjectTypeDevice));
 
     PipelineStates pipeline_states[LayerObjectTypeMaxEnum];
-    chassis::CreateRayTracingPipelinesNV chassis_state(pCreateInfos);
 
     for (const auto& vo : device_dispatch->object_dispatch) {
         if (!vo) {
@@ -591,8 +590,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesNV(VkDevice device, VkPi
         }
         auto lock = vo->ReadLock();
         skip |= vo->PreCallValidateCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator,
-                                                               pPipelines, error_obj, pipeline_states[vo->container_type],
-                                                               chassis_state);
+                                                               pPipelines, error_obj, pipeline_states[vo->container_type]);
         if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
     }
 
@@ -603,21 +601,12 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesNV(VkDevice device, VkPi
         }
         auto lock = vo->WriteLock();
         vo->PreCallRecordCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines,
-                                                     record_obj, pipeline_states[vo->container_type], chassis_state);
+                                                     record_obj, pipeline_states[vo->container_type]);
     }
 
     VkResult result;
-    {
-        result = device_dispatch->CreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, chassis_state.pCreateInfos,
-                                                              pAllocator, pPipelines);
-
-        // If we have modified the pCreateInfos caused things to fail, revert to allow the app to continue
-        if (result < VK_SUCCESS && chassis_state.is_modified) {
-            chassis_state.is_modified = false;
-            result = device_dispatch->CreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator,
-                                                                  pPipelines);
-        }
-    }
+    result =
+        device_dispatch->CreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines);
     record_obj.result = result;
 
     for (auto& vo : device_dispatch->object_dispatch) {
@@ -626,7 +615,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesNV(VkDevice device, VkPi
         }
         auto lock = vo->WriteLock();
         vo->PostCallRecordCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines,
-                                                      record_obj, pipeline_states[vo->container_type], chassis_state);
+                                                      record_obj, pipeline_states[vo->container_type]);
     }
     return result;
 }

--- a/layers/chassis/chassis_modification_state.h
+++ b/layers/chassis/chassis_modification_state.h
@@ -112,17 +112,6 @@ struct CreateComputePipelines {
     CreateComputePipelines(const VkComputePipelineCreateInfo* create_info) { pCreateInfos = create_info; }
 };
 
-struct CreateRayTracingPipelinesNV {
-    // When using GPU-AV the pCreateInfo is modified on the user
-    bool is_modified = false;
-    std::vector<vku::safe_VkRayTracingPipelineCreateInfoCommon> modified_create_infos;
-    const VkRayTracingPipelineCreateInfoNV* pCreateInfos = nullptr;
-    // 2D array for [pipelineCount][stageCount]
-    std::vector<std::vector<ShaderInstrumentationMetadata>> shader_instrumentations_metadata;
-
-    CreateRayTracingPipelinesNV(const VkRayTracingPipelineCreateInfoNV* create_info) { pCreateInfos = create_info; }
-};
-
 struct CreateRayTracingPipelinesKHR {
     // When using GPU-AV the pCreateInfo is modified on the user
     bool is_modified = false;

--- a/layers/chassis/validation_object.h
+++ b/layers/chassis/validation_object.h
@@ -299,24 +299,21 @@ class Device : public Logger {
                                                             uint32_t createInfoCount,
                                                             const VkRayTracingPipelineCreateInfoNV* pCreateInfos,
                                                             const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
-                                                            const ErrorObject& error_obj, PipelineStates& pipeline_states,
-                                                            chassis::CreateRayTracingPipelinesNV& chassis_state) const {
+                                                            const ErrorObject& error_obj, PipelineStates& pipeline_states) const {
         return PreCallValidateCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator,
                                                           pPipelines, error_obj);
     }
     virtual void PreCallRecordCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount,
                                                           const VkRayTracingPipelineCreateInfoNV* pCreateInfos,
                                                           const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
-                                                          const RecordObject& record_obj, PipelineStates& pipeline_states,
-                                                          chassis::CreateRayTracingPipelinesNV& chassis_state) {
+                                                          const RecordObject& record_obj, PipelineStates& pipeline_states) {
         PreCallRecordCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines,
                                                  record_obj);
     }
     virtual void PostCallRecordCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount,
                                                            const VkRayTracingPipelineCreateInfoNV* pCreateInfos,
                                                            const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
-                                                           const RecordObject& record_obj, PipelineStates& pipeline_states,
-                                                           chassis::CreateRayTracingPipelinesNV& chassis_state) {
+                                                           const RecordObject& record_obj, PipelineStates& pipeline_states) {
         PostCallRecordCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines,
                                                   record_obj);
     }

--- a/layers/core_checks/cc_pipeline_ray_tracing.cpp
+++ b/layers/core_checks/cc_pipeline_ray_tracing.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (C) 2015-2024 Google Inc.
+/* Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (C) 2015-2025 Google Inc.
  * Modifications Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -168,10 +168,9 @@ bool CoreChecks::ValidateRayTracingPipeline(const vvl::Pipeline &pipeline,
 bool CoreChecks::PreCallValidateCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                                             const VkRayTracingPipelineCreateInfoNV *pCreateInfos,
                                                             const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                            const ErrorObject &error_obj, PipelineStates &pipeline_states,
-                                                            chassis::CreateRayTracingPipelinesNV &chassis_state) const {
+                                                            const ErrorObject &error_obj, PipelineStates &pipeline_states) const {
     bool skip = BaseClass::PreCallValidateCreateRayTracingPipelinesNV(device, pipelineCache, count, pCreateInfos, pAllocator,
-                                                                      pPipelines, error_obj, pipeline_states, chassis_state);
+                                                                      pPipelines, error_obj, pipeline_states);
 
     skip |= ValidateDeviceQueueSupport(error_obj.location);
     for (uint32_t i = 0; i < count; i++) {

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1389,8 +1389,7 @@ class CoreChecks : public vvl::Device {
     bool PreCallValidateCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                                     const VkRayTracingPipelineCreateInfoNV* pCreateInfos,
                                                     const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
-                                                    const ErrorObject& error_obj, PipelineStates& pipeline_states,
-                                                    chassis::CreateRayTracingPipelinesNV& chassis_state) const override;
+                                                    const ErrorObject& error_obj, PipelineStates& pipeline_states) const override;
     bool PreCallValidateCreateRayTracingPipelinesKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                      VkPipelineCache pipelineCache, uint32_t count,
                                                      const VkRayTracingPipelineCreateInfoKHR* pCreateInfos,

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.h
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.h
@@ -121,11 +121,6 @@ class GpuShaderInstrumentor : public vvl::Device {
                                              const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
                                              const RecordObject &record_obj, PipelineStates &pipeline_states,
                                              chassis::CreateComputePipelines &chassis_state) override;
-    void PreCallRecordCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
-                                                  const VkRayTracingPipelineCreateInfoNV *pCreateInfos,
-                                                  const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                  const RecordObject &record_obj, PipelineStates &pipeline_states,
-                                                  chassis::CreateRayTracingPipelinesNV &chassis_state) override;
     void PreCallRecordCreateRayTracingPipelinesKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                    VkPipelineCache pipelineCache, uint32_t count,
                                                    const VkRayTracingPipelineCreateInfoKHR *pCreateInfos,
@@ -142,11 +137,6 @@ class GpuShaderInstrumentor : public vvl::Device {
                                               const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
                                               const RecordObject &record_obj, PipelineStates &pipeline_states,
                                               chassis::CreateComputePipelines &chassis_state) override;
-    void PostCallRecordCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
-                                                   const VkRayTracingPipelineCreateInfoNV *pCreateInfos,
-                                                   const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                   const RecordObject &record_obj, PipelineStates &pipeline_states,
-                                                   chassis::CreateRayTracingPipelinesNV &chassis_state) override;
     void PostCallRecordCreateRayTracingPipelinesKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                     VkPipelineCache pipelineCache, uint32_t count,
                                                     const VkRayTracingPipelineCreateInfoKHR *pCreateInfos,

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -1806,8 +1806,7 @@ std::shared_ptr<Pipeline> Device::CreateRayTracingPipelineState(const VkRayTraci
 bool Device::PreCallValidateCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                                         const VkRayTracingPipelineCreateInfoNV *pCreateInfos,
                                                         const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                        const ErrorObject &error_obj, PipelineStates &pipeline_states,
-                                                        chassis::CreateRayTracingPipelinesNV &chassis_state) const {
+                                                        const ErrorObject &error_obj, PipelineStates &pipeline_states) const {
     pipeline_states.reserve(count);
     auto pipeline_cache = Get<PipelineCache>(pipelineCache);
     for (uint32_t i = 0; i < count; i++) {
@@ -1821,8 +1820,7 @@ bool Device::PreCallValidateCreateRayTracingPipelinesNV(VkDevice device, VkPipel
 void Device::PostCallRecordCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                                        const VkRayTracingPipelineCreateInfoNV *pCreateInfos,
                                                        const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                                       const RecordObject &record_obj, PipelineStates &pipeline_states,
-                                                       chassis::CreateRayTracingPipelinesNV &chassis_state) {
+                                                       const RecordObject &record_obj, PipelineStates &pipeline_states) {
     // This API may create pipelines regardless of the return value
     for (uint32_t i = 0; i < count; i++) {
         if (pPipelines[i] != VK_NULL_HANDLE) {

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -963,13 +963,11 @@ class Device : public vvl::base::Device {
     bool PreCallValidateCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                                     const VkRayTracingPipelineCreateInfoNV* pCreateInfos,
                                                     const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
-                                                    const ErrorObject& error_obj, PipelineStates& pipeline_states,
-                                                    chassis::CreateRayTracingPipelinesNV& chassis_state) const override;
+                                                    const ErrorObject& error_obj, PipelineStates& pipeline_states) const override;
     void PostCallRecordCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                                    const VkRayTracingPipelineCreateInfoNV* pCreateInfos,
                                                    const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
-                                                   const RecordObject& record_obj, PipelineStates& pipeline_states,
-                                                   chassis::CreateRayTracingPipelinesNV& chassis_state) override;
+                                                   const RecordObject& record_obj, PipelineStates& pipeline_states) override;
     virtual std::shared_ptr<vvl::Pipeline> CreateRayTracingPipelineState(const VkRayTracingPipelineCreateInfoKHR* create_info,
                                                                          std::shared_ptr<const vvl::PipelineCache> pipeline_cache,
                                                                          std::shared_ptr<const vvl::PipelineLayout>&& layout,

--- a/layers/vulkan/generated/best_practices.cpp
+++ b/layers/vulkan/generated/best_practices.cpp
@@ -1567,10 +1567,9 @@ void BestPractices::PostCallRecordCreateRayTracingPipelinesNV(VkDevice device, V
                                                               uint32_t createInfoCount,
                                                               const VkRayTracingPipelineCreateInfoNV* pCreateInfos,
                                                               const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
-                                                              const RecordObject& record_obj, PipelineStates& pipeline_states,
-                                                              chassis::CreateRayTracingPipelinesNV& chassis_state) {
+                                                              const RecordObject& record_obj, PipelineStates& pipeline_states) {
     BaseClass::PostCallRecordCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator,
-                                                         pPipelines, record_obj, pipeline_states, chassis_state);
+                                                         pPipelines, record_obj, pipeline_states);
     bp_state::LogResult(*this, device, record_obj);
 }
 

--- a/layers/vulkan/generated/best_practices_device_methods.h
+++ b/layers/vulkan/generated/best_practices_device_methods.h
@@ -497,8 +497,7 @@ void PostCallRecordBindAccelerationStructureMemoryNV(VkDevice device, uint32_t b
 void PostCallRecordCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount,
                                                const VkRayTracingPipelineCreateInfoNV* pCreateInfos,
                                                const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
-                                               const RecordObject& record_obj, PipelineStates& pipeline_states,
-                                               chassis::CreateRayTracingPipelinesNV& chassis_state) override;
+                                               const RecordObject& record_obj, PipelineStates& pipeline_states) override;
 
 void PostCallRecordGetRayTracingShaderGroupHandlesKHR(VkDevice device, VkPipeline pipeline, uint32_t firstGroup,
                                                       uint32_t groupCount, size_t dataSize, void* pData,

--- a/scripts/generators/best_practices_generator.py
+++ b/scripts/generators/best_practices_generator.py
@@ -47,10 +47,10 @@ class BestPracticesOutputGenerator(BaseGenerator):
             'vkAllocateDescriptorSets' : 'vvl::AllocateDescriptorSetsData',
         }
         self.pipeline_parameter_map = {
-            'vkCreateGraphicsPipelines' : 'chassis::CreateGraphicsPipelines&',
-            'vkCreateComputePipelines' : 'chassis::CreateComputePipelines&',
-            'vkCreateRayTracingPipelinesNV' : 'chassis::CreateRayTracingPipelinesNV&',
-            'vkCreateRayTracingPipelinesKHR' : 'std::shared_ptr<chassis::CreateRayTracingPipelinesKHR>',
+            'vkCreateGraphicsPipelines' : ', chassis::CreateGraphicsPipelines& chassis_state',
+            'vkCreateComputePipelines' : ', chassis::CreateComputePipelines& chassis_state',
+            'vkCreateRayTracingPipelinesNV' : '',
+            'vkCreateRayTracingPipelinesKHR' : ', std::shared_ptr<chassis::CreateRayTracingPipelinesKHR> chassis_state',
         }
         # Commands that have a manually written post-call-record step which needs to be called from the autogen'd fcn
         self.manual_postcallrecord_list = [
@@ -126,7 +126,7 @@ class BestPracticesOutputGenerator(BaseGenerator):
             if command.name in self.extra_parameter_map:
                 prototype = prototype.replace(')', f', {self.extra_parameter_map[command.name]}& chassis_state)')
             elif command.name in self.pipeline_parameter_map:
-                prototype = prototype.replace(')', f', PipelineStates& pipeline_states, {self.pipeline_parameter_map[command.name]} chassis_state)')
+                prototype = prototype.replace(')', f', PipelineStates& pipeline_states {self.pipeline_parameter_map[command.name]})')
             out.append(prototype)
         out.extend(guard_helper.add_guard(None))
         self.write("".join(out))
@@ -196,7 +196,8 @@ class BestPracticesOutputGenerator(BaseGenerator):
                 paramList.append('chassis_state')
             elif command.name in self.pipeline_parameter_map:
                 paramList.append('pipeline_states')
-                paramList.append('chassis_state')
+                if self.pipeline_parameter_map[command.name]:
+                    paramList.append('chassis_state')
             params = ', '.join(paramList)
 
             class_name = 'BestPractices' if not command.instance else 'bp_state::Instance'
@@ -207,7 +208,7 @@ class BestPracticesOutputGenerator(BaseGenerator):
             if command.name in self.extra_parameter_map:
                 prototype = prototype.replace(')', f', {self.extra_parameter_map[command.name]}& chassis_state)')
             elif command.name in self.pipeline_parameter_map:
-                prototype = prototype.replace(')', f', PipelineStates& pipeline_states, {self.pipeline_parameter_map[command.name]} chassis_state)')
+                prototype = prototype.replace(')', f', PipelineStates& pipeline_states {self.pipeline_parameter_map[command.name]})')
             out.append(prototype)
 
             if command.alias:


### PR DESCRIPTION
The NV RTX path is fully unsupported and untested in GPU-AV, so removing for ease of maintaining the RTX version by itself 