### PR TITLE
layers: Move ValidateShaderTileImage

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -879,7 +879,7 @@ class CoreChecks : public vvl::DeviceProxy {
     bool ValidateWorkgroupSharedMemory(const spirv::Module& module_state, VkShaderStageFlagBits stage,
                                        uint32_t total_workgroup_shared_memory, const Location& loc) const;
     bool ValidateShaderTileImage(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
-                                 const vvl::Pipeline* pipeline, const VkShaderStageFlagBits stage, const Location& loc) const;
+                                 const vvl::Pipeline& pipeline, const Location& loc) const;
     bool ValidateShaderExecutionModes(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
                                       VkShaderStageFlagBits stage, const vvl::Pipeline* pipeline, const Location& loc) const;
     bool ValidateInterfaceVertexInput(const vvl::Pipeline& pipeline, const spirv::Module& module_state,


### PR DESCRIPTION
Try to clear code paths that are Pipeline/ShaderObject vs just Pipeline

`ValidateShaderTileImage` is a pipeline only check, so make the `vvl::Pipeline` a const ref