### PR TITLE
gpuav: Reduce duplicate indexing into descriptor array

### DIFF
--- a/layers/gpuav/spirv/descriptor_indexing_oob_pass.h
+++ b/layers/gpuav/spirv/descriptor_indexing_oob_pass.h
@@ -48,7 +48,9 @@ class DescriptorIndexingOOBPass : public Pass {
         uint32_t sampler_descriptor_index_id = 0;
     };
 
-    bool RequiresInstrumentation(const Function& function, const Instruction& inst, InstructionMeta& meta);
+    bool RequiresInstrumentation(const Function& function, const Instruction& inst, InstructionMeta& meta,
+                                 vvl::unordered_set<uint32_t>& found_in_block_set,
+                                 const DescriptroIndexPushConstantAccess& pc_access);
     uint32_t CreateFunctionCall(BasicBlock& block, InstructionIt* inst_it, const InstructionMeta& meta);
 
     uint32_t GetLinkFunctionId(bool is_combined_image_sampler);

--- a/layers/gpuav/spirv/pass.h
+++ b/layers/gpuav/spirv/pass.h
@@ -102,5 +102,24 @@ class Pass {
     const bool debug_disable_loops_ = false;
 };
 
+// Push Constants can be used to determine the index into descriptor arrays (Example: https://godbolt.org/z/jTEaaExov)
+// From examining many large shaders, the same access is made, but generated as a different OpLoad.
+// spirv-opt is not going to remove the duplicate loads because it is designed to allow the compiler to decide how long
+// it wants a single OpLoad to "live" (for register spilling algorithms)
+struct DescriptroIndexPushConstantAccess {
+    // The "final" ID that will determine the descriptor index
+    uint32_t descriptor_index_id = 0;
+    // We exploit the fact we only need to track the next ID that is an alias to |descriptor_index_id|
+    // The goal is this is only updated as we keep finding a matching descriptor index
+    uint32_t next_alias_id = 0;
+
+    // Which member inside the PC Block (expressed as ID of the OpConsant)
+    uint32_t member_index = 0;
+    // Sometimes a single OpIAdd is applied to the PC value
+    uint32_t add_id_value = 0;
+
+    void Update(const Module& module, InstructionIt inst_it);
+};
+
 }  // namespace spirv
 }  // namespace gpuav

--- a/layers/gpuav/spirv/post_process_descriptor_indexing_pass.h
+++ b/layers/gpuav/spirv/post_process_descriptor_indexing_pass.h
@@ -41,7 +41,8 @@ class PostProcessDescriptorIndexingPass : public Pass {
     };
 
     bool RequiresInstrumentation(const Function& function, const Instruction& inst, InstructionMeta& meta,
-                                 vvl::unordered_set<uint32_t>& found_in_block_set);
+                                 vvl::unordered_set<uint32_t>& found_in_block_set,
+                                 const DescriptroIndexPushConstantAccess& pc_access);
     void CreateFunctionCall(BasicBlock& block, InstructionIt* inst_it, const InstructionMeta& meta);
 
     uint32_t GetLinkFunctionId();

--- a/layers/gpuav/spirv/type_manager.cpp
+++ b/layers/gpuav/spirv/type_manager.cpp
@@ -614,6 +614,8 @@ const Variable& TypeManager::AddVariable(std::unique_ptr<Instruction> new_inst, 
         input_variables_.push_back(new_variable);
     } else if (new_variable->StorageClass() == spv::StorageClassOutput) {
         output_variables_.push_back(new_variable);
+    } else if (new_variable->StorageClass() == spv::StorageClassPushConstant) {
+        push_constant_variable_ = new_variable;
     }
 
     return *new_variable;
@@ -623,6 +625,8 @@ const Variable* TypeManager::FindVariableById(uint32_t id) const {
     auto variable = id_to_variable_.find(id);
     return (variable == id_to_variable_.end()) ? nullptr : variable->second.get();
 }
+
+const Variable* TypeManager::FindPushConstantVariable() const { return push_constant_variable_; }
 
 bool Type::IsArray() const { return spv_type_ == SpvType::kArray || spv_type_ == SpvType::kRuntimeArray; }
 

--- a/layers/gpuav/spirv/type_manager.h
+++ b/layers/gpuav/spirv/type_manager.h
@@ -154,6 +154,7 @@ class TypeManager {
 
     const Variable& AddVariable(std::unique_ptr<Instruction> new_inst, const Type& type);
     const Variable* FindVariableById(uint32_t id) const;
+    const Variable* FindPushConstantVariable() const;
 
   private:
     Module& module_;
@@ -195,6 +196,8 @@ class TypeManager {
 
     std::vector<const Variable*> input_variables_;
     std::vector<const Variable*> output_variables_;
+    // There is invalid to have more than 1 push constant variable per entrypoint
+    const Variable* push_constant_variable_ = nullptr;
 
     // Save the length of a struct so we don't have to look it up everytime
     // <struct_id, struct size>


### PR DESCRIPTION
See https://godbolt.org/z/cfqnbq77f

The `data[b]` is statically known to be the same (Push Constant are readonly uniform) but the SPIR-V (from GLSL/HLSL/Slang) will produce multiple `OpLoad` that are all aliased and `spirv-opt` doesn't reduce these because it want to preserve the "lifetime" of a variable

Found this was the reason causing large shaders to still take a second or more to compile, with this, it is finally under!

Found in `StressDescriptroIndexPushConstantAccess` this gets it down to a single instrumentation
