### PR TITLE
layer: Use vvl hashmap for SubmissionImageLayoutMap

### DIFF
--- a/layers/containers/range_map.h
+++ b/layers/containers/range_map.h
@@ -1195,12 +1195,12 @@ class small_range_map {
     }
     value_type *get_value(SmallIndex index) {
         RANGE_ASSERT(index < limit_);  // Must be inbounds
-        return reinterpret_cast<value_type *>(&(backing_store_[index]));
+        return reinterpret_cast<value_type *>(&(key_values_[index]));
     }
     const value_type *get_value(SmallIndex index) const {
         RANGE_ASSERT(index < limit_);                 // Must be inbounds
         RANGE_ASSERT(index == ranges_[index].begin);  // Must be the record at begin
-        return reinterpret_cast<const value_type *>(&(backing_store_[index]));
+        return reinterpret_cast<const value_type *>(&(key_values_[index]));
     }
 
     template <typename Value>
@@ -1303,15 +1303,10 @@ class small_range_map {
     // Stores range boundaries only
     //     open ranges, stored as inverted, invalid range (begining of next, end of prev]
     //     inuse(begin, end) for all entries  on (begin, end]
-    // Used for placement new of T for each range begin.
-    struct alignas(alignof(value_type)) BackingStore {
-        uint8_t data[sizeof(value_type)];
-    };
-
     SmallIndex size_;
     SmallIndex limit_;
     std::array<SmallRange, N> ranges_;
-    std::array<BackingStore, N> backing_store_;
+    std::array<std::pair<key_type, mapped_type>, N> key_values_;
     std::array<bool, N> in_use_;
 };
 

--- a/layers/core_checks/cc_image_layout.cpp
+++ b/layers/core_checks/cc_image_layout.cpp
@@ -190,7 +190,6 @@ bool CoreChecks::ValidateCmdBufImageLayouts(const Location &loc, const vvl::Comm
     if (disabled[image_layout_validation]) return false;
     bool skip = false;
     // Iterate over the layout maps for each referenced image
-    ImageLayoutRangeMap empty_map(1);
     for (const auto &[image, image_layout_registry] : cb_state.image_layout_map) {
         if (!image_layout_registry) continue;
         const auto image_state = Get<vvl::Image>(image);
@@ -208,7 +207,7 @@ bool CoreChecks::ValidateCmdBufImageLayouts(const Location &loc, const vvl::Comm
 
         const auto subresource_count = image_state->subresource_encoder.SubresourceCount();
         auto it = submission_image_layout_map.try_emplace(image_state.get(), subresource_count).first;
-        ImageLayoutRangeMap& submission_layout_map = *it->second;
+        ImageLayoutRangeMap &submission_layout_map = *it->second;
 
         const auto *global_layout_map = image_state->layout_range_map.get();
         ASSERT_AND_CONTINUE(global_layout_map);

--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -308,6 +308,7 @@ void Image::SetInitialLayoutMap() {
         // otherwise set up a new map.
         // set up the new map completely before making it available
         layout_map = std::make_shared<ImageLayoutRangeMap>(subresource_encoder.SubresourceCount());
+        layout_map->lock = &layout_range_map_lock;
         auto range_gen = subresource_adapter::RangeGenerator(subresource_encoder);
         for (; range_gen->non_empty(); ++range_gen) {
             layout_map->insert(layout_map->end(), std::make_pair(*range_gen, create_info.initialLayout));

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -116,10 +116,14 @@ class Image : public Bindable, public SubStateManager<ImageSubState> {
     const VkDevice store_device_as_workaround;                                       // TODO REMOVE WHEN encoder can be const
 
     // This map is used to validate/update image layouts during submit time processing.
-    // Record time validation can't use this. At the beginning of the command buffer
-    // the global image layout can't be determined because it depends on the previously
-    // submitted command buffers.
+    // Record time validation can't use this, because global image layout is undefined
+    // at record time (depends on the previous submissions, which are unknown at record time).
     std::shared_ptr<ImageLayoutRangeMap> layout_range_map;
+
+    // If there is no aliasing this mutex protects this->layout_range_map.
+    // With aliasing one of the images shares a mutex with other aliases,
+    // so for some aliased images this mutex can be unused.
+    mutable std::shared_mutex layout_range_map_lock;
 
     vvl::unordered_set<std::shared_ptr<const vvl::VideoProfileDesc>> supported_video_profiles;
 


### PR DESCRIPTION
The reasons vvl hashmap did not compile with `ImageLayoutRangeMap`:
*  `ImageLayoutRangeMap` contained non-moveable/copyable `std::shared_mutex` and our hashmap sometimes wants to move/copy.
* The underlying `BothRangeMap` was copyable but in a buggy way - no compiler issues, but ASAN caught use-after-free because underlying byte storage did not handle copies/moves.

The `std::shared_mutex` fix is based on the observation that only those `ImageLayoutRangeMap`s get locked that are owned by the `vvl::Image`, so by moving a mutex inside the image the layout range maps become moveable. This also works for the case of aliased images that share a single layout range map. They all indirecty refer to a single mutex object (hold by one of the aliased images).

The `BothRangeMap` backing storage is fixed by using `std::variant` which nicely handles construction/copying/destruction and we don't need to use array of bytes anymore. That's a nice change on its own!

From performance consideration one difference of vvl from std containers is that phmap uses flat array and during resize it needs to move/copy, which might have a difference for small_map/small_vector members - they usually implemented as small arrays so they might be a bit slower to copy comparing to regular maps that have fast move.