### PR TITLE
tests: Remove more include headers

### DIFF
--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -18,10 +18,7 @@
 
 #pragma once
 
-#include <algorithm>
 #include <cassert>
-#include <iterator>
-#include <memory>
 #include <vector>
 #include <optional>
 

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -30,31 +30,6 @@
 
 namespace vkt {
 
-template <class Dst, class Src>
-std::vector<Dst> MakeVkHandles(const std::vector<Src> &v) {
-    std::vector<Dst> handles;
-    handles.reserve(v.size());
-    std::transform(v.begin(), v.end(), std::back_inserter(handles), [](const Src &o) { return o.handle(); });
-    return handles;
-}
-
-template <class Dst, class Src>
-std::vector<Dst> MakeVkHandles(const std::vector<Src *> &v) {
-    std::vector<Dst> handles;
-    handles.reserve(v.size());
-    std::transform(v.begin(), v.end(), std::back_inserter(handles),
-                   [](const Src *o) { return (o) ? o->handle() : VK_NULL_HANDLE; });
-    return handles;
-}
-
-template <class Dst, class Src>
-std::vector<Dst> MakeVkHandles(const vvl::span<Src *> &v) {
-    std::vector<Dst> handles;
-    handles.reserve(v.size());
-    std::transform(v.begin(), v.end(), std::back_inserter(handles), [](const Src *o) { return o->handle(); });
-    return handles;
-}
-
 class PhysicalDevice;
 class Device;
 class Queue;

--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -10,6 +10,8 @@
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
+#include <cmath>
+#include <vector>
 #include "layer_validation_tests.h"
 #include "utils/convert_utils.h"
 
@@ -162,7 +164,7 @@ void PositiveTestRenderPass2KHRCreate(const vkt::Device &device, const VkRenderP
 }
 
 void TestRenderPass2KHRCreate(ErrorMonitor &error_monitor, const vkt::Device &device, const VkRenderPassCreateInfo2KHR &create_info,
-                              const std::initializer_list<const char *> &vuids) {
+                              const std::vector<const char *> &vuids) {
     for (auto vuid : vuids) {
         error_monitor.SetDesiredError(vuid);
     }
@@ -295,6 +297,18 @@ VkSamplerCreateInfo SafeSaneSamplerCreateInfo(void *p_next) {
     sampler_create_info.unnormalizedCoordinates = VK_FALSE;
 
     return sampler_create_info;
+}
+
+float NearestGreater(const float from) {
+    using Lim = std::numeric_limits<float>;
+    const auto positive_direction = Lim::has_infinity ? Lim::infinity() : Lim::max();
+    return std::nextafter(from, positive_direction);
+}
+
+float NearestSmaller(const float from) {
+    using Lim = std::numeric_limits<float>;
+    const auto negative_direction = Lim::has_infinity ? -Lim::infinity() : Lim::lowest();
+    return std::nextafter(from, negative_direction);
 }
 
 void VkLayerTest::Init(VkPhysicalDeviceFeatures *features, VkPhysicalDeviceFeatures2 *features2, void *instance_pnext) {

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -39,10 +39,6 @@
 #include "containers/limits.h"
 #include "render.h"
 
-#include <cmath>
-#include <functional>
-#include <limits>
-#include <string>
 #include <vector>
 #include <array> // Required for Windows in many tests
 

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -123,21 +123,8 @@ template <typename T>
 struct AlwaysFalse : std::false_type {};
 
 // Helpers to get nearest greater or smaller value (of float) -- useful for testing the boundary cases of Vulkan limits
-template <typename T>
-T NearestGreater(const T from) {
-    using Lim = std::numeric_limits<T>;
-    const auto positive_direction = Lim::has_infinity ? Lim::infinity() : Lim::max();
-
-    return std::nextafter(from, positive_direction);
-}
-
-template <typename T>
-T NearestSmaller(const T from) {
-    using Lim = std::numeric_limits<T>;
-    const auto negative_direction = Lim::has_infinity ? -Lim::infinity() : Lim::lowest();
-
-    return std::nextafter(from, negative_direction);
-}
+float NearestGreater(const float from);
+float NearestSmaller(const float from);
 
 // Defining VVL_TESTS_USE_CUSTOM_TEST_FRAMEWORK allows downstream users
 // to inject custom test framework changes. This includes the ability
@@ -455,7 +442,7 @@ void PositiveTestRenderPassCreate(ErrorMonitor *error_monitor, const vkt::Device
                                   bool rp2_supported);
 void PositiveTestRenderPass2KHRCreate(const vkt::Device &device, const VkRenderPassCreateInfo2KHR &create_info);
 void TestRenderPass2KHRCreate(ErrorMonitor &error_monitor, const vkt::Device &device, const VkRenderPassCreateInfo2KHR &create_info,
-                              const std::initializer_list<const char *> &vuids);
+                              const std::vector<const char *> &vuids);
 void TestRenderPassBegin(ErrorMonitor *error_monitor, const VkDevice device, const VkCommandBuffer command_buffer,
                          const VkRenderPassBeginInfo *begin_info, bool rp2Supported, const char *rp1_vuid, const char *rp2_vuid);
 

--- a/tests/framework/ray_tracing_objects.h
+++ b/tests/framework/ray_tracing_objects.h
@@ -15,7 +15,6 @@
 #include "descriptor_helper.h"
 #include "shader_helper.h"
 
-#include <memory>
 #include <optional>
 
 namespace vkt {

--- a/tests/framework/render.cpp
+++ b/tests/framework/render.cpp
@@ -1114,7 +1114,12 @@ void VkRenderFramework::DestroyRenderTarget() {
 void VkRenderFramework::SetDefaultDynamicStatesExclude(const std::vector<VkDynamicState> &exclude, bool tessellation,
                                                        VkCommandBuffer commandBuffer) {
     const auto excluded = [&exclude](VkDynamicState state) {
-        return std::find(exclude.begin(), exclude.end(), state) != exclude.end();
+        for (const auto &check_state : exclude) {
+            if (check_state == state) {
+                return true;
+            }
+        }
+        return false;
     };
     if (!m_vertex_buffer) {
         m_vertex_buffer = new vkt::Buffer(*m_device, 32u, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -22,7 +22,6 @@
 #include "test_framework.h"
 #include "feature_requirements.h"
 #include "binding.h"
-#include "generated/vk_extension_helper.h"
 
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
 #include <android/log.h>
@@ -32,6 +31,9 @@
 #include <vector>
 
 using vkt::MakeVkHandles;
+
+struct InstanceExtensions;
+struct DeviceExtensions;
 
 static constexpr uint64_t kWaitTimeout{10000000000};  // 10 seconds in ns
 static constexpr VkDeviceSize kZeroDeviceSize{0};
@@ -270,8 +272,8 @@ class VkRenderFramework : public VkTestFramework {
     std::vector<vkt::ImageView> m_render_target_views;   // color attachments but not depth
     std::vector<VkImageView> m_framebuffer_attachments;  // all attachments, can be consumed directly by the API
 
-    InstanceExtensions instance_extensions;
-    DeviceExtensions device_extensions;
+    InstanceExtensions *m_instance_extensions = nullptr;
+    DeviceExtensions *m_device_extensions = nullptr;
 
     // Add ext_name, the names of all instance extensions required by ext_name, and return true if ext_name is supported. If the
     // extension is not supported, no extension names are added for instance creation. `ext_name` can refer to a device or instance

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -30,8 +30,6 @@
 
 #include <vector>
 
-using vkt::MakeVkHandles;
-
 struct InstanceExtensions;
 struct DeviceExtensions;
 

--- a/tests/framework/shader_helper.h
+++ b/tests/framework/shader_helper.h
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@
 #include <glslang/Public/ShaderLang.h>
 
 #include "render.h"
+// This include is light and easier to have here a single place for all tests to grab
 #include "shader_templates.h"
 
 class VkRenderFramework;

--- a/tests/framework/video_objects.h
+++ b/tests/framework/video_objects.h
@@ -25,11 +25,8 @@
 #include <vk_video/vulkan_video_codec_av1std_decode.h>
 #include <vk_video/vulkan_video_codec_av1std_encode.h>
 
-#include <memory>
 #include <vector>
-#include <functional>
 #include <unordered_set>
-#include <math.h>
 
 class VideoConfig {
   public:

--- a/tests/unit/arm_best_practices.cpp
+++ b/tests/unit/arm_best_practices.cpp
@@ -14,6 +14,7 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/render_pass_helper.h"
+#include <algorithm>
 
 const char* kEnableArmValidation = "VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ARM";
 

--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -352,7 +352,9 @@ TEST_F(NegativeCommand, PushConstants) {
     for (const auto &iter : duplicate_stageFlags_tests) {
         pipeline_layout_ci.pPushConstantRanges = iter.ranges;
         pipeline_layout_ci.pushConstantRangeCount = ranges_per_test;
-        std::for_each(iter.msg.begin(), iter.msg.end(), [&](const char *vuid) { m_errorMonitor->SetDesiredError(vuid); });
+        for (const auto &vuid : iter.msg) {
+            m_errorMonitor->SetDesiredError(vuid);
+        }
         vk::CreatePipelineLayout(device(), &pipeline_layout_ci, NULL, &pipeline_layout);
         m_errorMonitor->VerifyFound();
     }

--- a/tests/unit/cooperative_vector_positive.cpp
+++ b/tests/unit/cooperative_vector_positive.cpp
@@ -13,7 +13,6 @@
 
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
-#include "../framework/descriptor_helper.h"
 
 class PositiveCooperativeVector : public VkLayerTest {};
 

--- a/tests/unit/copy_buffer_image.cpp
+++ b/tests/unit/copy_buffer_image.cpp
@@ -13,6 +13,7 @@
  */
 
 #include <gtest/gtest.h>
+#include <algorithm>
 #include "../framework/layer_validation_tests.h"
 
 class NegativeCopyBufferImage : public VkLayerTest {};

--- a/tests/unit/debug_printf_ray_tracing.cpp
+++ b/tests/unit/debug_printf_ray_tracing.cpp
@@ -14,10 +14,7 @@
 #include <vulkan/vulkan_core.h>
 #include <cstdint>
 #include "../framework/layer_validation_tests.h"
-#include "../framework/pipeline_helper.h"
-#include "../framework/shader_object_helper.h"
 #include "../framework/descriptor_helper.h"
-#include "../framework/buffer_helper.h"
 #include "../framework/gpu_av_helper.h"
 #include "../framework/ray_tracing_objects.h"
 

--- a/tests/unit/descriptors.cpp
+++ b/tests/unit/descriptors.cpp
@@ -21,6 +21,7 @@
 #include "../framework/descriptor_helper.h"
 #include "../framework/render_pass_helper.h"
 #include "../framework/ray_tracing_objects.h"
+#include <algorithm>
 
 class NegativeDescriptors : public VkLayerTest {};
 
@@ -1932,7 +1933,10 @@ TEST_F(NegativeDescriptors, DescriptorSetCompatibility) {
     dsl_binding[0].descriptorCount = 2;
     ds_layouts.emplace_back(*m_device, std::vector<VkDescriptorSetLayoutBinding>(1, dsl_binding[0]));
 
-    const auto &ds_vk_layouts = MakeVkHandles<VkDescriptorSetLayout>(ds_layouts);
+    std::vector<VkDescriptorSetLayout> ds_vk_layouts;
+    for (const auto &ds_layout : ds_layouts) {
+        ds_vk_layouts.push_back(ds_layout.handle());
+    }
 
     static const uint32_t NUM_SETS = 4;
     VkDescriptorSet descriptorSet[NUM_SETS] = {};

--- a/tests/unit/dynamic_state.cpp
+++ b/tests/unit/dynamic_state.cpp
@@ -3355,13 +3355,13 @@ TEST_F(NegativeDynamicState, SetViewportParam) {
     const auto one_past_max_w = NearestGreater(static_cast<float>(m_device->Physical().limits_.maxViewportDimensions[0]));
     const auto one_past_max_h = NearestGreater(static_cast<float>(m_device->Physical().limits_.maxViewportDimensions[1]));
 
-    const auto min_bound = m_device->Physical().limits_.viewportBoundsRange[0];
-    const auto max_bound = m_device->Physical().limits_.viewportBoundsRange[1];
-    const auto one_before_min_bounds = NearestSmaller(min_bound);
-    const auto one_past_max_bounds = NearestGreater(max_bound);
+    const float min_bound = m_device->Physical().limits_.viewportBoundsRange[0];
+    const float max_bound = m_device->Physical().limits_.viewportBoundsRange[1];
+    const float one_before_min_bounds = NearestSmaller(min_bound);
+    const float one_past_max_bounds = NearestGreater(max_bound);
 
-    const auto below_zero = NearestSmaller(0.0f);
-    const auto past_one = NearestGreater(1.0f);
+    const float below_zero = NearestSmaller(0.0f);
+    const float past_one = NearestGreater(1.0f);
 
     std::vector<TestCase> test_cases = {
         {{0.0, 0.0, 0.0, 64.0, 0.0, 1.0}, "VUID-VkViewport-width-01770"},

--- a/tests/unit/external_memory_sync.cpp
+++ b/tests/unit/external_memory_sync.cpp
@@ -12,7 +12,6 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#include "utils/cast_utils.h"
 #include "generated/enum_flag_bits.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/external_memory_sync.h"

--- a/tests/unit/external_memory_sync_positive.cpp
+++ b/tests/unit/external_memory_sync_positive.cpp
@@ -14,7 +14,6 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/external_memory_sync.h"
 #include "utils/math_utils.h"
-#include "generated/enum_flag_bits.h"
 
 class PositiveExternalMemorySync : public ExternalMemorySyncTest {};
 

--- a/tests/unit/geometry_tessellation.cpp
+++ b/tests/unit/geometry_tessellation.cpp
@@ -15,7 +15,6 @@
 #include <vulkan/vulkan_core.h>
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
-#include "../framework/shader_object_helper.h"
 
 class NegativeGeometryTessellation : public VkLayerTest {};
 

--- a/tests/unit/gpu_av_ray_tracing.cpp
+++ b/tests/unit/gpu_av_ray_tracing.cpp
@@ -14,7 +14,6 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/descriptor_helper.h"
 #include "../framework/ray_tracing_objects.h"
-#include "../framework/shader_helper.h"
 #include "../framework/gpu_av_helper.h"
 
 class NegativeGpuAVRayTracing : public GpuAVRayTracingTest {};

--- a/tests/unit/gpu_av_ray_tracing_positive.cpp
+++ b/tests/unit/gpu_av_ray_tracing_positive.cpp
@@ -14,7 +14,6 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/ray_tracing_objects.h"
 #include "../framework/descriptor_helper.h"
-#include "../framework/shader_helper.h"
 #include "../framework/gpu_av_helper.h"
 
 class PositiveGpuAVRayTracing : public GpuAVRayTracingTest {};

--- a/tests/unit/gpu_av_shader_object_positive.cpp
+++ b/tests/unit/gpu_av_shader_object_positive.cpp
@@ -10,9 +10,7 @@
  */
 
 #include "../framework/layer_validation_tests.h"
-#include "../framework/descriptor_helper.h"
 #include "../framework/shader_object_helper.h"
-#include "../framework/shader_templates.h"
 #include "../framework/pipeline_helper.h"
 
 class PositiveGpuAVShaderObject : public GpuAVTest {

--- a/tests/unit/host_image_copy_positive.cpp
+++ b/tests/unit/host_image_copy_positive.cpp
@@ -12,6 +12,7 @@
  */
 
 #include "../framework/layer_validation_tests.h"
+#include <algorithm>
 
 bool HostImageCopyTest::CopyLayoutSupported(const std::vector<VkImageLayout> &src_layouts,
                                             const std::vector<VkImageLayout> &dst_layouts, VkImageLayout layout) {

--- a/tests/unit/image.cpp
+++ b/tests/unit/image.cpp
@@ -15,9 +15,7 @@
 #include <vulkan/vulkan_core.h>
 #include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
-#include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
-#include "../framework/sync_helper.h"
 #include "utils/vk_layer_utils.h"
 
 class NegativeImage : public ImageTest {};

--- a/tests/unit/image_positive.cpp
+++ b/tests/unit/image_positive.cpp
@@ -12,9 +12,6 @@
  */
 
 #include "../framework/layer_validation_tests.h"
-#include "../framework/pipeline_helper.h"
-#include "../framework/descriptor_helper.h"
-#include "../framework/render_pass_helper.h"
 #include "../framework/sync_helper.h"
 
 #include "utils/vk_layer_utils.h"

--- a/tests/unit/instanceless.cpp
+++ b/tests/unit/instanceless.cpp
@@ -31,7 +31,6 @@
 #include <thread>
 #include <vector>
 
-#include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 
 static VkInstance dummy_instance;

--- a/tests/unit/layer_settings_positive.cpp
+++ b/tests/unit/layer_settings_positive.cpp
@@ -11,7 +11,6 @@
  */
 // stype-check off
 
-#include <array>
 #include "../framework/layer_validation_tests.h"
 
 class PositiveLayerSettings : public VkLayerTest {};

--- a/tests/unit/multiview_positive.cpp
+++ b/tests/unit/multiview_positive.cpp
@@ -15,7 +15,6 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/render_pass_helper.h"
-#include "error_message/log_message_type.h"
 
 class PositiveMultiview : public VkLayerTest {};
 

--- a/tests/unit/object_lifetime.cpp
+++ b/tests/unit/object_lifetime.cpp
@@ -18,7 +18,6 @@
 #include "../framework/render_pass_helper.h"
 #include "../framework/descriptor_helper.h"
 #include "../framework/external_memory_sync.h"
-#include "../framework/sync_helper.h"
 
 class NegativeObjectLifetime : public VkLayerTest {};
 

--- a/tests/unit/other_positive.cpp
+++ b/tests/unit/other_positive.cpp
@@ -12,8 +12,6 @@
  */
 
 #include "../framework/layer_validation_tests.h"
-#include "generated/vk_extension_helper.h"
-
 #include <cstdlib>
 
 class VkPositiveLayerTest : public VkLayerTest {};

--- a/tests/unit/pipeline_layout.cpp
+++ b/tests/unit/pipeline_layout.cpp
@@ -16,6 +16,7 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
+#include <algorithm>
 
 class NegativePipelineLayout : public VkLayerTest {};
 
@@ -971,7 +972,10 @@ TEST_F(NegativePipelineLayout, MultiplePushDescriptorSets) {
         ds_layouts.emplace_back(*m_device, std::vector<VkDescriptorSetLayoutBinding>(1, dsl_binding),
                                 VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT);
     }
-    const auto &ds_vk_layouts = MakeVkHandles<VkDescriptorSetLayout>(ds_layouts);
+    std::vector<VkDescriptorSetLayout> ds_vk_layouts;
+    for (const auto &ds_layout : ds_layouts) {
+        ds_vk_layouts.push_back(ds_layout.handle());
+    }
 
     VkPipelineLayout pipeline_layout;
     VkPipelineLayoutCreateInfo pipeline_layout_ci = vku::InitStructHelper();

--- a/tests/unit/query.cpp
+++ b/tests/unit/query.cpp
@@ -15,6 +15,7 @@
 #include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
+#include <algorithm>
 
 class NegativeQuery : public QueryTest {};
 

--- a/tests/unit/ray_tracing_nv.cpp
+++ b/tests/unit/ray_tracing_nv.cpp
@@ -15,6 +15,7 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/ray_tracing_helper_nv.h"
 #include "../framework/descriptor_helper.h"
+#include <algorithm>
 
 void RayTracingTest::NvInitFrameworkForRayTracingTest(VkPhysicalDeviceFeatures2KHR *features2 /*= nullptr*/,
                                                       VkValidationFeaturesEXT *enabled_features /*= nullptr*/) {

--- a/tests/unit/ray_tracing_positive.cpp
+++ b/tests/unit/ray_tracing_positive.cpp
@@ -13,12 +13,10 @@
 
 #include "../framework/layer_validation_tests.h"
 #include "../framework/ray_tracing_objects.h"
-#include "../framework/shader_helper.h"
 #include "../framework/feature_requirements.h"
-#include "../layers/utils/vk_layer_utils.h"
 #include "../framework/descriptor_helper.h"
 #include "../framework/pipeline_helper.h"
-#include <iterator>
+#include "utils/math_utils.h"
 
 void RayTracingTest::InitFrameworkForRayTracingTest(VkValidationFeaturesEXT* enabled_features /*= nullptr*/) {
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);

--- a/tests/unit/ray_tracing_positive.cpp
+++ b/tests/unit/ray_tracing_positive.cpp
@@ -17,6 +17,7 @@
 #include "../framework/descriptor_helper.h"
 #include "../framework/pipeline_helper.h"
 #include "utils/math_utils.h"
+#include <algorithm>
 
 void RayTracingTest::InitFrameworkForRayTracingTest(VkValidationFeaturesEXT* enabled_features /*= nullptr*/) {
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);

--- a/tests/unit/shader_compute.cpp
+++ b/tests/unit/shader_compute.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (c) 2015-2024 Google, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2025 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,7 @@
 
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
+#include <algorithm>
 
 class NegativeShaderCompute : public VkLayerTest {};
 

--- a/tests/unit/shader_image_access.cpp
+++ b/tests/unit/shader_image_access.cpp
@@ -11,7 +11,6 @@
 
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
-#include "error_message/log_message_type.h"
 
 class NegativeShaderImageAccess : public VkLayerTest {};
 

--- a/tests/unit/subgroups.cpp
+++ b/tests/unit/subgroups.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (c) 2015-2024 Google, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2025 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,7 @@
 
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
+#include <cmath>
 
 class NegativeSubgroup : public VkLayerTest {};
 

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -12,6 +12,7 @@
  */
 
 #include <thread>
+#include <algorithm>
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"

--- a/tests/unit/sync_val_semaphore_positive.cpp
+++ b/tests/unit/sync_val_semaphore_positive.cpp
@@ -17,6 +17,9 @@
 
 #include <thread>
 #include "../framework/layer_validation_tests.h"
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+#include "../framework/external_memory_sync.h"
+#endif  // VK_USE_PLATFORM_WIN32_KHR
 
 struct PositiveSyncValTimelineSemaphore : public VkSyncValTest {};
 

--- a/tests/unit/sync_val_semaphore_positive.cpp
+++ b/tests/unit/sync_val_semaphore_positive.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2024 The Khronos Group Inc.
- * Copyright (c) 2024 Valve Corporation
- * Copyright (c) 2024 LunarG, Inc.
+/* Copyright (c) 2024-2025 The Khronos Group Inc.
+ * Copyright (c) 2024-2025 Valve Corporation
+ * Copyright (c) 2024-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 
 #include <thread>
 #include "../framework/layer_validation_tests.h"
-#include "../framework/external_memory_sync.h"
 
 struct PositiveSyncValTimelineSemaphore : public VkSyncValTest {};
 

--- a/tests/unit/video_decode.cpp
+++ b/tests/unit/video_decode.cpp
@@ -11,6 +11,7 @@
  */
 
 #include "../framework/video_objects.h"
+#include <algorithm>
 
 class NegativeVideoDecode : public VkVideoLayerTest {};
 

--- a/tests/unit/video_encode.cpp
+++ b/tests/unit/video_encode.cpp
@@ -12,6 +12,7 @@
 
 #include "../framework/video_objects.h"
 #include "generated/enum_flag_bits.h"
+#include <algorithm>
 
 class NegativeVideoEncode : public VkVideoLayerTest {};
 

--- a/tests/unit/wsi.cpp
+++ b/tests/unit/wsi.cpp
@@ -15,6 +15,7 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "generated/vk_function_pointers.h"
+#include <algorithm>
 
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
 #include "wayland-client.h"
@@ -610,8 +611,13 @@ TEST_F(NegativeWsi, SwapchainAcquireTooManyImages) {
     m_swapchain.AcquireNextImage(error_fence, vvl::kU64Max);
     m_errorMonitor->VerifyFound();
 
+    std::vector<VkFence> fence_handles;
+    for (const auto &fence : fences) {
+        fence_handles.push_back(fence.handle());
+    }
+
     // Cleanup
-    vk::WaitForFences(device(), fences.size(), MakeVkHandles<VkFence>(fences).data(), VK_TRUE, kWaitTimeout);
+    vk::WaitForFences(device(), fence_handles.size(), fence_handles.data(), VK_TRUE, kWaitTimeout);
 }
 
 TEST_F(NegativeWsi, GetSwapchainImageAndTryDestroy) {
@@ -741,8 +747,13 @@ TEST_F(NegativeWsi, SwapchainAcquireTooManyImages2KHR) {
     vk::AcquireNextImage2KHR(device(), &acquire_info, &image_i);
     m_errorMonitor->VerifyFound();
 
+    std::vector<VkFence> fence_handles;
+    for (const auto &fence : fences) {
+        fence_handles.push_back(fence.handle());
+    }
+
     // Cleanup
-    vk::WaitForFences(device(), fences.size(), MakeVkHandles<VkFence>(fences).data(), VK_TRUE, kWaitTimeout);
+    vk::WaitForFences(device(), fence_handles.size(), fence_handles.data(), VK_TRUE, kWaitTimeout);
 }
 
 TEST_F(NegativeWsi, SwapchainImageFormatList) {


### PR DESCRIPTION
One final (for now) fix for test files to not include more then it needs. Looking at a clang trace, this is about as slim as we will get the tests files for now