### PR TITLE
gpuav: Separated generated link info from dynamic

### DIFF
--- a/.github/workflows/vvl.yml
+++ b/.github/workflows/vvl.yml
@@ -63,6 +63,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: '3.31.6' # until we fix jsoncpp bug
       - uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ matrix.config }}-address-${{matrix.custom_hash_map}}
@@ -101,6 +103,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: '3.31.6' # until we fix jsoncpp bug
       - uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ matrix.config }}-thread-${{matrix.custom_hash_map}}
@@ -129,6 +133,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: '3.31.6' # until we fix jsoncpp bug
       - uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: linux-ubsan
@@ -174,6 +180,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: '3.31.6' # until we fix jsoncpp bug
       - uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: linux-upload-ccache
@@ -196,6 +204,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: '3.31.6' # until we fix jsoncpp bug
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
@@ -309,6 +319,8 @@ jobs:
       steps:
         - uses: actions/checkout@v4
         - uses: lukka/get-cmake@latest
+          with:
+            cmakeVersion: '3.31.6' # until we fix jsoncpp bug
         - name: Setup ccache
           uses: hendrikmuhs/ccache-action@v1.2
           with:
@@ -338,6 +350,8 @@ jobs:
       steps:
         - uses: actions/checkout@v4
         - uses: lukka/get-cmake@latest
+          with:
+            cmakeVersion: '3.31.6' # until we fix jsoncpp bug
         - name: Setup ccache
           uses: hendrikmuhs/ccache-action@v1.2
           with:
@@ -381,6 +395,8 @@ jobs:
         with:
           key: iOS-cache
       - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: '3.31.6' # until we fix jsoncpp bug
       - name: Configure for iOS
         run: |
           cmake -S . -B build/ \
@@ -416,6 +432,8 @@ jobs:
         with:
           python-version: '3.10'
       - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: '3.31.6' # until we fix jsoncpp bug
       - run: |
           cmake -S. -B build \
           -D BUILD_WERROR=ON \

--- a/layers/gpuav/spirv/buffer_device_address_pass.cpp
+++ b/layers/gpuav/spirv/buffer_device_address_pass.cpp
@@ -25,22 +25,14 @@
 namespace gpuav {
 namespace spirv {
 
-static LinkInfo link_info = {instrumentation_buffer_device_address_comp, instrumentation_buffer_device_address_comp_size, 0,
-                             "inst_buffer_device_address", ZeroInitializeUintPrivateVariables};
+const static OfflineLinkInfo link_info = {instrumentation_buffer_device_address_comp,
+                                          instrumentation_buffer_device_address_comp_size, "inst_buffer_device_address",
+                                          ZeroInitializeUintPrivateVariables};
 
-BufferDeviceAddressPass::BufferDeviceAddressPass(Module& module) : Pass(module) {
-    module.use_bda_ = true;
-    link_info.function_id = 0;  // reset each pass
-}
+BufferDeviceAddressPass::BufferDeviceAddressPass(Module& module) : Pass(module) { module.use_bda_ = true; }
 
 // By appending the LinkInfo, it will attempt at linking stage to add the function.
-uint32_t BufferDeviceAddressPass::GetLinkFunctionId() {
-    if (link_info.function_id == 0) {
-        link_info.function_id = module_.TakeNextId();
-        module_.link_info_.push_back(link_info);
-    }
-    return link_info.function_id;
-}
+uint32_t BufferDeviceAddressPass::GetLinkFunctionId() { return module_.GetLinkFunction(link_function_id_, link_info); }
 
 uint32_t BufferDeviceAddressPass::CreateFunctionCall(BasicBlock& block, InstructionIt* inst_it, const InjectionData& injection_data,
                                                      const InstructionMeta& meta) {

--- a/layers/gpuav/spirv/buffer_device_address_pass.h
+++ b/layers/gpuav/spirv/buffer_device_address_pass.h
@@ -44,6 +44,9 @@ class BufferDeviceAddressPass : public Pass {
                                 const InstructionMeta& meta);
 
     uint32_t GetLinkFunctionId();
+
+    // Function IDs to link in
+    uint32_t link_function_id_ = 0;
 };
 
 }  // namespace spirv

--- a/layers/gpuav/spirv/descriptor_class_general_buffer_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_class_general_buffer_pass.cpp
@@ -28,23 +28,17 @@
 namespace gpuav {
 namespace spirv {
 
-static LinkInfo link_info = {instrumentation_descriptor_class_general_buffer_comp,
-                             instrumentation_descriptor_class_general_buffer_comp_size, 0, "inst_descriptor_class_general_buffer"};
+const static OfflineLinkInfo link_info = {instrumentation_descriptor_class_general_buffer_comp,
+                                          instrumentation_descriptor_class_general_buffer_comp_size,
+                                          "inst_descriptor_class_general_buffer"};
 
 DescriptorClassGeneralBufferPass::DescriptorClassGeneralBufferPass(Module& module)
     : Pass(module), unsafe_mode_(module.settings_.unsafe_mode) {
     module.use_bda_ = true;
-    link_info.function_id = 0;  // reset each pass
 }
 
 // By appending the LinkInfo, it will attempt at linking stage to add the function.
-uint32_t DescriptorClassGeneralBufferPass::GetLinkFunctionId() {
-    if (link_info.function_id == 0) {
-        link_info.function_id = module_.TakeNextId();
-        module_.link_info_.push_back(link_info);
-    }
-    return link_info.function_id;
-}
+uint32_t DescriptorClassGeneralBufferPass::GetLinkFunctionId() { return module_.GetLinkFunction(link_function_id_, link_info); }
 
 // Finds the offset into the SSBO/UBO an instruction would access
 // If it is a non-constant value, will return zero to indicate its a runtime value

--- a/layers/gpuav/spirv/descriptor_class_general_buffer_pass.h
+++ b/layers/gpuav/spirv/descriptor_class_general_buffer_pass.h
@@ -71,6 +71,9 @@ class DescriptorClassGeneralBufferPass : public Pass {
     //
     // < Descriptor SSA ID, Highest offset byte that will be accessed >
     vvl::unordered_map<uint32_t, uint32_t> block_highest_offset_map_;
+
+    // Function IDs to link in
+    uint32_t link_function_id_ = 0;
 };
 
 }  // namespace spirv

--- a/layers/gpuav/spirv/descriptor_class_texel_buffer_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_class_texel_buffer_pass.cpp
@@ -24,22 +24,14 @@
 namespace gpuav {
 namespace spirv {
 
-static LinkInfo link_info = {instrumentation_descriptor_class_texel_buffer_comp,
-                             instrumentation_descriptor_class_texel_buffer_comp_size, 0, "inst_descriptor_class_texel_buffer"};
+const static OfflineLinkInfo link_info = {instrumentation_descriptor_class_texel_buffer_comp,
+                                          instrumentation_descriptor_class_texel_buffer_comp_size,
+                                          "inst_descriptor_class_texel_buffer"};
 
-DescriptorClassTexelBufferPass::DescriptorClassTexelBufferPass(Module& module) : Pass(module) {
-    module.use_bda_ = true;
-    link_info.function_id = 0;  // reset each pass
-}
+DescriptorClassTexelBufferPass::DescriptorClassTexelBufferPass(Module& module) : Pass(module) { module.use_bda_ = true; }
 
 // By appending the LinkInfo, it will attempt at linking stage to add the function.
-uint32_t DescriptorClassTexelBufferPass::GetLinkFunctionId() {
-    if (link_info.function_id == 0) {
-        link_info.function_id = module_.TakeNextId();
-        module_.link_info_.push_back(link_info);
-    }
-    return link_info.function_id;
-}
+uint32_t DescriptorClassTexelBufferPass::GetLinkFunctionId() { return module_.GetLinkFunction(link_function_id_, link_info); }
 
 uint32_t DescriptorClassTexelBufferPass::CreateFunctionCall(BasicBlock& block, InstructionIt* inst_it,
                                                             const InjectionData& injection_data, const InstructionMeta& meta) {

--- a/layers/gpuav/spirv/descriptor_class_texel_buffer_pass.h
+++ b/layers/gpuav/spirv/descriptor_class_texel_buffer_pass.h
@@ -48,6 +48,9 @@ class DescriptorClassTexelBufferPass : public Pass {
                                 const InstructionMeta& meta);
 
     uint32_t GetLinkFunctionId();
+
+    // Function IDs to link in
+    uint32_t link_function_id_ = 0;
 };
 
 }  // namespace spirv

--- a/layers/gpuav/spirv/descriptor_indexing_oob_pass.h
+++ b/layers/gpuav/spirv/descriptor_indexing_oob_pass.h
@@ -61,6 +61,11 @@ class DescriptorIndexingOOBPass : public Pass {
     // index into it once to see if the descriptor is valid or not . We marks which variables were already instrumented
     // < Variable ID, [descriptor index IDs accessed with this variable >
     vvl::unordered_map<uint32_t, vvl::unordered_set<uint32_t>> block_instrumented_table_;
+
+    // Function IDs to link in
+    uint32_t link_bindless_id_ = 0;
+    uint32_t link_bindless_combined_image_sampler_id_ = 0;
+    uint32_t link_non_bindless_id_ = 0;
 };
 
 }  // namespace spirv

--- a/layers/gpuav/spirv/link.h
+++ b/layers/gpuav/spirv/link.h
@@ -26,20 +26,25 @@ enum LinkFlags {
     ZeroInitializeUintPrivateVariables = 0x00000001,
 };
 
-struct LinkInfo {
+// This struct is for things that are generated and therefor can be created once statically
+struct OfflineLinkInfo {
     // SPIR-V module to link in
     const uint32_t* words;
     const uint32_t word_count;
-
-    // Information about the function it has
-    // (Will change each time pass is ran)
-    uint32_t function_id;
 
     // used for debugging
     const char* opname;
 
     // Optional things to be done when linking
-    uint32_t flags = 0;
+    const uint32_t flags = 0;
+};
+
+struct LinkInfo {
+    // If it's not in generated offline, it will change each pass
+    const OfflineLinkInfo& offline;
+
+    // The result ID of OpFunction
+    const uint32_t function_id;
 };
 
 }  // namespace spirv

--- a/layers/gpuav/spirv/module.h
+++ b/layers/gpuav/spirv/module.h
@@ -23,6 +23,7 @@
 
 class DebugReport;
 struct DeviceFeatures;
+struct OfflineLinkInfo;
 
 namespace gpuav {
 namespace spirv {
@@ -86,6 +87,7 @@ class Module {
     // Order of functions that will try to be linked in
     std::vector<LinkInfo> link_info_;
     void LinkFunction(const LinkInfo& info);
+    uint32_t GetLinkFunction(uint32_t& link_function_id, const OfflineLinkInfo& offline_info);
     void PostProcess();
 
     // The class is designed to be written out to a binary file.

--- a/layers/gpuav/spirv/post_process_descriptor_indexing_pass.cpp
+++ b/layers/gpuav/spirv/post_process_descriptor_indexing_pass.cpp
@@ -24,22 +24,14 @@
 namespace gpuav {
 namespace spirv {
 
-static LinkInfo link_info = {instrumentation_post_process_descriptor_index_comp,
-                             instrumentation_post_process_descriptor_index_comp_size, 0, "inst_post_process_descriptor_index"};
+const static OfflineLinkInfo link_info = {instrumentation_post_process_descriptor_index_comp,
+                                          instrumentation_post_process_descriptor_index_comp_size,
+                                          "inst_post_process_descriptor_index"};
 
-PostProcessDescriptorIndexingPass::PostProcessDescriptorIndexingPass(Module& module) : Pass(module) {
-    module.use_bda_ = true;
-    link_info.function_id = 0;  // reset each pass
-}
+PostProcessDescriptorIndexingPass::PostProcessDescriptorIndexingPass(Module& module) : Pass(module) { module.use_bda_ = true; }
 
 // By appending the LinkInfo, it will attempt at linking stage to add the function.
-uint32_t PostProcessDescriptorIndexingPass::GetLinkFunctionId() {
-    if (link_info.function_id == 0) {
-        link_info.function_id = module_.TakeNextId();
-        module_.link_info_.push_back(link_info);
-    }
-    return link_info.function_id;
-}
+uint32_t PostProcessDescriptorIndexingPass::GetLinkFunctionId() { return module_.GetLinkFunction(link_function_id_, link_info); }
 
 void PostProcessDescriptorIndexingPass::CreateFunctionCall(BasicBlock& block, InstructionIt* inst_it, const InstructionMeta& meta) {
     const Constant& set_constant = module_.type_manager_.GetConstantUInt32(meta.descriptor_set);

--- a/layers/gpuav/spirv/post_process_descriptor_indexing_pass.h
+++ b/layers/gpuav/spirv/post_process_descriptor_indexing_pass.h
@@ -45,6 +45,9 @@ class PostProcessDescriptorIndexingPass : public Pass {
     void CreateFunctionCall(BasicBlock& block, InstructionIt* inst_it, const InstructionMeta& meta);
 
     uint32_t GetLinkFunctionId();
+
+    // Function IDs to link in
+    uint32_t link_function_id_ = 0;
 };
 
 }  // namespace spirv

--- a/layers/gpuav/spirv/ray_query_pass.cpp
+++ b/layers/gpuav/spirv/ray_query_pass.cpp
@@ -23,21 +23,12 @@
 namespace gpuav {
 namespace spirv {
 
-static LinkInfo link_info = {instrumentation_ray_query_comp, instrumentation_ray_query_comp_size, 0, "inst_ray_query"};
+const static OfflineLinkInfo link_info = {instrumentation_ray_query_comp, instrumentation_ray_query_comp_size, "inst_ray_query"};
 
-RayQueryPass::RayQueryPass(Module& module) : Pass(module) {
-    module.use_bda_ = true;
-    link_info.function_id = 0;  // reset each pass
-}
+RayQueryPass::RayQueryPass(Module& module) : Pass(module) { module.use_bda_ = true; }
 
 // By appending the LinkInfo, it will attempt at linking stage to add the function.
-uint32_t RayQueryPass::GetLinkFunctionId() {
-    if (link_info.function_id == 0) {
-        link_info.function_id = module_.TakeNextId();
-        module_.link_info_.push_back(link_info);
-    }
-    return link_info.function_id;
-}
+uint32_t RayQueryPass::GetLinkFunctionId() { return module_.GetLinkFunction(link_function_id_, link_info); }
 
 uint32_t RayQueryPass::CreateFunctionCall(BasicBlock& block, InstructionIt* inst_it, const InjectionData& injection_data,
                                           const InstructionMeta& meta) {

--- a/layers/gpuav/spirv/ray_query_pass.h
+++ b/layers/gpuav/spirv/ray_query_pass.h
@@ -39,6 +39,9 @@ class RayQueryPass : public Pass {
                                 const InstructionMeta& meta);
 
     uint32_t GetLinkFunctionId();
+
+    // Function IDs to link in
+    uint32_t link_function_id_ = 0;
 };
 
 }  // namespace spirv

--- a/layers/gpuav/spirv/vertex_attribute_fetch_oob.cpp
+++ b/layers/gpuav/spirv/vertex_attribute_fetch_oob.cpp
@@ -26,20 +26,12 @@
 namespace gpuav {
 namespace spirv {
 
-static LinkInfo link_info = {instrumentation_vertex_attribute_fetch_oob_vert, instrumentation_vertex_attribute_fetch_oob_vert_size,
-                             0, "inst_vertex_attribute_fetch_oob"};
+const static OfflineLinkInfo link_info = {instrumentation_vertex_attribute_fetch_oob_vert,
+                                          instrumentation_vertex_attribute_fetch_oob_vert_size, "inst_vertex_attribute_fetch_oob"};
 
-VertexAttributeFetchOob::VertexAttributeFetchOob(Module& module) : Pass(module) {
-    link_info.function_id = 0;  // reset each pass
-}
+VertexAttributeFetchOob::VertexAttributeFetchOob(Module& module) : Pass(module) {}
 
-uint32_t VertexAttributeFetchOob::GetLinkFunctionId() {
-    if (link_info.function_id == 0) {
-        link_info.function_id = module_.TakeNextId();
-        module_.link_info_.push_back(link_info);
-    }
-    return link_info.function_id;
-}
+uint32_t VertexAttributeFetchOob::GetLinkFunctionId() { return module_.GetLinkFunction(link_function_id_, link_info); }
 
 bool VertexAttributeFetchOob::Instrument() {
     for (const auto& entry_point_inst : module_.entry_points_) {

--- a/layers/gpuav/spirv/vertex_attribute_fetch_oob.h
+++ b/layers/gpuav/spirv/vertex_attribute_fetch_oob.h
@@ -36,6 +36,9 @@ class VertexAttributeFetchOob : public Pass {
     uint32_t GetLinkFunctionId();
 
     bool instrumentation_performed = false;
+
+    // Function IDs to link in
+    uint32_t link_function_id_ = 0;
 };
 
 }  // namespace spirv


### PR DESCRIPTION
replacement for https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/9808

Separates out what is generated (and can be `const static`) vs the data that is per-pass