### PR TITLE
gpuav: Thread safe LinkInfo

### DIFF
--- a/layers/gpuav/spirv/buffer_device_address_pass.cpp
+++ b/layers/gpuav/spirv/buffer_device_address_pass.cpp
@@ -24,7 +24,7 @@
 namespace gpuav {
 namespace spirv {
 
-static LinkInfo link_info = {instrumentation_buffer_device_address_comp, instrumentation_buffer_device_address_comp_size, 0,
+static thread_local LinkInfo link_info = {instrumentation_buffer_device_address_comp, instrumentation_buffer_device_address_comp_size, 0,
                              "inst_buffer_device_address", ZeroInitializeUintPrivateVariables};
 
 BufferDeviceAddressPass::BufferDeviceAddressPass(Module& module) : Pass(module) {

--- a/layers/gpuav/spirv/descriptor_class_general_buffer_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_class_general_buffer_pass.cpp
@@ -28,7 +28,7 @@
 namespace gpuav {
 namespace spirv {
 
-static LinkInfo link_info = {instrumentation_descriptor_class_general_buffer_comp,
+static thread_local LinkInfo link_info = {instrumentation_descriptor_class_general_buffer_comp,
                              instrumentation_descriptor_class_general_buffer_comp_size, 0, "inst_descriptor_class_general_buffer"};
 
 DescriptorClassGeneralBufferPass::DescriptorClassGeneralBufferPass(Module& module)

--- a/layers/gpuav/spirv/descriptor_class_texel_buffer_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_class_texel_buffer_pass.cpp
@@ -24,7 +24,7 @@
 namespace gpuav {
 namespace spirv {
 
-static LinkInfo link_info = {instrumentation_descriptor_class_texel_buffer_comp,
+static thread_local LinkInfo link_info = {instrumentation_descriptor_class_texel_buffer_comp,
                              instrumentation_descriptor_class_texel_buffer_comp_size, 0, "inst_descriptor_class_texel_buffer"};
 
 DescriptorClassTexelBufferPass::DescriptorClassTexelBufferPass(Module& module) : Pass(module) {

--- a/layers/gpuav/spirv/descriptor_indexing_oob_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_indexing_oob_pass.cpp
@@ -28,16 +28,16 @@ namespace gpuav {
 namespace spirv {
 
 // This pass has 2 variations of GLSL we can pull in. Non-Bindless is simpler and we want to use when possible
-static LinkInfo link_info_bindless = {instrumentation_descriptor_indexing_oob_bindless_comp,
+static thread_local LinkInfo link_info_bindless = {instrumentation_descriptor_indexing_oob_bindless_comp,
                                       instrumentation_descriptor_indexing_oob_bindless_comp_size, 0,
                                       "inst_descriptor_indexing_oob_bindless"};
 
-static LinkInfo link_info_bindless_combined_image_sampler = {
+static thread_local LinkInfo link_info_bindless_combined_image_sampler = {
     instrumentation_descriptor_indexing_oob_bindless_combined_image_sampler_comp,
     instrumentation_descriptor_indexing_oob_bindless_combined_image_sampler_comp_size, 0,
     "inst_descriptor_indexing_oob_bindless_combined_image_sampler"};
 
-static LinkInfo link_info_non_bindless = {instrumentation_descriptor_indexing_oob_non_bindless_comp,
+static thread_local LinkInfo link_info_non_bindless = {instrumentation_descriptor_indexing_oob_non_bindless_comp,
                                           instrumentation_descriptor_indexing_oob_non_bindless_comp_size, 0,
                                           "inst_descriptor_indexing_oob_non_bindless"};
 

--- a/layers/gpuav/spirv/post_process_descriptor_indexing_pass.cpp
+++ b/layers/gpuav/spirv/post_process_descriptor_indexing_pass.cpp
@@ -24,7 +24,7 @@
 namespace gpuav {
 namespace spirv {
 
-static LinkInfo link_info = {instrumentation_post_process_descriptor_index_comp,
+static thread_local LinkInfo link_info = {instrumentation_post_process_descriptor_index_comp,
                              instrumentation_post_process_descriptor_index_comp_size, 0, "inst_post_process_descriptor_index"};
 
 PostProcessDescriptorIndexingPass::PostProcessDescriptorIndexingPass(Module& module) : Pass(module) {

--- a/layers/gpuav/spirv/ray_query_pass.cpp
+++ b/layers/gpuav/spirv/ray_query_pass.cpp
@@ -23,7 +23,7 @@
 namespace gpuav {
 namespace spirv {
 
-static LinkInfo link_info = {instrumentation_ray_query_comp, instrumentation_ray_query_comp_size, 0, "inst_ray_query"};
+static thread_local LinkInfo link_info = {instrumentation_ray_query_comp, instrumentation_ray_query_comp_size, 0, "inst_ray_query"};
 
 RayQueryPass::RayQueryPass(Module& module) : Pass(module) {
     module.use_bda_ = true;

--- a/layers/gpuav/spirv/vertex_attribute_fetch_oob.cpp
+++ b/layers/gpuav/spirv/vertex_attribute_fetch_oob.cpp
@@ -26,7 +26,7 @@
 namespace gpuav {
 namespace spirv {
 
-static LinkInfo link_info = {instrumentation_vertex_attribute_fetch_oob_vert, instrumentation_vertex_attribute_fetch_oob_vert_size,
+static thread_local LinkInfo link_info = {instrumentation_vertex_attribute_fetch_oob_vert, instrumentation_vertex_attribute_fetch_oob_vert_size,
                              0, "inst_vertex_attribute_fetch_oob"};
 
 VertexAttributeFetchOob::VertexAttributeFetchOob(Module& module) : Pass(module) {


### PR DESCRIPTION
Issues showed up in Doom: digging showed that it was race conditions with the various LinkInfo. Making them thread_local fixed it