### PR TITLE
layers: Move YCbCr check from drawtime to pipeline

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -895,14 +895,18 @@ class CoreChecks : public vvl::DeviceProxy {
     bool ValidatePipelineTessellationStages(const spirv::Module& tesc_module_state, const spirv::EntryPoint& tesc_entrypoint,
                                             const spirv::Module& tese_module_state, const spirv::EntryPoint& tese_entrypoint,
                                             const Location& create_info_loc) const;
-    bool ValidateShaderInterfaceVariablePipeline(const spirv::Module& module_state, const vvl::Pipeline& pipeline,
-                                                 const spirv::ResourceInterfaceVariable& variable,
+    bool ValidateShaderInterfaceVariablePipeline(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
+                                                 const vvl::Pipeline& pipeline, const spirv::ResourceInterfaceVariable& variable,
                                                  vvl::unordered_set<uint32_t>& descriptor_type_set, const Location& loc) const;
     bool ValidateShaderInterfaceVariableShaderObject(const VkShaderCreateInfoEXT& create_info,
                                                      const spirv::ResourceInterfaceVariable& variable,
                                                      vvl::unordered_set<uint32_t>& descriptor_type_set, const Location& loc) const;
     bool ValidateShaderInterfaceVariable(const spirv::Module& module_state, const spirv::ResourceInterfaceVariable& variable,
                                          vvl::unordered_set<uint32_t>& descriptor_type_set, const Location& loc) const;
+    bool ValidateShaderYcbcrSamplerAccess(const VkDescriptorSetLayoutBinding& binding,
+                                          const spirv::ResourceInterfaceVariable& image_variable,
+                                          const spirv::ResourceInterfaceVariable* sampler_variable, const LogObjectList& objlist,
+                                          const Location& loc) const;
     bool ValidateTransformFeedbackPipeline(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
                                            const vvl::Pipeline& pipeline, const Location& loc) const;
     virtual bool ValidatePipelineShaderStage(const vvl::Pipeline& pipeline,

--- a/layers/drawdispatch/drawdispatch_vuids.cpp
+++ b/layers/drawdispatch/drawdispatch_vuids.cpp
@@ -182,8 +182,6 @@ struct DispatchVuidsCmdDraw : DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDraw-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDraw-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDraw-None-08117";
-        image_ycbcr_sampled_06550                = "VUID-vkCmdDraw-None-06550";
-        image_ycbcr_offset_06551                 = "VUID-vkCmdDraw-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDraw-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDraw-format-07753";
         stippled_rectangular_lines_07495         = "VUID-vkCmdDraw-stippledLineEnable-07495";
@@ -450,8 +448,6 @@ struct DispatchVuidsCmdDrawMultiEXT : DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDrawMultiEXT-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDrawMultiEXT-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDrawMultiEXT-None-08117";
-        image_ycbcr_sampled_06550                = "VUID-vkCmdDrawMultiEXT-None-06550";
-        image_ycbcr_offset_06551                 = "VUID-vkCmdDrawMultiEXT-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDrawMultiEXT-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDrawMultiEXT-format-07753";
         stippled_rectangular_lines_07495         = "VUID-vkCmdDrawMultiEXT-stippledLineEnable-07495";
@@ -719,8 +715,6 @@ struct DispatchVuidsCmdDrawIndexed : DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDrawIndexed-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDrawIndexed-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDrawIndexed-None-08117";
-        image_ycbcr_sampled_06550                = "VUID-vkCmdDrawIndexed-None-06550";
-        image_ycbcr_offset_06551                 = "VUID-vkCmdDrawIndexed-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDrawIndexed-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDrawIndexed-format-07753";
         stippled_rectangular_lines_07495         = "VUID-vkCmdDrawIndexed-stippledLineEnable-07495";
@@ -988,8 +982,6 @@ struct DispatchVuidsCmdDrawMultiIndexedEXT : DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDrawMultiIndexedEXT-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDrawMultiIndexedEXT-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDrawMultiIndexedEXT-None-08117";
-        image_ycbcr_sampled_06550                = "VUID-vkCmdDrawMultiIndexedEXT-None-06550";
-        image_ycbcr_offset_06551                 = "VUID-vkCmdDrawMultiIndexedEXT-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDrawMultiIndexedEXT-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDrawMultiIndexedEXT-format-07753";
         stippled_rectangular_lines_07495         = "VUID-vkCmdDrawMultiIndexedEXT-stippledLineEnable-07495";
@@ -1257,8 +1249,6 @@ struct DispatchVuidsCmdDrawIndirect : DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDrawIndirect-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDrawIndirect-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDrawIndirect-None-08117";
-        image_ycbcr_sampled_06550                = "VUID-vkCmdDrawIndirect-None-06550";
-        image_ycbcr_offset_06551                 = "VUID-vkCmdDrawIndirect-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDrawIndirect-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDrawIndirect-format-07753";
         stippled_rectangular_lines_07495         = "VUID-vkCmdDrawIndirect-stippledLineEnable-07495";
@@ -1525,8 +1515,6 @@ struct DispatchVuidsCmdDrawIndexedIndirect : DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDrawIndexedIndirect-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDrawIndexedIndirect-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDrawIndexedIndirect-None-08117";
-        image_ycbcr_sampled_06550                = "VUID-vkCmdDrawIndexedIndirect-None-06550";
-        image_ycbcr_offset_06551                 = "VUID-vkCmdDrawIndexedIndirect-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDrawIndexedIndirect-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDrawIndexedIndirect-format-07753";
         stippled_rectangular_lines_07495         = "VUID-vkCmdDrawIndexedIndirect-stippledLineEnable-07495";
@@ -1670,8 +1658,6 @@ struct DispatchVuidsCmdDispatch : DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDispatch-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDispatch-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDispatch-None-08117";
-        image_ycbcr_sampled_06550                = "VUID-vkCmdDispatch-None-06550";
-        image_ycbcr_offset_06551                 = "VUID-vkCmdDispatch-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDispatch-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDispatch-format-07753";
         image_layout_09600                       = "VUID-vkCmdDispatch-None-09600";
@@ -1719,8 +1705,6 @@ struct DispatchVuidsCmdDispatchIndirect : DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDispatchIndirect-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDispatchIndirect-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDispatchIndirect-None-08117";
-        image_ycbcr_sampled_06550                = "VUID-vkCmdDispatchIndirect-None-06550";
-        image_ycbcr_offset_06551                 = "VUID-vkCmdDispatchIndirect-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDispatchIndirect-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDispatchIndirect-format-07753";
         image_layout_09600                       = "VUID-vkCmdDispatchIndirect-None-09600";
@@ -1892,8 +1876,6 @@ struct DispatchVuidsCmdDrawIndirectCount : DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDrawIndirectCount-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDrawIndirectCount-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDrawIndirectCount-None-08117";
-        image_ycbcr_sampled_06550                = "VUID-vkCmdDrawIndirectCount-None-06550";
-        image_ycbcr_offset_06551                 = "VUID-vkCmdDrawIndirectCount-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDrawIndirectCount-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDrawIndirectCount-format-07753";
         stippled_rectangular_lines_07495         = "VUID-vkCmdDrawIndirectCount-stippledLineEnable-07495";
@@ -2163,8 +2145,6 @@ struct DispatchVuidsCmdDrawIndexedIndirectCount : DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDrawIndexedIndirectCount-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDrawIndexedIndirectCount-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDrawIndexedIndirectCount-None-08117";
-        image_ycbcr_sampled_06550                = "VUID-vkCmdDrawIndexedIndirectCount-None-06550";
-        image_ycbcr_offset_06551                 = "VUID-vkCmdDrawIndexedIndirectCount-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDrawIndexedIndirectCount-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDrawIndexedIndirectCount-format-07753";
         stippled_rectangular_lines_07495         = "VUID-vkCmdDrawIndexedIndirectCount-stippledLineEnable-07495";
@@ -2307,8 +2287,6 @@ struct DispatchVuidsCmdTraceRaysNV: DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdTraceRaysNV-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdTraceRaysNV-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdTraceRaysNV-None-08117";
-        image_ycbcr_sampled_06550                = "VUID-vkCmdTraceRaysNV-None-06550";
-        image_ycbcr_offset_06551                 = "VUID-vkCmdTraceRaysNV-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdTraceRaysNV-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdTraceRaysNV-format-07753";
         ray_tracing_pipeline_stack_size_09458    = "VUID-vkCmdTraceRaysNV-None-09458";
@@ -2355,8 +2333,6 @@ struct DispatchVuidsCmdTraceRaysKHR: DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdTraceRaysKHR-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdTraceRaysKHR-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdTraceRaysKHR-None-08117";
-        image_ycbcr_sampled_06550                = "VUID-vkCmdTraceRaysKHR-None-06550";
-        image_ycbcr_offset_06551                 = "VUID-vkCmdTraceRaysKHR-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdTraceRaysKHR-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdTraceRaysKHR-format-07753";
         ray_tracing_pipeline_stack_size_09458    = "VUID-vkCmdTraceRaysKHR-None-09458";
@@ -2405,8 +2381,6 @@ struct DispatchVuidsCmdTraceRaysIndirectKHR: DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdTraceRaysIndirectKHR-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdTraceRaysIndirectKHR-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdTraceRaysIndirectKHR-None-08117";
-        image_ycbcr_sampled_06550                = "VUID-vkCmdTraceRaysIndirectKHR-None-06550";
-        image_ycbcr_offset_06551                 = "VUID-vkCmdTraceRaysIndirectKHR-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdTraceRaysIndirectKHR-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdTraceRaysIndirectKHR-format-07753";
         ray_tracing_pipeline_stack_size_09458    = "VUID-vkCmdTraceRaysIndirectKHR-None-09458";
@@ -2455,8 +2429,6 @@ struct DispatchVuidsCmdTraceRaysIndirect2KHR: DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdTraceRaysIndirect2KHR-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdTraceRaysIndirect2KHR-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdTraceRaysIndirect2KHR-None-08117";
-        image_ycbcr_sampled_06550                = "VUID-vkCmdTraceRaysIndirect2KHR-None-06550";
-        image_ycbcr_offset_06551                 = "VUID-vkCmdTraceRaysIndirect2KHR-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdTraceRaysIndirect2KHR-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdTraceRaysIndirect2KHR-format-07753";
         ray_tracing_pipeline_stack_size_09458    = "VUID-vkCmdTraceRaysIndirect2KHR-None-09458";
@@ -2611,8 +2583,6 @@ struct DispatchVuidsCmdDrawMeshTasksNV: DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDrawMeshTasksNV-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDrawMeshTasksNV-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDrawMeshTasksNV-None-08117";
-        image_ycbcr_sampled_06550                = "VUID-vkCmdDrawMeshTasksNV-None-06550";
-        image_ycbcr_offset_06551                 = "VUID-vkCmdDrawMeshTasksNV-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDrawMeshTasksNV-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDrawMeshTasksNV-format-07753";
         stippled_rectangular_lines_07495         = "VUID-vkCmdDrawMeshTasksNV-stippledLineEnable-07495";
@@ -2866,8 +2836,6 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectNV: DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08117";
-        image_ycbcr_sampled_06550                = "VUID-vkCmdDrawMeshTasksIndirectNV-None-06550";
-        image_ycbcr_offset_06551                 = "VUID-vkCmdDrawMeshTasksIndirectNV-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDrawMeshTasksIndirectNV-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDrawMeshTasksIndirectNV-format-07753";
         stippled_rectangular_lines_07495         = "VUID-vkCmdDrawMeshTasksIndirectNV-stippledLineEnable-07495";
@@ -3124,8 +3092,6 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectCountNV : DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08117";
-        image_ycbcr_sampled_06550                = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-06550";
-        image_ycbcr_offset_06551                 = "VUID-vkCmdDrawMeshTasksIndirectCountNV-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDrawMeshTasksIndirectCountNV-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDrawMeshTasksIndirectCountNV-format-07753";
         stippled_rectangular_lines_07495         = "VUID-vkCmdDrawMeshTasksIndirectCountNV-stippledLineEnable-07495";
@@ -3376,8 +3342,6 @@ struct DispatchVuidsCmdDrawMeshTasksEXT: DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDrawMeshTasksEXT-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDrawMeshTasksEXT-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDrawMeshTasksEXT-None-08117";
-        image_ycbcr_sampled_06550                = "VUID-vkCmdDrawMeshTasksEXT-None-06550";
-        image_ycbcr_offset_06551                 = "VUID-vkCmdDrawMeshTasksEXT-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDrawMeshTasksEXT-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDrawMeshTasksEXT-format-07753";
         stippled_rectangular_lines_07495         = "VUID-vkCmdDrawMeshTasksEXT-stippledLineEnable-07495";
@@ -3631,8 +3595,6 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectEXT: DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08117";
-        image_ycbcr_sampled_06550                = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-06550";
-        image_ycbcr_offset_06551                 = "VUID-vkCmdDrawMeshTasksIndirectEXT-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDrawMeshTasksIndirectEXT-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDrawMeshTasksIndirectEXT-format-07753";
         stippled_rectangular_lines_07495         = "VUID-vkCmdDrawMeshTasksIndirectEXT-stippledLineEnable-07495";
@@ -3889,8 +3851,6 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectCountEXT : DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08117";
-        image_ycbcr_sampled_06550                = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-06550";
-        image_ycbcr_offset_06551                 = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-format-07753";
         stippled_rectangular_lines_07495         = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-stippledLineEnable-07495";
@@ -4156,8 +4116,6 @@ struct DispatchVuidsCmdDrawIndirectByteCountEXT: DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDrawIndirectByteCountEXT-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDrawIndirectByteCountEXT-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDrawIndirectByteCountEXT-None-08117";
-        image_ycbcr_sampled_06550                = "VUID-vkCmdDrawIndirectByteCountEXT-None-06550";
-        image_ycbcr_offset_06551                 = "VUID-vkCmdDrawIndirectByteCountEXT-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDrawIndirectByteCountEXT-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDrawIndirectByteCountEXT-format-07753";
         stippled_rectangular_lines_07495         = "VUID-vkCmdDrawIndirectByteCountEXT-stippledLineEnable-07495";
@@ -4301,8 +4259,6 @@ struct DispatchVuidsCmdDispatchBase: DrawDispatchVuid {
         descriptor_buffer_bit_set_08114          = "VUID-vkCmdDispatchBase-None-08114";
         descriptor_buffer_bit_not_set_08115      = "VUID-vkCmdDispatchBase-None-08115";
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDispatchBase-None-08117";
-        image_ycbcr_sampled_06550                = "VUID-vkCmdDispatchBase-None-06550";
-        image_ycbcr_offset_06551                 = "VUID-vkCmdDispatchBase-ConstOffset-06551";
         image_view_dim_07752                     = "VUID-vkCmdDispatchBase-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDispatchBase-format-07753";
     }

--- a/layers/drawdispatch/drawdispatch_vuids.h
+++ b/layers/drawdispatch/drawdispatch_vuids.h
@@ -201,8 +201,6 @@ struct DrawDispatchVuid {
     const char* descriptor_buffer_bit_set_08114 = kVUIDUndefined;
     const char* descriptor_buffer_bit_not_set_08115 = kVUIDUndefined;
     const char* descriptor_buffer_set_offset_missing_08117 = kVUIDUndefined;
-    const char* image_ycbcr_sampled_06550 = kVUIDUndefined;
-    const char* image_ycbcr_offset_06551 = kVUIDUndefined;
     const char* image_view_dim_07752 = kVUIDUndefined;
     const char* image_view_numeric_format_07753 = kVUIDUndefined;
     const char* stippled_rectangular_lines_07495 = kVUIDUndefined;

--- a/layers/state_tracker/descriptor_sets.cpp
+++ b/layers/state_tracker/descriptor_sets.cpp
@@ -274,7 +274,8 @@ vvl::DescriptorSetLayoutDef::DescriptorSetLayoutDef(const VkDescriptorSetLayoutC
       binding_count_(0),
       descriptor_count_(0),
       non_inline_descriptor_count_(0),
-      dynamic_descriptor_count_(0) {
+      dynamic_descriptor_count_(0),
+      has_immutable_samplers_(false) {
     const auto *flags_create_info = vku::FindStructInPNextChain<VkDescriptorSetLayoutBindingFlagsCreateInfo>(p_create_info->pNext);
 
     binding_type_stats_ = {0, 0};
@@ -336,6 +337,8 @@ vvl::DescriptorSetLayoutDef::DescriptorSetLayoutDef(const VkDescriptorSetLayoutC
                 binding_type_stats_.non_dynamic_buffer_count++;
             }
         }
+
+        has_immutable_samplers_ |= (binding_info.pImmutableSamplers != nullptr);
     }
     assert(bindings_.size() == binding_count_);
     assert(binding_flags_.size() == binding_count_);

--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -174,6 +174,7 @@ class DescriptorSetLayoutDef {
     uint32_t GetTotalDescriptorCount() const { return descriptor_count_; };
     uint32_t GetNonInlineDescriptorCount() const { return non_inline_descriptor_count_; };
     uint32_t GetDynamicDescriptorCount() const { return dynamic_descriptor_count_; };
+    bool HasImmutableSamplers() const { return has_immutable_samplers_; };
     VkDescriptorSetLayoutCreateFlags GetCreateFlags() const { return flags_; }
     // For a given binding, return the number of descriptors in that binding and all successive bindings
     uint32_t GetBindingCount() const { return binding_count_; };
@@ -252,6 +253,8 @@ class DescriptorSetLayoutDef {
     uint32_t non_inline_descriptor_count_;
     uint32_t dynamic_descriptor_count_;
     BindingTypeStats binding_type_stats_;
+
+    bool has_immutable_samplers_;
 };
 
 // Canonical dictionary of DSL definitions -- independent of device or handle
@@ -321,6 +324,7 @@ class DescriptorSetLayout : public StateObject {
     uint32_t GetNonInlineDescriptorCount() const { return layout_id_->GetNonInlineDescriptorCount(); };
     uint32_t GetDynamicDescriptorCount() const { return layout_id_->GetDynamicDescriptorCount(); };
     uint32_t GetBindingCount() const { return layout_id_->GetBindingCount(); };
+    bool HasImmutableSamplers() const { return layout_id_->HasImmutableSamplers(); };
     VkDescriptorSetLayoutCreateFlags GetCreateFlags() const { return layout_id_->GetCreateFlags(); }
     uint32_t GetIndexFromBinding(uint32_t binding) const { return layout_id_->GetIndexFromBinding(binding); }
     // Various Get functions that can either be passed a binding#, which will

--- a/layers/state_tracker/pipeline_layout_state.h
+++ b/layers/state_tracker/pipeline_layout_state.h
@@ -32,6 +32,9 @@ class DeviceState;
 class DescriptorSetLayout;
 class DescriptorSetLayoutDef;
 }  // namespace vvl
+namespace spirv {
+struct ResourceInterfaceVariable;
+}  // namespace spirv
 
 // Canonical dictionary for the pipeline layout's layout of descriptorsetlayouts
 using DescriptorSetLayoutDef = vvl::DescriptorSetLayoutDef;
@@ -79,6 +82,8 @@ class PipelineLayout : public StateObject {
     // table of "compatible for set N" cannonical forms for trivial accept validation
     const std::vector<PipelineLayoutCompatId> set_compat_ids;
     VkPipelineLayoutCreateFlags create_flags;
+    // Way to quick prevent searching if we know there are no immutable samplers
+    bool has_immutable_samplers;
 
     PipelineLayout(DeviceState &dev_data, VkPipelineLayout handle, const VkPipelineLayoutCreateInfo *pCreateInfo);
     // Merge 2 or more non-overlapping layouts
@@ -89,6 +94,8 @@ class PipelineLayout : public StateObject {
     VkPipelineLayout VkHandle() const { return handle_.Cast<VkPipelineLayout>(); }
 
     VkPipelineLayoutCreateFlags CreateFlags() const { return create_flags; }
+
+    const VkDescriptorSetLayoutBinding *FindBinding(const spirv::ResourceInterfaceVariable &variable) const;
 };
 
 }  // namespace vvl

--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -276,8 +276,8 @@ void VkLayerTest::CreateImageViewTest(const VkImageViewCreateInfo &create_info, 
     Monitor().VerifyFound();
 }
 
-VkSamplerCreateInfo SafeSaneSamplerCreateInfo() {
-    VkSamplerCreateInfo sampler_create_info = vku::InitStructHelper();
+VkSamplerCreateInfo SafeSaneSamplerCreateInfo(void *p_next) {
+    VkSamplerCreateInfo sampler_create_info = vku::InitStructHelper(p_next);
     sampler_create_info.magFilter = VK_FILTER_NEAREST;
     sampler_create_info.minFilter = VK_FILTER_NEAREST;
     sampler_create_info.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -119,7 +119,7 @@ bool ImageFormatIsSupported(const VkInstance inst, const VkPhysicalDevice phy, c
 bool BufferFormatAndFeaturesSupported(VkPhysicalDevice phy, VkFormat format, VkFormatFeatureFlags features);
 
 // Simple sane SamplerCreateInfo boilerplate
-VkSamplerCreateInfo SafeSaneSamplerCreateInfo();
+VkSamplerCreateInfo SafeSaneSamplerCreateInfo(void *p_next = nullptr);
 
 // Dependent "false" type for the static assert, as GCC will evaluate
 // non-dependent static_asserts even for non-instantiated templates

--- a/tests/unit/descriptors_positive.cpp
+++ b/tests/unit/descriptors_positive.cpp
@@ -1404,9 +1404,7 @@ TEST_F(PositiveDescriptors, CopyDestroyedMutableDescriptors) {
     vkt::Image image(*m_device, 32, 32, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
     vkt::ImageView view = image.CreateView();
 
-    VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
-    VkSampler sampler;
-    vk::CreateSampler(device(), &sampler_ci, nullptr, &sampler);
+    vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
     VkDescriptorImageInfo image_info = {};
     image_info.imageView = view;
@@ -1429,7 +1427,6 @@ TEST_F(PositiveDescriptors, CopyDestroyedMutableDescriptors) {
     copy_set.dstBinding = 0;
     copy_set.descriptorCount = 1;
 
-    vk::DestroySampler(device(), sampler, nullptr);
     vk::UpdateDescriptorSets(device(), 0, nullptr, 1, &copy_set);
 }
 

--- a/tests/unit/image_layout_positive.cpp
+++ b/tests/unit/image_layout_positive.cpp
@@ -427,9 +427,7 @@ TEST_F(PositiveImageLayout, Descriptor3D2DSubresource) {
                                    &subpass,
                                    (uint32_t)deps.size(),
                                    deps.data()};
-    // Create Sampler
-    VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
-    vkt::Sampler sampler(*m_device, sampler_ci);
+    vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
     descriptor_set.WriteDescriptorImageInfo(0, other_view, sampler);
     descriptor_set.UpdateDescriptorSets();

--- a/tests/unit/pipeline.cpp
+++ b/tests/unit/pipeline.cpp
@@ -2020,8 +2020,7 @@ TEST_F(NegativePipeline, SampledInvalidImageViews) {
     VkSamplerReductionModeCreateInfo reduction_mode_ci = vku::InitStructHelper();
     reduction_mode_ci.reductionMode = VK_SAMPLER_REDUCTION_MODE_WEIGHTED_AVERAGE;
 
-    VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
-    sampler_ci.pNext = &reduction_mode_ci;
+    VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo(&reduction_mode_ci);
     sampler_ci.minFilter = VK_FILTER_LINEAR;  // turned off feature bit for test
     sampler_ci.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
     sampler_ci.compareEnable = VK_FALSE;

--- a/tests/unit/sampler.cpp
+++ b/tests/unit/sampler.cpp
@@ -449,8 +449,7 @@ TEST_F(NegativeSampler, LinearReductionModeMinMax) {
     VkSamplerReductionModeCreateInfo reduction_mode_ci = vku::InitStructHelper();
     reduction_mode_ci.reductionMode = VK_SAMPLER_REDUCTION_MODE_MIN;
 
-    VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
-    sampler_ci.pNext = &reduction_mode_ci;
+    VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo(&reduction_mode_ci);
     sampler_ci.minFilter = VK_FILTER_LINEAR;  // turned off feature bit for test
     sampler_ci.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
     sampler_ci.compareEnable = VK_FALSE;
@@ -588,8 +587,7 @@ TEST_F(NegativeSampler, MultiplaneImageSamplerConversionMismatch) {
     ycbcr_info.conversion = conversions[0].handle();
 
     // Create a sampler using conversion
-    VkSamplerCreateInfo sci = SafeSaneSamplerCreateInfo();
-    sci.pNext = &ycbcr_info;
+    VkSamplerCreateInfo sci = SafeSaneSamplerCreateInfo(&ycbcr_info);
     // Create two samplers with two different conversions, such that one will mismatch
     // It will make the second sampler fail to see if the log prints the second sampler or the first sampler.
     vkt::Sampler samplers[2];
@@ -692,9 +690,7 @@ TEST_F(NegativeSampler, ImageSamplerConversionNullImageView) {
     vkt::SamplerYcbcrConversion conversion(*m_device, VK_FORMAT_G8_B8R8_2PLANE_420_UNORM);
     VkSamplerYcbcrConversionInfo ycbcr_info = vku::InitStructHelper();
     ycbcr_info.conversion = conversion.handle();
-    VkSamplerCreateInfo sci = SafeSaneSamplerCreateInfo();
-    sci.pNext = &ycbcr_info;
-    vkt::Sampler sampler(*m_device, sci);
+    vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo(&ycbcr_info));
 
     OneOffDescriptorSet descriptor_set(
         m_device, {
@@ -743,8 +739,7 @@ TEST_F(NegativeSampler, FilterMinmax) {
     VkSamplerReductionModeCreateInfo reduction_info = vku::InitStructHelper();
     reduction_info.reductionMode = VK_SAMPLER_REDUCTION_MODE_MIN;
 
-    VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
-    sampler_info.pNext = &reduction_info;
+    VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo(&reduction_info);
 
     // Wrong mode with a YCbCr Conversion used
     reduction_info.pNext = &ycbcr_info;
@@ -819,11 +814,10 @@ TEST_F(NegativeSampler, CustomBorderColorFormatUndefined) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
+    VkSamplerCustomBorderColorCreateInfoEXT custom_color_ci = vku::InitStructHelper();
+    custom_color_ci.format = VK_FORMAT_UNDEFINED;
+    VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo(&custom_color_ci);
     sampler_info.borderColor = VK_BORDER_COLOR_INT_CUSTOM_EXT;
-    VkSamplerCustomBorderColorCreateInfoEXT custom_color_cinfo = vku::InitStructHelper();
-    custom_color_cinfo.format = VK_FORMAT_UNDEFINED;
-    sampler_info.pNext = &custom_color_cinfo;
     vkt::Sampler sampler(*m_device, sampler_info);
 
     vkt::Image image(*m_device, 32, 32, VK_FORMAT_B4G4R4A4_UNORM_PACK16, VK_IMAGE_USAGE_SAMPLED_BIT);
@@ -872,11 +866,10 @@ TEST_F(NegativeSampler, CustomBorderColorFormatUndefinedNonCombined) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
+    VkSamplerCustomBorderColorCreateInfoEXT custom_color_ci = vku::InitStructHelper();
+    custom_color_ci.format = VK_FORMAT_UNDEFINED;
+    VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo(&custom_color_ci);
     sampler_info.borderColor = VK_BORDER_COLOR_INT_CUSTOM_EXT;
-    VkSamplerCustomBorderColorCreateInfoEXT custom_color_cinfo = vku::InitStructHelper();
-    custom_color_cinfo.format = VK_FORMAT_UNDEFINED;
-    sampler_info.pNext = &custom_color_cinfo;
     vkt::Sampler sampler(*m_device, sampler_info);
 
     vkt::Image image(*m_device, 32, 32, VK_FORMAT_B4G4R4A4_UNORM_PACK16, VK_IMAGE_USAGE_SAMPLED_BIT);
@@ -929,11 +922,10 @@ TEST_F(NegativeSampler, DISABLED_CustomBorderColorFormatUndefinedNonCombinedMult
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
+    VkSamplerCustomBorderColorCreateInfoEXT custom_color_ci = vku::InitStructHelper();
+    custom_color_ci.format = VK_FORMAT_UNDEFINED;
+    VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo(&custom_color_ci);
     sampler_info.borderColor = VK_BORDER_COLOR_INT_CUSTOM_EXT;
-    VkSamplerCustomBorderColorCreateInfoEXT custom_color_cinfo = vku::InitStructHelper();
-    custom_color_cinfo.format = VK_FORMAT_UNDEFINED;
-    sampler_info.pNext = &custom_color_cinfo;
     vkt::Sampler sampler(*m_device, sampler_info);
 
     vkt::Image image(*m_device, 32, 32, VK_FORMAT_B4G4R4A4_UNORM_PACK16, VK_IMAGE_USAGE_SAMPLED_BIT);
@@ -1722,8 +1714,7 @@ TEST_F(NegativeSampler, ReductionModeFeature) {
     VkSamplerReductionModeCreateInfo sampler_reduction_mode_ci = vku::InitStructHelper();
     sampler_reduction_mode_ci.reductionMode = VK_SAMPLER_REDUCTION_MODE_MIN;
 
-    auto sampler_ci = SafeSaneSamplerCreateInfo();
-    sampler_ci.pNext = &sampler_reduction_mode_ci;
+    auto sampler_ci = SafeSaneSamplerCreateInfo(&sampler_reduction_mode_ci);
     CreateSamplerTest(sampler_ci, "VUID-VkSamplerCreateInfo-pNext-06726");
 }
 
@@ -1764,11 +1755,8 @@ TEST_F(NegativeSampler, BorderColorSwizzle) {
     border_color_component_mapping.components = {VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY,
                                                  VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY};
 
-    VkSamplerCreateInfo sampler_create_info = SafeSaneSamplerCreateInfo();
-    sampler_create_info.pNext = &border_color_component_mapping;
-
     m_errorMonitor->SetDesiredError("VUID-VkSamplerBorderColorComponentMappingCreateInfoEXT-borderColorSwizzle-06437");
-    vkt::Sampler sampler(*m_device, sampler_create_info);
+    vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo(&border_color_component_mapping));
     m_errorMonitor->VerifyFound();
 }
 

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -3250,8 +3250,7 @@ TEST_F(NegativeSyncVal, RenderPassAsyncHazard) {
     renderpass_info.dependencyCount = 0;
     renderpass_info.pDependencies = nullptr;
 
-    VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
-    vkt::Sampler sampler(*m_device, sampler_info);
+    vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
     VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(this, kFragmentSubpassLoadGlsl, VK_SHADER_STAGE_FRAGMENT_BIT);


### PR DESCRIPTION
The 2 drawtime VUs for YCbCr got moved to compile time, I moved them here

While here, I tried to add the new "you can't dynamically descriptor index into a YCbCr array" but hit many hard issues and going to defer it to https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9893 (but at least I have plenty of good tests in here!)

