### PR TITLE
layers: Add SpecialSupported struct

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -284,6 +284,7 @@ vvl_sources = [
   "layers/state_tracker/shader_object_state.h",
   "layers/state_tracker/shader_stage_state.cpp",
   "layers/state_tracker/shader_stage_state.h",
+  "layers/state_tracker/special_supported.h",
   "layers/state_tracker/state_object.cpp",
   "layers/state_tracker/state_object.h",
   "layers/state_tracker/state_tracker.cpp",

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -350,6 +350,7 @@ target_sources(vvl PRIVATE
     state_tracker/query_state.h
     state_tracker/semaphore_state.cpp
     state_tracker/semaphore_state.h
+    state_tracker/special_supported.h
     state_tracker/state_object.cpp
     state_tracker/state_object.h
     state_tracker/queue_state.cpp

--- a/layers/chassis/dispatch_object.h
+++ b/layers/chassis/dispatch_object.h
@@ -36,6 +36,7 @@
 #include "generated/vk_extension_helper.h"
 #include "generated/vk_layer_dispatch_table.h"
 #include "layer_object_id.h"
+#include "state_tracker/special_supported.h"
 
 // To avoid re-hashing unique ids on each use, we precompute the hash and store the
 // hash's LSBs in the high 24 bits.
@@ -130,17 +131,7 @@ class StatelessDeviceData {
     std::vector<VkImageLayout> host_imape_copy_props_copy_dst_layouts{};
     DeviceExtensionProperties phys_dev_ext_props = {};
 
-    // Some extensions/features changes the behavior of the app/layers/spec if present.
-    // So it needs its own special boolean unlike the enabled_fatures.
-    bool has_format_feature2;  // VK_KHR_format_feature_flags2
-    // VK_EXT_pipeline_robustness was designed to be a subset of robustness extensions
-    // Enabling the other robustness features can reduce performance on GPU, so just the
-    // support is needed to check
-    bool has_robust_image_access;  // VK_EXT_image_robustness
-    // Validation requires special handling for VkPhysicalDeviceRobustness2FeaturesEXT, because for some cases robustness features
-    // // need to only be supported, not enabled
-    bool has_robust_image_access2;   // VK_EXT_robustness2
-    bool has_robust_buffer_access2;  // VK_EXT_robustness2
+    SpecialSupported special_supported;
 };
 
 namespace dispatch {

--- a/layers/core_checks/cc_device.cpp
+++ b/layers/core_checks/cc_device.cpp
@@ -533,7 +533,7 @@ VkFormatProperties3KHR CoreChecks::GetPDFormatProperties(const VkFormat format) 
     VkFormatProperties3KHR fmt_props_3 = vku::InitStructHelper();
     VkFormatProperties2 fmt_props_2 = vku::InitStructHelper(&fmt_props_3);
 
-    if (device_state->has_format_feature2) {
+    if (device_state->special_supported.vk_khr_format_feature_flags2) {
         DispatchGetPhysicalDeviceFormatProperties2Helper(api_version, physical_device, format, &fmt_props_2);
         fmt_props_3.linearTilingFeatures |= fmt_props_2.formatProperties.linearTilingFeatures;
         fmt_props_3.optimalTilingFeatures |= fmt_props_2.formatProperties.optimalTilingFeatures;

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -70,7 +70,7 @@ bool CoreChecks::ValidateImageFormatFeatures(const VkImageCreateInfo &create_inf
             }
         }
 
-        if (device_state->has_format_feature2) {
+        if (device_state->special_supported.vk_khr_format_feature_flags2) {
             VkDrmFormatModifierPropertiesList2EXT fmt_drm_props = vku::InitStructHelper();
             VkFormatProperties2 fmt_props_2 = vku::InitStructHelper(&fmt_drm_props);
             DispatchGetPhysicalDeviceFormatProperties2Helper(api_version, physical_device, image_format, &fmt_props_2);
@@ -1684,7 +1684,7 @@ bool CoreChecks::ValidateImageViewFormatFeatures(const vvl::Image &image_state, 
         VkImageDrmFormatModifierPropertiesEXT drm_format_properties = vku::InitStructHelper();
         DispatchGetImageDrmFormatModifierPropertiesEXT(device, image_state.VkHandle(), &drm_format_properties);
 
-        if (device_state->has_format_feature2) {
+        if (device_state->special_supported.vk_khr_format_feature_flags2) {
             VkDrmFormatModifierPropertiesList2EXT fmt_drm_props = vku::InitStructHelper();
             VkFormatProperties2 fmt_props_2 = vku::InitStructHelper(&fmt_drm_props);
             DispatchGetPhysicalDeviceFormatProperties2Helper(api_version, physical_device, view_format, &fmt_props_2);

--- a/layers/core_checks/cc_pipeline.cpp
+++ b/layers/core_checks/cc_pipeline.cpp
@@ -122,15 +122,15 @@ bool CoreChecks::ValidatePipelineRobustnessCreateInfo(const vvl::Pipeline &pipel
     }
 
     // These validation depend if the features are exposed (not just enabled)
-    if (!device_state->has_robust_image_access &&
+    if (!device_state->special_supported.robust_image_access &&
         pipeline_robustness_info.images == VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS) {
         skip |= LogError("VUID-VkPipelineRobustnessCreateInfo-robustImageAccess-06930", device,
                          loc.pNext(Struct::VkPipelineRobustnessCreateInfo, Field::images),
                          "is VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS "
-                         "but robustImageAccess2 is not supported.");
+                         "but robustImageAccess is not supported.");
     }
 
-    if (!device_state->has_robust_buffer_access2) {
+    if (!device_state->special_supported.robust_buffer_access2) {
         if (pipeline_robustness_info.storageBuffers == VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2) {
             skip |= LogError(
                 "VUID-VkPipelineRobustnessCreateInfo-robustBufferAccess2-06931", device,
@@ -151,7 +151,7 @@ bool CoreChecks::ValidatePipelineRobustnessCreateInfo(const vvl::Pipeline &pipel
         }
     }
 
-    if (!device_state->has_robust_image_access2) {
+    if (!device_state->special_supported.robust_image_access2) {
         if (pipeline_robustness_info.images == VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2) {
             skip |= LogError(
                 "VUID-VkPipelineRobustnessCreateInfo-robustImageAccess2-06934", device,

--- a/layers/drawdispatch/descriptor_validator.cpp
+++ b/layers/drawdispatch/descriptor_validator.cpp
@@ -516,7 +516,7 @@ bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVaria
     // When KHR_format_feature_flags2 is supported, the read/write without
     // format support is reported per format rather than a single physical
     // device feature.
-    if (dev_proxy.device_state->has_format_feature2) {
+    if (dev_proxy.device_state->special_supported.vk_khr_format_feature_flags2) {
         const VkFormatFeatureFlags2 format_features = image_view_state->format_features;
 
         if (descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) {
@@ -1015,7 +1015,7 @@ bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVaria
     // When KHR_format_feature_flags2 is supported, the read/write without
     // format support is reported per format rather than a single physical
     // device feature.
-    if (dev_proxy.device_state->has_format_feature2) {
+    if (dev_proxy.device_state->special_supported.vk_khr_format_feature_flags2) {
         if (descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER) {
             if ((resource_variable.info.is_read_without_format) &&
                 !(buffer_format_features & VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR)) {

--- a/layers/state_tracker/special_supported.h
+++ b/layers/state_tracker/special_supported.h
@@ -1,0 +1,31 @@
+/* Copyright (c) 2025 The Khronos Group Inc.
+ * Copyright (c) 2025 Valve Corporation
+ * Copyright (c) 2025 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+// Validation requires "special" handling for some extensions/feature because the VU depends on if the feature is "supported" not
+// "enabled". This struct/file is dedicatd to contain them in a single location, while also giving background for each.
+struct SpecialSupported {
+    // Adds flags that need to be queried and if the device supports the flags, we look for the app
+    bool vk_khr_format_feature_flags2{false};  // VK_KHR_format_feature_flags2
+
+    // VK_EXT_pipeline_robustness was designed to be a subset of robustness extensions
+    // Enabling the other robustness features can reduce performance on GPU, so just the
+    // support is needed to check
+    bool robust_image_access{false};    // robustImageAccess (VK_EXT_image_robustness)
+    bool robust_image_access2{false};   // robustImageAccess2 (VK_EXT_robustness2)
+    bool robust_buffer_access2{false};  // robustBufferAccess2 (VK_EXT_robustness2)
+};

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -22,6 +22,7 @@
 #include "chassis/validation_object.h"
 #include "utils/hash_vk_types.h"
 #include "state_tracker/video_session_state.h"  // TODO - Remove from this header
+#include "state_tracker/special_supported.h"
 #include "chassis/dispatch_object.h"
 #include "error_message/logging.h"
 #include "containers/span.h"
@@ -528,10 +529,7 @@ class DeviceState : public vvl::base::Device {
     DeviceState(vvl::dispatch::Device* dev, InstanceState* instance)
         : BaseClass(dev, instance, LayerObjectTypeStateTracker),
           instance_state(instance),
-          has_format_feature2(dev->stateless_device_data.has_format_feature2),
-          has_robust_image_access(dev->stateless_device_data.has_robust_image_access),
-          has_robust_image_access2(dev->stateless_device_data.has_robust_image_access2),
-          has_robust_buffer_access2(dev->stateless_device_data.has_robust_buffer_access2) {
+          special_supported(dev->stateless_device_data.special_supported) {
         physical_device_state = instance_state->Get<vvl::PhysicalDevice>(physical_device).get();
     }
     ~DeviceState();
@@ -1920,17 +1918,7 @@ class DeviceState : public vvl::base::Device {
     uint32_t custom_border_color_sampler_count = 0;
     bool disable_internal_pipeline_cache;
 
-    // Some extensions/features changes the behavior of the app/layers/spec if present.
-    // So it needs its own special boolean unlike the enabled_fatures.
-    const bool has_format_feature2;  // VK_KHR_format_feature_flags2
-    // VK_EXT_pipeline_robustness was designed to be a subset of robustness extensions
-    // Enabling the other robustness features can reduce performance on GPU, so just the
-    // support is needed to check
-    const bool has_robust_image_access;  // VK_EXT_image_robustness
-    // Validation requires special handling for VkPhysicalDeviceRobustness2FeaturesEXT, because for some cases robustness features
-    // // need to only be supported, not enabled
-    const bool has_robust_image_access2;   // VK_EXT_robustness2
-    const bool has_robust_buffer_access2;  // VK_EXT_robustness2
+    SpecialSupported special_supported;
 
     std::vector<VkCooperativeMatrixPropertiesNV> cooperative_matrix_properties_nv;
     std::vector<VkCooperativeMatrixPropertiesKHR> cooperative_matrix_properties_khr;

--- a/layers/stateless/sl_spirv.cpp
+++ b/layers/stateless/sl_spirv.cpp
@@ -68,7 +68,7 @@ SpirvValidator::SpirvValidator(DebugReport *debug_report, const vvl::StatelessDe
       phys_dev_props_core14(stateless_device_data.phys_dev_props_core14),
       phys_dev_ext_props(stateless_device_data.phys_dev_ext_props),
       enabled_features(stateless_device_data.enabled_features),
-      has_format_feature2(stateless_device_data.has_format_feature2) {}
+      special_supported(stateless_device_data.special_supported) {}
 
 // stateless spirv == doesn't require pipeline state and/or shader object info
 // Originally the goal was to move more validation to vkCreateShaderModule time in case the driver decided to parse an invalid
@@ -387,7 +387,7 @@ bool SpirvValidator::ValidateVariables(const spirv::Module &module_state, const 
         // The other checks need to take into account the format features and so
         // we apply that in the descriptor set matching validation code (see
         // descriptor_sets.cpp).
-        if (!has_format_feature2) {
+        if (!special_supported.vk_khr_format_feature_flags2) {
             skip |= ValidateShaderStorageImageFormatsVariables(module_state, *insn, loc);
         }
     }

--- a/layers/stateless/sl_spirv.h
+++ b/layers/stateless/sl_spirv.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "error_message/logging.h"
+#include "state_tracker/special_supported.h"
 
 namespace spirv {
 struct StatelessData;
@@ -54,7 +55,7 @@ class SpirvValidator : public Logger {
     const VkPhysicalDeviceVulkan14Properties& phys_dev_props_core14;
     const vvl::DeviceExtensionProperties& phys_dev_ext_props;
     const DeviceFeatures& enabled_features;
-    const bool has_format_feature2;
+    const SpecialSupported& special_supported;
 
   private:
     bool ValidateShaderClock(const spirv::Module& module_state, const spirv::StatelessData& stateless_data,


### PR DESCRIPTION
I know @ziga-lunarg is touching this code for a future extension, but also we need this for a very-close-in-the-future spec fix.

We have this aweful system where `Stateless` gets the "is it supported" and needs to pass it around to different classes and having a single spot we define these "exceptions" is better IMO