### PR TITLE
gpuav: Reduce BDA when statically can detect range

### DIFF
--- a/tests/unit/gpu_av_buffer_device_address_positive.cpp
+++ b/tests/unit/gpu_av_buffer_device_address_positive.cpp
@@ -2328,9 +2328,11 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, ManyAccessToSameStruct) {
 
 // Used to test large accesses to a single struct from a single pointer
 // If on Mesa, also add MESA_SHADER_CACHE_DISABLE=1
-TEST_F(PositiveGpuAVBufferDeviceAddress, DISABLED_Stress) {
+TEST_F(PositiveGpuAVBufferDeviceAddress, Stress) {
+    // About a 5x speed up to run in unsafe mode
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress(false));
     InitRenderTarget();
+    const uint32_t count = 32;
 
     std::stringstream cs_source;
     cs_source << R"glsl(
@@ -2357,7 +2359,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, DISABLED_Stress) {
             // ptr.x = a;
     )glsl";
 
-    for (uint32_t i = 0; i < 512; i += 3) {
+    for (uint32_t i = 0; i < count; i += 3) {
         cs_source << "a += fma(vec3(ptr.payload[" << i << "].x, ptr.payload[" << i << "].y, ptr.payload[" << i << "].z), ";
         cs_source << "vec3(ptr.payload[" << i + 1 << "].x, ptr.payload[" << i + 1 << "].y, ptr.payload[" << i + 1 << "].z), ";
         cs_source << "vec3(ptr.payload[" << i + 2 << "].x, ptr.payload[" << i + 2 << "].y, ptr.payload[" << i + 2 << "].z));\n";


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9725

We found shaders that would look "like"

```glsl
layout(buffer_reference) buffer BDA {
    uint x[4096];
};

void main() {
    BDA ptr;
    ptr.x[4] = ptr.x[8] + ptr.x[12]
}
```

and our check would look like

```glsl
inst_bda(ptr + 6, 4);
inst_bda(ptr + 8, 4);
inst_bda(ptr + 12, 4);
ptr.x[6] = ptr.x[8] + ptr.x[12]
```

and would easily get 500+ instrumentation in a single shader, but just getting the being/end range statically it will now look like

```glsl
inst_bda(ptr + 6, 28); // covers range from x[4] to x[12]
ptr.x[6] = ptr.x[8] + ptr.x[12]
```

I got `PositiveGpuAVBufferDeviceAddress.Stress` down from 2 minutes to 0.3 seconds with this

I have a fossilize of the 5 worst pipeline in a large trace, it went from single-threaded 15.2 seconds down to 3 seconds