### PR TITLE
layers: Split up image validation mega function

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -953,8 +953,12 @@ class CoreChecks : public vvl::Device {
                                   const Location& loc) const;
 
     bool ValidateImageFormatFeatures(const VkImageCreateInfo& create_info, const Location& loc) const;
-
     bool ValidateImageAlignmentControlCreateInfo(const VkImageCreateInfo& create_info, const Location& create_info_loc) const;
+    bool ValidateImageVideo(const VkImageCreateInfo& create_info, const Location& create_info_loc,
+                            const ErrorObject& error_obj) const;
+    bool ValidateImageSwapchain(const VkImageCreateInfo& create_info, const Location& create_info_loc) const;
+    bool ValidateImageExternalMemory(const VkImageCreateInfo& create_info, const Location& create_info_loc,
+                                     VkPhysicalDeviceImageFormatInfo2& image_format_info) const;
 
     bool PreCallValidateCreateImage(VkDevice device, const VkImageCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                     VkImage* pImage, const ErrorObject& error_obj) const override;

--- a/tests/unit/image.cpp
+++ b/tests/unit/image.cpp
@@ -3776,7 +3776,7 @@ TEST_F(NegativeImage, ImageCompressionControl) {
         auto image_create_info = vkt::Image::ImageCreateInfo2D(128, 128, 1, 1, VK_FORMAT_R8G8B8A8_UNORM,
                                                                VK_IMAGE_USAGE_TRANSFER_SRC_BIT, VK_IMAGE_TILING_LINEAR);
         image_create_info.pNext = &compression_control;
-
+        m_errorMonitor->SetDesiredError("VUID-VkImageCreateInfo-pNext-06744");
         CreateImageTest(image_create_info, "VUID-VkImageCompressionControlEXT-flags-06748");
     }
 


### PR DESCRIPTION
I had in my backlog to split up ` CoreChecks::PreCallValidateCreateImage` as it size makes it easy to misplace things and was a cause of a bug awhile ago

1. Split thing like Video, Swapchain, External memory into own functions
2. Move more things to stateless that are very much stateless