### PR TITLE
corechecks: Fix bad instance cast

### DIFF
--- a/layers/core_checks/cc_wsi.cpp
+++ b/layers/core_checks/cc_wsi.cpp
@@ -1507,7 +1507,7 @@ bool CoreChecks::PreCallValidateGetDeviceGroupSurfacePresentModesKHR(VkDevice de
                                                                      VkDeviceGroupPresentModeFlagsKHR *pModes,
                                                                      const ErrorObject &error_obj) const {
     bool skip = false;
-    const auto *core_instance = reinterpret_cast<core::Instance *>(instance_state);
+    const auto *core_instance = static_cast<core::Instance *>(instance_proxy);
     if (device_state->physical_device_count == 1) {
         skip |= core_instance->ValidatePhysicalDeviceSurfaceSupport(
             physical_device, surface, "VUID-vkGetDeviceGroupSurfacePresentModesKHR-surface-06212", error_obj.location);

--- a/tests/unit/wsi_positive.cpp
+++ b/tests/unit/wsi_positive.cpp
@@ -2286,3 +2286,12 @@ TEST_F(PositiveWsi, SignalPresentSemaphoreAfterFenceWait) {
 
     m_default_queue->Wait();
 }
+
+TEST_F(PositiveWsi, GetDeviceGroupSurfacePresentModes) {
+    AddSurfaceExtension();
+    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitSwapchain());
+
+    VkDeviceGroupPresentModeFlagsKHR present_mode_flags;
+    vk::GetDeviceGroupSurfacePresentModesKHR(m_device->handle(), m_surface.Handle(), &present_mode_flags);
+}


### PR DESCRIPTION
CoreChecks::PreCallValidateGetDeviceGroupSurfacePresentModesKHR wants to call a validation method in the core::Instance class but it was using instance_state, which is the state tracker instead of in instance_proxy which is the core::Instance object. Bleah.

Fixes #9854