### PR TITLE
layers: First step to moving cb state to core only

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -54,6 +54,10 @@ namespace spirv {
 struct StatelessData;
 }  // namespace spirv
 
+namespace core {
+class CommandBufferSubState;
+}  // namespace core
+
 struct SubpassLayout;
 struct DAGNode;
 struct SemaphoreSubmitState;
@@ -661,7 +665,7 @@ class CoreChecks : public vvl::DeviceProxy {
     bool IsBeforeCtsVersion(uint32_t major, uint32_t minor, uint32_t subminor) const;
 
     template <typename TransferBarrier>
-    bool ValidateQueuedQFOTransferBarriers(const vvl::CommandBuffer& cb_state,
+    bool ValidateQueuedQFOTransferBarriers(const core::CommandBufferSubState& cb_sub_state,
                                            QFOTransferCBScoreboards<TransferBarrier>* scoreboards,
                                            const GlobalQFOTransferBarrierMap<TransferBarrier>& global_release_barriers,
                                            const Location& loc) const;

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -296,9 +296,6 @@ void CommandBuffer::ResetCBState() {
     activeFramebuffer = VK_NULL_HANDLE;
     index_buffer_binding.reset();
 
-    qfo_transfer_image_barriers.Reset();
-    qfo_transfer_buffer_barriers.Reset();
-
     // Clean up video specific states
     bound_video_session = nullptr;
     bound_video_session_parameters = nullptr;
@@ -314,8 +311,6 @@ void CommandBuffer::ResetCBState() {
     push_constant_data_chunks.clear();
     push_constant_latest_used_layout.fill(VK_NULL_HANDLE);
     push_constant_ranges_layout.reset();
-
-    nesting_level = 0;
 
     transform_feedback_active = false;
     transform_feedback_buffers_bound = 0;
@@ -1088,6 +1083,10 @@ void CommandBuffer::Begin(const VkCommandBufferBeginInfo *pBeginInfo) {
     }
     performance_lock_acquired = dev_data.performance_lock_acquired;
     updatedQueries.clear();
+
+    for (auto &item : sub_states_) {
+        item.second->Begin(beginInfo);
+    }
 }
 
 void CommandBuffer::End(VkResult result) {
@@ -1173,13 +1172,13 @@ void CommandBuffer::ExecuteCommands(vvl::span<const VkCommandBuffer> secondary_c
             hasRenderPassInstance |= secondary_cb_state->hasRenderPassInstance;
         }
 
-        if (secondary_cb_state->IsSecondary()) {
-            nesting_level = std::max(nesting_level, secondary_cb_state->nesting_level + 1);
-        }
-
         label_stack_depth_ += secondary_cb_state->label_stack_depth_;
         label_commands_.insert(label_commands_.end(), secondary_cb_state->label_commands_.begin(),
                                secondary_cb_state->label_commands_.end());
+
+        for (auto &item : sub_states_) {
+            item.second->ExecuteCommands(*secondary_cb_state);
+        }
     }
 }
 

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -471,9 +471,6 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     vvl::unordered_set<std::shared_ptr<StateObject>> object_bindings;
     vvl::unordered_map<VulkanTypedHandle, LogObjectList> broken_bindings;
 
-    QFOTransferBarrierSets<QFOBufferTransferBarrier> qfo_transfer_buffer_barriers;
-    QFOTransferBarrierSets<QFOImageTransferBarrier> qfo_transfer_image_barriers;
-
     // VK_KHR_dynamic_rendering_local_read works like dynamic state, but lives for the rendering lifetime only
     struct RenderingAttachment {
         // VkRenderingAttachmentLocationInfo
@@ -543,15 +540,13 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     std::optional<uint32_t> video_encode_quality_level{};
     VideoSessionUpdateMap video_session_updates;
 
-    // VK_EXT_nested_command_buffer
-    uint32_t nesting_level;
-
     bool transform_feedback_active{false};
     uint32_t transform_feedback_buffers_bound;
 
     bool conditional_rendering_active{false};
     bool conditional_rendering_inside_render_pass{false};
     uint32_t conditional_rendering_subpass{0};
+
     std::vector<VkDescriptorBufferBindingInfoEXT> descriptor_buffer_binding_info;
 
     mutable std::shared_mutex lock;
@@ -593,14 +588,6 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     std::shared_ptr<const ImageLayoutRegistry> GetImageLayoutRegistry(VkImage image) const;
     std::shared_ptr<ImageLayoutRegistry> GetOrCreateImageLayoutRegistry(const vvl::Image &image_state);
     const CommandBufferImageLayoutMap &GetImageLayoutMap() const;
-
-    const QFOTransferBarrierSets<QFOImageTransferBarrier> &GetQFOBarrierSets(const QFOImageTransferBarrier &type_tag) const {
-        return qfo_transfer_image_barriers;
-    }
-
-    const QFOTransferBarrierSets<QFOBufferTransferBarrier> &GetQFOBarrierSets(const QFOBufferTransferBarrier &type_tag) const {
-        return qfo_transfer_buffer_barriers;
-    }
 
     // Used to get error message objects, but overloads depending on what information is known
     LogObjectList GetObjectList(VkShaderStageFlagBits stage) const;
@@ -751,9 +738,13 @@ class CommandBufferSubState {
     CommandBufferSubState(const CommandBufferSubState &) = delete;
     CommandBufferSubState &operator=(const CommandBufferSubState &) = delete;
     virtual ~CommandBufferSubState() {}
+
+    virtual void Begin(const VkCommandBufferBeginInfo &begin_info) {}
+    virtual void Reset(const Location &loc) {}
     virtual void Destroy() {}
 
-    virtual void Reset(const Location &loc) {}
+    virtual void ExecuteCommands(vvl::CommandBuffer &secondary_command_buffer) {}
+
     virtual void RecordCmd(Func command) {}
     virtual void RecordWaitEvents(Func command, uint32_t eventCount, const VkEvent *pEvents,
                                   VkPipelineStageFlags2KHR src_stage_mask) {}


### PR DESCRIPTION
- Gets some misc cleanup to get `vvl::CommandBuffer` stuff to some `core::CommandBufferSubState` going
- small starting win of getting `sizeof(vvl::CommandBuffer)` from `3880` to `3648`
