### PR TITLE
layers: Add Linking INDEPENDENT_SETS check

### DIFF
--- a/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
@@ -512,7 +512,7 @@ void PreCallSetupShaderInstrumentationResources(Validator &gpuav, CommandBufferS
 
         // One exception when using GPL is we need to look out for INDEPENDENT_SETS_BIT which will have null sets inside them.
         // We have a fake merged_graphics_layout to mimic the complete layout, but the app must bind it to descriptor set
-        if (inst_binding_pipe_layout_state->create_flags & VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT) {
+        if (inst_binding_pipe_layout_state->IsIndependentSets()) {
             inst_binding_pipe_layout_state = gpuav.Get<vvl::PipelineLayout>(last_bound.desc_set_pipeline_layout);
             inst_binding_pipe_layout_src = PipelineLayoutSource::LastBoundDescriptorSet;
         }

--- a/layers/state_tracker/pipeline_sub_state.cpp
+++ b/layers/state_tracker/pipeline_sub_state.cpp
@@ -19,9 +19,13 @@
 #include "state_tracker/pipeline_state.h"
 #include "state_tracker/shader_module.h"
 
-VkPipelineLayoutCreateFlags PipelineSubState::PipelineLayoutCreateFlags() const {
-    const auto layout_state = parent.PipelineLayoutState();
-    return (layout_state) ? layout_state->CreateFlags() : static_cast<VkPipelineLayoutCreateFlags>(0);
+bool PipelineSubState::IsIndependentSets() const {
+    if (const auto layout_state = parent.PipelineLayoutState()) {
+        if (layout_state->CreateFlags() & VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT) {
+            return true;
+        }
+    }
+    return false;
 }
 
 VertexInputState::VertexInputState(const vvl::Pipeline &p, const vku::safe_VkGraphicsPipelineCreateInfo &create_info)

--- a/layers/state_tracker/pipeline_sub_state.h
+++ b/layers/state_tracker/pipeline_sub_state.h
@@ -50,7 +50,7 @@ struct PipelineSubState {
     PipelineSubState(const vvl::Pipeline &p) : parent(p) {}
     const vvl::Pipeline &parent;
 
-    VkPipelineLayoutCreateFlags PipelineLayoutCreateFlags() const;
+    bool IsIndependentSets() const;  // VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT
 };
 
 struct VertexAttrState {

--- a/layers/state_tracker/shader_object_state.cpp
+++ b/layers/state_tracker/shader_object_state.cpp
@@ -40,7 +40,7 @@ ShaderObject::ShaderObject(DeviceState &dev_data, const VkShaderCreateInfoEXT &c
       max_active_slot(GetMaxActiveSlot(active_slots)),
       set_layouts(GetSetLayouts(dev_data, create_info)),
       push_constant_ranges(GetCanonicalId(create_info.pushConstantRangeCount, create_info.pPushConstantRanges)),
-      set_compat_ids(GetCompatForSet(set_layouts, push_constant_ranges)) {
+      set_compat_ids(GetCompatForSet(set_layouts, push_constant_ranges, 0)) {
     if ((create_info.flags & VK_SHADER_CREATE_LINK_STAGE_BIT_EXT) != 0) {
         for (uint32_t i = 0; i < createInfoCount; ++i) {
             const VkShaderEXT shader_handle = pShaders[i];


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9870

if you went

```
 vkPipelineLayout pipeline_layout_vs(VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT);
 vkPipelineLayout pipeline_layout_fs(VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT);
 vkPipelineLayout pipeline_layout_link(0);
```

it would not produce a error, now it does