### PR TITLE
gpuav: Warn on reaching max actions cmd validation

### DIFF
--- a/layers/gpuav/core/gpuav_record.cpp
+++ b/layers/gpuav/core/gpuav_record.cpp
@@ -378,14 +378,20 @@ void Validator::PreCallRecordCmdBindDescriptorBufferEmbeddedSamplers2EXT(
 // Common logic before any draw/dispatch/traceRays
 void Validator::PreCallActionCommand(Validator &gpuav, CommandBufferSubState &cb_state, VkPipelineBindPoint bind_point,
                                      const Location &loc) {
+    if (cb_state.max_actions_cmd_validation_reached_) {
+        return;
+    }
     PreCallSetupShaderInstrumentationResources(gpuav, cb_state, bind_point, loc);
 }
 
 // Common logic after any draw/dispatch/traceRays
 void Validator::PostCallActionCommand(Validator &gpuav, CommandBufferSubState &cb_state, VkPipelineBindPoint bind_point,
                                       const Location &loc) {
+    if (cb_state.max_actions_cmd_validation_reached_) {
+        return;
+    }
     PostCallSetupShaderInstrumentationResources(gpuav, cb_state, bind_point, loc);
-    cb_state.IncrementCommandCount(bind_point);
+    cb_state.IncrementCommandCount(gpuav, bind_point, loc);
 }
 
 void Validator::PreCallRecordCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount,

--- a/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
@@ -439,16 +439,24 @@ void UpdateInstrumentationDescSet(Validator &gpuav, CommandBufferSubState &cb_st
 
 void PreCallSetupShaderInstrumentationResources(Validator &gpuav, CommandBufferSubState &cb_state, VkPipelineBindPoint bind_point,
                                                 const Location &loc) {
-    if (!gpuav.gpuav_settings.IsSpirvModified()) return;
+    if (!gpuav.gpuav_settings.IsSpirvModified()) {
+        return;
+    }
 
     assert(bind_point == VK_PIPELINE_BIND_POINT_GRAPHICS || bind_point == VK_PIPELINE_BIND_POINT_COMPUTE ||
            bind_point == VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR);
+
+    if (cb_state.max_actions_cmd_validation_reached_) {
+        return;
+    }
 
     const auto lv_bind_point = ConvertToLvlBindPoint(bind_point);
     const LastBound &last_bound = cb_state.base.lastBound[lv_bind_point];
 
     // If nothing was updated, we don't want to bind anything
-    if (!last_bound.WasInstrumented()) return;
+    if (!last_bound.WasInstrumented()) {
+        return;
+    }
 
     if (!last_bound.pipeline_state && !last_bound.HasShaderObjects()) {
         gpuav.InternalError(cb_state.VkHandle(), loc, "Neither pipeline state nor shader object states were found.");

--- a/layers/gpuav/resources/gpuav_state_trackers.h
+++ b/layers/gpuav/resources/gpuav_state_trackers.h
@@ -63,6 +63,7 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     VkBuffer post_process_buffer_lut = VK_NULL_HANDLE;
 
     // Used to track which spot in the command buffer the error came from
+    bool max_actions_cmd_validation_reached_ = false;
     uint32_t draw_index = 0;
     uint32_t compute_index = 0;
     uint32_t trace_rays_index = 0;
@@ -111,7 +112,7 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
 
     const vko::Buffer &GetBdaRangesSnapshot() const { return bda_ranges_snapshot_; }
 
-    void IncrementCommandCount(VkPipelineBindPoint bind_point);
+    void IncrementCommandCount(Validator &gpuav, VkPipelineBindPoint bind_point, const Location &loc);
 
     std::string GetDebugLabelRegion(uint32_t label_command_i, const std::vector<std::string> &initial_label_stack) const;
 
@@ -142,7 +143,6 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     [[nodiscard]] bool UpdateBdaRangesBuffer(const Location &loc);
 
     Validator &state_;
-
     VkDescriptorSetLayout instrumentation_desc_set_layout_ = VK_NULL_HANDLE;
 
     VkDescriptorSetLayout error_logging_desc_set_layout_ = VK_NULL_HANDLE;

--- a/layers/gpuav/shaders/gpuav_shaders_constants.h
+++ b/layers/gpuav/shaders/gpuav_shaders_constants.h
@@ -135,7 +135,7 @@ const uint kShaderIdMask = 0x3FFFF;
 //
 // We make some assumptions from profiling that we can maintain these limits and squeeze all this information in a single dword
 // these values are asserted for and can be adjusted if we edge cases that matter
-const uint kMaxActionsPerCommandBuffer = 1u << 13;  // 8k
+const uint kMaxActionsPerCommandBuffer = 1u << 13;  // 8,192
 // We use a single bit mark if this descriptor was accessed or not
 const uint kPostProcessMetaMaskAccessed = 1u << 31;
 const uint kPostProcessMetaShiftActionIndex = 18;

--- a/layers/gpuav/validation_cmd/gpuav_copy_buffer_to_image.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_copy_buffer_to_image.cpp
@@ -147,6 +147,10 @@ void InsertCopyBufferToImageValidation(Validator &gpuav, const Location &loc, Co
         return;
     }
 
+    if (cb_state.max_actions_cmd_validation_reached_) {
+        return;
+    }
+
     auto image_state = gpuav.Get<vvl::Image>(copy_buffer_to_img_info->dstImage);
     if (!image_state) {
         gpuav.InternalError(cb_state.VkHandle(), loc, "AllocatePreCopyBufferToImageValidationResources: Unrecognized image.");

--- a/layers/gpuav/validation_cmd/gpuav_dispatch.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_dispatch.cpp
@@ -149,6 +149,10 @@ void InsertIndirectDispatchValidation(Validator &gpuav, const Location &loc, Com
         return;
     }
 
+    if (cb_state.max_actions_cmd_validation_reached_) {
+        return;
+    }
+
     // Insert a dispatch that can examine some device memory right before the dispatch we're validating
     //
     // NOTE that this validation does not attempt to abort invalid api calls as most other validation does. A crash

--- a/layers/gpuav/validation_cmd/gpuav_draw.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_draw.cpp
@@ -235,7 +235,13 @@ void FirstInstance(Validator &gpuav, CommandBufferSubState &cb_state, const Loca
         return;
     }
 
-    if (gpuav.enabled_features.drawIndirectFirstInstance) return;
+    if (gpuav.enabled_features.drawIndirectFirstInstance) {
+        return;
+    }
+
+    if (cb_state.max_actions_cmd_validation_reached_) {
+        return;
+    }
 
     ValidationCommandFunc validation_cmd = [api_buffer, api_offset, api_stride, first_instance_member_pos, api_draw_count,
                                             api_count_buffer, api_count_buffer_offset, draw_i = cb_state.draw_index,
@@ -429,6 +435,10 @@ void CountBuffer(Validator &gpuav, CommandBufferSubState &cb_state, const Locati
         return;
     }
 
+    if (cb_state.max_actions_cmd_validation_reached_) {
+        return;
+    }
+
     auto draw_buffer_state = gpuav.Get<vvl::Buffer>(api_buffer);
     if (!draw_buffer_state) {
         gpuav.InternalError(LogObjectList(cb_state.VkHandle(), api_buffer), loc, "buffer must be a valid VkBuffer handle");
@@ -584,6 +594,10 @@ void DrawMeshIndirect(Validator &gpuav, CommandBufferSubState &cb_state, const L
                       VkDeviceSize api_offset, uint32_t api_stride, VkBuffer api_count_buffer, VkDeviceSize api_count_buffer_offset,
                       uint32_t api_draw_count) {
     if (!gpuav.gpuav_settings.validate_indirect_draws_buffers) {
+        return;
+    }
+
+    if (cb_state.max_actions_cmd_validation_reached_) {
         return;
     }
 
@@ -896,6 +910,10 @@ void DrawIndexedIndirectIndexBuffer(Validator &gpuav, CommandBufferSubState &cb_
                 return;
             }
         }
+    }
+
+    if (cb_state.max_actions_cmd_validation_reached_) {
+        return;
     }
 
     if (!cb_state.base.IsPrimary()) {

--- a/layers/gpuav/validation_cmd/gpuav_trace_rays.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_trace_rays.cpp
@@ -207,6 +207,11 @@ void InsertIndirectTraceRaysValidation(Validator& gpuav, const Location& loc, Co
     if (!gpuav.modified_features.shaderInt64) {
         return;
     }
+
+    if (cb_state.max_actions_cmd_validation_reached_) {
+        return;
+    }
+
     auto& shared_trace_rays_resources =
         gpuav.shared_resources_manager.Get<SharedTraceRaysValidationResources>(gpuav, cb_state.GetErrorLoggingDescSetLayout(), loc);
 

--- a/tests/unit/gpu_av_descriptor_class_general_buffer.cpp
+++ b/tests/unit/gpu_av_descriptor_class_general_buffer.cpp
@@ -23,6 +23,79 @@ class NegativeGpuAVDescriptorClassGeneralBuffer : public GpuAVDescriptorClassGen
                               std::vector<const char *> expected_errors, bool shader_objects = false);
 };
 
+TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, ReachMaxActionsCommandValidationLimit) {
+    TEST_DESCRIPTION(
+        "Within a single command buffer, add a number of draws that goes above the glsl::kMaxActionsPerCommandBuffer GPU-AV limit. "
+        "Expect a warning.");
+    AddRequiredExtensions(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::nullDescriptor);
+    AddRequiredFeature(vkt::Feature::vertexPipelineStoresAndAtomics);
+
+    RETURN_IF_SKIP(InitGpuAvFramework());
+    RETURN_IF_SKIP(InitState());
+    InitRenderTarget();
+    vkt::Buffer offset_buffer(*m_device, 4, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
+    vkt::Buffer write_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
+    vkt::Buffer storage_texel_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT, kHostVisibleMemProps);
+    vkt::BufferView storage_buffer_view(*m_device, storage_texel_buffer, VK_FORMAT_R32_SFLOAT);
+
+    OneOffDescriptorSet descriptor_set(m_device, {{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
+                                                  {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
+                                                  {2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
+                                                  {3, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}});
+
+    const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
+    descriptor_set.WriteDescriptorBufferInfo(0, offset_buffer.handle(), 0, 4);
+    descriptor_set.WriteDescriptorBufferInfo(1, write_buffer.handle(), 0, 16, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    descriptor_set.WriteDescriptorBufferInfo(2, VK_NULL_HANDLE, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    descriptor_set.WriteDescriptorBufferView(3, storage_buffer_view.handle(), VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER);
+    descriptor_set.UpdateDescriptorSets();
+    const char vs_source[] = R"glsl(
+        #version 450
+        layout(set = 0, binding = 0) uniform ufoo { uint index[]; } u_index;      // index[1]
+        layout(set = 0, binding = 1) buffer StorageBuffer { uint data[]; } Data;  // data[4]
+        layout(set = 0, binding = 2) buffer NullBuffer { uint data[]; } Null;     // VK_NULL_HANDLE
+        layout(set = 0, binding = 3, r32f) uniform imageBuffer s_buffer;          // texel_buffer[4]
+        void main() {
+        vec4 x;
+        if (u_index.index[0] == 1) {
+        Data.data[0] = Null.data[40];
+        }
+        else if (u_index.index[0] == 2) {
+        imageStore(s_buffer, 0, x);
+        }
+        else if (u_index.index[0] == 3) {
+        x = imageLoad(s_buffer, 0);
+        }
+        }
+        )glsl";
+
+    VkShaderObj vs(this, vs_source, VK_SHADER_STAGE_VERTEX_BIT);
+    CreatePipelineHelper pipe(*this);
+    pipe.shader_stages_[0] = vs.GetStageCreateInfo();
+    pipe.gp_ci_.layout = pipeline_layout.handle();
+    pipe.CreateGraphicsPipeline();
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
+    vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
+    vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
+                              &descriptor_set.set_, 0, nullptr);
+    m_errorMonitor->SetDesiredWarning("GPU-AV::Max action per command buffer reached");
+    for (uint32_t i = 0; i < 10'000; ++i) {
+        vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
+    }
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+
+    uint32_t *data = (uint32_t *)offset_buffer.Memory().Map();
+    *data = 1;
+    offset_buffer.Memory().Unmap();
+    m_default_queue->Submit(m_command_buffer);
+    m_default_queue->Wait();
+}
+
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, RobustBuffer) {
     TEST_DESCRIPTION("Check buffer oob validation when per pipeline robustness is enabled");
 


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9852

Actually nothing was done when reaching this limit, so I added the logic to skip validation when it is reached. It was more cumbersome to do than what I would like it to be...
The warning:

Validation Warning: [ GPU-AV::Max action per command buffer reached ] | MessageID = 0x275e89d
vkCmdDraw(): Reached maximum validation commands count for command buffer ( 8192 ). No more draw/dispatch/trace rays commands will be validated inside this command buffer.
Objects: 1
    [0] VkCommandBuffer 0x1eaf1c58960