### PR TITLE
gpuav: Handle Binary Shader Objects

### DIFF
--- a/layers/chassis/chassis.h
+++ b/layers/chassis/chassis.h
@@ -1,10 +1,10 @@
 /***************************************************************************
  *
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (c) 2015-2024 Google Inc.
- * Copyright (c) 2023-2024 RasterGrid Kft.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2025 Google Inc.
+ * Copyright (c) 2023-2025 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,6 +65,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateShaderModule(VkDevice device, const VkShade
 VKAPI_ATTR VkResult VKAPI_CALL CreateShadersEXT(VkDevice device, uint32_t createInfoCount,
                                                 const VkShaderCreateInfoEXT* pCreateInfos, const VkAllocationCallbacks* pAllocator,
                                                 VkShaderEXT* pShaders);
+VKAPI_ATTR VkResult VKAPI_CALL GetShaderBinaryDataEXT(VkDevice device, VkShaderEXT shader, size_t* pDataSize, void* pData);
 VKAPI_ATTR VkResult VKAPI_CALL AllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo* pAllocateInfo,
                                                       VkDescriptorSet* pDescriptorSets);
 VKAPI_ATTR VkResult VKAPI_CALL CreateBuffer(VkDevice device, const VkBufferCreateInfo* pCreateInfo,

--- a/layers/chassis/chassis_modification_state.h
+++ b/layers/chassis/chassis_modification_state.h
@@ -65,7 +65,7 @@ struct ShaderObject {
 
     // When using GPU-AV the pCreateInfo is modified on the user
     bool is_modified = false;
-    std::vector<VkShaderCreateInfoEXT> modified_create_infos;
+    std::vector<vku::safe_VkShaderCreateInfoEXT> modified_create_infos;
     const VkShaderCreateInfoEXT* pCreateInfos = nullptr;
 
     // Pass the instrumented SPIR-V info from PreCallRecord to Dispatch (so GPU-AV logic can run with it)
@@ -128,6 +128,10 @@ struct CreatePipelineLayout {
     // If a 2nd layer starts to use it, can have conflicting values
     std::vector<VkDescriptorSetLayout> new_layouts;
     VkPipelineLayoutCreateInfo modified_create_info;
+};
+
+struct ShaderBinaryData {
+    VkShaderEXT modified_shader_handle;
 };
 
 struct CreateBuffer {

--- a/layers/chassis/validation_object.h
+++ b/layers/chassis/validation_object.h
@@ -50,6 +50,7 @@ struct CreateRayTracingPipelinesNV;
 struct CreateRayTracingPipelinesKHR;
 struct CreateShaderModule;
 struct ShaderObject;
+struct ShaderBinaryData;
 struct CreatePipelineLayout;
 struct CreateBuffer;
 }  // namespace chassis
@@ -376,6 +377,12 @@ class Device : public Logger {
                                                 VkShaderEXT* pShaders, const RecordObject& record_obj,
                                                 chassis::ShaderObject& chassis_state) {
         PostCallRecordCreateShadersEXT(device, createInfoCount, pCreateInfos, pAllocator, pShaders, record_obj);
+    }
+
+    // Allow modification of a down-chain parameter for CreatePipelineLayout
+    virtual void PreCallRecordGetShaderBinaryDataEXT(VkDevice device, VkShaderEXT shader, size_t* pDataSize, void* pData,
+                                                     const RecordObject& record_obj, chassis::ShaderBinaryData& chassis_state) {
+        PreCallRecordGetShaderBinaryDataEXT(device, shader, pDataSize, pData, record_obj);
     }
 
     // Allow AllocateDescriptorSets to use some local stack storage for performance purposes

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.h
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.h
@@ -101,7 +101,10 @@ class GpuShaderInstrumentor : public vvl::DeviceProxy {
     void PostCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo *pCreateInfo,
                                           const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule,
                                           const RecordObject &record_obj, chassis::CreateShaderModule &chassis_state) override;
-    void PreCallRecordShaderObjectInstrumentation(VkShaderCreateInfoEXT &create_info, const Location &create_info_loc,
+    void PreCallRecordGetShaderBinaryDataEXT(VkDevice device, VkShaderEXT shader, size_t *pDataSize, void *pData,
+                                             const RecordObject &record_obj, chassis::ShaderBinaryData &chassis_state) override;
+    bool PreCallRecordShaderObjectInstrumentation(vku::safe_VkShaderCreateInfoEXT &modified_create_info,
+                                                  const Location &create_info_loc,
                                                   chassis::ShaderObjectInstrumentationData &shader_instrumentation_data);
     void PreCallRecordCreateShadersEXT(VkDevice device, uint32_t createInfoCount, const VkShaderCreateInfoEXT *pCreateInfos,
                                        const VkAllocationCallbacks *pAllocator, VkShaderEXT *pShaders,
@@ -180,7 +183,7 @@ class GpuShaderInstrumentor : public vvl::DeviceProxy {
     };
     void BuildDescriptorSetLayoutInfo(const vvl::Pipeline &pipeline_state,
                                       InstrumentationDescriptorSetLayouts &out_instrumentation_dsl);
-    void BuildDescriptorSetLayoutInfo(const VkShaderCreateInfoEXT &create_info,
+    void BuildDescriptorSetLayoutInfo(const vku::safe_VkShaderCreateInfoEXT &modified_create_info,
                                       InstrumentationDescriptorSetLayouts &out_instrumentation_dsl);
     void BuildDescriptorSetLayoutInfo(const vvl::DescriptorSetLayout &set_layout_state, const uint32_t set_layout_index,
                                       InstrumentationDescriptorSetLayouts &out_instrumentation_dsl);

--- a/layers/state_tracker/shader_object_state.h
+++ b/layers/state_tracker/shader_object_state.h
@@ -53,6 +53,9 @@ struct ShaderObject : public StateObject {
     struct InstrumentationData {
         bool was_instrumented = false;
         uint32_t unique_shader_id = 0;
+        // We need to keep incase the user calls vkGetShaderBinaryDataEXT
+        vku::safe_VkShaderCreateInfoEXT original_create_info;
+        VkShaderEXT original_handle = VK_NULL_HANDLE;
     } instrumentation_data;
 
     VkShaderEXT VkHandle() const { return handle_.Cast<VkShaderEXT>(); }

--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -30509,53 +30509,6 @@ VKAPI_ATTR void VKAPI_CALL DestroyShaderEXT(VkDevice device, VkShaderEXT shader,
     }
 }
 
-VKAPI_ATTR VkResult VKAPI_CALL GetShaderBinaryDataEXT(VkDevice device, VkShaderEXT shader, size_t* pDataSize, void* pData) {
-    VVL_ZoneScoped;
-
-    auto device_dispatch = vvl::dispatch::GetData(device);
-    bool skip = false;
-    ErrorObject error_obj(vvl::Func::vkGetShaderBinaryDataEXT, VulkanTypedHandle(device, kVulkanObjectTypeDevice));
-    {
-        VVL_ZoneScopedN("PreCallValidate_vkGetShaderBinaryDataEXT");
-        for (const auto& vo : device_dispatch->intercept_vectors[InterceptIdPreCallValidateGetShaderBinaryDataEXT]) {
-            if (!vo) {
-                continue;
-            }
-            auto lock = vo->ReadLock();
-            skip |= vo->PreCallValidateGetShaderBinaryDataEXT(device, shader, pDataSize, pData, error_obj);
-            if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
-        }
-    }
-    RecordObject record_obj(vvl::Func::vkGetShaderBinaryDataEXT);
-    {
-        VVL_ZoneScopedN("PreCallRecord_vkGetShaderBinaryDataEXT");
-        for (auto& vo : device_dispatch->intercept_vectors[InterceptIdPreCallRecordGetShaderBinaryDataEXT]) {
-            if (!vo) {
-                continue;
-            }
-            auto lock = vo->WriteLock();
-            vo->PreCallRecordGetShaderBinaryDataEXT(device, shader, pDataSize, pData, record_obj);
-        }
-    }
-    VkResult result;
-    {
-        VVL_ZoneScopedN("Dispatch_vkGetShaderBinaryDataEXT");
-        result = device_dispatch->GetShaderBinaryDataEXT(device, shader, pDataSize, pData);
-    }
-    record_obj.result = result;
-    {
-        VVL_ZoneScopedN("PostCallRecord_vkGetShaderBinaryDataEXT");
-        for (auto& vo : device_dispatch->intercept_vectors[InterceptIdPostCallRecordGetShaderBinaryDataEXT]) {
-            if (!vo) {
-                continue;
-            }
-            auto lock = vo->WriteLock();
-            vo->PostCallRecordGetShaderBinaryDataEXT(device, shader, pDataSize, pData, record_obj);
-        }
-    }
-    return result;
-}
-
 VKAPI_ATTR void VKAPI_CALL CmdBindShadersEXT(VkCommandBuffer commandBuffer, uint32_t stageCount,
                                              const VkShaderStageFlagBits* pStages, const VkShaderEXT* pShaders) {
     VVL_ZoneScoped;

--- a/layers/vulkan/generated/dispatch_vector.cpp
+++ b/layers/vulkan/generated/dispatch_vector.cpp
@@ -1794,7 +1794,6 @@ void Device::InitObjectDispatchVectors() {
     BUILD_DESTROY_DISPATCH_VECTOR(PreCallRecordDestroyShaderEXT);
     BUILD_DESTROY_DISPATCH_VECTOR(PostCallRecordDestroyShaderEXT);
     BUILD_DISPATCH_VECTOR(PreCallValidateGetShaderBinaryDataEXT);
-    BUILD_DISPATCH_VECTOR(PreCallRecordGetShaderBinaryDataEXT);
     BUILD_DISPATCH_VECTOR(PostCallRecordGetShaderBinaryDataEXT);
     BUILD_DISPATCH_VECTOR(PreCallValidateCmdBindShadersEXT);
     BUILD_DISPATCH_VECTOR(PreCallRecordCmdBindShadersEXT);

--- a/layers/vulkan/generated/dispatch_vector.h
+++ b/layers/vulkan/generated/dispatch_vector.h
@@ -1689,7 +1689,6 @@ typedef enum InterceptId {
     InterceptIdPreCallRecordDestroyShaderEXT,
     InterceptIdPostCallRecordDestroyShaderEXT,
     InterceptIdPreCallValidateGetShaderBinaryDataEXT,
-    InterceptIdPreCallRecordGetShaderBinaryDataEXT,
     InterceptIdPostCallRecordGetShaderBinaryDataEXT,
     InterceptIdPreCallValidateCmdBindShadersEXT,
     InterceptIdPreCallRecordCmdBindShadersEXT,

--- a/scripts/generators/dispatch_vector_generator.py
+++ b/scripts/generators/dispatch_vector_generator.py
@@ -54,6 +54,7 @@ class DispatchVectorGenerator(BaseGenerator):
     skip_intercept_id_pre_record = (
         'vkCreatePipelineLayout',
         'vkCreateBuffer',
+        'vkGetShaderBinaryDataEXT',
     )
     skip_intercept_id_post_record = (
         'vkAllocateDescriptorSets'

--- a/scripts/generators/layer_chassis_generator.py
+++ b/scripts/generators/layer_chassis_generator.py
@@ -81,7 +81,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
         'vkEnumerateDeviceLayerProperties',
         'vkEnumerateDeviceExtensionProperties',
         # Functions that are handled explicitly due to chassis architecture violations
-        # Note: If added, may need to add to skip_intercept_id_functions list as well
+        # Note: If added, may need to add to skip_intercept_id_functions list as well (in dispatch_vector_generator.py)
         'vkCreateGraphicsPipelines',
         'vkCreateComputePipelines',
         'vkCreateRayTracingPipelinesNV',
@@ -89,6 +89,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
         'vkCreatePipelineLayout',
         'vkCreateShaderModule',
         'vkCreateShadersEXT',
+        'vkGetShaderBinaryDataEXT',
         'vkAllocateDescriptorSets',
         'vkCreateBuffer',
         'vkQueuePresentKHR',

--- a/tests/unit/gpu_av_indirect_buffer.cpp
+++ b/tests/unit/gpu_av_indirect_buffer.cpp
@@ -630,7 +630,6 @@ TEST_F(NegativeGpuAVIndirectBuffer, FirstInstanceIndexed) {
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::multiDrawIndirect);
     RETURN_IF_SKIP(InitGpuAvFramework());
-
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9853

the `vkGetShaderBinaryDataEXT` is a problem for GPU-AV as we have already instrumented the shader

This change overrides `vkGetShaderBinaryDataEXT`  to return the original, non-instrumented shader. From here things work "as they should" as we ignore BINARY shaders coming in