### PR TITLE
layers: Remove non-semantic info from SPIR-V if portability enabled

### DIFF
--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
@@ -1140,7 +1140,8 @@ bool GpuShaderInstrumentor::InstrumentShader(const vvl::span<const uint32_t> &in
     module_settings.unsafe_mode = gpuav_settings.unsafe_mode;
     module_settings.print_debug_info = gpuav_settings.debug_print_instrumentation_info;
     module_settings.max_instrumentations_count = gpuav_settings.debug_max_instrumentations_count;
-    module_settings.support_non_semantic_info = IsExtEnabled(extensions.vk_khr_shader_non_semantic_info);
+    module_settings.support_non_semantic_info =
+        IsExtEnabled(extensions.vk_khr_shader_non_semantic_info) && !IsExtEnabled(extensions.vk_khr_portability_subset);
     module_settings.has_bindless_descriptors = instrumentation_dsl.has_bindless_descriptors;
 
     spirv::Module module(input_spirv, debug_report, module_settings, modified_features,


### PR DESCRIPTION
This PR removes non-semantic info from instrumented SPIR-V ouput if `VK_KHR_portability_subset` is enabled.  This is to prevent problems with shader compilers / cross-compilers (e.g. SPIR-V to MSL) and alternative graphics APIs (e.g. Metal) that don't understand SPIR-V non-semantic info.

Thanks to @spencer-lunarg for the solution.  I have simply created a PR with his suggested change and tested with Sascha Willems' _debugprintf_ sample and the Vulkan-Samples _shader_debugprintf_ example on macOS Ventura.  Both samples are now working fine.

Fixes #9819.