### PR TITLE
gpuav: Fix bug not casting compute builtin

### DIFF
--- a/layers/gpuav/spirv/type_manager.cpp
+++ b/layers/gpuav/spirv/type_manager.cpp
@@ -565,6 +565,20 @@ const Variable* TypeManager::FindVariableById(uint32_t id) const {
     return (variable == id_to_variable_.end()) ? nullptr : variable->second.get();
 }
 
+bool Type::IsArray() const { return spv_type_ == SpvType::kArray || spv_type_ == SpvType::kRuntimeArray; }
+
+bool Type::IsSignedInt() const { return spv_type_ == SpvType::kInt && inst_.Word(3) == 1; }
+
+bool Type::IsIVec3(const TypeManager& type_manager) const {
+    if (spv_type_ == SpvType::kVector) {
+        const Type* vector_component_type = type_manager.FindTypeById(inst_.Word(2));
+        if (vector_component_type && vector_component_type->IsSignedInt()) {
+            return true;
+        }
+    }
+    return false;
+}
+
 uint32_t Constant::GetValueUint32() const {
     assert(inst_.Opcode() == spv::OpConstant);
     return inst_.Word(3);

--- a/layers/gpuav/spirv/type_manager.h
+++ b/layers/gpuav/spirv/type_manager.h
@@ -55,7 +55,11 @@ struct Type {
 
     bool operator==(Type const& other) const;
     uint32_t Id() const { return inst_.ResultId(); }
-    bool IsArray() const { return spv_type_ == SpvType::kArray || spv_type_ == SpvType::kRuntimeArray; }
+
+    // Helpers to detect what the type is
+    bool IsArray() const;
+    bool IsSignedInt() const;
+    bool IsIVec3(const TypeManager& type_manager) const;
 
     const SpvType spv_type_;
     const Instruction& inst_;


### PR DESCRIPTION
This fixes running GPU-AV on a trace where we were crashing because we didn't account that while the `GlobalInvocationId` builtin (`gl_GlobalInvocationID`) is normally a `uvec3` it can be a `ivec3`

![image](https://github.com/user-attachments/assets/d20b1372-e667-4b14-a8ec-9c9c38792ab8)

and we were not casting this causing RADV to blow up :boom: 