### PR TITLE
layers: Small cleanup of SPIR-V helpers

### DIFF
--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -201,7 +201,7 @@ static void TypeToDescriptorTypeSet(const spirv::Module &module_state, uint32_t 
     switch (type->Opcode()) {
         case spv::OpTypeStruct: {
             for (const spirv::Instruction *insn : module_state.static_data_.decoration_inst) {
-                if (insn->Word(1) == type->Word(1)) {
+                if (insn->Word(1) == type->ResultId()) {
                     if (insn->Word(2) == spv::DecorationBlock) {
                         if (is_storage_buffer) {
                             descriptor_type_set.insert(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
@@ -453,7 +453,7 @@ bool CoreChecks::ValidateCooperativeMatrix(const spirv::Module &module_state, co
         const spirv::Instruction &insn = *cooperative_matrix_inst;
         switch (insn.Opcode()) {
             case spv::OpTypeCooperativeMatrixKHR: {
-                CoopMatType m(insn.Word(1), module_state, stage_state, IsSignedIntType(insn.Word(2)));
+                CoopMatType m(insn.ResultId(), module_state, stage_state, IsSignedIntType(insn.Word(2)));
 
                 if ((entrypoint.stage & VK_SHADER_STAGE_COMPUTE_BIT) != 0) {
                     if (SafeModulo(local_size_x, phys_dev_props_core11.subgroupSize) != 0) {
@@ -682,7 +682,7 @@ bool CoreChecks::ValidateCooperativeMatrix(const spirv::Module &module_state, co
                 break;
             }
             case spv::OpTypeCooperativeMatrixNV: {
-                CoopMatType m(insn.Word(1), module_state, stage_state, IsSignedIntType(insn.Word(2)));
+                CoopMatType m(insn.ResultId(), module_state, stage_state, IsSignedIntType(insn.Word(2)));
 
                 if (!m.all_constant) {
                     break;

--- a/layers/gpuav/spirv/vertex_attribute_fetch_oob.cpp
+++ b/layers/gpuav/spirv/vertex_attribute_fetch_oob.cpp
@@ -41,7 +41,7 @@ bool VertexAttributeFetchOob::Instrument() {
         const uint32_t vertex_shader_entry_point_id = entry_point_inst->Word(2);
         for (const auto& function : module_.functions_) {
             if (function->instrumentation_added_) continue;
-            const uint32_t function_id = function->GetDef().Word(2);
+            const uint32_t function_id = function->GetDef().ResultId();
             if (vertex_shader_entry_point_id != function_id) continue;
 
             BasicBlock& first_block = function->GetFirstBlock();

--- a/layers/state_tracker/shader_instruction.cpp
+++ b/layers/state_tracker/shader_instruction.cpp
@@ -202,8 +202,6 @@ spv::StorageClass Instruction::StorageClass() const {
     spv::StorageClass storage_class = spv::StorageClassMax;
     switch (Opcode()) {
         case spv::OpTypePointer:
-            storage_class = static_cast<spv::StorageClass>(Word(2));
-            break;
         case spv::OpTypeForwardPointer:
             storage_class = static_cast<spv::StorageClass>(Word(2));
             break;

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -694,8 +694,6 @@ struct Module {
         return (it != static_data_.execution_modes.end()) ? it->second : static_data_.empty_execution_mode;
     }
 
-    std::shared_ptr<const TypeStructInfo> GetTypeStructInfo(uint32_t struct_id) const;
-    // Overload to walk down and find the OpTypeStruct
     std::shared_ptr<const TypeStructInfo> GetTypeStructInfo(const Instruction *insn) const;
 
     // Used to get human readable strings for error messages

--- a/layers/stateless/sl_spirv.cpp
+++ b/layers/stateless/sl_spirv.cpp
@@ -480,7 +480,7 @@ bool SpirvValidator::ValidateShaderStorageImageFormatsVariables(const spirv::Mod
             return skip;
         }
 
-        const uint32_t var_id = insn.Word(2);
+        const uint32_t var_id = insn.ResultId();
         const auto decorations = module_state.GetDecorationSet(var_id);
 
         if (!enabled_features.shaderStorageImageReadWithoutFormat && !decorations.Has(spirv::DecorationSet::nonreadable_bit)) {


### PR DESCRIPTION
Small cleanup to use things like `ResultId()` and `TypeId()` helper where possible for future extension to apply easier