### PR TITLE
state_tracker: Restore VALSTATETRACK_DERIVED_STATE_OBJECT

### DIFF
--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -127,6 +127,13 @@ struct TraitsBase {
     struct Traits<state_type> : public TraitsBase<handle_type, state_type> {}; \
     }
 
+// Downstream projects may want to extend various state object types
+#define VALSTATETRACK_DERIVED_STATE_OBJECT(handle_type, state_type, base_type)            \
+    namespace state_object {                                                              \
+    template <>                                                                           \
+    struct Traits<state_type> : public TraitsBase<handle_type, state_type, base_type> {}; \
+    }
+
 VALSTATETRACK_STATE_OBJECT(VkQueue, vvl::Queue)
 VALSTATETRACK_STATE_OBJECT(VkAccelerationStructureNV, vvl::AccelerationStructureNV)
 VALSTATETRACK_STATE_OBJECT(VkRenderPass, vvl::RenderPass)


### PR DESCRIPTION
This is still used downstream in VulkanSC