### PR TITLE
layers: Allow to use ALL_COMMANDS in subpass dependency

### DIFF
--- a/layers/stateless/sl_render_pass.cpp
+++ b/layers/stateless/sl_render_pass.cpp
@@ -29,7 +29,10 @@ bool Device::ValidateSubpassGraphicsFlags(VkDevice device, const VkRenderPassCre
     const auto kExcludeStages = VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT | VK_PIPELINE_STAGE_2_COPY_BIT |
                                 VK_PIPELINE_STAGE_2_RESOLVE_BIT | VK_PIPELINE_STAGE_2_BLIT_BIT | VK_PIPELINE_STAGE_2_CLEAR_BIT;
     const auto kMetaGraphicsStages = VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT | VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT |
-                                     VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT;
+                                     VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT |
+                                     // ALL_COMMANDS means only graphics in graphics only context
+                                     // https://gitlab.khronos.org/vulkan/vulkan/-/issues/4257
+                                     VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
     const auto kGraphicsStages =
         (sync_utils::ExpandPipelineStages(VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, VK_QUEUE_GRAPHICS_BIT) | kMetaGraphicsStages) &
         ~kExcludeStages;

--- a/tests/framework/binding.cpp
+++ b/tests/framework/binding.cpp
@@ -1941,7 +1941,7 @@ void CommandBuffer::BeginRenderPass(const VkRenderPassBeginInfo &info, VkSubpass
 }
 
 void CommandBuffer::BeginRenderPass(VkRenderPass rp, VkFramebuffer fb, uint32_t render_area_width, uint32_t render_area_height,
-                                    uint32_t clear_count, VkClearValue *clear_values) {
+                                    uint32_t clear_count, const VkClearValue *clear_values) {
     VkRenderPassBeginInfo render_pass_begin_info = vku::InitStructHelper();
     render_pass_begin_info.renderPass = rp;
     render_pass_begin_info.framebuffer = fb;

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -1119,7 +1119,7 @@ class CommandBuffer : public internal::Handle<VkCommandBuffer> {
 
     void BeginRenderPass(const VkRenderPassBeginInfo &info, VkSubpassContents contents = VK_SUBPASS_CONTENTS_INLINE);
     void BeginRenderPass(VkRenderPass rp, VkFramebuffer fb, uint32_t render_area_width = 1, uint32_t render_area_height = 1,
-                         uint32_t clear_count = 0, VkClearValue *clear_values = nullptr);
+                         uint32_t clear_count = 0, const VkClearValue *clear_values = nullptr);
     void NextSubpass(VkSubpassContents contents = VK_SUBPASS_CONTENTS_INLINE);
     void EndRenderPass();
     void BeginRendering(const VkRenderingInfo &renderingInfo);

--- a/tests/unit/subpass.cpp
+++ b/tests/unit/subpass.cpp
@@ -120,10 +120,6 @@ TEST_F(NegativeSubpass, SubpassDependencies) {
     TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkRenderPassCreateInfo-pDependencies-00837",
                          "VUID-VkRenderPassCreateInfo2-pDependencies-03054");
 
-    dependency = {0, 1, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0, 0, 0};
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkRenderPassCreateInfo-pDependencies-00837",
-                         "VUID-VkRenderPassCreateInfo2-pDependencies-03054");
-
     dependency = {0, 1, VK_PIPELINE_STAGE_HOST_BIT, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0, 0, 0};
     TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkRenderPassCreateInfo-pDependencies-00837",
                          "VUID-VkRenderPassCreateInfo2-pDependencies-03054");

--- a/tests/unit/subpass_positive.cpp
+++ b/tests/unit/subpass_positive.cpp
@@ -17,6 +17,7 @@
 
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
+#include "../framework/render_pass_helper.h"
 #include "utils/convert_utils.h"
 
 class PositiveSubpass : public VkLayerTest {};
@@ -248,4 +249,21 @@ TEST_F(PositiveSubpass, AccessFlags3) {
         vku::InitStruct<VkRenderPassCreateInfo2>(nullptr, 0u, 1u, &attach_desc, 1u, &subpass, 1u, &subpass_dependency, 0u, nullptr);
 
     PositiveTestRenderPass2KHRCreate(*m_device, rpci2);
+}
+
+TEST_F(PositiveSubpass, AllCommandsInSubpassDependency) {
+    TEST_DESCRIPTION("Test ALL_COMMANDS_BIT is allowed in subpass dependency");
+    RETURN_IF_SKIP(Init());
+
+    VkSubpassDependency subpass_dep{};
+    subpass_dep.srcSubpass = 0;
+    subpass_dep.dstSubpass = VK_SUBPASS_EXTERNAL;
+    subpass_dep.srcStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;  // Here!
+    subpass_dep.dstStageMask = VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
+    subpass_dep.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    subpass_dep.dstAccessMask = VK_ACCESS_NONE;
+
+    RenderPassSingleSubpass rp(*this);
+    rp.AddSubpassDependency(subpass_dep);
+    rp.CreateRenderPass();
 }


### PR DESCRIPTION
Side effect of https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9903 investigation.
Waiting for confirmation here https://gitlab.khronos.org/vulkan/vulkan/-/issues/4257 but expect that's correct (this is used by some examples in the spec and in khronos issues like this one https://gitlab.khronos.org/vulkan/vulkan/-/issues/1998).
