### PR TITLE
gpuav: Remove unnecessary link id member variable

### DIFF
--- a/layers/gpuav/spirv/buffer_device_address_pass.cpp
+++ b/layers/gpuav/spirv/buffer_device_address_pass.cpp
@@ -24,17 +24,20 @@
 namespace gpuav {
 namespace spirv {
 
+static LinkInfo link_info = {instrumentation_buffer_device_address_comp, instrumentation_buffer_device_address_comp_size, 0,
+                             "inst_buffer_device_address"};
+
+BufferDeviceAddressPass::BufferDeviceAddressPass(Module& module) : InjectConditionalFunctionPass(module) {
+    link_info.function_id = 0;  // reset each pass
+}
+
 // By appending the LinkInfo, it will attempt at linking stage to add the function.
 uint32_t BufferDeviceAddressPass::GetLinkFunctionId() {
-    static LinkInfo link_info = {instrumentation_buffer_device_address_comp, instrumentation_buffer_device_address_comp_size, 0,
-                                 "inst_buffer_device_address"};
-
-    if (link_function_id == 0) {
-        link_function_id = module_.TakeNextId();
-        link_info.function_id = link_function_id;
+    if (link_info.function_id == 0) {
+        link_info.function_id = module_.TakeNextId();
         module_.link_info_.push_back(link_info);
     }
-    return link_function_id;
+    return link_info.function_id;
 }
 
 uint32_t BufferDeviceAddressPass::CreateFunctionCall(BasicBlock& block, InstructionIt* inst_it, const InjectionData& injection_data,

--- a/layers/gpuav/spirv/buffer_device_address_pass.h
+++ b/layers/gpuav/spirv/buffer_device_address_pass.h
@@ -25,7 +25,7 @@ namespace spirv {
 // all referenced bytes fall in a valid buffer.
 class BufferDeviceAddressPass : public InjectConditionalFunctionPass {
   public:
-    BufferDeviceAddressPass(Module& module) : InjectConditionalFunctionPass(module) {}
+    BufferDeviceAddressPass(Module& module);
     const char* Name() const final { return "BufferDeviceAddressPass"; }
     void PrintDebugInfo() const final;
 
@@ -34,7 +34,6 @@ class BufferDeviceAddressPass : public InjectConditionalFunctionPass {
     uint32_t CreateFunctionCall(BasicBlock& block, InstructionIt* inst_it, const InjectionData& injection_data,
                                 const InstructionMeta& meta) final;
 
-    uint32_t link_function_id = 0;
     uint32_t GetLinkFunctionId();
 };
 

--- a/layers/gpuav/spirv/descriptor_class_general_buffer_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_class_general_buffer_pass.cpp
@@ -28,23 +28,22 @@
 namespace gpuav {
 namespace spirv {
 
+static LinkInfo link_info = {instrumentation_descriptor_class_general_buffer_comp,
+                             instrumentation_descriptor_class_general_buffer_comp_size, 0, "inst_descriptor_class_general_buffer"};
+
 DescriptorClassGeneralBufferPass::DescriptorClassGeneralBufferPass(Module& module)
     : Pass(module), unsafe_mode_(module.settings_.unsafe_mode) {
     module.use_bda_ = true;
+    link_info.function_id = 0;  // reset each pass
 }
 
 // By appending the LinkInfo, it will attempt at linking stage to add the function.
 uint32_t DescriptorClassGeneralBufferPass::GetLinkFunctionId() {
-    static LinkInfo link_info = {instrumentation_descriptor_class_general_buffer_comp,
-                                 instrumentation_descriptor_class_general_buffer_comp_size, 0,
-                                 "inst_descriptor_class_general_buffer"};
-
-    if (link_function_id == 0) {
-        link_function_id = module_.TakeNextId();
-        link_info.function_id = link_function_id;
+    if (link_info.function_id == 0) {
+        link_info.function_id = module_.TakeNextId();
         module_.link_info_.push_back(link_info);
     }
-    return link_function_id;
+    return link_info.function_id;
 }
 
 // Finds the offset into the SSBO/UBO an instruction would access

--- a/layers/gpuav/spirv/descriptor_class_general_buffer_pass.h
+++ b/layers/gpuav/spirv/descriptor_class_general_buffer_pass.h
@@ -54,7 +54,6 @@ class DescriptorClassGeneralBufferPass : public Pass {
     uint32_t CreateFunctionCall(BasicBlock& block, InstructionIt* inst_it, const InjectionData& injection_data,
                                 const InstructionMeta& meta);
 
-    uint32_t link_function_id = 0;
     uint32_t GetLinkFunctionId();
 
     // Finds the offset into the SSBO/UBO

--- a/layers/gpuav/spirv/descriptor_class_texel_buffer_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_class_texel_buffer_pass.cpp
@@ -24,19 +24,21 @@
 namespace gpuav {
 namespace spirv {
 
-DescriptorClassTexelBufferPass::DescriptorClassTexelBufferPass(Module& module) : Pass(module) { module.use_bda_ = true; }
+static LinkInfo link_info = {instrumentation_descriptor_class_texel_buffer_comp,
+                             instrumentation_descriptor_class_texel_buffer_comp_size, 0, "inst_descriptor_class_texel_buffer"};
+
+DescriptorClassTexelBufferPass::DescriptorClassTexelBufferPass(Module& module) : Pass(module) {
+    module.use_bda_ = true;
+    link_info.function_id = 0;  // reset each pass
+}
 
 // By appending the LinkInfo, it will attempt at linking stage to add the function.
 uint32_t DescriptorClassTexelBufferPass::GetLinkFunctionId() {
-    static LinkInfo link_info = {instrumentation_descriptor_class_texel_buffer_comp,
-                                 instrumentation_descriptor_class_texel_buffer_comp_size, 0, "inst_descriptor_class_texel_buffer"};
-
-    if (link_function_id == 0) {
-        link_function_id = module_.TakeNextId();
-        link_info.function_id = link_function_id;
+    if (link_info.function_id == 0) {
+        link_info.function_id = module_.TakeNextId();
         module_.link_info_.push_back(link_info);
     }
-    return link_function_id;
+    return link_info.function_id;
 }
 
 uint32_t DescriptorClassTexelBufferPass::CreateFunctionCall(BasicBlock& block, InstructionIt* inst_it,

--- a/layers/gpuav/spirv/descriptor_class_texel_buffer_pass.h
+++ b/layers/gpuav/spirv/descriptor_class_texel_buffer_pass.h
@@ -48,7 +48,6 @@ class DescriptorClassTexelBufferPass : public Pass {
     uint32_t CreateFunctionCall(BasicBlock& block, InstructionIt* inst_it, const InjectionData& injection_data,
                                 const InstructionMeta& meta);
 
-    uint32_t link_function_id = 0;
     uint32_t GetLinkFunctionId();
 };
 

--- a/layers/gpuav/spirv/descriptor_indexing_oob_pass.h
+++ b/layers/gpuav/spirv/descriptor_indexing_oob_pass.h
@@ -24,7 +24,7 @@ namespace spirv {
 // This pass makes sure any index into an descriptor array is not OOB or uninitialized
 class DescriptorIndexingOOBPass : public InjectConditionalFunctionPass {
   public:
-    DescriptorIndexingOOBPass(Module& module) : InjectConditionalFunctionPass(module) {}
+    DescriptorIndexingOOBPass(Module& module);
     const char* Name() const final { return "DescriptorIndexingOOBPass"; }
     bool EarlySkip() const final;
     void PrintDebugInfo() const final;
@@ -36,9 +36,6 @@ class DescriptorIndexingOOBPass : public InjectConditionalFunctionPass {
     uint32_t CreateFunctionCall(BasicBlock& block, InstructionIt* inst_it, const InjectionData& injection_data,
                                 const InstructionMeta& meta) final;
 
-    uint32_t link_function_id_bindless_ = 0;
-    uint32_t link_function_id_bindless_combined_image_sampler_ = 0;
-    uint32_t link_function_id_non_bindless_ = 0;
     uint32_t GetLinkFunctionId(bool is_combined_image_sampler);
 
     // < original ID, new CopyObject ID >

--- a/layers/gpuav/spirv/link.h
+++ b/layers/gpuav/spirv/link.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2024 LunarG, Inc.
+/* Copyright (c) 2024-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ struct LinkInfo {
     const uint32_t word_count;
 
     // Information about the function it has
+    // (Will change each time pass is ran)
     uint32_t function_id;
 
     // used for debugging

--- a/layers/gpuav/spirv/post_process_descriptor_indexing_pass.cpp
+++ b/layers/gpuav/spirv/post_process_descriptor_indexing_pass.cpp
@@ -24,19 +24,21 @@
 namespace gpuav {
 namespace spirv {
 
-PostProcessDescriptorIndexingPass::PostProcessDescriptorIndexingPass(Module& module) : Pass(module) { module.use_bda_ = true; }
+static LinkInfo link_info = {instrumentation_post_process_descriptor_index_comp,
+                             instrumentation_post_process_descriptor_index_comp_size, 0, "inst_post_process_descriptor_index"};
+
+PostProcessDescriptorIndexingPass::PostProcessDescriptorIndexingPass(Module& module) : Pass(module) {
+    module.use_bda_ = true;
+    link_info.function_id = 0;  // reset each pass
+}
 
 // By appending the LinkInfo, it will attempt at linking stage to add the function.
 uint32_t PostProcessDescriptorIndexingPass::GetLinkFunctionId() {
-    static LinkInfo link_info = {instrumentation_post_process_descriptor_index_comp,
-                                 instrumentation_post_process_descriptor_index_comp_size, 0, "inst_post_process_descriptor_index"};
-
-    if (link_function_id == 0) {
-        link_function_id = module_.TakeNextId();
-        link_info.function_id = link_function_id;
+    if (link_info.function_id == 0) {
+        link_info.function_id = module_.TakeNextId();
         module_.link_info_.push_back(link_info);
     }
-    return link_function_id;
+    return link_info.function_id;
 }
 
 void PostProcessDescriptorIndexingPass::CreateFunctionCall(BasicBlockIt block_it, InstructionIt* inst_it,

--- a/layers/gpuav/spirv/post_process_descriptor_indexing_pass.h
+++ b/layers/gpuav/spirv/post_process_descriptor_indexing_pass.h
@@ -45,7 +45,6 @@ class PostProcessDescriptorIndexingPass : public Pass {
                                  vvl::unordered_set<uint32_t>& found_in_block_set);
     void CreateFunctionCall(BasicBlockIt block_it, InstructionIt* inst_it, const InstructionMeta& meta);
 
-    uint32_t link_function_id = 0;
     uint32_t GetLinkFunctionId();
 };
 

--- a/layers/gpuav/spirv/ray_query_pass.cpp
+++ b/layers/gpuav/spirv/ray_query_pass.cpp
@@ -23,16 +23,19 @@
 namespace gpuav {
 namespace spirv {
 
+static LinkInfo link_info = {instrumentation_ray_query_comp, instrumentation_ray_query_comp_size, 0, "inst_ray_query"};
+
+RayQueryPass::RayQueryPass(Module& module) : InjectConditionalFunctionPass(module) {
+    link_info.function_id = 0;  // reset each pass
+}
+
 // By appending the LinkInfo, it will attempt at linking stage to add the function.
 uint32_t RayQueryPass::GetLinkFunctionId() {
-    static LinkInfo link_info = {instrumentation_ray_query_comp, instrumentation_ray_query_comp_size, 0, "inst_ray_query"};
-
-    if (link_function_id == 0) {
-        link_function_id = module_.TakeNextId();
-        link_info.function_id = link_function_id;
+    if (link_info.function_id == 0) {
+        link_info.function_id = module_.TakeNextId();
         module_.link_info_.push_back(link_info);
     }
-    return link_function_id;
+    return link_info.function_id;
 }
 
 uint32_t RayQueryPass::CreateFunctionCall(BasicBlock& block, InstructionIt* inst_it, const InjectionData& injection_data,

--- a/layers/gpuav/spirv/ray_query_pass.h
+++ b/layers/gpuav/spirv/ray_query_pass.h
@@ -23,7 +23,7 @@ namespace spirv {
 // Create a pass to instrument SPV_KHR_ray_query instructions
 class RayQueryPass : public InjectConditionalFunctionPass {
   public:
-    RayQueryPass(Module& module) : InjectConditionalFunctionPass(module) {}
+    RayQueryPass(Module& module);
     const char* Name() const final { return "RayQueryPass"; }
     void PrintDebugInfo() const final;
 
@@ -32,7 +32,6 @@ class RayQueryPass : public InjectConditionalFunctionPass {
     uint32_t CreateFunctionCall(BasicBlock& block, InstructionIt* inst_it, const InjectionData& injection_data,
                                 const InstructionMeta& meta) final;
 
-    uint32_t link_function_id = 0;
     uint32_t GetLinkFunctionId();
 };
 

--- a/layers/gpuav/spirv/vertex_attribute_fetch_oob.cpp
+++ b/layers/gpuav/spirv/vertex_attribute_fetch_oob.cpp
@@ -26,19 +26,20 @@
 namespace gpuav {
 namespace spirv {
 
-uint32_t VertexAttributeFetchOob::GetLinkFunctionId() {
-    static LinkInfo link_info = {instrumentation_vertex_attribute_fetch_oob_vert,
-                                 instrumentation_vertex_attribute_fetch_oob_vert_size, 0, "inst_vertex_attribute_fetch_oob"};
+static LinkInfo link_info = {instrumentation_vertex_attribute_fetch_oob_vert, instrumentation_vertex_attribute_fetch_oob_vert_size,
+                             0, "inst_vertex_attribute_fetch_oob"};
 
-    if (link_function_id == 0) {
-        link_function_id = module_.TakeNextId();
-        link_info.function_id = link_function_id;
-        module_.link_info_.push_back(link_info);
-    }
-    return link_function_id;
+VertexAttributeFetchOob::VertexAttributeFetchOob(Module& module) : Pass(module) {
+    link_info.function_id = 0;  // reset each pass
 }
 
-VertexAttributeFetchOob::VertexAttributeFetchOob(Module& module) : Pass(module) {}
+uint32_t VertexAttributeFetchOob::GetLinkFunctionId() {
+    if (link_info.function_id == 0) {
+        link_info.function_id = module_.TakeNextId();
+        module_.link_info_.push_back(link_info);
+    }
+    return link_info.function_id;
+}
 
 bool VertexAttributeFetchOob::Instrument() {
     for (const auto& entry_point_inst : module_.entry_points_) {

--- a/layers/gpuav/spirv/vertex_attribute_fetch_oob.h
+++ b/layers/gpuav/spirv/vertex_attribute_fetch_oob.h
@@ -35,7 +35,6 @@ class VertexAttributeFetchOob : public Pass {
   private:
     uint32_t GetLinkFunctionId();
 
-    uint32_t link_function_id = 0;
     bool instrumentation_performed = false;
 };
 


### PR DESCRIPTION
Realized there is zero reason to have a `link_function_id` member variable when we literally are saving the information in the `static LinkInfo` already