### PR TITLE
layers: Fix missing includes for small_vector.h

### DIFF
--- a/layers/containers/small_vector.h
+++ b/layers/containers/small_vector.h
@@ -22,6 +22,8 @@
 #include <cstddef>
 #include <cstdint>
 #include <limits>
+#include <type_traits>
+#include <utility>
 
 // A vector class with "small string optimization" -- meaning that the class contains a fixed working store for N elements.
 // Useful in in situations where the needed size is unknown, but the typical size is known  If size increases beyond the


### PR DESCRIPTION
To fix module build in Chromium, this adds includes for `std::is_default_constructible_v` and `std::move`.