### PR TITLE
layers: Fix crash when using not enabled feature

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -334,7 +334,7 @@ class CoreChecks : public vvl::Device {
                                                 uint32_t image_barrier_count) const;
 
     bool ValidatePipelineStageFeatureEnables(const LogObjectList& objlist, const Location& stage_mask_loc,
-                                             VkPipelineStageFlags2KHR stage_mask) const;
+                                             VkPipelineStageFlags2 stage_mask) const;
     bool ValidatePipelineStage(const LogObjectList& objlist, const Location& stage_mask_loc, VkQueueFlags queue_flags,
                                VkPipelineStageFlags2KHR stage_mask) const;
     bool ValidateDynamicRenderingPipelineStage(const LogObjectList& objlist, const Location& loc, VkPipelineStageFlags2 stage_mask,

--- a/layers/sync/sync_utils.cpp
+++ b/layers/sync/sync_utils.cpp
@@ -21,31 +21,32 @@
 namespace sync_utils {
 static constexpr uint32_t kNumPipelineStageBits = sizeof(VkPipelineStageFlags2) * 8;
 
+// IMPORTANT: the features listed here should also be reflected in GetFeatureNameMap()
 VkPipelineStageFlags2 DisabledPipelineStages(const DeviceFeatures &features, const DeviceExtensions &device_extensions) {
     VkPipelineStageFlags2 result = 0;
     if (!features.geometryShader) {
-        result |= VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT;
+        result |= VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT;
     }
     if (!features.tessellationShader) {
-        result |= VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT | VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT;
+        result |= VK_PIPELINE_STAGE_2_TESSELLATION_CONTROL_SHADER_BIT | VK_PIPELINE_STAGE_2_TESSELLATION_EVALUATION_SHADER_BIT;
     }
     if (!features.conditionalRendering) {
-        result |= VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT;
+        result |= VK_PIPELINE_STAGE_2_CONDITIONAL_RENDERING_BIT_EXT;
     }
     if (!features.fragmentDensityMap) {
-        result |= VK_PIPELINE_STAGE_FRAGMENT_DENSITY_PROCESS_BIT_EXT;
+        result |= VK_PIPELINE_STAGE_2_FRAGMENT_DENSITY_PROCESS_BIT_EXT;
     }
     if (!features.transformFeedback) {
-        result |= VK_PIPELINE_STAGE_TRANSFORM_FEEDBACK_BIT_EXT;
+        result |= VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT;
     }
     if (!features.meshShader) {
-        result |= VK_PIPELINE_STAGE_MESH_SHADER_BIT_EXT;
+        result |= VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT;
     }
     if (!features.taskShader) {
-        result |= VK_PIPELINE_STAGE_TASK_SHADER_BIT_EXT;
+        result |= VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT;
     }
     if (!features.attachmentFragmentShadingRate && !features.shadingRateImage) {
-        result |= VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR;
+        result |= VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR;
     }
     if (!features.subpassShading) {
         result |= VK_PIPELINE_STAGE_2_SUBPASS_SHADER_BIT_HUAWEI;
@@ -54,10 +55,10 @@ VkPipelineStageFlags2 DisabledPipelineStages(const DeviceFeatures &features, con
         result |= VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI;
     }
     if (!IsExtEnabled(device_extensions.vk_nv_ray_tracing) && !features.rayTracingPipeline) {
-        result |= VK_PIPELINE_STAGE_RAY_TRACING_SHADER_BIT_KHR;
+        result |= VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR;
     }
     if (!IsExtEnabled(device_extensions.vk_nv_ray_tracing) && !IsExtEnabled(device_extensions.vk_khr_acceleration_structure)) {
-        result |= VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR;
+        result |= VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR;
     }
     if (!features.rayTracingMaintenance1) {
         result |= VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR;

--- a/layers/sync/sync_vuid_maps.cpp
+++ b/layers/sync/sync_vuid_maps.cpp
@@ -29,6 +29,7 @@ using vvl::Func;
 using vvl::Key;
 using vvl::Struct;
 
+// IMPORTANT: this map should be in sync with features enumerated in DisabledPipelineStages()
 const vvl::unordered_map<VkPipelineStageFlags2, std::string> &GetFeatureNameMap() {
     static const vvl::unordered_map<VkPipelineStageFlags2, std::string> feature_name_map{
         {VK_PIPELINE_STAGE_2_GEOMETRY_SHADER_BIT, "geometryShader"},
@@ -39,12 +40,13 @@ const vvl::unordered_map<VkPipelineStageFlags2, std::string> &GetFeatureNameMap(
         {VK_PIPELINE_STAGE_2_TRANSFORM_FEEDBACK_BIT_EXT, "transformFeedback"},
         {VK_PIPELINE_STAGE_2_MESH_SHADER_BIT_EXT, "meshShader"},
         {VK_PIPELINE_STAGE_2_TASK_SHADER_BIT_EXT, "taskShader"},
-        {VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR, "shadingRate"},
-        {VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR, "rayTracing"},
-        {VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR, "rayTracing"},
         {VK_PIPELINE_STAGE_2_SUBPASS_SHADER_BIT_HUAWEI, "subpassShading"},
         {VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI, "invocationMask"},
-    };
+        {VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR, "rayTracing"},
+        {VK_PIPELINE_STAGE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR, "shadingRate"},
+        {VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_BUILD_BIT_KHR, "rayTracing"},
+        {VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR, "rayTracingMaintenance1"},
+        {VK_PIPELINE_STAGE_2_MICROMAP_BUILD_BIT_EXT, "micromap"}};
     return feature_name_map;
 }
 // commonvalidity/pipeline_stage_common.txt
@@ -378,6 +380,12 @@ const std::string &GetBadFeatureVUID(const Location &loc, VkPipelineStageFlags2 
         return FindVUID(loc, GetStageMaskErrorsSubpassShader());
     } else if (bit == VK_PIPELINE_STAGE_2_INVOCATION_MASK_BIT_HUAWEI) {
         return FindVUID(loc, GetStageMaskErrorsInvocationMask());
+    } else if (bit == VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR) {
+        static const std::string missing_rt_maintenance1_feature = "UNASSIGNED-CoreChecks-missing-rayTracingMaintenance1-feature";
+        return missing_rt_maintenance1_feature;
+    } else if (bit == VK_PIPELINE_STAGE_2_MICROMAP_BUILD_BIT_EXT) {
+        static const std::string missing_micromap_feature = "UNASSIGNED-CoreChecks-missing-micromap-feature";
+        return missing_micromap_feature;
     }
 
     const auto &result = FindVUID(bit, loc, GetStageMaskErrorsMap());

--- a/tests/unit/sync_object.cpp
+++ b/tests/unit/sync_object.cpp
@@ -4890,3 +4890,37 @@ TEST_F(NegativeSyncObject, AccessFlags3) {
 
     m_command_buffer.End();
 }
+
+TEST_F(NegativeSyncObject, AccelerationCopyStageWithoutEnabledFeature) {
+    TEST_DESCRIPTION("Use VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR without enabling rayTracingMaintenance1 feature");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_KHR_RAY_TRACING_MAINTENANCE_1_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(Init());
+
+    VkMemoryBarrier2 barrier = vku::InitStructHelper();
+    barrier.srcStageMask = VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR;
+
+    m_command_buffer.Begin();
+    m_errorMonitor->SetDesiredError("UNASSIGNED-CoreChecks-missing-rayTracingMaintenance1-feature");
+    m_command_buffer.Barrier(barrier);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeSyncObject, MicromapBuildStageWithoutEnabledFeature) {
+    TEST_DESCRIPTION("Use VK_PIPELINE_STAGE_2_MICROMAP_BUILD_BIT_EXT without enabling micromap feature");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_EXT_OPACITY_MICROMAP_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(Init());
+
+    VkMemoryBarrier2 barrier = vku::InitStructHelper();
+    barrier.srcStageMask = VK_PIPELINE_STAGE_2_MICROMAP_BUILD_BIT_EXT;
+
+    m_command_buffer.Begin();
+    m_errorMonitor->SetDesiredError("UNASSIGNED-CoreChecks-missing-micromap-feature");
+    m_command_buffer.Barrier(barrier);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9815. 

This fixes crash and reports the missing feature.
@spencer-lunarg  I did not check if there should be a warning during device initialization as suggested here:(https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9815#issuecomment-2762127025). The crash is not related to the suggested check during device creation (just sloppy code).
