### PR TITLE
layer: Add 'prefix' in layer manifest, used by doc generation

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -2,6 +2,7 @@
     "file_format_version": "1.2.0",
     "layer": {
         "name": "@JSON_LAYER_NAME@",
+        "prefix": "vvl",
         "type": "GLOBAL",
         "library_path": "@JSON_LIBRARY_PATH@",
         "api_version": "1.4.312",
@@ -1309,7 +1310,7 @@
                             "key": "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT",
                             "label": "Reserve Descriptor Set Binding Slot",
                             "description": "Specifies that the validation layers reserve a descriptor set binding slot for their own use. The layer reports a value for VkPhysicalDeviceLimits::maxBoundDescriptorSets that is one less than the value reported by the device. If the device supports the binding of only one descriptor set, the validation layer does not perform GPU-assisted validation.",
-                            "platforms": ["WINDOWS", "LINUX" ]
+                            "platforms": [ "WINDOWS", "LINUX" ]
                         },
                         {
                             "key": "VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT",


### PR DESCRIPTION
This allows listing te short version of the Android system properties of a setting in the generated layer setting doc.

![image](https://github.com/user-attachments/assets/542ee8fd-d9a0-4b6a-81d4-3b10b7acb89a)
