### PR TITLE
tests: Fix TestICD freeing for aligned_alloc

### DIFF
--- a/tests/icd/test_icd.cpp
+++ b/tests/icd/test_icd.cpp
@@ -652,7 +652,11 @@ static VKAPI_ATTR VkResult VKAPI_CALL MapMemory(VkDevice device, VkDeviceMemory 
 static VKAPI_ATTR void VKAPI_CALL UnmapMemory(VkDevice device, VkDeviceMemory memory) {
     unique_lock_t lock(global_lock);
     for (auto map_addr : mapped_memory_map[memory]) {
+#if defined(_WIN32)
+        _aligned_free(map_addr);
+#else
         free(map_addr);
+#endif
     }
     mapped_memory_map.erase(memory);
 }


### PR DESCRIPTION
The Test ICD incorrectly uses `free` to free memory allocated with `_aligned_alloc` on Windows.

I don't know how this didn't cause any issue for you, but for us it resulted in hanging CI on Github Actions and in our own CI.