### PR TITLE
Move logic into Image/ImageView state and fix VK_REMAINING_ARRAY_LAYERS 

### DIFF
--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -1215,7 +1215,7 @@ bool CoreChecks::ValidateImageUpdate(const vvl::ImageView &view_state, VkImageLa
     const LogObjectList objlist(view_state.Handle(), image_node->Handle());
     // KHR_maintenance1 allows rendering into 2D or 2DArray views which slice a 3D image,
     // but not binding them to descriptor sets.
-    if (view_state.IsDepthSliced() && image_node->create_info.imageType == VK_IMAGE_TYPE_3D) {
+    if (view_state.is_depth_sliced && image_node->create_info.imageType == VK_IMAGE_TYPE_3D) {
         // VK_EXT_image_2d_view_of_3d allows use of VIEW_TYPE_2D in descriptor
         if (view_state.create_info.viewType == VK_IMAGE_VIEW_TYPE_2D_ARRAY) {
             skip |= LogError("VUID-VkDescriptorImageInfo-imageView-06712", objlist, image_info_loc.dot(Field::imageView),

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -2043,7 +2043,7 @@ void CoreChecks::RecordBarrierValidationInfo(const Location &barrier_loc, vvl::C
     if (IsOwnershipTransfer(image_barrier)) {
         if (auto image = Get<vvl::Image>(image_barrier.image)) {
             ImageBarrier barrier = image_barrier;
-            barrier.subresourceRange = NormalizeSubresourceRange(image->create_info, image_barrier.subresourceRange);
+            barrier.subresourceRange = image->NormalizeSubresourceRange(image_barrier.subresourceRange);
 
             if (cb_state.IsReleaseOp(barrier) && !IsQueueFamilyExternal(barrier.dstQueueFamilyIndex)) {
                 barrier_sets.release.emplace(barrier);

--- a/layers/error_message/error_strings.h
+++ b/layers/error_message/error_strings.h
@@ -83,6 +83,18 @@
     return ss.str();
 }
 
+[[maybe_unused]] static std::string string_LayerCount(const VkImageCreateInfo &ci, VkImageSubresourceLayers const &resource) {
+    std::stringstream ss;
+    if (resource.layerCount == VK_REMAINING_ARRAY_LAYERS) {
+        const uint32_t layer_count = ci.arrayLayers - resource.baseArrayLayer;
+        ss << "VK_REMAINING_ARRAY_LAYERS [arrayLayers (" << ci.arrayLayers << ") - baseArrayLayer (" << resource.baseArrayLayer
+           << ") = " << layer_count << "]";
+    } else {
+        ss << resource.layerCount;
+    }
+    return ss.str();
+}
+
 [[maybe_unused]] static std::string string_VkPushConstantRange(VkPushConstantRange range) {
     std::stringstream ss;
     ss << "range [" << range.offset << ", " << (range.offset + range.size) << ") for "

--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -274,6 +274,11 @@ VkImageSubresourceRange Image::NormalizeSubresourceRange(const VkImageSubresourc
     return norm;
 }
 
+uint32_t Image::NormalizeLayerCount(const VkImageSubresourceLayers &resource) const {
+    return (resource.layerCount == VK_REMAINING_ARRAY_LAYERS) ? (create_info.arrayLayers - resource.baseArrayLayer)
+                                                              : resource.layerCount;
+}
+
 VkImageSubresourceRange Image::MakeImageFullRange() {
     const auto format = create_info.format;
     VkImageSubresourceRange init_range{0, 0, VK_REMAINING_MIP_LEVELS, 0, VK_REMAINING_ARRAY_LAYERS};

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -212,6 +212,7 @@ class Image : public Bindable, public SubStateManager<ImageSubState> {
     }
 
     VkImageSubresourceRange NormalizeSubresourceRange(const VkImageSubresourceRange &range) const;
+    uint32_t NormalizeLayerCount(const VkImageSubresourceLayers &resource) const;
 
     void SetInitialLayoutMap();
     void SetImageLayout(const VkImageSubresourceRange &range, VkImageLayout layout);

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -377,7 +377,7 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
                         const auto *img_view_state = image_descriptor->GetImageViewState();
                         VkImageLayout image_layout = image_descriptor->GetImageLayout();
 
-                        if (img_view_state->IsDepthSliced()) {
+                        if (img_view_state->is_depth_sliced) {
                             // NOTE: 2D ImageViews of VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT Images are not allowed in
                             // Descriptors, unless VK_EXT_image_2d_view_of_3d is supported, which it isn't at the moment.
                             // See: VUID 00343
@@ -536,7 +536,7 @@ void CommandBufferAccessContext::RecordDispatchDrawDescriptorSet(VkPipelineBindP
                             continue;
                         }
                         const auto *img_view_state = image_descriptor->GetImageViewState();
-                        if (img_view_state->IsDepthSliced()) {
+                        if (img_view_state->is_depth_sliced) {
                             // NOTE: 2D ImageViews of VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT Images are not allowed in
                             // Descriptors, unless VK_EXT_image_2d_view_of_3d is supported, which it isn't at the moment.
                             // See: VUID 00343
@@ -937,7 +937,7 @@ bool CommandBufferAccessContext::ValidateClearAttachment(const Location &loc, co
         subresource_range.aspectMask = aspect;
 
         HazardResult hazard = current_context_->DetectHazard(
-            *info.attachment_view.image_state, subresource_range, offset, extent, info.attachment_view.IsDepthSliced(),
+            *info.attachment_view.image_state, subresource_range, offset, extent, info.attachment_view.is_depth_sliced,
             SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, SyncOrdering::kColorAttachment);
         if (hazard.IsHazard()) {
             std::stringstream ss;
@@ -964,7 +964,7 @@ bool CommandBufferAccessContext::ValidateClearAttachment(const Location &loc, co
             // vkCmdClearAttachments depth/stencil writes are executed by the EARLY_FRAGMENT_TESTS_BIT and LATE_FRAGMENT_TESTS_BIT
             // stages. The implementation tracks the most recent access, which happens in the LATE_FRAGMENT_TESTS_BIT stage.
             HazardResult hazard = current_context_->DetectHazard(
-                *info.attachment_view.image_state, info.subresource_range, offset, extent, info.attachment_view.IsDepthSliced(),
+                *info.attachment_view.image_state, info.subresource_range, offset, extent, info.attachment_view.is_depth_sliced,
                 SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, SyncOrdering::kDepthStencilAttachment);
 
             if (hazard.IsHazard()) {

--- a/layers/sync/sync_image.cpp
+++ b/layers/sync/sync_image.cpp
@@ -81,7 +81,7 @@ ImageRangeGen syncval_state::ImageSubState::MakeImageRangeGen(const VkImageSubre
 
 ImageRangeGen syncval_state::MakeImageRangeGen(const vvl::ImageView &view) {
     const auto &sub_state = SubState(*view.image_state);
-    return sub_state.MakeImageRangeGen(view.normalized_subresource_range, view.IsDepthSliced());
+    return sub_state.MakeImageRangeGen(view.normalized_subresource_range, view.is_depth_sliced);
 }
 
 ImageRangeGen syncval_state::MakeImageRangeGen(const vvl::ImageView &view, const VkOffset3D &offset, const VkExtent3D &extent,
@@ -95,5 +95,5 @@ ImageRangeGen syncval_state::MakeImageRangeGen(const vvl::ImageView &view, const
         subresource_range.aspectMask = override_depth_stencil_aspect_mask;
     }
     const auto &sub_state = SubState(*view.image_state);
-    return sub_state.MakeImageRangeGen(subresource_range, offset, extent, view.IsDepthSliced());
+    return sub_state.MakeImageRangeGen(subresource_range, offset, extent, view.is_depth_sliced);
 }

--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -337,7 +337,7 @@ void BarrierSet::MakeImageMemoryBarriers(const SyncValidator &sync_state, const 
     image_memory_barriers.reserve(barrier_count);
     for (const auto [index, barrier] : vvl::enumerate(barriers, barrier_count)) {
         if (auto image = sync_state.Get<vvl::Image>(barrier.image)) {
-            auto subresource_range = NormalizeSubresourceRange(image->create_info, barrier.subresourceRange);
+            auto subresource_range = image->NormalizeSubresourceRange(barrier.subresourceRange);
             const SyncBarrier sync_barrier(barrier, src, dst);
             const bool layout_transition = barrier.oldLayout != barrier.newLayout;
             image_memory_barriers.emplace_back(image, sync_barrier, subresource_range, layout_transition, index);
@@ -353,7 +353,7 @@ void BarrierSet::MakeImageMemoryBarriers(const SyncValidator &sync_state, VkQueu
         auto dst = SyncExecScope::MakeDst(queue_flags, barrier.dstStageMask);
         auto image = sync_state.Get<vvl::Image>(barrier.image);
         if (image) {
-            auto subresource_range = NormalizeSubresourceRange(image->create_info, barrier.subresourceRange);
+            auto subresource_range = image->NormalizeSubresourceRange(barrier.subresourceRange);
             const SyncBarrier sync_barrier(barrier, src, dst);
             const bool layout_transition = barrier.oldLayout != barrier.newLayout;
             image_memory_barriers.emplace_back(image, sync_barrier, subresource_range, layout_transition, index);

--- a/tests/unit/image.cpp
+++ b/tests/unit/image.cpp
@@ -835,6 +835,9 @@ TEST_F(NegativeImage, BlitToDepth) {
 
 TEST_F(NegativeImage, BlitWithoutMaintenance8) {
     TEST_DESCRIPTION("Would be valid if Maintenance8 was added.");
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredFeature(vkt::Feature::maintenance5);
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_5_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
     VkFormat format = VK_FORMAT_R32_SFLOAT;  // Need features ..BLIT_SRC_BIT & ..BLIT_DST_BIT
@@ -870,6 +873,13 @@ TEST_F(NegativeImage, BlitWithoutMaintenance8) {
     blit_region.dstOffsets[1] = {64, 64, 1};
 
     m_command_buffer.Begin();
+    m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-srcImage-00240");
+    vk::CmdBlitImage(m_command_buffer.handle(), image_2d, VK_IMAGE_LAYOUT_GENERAL, image_3d, VK_IMAGE_LAYOUT_GENERAL, 1,
+                     &blit_region, VK_FILTER_NEAREST);
+    m_errorMonitor->VerifyFound();
+
+    blit_region.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, VK_REMAINING_ARRAY_LAYERS};
+    m_errorMonitor->SetDesiredError("VUID-VkImageBlit-layerCount-08801");
     m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-srcImage-00240");
     vk::CmdBlitImage(m_command_buffer.handle(), image_2d, VK_IMAGE_LAYOUT_GENERAL, image_3d, VK_IMAGE_LAYOUT_GENERAL, 1,
                      &blit_region, VK_FILTER_NEAREST);


### PR DESCRIPTION
@ziga-lunarg discovered in https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/9747 we messed up the Array Layers using `VK_REMAINING_ARRAY_LAYERS` (which you could only use in Blit/Resolve since maintenance5)

We have this "Normalize" logic for `VkImageSubresourceRange` but not for `VkImageSubresourceLayers` and this 

1. Move the Normalize functions to be Image/ImageView state function
2. Fix Resolve check like the other PR
3. Print better error message for the blit case