### PR TITLE
layers: Cleanup BothRangeMap

### DIFF
--- a/layers/state_tracker/image_layout_map.cpp
+++ b/layers/state_tracker/image_layout_map.cpp
@@ -109,11 +109,10 @@ bool ImageLayoutRegistry::SetSubresourceRangeLayout(const vvl::CommandBuffer& cb
     if (!InRange(range)) return false;  // Don't even try to track bogus subreources
 
     RangeGenerator range_gen(encoder_, range);
-    if (layout_map_.SmallMode()) {
+    if (layout_map_.UsesSmallMap()) {
         return SetSubresourceRangeLayoutImpl(layout_map_.GetSmallMap(), initial_layout_states_, range_gen, cb_state, layout,
                                              expected_layout);
     } else {
-        assert(!layout_map_.Tristate());
         return SetSubresourceRangeLayoutImpl(layout_map_.GetBigMap(), initial_layout_states_, range_gen, cb_state, layout,
                                              expected_layout);
     }
@@ -136,11 +135,10 @@ void ImageLayoutRegistry::SetSubresourceRangeInitialLayout(const vvl::CommandBuf
     if (!InRange(range)) return;  // Don't even try to track bogus subreources
 
     RangeGenerator range_gen(encoder_, range);
-    if (layout_map_.SmallMode()) {
+    if (layout_map_.UsesSmallMap()) {
         SetSubresourceRangeInitialLayoutImpl(layout_map_.GetSmallMap(), initial_layout_states_, range_gen, cb_state, layout,
                                              nullptr);
     } else {
-        assert(!layout_map_.Tristate());
         SetSubresourceRangeInitialLayoutImpl(layout_map_.GetBigMap(), initial_layout_states_, range_gen, cb_state, layout, nullptr);
     }
 }
@@ -149,11 +147,10 @@ void ImageLayoutRegistry::SetSubresourceRangeInitialLayout(const vvl::CommandBuf
 void ImageLayoutRegistry::SetSubresourceRangeInitialLayout(const vvl::CommandBuffer& cb_state, VkImageLayout layout,
                                                            const vvl::ImageView& view_state) {
     RangeGenerator range_gen(view_state.range_generator);
-    if (layout_map_.SmallMode()) {
+    if (layout_map_.UsesSmallMap()) {
         SetSubresourceRangeInitialLayoutImpl(layout_map_.GetSmallMap(), initial_layout_states_, range_gen, cb_state, layout,
                                              &view_state);
     } else {
-        assert(!layout_map_.Tristate());
         SetSubresourceRangeInitialLayoutImpl(layout_map_.GetBigMap(), initial_layout_states_, range_gen, cb_state, layout,
                                              &view_state);
     }

--- a/layers/state_tracker/image_layout_map.h
+++ b/layers/state_tracker/image_layout_map.h
@@ -163,7 +163,6 @@ class ImageLayoutRegistry {
 class GlobalImageLayoutRangeMap : public subresource_adapter::BothRangeMap<VkImageLayout, 16> {
   public:
     using RangeGenerator = image_layout_map::RangeGenerator;
-    using RangeType = key_type;
 
     GlobalImageLayoutRangeMap(index_type index) : BothRangeMap<VkImageLayout, 16>(index) {}
     ReadLockGuard ReadLock() const { return ReadLockGuard(lock_); }


### PR DESCRIPTION
Remove kTrisolar state. `BothRangeMap` has a single constructor that creates either a small or a big map, no other option is possible.  More streamlined assignment/copy implementation - in some places no need to do conditions for small or big use case if member-wise assignment gives the same result and potentially is more performant (no conditions).