### PR TITLE
gpuav: Simplify LogInstrumentationError

### DIFF
--- a/layers/gpuav/resources/gpuav_state_trackers.cpp
+++ b/layers/gpuav/resources/gpuav_state_trackers.cpp
@@ -420,7 +420,7 @@ void CommandBufferSubState::PostProcess(VkQueue queue, const std::vector<std::st
                 assert(error_logger_i < per_command_error_loggers.size());
                 auto &error_logger = per_command_error_loggers[error_logger_i];
                 const LogObjectList objlist(queue, VkHandle());
-                skip |= error_logger(state_, *this, error_record_ptr, objlist, initial_label_stack);
+                skip |= error_logger(error_record_ptr, objlist, initial_label_stack);
 
                 // Next record
                 error_record_ptr += record_size;

--- a/layers/gpuav/resources/gpuav_state_trackers.h
+++ b/layers/gpuav/resources/gpuav_state_trackers.h
@@ -123,8 +123,8 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     vko::GpuResourcesManager gpu_resources_manager;
     // Using stdext::inplace_function over std::function to allocate memory in place
     using ErrorLoggerFunc =
-        stdext::inplace_function<bool(Validator &gpuav, const CommandBufferSubState &cb_state, const uint32_t *error_record,
-                                      const LogObjectList &objlist, const std::vector<std::string> &initial_label_stack),
+        stdext::inplace_function<bool(const uint32_t *error_record, const LogObjectList &objlist,
+                                      const std::vector<std::string> &initial_label_stack),
                                  280 /*lambda storage size (bytes), large enough to store biggest error lambda*/>;
     std::vector<ErrorLoggerFunc> per_command_error_loggers;
     vvl::unordered_map<uint32_t, uint32_t> action_cmd_i_to_label_cmd_i_map;

--- a/layers/gpuav/validation_cmd/gpuav_copy_buffer_to_image.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_copy_buffer_to_image.cpp
@@ -225,8 +225,7 @@ void CopyBufferToImage(Validator &gpuav, const Location &loc, CommandBufferSubSt
         DispatchCmdDispatch(cb_state.VkHandle(), group_count_x, 1, 1);
     }
 
-    CommandBufferSubState::ErrorLoggerFunc error_logger = [loc, src_buffer = copy_buffer_to_img_info->srcBuffer](
-                                                              Validator &gpuav, const CommandBufferSubState &,
+    CommandBufferSubState::ErrorLoggerFunc error_logger = [&gpuav, loc, src_buffer = copy_buffer_to_img_info->srcBuffer](
                                                               const uint32_t *error_record, const LogObjectList &objlist,
                                                               const std::vector<std::string> &) {
         bool skip = false;

--- a/layers/gpuav/validation_cmd/gpuav_dispatch.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_dispatch.cpp
@@ -104,9 +104,8 @@ void DispatchIndirect(Validator &gpuav, const Location &loc, CommandBufferSubSta
         DispatchCmdDispatch(cb_state.VkHandle(), 1, 1, 1);
     }
 
-    CommandBufferSubState::ErrorLoggerFunc error_logger = [loc](Validator &gpuav, const CommandBufferSubState &,
-                                                                const uint32_t *error_record, const LogObjectList &objlist,
-                                                                const std::vector<std::string> &) {
+    CommandBufferSubState::ErrorLoggerFunc error_logger = [&gpuav, loc](const uint32_t *error_record, const LogObjectList &objlist,
+                                                                        const std::vector<std::string> &) {
         bool skip = false;
         using namespace glsl;
 

--- a/layers/gpuav/validation_cmd/gpuav_draw.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_draw.cpp
@@ -239,9 +239,9 @@ void FirstInstance(Validator &gpuav, CommandBufferSubState &cb_state, const Loca
     // ---
     const uint32_t label_command_i =
         !cb_state.base.GetLabelCommands().empty() ? uint32_t(cb_state.base.GetLabelCommands().size() - 1) : vvl::kU32Max;
-    ErrorLoggerFunc error_logger = [loc, vuid, api_struct_name, label_command_i](
-                                       Validator &gpuav, const CommandBufferSubState &cb_state, const uint32_t *error_record,
-                                       const LogObjectList &objlist, const std::vector<std::string> &initial_label_stack) {
+    ErrorLoggerFunc error_logger = [&gpuav, &cb_state, loc, vuid, api_struct_name, label_command_i](
+                                       const uint32_t *error_record, const LogObjectList &objlist,
+                                       const std::vector<std::string> &initial_label_stack) {
         bool skip = false;
         using namespace glsl;
 
@@ -397,10 +397,10 @@ void CountBuffer(Validator &gpuav, CommandBufferSubState &cb_state, const Locati
     // ---
     const uint32_t label_command_i =
         !cb_state.base.GetLabelCommands().empty() ? uint32_t(cb_state.base.GetLabelCommands().size() - 1) : vvl::kU32Max;
-    ErrorLoggerFunc error_logger = [loc, api_buffer, draw_buffer_size = draw_buffer_state->create_info.size, api_offset,
-                                    api_struct_size_byte, api_stride, api_struct_name, vuid, label_command_i](
-                                       Validator &gpuav, const CommandBufferSubState &cb_state, const uint32_t *error_record,
-                                       const LogObjectList &objlist, const std::vector<std::string> &initial_label_stack) {
+    ErrorLoggerFunc error_logger = [&gpuav, &cb_state, loc, api_buffer, draw_buffer_size = draw_buffer_state->create_info.size,
+                                    api_offset, api_struct_size_byte, api_stride, api_struct_name, vuid,
+                                    label_command_i](const uint32_t *error_record, const LogObjectList &objlist,
+                                                     const std::vector<std::string> &initial_label_stack) {
         bool skip = false;
         using namespace glsl;
 
@@ -609,9 +609,9 @@ void DrawMeshIndirect(Validator &gpuav, CommandBufferSubState &cb_state, const L
     // ---
     const uint32_t label_command_i =
         !cb_state.base.GetLabelCommands().empty() ? uint32_t(cb_state.base.GetLabelCommands().size() - 1) : vvl::kU32Max;
-    ErrorLoggerFunc error_logger = [loc, is_task_shader, label_command_i](
-                                       Validator &gpuav, const CommandBufferSubState &cb_state, const uint32_t *error_record,
-                                       const LogObjectList &objlist, const std::vector<std::string> &initial_label_stack) {
+    ErrorLoggerFunc error_logger = [&gpuav, &cb_state, loc, is_task_shader, label_command_i](
+                                       const uint32_t *error_record, const LogObjectList &objlist,
+                                       const std::vector<std::string> &initial_label_stack) {
         bool skip = false;
         using namespace glsl;
 
@@ -976,10 +976,10 @@ void DrawIndexedIndirectIndexBuffer(Validator &gpuav, CommandBufferSubState &cb_
 
     const uint32_t label_command_i =
         !cb_state.base.GetLabelCommands().empty() ? uint32_t(cb_state.base.GetLabelCommands().size() - 1) : vvl::kU32Max;
-    ErrorLoggerFunc error_logger = [loc, vuid, api_buffer, api_offset, api_stride,
-                                    index_buffer_binding = cb_state.base.index_buffer_binding, label_command_i](
-                                       Validator &gpuav, const CommandBufferSubState &cb_state, const uint32_t *error_record,
-                                       const LogObjectList &objlist, const std::vector<std::string> &initial_label_stack) {
+    ErrorLoggerFunc error_logger = [&gpuav, &cb_state, loc, vuid, api_buffer, api_offset, api_stride,
+                                    index_buffer_binding = cb_state.base.index_buffer_binding,
+                                    label_command_i](const uint32_t *error_record, const LogObjectList &objlist,
+                                                     const std::vector<std::string> &initial_label_stack) {
         bool skip = false;
         using namespace glsl;
 

--- a/layers/gpuav/validation_cmd/gpuav_trace_rays.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_trace_rays.cpp
@@ -104,9 +104,8 @@ void TraceRaysIndirect(Validator& gpuav, const Location& loc, CommandBufferSubSt
         DispatchCmdDispatch(cb_state.VkHandle(), 1, 1, 1);
     }
 
-    CommandBufferSubState::ErrorLoggerFunc error_logger = [loc](Validator& gpuav, const CommandBufferSubState&,
-                                                                const uint32_t* error_record, const LogObjectList& objlist,
-                                                                const std::vector<std::string>&) {
+    CommandBufferSubState::ErrorLoggerFunc error_logger = [&gpuav, loc](const uint32_t* error_record, const LogObjectList& objlist,
+                                                                        const std::vector<std::string>&) {
         bool skip = false;
         using namespace glsl;
 

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1089,7 +1089,7 @@ void CommandBuffer::Begin(const VkCommandBufferBeginInfo *pBeginInfo) {
     updatedQueries.clear();
 
     for (auto &item : sub_states_) {
-        item.second->Begin(beginInfo);
+        item.second->Begin(*pBeginInfo);
     }
 }
 


### PR DESCRIPTION
`LogInstrumentationError` has changed a lot, and this 

- Reduces what we pass in the lambda
- Makes better use of `InstrumentationErrorBlob`