### PR TITLE
gpuav: Add a BufferSlab to help sub allocate

### DIFF
--- a/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
@@ -23,6 +23,7 @@
 #include "gpuav/error_message/gpuav_vuids.h"
 #include "gpuav/resources/gpuav_shader_resources.h"
 #include "gpuav/resources/gpuav_state_trackers.h"
+#include "gpuav/resources/gpuav_vulkan_objects.h"
 #include "gpuav/shaders/gpuav_error_header.h"
 #include "gpuav/debug_printf/debug_printf.h"
 #include "containers/limits.h"
@@ -388,19 +389,12 @@ void UpdateInstrumentationDescSet(Validator &gpuav, CommandBufferSubState &cb_st
     if (gpuav.gpuav_settings.shader_instrumentation.vertex_attribute_fetch_oob && vvl::IsCommandDrawVertex(loc.function)) {
         // This check is only for indexed draws
         if (vvl::IsCommandDrawVertexIndexed(loc.function)) {
-            VkBufferCreateInfo buffer_info = vku::InitStructHelper();
-            buffer_info.size = 4 * sizeof(uint32_t);
-            buffer_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
-            VmaAllocationCreateInfo alloc_info = {};
-            alloc_info.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-            alloc_info.preferredFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
-            vko::Buffer vertex_attribute_fetch_limits_buffer =
-                cb_state.gpu_resources_manager.GetManagedBuffer(gpuav, loc, buffer_info, alloc_info);
-            if (vertex_attribute_fetch_limits_buffer.IsDestroyed()) {
+            vko::SlabSlice slab_slice = cb_state.vertex_attribute_fetch_slab.GetNextSlice(loc);
+            if (slab_slice.buffer == VK_NULL_HANDLE) {
                 return;
             }
 
-            auto vertex_attribute_fetch_limits_buffer_ptr = (uint32_t *)vertex_attribute_fetch_limits_buffer.GetMappedPtr();
+            auto vertex_attribute_fetch_limits_buffer_ptr = (uint32_t *)slab_slice.mapped_ptr;
 
             const auto [vertex_attribute_fetch_limit_vertex_input_rate, vertex_attribute_fetch_limit_instance_input_rate] =
                 GetVertexAttributeFetchLimits(cb_state.base);
@@ -426,9 +420,9 @@ void UpdateInstrumentationDescSet(Validator &gpuav, CommandBufferSubState &cb_st
                 vertex_attribute_fetch_limit_instance_input_rate;
             out_instrumentation_error_blob.index_buffer_binding = cb_state.base.index_buffer_binding;
 
-            vertex_attribute_fetch_limits_buffer_bi.buffer = vertex_attribute_fetch_limits_buffer.VkHandle();
-            vertex_attribute_fetch_limits_buffer_bi.offset = 0;
-            vertex_attribute_fetch_limits_buffer_bi.range = VK_WHOLE_SIZE;
+            vertex_attribute_fetch_limits_buffer_bi.buffer = slab_slice.buffer;
+            vertex_attribute_fetch_limits_buffer_bi.offset = slab_slice.offset;
+            vertex_attribute_fetch_limits_buffer_bi.range = slab_slice.range;
         } else {
             // Point all non-indexed draws to our global buffer that will bypass the check in shader
             vertex_attribute_fetch_limits_buffer_bi.buffer = gpuav.vertex_attribute_fetch_off_.VkHandle();

--- a/layers/gpuav/resources/gpuav_state_trackers.h
+++ b/layers/gpuav/resources/gpuav_state_trackers.h
@@ -121,6 +121,7 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     void Reset(const Location &loc) final;
 
     vko::GpuResourcesManager gpu_resources_manager;
+
     // Using stdext::inplace_function over std::function to allocate memory in place
     using ErrorLoggerFunc =
         stdext::inplace_function<bool(const uint32_t *error_record, const LogObjectList &objlist,
@@ -134,6 +135,8 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     std::vector<ValidationCommandFunc> per_render_pass_validation_commands;
 
     std::vector<DebugPrintfBufferInfo> debug_printf_buffer_infos;
+
+    vko::BufferSlab vertex_attribute_fetch_slab;
 
   private:
     void AllocateResources(const Location &loc);

--- a/tests/unit/gpu_av_positive.cpp
+++ b/tests/unit/gpu_av_positive.cpp
@@ -21,6 +21,7 @@
 #include "../framework/descriptor_helper.h"
 #include "../framework/gpu_av_helper.h"
 #include "../framework/external_memory_sync.h"
+#include "../framework/buffer_helper.h"
 #include "../../layers/gpuav/shaders/gpuav_shaders_constants.h"
 
 class PositiveGpuAV : public GpuAVTest {};
@@ -2061,4 +2062,51 @@ TEST_F(PositiveGpuAV, EmptySubmit) {
     vk::QueueSubmit(m_default_queue->handle(), 1, &submit, fence);
     vk::WaitForFences(device(), 1, &fence.handle(), VK_TRUE, 1000000000);
     m_device->Wait();
+}
+
+TEST_F(PositiveGpuAV, BufferSlab) {
+    TEST_DESCRIPTION("Assuming we making slice per index draw for Vertex Attribute Fetch check");
+    RETURN_IF_SKIP(InitGpuAvFramework());
+    RETURN_IF_SKIP(InitState());
+    InitRenderTarget();
+
+    CreatePipelineHelper pipe(*this);
+    pipe.CreateGraphicsPipeline();
+
+    constexpr uint32_t num_vertices = 12;
+    std::vector<uint32_t> indicies(num_vertices);
+    for (uint32_t i = 0; i < num_vertices; i++) {
+        indicies[i] = num_vertices - 1 - i;
+    }
+    vkt::Buffer index_buffer = vkt::IndexBuffer(*m_device, std::move(indicies));
+
+    VkDrawIndexedIndirectCommand draw_params{};
+    draw_params.indexCount = 3;
+    draw_params.instanceCount = 1;
+    draw_params.firstIndex = 0;
+    draw_params.vertexOffset = 0;
+    draw_params.firstInstance = 0;
+    vkt::Buffer draw_params_buffer = vkt::IndirectBuffer<VkDrawIndexedIndirectCommand>(*m_device, {draw_params});
+    VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
+    m_command_buffer.Begin(&begin_info);
+    m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
+    vk::CmdBindIndexBuffer(m_command_buffer, index_buffer, 0, VK_INDEX_TYPE_UINT32);
+    for (uint32_t i = 0; i < 1025; i++) {
+        vk::CmdDrawIndexedIndirect(m_command_buffer, draw_params_buffer, 0, 1, sizeof(VkDrawIndexedIndirectCommand));
+    }
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+
+    vk::ResetCommandBuffer(m_command_buffer, 0);
+
+    m_command_buffer.Begin(&begin_info);
+    m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
+    vk::CmdBindIndexBuffer(m_command_buffer, index_buffer, 0, VK_INDEX_TYPE_UINT32);
+    for (uint32_t i = 0; i < 1025; i++) {
+        vk::CmdDrawIndexedIndirect(m_command_buffer, draw_params_buffer, 0, 1, sizeof(VkDrawIndexedIndirectCommand));
+    }
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
 }


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9786

Things like Vertex Attribute Fetch need a simple 16 byte VkBuffer to hold information, but for traces with 100s of draws, this slowly became a matter of 12 seconds per frame

By adding a simple "slab and slice" sub allocation, I was able to instantly regain all the perf to the same as running with `VK_LAYER_GPUAV_VERTEX_ATTRIBUTE_FETCH_OOB=0` :tada: 

There is likely we could do to expand on this `BufferSlab` as we try to apply it elsewhere, but for now this helps reduce memory fragmentation, without giving up too much memory