### PR TITLE
Utilize pre-installed Ninja

### DIFF
--- a/.github/workflows/sdk_android_build.yml
+++ b/.github/workflows/sdk_android_build.yml
@@ -58,7 +58,6 @@ jobs:
     steps:
     - name: Clone repository
       uses: actions/checkout@v4
-    - uses: lukka/get-cmake@latest
     - uses: actions/setup-python@v5
       with:
         python-version: '3.10'

--- a/.github/workflows/vvl.yml
+++ b/.github/workflows/vvl.yml
@@ -62,7 +62,6 @@ jobs:
         custom_hash_map: [ "ON", "OFF" ]
     steps:
       - uses: actions/checkout@v4
-      - uses: lukka/get-cmake@latest
       - uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ matrix.config }}-address-${{matrix.custom_hash_map}}
@@ -100,7 +99,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: lukka/get-cmake@latest
       - uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ${{ matrix.config }}-thread-${{matrix.custom_hash_map}}
@@ -128,7 +126,6 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      - uses: lukka/get-cmake@latest
       - uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: linux-ubsan
@@ -173,7 +170,6 @@ jobs:
     name: "linux Upload"
     steps:
       - uses: actions/checkout@v4
-      - uses: lukka/get-cmake@latest
       - uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: linux-upload-ccache
@@ -195,7 +191,6 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: lukka/get-cmake@latest
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
@@ -308,7 +303,6 @@ jobs:
 
       steps:
         - uses: actions/checkout@v4
-        - uses: lukka/get-cmake@latest
         - name: Setup ccache
           uses: hendrikmuhs/ccache-action@v1.2
           with:
@@ -337,7 +331,6 @@ jobs:
       runs-on: ubuntu-24.04
       steps:
         - uses: actions/checkout@v4
-        - uses: lukka/get-cmake@latest
         - name: Setup ccache
           uses: hendrikmuhs/ccache-action@v1.2
           with:
@@ -380,7 +373,6 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: iOS-cache
-      - uses: lukka/get-cmake@latest
       - name: Configure for iOS
         run: |
           cmake -S . -B build/ \
@@ -415,7 +407,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-      - uses: lukka/get-cmake@latest
       - run: |
           cmake -S. -B build \
           -D BUILD_WERROR=ON \


### PR DESCRIPTION
Ninja is now available by default on all the runner images.

The version of CMake provided by the runner images is always pretty new and gets updated frequently.

The main benefit of lukka/get-cmake was
1.) Test older version of cmake
2.) Get ninja and cache it.

Reason 2 is now outdated for most of these checks.

Removing it saves CI time & cache on runs that don't need it.