### PR TITLE
tests: Fix test on lavapipe

### DIFF
--- a/tests/unit/vertex_input_positive.cpp
+++ b/tests/unit/vertex_input_positive.cpp
@@ -1285,6 +1285,9 @@ TEST_F(PositiveVertexInput, AttribDivisorExtAndKhr) {
 
     VkPhysicalDeviceVertexAttributeDivisorPropertiesKHR pdvad_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(pdvad_props);
+    if (!pdvad_props.supportsNonZeroFirstInstance) {
+        GTEST_SKIP() << "Test requires supportsNonZeroFirstInstance to be VK_FALSE";
+    }
 
     VkVertexInputBindingDivisorDescription vertex_binding_divisor;
     vertex_binding_divisor.binding = 0u;


### PR DESCRIPTION
Was hitting 

> Validation Error: [ VUID-vkCmdDraw-pNext-09461 ] | MessageID = 0xfefbb617
vkCmdDraw(): VkPipelineVertexInputDivisorStateCreateInfo::pVertexBindingDivisors[0].divisor is 2 and firstInstance is 1, but supportsNonZeroFirstInstance is VK_FALSE.
