### PR TITLE
scripts: Tool to inspect instrumented spirv

### DIFF
--- a/scripts/inspect_gpuav_spirv.py
+++ b/scripts/inspect_gpuav_spirv.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+# Copyright (c) 2025 The Khronos Group Inc.
+# Copyright (c) 2025 Valve Corporation
+# Copyright (c) 2025 LunarG, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import re
+import sys
+import struct
+from collections import defaultdict
+
+def PrintExecutionModels(execution_models: set):
+    names = []
+    for e in execution_models:
+        if e == 0: # Maps to ExecutionModelVertex
+            names.append('Vertex')
+        elif e == 1:
+            names.append('TessControl')
+        elif e == 2:
+            names.append('TessEval')
+        elif e == 3:
+            names.append('Geometry')
+        elif e == 4:
+            names.append('Fragment')
+        elif e == 5:
+            names.append('Compute')
+        elif e == 6:
+            names.append('Kernel') # not allowed
+        elif e == 5267:
+            names.append('TaskNV')
+        elif e == 5268:
+            names.append('MeshNV')
+        elif e == 5364:
+            names.append('TaskEXT')
+        elif e == 5365:
+            names.append('MeshEXT')
+        elif e == 5313:
+            names.append("RayGenerationKHR")
+        elif e == 5314:
+            names.append("IntersectionKHR")
+        elif e == 5315:
+            names.append("AnyHitKHR")
+        elif e == 5316:
+            names.append("ClosestHitKHR")
+        elif e == 5317:
+            names.append("MissKHR")
+        elif e == 5318:
+            names.append("CallableKHR")
+        else:
+            print("ERROR - Stage not found")
+    return ",".join(names)
+
+def ExtractShaderId(path: str):
+    match = re.search(r'dump_(\d+)_after\.spv', path)
+    return int(match.group(1)) if match else None
+
+def ParseSpirv(file: str):
+    with open(file, "rb") as f:
+        # Read the whole binary file as uint32 words
+        words = list(struct.unpack(f"{len(f.read()) // 4}I", f.seek(0) or f.read()))
+
+    name_dict = dict()
+    function_call_count = defaultdict(int)
+    execution_models = set()  # Use a set to store unique numbers
+
+    offset = 5  # First 5 words are the header
+
+    while offset < len(words):
+        instruction = words[offset]
+        length = instruction >> 16
+        opcode = instruction & 0xFFFF
+
+        if opcode == 5: # OpName
+            target_id = words[offset + 1]
+            raw_string = words[offset + 2 : offset + length]
+            byte_data = b''.join(struct.pack("I", word) for word in raw_string)
+            name = byte_data.split(b'\x00', 1)[0].decode("utf-8")
+            name_dict[target_id] = name
+
+        elif opcode == 15: # OpEntryPoint
+            execution_model = words[offset + 1]
+            execution_models.add(execution_model)
+
+        elif opcode == 57: # OpFunctionCall
+            function_id = words[offset + 3]
+            function_call_count[function_id] += 1
+
+        offset += length  # Move to the next instruction
+
+    print(f'Shader Id {ExtractShaderId(file)} ({PrintExecutionModels(execution_models)})')
+    for function_id, count in function_call_count.items():
+        # Non-instrumented functions might not have a name
+        if function_id in name_dict:
+            function_name = name_dict[function_id]
+            if function_name.startswith('inst_'):
+                print(f"  {function_name}: {count}")
+
+def main(argv):
+    parser = argparse.ArgumentParser(description='Get info about a GPU-AV instrumented SPIR-V dump')
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--files', nargs='+', help='List of files to inspect')
+    group.add_argument('--dir', help='Pass in a directory path that contains all the dumped files.', dest='directory')
+    args = parser.parse_args(argv)
+
+    spirv_list = []
+    if args.directory:
+        after_files = []
+        pattern = re.compile(r'dump_(\d+)_after')
+        for root, _, files in os.walk(args.directory):
+            for file in files:
+                if pattern.search(file):
+                    full_path = os.path.join(root, file)
+                    after_files.append(full_path)
+
+        spirv_list = sorted(after_files, key=ExtractShaderId)
+
+    else:
+        spirv_list = args.files
+
+    for file in spirv_list:
+        ParseSpirv(file)
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))
+


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9800 

@arno-lunarg I just go `python3 scripts/inspect_gpuav_spirv.py --dir path/to/dump` and I get this (very fast, like instant fast for hundreds of shaders)

![image](https://github.com/user-attachments/assets/a19d8946-db72-4126-99f4-2b74afa655cf)

... we can tweak to our liking as we find needed

(Just want to say I have now built a SPIR-V parser in too many programming languages at this point)