### PR TITLE
layers: Rename ShaderTileImage VUIDs to DynamicRenderingBarrier

### DIFF
--- a/layers/core_checks/cc_image_layout.cpp
+++ b/layers/core_checks/cc_image_layout.cpp
@@ -421,7 +421,7 @@ bool CoreChecks::ValidateRenderPassLayoutAgainstFramebufferImageUsage(VkImageLay
                !(image_usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)) {
         vuid = use_rp2 ? "VUID-vkCmdBeginRenderPass2-initialLayout-03096" : "VUID-vkCmdBeginRenderPass-initialLayout-01758";
         skip = true;
-    } else if (layout == VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ && !IsShaderTileImageUsageValid(image_usage)) {
+    } else if (layout == VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ && !IsDynamicRenderingImageUsageValid(image_usage)) {
         vuid = use_rp2 ? "VUID-vkCmdBeginRenderPass2-initialLayout-09538" : "VUID-vkCmdBeginRenderPass-initialLayout-09537";
         skip = true;
     } else if ((IsImageLayoutDepthOnly(layout) || IsImageLayoutStencilOnly(layout)) &&
@@ -955,8 +955,8 @@ bool CoreChecks::VerifyDynamicRenderingImageBarrierLayouts(const vvl::CommandBuf
                     bool local_skip = false;
                     if (state.current_layout != VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ &&
                         state.current_layout != VK_IMAGE_LAYOUT_GENERAL) {
-                        const auto &vuid = sync_vuid_maps::GetShaderTileImageVUID(
-                            barrier_loc, sync_vuid_maps::ShaderTileImageError::kShaderTileImageLayout);
+                        const auto &vuid = sync_vuid_maps::GetDynamicRenderingBarrierVUID(
+                            barrier_loc, sync_vuid_maps::DynamicRenderingBarrierError::kImageLayout);
                         local_skip |= LogError(vuid, image_state.VkHandle(), barrier_loc, "image layout is %s.",
                                                string_VkImageLayout(state.current_layout));
                     }

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -231,7 +231,7 @@ class CoreChecks : public vvl::Device {
                                 const LogObjectList& objlist, const Location& loc) const;
     bool ValidateSemaphoresForSubmit(struct SemaphoreSubmitState& state, const VkSubmitInfo& submit,
                                      const Location& submit_loc) const;
-    bool ValidateSemaphoresForSubmit(struct SemaphoreSubmitState& state, const VkSubmitInfo2KHR& submit,
+    bool ValidateSemaphoresForSubmit(struct SemaphoreSubmitState& state, const VkSubmitInfo2& submit,
                                      const Location& submit_loc) const;
     bool ValidateSemaphoresForSubmit(struct SemaphoreSubmitState& state, const VkBindSparseInfo& submit,
                                      const Location& submit_loc) const;
@@ -318,25 +318,27 @@ class CoreChecks : public vvl::Device {
                           uint32_t bufferBarrierCount, const VkBufferMemoryBarrier* pBufferMemBarriers,
                           uint32_t imageMemBarrierCount, const VkImageMemoryBarrier* pImageMemBarriers) const;
 
-    bool IsShaderTileImageUsageValid(VkImageUsageFlags image_usage) const;
-    bool ValidateShaderTileImageBarriers(const LogObjectList& objlist, const Location& outer_loc,
-                                         const VkDependencyInfo& dep_info) const;
+    bool IsDynamicRenderingImageUsageValid(VkImageUsageFlags image_usage) const;
 
-    bool ValidateShaderTileImageBarriers(const LogObjectList& objlist, const Location& outer_loc,
-                                         VkDependencyFlags dependency_flags, uint32_t memory_barrier_count,
-                                         const VkMemoryBarrier* memory_barriers, uint32_t buffer_barrier_count,
-                                         uint32_t image_barrier_count, const VkImageMemoryBarrier* image_barriers,
-                                         VkPipelineStageFlags src_stage_mask, VkPipelineStageFlags dst_stage_mask) const;
+    bool ValidateDynamicRenderingBarriers(const LogObjectList& objlist, const Location& outer_loc,
+                                          const VkDependencyInfo& dep_info) const;
 
-    bool ValidateShaderTileImageCommon(const LogObjectList& objlist, const Location& outer_loc, VkDependencyFlags dependency_flags,
-                                       uint32_t buffer_barrier_count, uint32_t image_barrier_count) const;
+    bool ValidateDynamicRenderingBarriers(const LogObjectList& objlist, const Location& outer_loc,
+                                          VkDependencyFlags dependency_flags, uint32_t memory_barrier_count,
+                                          const VkMemoryBarrier* memory_barriers, uint32_t buffer_barrier_count,
+                                          uint32_t image_barrier_count, const VkImageMemoryBarrier* image_barriers,
+                                          VkPipelineStageFlags src_stage_mask, VkPipelineStageFlags dst_stage_mask) const;
+
+    bool ValidateDynamicRenderingBarriersCommon(const LogObjectList& objlist, const Location& outer_loc,
+                                                VkDependencyFlags dependency_flags, uint32_t buffer_barrier_count,
+                                                uint32_t image_barrier_count) const;
 
     bool ValidatePipelineStageFeatureEnables(const LogObjectList& objlist, const Location& stage_mask_loc,
                                              VkPipelineStageFlags2KHR stage_mask) const;
     bool ValidatePipelineStage(const LogObjectList& objlist, const Location& stage_mask_loc, VkQueueFlags queue_flags,
                                VkPipelineStageFlags2KHR stage_mask) const;
-    bool ValidatePipelineStageForShaderTileImage(const LogObjectList& objlist, const Location& loc,
-                                                 VkPipelineStageFlags2KHR stage_mask, VkDependencyFlags dependency_flags) const;
+    bool ValidateDynamicRenderingPipelineStage(const LogObjectList& objlist, const Location& loc, VkPipelineStageFlags2 stage_mask,
+                                               VkDependencyFlags dependency_flags) const;
     bool ValidateAccessMask(const LogObjectList& objlist, const Location& access_mask_loc, const Location& stage_mask_loc,
                             VkQueueFlags queue_flags, VkAccessFlags2KHR access_mask, VkPipelineStageFlags2KHR stage_mask) const;
     bool ValidateMemoryBarrier(const LogObjectList& objlist, const Location& barrier_loc, const vvl::CommandBuffer& cb_state,
@@ -434,14 +436,13 @@ class CoreChecks : public vvl::Device {
 
     bool ValidateRenderPassPipelineStage(VkRenderPass render_pass, const Location& barrier_loc,
                                          VkPipelineStageFlags2 src_stage_mask, VkPipelineStageFlags2 dst_stage_mask) const;
-    bool ValidateRenderPassPipelineBarriers(const Location& loc, const vvl::CommandBuffer& cb_state,
-                                            VkPipelineStageFlags src_stage_mask, VkPipelineStageFlags dst_stage_mask,
-                                            VkDependencyFlags dependency_flags, uint32_t mem_barrier_count,
-                                            const VkMemoryBarrier* mem_barriers, uint32_t buffer_mem_barrier_count,
-                                            const VkBufferMemoryBarrier* buffer_mem_barriers, uint32_t image_mem_barrier_count,
-                                            const VkImageMemoryBarrier* image_barriers) const;
-    bool ValidateRenderPassPipelineBarriers(const Location& loc, const vvl::CommandBuffer& cb_state,
-                                            const VkDependencyInfo& dep_info) const;
+    bool ValidateRenderPassBarriers(const Location& loc, const vvl::CommandBuffer& cb_state, VkPipelineStageFlags src_stage_mask,
+                                    VkPipelineStageFlags dst_stage_mask, VkDependencyFlags dependency_flags,
+                                    uint32_t mem_barrier_count, const VkMemoryBarrier* mem_barriers,
+                                    uint32_t buffer_mem_barrier_count, const VkBufferMemoryBarrier* buffer_mem_barriers,
+                                    uint32_t image_mem_barrier_count, const VkImageMemoryBarrier* image_barriers) const;
+    bool ValidateRenderPassBarriers(const Location& loc, const vvl::CommandBuffer& cb_state,
+                                    const VkDependencyInfo& dep_info) const;
 
     bool ValidateStageMasksAgainstQueueCapabilities(const LogObjectList& objlist, const Location& stage_mask_loc,
                                                     VkQueueFlags queue_flags, VkPipelineStageFlags2KHR stage_mask) const;

--- a/layers/sync/sync_vuid_maps.cpp
+++ b/layers/sync/sync_vuid_maps.cpp
@@ -1381,36 +1381,36 @@ const std::string &GetQueueSubmitVUID(const Location &loc, SubmitError error) {
     return result;
 }
 
-const std::string &GetShaderTileImageVUID(const Location &loc, ShaderTileImageError error) {
-    static const vvl::unordered_map<ShaderTileImageError, std::vector<Entry>> kShaderTileImageErrors{
-        {ShaderTileImageError::kShaderTileImageFeatureError,
+const std::string &GetDynamicRenderingBarrierVUID(const Location &loc, DynamicRenderingBarrierError error) {
+    static const vvl::unordered_map<DynamicRenderingBarrierError, std::vector<Entry>> kDynamicRenderingBarrierErrors{
+        {DynamicRenderingBarrierError::kFeatureError,
          {
              {Key(Func::vkCmdPipelineBarrier), "VUID-vkCmdPipelineBarrier-None-09553"},
              {Key(Func::vkCmdPipelineBarrier2), "VUID-vkCmdPipelineBarrier2-None-09553"},
          }},
-        {ShaderTileImageError::kShaderTileImageFramebufferSpace,
+        {DynamicRenderingBarrierError::kFramebufferSpace,
          {
              {Key(Func::vkCmdPipelineBarrier), "VUID-vkCmdPipelineBarrier-srcStageMask-09556"},
              {Key(Func::vkCmdPipelineBarrier2), "VUID-vkCmdPipelineBarrier2-srcStageMask-09556"},
          }},
-        {ShaderTileImageError::kShaderTileImageNoBuffersOrImages,
+        {DynamicRenderingBarrierError::kNoBuffersOrImages,
          {
              {Key(Func::vkCmdPipelineBarrier), "VUID-vkCmdPipelineBarrier-None-09554"},
              {Key(Func::vkCmdPipelineBarrier2), "VUID-vkCmdPipelineBarrier2-None-09554"},
          }},
-        {ShaderTileImageError::kShaderTileImageLayout,
+        {DynamicRenderingBarrierError::kImageLayout,
          {
              {Key(Func::vkCmdPipelineBarrier), "VUID-vkCmdPipelineBarrier-image-09555"},
              {Key(Func::vkCmdPipelineBarrier2), "VUID-vkCmdPipelineBarrier2-image-09555"},
          }},
-        {ShaderTileImageError::kShaderTileImageDependencyFlags,
+        {DynamicRenderingBarrierError::kDependencyFlags,
          {
              {Key(Func::vkCmdPipelineBarrier), "VUID-vkCmdPipelineBarrier-dependencyFlags-07891"},
              {Key(Func::vkCmdPipelineBarrier2), "VUID-vkCmdPipelineBarrier2-dependencyFlags-07891"},
          }},
     };
 
-    const auto &result = FindVUID(error, loc, kShaderTileImageErrors);
+    const auto &result = FindVUID(error, loc, kDynamicRenderingBarrierErrors);
     assert(!result.empty());
     if (result.empty()) {
         static const std::string unhandled("UNASSIGNED-CoreChecks-unhandled-barrier-error");

--- a/layers/sync/sync_vuid_maps.h
+++ b/layers/sync/sync_vuid_maps.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2021-2024 The Khronos Group Inc.
- * Copyright (c) 2021-2024 Valve Corporation
- * Copyright (c) 2021-2024 LunarG, Inc.
- * Copyright (C) 2021-2024 Google Inc.
+/* Copyright (c) 2021-2025 The Khronos Group Inc.
+ * Copyright (c) 2021-2025 Valve Corporation
+ * Copyright (c) 2021-2025 LunarG, Inc.
+ * Copyright (C) 2021-2025 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -115,15 +115,15 @@ enum class SubmitError {
 
 const std::string &GetQueueSubmitVUID(const Location &loc, SubmitError error);
 
-enum class ShaderTileImageError {
-    kShaderTileImageFeatureError,
-    kShaderTileImageFramebufferSpace,
-    kShaderTileImageNoBuffersOrImages,
-    kShaderTileImageLayout,
-    kShaderTileImageDependencyFlags,
+enum class DynamicRenderingBarrierError {
+    kFeatureError,
+    kFramebufferSpace,
+    kNoBuffersOrImages,
+    kImageLayout,
+    kDependencyFlags,
 };
 
-const std::string &GetShaderTileImageVUID(const Location &loc, ShaderTileImageError error);
+const std::string &GetDynamicRenderingBarrierVUID(const Location &loc, DynamicRenderingBarrierError error);
 
 const std::string &GetAccessMaskRayQueryVUIDSelector(const Location &loc, const DeviceExtensions &device_extensions);
 


### PR DESCRIPTION
Previously VUIDs for barriers inside dynamic render pass were mostly about Shader Tile Images, but now it is also about Local Read barriers. The common denominator these vuids are about barriers inside Dynamic Render Pass.