### PR TITLE
chassis: Fix Device and Instance destroy order

### DIFF
--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -755,6 +755,15 @@ void SyncValidator::FinishDeviceSetup(const VkDeviceCreateInfo *pCreateInfo, con
     text::ToLower(debug_cmdbuf_pattern);
 }
 
+void SyncValidator::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks *pAllocator,
+                                               const RecordObject &record_obj) {
+    queue_sync_states_.clear();
+    binary_signals_.clear();
+    timeline_signals_.clear();
+    waitable_fences_.clear();
+    host_waitable_semaphores_.clear();
+}
+
 void SyncValidator::PostCallRecordCreateSemaphore(VkDevice device, const VkSemaphoreCreateInfo *pCreateInfo,
                                                   const VkAllocationCallbacks *pAllocator, VkSemaphore *pSemaphore,
                                                   const RecordObject &record_obj) {

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -142,6 +142,9 @@ class SyncValidator : public vvl::DeviceProxy, public SyncStageAccess {
 
     void FinishDeviceSetup(const VkDeviceCreateInfo *pCreateInfo, const Location &loc) override;
 
+    void PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator,
+                                    const RecordObject& record_obj) override;
+
     void PostCallRecordCreateSemaphore(VkDevice device, const VkSemaphoreCreateInfo *pCreateInfo,
                                        const VkAllocationCallbacks *pAllocator, VkSemaphore *pSemaphore,
                                        const RecordObject &record_obj) override;


### PR DESCRIPTION
Make sure the state tracker runs last in vkDestroyDevice() and vkDestroyInstance().

Make sure syncval cleans up its custom state tracking in vkDestroyDevice().