### PR TITLE
layers: Update semaphore in use by swapchain error message

### DIFF
--- a/layers/state_tracker/fence_state.cpp
+++ b/layers/state_tracker/fence_state.cpp
@@ -86,7 +86,7 @@ void vvl::Fence::NotifyAndWait(const Location &loc) {
             present_submission_ref_.reset();
 
             for (auto &semaphore : present_wait_semaphores_) {
-                semaphore->SetInUseBySwapchain(false);
+                semaphore->ClearSwapchainWaitInfo();
             }
             present_wait_semaphores_.clear();
         }

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -365,6 +365,11 @@ class Swapchain : public StateObject, public SubStateManager<SwapchainSubState> 
     DeviceState &dev_data;
     uint32_t acquired_images = 0;
 
+    // Image acquire history
+    static constexpr uint32_t acquire_history_max_length = 16;
+    std::array<uint32_t, acquire_history_max_length> acquire_history;  // ring buffer contanis the last acquired images
+    uint32_t acquire_count = 0;                                        // total number of image acquire requests
+
     Swapchain(DeviceState &dev_data, const VkSwapchainCreateInfoKHR *pCreateInfo, VkSwapchainKHR handle);
 
     ~Swapchain() {
@@ -388,6 +393,9 @@ class Swapchain : public StateObject, public SubStateManager<SwapchainSubState> 
     SwapchainImage GetSwapChainImage(uint32_t index) const;
 
     std::shared_ptr<const vvl::Image> GetSwapChainImageShared(uint32_t index) const;
+
+    uint32_t GetAcquireHistoryLength() const;
+    uint32_t GetAcquiredImageIndexFromHistory(uint32_t acquire_history_index) const;
 
     std::shared_ptr<const Swapchain> shared_from_this() const { return SharedFromThisImpl(this); }
     std::shared_ptr<Swapchain> shared_from_this() { return SharedFromThisImpl(this); }


### PR DESCRIPTION
Follow up of https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/9840.
This tracks the history of the last few acquired swapchain images and uses this information to provide more informative error message to more clearly demonstrate the problem. The history of the acquired images can also be useful for debuggign swapchain issues.

Use case of swapchain with many images:
```
vkQueueSubmit(): pSubmits[0].pSignalSemaphores[0] (VkSemaphore 0x2afc0000002afc) is being signaled by VkQueue 0x14575689330, but it may still be in use by VkSwapchainKHR 0x1940000000194.

Here are the last 6 acquired image indices (brackets mark the last use of VkSemaphore 0x2afc0000002afc in a presentation operation): 0, 1, 2, [3], 4, 0.
Swapchain image 3 was presented but not re-acquired, so VkSemaphore 0x2afc0000002afc may still be in use and cannot be safely reused with image index 0.

Vulkan insight: One solution is to assign each image its own semaphore.
Here are common methods to ensure that a semaphore passed to vkQueuePresentKHR is not in use and can be safely reused:
	a) Use a separate semaphore per swapchain image. Index these semaphores using the index of the acquired image.
	b) Consider the VK_EXT_swapchain_maintenance1 extension. It allows using a VkFence with the presentation operation.
```

Use case when AcquireNextImage can return the same index few times in a row (windows nvidia drivers):
```
vkQueueSubmit2(): pSubmits[0].pSignalSemaphoreInfos[0].semaphore (VkSemaphore 0x50000000005) is being signaled by VkQueue 0x1d3b292e720, but it may still be in use by VkSwapchainKHR 0xb000000000b.

Here are the last 8 acquired image indices (brackets mark the last use of VkSemaphore 0x50000000005 in a presentation operation): 1, 0, 1, 0, 1, [0], 1, 1.
Swapchain image 0 was presented but not re-acquired, so VkSemaphore 0x50000000005 may still be in use and cannot be safely reused with image index 1.

Vulkan insight: One solution is to assign each image its own semaphore. This also handles the case where vkAcquireNextImageKHR returns the same index twice in a row.
Here are common methods to ensure that a semaphore passed to vkQueuePresentKHR is not in use and can be safely reused:
        a) Use a separate semaphore per swapchain image. Index these semaphores using the index of the acquired image.
        b) Consider the VK_EXT_swapchain_maintenance1 extension. It allows using a VkFence with the presentation operation.

```