### PR TITLE
layers: Create a Variable Pointer helper

### DIFF
--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -696,27 +696,9 @@ struct Module {
         return (it != static_data_.execution_modes.end()) ? it->second : static_data_.empty_execution_mode;
     }
 
-    std::shared_ptr<const TypeStructInfo> GetTypeStructInfo(uint32_t struct_id) const {
-        // return the actual execution modes for this id, or a default empty set.
-        const auto it = static_data_.type_struct_map.find(struct_id);
-        return (it != static_data_.type_struct_map.end()) ? it->second : nullptr;
-    }
+    std::shared_ptr<const TypeStructInfo> GetTypeStructInfo(uint32_t struct_id) const;
     // Overload to walk down and find the OpTypeStruct
-    std::shared_ptr<const TypeStructInfo> GetTypeStructInfo(const Instruction *insn) const {
-        while (true) {
-            if (insn->Opcode() == spv::OpVariable) {
-                insn = FindDef(insn->Word(1));
-            } else if (insn->Opcode() == spv::OpTypePointer) {
-                insn = FindDef(insn->Word(3));
-            } else if (insn->IsArray()) {
-                insn = FindDef(insn->Word(2));
-            } else if (insn->Opcode() == spv::OpTypeStruct) {
-                return GetTypeStructInfo(insn->Word(1));
-            } else {
-                return nullptr;
-            }
-        }
-    }
+    std::shared_ptr<const TypeStructInfo> GetTypeStructInfo(const Instruction *insn) const;
 
     // Used to get human readable strings for error messages
     std::string GetDecorations(uint32_t id) const;
@@ -750,6 +732,7 @@ struct Module {
     uint32_t GetTypeBytesSize(const Instruction *insn) const;
     uint32_t GetBaseType(const Instruction *insn) const;
     const Instruction *GetBaseTypeInstruction(uint32_t type) const;
+    const Instruction *GetVariablePointerType(const spirv::Instruction &var_insn) const;
     uint32_t GetTypeId(uint32_t id) const;
     uint32_t GetTexelComponentCount(const Instruction &insn) const;
     uint32_t GetFlattenArraySize(const Instruction &insn) const;

--- a/layers/stateless/sl_spirv.cpp
+++ b/layers/stateless/sl_spirv.cpp
@@ -386,13 +386,12 @@ bool SpirvValidator::Validate8And16BitStorage(const spirv::Module &module_state,
                                               const Location &loc) const {
     bool skip = false;
 
-    const uint32_t storage_class = var_insn.StorageClass();
-
-    const spirv::Instruction *type_pointer = module_state.FindDef(var_insn.Word(1));
-    const spirv::Instruction *type = module_state.FindDef(type_pointer->Word(3));
     // type will either be a float, int, or struct and if struct need to traverse it
+    const spirv::Instruction *type = module_state.GetVariablePointerType(var_insn);
     VariableInstInfo info;
     GetVariableInfo(module_state, type, info);
+
+    const uint32_t storage_class = var_insn.StorageClass();
 
     if (info.has_8bit) {
         if (!enabled_features.storageBuffer8BitAccess &&
@@ -460,7 +459,7 @@ bool SpirvValidator::ValidateShaderStorageImageFormatsVariables(const spirv::Mod
     // to trigger the error.
     assert(insn.Opcode() == spv::OpVariable);
     // spirv-val validates this is an OpTypePointer
-    const spirv::Instruction *pointer_def = module_state.FindDef(insn.Word(1));
+    const spirv::Instruction *pointer_def = module_state.FindDef(insn.TypeId());
     if (pointer_def->Word(2) != spv::StorageClassUniformConstant) {
         return skip;  // Vulkan Spec says storage image must be UniformConstant
     }


### PR DESCRIPTION
@ziga-lunarg here is a follow up to https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/9736/files#r2006576276

going `const Instruction* type = GetVariablePointerType(*insn);` is a bit cleaner and prevents mis-copy-and-pasting this if we need to update it in one spot