### PR TITLE
gpauv: Remove substate where not needed

### DIFF
--- a/layers/gpuav/core/gpuav.h
+++ b/layers/gpuav/core/gpuav.h
@@ -97,7 +97,7 @@ class Validator : public GpuShaderInstrumentor {
 
     void RecordCmdBeginRenderPassLayouts(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
                                          const VkSubpassContents contents);
-    void RecordCmdEndRenderPassLayouts(CommandBufferSubState& cb_state);
+    void RecordCmdEndRenderPassLayouts(vvl::CommandBuffer& cb_state);
     void PreCallRecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
                                          VkSubpassContents contents, const RecordObject&) final;
     void PreCallRecordCmdBeginRenderPass2KHR(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
@@ -105,7 +105,7 @@ class Validator : public GpuShaderInstrumentor {
     void PreCallRecordCmdBeginRenderPass2(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
                                           const VkSubpassBeginInfo* pSubpassBeginInfo, const RecordObject&) final;
 
-    void RecordCmdNextSubpassLayouts(CommandBufferSubState& cb_state, VkSubpassContents contents);
+    void RecordCmdNextSubpassLayouts(vvl::CommandBuffer& cb_state, VkSubpassContents contents);
     void PostCallRecordCmdNextSubpass(VkCommandBuffer commandBuffer, VkSubpassContents contents,
                                       const RecordObject& record_obj) final;
     void PostCallRecordCmdNextSubpass2KHR(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo* pSubpassBeginInfo,

--- a/layers/gpuav/descriptor_validation/gpuav_image_layout.h
+++ b/layers/gpuav/descriptor_validation/gpuav_image_layout.h
@@ -20,15 +20,15 @@
 
 namespace vvl {
 class RenderPass;
+class CommandBuffer;
 }  // namespace vvl
 
 namespace gpuav {
 class Validator;
-class CommandBufferSubState;
 
-void UpdateCmdBufImageLayouts(Validator &gpuav, const CommandBufferSubState &cb_state);
-void TransitionSubpassLayouts(CommandBufferSubState &cb_state, const vvl::RenderPass &render_pass_state, const int subpass_index);
-void TransitionBeginRenderPassLayouts(CommandBufferSubState &cb_state, const vvl::RenderPass &render_pass_state);
-void TransitionFinalSubpassLayouts(CommandBufferSubState &cb_state);
+void UpdateCmdBufImageLayouts(Validator &gpuav, const vvl::CommandBuffer &cb_state);
+void TransitionSubpassLayouts(vvl::CommandBuffer &cb_state, const vvl::RenderPass &render_pass_state, const int subpass_index);
+void TransitionBeginRenderPassLayouts(vvl::CommandBuffer &cb_state, const vvl::RenderPass &render_pass_state);
+void TransitionFinalSubpassLayouts(vvl::CommandBuffer &cb_state);
 
 }  // namespace gpuav

--- a/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
@@ -34,8 +34,7 @@
 namespace gpuav {
 
 // If application is using shader objects, bindings count will be computed from bound shaders
-static uint32_t LastBoundPipelineOrShaderDescSetBindingsCount(Validator &gpuav, VkPipelineBindPoint bind_point,
-                                                              CommandBufferSubState &cb_state, const LastBound &last_bound) {
+static uint32_t LastBoundPipelineOrShaderDescSetBindingsCount(VkPipelineBindPoint bind_point, const LastBound &last_bound) {
     if (last_bound.pipeline_state && last_bound.pipeline_state->PreRasterPipelineLayoutState()) {
         return static_cast<uint32_t>(last_bound.pipeline_state->PreRasterPipelineLayoutState()->set_layouts.size());
     }
@@ -50,8 +49,7 @@ static uint32_t LastBoundPipelineOrShaderDescSetBindingsCount(Validator &gpuav, 
 }
 
 // If application is using shader objects, bindings count will be computed from bound shaders
-static uint32_t LastBoundPipelineOrShaderPushConstantsRangesCount(Validator &gpuav, VkPipelineBindPoint bind_point,
-                                                                  CommandBufferSubState &cb_state, const LastBound &last_bound) {
+static uint32_t LastBoundPipelineOrShaderPushConstantsRangesCount(VkPipelineBindPoint bind_point, const LastBound &last_bound) {
     if (last_bound.pipeline_state && last_bound.pipeline_state->PreRasterPipelineLayoutState()) {
         return static_cast<uint32_t>(
             last_bound.pipeline_state->PreRasterPipelineLayoutState()->push_constant_ranges_layout->size());
@@ -550,10 +548,8 @@ void PreCallSetupShaderInstrumentationResources(Validator &gpuav, CommandBufferS
                 // last bound shader objects is created and used.
                 // If will also be cached: heuristic is next action command will likely need the same.
 
-                const uint32_t last_pipe_bindings_count =
-                    LastBoundPipelineOrShaderDescSetBindingsCount(gpuav, bind_point, cb_state, last_bound);
-                const uint32_t last_pipe_pcr_count =
-                    LastBoundPipelineOrShaderPushConstantsRangesCount(gpuav, bind_point, cb_state, last_bound);
+                const uint32_t last_pipe_bindings_count = LastBoundPipelineOrShaderDescSetBindingsCount(bind_point, last_bound);
+                const uint32_t last_pipe_pcr_count = LastBoundPipelineOrShaderPushConstantsRangesCount(bind_point, last_bound);
 
                 // If the number of binding of the currently bound pipeline's layout (or the equivalent for shader objects) is
                 // less that the number of bindings in the pipeline layout used to bind descriptor sets,
@@ -642,7 +638,7 @@ void PostCallSetupShaderInstrumentationResources(Validator &gpuav, CommandBuffer
             gpuav.Get<vvl::PipelineLayout>(last_bound.desc_set_pipeline_layout);
         if (last_bound_desc_set_pipe_layout_state) {
             const uint32_t desc_set_bindings_counts_from_last_pipeline =
-                LastBoundPipelineOrShaderDescSetBindingsCount(gpuav, bind_point, cb_state, last_bound);
+                LastBoundPipelineOrShaderDescSetBindingsCount(bind_point, last_bound);
 
             const bool any_disturbed_desc_sets_bindings =
                 desc_set_bindings_counts_from_last_pipeline <

--- a/layers/gpuav/resources/gpuav_state_trackers.cpp
+++ b/layers/gpuav/resources/gpuav_state_trackers.cpp
@@ -435,7 +435,7 @@ void CommandBufferSubState::PostProcess(VkQueue queue, const std::vector<std::st
     }
 
     if (gpuav_success) {
-        UpdateCmdBufImageLayouts(state_, *this);
+        UpdateCmdBufImageLayouts(state_, base);
     }
 }
 


### PR DESCRIPTION
small follow up from https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/9651

basically path through Image Layout stuff currently is shared, can update these when sub state is actually needed