### PR TITLE
state_tracker: Fix bindless descriptor performance regression

### DIFF
--- a/layers/gpuav/core/gpuav.h
+++ b/layers/gpuav/core/gpuav.h
@@ -410,6 +410,13 @@ class Validator : public GpuShaderInstrumentor {
     void Created(vvl::DescriptorSet& set) final;
     void Created(vvl::CommandBuffer& cb_state) final;
     void Created(vvl::Queue& queue) final;
+    void Created(vvl::Image&) final;
+    void Created(vvl::ImageView&) final;
+    void Created(vvl::Buffer&) final;
+    void Created(vvl::BufferView&) final;
+    void Created(vvl::Sampler&) final;
+    void Created(vvl::AccelerationStructureNV&) final;
+    void Created(vvl::AccelerationStructureKHR&) final;
 
   public:
     std::optional<DescriptorHeap> desc_heap_{};  // optional only to defer construction

--- a/layers/gpuav/core/gpuav_setup.cpp
+++ b/layers/gpuav/core/gpuav_setup.cpp
@@ -40,6 +40,22 @@ void Validator::Created(vvl::CommandBuffer &cb_state) {
 
 void Validator::Created(vvl::Queue &queue) { queue.SetSubState(container_type, std::make_unique<QueueSubState>(*this, queue)); }
 
+void Validator::Created(vvl::Image &obj) { obj.SetSubState(container_type, std::make_unique<ImageSubState>(obj, *desc_heap_)); }
+void Validator::Created(vvl::ImageView &obj) {
+    obj.SetSubState(container_type, std::make_unique<ImageViewSubState>(obj, *desc_heap_));
+}
+void Validator::Created(vvl::Buffer &obj) { obj.SetSubState(container_type, std::make_unique<BufferSubState>(obj, *desc_heap_)); }
+void Validator::Created(vvl::BufferView &obj) {
+    obj.SetSubState(container_type, std::make_unique<BufferViewSubState>(obj, *desc_heap_));
+}
+void Validator::Created(vvl::Sampler &obj) { obj.SetSubState(container_type, std::make_unique<SamplerSubState>(obj, *desc_heap_)); }
+void Validator::Created(vvl::AccelerationStructureNV &obj) {
+    obj.SetSubState(container_type, std::make_unique<AccelerationStructureNVSubState>(obj, *desc_heap_));
+}
+void Validator::Created(vvl::AccelerationStructureKHR &obj) {
+    obj.SetSubState(container_type, std::make_unique<AccelerationStructureKHRSubState>(obj, *desc_heap_));
+}
+
 // Trampolines to make VMA call Dispatch for Vulkan calls
 static VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL gpuVkGetInstanceProcAddr(VkInstance inst, const char *name) {
     return DispatchGetInstanceProcAddr(inst, name);

--- a/layers/gpuav/descriptor_validation/gpuav_descriptor_set.h
+++ b/layers/gpuav/descriptor_validation/gpuav_descriptor_set.h
@@ -47,7 +47,6 @@ class DescriptorSetSubState : public vvl::DescriptorSetSubState {
     DescriptorSetSubState(const vvl::DescriptorSet &set, Validator &state_data);
     virtual ~DescriptorSetSubState();
 
-    void NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) override;
     void NotifyUpdate() override;
 
     VkDeviceAddress GetTypeAddress(Validator &gpuav, const Location &loc);
@@ -74,7 +73,6 @@ class DescriptorSetSubState : public vvl::DescriptorSetSubState {
     vko::Buffer input_buffer_;
 
     mutable std::mutex state_lock_;
-    DescriptorHeap *heap_{};
 };
 
 static inline DescriptorSetSubState &SubState(vvl::DescriptorSet &set) {
@@ -87,10 +85,8 @@ class DescriptorHeap {
     DescriptorHeap(Validator &gpuav, uint32_t max_descriptors, const Location &loc);
     ~DescriptorHeap();
 
-    DescriptorId GetId(const VulkanTypedHandle &handle);
-    const VulkanTypedHandle GetHandle(DescriptorId id) const;
-
-    void Delete(const VulkanTypedHandle &handle);
+    DescriptorId NextId(const VulkanTypedHandle &handle);
+    void DeleteId(DescriptorId id);
 
     VkDeviceAddress GetDeviceAddress() const { return buffer_.Address(); }
 
@@ -102,7 +98,6 @@ class DescriptorHeap {
     const uint32_t max_descriptors_;
     DescriptorId next_id_{1};
     vvl::unordered_map<DescriptorId, VulkanTypedHandle> alloc_map_;
-    vvl::unordered_map<VulkanTypedHandle, DescriptorId> handle_map_;
 
     vko::Buffer buffer_;
     uint32_t *gpu_heap_state_{nullptr};

--- a/layers/gpuav/resources/gpuav_state_trackers.cpp
+++ b/layers/gpuav/resources/gpuav_state_trackers.cpp
@@ -607,4 +607,57 @@ void QueueSubState::Retire(vvl::QueueSubmission &submission) {
     }
 }
 
+ImageSubState::ImageSubState(vvl::Image &obj, DescriptorHeap &heap)
+    : vvl::ImageSubState(obj), id_tracker(std::in_place, heap, obj.Handle()) {}
+
+void ImageSubState::Destroy() { id_tracker.reset(); }
+
+void ImageSubState::NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) { id_tracker.reset(); }
+
+ImageViewSubState::ImageViewSubState(vvl::ImageView &obj, DescriptorHeap &heap)
+    : vvl::ImageViewSubState(obj), id_tracker(std::in_place, heap, obj.Handle()) {}
+
+void ImageViewSubState::Destroy() { id_tracker.reset(); }
+
+void ImageViewSubState::NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) { id_tracker.reset(); }
+
+BufferSubState::BufferSubState(vvl::Buffer &obj, DescriptorHeap &heap)
+    : vvl::BufferSubState(obj), id_tracker(std::in_place, heap, obj.Handle()) {}
+
+void BufferSubState::Destroy() { id_tracker.reset(); }
+
+void BufferSubState::NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) { id_tracker.reset(); }
+
+BufferViewSubState::BufferViewSubState(vvl::BufferView &obj, DescriptorHeap &heap)
+    : vvl::BufferViewSubState(obj), id_tracker(std::in_place, heap, obj.Handle()) {}
+
+void BufferViewSubState::Destroy() { id_tracker.reset(); }
+
+void BufferViewSubState::NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) { id_tracker.reset(); }
+
+SamplerSubState::SamplerSubState(vvl::Sampler &obj, DescriptorHeap &heap)
+    : vvl::SamplerSubState(obj), id_tracker(std::in_place, heap, obj.Handle()) {}
+
+void SamplerSubState::Destroy() { id_tracker.reset(); }
+
+void SamplerSubState::NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) { id_tracker.reset(); }
+
+AccelerationStructureNVSubState::AccelerationStructureNVSubState(vvl::AccelerationStructureNV &obj, DescriptorHeap &heap)
+    : vvl::AccelerationStructureNVSubState(obj), id_tracker(std::in_place, heap, obj.Handle()) {}
+
+void AccelerationStructureNVSubState::Destroy() { id_tracker.reset(); }
+
+void AccelerationStructureNVSubState::NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) {
+    id_tracker.reset();
+}
+
+AccelerationStructureKHRSubState::AccelerationStructureKHRSubState(vvl::AccelerationStructureKHR &obj, DescriptorHeap &heap)
+    : vvl::AccelerationStructureKHRSubState(obj), id_tracker(std::in_place, heap, obj.Handle()) {}
+
+void AccelerationStructureKHRSubState::Destroy() { id_tracker.reset(); }
+
+void AccelerationStructureKHRSubState::NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) {
+    id_tracker.reset();
+}
+
 }  // namespace gpuav

--- a/layers/gpuav/resources/gpuav_state_trackers.h
+++ b/layers/gpuav/resources/gpuav_state_trackers.h
@@ -183,4 +183,131 @@ class QueueSubState : public vvl::QueueSubState {
     const bool timeline_khr_;
 };
 
+// Descriptor Ids are used on the GPU to identify if a given descriptor is valid.
+// In some applications there are very large bindless descriptor arrays where it isn't feasible to track validity
+// via the StateObject::parent_nodes_ map as usual. Instead, these ids are stored in a giant GPU accessible bitmap
+// so that the instrumentation can decide if a descriptor is actually valid when it is used in a shader.
+class DescriptorIdTracker {
+  public:
+    DescriptorIdTracker(DescriptorHeap &heap_, VulkanTypedHandle handle) : heap(heap_), id(heap_.NextId(handle)) {}
+
+    DescriptorIdTracker(const DescriptorIdTracker &) = delete;
+    DescriptorIdTracker &operator=(const DescriptorIdTracker &) = delete;
+
+    ~DescriptorIdTracker() { heap.DeleteId(id); }
+
+    DescriptorHeap &heap;
+    const DescriptorId id{};
+};
+
+class ImageSubState : public vvl::ImageSubState {
+  public:
+    ImageSubState(vvl::Image &obj, DescriptorHeap &heap);
+    void Destroy() override;
+    void NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) override;
+
+    DescriptorId Id() const { return id_tracker ? id_tracker->id : 0; }
+    std::optional<DescriptorIdTracker> id_tracker;
+};
+static inline ImageSubState &SubState(vvl::Image &obj) {
+    return *static_cast<ImageSubState *>(obj.SubState(LayerObjectTypeGpuAssisted));
+}
+static inline const ImageSubState &SubState(const vvl::Image &obj) {
+    return *static_cast<const ImageSubState *>(obj.SubState(LayerObjectTypeGpuAssisted));
+}
+
+class ImageViewSubState : public vvl::ImageViewSubState {
+  public:
+    ImageViewSubState(vvl::ImageView &obj, DescriptorHeap &heap);
+    void Destroy() override;
+    void NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) override;
+
+    DescriptorId Id() const { return id_tracker ? id_tracker->id : 0; }
+    std::optional<DescriptorIdTracker> id_tracker;
+};
+static inline ImageViewSubState &SubState(vvl::ImageView &obj) {
+    return *static_cast<ImageViewSubState *>(obj.SubState(LayerObjectTypeGpuAssisted));
+}
+static inline const ImageViewSubState &SubState(const vvl::ImageView &obj) {
+    return *static_cast<const ImageViewSubState *>(obj.SubState(LayerObjectTypeGpuAssisted));
+}
+
+class BufferSubState : public vvl::BufferSubState {
+  public:
+    BufferSubState(vvl::Buffer &obj, DescriptorHeap &heap);
+    void Destroy() override;
+    void NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) override;
+
+    DescriptorId Id() const { return id_tracker ? id_tracker->id : 0; }
+    std::optional<DescriptorIdTracker> id_tracker;
+};
+static inline BufferSubState &SubState(vvl::Buffer &obj) {
+    return *static_cast<BufferSubState *>(obj.SubState(LayerObjectTypeGpuAssisted));
+}
+static inline const BufferSubState &SubState(const vvl::Buffer &obj) {
+    return *static_cast<const BufferSubState *>(obj.SubState(LayerObjectTypeGpuAssisted));
+}
+
+class BufferViewSubState : public vvl::BufferViewSubState {
+  public:
+    BufferViewSubState(vvl::BufferView &obj, DescriptorHeap &heap);
+    void Destroy() override;
+    void NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) override;
+
+    DescriptorId Id() const { return id_tracker ? id_tracker->id : 0; }
+    std::optional<DescriptorIdTracker> id_tracker;
+};
+static inline BufferViewSubState &SubState(vvl::BufferView &obj) {
+    return *static_cast<BufferViewSubState *>(obj.SubState(LayerObjectTypeGpuAssisted));
+}
+static inline const BufferViewSubState &SubState(const vvl::BufferView &obj) {
+    return *static_cast<const BufferViewSubState *>(obj.SubState(LayerObjectTypeGpuAssisted));
+}
+
+class SamplerSubState : public vvl::SamplerSubState {
+  public:
+    SamplerSubState(vvl::Sampler &obj, DescriptorHeap &heap);
+    void Destroy() override;
+    void NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) override;
+
+    DescriptorId Id() const { return id_tracker ? id_tracker->id : 0; }
+    std::optional<DescriptorIdTracker> id_tracker;
+};
+static inline SamplerSubState &SubState(vvl::Sampler &obj) {
+    return *static_cast<SamplerSubState *>(obj.SubState(LayerObjectTypeGpuAssisted));
+}
+static inline const SamplerSubState &SubState(const vvl::Sampler &obj) {
+    return *static_cast<const SamplerSubState *>(obj.SubState(LayerObjectTypeGpuAssisted));
+}
+
+class AccelerationStructureNVSubState : public vvl::AccelerationStructureNVSubState {
+  public:
+    AccelerationStructureNVSubState(vvl::AccelerationStructureNV &obj, DescriptorHeap &heap);
+    void Destroy() override;
+    void NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) override;
+
+    DescriptorId Id() const { return id_tracker ? id_tracker->id : 0; }
+    std::optional<DescriptorIdTracker> id_tracker;
+};
+static inline AccelerationStructureNVSubState &SubState(vvl::AccelerationStructureNV &obj) {
+    return *static_cast<AccelerationStructureNVSubState *>(obj.SubState(LayerObjectTypeGpuAssisted));
+}
+static inline const AccelerationStructureNVSubState &SubState(const vvl::AccelerationStructureNV &obj) {
+    return *static_cast<const AccelerationStructureNVSubState *>(obj.SubState(LayerObjectTypeGpuAssisted));
+}
+class AccelerationStructureKHRSubState : public vvl::AccelerationStructureKHRSubState {
+  public:
+    AccelerationStructureKHRSubState(vvl::AccelerationStructureKHR &obj, DescriptorHeap &heap);
+    void Destroy() override;
+    void NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) override;
+
+    DescriptorId Id() const { return id_tracker ? id_tracker->id : 0; }
+    std::optional<DescriptorIdTracker> id_tracker;
+};
+static inline AccelerationStructureKHRSubState &SubState(vvl::AccelerationStructureKHR &obj) {
+    return *static_cast<AccelerationStructureKHRSubState *>(obj.SubState(LayerObjectTypeGpuAssisted));
+}
+static inline const AccelerationStructureKHRSubState &SubState(const vvl::AccelerationStructureKHR &obj) {
+    return *static_cast<const AccelerationStructureKHRSubState *>(obj.SubState(LayerObjectTypeGpuAssisted));
+}
 }  // namespace gpuav

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -2119,11 +2119,17 @@ class DeviceProxy : public vvl::base::Device {
     }
 
     // callbacks for adding sub state information to new state objects
-    virtual void Created(vvl::CommandBuffer& cb_state) {}
-    virtual void Created(vvl::Queue& queue_state) {}
-    virtual void Created(vvl::Image& image_state) {}
-    virtual void Created(vvl::Swapchain& swapchain_state) {}
-    virtual void Created(vvl::DescriptorSet& swapchain_state) {}
+    virtual void Created(vvl::CommandBuffer& state) {}
+    virtual void Created(vvl::Queue& state) {}
+    virtual void Created(vvl::AccelerationStructureKHR& state) {}
+    virtual void Created(vvl::AccelerationStructureNV& state) {}
+    virtual void Created(vvl::Buffer& state) {}
+    virtual void Created(vvl::BufferView& state) {}
+    virtual void Created(vvl::Image& state) {}
+    virtual void Created(vvl::ImageView& state) {}
+    virtual void Created(vvl::Sampler& state) {}
+    virtual void Created(vvl::Swapchain& state) {}
+    virtual void Created(vvl::DescriptorSet& tate) {}
 
     // callbacks for image layout validation, which is implemented in both core validation and gpu-av
     virtual bool ValidateProtectedImage(const vvl::CommandBuffer& cb_state, const vvl::Image& image_state,


### PR DESCRIPTION
Commit 313d1d4 caused a performance regression for very large bindless descriptor arrays. Redo the old implementation on top of sub states.