### PR TITLE
tests: Add Stress test for GPU loops

### DIFF
--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -260,7 +260,8 @@ class GpuAVDescriptorIndexingTest : public GpuAVTest {
 
 class GpuAVDescriptorClassGeneralBuffer : public GpuAVTest {
   public:
-    void ComputeStorageBufferTest(const char *shader, bool is_glsl, VkDeviceSize buffer_size, const char *expected_error = nullptr);
+    void ComputeStorageBufferTest(const char *shader, bool is_glsl, VkDeviceSize buffer_size, const char *expected_error = nullptr,
+                                  uint32_t error_count = 1);
 };
 
 class GpuAVRayQueryTest : public GpuAVTest {


### PR DESCRIPTION
Stress test to prove issue with https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9722

Basically we need `VK_LAYER_GPUAV_UNSAFE_MODE` to hoist the check out of the loop and do it just once (if it can be clearly determined the loop variable won't effect the check of course)
