### PR TITLE
gpuav: Handle OpInBoundsAccessChain

### DIFF
--- a/layers/gpuav/spirv/descriptor_class_general_buffer_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_class_general_buffer_pass.cpp
@@ -208,13 +208,13 @@ bool DescriptorClassGeneralBufferPass::RequiresInstrumentation(const Function& f
     }
 
     const Instruction* next_access_chain = function.FindInstruction(inst.Operand(0));
-    if (!next_access_chain || next_access_chain->Opcode() != spv::OpAccessChain) {
+    if (!next_access_chain || !next_access_chain->IsNonPtrAccessChain()) {
         return false;
     }
 
     const Variable* variable = nullptr;
     // We need to walk down possibly multiple chained OpAccessChains or OpCopyObject to get the variable
-    while (next_access_chain && next_access_chain->Opcode() == spv::OpAccessChain) {
+    while (next_access_chain && next_access_chain->IsNonPtrAccessChain()) {
         meta.access_chain_insts.push_back(next_access_chain);
         const uint32_t access_chain_base_id = next_access_chain->Operand(0);
         variable = module_.type_manager_.FindVariableById(access_chain_base_id);

--- a/layers/gpuav/spirv/descriptor_class_texel_buffer_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_class_texel_buffer_pass.cpp
@@ -111,14 +111,14 @@ bool DescriptorClassTexelBufferPass::RequiresInstrumentation(const Function& fun
         const Variable* global_var = module_.type_manager_.FindVariableById(load_inst->Operand(0));
         meta.var_inst = global_var ? &global_var->inst_ : nullptr;
     }
-    if (!meta.var_inst || (meta.var_inst->Opcode() != spv::OpAccessChain && meta.var_inst->Opcode() != spv::OpVariable)) {
+    if (!meta.var_inst || (!meta.var_inst->IsNonPtrAccessChain() && meta.var_inst->Opcode() != spv::OpVariable)) {
         return false;
     }
 
     // If OpVariable, access_chain_inst_ is never checked because it should be a direct image access
     meta.access_chain_inst = meta.var_inst;
 
-    if (meta.var_inst->Opcode() == spv::OpAccessChain) {
+    if (meta.var_inst->IsNonPtrAccessChain()) {
         meta.descriptor_index_id = meta.var_inst->Operand(1);
 
         if (meta.var_inst->Length() > 5) {

--- a/layers/gpuav/spirv/descriptor_indexing_oob_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_indexing_oob_pass.cpp
@@ -179,7 +179,7 @@ bool DescriptorIndexingOOBPass::RequiresInstrumentation(const Function& function
         const Variable* variable = nullptr;
         const Instruction* access_chain_inst = function.FindInstruction(inst.Operand(0));
         // We need to walk down possibly multiple chained OpAccessChains or OpCopyObject to get the variable
-        while (access_chain_inst && access_chain_inst->Opcode() == spv::OpAccessChain) {
+        while (access_chain_inst && access_chain_inst->IsNonPtrAccessChain()) {
             const uint32_t access_chain_base_id = access_chain_inst->Operand(0);
             variable = module_.type_manager_.FindVariableById(access_chain_base_id);
             if (variable) {
@@ -257,11 +257,11 @@ bool DescriptorIndexingOOBPass::RequiresInstrumentation(const Function& function
             const Variable* global_var = module_.type_manager_.FindVariableById(load_inst->Operand(0));
             meta.var_inst = global_var ? &global_var->inst_ : nullptr;
         }
-        if (!meta.var_inst || (meta.var_inst->Opcode() != spv::OpAccessChain && meta.var_inst->Opcode() != spv::OpVariable)) {
+        if (!meta.var_inst || (!meta.var_inst->IsNonPtrAccessChain() && meta.var_inst->Opcode() != spv::OpVariable)) {
             return false;
         }
 
-        if (meta.var_inst->Opcode() == spv::OpAccessChain) {
+        if (meta.var_inst->IsNonPtrAccessChain()) {
             array_found = true;
             meta.descriptor_index_id = meta.var_inst->Operand(1);
 
@@ -327,11 +327,11 @@ bool DescriptorIndexingOOBPass::RequiresInstrumentation(const Function& function
             meta.sampler_var_inst = global_var ? &global_var->inst_ : nullptr;
         }
         if (!meta.sampler_var_inst ||
-            (meta.sampler_var_inst->Opcode() != spv::OpAccessChain && meta.sampler_var_inst->Opcode() != spv::OpVariable)) {
+            (!meta.sampler_var_inst->IsNonPtrAccessChain() && meta.sampler_var_inst->Opcode() != spv::OpVariable)) {
             return false;
         }
 
-        if (meta.sampler_var_inst->Opcode() == spv::OpAccessChain) {
+        if (meta.sampler_var_inst->IsNonPtrAccessChain()) {
             array_found = true;
             meta.sampler_descriptor_index_id = meta.sampler_var_inst->Operand(1);
 

--- a/layers/gpuav/spirv/post_process_descriptor_indexing_pass.cpp
+++ b/layers/gpuav/spirv/post_process_descriptor_indexing_pass.cpp
@@ -62,7 +62,7 @@ bool PostProcessDescriptorIndexingPass::RequiresInstrumentation(const Function& 
         const Variable* variable = nullptr;
         const Instruction* access_chain_inst = function.FindInstruction(inst.Operand(0));
         // We need to walk down possibly multiple chained OpAccessChains or OpCopyObject to get the variable
-        while (access_chain_inst && access_chain_inst->Opcode() == spv::OpAccessChain) {
+        while (access_chain_inst && access_chain_inst->IsNonPtrAccessChain()) {
             const uint32_t access_chain_base_id = access_chain_inst->Operand(0);
             variable = module_.type_manager_.FindVariableById(access_chain_base_id);
             if (variable) {
@@ -113,11 +113,11 @@ bool PostProcessDescriptorIndexingPass::RequiresInstrumentation(const Function& 
             const Variable* global_var = module_.type_manager_.FindVariableById(load_inst->Operand(0));
             var_inst = global_var ? &global_var->inst_ : nullptr;
         }
-        if (!var_inst || (var_inst->Opcode() != spv::OpAccessChain && var_inst->Opcode() != spv::OpVariable)) {
+        if (!var_inst || (!var_inst->IsNonPtrAccessChain() && var_inst->Opcode() != spv::OpVariable)) {
             return false;
         }
 
-        if (var_inst->Opcode() == spv::OpAccessChain) {
+        if (var_inst->IsNonPtrAccessChain()) {
             meta.descriptor_index_id = var_inst->Operand(1);
 
             if (var_inst->Length() > 5) {

--- a/layers/state_tracker/shader_instruction.cpp
+++ b/layers/state_tracker/shader_instruction.cpp
@@ -183,6 +183,11 @@ spv::BuiltIn Instruction::GetBuiltIn() const {
 
 bool Instruction::IsArray() const { return (Opcode() == spv::OpTypeArray || Opcode() == spv::OpTypeRuntimeArray); }
 
+bool Instruction::IsNonPtrAccessChain() const {
+    const uint32_t opcode = Opcode();
+    return opcode == spv::OpAccessChain || opcode == spv::OpInBoundsAccessChain;
+}
+
 bool Instruction::IsAccessChain() const {
     const uint32_t opcode = Opcode();
     return opcode == spv::OpAccessChain || opcode == spv::OpPtrAccessChain || opcode == spv::OpInBoundsAccessChain ||

--- a/layers/state_tracker/shader_instruction.h
+++ b/layers/state_tracker/shader_instruction.h
@@ -75,6 +75,7 @@ class Instruction {
     spv::BuiltIn GetBuiltIn() const;
     uint32_t GetPositionIndex() const { return position_index_; }
     bool IsArray() const;
+    bool IsNonPtrAccessChain() const;
     bool IsAccessChain() const;
     // Helpers for OpTypeImage
     spv::Dim FindImageDim() const;


### PR DESCRIPTION
We didn't handle `OpInBoundsAccessChain`, which are just `OpAccessChain` but known to be bounded statically (bounded as in they don't point outside the struct, not the memory that GPU-AV is checking)