### PR TITLE
layers: Track semaphore is in use by swapchain

### DIFF
--- a/layers/state_tracker/fence_state.h
+++ b/layers/state_tracker/fence_state.h
@@ -21,12 +21,14 @@
 
 #include "state_tracker/state_object.h"
 #include "state_tracker/submission_reference.h"
+#include "containers/span.h"
 #include <optional>
 #include <future>
 
 class Logger;
 
 namespace vvl {
+class Semaphore;
 class Queue;
 
 class Fence : public RefcountedStateObject {
@@ -65,7 +67,11 @@ class Fence : public RefcountedStateObject {
     void Export(VkExternalFenceHandleTypeFlagBits handle_type);
     std::optional<VkExternalFenceHandleTypeFlagBits> ImportedHandleType() const;
 
+    // Called on AcquireNextImage fence
     void SetPresentSubmissionRef(const SubmissionReference &present_submission_ref);
+
+    // Called on VkSwapchainPresentFenceInfoEXT fence
+    void SetPresentWaitSemaphores(vvl::span<std::shared_ptr<vvl::Semaphore>> present_wait_semaphores);
 
     const VkFenceCreateFlags flags;
     const VkExternalFenceHandleTypeFlags export_handle_types;
@@ -101,6 +107,8 @@ class Fence : public RefcountedStateObject {
     // submit batch from step e) and also to ensure that the semaphore from step e) is no longer in use.
     //
     std::optional<SubmissionReference> present_submission_ref_;
+
+    small_vector<std::shared_ptr<vvl::Semaphore>, 1> present_wait_semaphores_;
 };
 
 }  // namespace vvl

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -329,6 +329,8 @@ class ImageView : public StateObject {
 
 struct SwapchainImage {
     vvl::Image *image_state = nullptr;
+
+    // Acquire state
     bool acquired = false;
     std::shared_ptr<vvl::Semaphore> acquire_semaphore;
     std::shared_ptr<vvl::Fence> acquire_fence;
@@ -336,6 +338,10 @@ struct SwapchainImage {
     // Queue location (seq) for present operation that presented this image.
     // When this image is reacquired, the acquire fence can synchronize with this location.
     std::optional<SubmissionReference> present_submission_ref;
+
+    // Wait semaphores from the presentation request
+    small_vector<std::shared_ptr<vvl::Semaphore>, 1> present_wait_semaphores;
+    void ResetPresentWaitSemaphores();
 };
 
 // State for VkSwapchainKHR objects.
@@ -369,7 +375,8 @@ class Swapchain : public StateObject, public SubStateManager<SwapchainSubState> 
 
     VkSwapchainKHR VkHandle() const { return handle_.Cast<VkSwapchainKHR>(); }
 
-    void PresentImage(uint32_t image_index, uint64_t present_id, const SubmissionReference &present_submission_ref);
+    void PresentImage(uint32_t image_index, uint64_t present_id, const SubmissionReference &present_submission_ref,
+                      vvl::span<std::shared_ptr<vvl::Semaphore>> present_wait_semaphores);
 
     void ReleaseImage(uint32_t image_index);
 

--- a/layers/state_tracker/semaphore_state.cpp
+++ b/layers/state_tracker/semaphore_state.cpp
@@ -430,6 +430,16 @@ void vvl::Semaphore::RetireSignal(uint64_t payload) {
     RetireTimePoint(payload, completed_op, completed_submit);
 }
 
+void vvl::Semaphore::SetInUseBySwapchain(bool in_use_by_swapchain) {
+    auto guard = WriteLock();
+    in_use_by_swapchain_ = in_use_by_swapchain;
+}
+
+bool vvl::Semaphore::IsInUseBySwapchain() const {
+    auto guard = ReadLock();
+    return in_use_by_swapchain_;
+}
+
 void vvl::Semaphore::RetireTimePoint(uint64_t payload, OpType completed_op, SubmissionReference completed_submit) {
     auto it = timeline_.begin();
     while (it != timeline_.end() && it->first <= payload) {

--- a/layers/state_tracker/semaphore_state.h
+++ b/layers/state_tracker/semaphore_state.h
@@ -103,6 +103,9 @@ class Semaphore : public RefcountedStateObject {
     // Process signal by retiring timeline timepoints up to the specified payload
     void RetireSignal(uint64_t payload);
 
+    void SetInUseBySwapchain(bool in_use_by_swapchain);
+    bool IsInUseBySwapchain() const;
+
     // Look for most recent / highest payload operation that matches
     std::optional<SemOp> LastOp(const std::function<bool(OpType op_type, uint64_t payload, bool is_pending)> &filter) const;
 
@@ -164,8 +167,13 @@ class Semaphore : public RefcountedStateObject {
 
     // the most recently completed operation
     SemOp completed_;
+
     // next payload value for binary semaphore operations
     uint64_t next_payload_;
+
+    // True, if this semaphore was used in QueuePresent but has not been re-acquired yet
+    // and the presentation fence (if provided) has not been waited on.
+    bool in_use_by_swapchain_ = false;
 
     // Set of pending operations ordered by payload.
     // Timeline operations can be added in any order and multiple wait operations

--- a/tests/unit/wsi.cpp
+++ b/tests/unit/wsi.cpp
@@ -4467,3 +4467,32 @@ TEST_F(NegativeWsi, SwapchainUseAfterDestroy) {
         m_errorMonitor->VerifyFound();
     }
 }
+
+TEST_F(NegativeWsi, SignalPresentSemaphore) {
+    TEST_DESCRIPTION("Signal present wait semaphore after presentation and before corresponding image was re-acquired");
+    AddSurfaceExtension();
+    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitSwapchain());
+    const auto swapchain_images = m_swapchain.GetImages();
+    for (auto image : swapchain_images) {
+        SetImageLayoutPresentSrc(image);
+    }
+
+    vkt::Semaphore acquire_semaphore(*m_device);
+    uint32_t image_index = m_swapchain.AcquireNextImage(acquire_semaphore, kWaitTimeout);
+
+    vkt::Semaphore present_semaphore(*m_device);
+    // Signal present semaphore
+    m_default_queue->Submit(vkt::no_cmd, vkt::Wait(acquire_semaphore), vkt::Signal(present_semaphore));
+    // Wait on present semaphore
+    m_default_queue->Present(m_swapchain, image_index, present_semaphore);
+
+    // The queue operations associated with the presentation request can still be in flight.
+    // Presentation does not postpone execution of other commands, so the following signal
+    // can happen before the previous wait finished.
+    m_errorMonitor->SetDesiredError("VUID-vkQueueSubmit-pSignalSemaphores-00067");
+    m_default_queue->Submit(vkt::no_cmd, vkt::Signal(present_semaphore));
+    m_errorMonitor->VerifyFound();
+
+    m_default_queue->Wait();
+}


### PR DESCRIPTION
Addresses https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9802

The main idea is to set a boolean flag as part of the semaphore state between QueuePresent and the next AcquireNextImage that returns the same image. If any QueueSubmit uses this semaphore as a signal and the semaphore's flag is set then it means  it can still be used by the presentation.