### PR TITLE
gpuav: Move pre pass out of RequiresInstrumentation

### DIFF
--- a/layers/gpuav/spirv/pass.h
+++ b/layers/gpuav/spirv/pass.h
@@ -63,6 +63,9 @@ class Pass {
     uint32_t FindTypeByteSize(uint32_t type_id, uint32_t matrix_stride = 0, bool col_major = false, bool in_matrix = false) const;
     uint32_t GetLastByte(const Type& descriptor_type, const std::vector<const Instruction*>& access_chain_insts, BasicBlock& block,
                          InstructionIt* inst_it);
+    uint32_t FindOffsetInStruct(uint32_t struct_id, bool is_descriptor_array,
+                                const std::vector<const Instruction*>& access_chain_insts) const;
+
     // Generate SPIR-V needed to help convert things to be uniformly uint32_t
     // If no inst_it is passed in, any new instructions will be added to end of the Block
     uint32_t ConvertTo32(uint32_t id, BasicBlock& block, InstructionIt* inst_it) const;


### PR DESCRIPTION
1. Moves `FindLastByteOffset` to `FindOffsetInStruct` in `Pass` so BDA can use it in my next PR
2. Redid things so we don't need to awkwardly pass in `bool pre_pass` which was clumsy 