### PR TITLE
layers: Fix threading bug with PhyscialDevice

### DIFF
--- a/layers/best_practices/bp_instance_device.cpp
+++ b/layers/best_practices/bp_instance_device.cpp
@@ -168,7 +168,7 @@ bool bp_state::Instance::PreCallValidateCreateDevice(VkPhysicalDevice physicalDe
     }
 
     const auto bp_pd_state = Get<vvl::PhysicalDevice>(physicalDevice);
-    if (bp_pd_state && (bp_pd_state->GetCallState(vvl::Func::vkGetPhysicalDeviceFeatures) == vvl::UNCALLED) &&
+    if (bp_pd_state && (bp_pd_state->GetCallState(vvl::Func::vkGetPhysicalDeviceFeatures) == vvl::CallState::Uncalled) &&
         (pCreateInfo->pEnabledFeatures != NULL)) {
         skip |= LogWarning("BestPractices-vkCreateDevice-physical-device-features-not-retrieved", instance, error_obj.location,
                            "called before getting physical device features from vkGetPhysicalDeviceFeatures().");

--- a/layers/best_practices/bp_wsi.cpp
+++ b/layers/best_practices/bp_wsi.cpp
@@ -19,12 +19,13 @@
 
 #include "best_practices/best_practices_validation.h"
 #include "best_practices/bp_state.h"
+#include "state_tracker/device_state.h"
 
 bool bp_state::Instance::ValidateGetPhysicalDeviceDisplayPlanePropertiesKHRQuery(VkPhysicalDevice physicalDevice,
                                                                                  const Location& loc) const {
     bool skip = false;
     if (const auto bp_pd_state = Get<vvl::PhysicalDevice>(physicalDevice)) {
-        if (bp_pd_state->GetCallState(vvl::Func::vkGetPhysicalDeviceDisplayPlanePropertiesKHR) == vvl::UNCALLED) {
+        if (bp_pd_state->GetCallState(vvl::Func::vkGetPhysicalDeviceDisplayPlanePropertiesKHR) == vvl::CallState::Uncalled) {
             skip |= LogWarning("BestPractices-vkGetDisplayPlaneSupportedDisplaysKHR-properties-not-retrieved", physicalDevice, loc,
                                "was called without first retrieving properties from "
                                "vkGetPhysicalDeviceDisplayPlanePropertiesKHR or vkGetPhysicalDeviceDisplayPlaneProperties2KHR.");
@@ -71,20 +72,21 @@ bool BestPractices::PreCallValidateCreateSwapchainKHR(VkDevice device, const VkS
                                                       const ErrorObject& error_obj) const {
     bool skip = false;
 
-    if (physical_device_state->GetCallState(vvl::Func::vkGetPhysicalDeviceSurfaceCapabilitiesKHR) == vvl::UNCALLED) {
+    if (physical_device_state->GetCallState(vvl::Func::vkGetPhysicalDeviceSurfaceCapabilitiesKHR) == vvl::CallState::Uncalled) {
         skip |= LogWarning("BestPractices-vkCreateSwapchainKHR-capabilities-no-surface", device, error_obj.location,
                            "called before getting surface capabilities from "
                            "vkGetPhysicalDeviceSurfaceCapabilitiesKHR().");
     }
 
     if ((pCreateInfo->presentMode != VK_PRESENT_MODE_FIFO_KHR) &&
-        (physical_device_state->GetCallState(vvl::Func::vkGetPhysicalDeviceSurfacePresentModesKHR) != vvl::QUERY_DETAILS)) {
+        (physical_device_state->GetCallState(vvl::Func::vkGetPhysicalDeviceSurfacePresentModesKHR) !=
+         vvl::CallState::QueryDetails)) {
         skip |= LogWarning("BestPractices-vkCreateSwapchainKHR-present-mode-no-surface", device, error_obj.location,
                            "called before getting surface present mode(s) from "
                            "vkGetPhysicalDeviceSurfacePresentModesKHR().");
     }
 
-    if (physical_device_state->GetCallState(vvl::Func::vkGetPhysicalDeviceSurfaceFormatsKHR) != vvl::QUERY_DETAILS) {
+    if (physical_device_state->GetCallState(vvl::Func::vkGetPhysicalDeviceSurfaceFormatsKHR) != vvl::CallState::QueryDetails) {
         skip |= LogWarning("BestPractices-vkCreateSwapchainKHR-formats-no-surface", device, error_obj.location,
                            "called before getting surface format(s) from vkGetPhysicalDeviceSurfaceFormatsKHR().");
     }

--- a/layers/core_checks/cc_wsi.cpp
+++ b/layers/core_checks/cc_wsi.cpp
@@ -1361,7 +1361,7 @@ bool core::Instance::PreCallValidateCreateDisplayPlaneSurfaceKHR(VkInstance inst
                          device_properties.limits.maxImageDimension2D);
     }
 
-    if (pd_state->GetCallState(vvl::Func::vkGetPhysicalDeviceDisplayPlanePropertiesKHR) != vvl::UNCALLED) {
+    if (pd_state->GetCallState(vvl::Func::vkGetPhysicalDeviceDisplayPlanePropertiesKHR) != vvl::CallState::Uncalled) {
         if (plane_index >= pd_state->display_plane_property_count) {
             skip |= LogError("VUID-VkDisplaySurfaceCreateInfoKHR-planeIndex-01252", display_mode,
                              create_info_loc.dot(Field::planeIndex),
@@ -1651,7 +1651,7 @@ bool core::Instance::ValidateGetPhysicalDeviceDisplayPlanePropertiesKHRQuery(VkP
                                                                              const Location &loc) const {
     bool skip = false;
     auto pd_state = Get<vvl::PhysicalDevice>(physicalDevice);
-    if (pd_state->GetCallState(vvl::Func::vkGetPhysicalDeviceDisplayPlanePropertiesKHR) != vvl::UNCALLED) {
+    if (pd_state->GetCallState(vvl::Func::vkGetPhysicalDeviceDisplayPlanePropertiesKHR) != vvl::CallState::Uncalled) {
         if (planeIndex >= pd_state->display_plane_property_count) {
             skip |= LogError("VUID-vkGetDisplayPlaneSupportedDisplaysKHR-planeIndex-01249", physicalDevice, loc,
                              "is %" PRIu32 ", but vkGetPhysicalDeviceDisplayPlaneProperties(2)KHR returned %" PRIu32

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -4200,7 +4200,7 @@ void InstanceState::PostCallRecordGetPhysicalDeviceSurfaceCapabilitiesKHR(VkPhys
     }
     auto pd_state = Get<PhysicalDevice>(physicalDevice);
     ASSERT_AND_RETURN(pd_state);
-    pd_state->call_state[record_obj.location.function] = QUERY_DETAILS;
+    pd_state->SetCallState(record_obj.location.function, CallState::QueryDetails);
 
     auto surface_state = Get<Surface>(surface);
     ASSERT_AND_RETURN(surface_state);
@@ -4218,7 +4218,7 @@ void InstanceState::PostCallRecordGetPhysicalDeviceSurfaceCapabilities2KHR(VkPhy
     auto pd_state = Get<PhysicalDevice>(physicalDevice);
     ASSERT_AND_RETURN(pd_state);
 
-    pd_state->call_state[record_obj.location.function] = QUERY_DETAILS;
+    pd_state->SetCallState(record_obj.location.function, CallState::QueryDetails);
 
     if (pSurfaceInfo->surface) {
         auto surface_state = Get<Surface>(pSurfaceInfo->surface);
@@ -4249,7 +4249,7 @@ void InstanceState::PostCallRecordGetPhysicalDeviceSurfaceCapabilities2EXT(VkPhy
                                                                            const RecordObject &record_obj) {
     auto pd_state = Get<PhysicalDevice>(physicalDevice);
     ASSERT_AND_RETURN(pd_state);
-    pd_state->call_state[record_obj.location.function] = QUERY_DETAILS;
+    pd_state->SetCallState(record_obj.location.function, CallState::Uncalled);
 
     const VkSurfaceCapabilitiesKHR caps{
         pSurfaceCapabilities->minImageCount,           pSurfaceCapabilities->maxImageCount,


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9931

we didn't have `unordered_map<Func, CALL_STATE> call_state;` wrapped away in a thread safe environment 