### PR TITLE
Fix typo in "requirements"

### DIFF
--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -97,7 +97,7 @@ class Image : public Bindable, public SubStateManager<ImageSubState> {
     std::shared_ptr<vvl::Swapchain> bind_swapchain;
     uint32_t swapchain_image_index;
     const VkFormatFeatureFlags2KHR format_features;
-    // Need to memory requirments for each plane if image is disjoint
+    // Need to memory requirements for each plane if image is disjoint
     const bool disjoint;  // True if image was created with VK_IMAGE_CREATE_DISJOINT_BIT
     static constexpr int kMaxPlanes = 3;
     using MemoryReqs = std::array<VkMemoryRequirements, kMaxPlanes>;

--- a/layers/vulkan/generated/spirv_validation_helper.cpp
+++ b/layers/vulkan/generated/spirv_validation_helper.cpp
@@ -1174,7 +1174,7 @@ static inline const char* SpvCapabilityRequirements(uint32_t capability) {
 // clang-format on
 
 // clang-format off
-static inline std::string SpvExtensionRequirments(std::string_view extension) {
+static inline std::string SpvExtensionRequirements(std::string_view extension) {
     static const vvl::unordered_map<std::string_view, vvl::Requirements> table {
     {"SPV_KHR_variable_pointers", {{vvl::Version::_VK_VERSION_1_1}, {vvl::Extension::_VK_KHR_variable_pointers}}},
     {"SPV_AMD_shader_explicit_vertex_parameter", {{vvl::Extension::_VK_AMD_shader_explicit_vertex_parameter}}},
@@ -1449,7 +1449,7 @@ bool stateless::SpirvValidator::ValidateShaderCapabilitiesAndExtensions(const sp
             const char* vuid = pipeline ? "VUID-VkShaderModuleCreateInfo-pCode-08742" : "VUID-VkShaderCreateInfoEXT-pCode-08742";
             skip |= LogError(vuid, module_state.handle(), loc,
                              "SPIR-V Extension %s was declared, but one of the following requirements is required (%s).",
-                             extension_name.c_str(), SpvExtensionRequirments(extension_name).c_str());
+                             extension_name.c_str(), SpvExtensionRequirements(extension_name).c_str());
         }
     }  // spv::OpExtension
     return skip;

--- a/scripts/generators/spirv_validation_generator.py
+++ b/scripts/generators/spirv_validation_generator.py
@@ -209,7 +209,7 @@ class SpirvValidationHelperOutputGenerator(BaseGenerator):
             ''')
 
         #
-        # Build the struct with all the requirments for the spirv capabilities
+        # Build the struct with all the requirements for the spirv capabilities
         out.append('const std::unordered_multimap<uint32_t, RequiredSpirvInfo>& GetSpirvCapabilites() {\n')
         out.append('// clang-format off\n')
         out.append('    static const std::unordered_multimap<uint32_t, RequiredSpirvInfo> spirv_capabilities = {')
@@ -231,7 +231,7 @@ class SpirvValidationHelperOutputGenerator(BaseGenerator):
         out.append('\n')
 
         #
-        # Build the struct with all the requirments for the spirv extensions
+        # Build the struct with all the requirements for the spirv extensions
         out.append('const std::unordered_multimap<std::string_view, RequiredSpirvInfo>& GetSpirvExtensions() {\n')
         out.append('// clang-format off\n')
         out.append('    static const std::unordered_multimap<std::string_view, RequiredSpirvInfo> spirv_extensions = {')
@@ -324,7 +324,7 @@ static inline const char* SpvCapabilityRequirements(uint32_t capability) {
 
         out.append('''
 // clang-format off
-static inline std::string SpvExtensionRequirments(std::string_view extension) {
+static inline std::string SpvExtensionRequirements(std::string_view extension) {
     static const vvl::unordered_map<std::string_view, vvl::Requirements> table {
 ''')
         for spirv in [x for x in self.vk.spirv if x.extension]:
@@ -488,7 +488,7 @@ static inline std::string SpvExtensionRequirments(std::string_view extension) {
                 if (has_support == false) {
                     const char *vuid = pipeline ? "VUID-VkShaderModuleCreateInfo-pCode-08742" : "VUID-VkShaderCreateInfoEXT-pCode-08742";
                     skip |= LogError(vuid, module_state.handle(), loc,
-                        "SPIR-V Extension %s was declared, but one of the following requirements is required (%s).", extension_name.c_str(), SpvExtensionRequirments(extension_name).c_str());
+                        "SPIR-V Extension %s was declared, but one of the following requirements is required (%s).", extension_name.c_str(), SpvExtensionRequirements(extension_name).c_str());
                 }
             } //spv::OpExtension
             return skip;

--- a/tests/unit/memory.cpp
+++ b/tests/unit/memory.cpp
@@ -1865,7 +1865,7 @@ TEST_F(NegativeMemory, DedicatedAllocation) {
 }
 
 TEST_F(NegativeMemory, MemoryRequirements) {
-    TEST_DESCRIPTION("Create invalid requests to image and buffer memory requirments.");
+    TEST_DESCRIPTION("Create invalid requests to image and buffer memory requirements.");
     AddRequiredExtensions(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_BIND_MEMORY_2_EXTENSION_NAME);


### PR DESCRIPTION
In a few places, "requirements" is spelled "requirments".