### PR TITLE
Present semaphore fixes

### DIFF
--- a/layers/state_tracker/queue_state.h
+++ b/layers/state_tracker/queue_state.h
@@ -162,6 +162,9 @@ class Queue : public StateObject, public SubStateManager<QueueSubState> {
     // Access to this variable relies on external queue synchronization.
     bool found_unbalanced_cmdbuf_label = false;
 
+    // If at any point this queue was used for presentation.
+    bool is_used_for_presentation = false;
+
   protected:
     // called from the various PostCallRecordQueueSubmit() methods
     void PostSubmit(QueueSubmission &submission);

--- a/tests/unit/wsi_positive.cpp
+++ b/tests/unit/wsi_positive.cpp
@@ -2287,6 +2287,28 @@ TEST_F(PositiveWsi, SignalPresentSemaphoreAfterFenceWait) {
     m_default_queue->Wait();
 }
 
+TEST_F(PositiveWsi, SignalPresentSemaphoreAfterQueueWait) {
+    TEST_DESCRIPTION("Signal present wait semaphore after waiting on device queue. Only works for pre-swapchain-maintenance1");
+    AddSurfaceExtension();
+    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitSwapchain());
+    const auto swapchain_images = m_swapchain.GetImages();
+    for (auto image : swapchain_images) {
+        SetImageLayoutPresentSrc(image);
+    }
+
+    vkt::Semaphore acquire_semaphore(*m_device);
+    uint32_t image_index = m_swapchain.AcquireNextImage(acquire_semaphore, kWaitTimeout);
+
+    vkt::Semaphore present_semaphore(*m_device);
+    m_default_queue->Submit(vkt::no_cmd, vkt::Wait(acquire_semaphore), vkt::Signal(present_semaphore));
+    m_default_queue->Present(m_swapchain, image_index, present_semaphore);
+
+    m_default_queue->Wait();
+    m_default_queue->Submit(vkt::no_cmd, vkt::Signal(present_semaphore));
+    m_default_queue->Wait();
+}
+
 TEST_F(PositiveWsi, GetDeviceGroupSurfacePresentModes) {
     AddSurfaceExtension();
     RETURN_IF_SKIP(Init());


### PR DESCRIPTION
* Fix waiting on present fence did not have effect
* More strict handling of QueueWaitIdle/DeviceWaitIdle. They don't have effect on present semaphores when swapchain maintenance 1 is enabled.
