### PR TITLE
layers: Fix ObjectTracker not printing device handle

### DIFF
--- a/layers/object_tracker/object_lifetime_validation.h
+++ b/layers/object_tracker/object_lifetime_validation.h
@@ -42,9 +42,7 @@ typedef vvl::concurrent_unordered_map<uint64_t, std::shared_ptr<ObjTrackState>, 
 typedef vvl::concurrent_unordered_map<uint64_t, small_vector<std::shared_ptr<ObjTrackState>, 4>, 6> object_list_map_type;
 
 class Tracker : public Logger {
-public:
-    VulkanTypedHandle handle;
-
+  public:
     Tracker(DebugReport *dr) : Logger(dr) {}
 
     void DestroyUndestroyedObjects(VulkanObjectType object_type, const Location &loc);
@@ -140,6 +138,13 @@ public:
                              const char *wrong_parent_vuid, const Location &loc, VulkanObjectType parent_type) const;
     // Vector of unordered_maps per object type to hold ObjTrackState info
     object_map_type object_map[kVulkanObjectTypeMax + 1];
+
+    void SetDeviceHandle(VkDevice device);
+    void SetInstanceHandle(VkInstance instance);
+
+  private:
+    // We don't know the handle (VkDevice or VkInstance) when Tracker is created and need to set afterwards
+    VulkanTypedHandle handle_;
 };
 
 class Instance : public vvl::base::Instance {
@@ -209,6 +214,8 @@ class Device : public vvl::base::Device {
     // Constructor for object lifetime tracking
     Device(vvl::dispatch::Device *dev, Instance *instance);
     ~Device();
+
+    void FinishDeviceSetup(const VkDeviceCreateInfo *pCreateInfo, const Location &loc) override;
 
     void DestroyLeakedObjects();
     bool ReportUndestroyedObjects(const Location &loc) const;

--- a/tests/unit/others.cpp
+++ b/tests/unit/others.cpp
@@ -493,18 +493,18 @@ TEST_F(VkLayerTest, UseObjectWithWrongDevice) {
     device_create_info.queueCreateInfoCount = 1;
     device_create_info.pQueueCreateInfos = &queue_info;
     device_create_info.enabledLayerCount = 0;
-    device_create_info.ppEnabledLayerNames = NULL;
+    device_create_info.ppEnabledLayerNames = nullptr;
     device_create_info.pEnabledFeatures = &features;
 
     VkDevice second_device;
-    ASSERT_EQ(VK_SUCCESS, vk::CreateDevice(Gpu(), &device_create_info, NULL, &second_device));
+    ASSERT_EQ(VK_SUCCESS, vk::CreateDevice(Gpu(), &device_create_info, nullptr, &second_device));
 
     // Try to destroy the renderpass from the first device using the second device
     m_errorMonitor->SetDesiredError("VUID-vkDestroyRenderPass-renderPass-parent");
-    vk::DestroyRenderPass(second_device, m_renderPass, NULL);
+    vk::DestroyRenderPass(second_device, m_renderPass, nullptr);
     m_errorMonitor->VerifyFound();
 
-    vk::DestroyDevice(second_device, NULL);
+    vk::DestroyDevice(second_device, nullptr);
 }
 
 TEST_F(VkLayerTest, InvalidAllocationCallbacks) {


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9780

Now actually prints the `VkDevice` handles like

> vkDestroyRenderPass(): renderPass (VkRenderPass 0x70000000007) was created, allocated or retrieved from VkDevice 0x5fa0755ad0c0, but command is using (or its dispatchable parameter is associated with) VkDevice 0x5fa07830bce0.
