### PR TITLE
settings: Remove stable messages option

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -1197,14 +1197,6 @@
                             "type": "BOOL",
                             "default": false,
                             "platforms": [ "WINDOWS", "LINUX", "MACOS", "ANDROID" ]
-                        },
-                        {
-                            "key": "debug_stable_messages",
-                            "label": "Stable messages",
-                            "view": "ADVANCED",
-                            "description": "Improves the reproducibility of error messages by removing fields that can vary between application runs (e.g., dispatchable handles) for comparison purposes.",
-                            "type": "BOOL",
-                            "default": false
                         }
                     ]
                 },

--- a/layers/error_message/logging.cpp
+++ b/layers/error_message/logging.cpp
@@ -343,9 +343,7 @@ std::string DebugReport::CreateMessageJson(VkFlags msg_flags, const Location &lo
             oss << line_start << line_start;
             oss << "{\"type\" : \"" << string_VkObjectTypeHandleName(src_object.objectType) << "\", \"handle\" : \"";
             if (0 != src_object.objectHandle) {
-                if (!debug_stable_messages) {
-                    oss << "0x" << std::hex << src_object.objectHandle;
-                }
+                oss << "0x" << std::hex << src_object.objectHandle;
                 oss << "\", \"name\" : \"";
                 if (src_object.pObjectName) {
                     oss << src_object.pObjectName;
@@ -474,21 +472,10 @@ std::string DebugReport::FormatHandle(const char *handle_type_name, uint64_t han
         handle_name = GetMarkerObjectNameNoLock(handle);
     }
 
-    bool print_handle = true;
-    if (debug_stable_messages) {
-        if (!strcmp(handle_type_name, "VkInstance") || !strcmp(handle_type_name, "VkPhysicalDevice") ||
-            !strcmp(handle_type_name, "VkDevice") || !strcmp(handle_type_name, "VkQueue") ||
-            !strcmp(handle_type_name, "VkCommandBuffer")) {
-            // In stable message mode do not print dispatchable handles because they vary
-            print_handle = false;
-        }
-    }
-
     std::ostringstream str;
     str << handle_type_name << " ";
-    if (print_handle) {
-        str << "0x" << std::hex << handle;
-    }
+    str << "0x" << std::hex << handle;
+
     if (!handle_name.empty()) {
         str << "[" << handle_name.c_str() << "]";
     }

--- a/layers/error_message/logging.h
+++ b/layers/error_message/logging.h
@@ -202,7 +202,6 @@ class DebugReport {
     bool force_default_log_callback{false};
     uint32_t device_created = 0;
     MessageFormatSettings message_format_settings;
-    bool debug_stable_messages{false};
 
     void SetUtilsObjectName(const VkDebugUtilsObjectNameInfoEXT *pNameInfo);
     void SetMarkerObjectName(const VkDebugMarkerObjectNameInfoEXT *pNameInfo);

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -173,7 +173,6 @@ const char *VK_LAYER_DUPLICATE_MESSAGE_LIMIT = "duplicate_message_limit";
 const char *VK_LAYER_FINE_GRAINED_LOCKING = "fine_grained_locking";
 // Debug settings used for internal development
 const char *VK_LAYER_DEBUG_DISABLE_SPIRV_VAL = "debug_disable_spirv_val";
-const char *VK_LAYER_DEBUG_STABLE_MESSAGES = "debug_stable_messages";
 
 // DebugPrintf (which is now part of GPU-AV internally)
 // ---
@@ -784,11 +783,6 @@ static void ProcessDebugReportSettings(ConfigAndEnvSettings *settings_data, VkuL
         vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_LOG_FILENAME, log_filename);
     }
     const bool is_stdout = log_filename.compare("stdout") == 0;
-
-    // Debug mode to simplify comparison of error messages between application runs
-    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_DEBUG_STABLE_MESSAGES)) {
-        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_DEBUG_STABLE_MESSAGES, debug_report->debug_stable_messages);
-    }
 
     // Default
     std::vector<std::string> debug_actions_list = {"VK_DBG_LAYER_ACTION_DEFAULT", "VK_DBG_LAYER_ACTION_LOG_MSG"};


### PR DESCRIPTION
After we cleaned up messages this option can't remove all dispatchable handles anymore and it's not cheap to rework this.
There's an alternative to run a filtering script over the message output, which produces identical result.