### PR TITLE
gpuav: Add debug info to spirv dumps

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -196,6 +196,8 @@ vvl_sources = [
   "layers/gpuav/instrumentation/gpuav_shader_instrumentor.h",
   "layers/gpuav/instrumentation/gpuav_instrumentation.cpp",
   "layers/gpuav/instrumentation/gpuav_instrumentation.h",
+  "layers/gpuav/instrumentation/gpuav_instrumentation_debug.cpp",
+  "layers/gpuav/instrumentation/gpuav_instrumentation_debug.h",
   "layers/gpuav/resources/gpuav_vulkan_objects.cpp",
   "layers/gpuav/resources/gpuav_vulkan_objects.h",
   "layers/gpuav/resources/gpuav_shader_resources.h",

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -286,6 +286,8 @@ target_sources(vvl PRIVATE
     gpuav/instrumentation/gpuav_shader_instrumentor.h
     gpuav/instrumentation/gpuav_instrumentation.h
     gpuav/instrumentation/gpuav_instrumentation.cpp
+    gpuav/instrumentation/gpuav_instrumentation_debug.h
+    gpuav/instrumentation/gpuav_instrumentation_debug.cpp
     gpuav/resources/gpuav_state_trackers.cpp
     gpuav/resources/gpuav_state_trackers.h
     gpuav/resources/gpuav_shader_resources.h

--- a/layers/gpuav/instrumentation/gpuav_instrumentation_debug.cpp
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation_debug.cpp
@@ -1,0 +1,90 @@
+/* Copyright (c) 2020-2025 The Khronos Group Inc.
+ * Copyright (c) 2020-2025 Valve Corporation
+ * Copyright (c) 2020-2025 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gpuav/instrumentation/gpuav_instrumentation_debug.h"
+
+#include <cassert>
+#include <sstream>
+#include <fstream>
+
+namespace gpuav {
+
+thread_local InstrumentedShaderDebugInfo tl_instrumentation_debug_info;
+
+std::string InstrumentedShaderDebugInfo::ToStringFileSuffix() const {
+    std::stringstream ss;
+
+    ss << "bda_" << bda << "_dbgpf_" << dbgpf << "_dcgb_" << dcgb << "_dctb_" << dctb << "_dioob_" << dioob << "_postp_" << postp
+       << "_rayq_" << rayq << "_vaoob_" << vaoob;
+
+    switch (shader_stage) {
+        case VK_SHADER_STAGE_VERTEX_BIT:
+            ss << "_vert";
+            break;
+        case VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT:
+            ss << "_tess_ctrl";
+            break;
+        case VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT:
+            ss << "_tess_eval";
+            break;
+        case VK_SHADER_STAGE_GEOMETRY_BIT:
+            ss << "_geom";
+            break;
+        case VK_SHADER_STAGE_FRAGMENT_BIT:
+            ss << "_frag";
+            break;
+        case VK_SHADER_STAGE_COMPUTE_BIT:
+            ss << "_comp";
+            break;
+        case VK_SHADER_STAGE_RAYGEN_BIT_KHR:
+            ss << "_rgen";
+            break;
+        case VK_SHADER_STAGE_ANY_HIT_BIT_KHR:
+            ss << "_ahit";
+            break;
+        case VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR:
+            ss << "_chit";
+            break;
+        case VK_SHADER_STAGE_MISS_BIT_KHR:
+            ss << "_miss";
+            break;
+        case VK_SHADER_STAGE_INTERSECTION_BIT_KHR:
+            ss << "_inter";
+            break;
+        case VK_SHADER_STAGE_CALLABLE_BIT_KHR:
+            ss << "_call";
+            break;
+        case VK_SHADER_STAGE_TASK_BIT_EXT:
+            ss << "_task";
+            break;
+        case VK_SHADER_STAGE_MESH_BIT_EXT:
+            ss << "_mesh";
+            break;
+        default:
+            assert(false);
+            break;
+    }
+
+    const std::string ret = ss.str();
+    return ret;
+}
+
+void DumpSpirvToFile(const std::filesystem::path &file_path, const char *spirv_data, size_t spirv_size) {
+    std::ofstream debug_file(file_path, std::ios::out | std::ios::binary);
+    debug_file.write(spirv_data, spirv_size);
+}
+}  // namespace gpuav

--- a/layers/gpuav/instrumentation/gpuav_instrumentation_debug.h
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation_debug.h
@@ -1,0 +1,48 @@
+/* Copyright (c) 2020-2025 The Khronos Group Inc.
+ * Copyright (c) 2020-2025 Valve Corporation
+ * Copyright (c) 2020-2025 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <vulkan/vulkan.h>
+#include <cstdint>
+#include <filesystem>
+#include <string>
+
+namespace gpuav {
+
+struct InstrumentedShaderDebugInfo {
+    VkShaderStageFlagBits shader_stage = VK_SHADER_STAGE_FLAG_BITS_MAX_ENUM;
+
+    // instrumenation counts
+    uint32_t bda{};
+    uint32_t dbgpf{};
+    uint32_t dcgb{};
+    uint32_t dctb{};
+    uint32_t dioob{};
+    uint32_t postp{};
+    uint32_t rayq{};
+    uint32_t vaoob{};
+
+    void Clear() { *this = InstrumentedShaderDebugInfo(); }
+    std::string ToStringFileSuffix() const;
+};
+
+extern thread_local InstrumentedShaderDebugInfo tl_instrumentation_debug_info;
+
+void DumpSpirvToFile(const std::filesystem::path &file_path, const char *spirv_data, size_t spirv_size);
+
+}  // namespace gpuav

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.h
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.h
@@ -203,8 +203,8 @@ class GpuShaderInstrumentor : public vvl::Device {
     // GPU-AV and DebugPrint are using the same way to do the actual shader instrumentation logic
     // Returns if shader was instrumented successfully or not
     bool InstrumentShader(const vvl::span<const uint32_t> &input_spirv, uint32_t unique_shader_id,
-                          const InstrumentationDescriptorSetLayouts &instrumentation_dsl, const Location &loc,
-                          std::vector<uint32_t> &out_instrumented_spirv);
+                          const InstrumentationDescriptorSetLayouts &instrumentation_dsl, VkShaderStageFlagBits stage,
+                          const Location &loc, std::vector<uint32_t> &out_instrumented_spirv);
 
   public:
     VkDescriptorSetLayout GetInstrumentationDescriptorSetLayout() { return instrumentation_desc_layout_; }

--- a/layers/gpuav/spirv/buffer_device_address_pass.cpp
+++ b/layers/gpuav/spirv/buffer_device_address_pass.cpp
@@ -20,6 +20,7 @@
 #include "utils/math_utils.h"
 
 #include "generated/instrumentation_buffer_device_address_comp.h"
+#include "gpuav/instrumentation/gpuav_instrumentation_debug.h"
 
 namespace gpuav {
 namespace spirv {
@@ -176,6 +177,7 @@ bool BufferDeviceAddressPass::Instrument() {
         }
     }
 
+    tl_instrumentation_debug_info.bda = instrumentations_count_;
     return instrumentations_count_ != 0;
 }
 

--- a/layers/gpuav/spirv/debug_printf_pass.cpp
+++ b/layers/gpuav/spirv/debug_printf_pass.cpp
@@ -26,6 +26,8 @@
 
 #include "generated/device_features.h"
 
+#include "gpuav/instrumentation/gpuav_instrumentation_debug.h"
+
 namespace gpuav {
 namespace spirv {
 
@@ -563,6 +565,7 @@ bool DebugPrintfPass::Instrument() {
         }
     }
 
+    tl_instrumentation_debug_info.dbgpf = instrumentations_count_;
     return true;
 }
 

--- a/layers/gpuav/spirv/descriptor_class_general_buffer_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_class_general_buffer_pass.cpp
@@ -24,6 +24,7 @@
 
 #include "generated/instrumentation_descriptor_class_general_buffer_comp.h"
 #include "gpuav/shaders/gpuav_shaders_constants.h"
+#include "gpuav/instrumentation/gpuav_instrumentation_debug.h"
 
 namespace gpuav {
 namespace spirv {
@@ -310,6 +311,7 @@ bool DescriptorClassGeneralBufferPass::RequiresInstrumentation(const Function& f
     // Save information to be used to make the Function
     meta.target_instruction = &inst;
 
+    tl_instrumentation_debug_info.dcgb = instrumentations_count_;
     return true;
 }
 

--- a/layers/gpuav/spirv/descriptor_class_texel_buffer_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_class_texel_buffer_pass.cpp
@@ -20,6 +20,7 @@
 
 #include "generated/instrumentation_descriptor_class_texel_buffer_comp.h"
 #include "gpuav/shaders/gpuav_shaders_constants.h"
+#include "gpuav/instrumentation/gpuav_instrumentation_debug.h"
 
 namespace gpuav {
 namespace spirv {
@@ -164,6 +165,7 @@ bool DescriptorClassTexelBufferPass::RequiresInstrumentation(const Function& fun
     // Save information to be used to make the Function
     meta.target_instruction = &inst;
 
+    tl_instrumentation_debug_info.dctb = instrumentations_count_;
     return true;
 }
 

--- a/layers/gpuav/spirv/descriptor_indexing_oob_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_indexing_oob_pass.cpp
@@ -23,6 +23,7 @@
 #include "generated/instrumentation_descriptor_indexing_oob_bindless_combined_image_sampler_comp.h"
 #include "generated/instrumentation_descriptor_indexing_oob_non_bindless_comp.h"
 #include "gpuav/shaders/gpuav_shaders_constants.h"
+#include "gpuav/instrumentation/gpuav_instrumentation_debug.h"
 
 namespace gpuav {
 namespace spirv {
@@ -459,6 +460,7 @@ bool DescriptorIndexingOOBPass::Instrument() {
         }
     }
 
+    tl_instrumentation_debug_info.dioob = instrumentations_count_;
     return instrumentations_count_ != 0;
 }
 

--- a/layers/gpuav/spirv/post_process_descriptor_indexing_pass.cpp
+++ b/layers/gpuav/spirv/post_process_descriptor_indexing_pass.cpp
@@ -20,6 +20,7 @@
 #include "generated/instrumentation_post_process_descriptor_index_comp.h"
 #include "gpuav/shaders/gpuav_shaders_constants.h"
 #include "utils/hash_util.h"
+#include "gpuav/instrumentation/gpuav_instrumentation_debug.h"
 
 namespace gpuav {
 namespace spirv {
@@ -202,6 +203,7 @@ bool PostProcessDescriptorIndexingPass::Instrument() {
         }
     }
 
+    tl_instrumentation_debug_info.postp = instrumentations_count_;
     return (instrumentations_count_ != 0);
 }
 

--- a/layers/gpuav/spirv/ray_query_pass.cpp
+++ b/layers/gpuav/spirv/ray_query_pass.cpp
@@ -19,6 +19,7 @@
 #include <iostream>
 
 #include "generated/instrumentation_ray_query_comp.h"
+#include "gpuav/instrumentation/gpuav_instrumentation_debug.h"
 
 namespace gpuav {
 namespace spirv {
@@ -109,6 +110,7 @@ bool RayQueryPass::Instrument() {
         }
     }
 
+    tl_instrumentation_debug_info.rayq = instrumentations_count_;
     return instrumentations_count_ != 0;
 }
 

--- a/layers/gpuav/spirv/vertex_attribute_fetch_oob.cpp
+++ b/layers/gpuav/spirv/vertex_attribute_fetch_oob.cpp
@@ -18,6 +18,7 @@
 #include "vertex_attribute_fetch_oob.h"
 #include "module.h"
 #include "generated/instrumentation_vertex_attribute_fetch_oob_vert.h"
+#include "gpuav/instrumentation/gpuav_instrumentation_debug.h"
 
 #include <iostream>
 
@@ -75,9 +76,12 @@ bool VertexAttributeFetchOob::Instrument() {
                                           &stage_info_inst_it);
 
             instrumentation_performed = true;
+            tl_instrumentation_debug_info.vaoob = 1;
             return true;
         }
     }
+
+    tl_instrumentation_debug_info.vaoob = 0;
     return false;
 }
 

--- a/layers/utils/shader_utils.cpp
+++ b/layers/utils/shader_utils.cpp
@@ -187,7 +187,7 @@ void AdjustValidatorOptions(const DeviceExtensions &device_extensions, const Dev
 }
 
 // This is used to help dump SPIR-V while debugging intermediate phases of any altercations to the SPIR-V
-void DumpSpirvToFile(std::string file_name, const char *spirv_data, size_t spirv_size) {
-    std::ofstream debug_file(file_name, std::ios::out | std::ios::binary);
+void DumpSpirvToFile(const std::filesystem::path &file_path, const char *spirv_data, size_t spirv_size) {
+    std::ofstream debug_file(file_path, std::ios::out | std::ios::binary);
     debug_file.write(spirv_data, spirv_size);
 }

--- a/layers/utils/shader_utils.cpp
+++ b/layers/utils/shader_utils.cpp
@@ -185,9 +185,3 @@ void AdjustValidatorOptions(const DeviceExtensions &device_extensions, const Dev
         *out_hash = hash_util::Hash32(&settings, sizeof(Settings));
     }
 }
-
-// This is used to help dump SPIR-V while debugging intermediate phases of any altercations to the SPIR-V
-void DumpSpirvToFile(const std::filesystem::path &file_path, const char *spirv_data, size_t spirv_size) {
-    std::ofstream debug_file(file_path, std::ios::out | std::ios::binary);
-    debug_file.write(spirv_data, spirv_size);
-}

--- a/layers/utils/shader_utils.h
+++ b/layers/utils/shader_utils.h
@@ -25,6 +25,7 @@
 #include "containers/custom_containers.h"
 
 #include <spirv-tools/libspirv.hpp>
+#include <filesystem>
 
 struct DeviceFeatures;
 struct DeviceExtensions;
@@ -115,4 +116,4 @@ spv_target_env PickSpirvEnv(const APIVersion &api_version, bool spirv_1_4);
 void AdjustValidatorOptions(const DeviceExtensions &device_extensions, const DeviceFeatures &enabled_features,
                             spvtools::ValidatorOptions &out_options, uint32_t *out_hash);
 
-void DumpSpirvToFile(std::string file_name, const char *spirv_data, size_t spirv_size);
+void DumpSpirvToFile(const std::filesystem::path &file_path, const char *spirv_data, size_t spirv_size);

--- a/layers/utils/shader_utils.h
+++ b/layers/utils/shader_utils.h
@@ -25,7 +25,6 @@
 #include "containers/custom_containers.h"
 
 #include <spirv-tools/libspirv.hpp>
-#include <filesystem>
 
 struct DeviceFeatures;
 struct DeviceExtensions;
@@ -115,5 +114,3 @@ spv_target_env PickSpirvEnv(const APIVersion &api_version, bool spirv_1_4);
 
 void AdjustValidatorOptions(const DeviceExtensions &device_extensions, const DeviceFeatures &enabled_features,
                             spvtools::ValidatorOptions &out_options, uint32_t *out_hash);
-
-void DumpSpirvToFile(const std::filesystem::path &file_path, const char *spirv_data, size_t spirv_size);


### PR DESCRIPTION
- Auto dump invalid instrumented spirv
- Add instrumentation info to dumped file names

I did this by using an horrible thread_local global variable, for it is the less intrusive way to try to have passes communicate whatever info they want to something in charge of gathering and formatting this data before dumping it