### PR TITLE
layers: Add handle to shader object spirv state

### DIFF
--- a/layers/state_tracker/shader_object_state.cpp
+++ b/layers/state_tracker/shader_object_state.cpp
@@ -47,6 +47,10 @@ ShaderObject::ShaderObject(DeviceState &dev_data, const VkShaderCreateInfoEXT &c
             }
         }
     }
+    // We need to update handle, but if using VK_SHADER_CODE_TYPE_SPIRV_EXT, it will be null
+    if (spirv_module) {
+        spirv_module->handle_ = handle_;
+    }
 }
 
 VkPrimitiveTopology ShaderObject::GetTopology() const {


### PR DESCRIPTION
We do this in `vvl::ShaderModule` and just seemed to have forgot in shader object

without this, common code that just has the SPIR-V, is currently not printing out the `VkShadersEXT` handle