### PR TITLE
gpuav: Skip VertexAttributeFetchOOB on normal draws

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -350,7 +350,7 @@ vvl_sources = [
   "layers/thread_tracker/thread_safety_validation.cpp",
   "layers/thread_tracker/thread_safety_validation.h",
   "layers/utils/android_ndk_types.h",
-  "layers/utils/android_ndk_types.h",
+  "layers/utils/action_command_utils.h",
   "layers/utils/cast_utils.h",
   "layers/utils/convert_utils.cpp",
   "layers/utils/convert_utils.h",

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -55,6 +55,7 @@ target_sources(VkLayer_utils PRIVATE
     ${API_TYPE}/generated/vk_api_version.h
     ${API_TYPE}/generated/vk_extension_helper.h
     ${API_TYPE}/generated/vk_extension_helper.cpp
+    utils/action_command_utils.h
     utils/cast_utils.h
     utils/convert_utils.cpp
     utils/convert_utils.h

--- a/layers/core_checks/cc_shader_object.cpp
+++ b/layers/core_checks/cc_shader_object.cpp
@@ -829,7 +829,7 @@ bool CoreChecks::ValidateDrawShaderObjectMesh(const LastBound& last_bound_state,
     const bool has_task_shader = task_shader_handle != VK_NULL_HANDLE;
     const bool has_mesh_shader = mesh_shader_handle != VK_NULL_HANDLE;
 
-    const bool is_mesh_command = IsCommandDrawMesh(vuid.function);
+    const bool is_mesh_command = vvl::IsCommandDrawMesh(vuid.function);
 
     if (has_task_shader || has_mesh_shader) {
         auto print_mesh_task = [this, has_task_shader, has_mesh_shader, mesh_shader_handle, task_shader_handle]() {

--- a/layers/core_checks/cc_shader_object.cpp
+++ b/layers/core_checks/cc_shader_object.cpp
@@ -25,6 +25,7 @@
 #include "generated/spirv_grammar_helper.h"
 #include "drawdispatch/drawdispatch_vuids.h"
 #include "containers/limits.h"
+#include "utils/action_command_utils.h"
 #include "utils/shader_utils.h"
 #include "utils/vk_layer_utils.h"
 
@@ -828,10 +829,7 @@ bool CoreChecks::ValidateDrawShaderObjectMesh(const LastBound& last_bound_state,
     const bool has_task_shader = task_shader_handle != VK_NULL_HANDLE;
     const bool has_mesh_shader = mesh_shader_handle != VK_NULL_HANDLE;
 
-    const bool is_mesh_command =
-        IsValueIn(vuid.function,
-                  {Func::vkCmdDrawMeshTasksNV, Func::vkCmdDrawMeshTasksIndirectNV, Func::vkCmdDrawMeshTasksIndirectCountNV,
-                   Func::vkCmdDrawMeshTasksEXT, Func::vkCmdDrawMeshTasksIndirectEXT, Func::vkCmdDrawMeshTasksIndirectCountEXT});
+    const bool is_mesh_command = IsCommandDrawMesh(vuid.function);
 
     if (has_task_shader || has_mesh_shader) {
         auto print_mesh_task = [this, has_task_shader, has_mesh_shader, mesh_shader_handle, task_shader_handle]() {

--- a/layers/drawdispatch/descriptor_validator.cpp
+++ b/layers/drawdispatch/descriptor_validator.cpp
@@ -31,28 +31,19 @@
 #include "state_tracker/ray_tracing_state.h"
 #include "state_tracker/shader_module.h"
 #include "drawdispatch/drawdispatch_vuids.h"
+#include "utils/action_command_utils.h"
 #include "utils/vk_layer_utils.h"
 
 namespace vvl {
 
 // This seems like it could be useful elsewhere, but until find another spot, just keep here.
 static const char *GetActionType(Func command) {
-    switch (command) {
-        case Func::vkCmdDispatch:
-        case Func::vkCmdDispatchIndirect:
-        case Func::vkCmdDispatchBase:
-        case Func::vkCmdDispatchBaseKHR:
-        case Func::vkCmdDispatchGraphAMDX:
-        case Func::vkCmdDispatchGraphIndirectAMDX:
-        case Func::vkCmdDispatchGraphIndirectCountAMDX:
-            return "dispatch";
-        case Func::vkCmdTraceRaysNV:
-        case Func::vkCmdTraceRaysKHR:
-        case Func::vkCmdTraceRaysIndirectKHR:
-        case Func::vkCmdTraceRaysIndirect2KHR:
-            return "trace rays";
-        default:
-            return "draw";
+    if (IsCommandDispatch(command)) {
+        return "dispatch";
+    } else if (IsCommandTraceRays(command)) {
+        return "trace rays";
+    } else {
+        return "draw";
     }
 }
 

--- a/layers/gpuav/core/gpuav.h
+++ b/layers/gpuav/core/gpuav.h
@@ -65,7 +65,7 @@ class Validator : public GpuShaderInstrumentor {
 
   public:
     Validator(vvl::dispatch::Device* dev, Instance* instance_vo)
-        : BaseClass(dev, instance_vo, LayerObjectTypeGpuAssisted), indices_buffer_(*this) {}
+        : BaseClass(dev, instance_vo, LayerObjectTypeGpuAssisted), indices_buffer_(*this), vertex_attribute_fetch_off_(*this) {}
 
     // gpuav_setup.cpp
     // -------------
@@ -432,6 +432,11 @@ class Validator : public GpuShaderInstrumentor {
 
     vko::Buffer indices_buffer_;
     unsigned int indices_buffer_alignment_ = 0;
+
+    // Vertex Attribute Fetch OOB checks are for Indexed draws, so when using another draw, we set the values of the small buffer to
+    // zero to indicate the instrumented vertex shader to skip validating the limits. We have a single global buffer that we can
+    // have all non-index draws point at.
+    vko::Buffer vertex_attribute_fetch_off_;
 
   private:
     std::string instrumented_shader_cache_path_{};

--- a/layers/gpuav/core/gpuav_record.cpp
+++ b/layers/gpuav/core/gpuav_record.cpp
@@ -124,6 +124,7 @@ void Validator::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCa
     shared_resources_manager.Clear();
 
     indices_buffer_.Destroy();
+    vertex_attribute_fetch_off_.Destroy();
 
     BaseClass::PreCallRecordDestroyDevice(device, pAllocator, record_obj);
 

--- a/layers/gpuav/core/gpuav_setup.cpp
+++ b/layers/gpuav/core/gpuav_setup.cpp
@@ -284,6 +284,24 @@ void Validator::FinishDeviceSetup(const VkDeviceCreateInfo *pCreateInfo, const L
             indices_ptr[i] = i / (indices_buffer_alignment_ / sizeof(uint32_t));
         }
     }
+
+    // Create Vertex Attribute Fetch buffer to turn off check when needed
+    {
+        VkBufferCreateInfo buffer_info = vku::InitStructHelper();
+        buffer_info.size = 4 * sizeof(uint32_t);
+        buffer_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
+        VmaAllocationCreateInfo alloc_info = {};
+        alloc_info.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+        alloc_info.preferredFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+        const bool success = vertex_attribute_fetch_off_.Create(loc, &buffer_info, &alloc_info);
+        if (!success) {
+            return;
+        }
+
+        auto vertex_attribute_fetch_limits_buffer_ptr = (uint32_t *)vertex_attribute_fetch_off_.GetMappedPtr();
+        vertex_attribute_fetch_limits_buffer_ptr[0] = 0u;  // has_max_vbb_vertex_input_rate
+        vertex_attribute_fetch_limits_buffer_ptr[2] = 0u;  // has_max_vbb_instance_input_rate
+    }
 }
 
 namespace setting {

--- a/layers/utils/action_command_utils.h
+++ b/layers/utils/action_command_utils.h
@@ -1,0 +1,76 @@
+/* Copyright (c) 2025 The Khronos Group Inc.
+ * Copyright (c) 2025 Valve Corporation
+ * Copyright (c) 2025 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include "generated/error_location_helper.h"
+
+// clang-format off
+
+static inline bool IsCommandDrawMesh(vvl::Func command) {
+    return
+        command == vvl::Func::vkCmdDrawMeshTasksNV ||
+        command == vvl::Func::vkCmdDrawMeshTasksIndirectNV ||
+        command == vvl::Func::vkCmdDrawMeshTasksIndirectCountNV ||
+        command == vvl::Func::vkCmdDrawMeshTasksEXT ||
+        command == vvl::Func::vkCmdDrawMeshTasksIndirectEXT ||
+        command == vvl::Func::vkCmdDrawMeshTasksIndirectCountEXT;
+}
+
+static inline bool IsCommandDrawVertexIndexed(vvl::Func command) {
+    return
+        command == vvl::Func::vkCmdDrawIndexed ||
+        command == vvl::Func::vkCmdDrawMultiIndexedEXT ||
+        command == vvl::Func::vkCmdDrawIndexedIndirect ||
+        command == vvl::Func::vkCmdDrawIndexedIndirectCount ||
+        command == vvl::Func::vkCmdDrawIndexedIndirectCountKHR;
+}
+
+static inline bool IsCommandDrawVertex(vvl::Func command) {
+    return
+        command == vvl::Func::vkCmdDraw ||
+        command == vvl::Func::vkCmdDrawMultiEXT ||
+        command == vvl::Func::vkCmdDrawIndexed ||
+        command == vvl::Func::vkCmdDrawMultiIndexedEXT ||
+        command == vvl::Func::vkCmdDrawIndirect ||
+        command == vvl::Func::vkCmdDrawIndexedIndirect ||
+        command == vvl::Func::vkCmdDrawIndirectCount ||
+        command == vvl::Func::vkCmdDrawIndirectCountKHR ||
+        command == vvl::Func::vkCmdDrawIndexedIndirectCount ||
+        command == vvl::Func::vkCmdDrawIndexedIndirectCountKHR ||
+        command == vvl::Func::vkCmdDrawIndirectByteCountEXT;
+}
+
+static inline bool IsCommandDispatch(vvl::Func command) {
+    return
+        command == vvl::Func::vkCmdDispatch ||
+        command == vvl::Func::vkCmdDispatchIndirect ||
+        command == vvl::Func::vkCmdDispatchBase ||
+        command == vvl::Func::vkCmdDispatchBaseKHR ||
+        command == vvl::Func::vkCmdDispatchGraphAMDX ||
+        command == vvl::Func::vkCmdDispatchGraphIndirectAMDX ||
+        command == vvl::Func::vkCmdDispatchGraphIndirectCountAMDX ||
+        command == vvl::Func::vkCmdDispatchTileQCOM;
+}
+
+static inline bool IsCommandTraceRays(vvl::Func command) {
+    return
+        command == vvl::Func::vkCmdTraceRaysNV ||
+        command == vvl::Func::vkCmdTraceRaysKHR ||
+        command == vvl::Func::vkCmdTraceRaysIndirectKHR ||
+        command == vvl::Func::vkCmdTraceRaysIndirect2KHR;
+}
+
+// clang-format on

--- a/layers/utils/action_command_utils.h
+++ b/layers/utils/action_command_utils.h
@@ -19,58 +19,62 @@
 
 // clang-format off
 
-static inline bool IsCommandDrawMesh(vvl::Func command) {
+namespace vvl {
+
+static inline bool IsCommandDrawMesh(Func command) {
     return
-        command == vvl::Func::vkCmdDrawMeshTasksNV ||
-        command == vvl::Func::vkCmdDrawMeshTasksIndirectNV ||
-        command == vvl::Func::vkCmdDrawMeshTasksIndirectCountNV ||
-        command == vvl::Func::vkCmdDrawMeshTasksEXT ||
-        command == vvl::Func::vkCmdDrawMeshTasksIndirectEXT ||
-        command == vvl::Func::vkCmdDrawMeshTasksIndirectCountEXT;
+        command == Func::vkCmdDrawMeshTasksNV ||
+        command == Func::vkCmdDrawMeshTasksIndirectNV ||
+        command == Func::vkCmdDrawMeshTasksIndirectCountNV ||
+        command == Func::vkCmdDrawMeshTasksEXT ||
+        command == Func::vkCmdDrawMeshTasksIndirectEXT ||
+        command == Func::vkCmdDrawMeshTasksIndirectCountEXT;
 }
 
-static inline bool IsCommandDrawVertexIndexed(vvl::Func command) {
+static inline bool IsCommandDrawVertexIndexed(Func command) {
     return
-        command == vvl::Func::vkCmdDrawIndexed ||
-        command == vvl::Func::vkCmdDrawMultiIndexedEXT ||
-        command == vvl::Func::vkCmdDrawIndexedIndirect ||
-        command == vvl::Func::vkCmdDrawIndexedIndirectCount ||
-        command == vvl::Func::vkCmdDrawIndexedIndirectCountKHR;
+        command == Func::vkCmdDrawIndexed ||
+        command == Func::vkCmdDrawMultiIndexedEXT ||
+        command == Func::vkCmdDrawIndexedIndirect ||
+        command == Func::vkCmdDrawIndexedIndirectCount ||
+        command == Func::vkCmdDrawIndexedIndirectCountKHR;
 }
 
-static inline bool IsCommandDrawVertex(vvl::Func command) {
+static inline bool IsCommandDrawVertex(Func command) {
     return
-        command == vvl::Func::vkCmdDraw ||
-        command == vvl::Func::vkCmdDrawMultiEXT ||
-        command == vvl::Func::vkCmdDrawIndexed ||
-        command == vvl::Func::vkCmdDrawMultiIndexedEXT ||
-        command == vvl::Func::vkCmdDrawIndirect ||
-        command == vvl::Func::vkCmdDrawIndexedIndirect ||
-        command == vvl::Func::vkCmdDrawIndirectCount ||
-        command == vvl::Func::vkCmdDrawIndirectCountKHR ||
-        command == vvl::Func::vkCmdDrawIndexedIndirectCount ||
-        command == vvl::Func::vkCmdDrawIndexedIndirectCountKHR ||
-        command == vvl::Func::vkCmdDrawIndirectByteCountEXT;
+        command == Func::vkCmdDraw ||
+        command == Func::vkCmdDrawMultiEXT ||
+        command == Func::vkCmdDrawIndexed ||
+        command == Func::vkCmdDrawMultiIndexedEXT ||
+        command == Func::vkCmdDrawIndirect ||
+        command == Func::vkCmdDrawIndexedIndirect ||
+        command == Func::vkCmdDrawIndirectCount ||
+        command == Func::vkCmdDrawIndirectCountKHR ||
+        command == Func::vkCmdDrawIndexedIndirectCount ||
+        command == Func::vkCmdDrawIndexedIndirectCountKHR ||
+        command == Func::vkCmdDrawIndirectByteCountEXT;
 }
 
-static inline bool IsCommandDispatch(vvl::Func command) {
+static inline bool IsCommandDispatch(Func command) {
     return
-        command == vvl::Func::vkCmdDispatch ||
-        command == vvl::Func::vkCmdDispatchIndirect ||
-        command == vvl::Func::vkCmdDispatchBase ||
-        command == vvl::Func::vkCmdDispatchBaseKHR ||
-        command == vvl::Func::vkCmdDispatchGraphAMDX ||
-        command == vvl::Func::vkCmdDispatchGraphIndirectAMDX ||
-        command == vvl::Func::vkCmdDispatchGraphIndirectCountAMDX ||
-        command == vvl::Func::vkCmdDispatchTileQCOM;
+        command == Func::vkCmdDispatch ||
+        command == Func::vkCmdDispatchIndirect ||
+        command == Func::vkCmdDispatchBase ||
+        command == Func::vkCmdDispatchBaseKHR ||
+        command == Func::vkCmdDispatchGraphAMDX ||
+        command == Func::vkCmdDispatchGraphIndirectAMDX ||
+        command == Func::vkCmdDispatchGraphIndirectCountAMDX ||
+        command == Func::vkCmdDispatchTileQCOM;
 }
 
-static inline bool IsCommandTraceRays(vvl::Func command) {
+static inline bool IsCommandTraceRays(Func command) {
     return
-        command == vvl::Func::vkCmdTraceRaysNV ||
-        command == vvl::Func::vkCmdTraceRaysKHR ||
-        command == vvl::Func::vkCmdTraceRaysIndirectKHR ||
-        command == vvl::Func::vkCmdTraceRaysIndirect2KHR;
+        command == Func::vkCmdTraceRaysNV ||
+        command == Func::vkCmdTraceRaysKHR ||
+        command == Func::vkCmdTraceRaysIndirectKHR ||
+        command == Func::vkCmdTraceRaysIndirect2KHR;
 }
+
+} // namespace vvl
 
 // clang-format on


### PR DESCRIPTION
While we instrument every Vertex shader for `VK_LAYER_GPUAV_VERTEX_ATTRIBUTE_FETCH_OOB`, it is only for indexed buffers (because for things like `VUID-vkCmdDraw-None-02721` we can validate on the CPU)

This just skips calling `GetVertexAttributeFetchLimits` when not required 

edit - I added another commit that just creates a single VkBuffer to point all the non-indexed draws at