### PR TITLE
layers: Rename image layout map types

### DIFF
--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -38,14 +38,13 @@ struct CommandBufferSubmitState {
     QFOTransferCBScoreboards<QFOImageTransferBarrier> qfo_image_scoreboards;
     QFOTransferCBScoreboards<QFOBufferTransferBarrier> qfo_buffer_scoreboards;
     std::vector<VkCommandBuffer> current_cmds;
-    GlobalImageLayoutMap global_image_layout_map;
     std::vector<std::string> cmdbuf_label_stack;
     std::string last_closed_cmdbuf_label;
     bool found_unbalanced_cmdbuf_label;
 
-    // The "local" prefix is about tracking state within a *single* queue submission
-    // (accross all command buffers of that submission), as opposed to globally
-    // tracking state accross *all* submissions to the same queue.
+    // The "local" prefix is about tracking state accross all command buffers of a *single* QueueSubmit command.
+    // This does not track global state based on all previous submissions.
+    SubmissionImageLayoutMap local_image_layout_map;
     QueryMap local_query_to_state_map;
     EventMap local_event_signal_info;
     vvl::unordered_map<VkVideoSessionKHR, vvl::VideoSessionDeviceState> local_video_session_state{};
@@ -60,7 +59,7 @@ struct CommandBufferSubmitState {
 
     bool Validate(const Location &loc, const vvl::CommandBuffer &cb_state, uint32_t perf_pass) {
         bool skip = false;
-        skip |= core.ValidateCmdBufImageLayouts(loc, cb_state, global_image_layout_map);
+        skip |= core.ValidateCmdBufImageLayouts(loc, cb_state, local_image_layout_map);
         const VkCommandBuffer cmd = cb_state.VkHandle();
         current_cmds.push_back(cmd);
         skip |= core.ValidatePrimaryCommandBufferState(

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1184,7 +1184,7 @@ class CoreChecks : public vvl::DeviceProxy {
                                      const RecordObject& record_obj) override;
 
     bool ValidateCmdBufImageLayouts(const Location& loc, const vvl::CommandBuffer& cb_state,
-                                    GlobalImageLayoutMap& global_image_layout_map) const;
+                                    SubmissionImageLayoutMap& submission_image_layout_map) const;
 
     void UpdateCmdBufImageLayouts(const vvl::CommandBuffer& cb_state);
 

--- a/layers/gpuav/descriptor_validation/gpuav_image_layout.cpp
+++ b/layers/gpuav/descriptor_validation/gpuav_image_layout.cpp
@@ -173,14 +173,13 @@ static bool VerifyImageLayoutRange(const Validator &gpuav, const vvl::CommandBuf
 
     const auto &layout_map = image_layout_registry->GetLayoutMap();
     const auto *global_range_map = image_state.layout_range_map.get();
-    GlobalImageLayoutRangeMap empty_map(1);
+    ImageLayoutRangeMap empty_map(1);
     assert(global_range_map);
     auto global_range_map_guard = global_range_map->ReadLock();
 
     auto pos = layout_map.begin();
     const auto end = layout_map.end();
-    sparse_container::parallel_iterator<const GlobalImageLayoutRangeMap> current_layout(empty_map, *global_range_map,
-                                                                                        pos->first.begin);
+    sparse_container::parallel_iterator<const ImageLayoutRangeMap> current_layout(empty_map, *global_range_map, pos->first.begin);
     while (pos != end) {
         const VkImageLayout initial_layout = pos->second.initial_layout;
         ASSERT_AND_CONTINUE(initial_layout != image_layout_map::kInvalidLayout);

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -170,7 +170,7 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     using Func = vvl::Func;
 
   public:
-    using AliasedLayoutMap = vvl::unordered_map<const GlobalImageLayoutRangeMap *, std::shared_ptr<ImageLayoutRegistry>>;
+    using AliasedLayoutMap = vvl::unordered_map<const ImageLayoutRangeMap *, std::shared_ptr<ImageLayoutRegistry>>;
 
     VkCommandBufferAllocateInfo allocate_info;
 

--- a/layers/state_tracker/image_layout_map.h
+++ b/layers/state_tracker/image_layout_map.h
@@ -145,11 +145,11 @@ class ImageLayoutRegistry {
 };
 }  // namespace image_layout_map
 
-class GlobalImageLayoutRangeMap : public subresource_adapter::BothRangeMap<VkImageLayout, 16> {
+class ImageLayoutRangeMap : public subresource_adapter::BothRangeMap<VkImageLayout, 16> {
   public:
     using RangeGenerator = image_layout_map::RangeGenerator;
 
-    GlobalImageLayoutRangeMap(index_type index) : BothRangeMap<VkImageLayout, 16>(index) {}
+    ImageLayoutRangeMap(index_type index) : BothRangeMap<VkImageLayout, 16>(index) {}
     ReadLockGuard ReadLock() const { return ReadLockGuard(lock_); }
     WriteLockGuard WriteLock() { return WriteLockGuard(lock_); }
 
@@ -160,7 +160,7 @@ class GlobalImageLayoutRangeMap : public subresource_adapter::BothRangeMap<VkIma
 };
 
 // TODO - Get to work with non-STL custom hashmap
-using GlobalImageLayoutMap = std::unordered_map<const vvl::Image*, std::optional<GlobalImageLayoutRangeMap>>;
+using SubmissionImageLayoutMap = std::unordered_map<const vvl::Image*, std::optional<ImageLayoutRangeMap>>;
 
 // Not declared in the CommandBuffer class to allow other files to forward reference this
 // (was slow to have ever file need to compile in the Image Layout map)

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -119,7 +119,7 @@ class Image : public Bindable, public SubStateManager<ImageSubState> {
     // Record time validation can't use this. At the beginning of the command buffer
     // the global image layout can't be determined because it depends on the previously
     // submitted command buffers.
-    std::shared_ptr<GlobalImageLayoutRangeMap> layout_range_map;
+    std::shared_ptr<ImageLayoutRangeMap> layout_range_map;
 
     vvl::unordered_set<std::shared_ptr<const vvl::VideoProfileDesc>> supported_video_profiles;
 


### PR DESCRIPTION
The usage of the word Global was not accurate for `CommandBufferSubmitState::global_image_layout_map` since it tracks state for a single submission and then it gets confusing when comparing to `vvl::Image::layout_range_map` which tracks global layout state.

`GlobalImageLayoutMap -> SubmissionImageLayoutMap` - per above this is more about a single submission
`GlobalImageLayoutRangeMap -> ImageLayoutRangeMap` - this type is used in both local and global layout tracking.
