### PR TITLE
layers: Rename cleanup of vvl::CommandBuffer

### DIFF
--- a/layers/best_practices/bp_copy_blit_resolve.cpp
+++ b/layers/best_practices/bp_copy_blit_resolve.cpp
@@ -30,7 +30,7 @@ void BestPractices::PostCallRecordCmdClearAttachments(VkCommandBuffer commandBuf
 
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto* rp_state = cb_state->active_render_pass.get();
-    auto* fb_state = cb_state->activeFramebuffer.get();
+    auto* fb_state = cb_state->active_framebuffer.get();
 
     if (rectCount == 0 || !rp_state) {
         return;

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -830,7 +830,7 @@ bool CoreChecks::ValidateDrawState(const vvl::DescriptorSet &descriptor_set, uin
                                    const vvl::DrawDispatchVuid &vuids, const VulkanTypedHandle &shader_handle) const {
     bool result = false;
     const Location &loc = vuids.loc();
-    const VkFramebuffer framebuffer = cb_state.activeFramebuffer ? cb_state.activeFramebuffer->VkHandle() : VK_NULL_HANDLE;
+    const VkFramebuffer framebuffer = cb_state.active_framebuffer ? cb_state.active_framebuffer->VkHandle() : VK_NULL_HANDLE;
     // NOTE: GPU-AV needs non-const state objects to do lazy updates of descriptor state of only the dynamically used
     // descriptors, via the non-const version of ValidateBindingDynamic(), this code uses the const path only even it gives up
     // non-const versions of its state objects here.

--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -147,7 +147,7 @@ bool CoreChecks::ValidateMeshShaderStage(const vvl::CommandBuffer &cb_state, con
                          "bound pipeline are %s.",
                          string_VkShaderStageFlags(pipeline_state->active_shaders).c_str());
     }
-    for (const auto &query : cb_state.activeQueries) {
+    for (const auto &query : cb_state.active_queries) {
         const auto query_pool_state = Get<vvl::QueryPool>(query.pool);
         if (!query_pool_state) continue;
         if (query_pool_state->create_info.queryType == VK_QUERY_TYPE_TRANSFORM_FEEDBACK_STREAM_EXT) {
@@ -1635,7 +1635,7 @@ bool CoreChecks::ValidateDrawPrimitivesGeneratedQuery(const LastBound &last_boun
     }
 
     bool primitives_generated_query = false;
-    for (const auto &query : cb_state.activeQueries) {
+    for (const auto &query : cb_state.active_queries) {
         auto query_pool_state = Get<vvl::QueryPool>(query.pool);
         if (query_pool_state && query_pool_state->create_info.queryType == VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT) {
             primitives_generated_query = true;

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -1149,7 +1149,7 @@ bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffe
         if (rp_state->UsesDynamicRendering()) {
             layer_count = rp_state->dynamic_rendering_begin_rendering_info.layerCount;
         } else {
-            layer_count = cb_state.activeFramebuffer.get()->create_info.layers;
+            layer_count = cb_state.active_framebuffer.get()->create_info.layers;
         }
         skip |= ValidateClearAttachmentExtent(cb_state, cb_state.render_area, layer_count, rectCount, pRects, error_obj.location);
     }
@@ -1194,7 +1194,7 @@ bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffe
         } else {
             const auto *renderpass_create_info = rp_state->create_info.ptr();
             const auto *subpass_desc = &renderpass_create_info->pSubpasses[cb_state.GetActiveSubpass()];
-            const auto *framebuffer = cb_state.activeFramebuffer.get();
+            const auto *framebuffer = cb_state.active_framebuffer.get();
 
             if (subpass_desc) {
                 if (framebuffer && (clear_desc->colorAttachment != VK_ATTACHMENT_UNUSED) &&

--- a/layers/core_checks/cc_image_layout.cpp
+++ b/layers/core_checks/cc_image_layout.cpp
@@ -145,7 +145,7 @@ bool CoreChecks::VerifyImageLayout(const vvl::CommandBuffer &cb_state, const vvl
 
 void CoreChecks::TransitionFinalSubpassLayouts(vvl::CommandBuffer &cb_state) {
     auto render_pass_state = cb_state.active_render_pass.get();
-    auto framebuffer_state = cb_state.activeFramebuffer.get();
+    auto framebuffer_state = cb_state.active_framebuffer.get();
     if (!render_pass_state || !framebuffer_state) {
         return;
     }

--- a/layers/core_checks/cc_pipeline.cpp
+++ b/layers/core_checks/cc_pipeline.cpp
@@ -403,7 +403,7 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
             }
 
             if (cb_state->GetCurrentPipeline(pipelineBindPoint) &&
-                pipeline == cb_state->GetCurrentPipeline(pipelineBindPoint)->VkHandle() && cb_state->dirtyStaticState &&
+                pipeline == cb_state->GetCurrentPipeline(pipelineBindPoint)->VkHandle() && cb_state->dirty_static_state &&
                 IsBeforeCtsVersion(1, 3, 8)) {
                 const LogObjectList objlist(commandBuffer, pipeline);
                 // This catches a bug in some drivers with conformance version lower than 1.3.8

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -3202,7 +3202,7 @@ bool CoreChecks::ValidateGraphicsPipelineBindPoint(const vvl::CommandBuffer &cb_
                                                    const Location &loc) const {
     bool skip = false;
 
-    if (!cb_state.inheritedViewportDepths.empty()) {
+    if (!cb_state.viewport.inherited_depths.empty()) {
         bool dyn_viewport =
             pipeline.IsDynamic(CB_DYNAMIC_STATE_VIEWPORT_WITH_COUNT) || pipeline.IsDynamic(CB_DYNAMIC_STATE_VIEWPORT);
         bool dyn_scissor = pipeline.IsDynamic(CB_DYNAMIC_STATE_SCISSOR_WITH_COUNT) || pipeline.IsDynamic(CB_DYNAMIC_STATE_SCISSOR);
@@ -3352,7 +3352,7 @@ bool CoreChecks::ValidateDrawPipeline(const LastBound &last_bound_state, const v
 
     if ((pipeline.create_info_shaders & (VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT |
                                          VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT | VK_SHADER_STAGE_GEOMETRY_BIT)) != 0) {
-        for (const auto &query : cb_state.activeQueries) {
+        for (const auto &query : cb_state.active_queries) {
             const auto query_pool_state = Get<vvl::QueryPool>(query.pool);
             if (query_pool_state && query_pool_state->create_info.queryType == VK_QUERY_TYPE_MESH_PRIMITIVES_GENERATED_EXT) {
                 const LogObjectList objlist(cb_state.Handle(), pipeline.Handle(), query.pool);
@@ -4191,7 +4191,7 @@ bool CoreChecks::ValidateMultiViewShaders(const vvl::Pipeline &pipeline, const L
 bool CoreChecks::ValidateDrawPipelineFramebuffer(const vvl::CommandBuffer &cb_state, const vvl::Pipeline &pipeline,
                                                  const vvl::DrawDispatchVuid &vuid) const {
     bool skip = false;
-    if (!cb_state.activeFramebuffer) return skip;
+    if (!cb_state.active_framebuffer) return skip;
 
     // Verify attachments for unprotected/protected command buffer.
     if (enabled_features.protectedMemory == VK_TRUE) {
@@ -4216,7 +4216,7 @@ bool CoreChecks::ValidateDrawPipelineFramebuffer(const vvl::CommandBuffer &cb_st
     for (auto &stage_state : pipeline.stage_states) {
         const VkShaderStageFlagBits stage = stage_state.GetStage();
         if (stage_state.entrypoint && stage_state.entrypoint->written_builtin_layer &&
-            cb_state.activeFramebuffer->create_info.layers == 1) {
+            cb_state.active_framebuffer->create_info.layers == 1) {
             if (cb_state.active_render_pass && cb_state.active_render_pass->has_multiview_enabled) {
                 // If using MultiView, you should already have hit an error that Framebuffer Layer must be 1, but due to things like
                 // https://gitlab.khronos.org/vulkan/vulkan/-/issues/4194 we should check here and ignore if things are invalid

--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -703,7 +703,7 @@ bool CoreChecks::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const V
         skip |= LogError(vuid, objlist, error_obj.location, "transform feedback is active.");
     }
 
-    for (const auto &query : cb_state.renderPassQueries) {
+    for (const auto &query : cb_state.render_pass_queries) {
         vuid = use_rp2 ? "VUID-vkCmdEndRenderPass2-None-07005" : "VUID-vkCmdEndRenderPass-None-07004";
         const LogObjectList objlist(commandBuffer, rp_state.Handle(), query.pool);
         skip |= LogError(vuid, objlist, error_obj.location,
@@ -818,7 +818,7 @@ bool CoreChecks::ValidateFragmentDensityMapOffsetEnd(const vvl::CommandBuffer &c
     // dynamic rendering) (Same thing currently with multiView mask)
     if (!rp_state.UsesDynamicRendering()) {
         const VkRenderPassCreateInfo2 *rpci = rp_state.create_info.ptr();
-        const VkImageView *image_views = cb_state.activeFramebuffer.get()->create_info.pAttachments;
+        const VkImageView *image_views = cb_state.active_framebuffer.get()->create_info.pAttachments;
         for (uint32_t i = 0; i < rpci->attachmentCount; ++i) {
             const auto view_state = Get<vvl::ImageView>(image_views[i]);
             ASSERT_AND_CONTINUE(view_state && view_state->image_state);
@@ -4019,7 +4019,7 @@ bool CoreChecks::PreCallValidateCmdEndRendering(VkCommandBuffer commandBuffer, c
         skip |= LogError("VUID-vkCmdEndRendering-commandBuffer-06162", commandBuffer, error_obj.location,
                          "in a render pass instance that was not begun in this command buffer.");
     }
-    for (const auto &query : cb_state->renderPassQueries) {
+    for (const auto &query : cb_state->render_pass_queries) {
         const LogObjectList objlist(commandBuffer, query.pool);
         skip |= LogError("VUID-vkCmdEndRendering-None-06999", objlist, error_obj.location,
                          "query %" PRIu32 " from %s was began in the render pass, but never ended.", query.slot,
@@ -4998,7 +4998,7 @@ bool CoreChecks::ValidateInheritanceInfoFramebuffer(const vvl::CommandBuffer &cb
                                                     const VkCommandBufferInheritanceInfo &secondary_inheritance_info,
                                                     const Location &loc) const {
     bool skip = false;
-    VkFramebuffer primary_fb = cb_state.activeFramebuffer ? cb_state.activeFramebuffer->VkHandle() : VK_NULL_HANDLE;
+    VkFramebuffer primary_fb = cb_state.active_framebuffer ? cb_state.active_framebuffer->VkHandle() : VK_NULL_HANDLE;
     VkFramebuffer secondary_fb = secondary_inheritance_info.framebuffer;
     if (secondary_fb != VK_NULL_HANDLE && primary_fb != secondary_fb) {
         const LogObjectList objlist(cb_state.Handle(), secondary_cb_state.Handle(), secondary_fb, primary_fb);

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -1025,8 +1025,8 @@ bool CoreChecks::ValidateRenderPassBarriers(const Location &outer_loc, const vvl
                              img_barrier.srcQueueFamilyIndex, img_barrier.dstQueueFamilyIndex);
         }
         // Secondary CBs can have null framebuffer so record will queue up validation in that case 'til FB is known
-        if (cb_state.activeFramebuffer) {
-            skip |= ValidateImageBarrierAttachment(barrier_loc, cb_state, *cb_state.activeFramebuffer, state.active_subpass,
+        if (cb_state.active_framebuffer) {
+            skip |= ValidateImageBarrierAttachment(barrier_loc, cb_state, *cb_state.active_framebuffer, state.active_subpass,
                                                    sub_desc, state.rp_handle, img_barrier);
         }
     }
@@ -1089,8 +1089,8 @@ bool CoreChecks::ValidateRenderPassBarriers(const Location &outer_loc, const vvl
                              img_barrier.srcQueueFamilyIndex, img_barrier.dstQueueFamilyIndex);
         }
         // Secondary CBs can have null framebuffer so record will queue up validation in that case 'til FB is known
-        if (cb_state.activeFramebuffer) {
-            skip |= ValidateImageBarrierAttachment(barrier_loc, cb_state, *cb_state.activeFramebuffer, state.active_subpass,
+        if (cb_state.active_framebuffer) {
+            skip |= ValidateImageBarrierAttachment(barrier_loc, cb_state, *cb_state.active_framebuffer, state.active_subpass,
                                                    sub_desc, state.rp_handle, img_barrier);
         }
     }
@@ -2000,7 +2000,7 @@ void CoreChecks::EnqueueSubmitTimeValidateImageBarrierAttachment(const Location 
                                                                  const ImageBarrier &barrier) {
     // Secondary CBs can have null framebuffer so queue up validation in that case 'til FB is known
     const vvl::RenderPass *rp_state = cb_state.active_render_pass.get();
-    if (rp_state && (VK_NULL_HANDLE == cb_state.activeFramebuffer) && cb_state.IsSecondary()) {
+    if (rp_state && (VK_NULL_HANDLE == cb_state.active_framebuffer) && cb_state.IsSecondary()) {
         const auto active_subpass = cb_state.GetActiveSubpass();
         if (active_subpass < rp_state->create_info.subpassCount) {
             const auto &sub_desc = rp_state->create_info.pSubpasses[active_subpass];

--- a/layers/core_checks/cc_video.cpp
+++ b/layers/core_checks/cc_video.cpp
@@ -4490,7 +4490,7 @@ bool CoreChecks::PreCallValidateCmdBeginVideoCodingKHR(VkCommandBuffer commandBu
 
     skip |= ValidateCmd(*cb_state, error_obj.location);
 
-    if (cb_state->activeQueries.size() > 0) {
+    if (cb_state->active_queries.size() > 0) {
         skip |= LogError("VUID-vkCmdBeginVideoCodingKHR-None-07232", commandBuffer, error_obj.location.dot(Field::commandBuffer),
                          "%s has active queries.", FormatHandle(commandBuffer).c_str());
     }
@@ -4844,7 +4844,7 @@ bool CoreChecks::PreCallValidateCmdEndVideoCodingKHR(VkCommandBuffer commandBuff
 
     skip |= ValidateCmd(*cb_state, error_obj.location);
 
-    if (cb_state->activeQueries.size() > 0) {
+    if (cb_state->active_queries.size() > 0) {
         skip |= LogError("VUID-vkCmdEndVideoCodingKHR-None-07251", commandBuffer, error_obj.location.dot(Field::commandBuffer),
                          "%s has active queries.", FormatHandle(commandBuffer).c_str());
     }
@@ -5209,7 +5209,7 @@ bool CoreChecks::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuffer,
     }
 
     uint32_t op_count = vs_state->GetVideoDecodeOperationCount(pDecodeInfo);
-    for (const auto &query : cb_state->activeQueries) {
+    for (const auto &query : cb_state->active_queries) {
         if (query.active_query_index + op_count > query.last_activatable_query_index + 1) {
             auto query_pool_state = Get<vvl::QueryPool>(query.pool);
             skip |= LogError("VUID-vkCmdDecodeVideoKHR-opCount-07134", commandBuffer, error_obj.location,
@@ -5703,7 +5703,7 @@ bool CoreChecks::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuffer,
 
     uint32_t op_count = vs_state->GetVideoEncodeOperationCount(pEncodeInfo);
 
-    for (const auto &query : cb_state->activeQueries) {
+    for (const auto &query : cb_state->active_queries) {
         if (query.active_query_index + op_count > query.last_activatable_query_index + 1) {
             auto query_pool_state = Get<vvl::QueryPool>(query.pool);
             skip |= LogError("VUID-vkCmdEncodeVideoKHR-opCount-07174", commandBuffer, error_obj.location,

--- a/layers/gpuav/descriptor_validation/gpuav_image_layout.cpp
+++ b/layers/gpuav/descriptor_validation/gpuav_image_layout.cpp
@@ -308,7 +308,7 @@ void TransitionBeginRenderPassLayouts(vvl::CommandBuffer &cb_state, const vvl::R
 
 void TransitionFinalSubpassLayouts(vvl::CommandBuffer &cb_state) {
     auto render_pass_state = cb_state.active_render_pass.get();
-    auto framebuffer_state = cb_state.activeFramebuffer.get();
+    auto framebuffer_state = cb_state.active_framebuffer.get();
     if (!render_pass_state || !framebuffer_state) {
         return;
     }

--- a/layers/gpuav/resources/gpuav_state_trackers.cpp
+++ b/layers/gpuav/resources/gpuav_state_trackers.cpp
@@ -553,7 +553,7 @@ void QueueSubState::PreSubmit(std::vector<vvl::QueueSubmission> &submissions) {
             auto guard = cb_submission.cb->ReadLock();
             auto &gpu_cb = SubState(*cb_submission.cb);
             gpu_cb.PreProcess(loc);
-            for (auto *secondary_cb : gpu_cb.base.linkedCommandBuffers) {
+            for (auto *secondary_cb : gpu_cb.base.linked_command_buffers) {
                 auto secondary_guard = secondary_cb->ReadLock();
                 auto &secondary_gpu_cb = SubState(*secondary_cb);
                 secondary_gpu_cb.PreProcess(loc);
@@ -595,7 +595,7 @@ void QueueSubState::Retire(vvl::QueueSubmission &submission) {
                 auto &gpu_cb = SubState(*cb_submission.cb);
                 auto loc = submission.loc.Get();
                 gpu_cb.PostProcess(VkHandle(), cb_submission.initial_label_stack, loc);
-                for (vvl::CommandBuffer *secondary_cb : gpu_cb.base.linkedCommandBuffers) {
+                for (vvl::CommandBuffer *secondary_cb : gpu_cb.base.linked_command_buffers) {
                     auto secondary_guard = secondary_cb->WriteLock();
                     auto &secondary_gpu_cb = SubState(*secondary_cb);
                     secondary_gpu_cb.PostProcess(VkHandle(), cb_submission.initial_label_stack, loc);

--- a/layers/state_tracker/queue_state.cpp
+++ b/layers/state_tracker/queue_state.cpp
@@ -64,11 +64,11 @@ vvl::PreSubmitResult vvl::Queue::PreSubmit(std::vector<vvl::QueueSubmission> &&s
     for (QueueSubmission &submission : submissions) {
         for (CommandBufferSubmission &cb_submission : submission.cb_submissions) {
             auto cb_guard = cb_submission.cb->WriteLock();
-            for (CommandBuffer *secondary_cmd_buffer : cb_submission.cb->linkedCommandBuffers) {
+            for (CommandBuffer *secondary_cmd_buffer : cb_submission.cb->linked_command_buffers) {
                 auto secondary_guard = secondary_cmd_buffer->WriteLock();
-                secondary_cmd_buffer->IncrementResources();
+                secondary_cmd_buffer->submit_count++;
             }
-            cb_submission.cb->IncrementResources();
+            cb_submission.cb->submit_count++;
             cb_submission.cb->Submit(*this, submission.perf_submit_pass, submission.loc.Get());
         }
         // seq_ is atomic so we don't need a lock until updating the deque below.
@@ -271,7 +271,7 @@ void vvl::Queue::Retire(QueueSubmission &submission) {
     }
     for (CommandBufferSubmission &cb_submission : submission.cb_submissions) {
         auto cb_guard = cb_submission.cb->WriteLock();
-        for (CommandBuffer *secondary_cmd_buffer : cb_submission.cb->linkedCommandBuffers) {
+        for (CommandBuffer *secondary_cmd_buffer : cb_submission.cb->linked_command_buffers) {
             auto secondary_guard = secondary_cmd_buffer->WriteLock();
             secondary_cmd_buffer->Retire(submission.perf_submit_pass, is_query_updated_after);
         }


### PR DESCRIPTION
1. Use consistent naming style
2. Create a `Viewport`/`Scissor` struct to group viewport/scissor inheritances stuff