### PR TITLE
gpuav: ShaderObject missing keeping old spirv

### DIFF
--- a/layers/gpuav/debug_printf/debug_printf.cpp
+++ b/layers/gpuav/debug_printf/debug_printf.cpp
@@ -204,14 +204,14 @@ void AnalyzeAndGenerateMessage(Validator &gpuav, VkCommandBuffer command_buffer,
         }
 
         // without the instrumented spirv, there is nothing valuable to print out
-        if (!instrumented_shader || instrumented_shader->instrumented_spirv.empty()) {
+        if (!instrumented_shader || instrumented_shader->original_spirv.empty()) {
             gpuav.InternalWarning(queue, loc, "Can't find instructions from any handles in shader_map");
             return;
         }
 
         // Search through the shader source for the printf format string for this invocation
         std::string format_string;
-        const char *op_string = ::spirv::GetOpString(instrumented_shader->instrumented_spirv, debug_record->format_string_id);
+        const char *op_string = ::spirv::GetOpString(instrumented_shader->original_spirv, debug_record->format_string_id);
         if (op_string) {
             format_string = std::string(op_string);
         } else {

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.h
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.h
@@ -58,7 +58,8 @@ struct InstrumentedShader {
     VkPipeline pipeline;
     VkShaderModule shader_module;
     VkShaderEXT shader_object;
-    std::vector<uint32_t> instrumented_spirv;
+    // We keep the original SPIR-V so we can match up where the error occured to map to shader source files
+    std::vector<uint32_t> original_spirv;
 };
 
 // Historically this was an common interface to both GPU-AV and DebugPrintf before the were merged together.


### PR DESCRIPTION
We were not saving the original SPIR-V and it was causing using Shader Debug Info to produce the wrong line from the source code (when using Shader Object)