### PR TITLE
gpuav: Rework buffer caching

### DIFF
--- a/layers/gpuav/resources/gpuav_state_trackers.cpp
+++ b/layers/gpuav/resources/gpuav_state_trackers.cpp
@@ -32,7 +32,7 @@ namespace gpuav {
 
 CommandBufferSubState::CommandBufferSubState(Validator &gpuav, vvl::CommandBuffer &cb)
     : vvl::CommandBufferSubState(cb),
-      gpu_resources_manager(*gpuav.desc_set_manager_),
+      gpu_resources_manager(gpuav),
       state_(gpuav),
       error_output_buffer_(gpuav),
       cmd_errors_counts_buffer_(gpuav),

--- a/layers/gpuav/resources/gpuav_vulkan_objects.cpp
+++ b/layers/gpuav/resources/gpuav_vulkan_objects.cpp
@@ -19,6 +19,7 @@
 
 #include "gpuav/core/gpuav.h"
 #include "generated/dispatch_functions.h"
+#include "utils/math_utils.h"
 #include <vulkan/utility/vk_struct_helper.hpp>
 
 namespace gpuav {
@@ -179,7 +180,8 @@ bool Buffer::Create(const Location &loc, const VkBufferCreateInfo *buffer_create
             return false;
         }
     }
-    if (allocation_create_info->requiredFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) {
+    if ((allocation_create_info->requiredFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) ||
+        (allocation_create_info->flags & VMA_ALLOCATION_CREATE_MAPPED_BIT)) {
         result = vmaMapMemory(gpuav.vma_allocator_, allocation, &mapped_ptr);
         if (result != VK_SUCCESS) {
             mapped_ptr = nullptr;
@@ -194,6 +196,7 @@ void Buffer::Destroy() {
     if (buffer != VK_NULL_HANDLE) {
         if (mapped_ptr != nullptr) {
             vmaUnmapMemory(gpuav.vma_allocator_, allocation);
+            mapped_ptr = nullptr;
         }
         vmaDestroyBuffer(gpuav.vma_allocator_, buffer, allocation);
         buffer = VK_NULL_HANDLE;
@@ -208,6 +211,30 @@ void Buffer::Clear() const {
     memset((uint8_t *)mapped_ptr, 0, static_cast<size_t>(size));
 }
 
+GpuResourcesManager::GpuResourcesManager(Validator &gpuav) : gpuav_(gpuav) {
+    {
+        VmaAllocationCreateInfo alloc_ci = {};
+        alloc_ci.usage = VMA_MEMORY_USAGE_AUTO;
+        alloc_ci.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT;
+        host_visible_buffer_cache_.Create(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, alloc_ci);
+    }
+
+    {
+        VmaAllocationCreateInfo alloc_ci = {};
+        alloc_ci.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
+        alloc_ci.preferredFlags = VK_MEMORY_PROPERTY_HOST_COHERENT_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
+        alloc_ci.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT;
+        host_cached_buffer_cache_.Create(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, alloc_ci);
+    }
+
+    {
+        VmaAllocationCreateInfo alloc_ci = {};
+        alloc_ci.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
+        device_local_indirect_buffer_cache_.Create(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
+                                                   alloc_ci);
+    }
+}
+
 VkDescriptorSet GpuResourcesManager::GetManagedDescriptorSet(VkDescriptorSetLayout desc_set_layout) {
     // Look for a descriptor set layout matching input,
     // if found get or add an associated descriptor set
@@ -218,8 +245,8 @@ VkDescriptorSet GpuResourcesManager::GetManagedDescriptorSet(VkDescriptorSetLayo
 
         if (layout_to_sets.first_available_desc_set == layout_to_sets.cached_descriptors.size()) {
             CachedDescriptor cached_descriptor;
-            const VkResult result = descriptor_set_manager_.GetDescriptorSet(&cached_descriptor.desc_pool, desc_set_layout,
-                                                                             &cached_descriptor.desc_set);
+            const VkResult result = gpuav_.desc_set_manager_->GetDescriptorSet(&cached_descriptor.desc_pool, desc_set_layout,
+                                                                               &cached_descriptor.desc_set);
             if (result != VK_SUCCESS) {
                 return VK_NULL_HANDLE;
             }
@@ -238,43 +265,20 @@ VkDescriptorSet GpuResourcesManager::GetManagedDescriptorSet(VkDescriptorSetLayo
     return GetManagedDescriptorSet(desc_set_layout);
 }
 
-vko::Buffer GpuResourcesManager::GetManagedBuffer(Validator &gpuav, const Location &loc, const VkBufferCreateInfo &buffer_ci,
-                                                  const VmaAllocationCreateInfo &alloc_ci) {
-    assert(buffer_ci.pNext == nullptr);
-    assert(buffer_ci.sharingMode == VK_SHARING_MODE_EXCLUSIVE);
-    assert(alloc_ci.pUserData == nullptr);
+vko::BufferRange GpuResourcesManager::GetHostVisibleBufferRange(const Location &loc, VkDeviceSize size) {
+    // Kind of arbitrary, considered "big enough"
+    constexpr VkDeviceSize min_buffer_block_size = 4 * 1024;
+    // Buffers are used as storage buffers, align to corresponding limit
+    const VkDeviceSize alignment = gpuav_.phys_dev_props.limits.minStorageBufferOffsetAlignment;
+    return host_visible_buffer_cache_.GetBufferRange(gpuav_, loc, size, alignment, min_buffer_block_size);
+}
 
-    // Try to find a cached and available buffer created with equivalent characteristics
-    for (CachedBuffer &cached_buffer : cached_buffers_) {
-        if (!(cached_buffer.status == CachedStatus::Available)) {
-            continue;
-        }
-        const bool same_buffer_ci = buffer_ci.flags == cached_buffer.buffer_ci.flags &&
-                                    buffer_ci.size <= cached_buffer.buffer_ci.size &&
-                                    buffer_ci.usage == cached_buffer.buffer_ci.usage;
-
-        const bool same_alloc_ci =
-            alloc_ci.flags == cached_buffer.allocation_ci.flags && alloc_ci.usage == cached_buffer.allocation_ci.usage &&
-            alloc_ci.requiredFlags == cached_buffer.allocation_ci.requiredFlags &&
-            alloc_ci.preferredFlags == cached_buffer.allocation_ci.preferredFlags &&
-            alloc_ci.memoryTypeBits == cached_buffer.allocation_ci.memoryTypeBits &&
-            alloc_ci.pool == cached_buffer.allocation_ci.pool && alloc_ci.priority == cached_buffer.allocation_ci.priority;
-
-        if (same_buffer_ci && same_alloc_ci) {
-            cached_buffer.status = CachedStatus::InUse;
-            return cached_buffer.buffer;
-        }
-    }
-
-    // Did not find a cached buffer, create one, cache it and return its handle
-    Buffer buffer(gpuav);
-    const bool success = buffer.Create(loc, &buffer_ci, &alloc_ci);
-    if (!success) {
-        return buffer;
-    }
-    CachedBuffer cached_buffer = {buffer_ci, alloc_ci, buffer, CachedStatus::InUse};
-    cached_buffers_.emplace_back(cached_buffer);
-    return buffer;
+vko::BufferRange GpuResourcesManager::GetDeviceLocalIndirectBufferRange(const Location &loc, VkDeviceSize size) {
+    // Kind of arbitrary, considered "big enough"
+    constexpr VkDeviceSize min_buffer_block_size = 4 * 1024;
+    // Buffers are used as storage buffers, align to corresponding limit
+    const VkDeviceSize alignment = gpuav_.phys_dev_props.limits.minStorageBufferOffsetAlignment;
+    return device_local_indirect_buffer_cache_.GetBufferRange(gpuav_, loc, size, alignment, min_buffer_block_size);
 }
 
 void GpuResourcesManager::ReturnResources() {
@@ -282,24 +286,104 @@ void GpuResourcesManager::ReturnResources() {
         layout_to_set.first_available_desc_set = 0;
     }
 
-    for (CachedBuffer &cached_buffer : cached_buffers_) {
-        cached_buffer.status = CachedStatus::Available;
-    }
+    host_visible_buffer_cache_.ReturnBuffers();
+    host_cached_buffer_cache_.ReturnBuffers();
+    device_local_indirect_buffer_cache_.ReturnBuffers();
 }
 
 void GpuResourcesManager::DestroyResources() {
     for (LayoutToSets &layout_to_set : cache_layouts_to_sets_) {
         for (CachedDescriptor &cached_descriptor : layout_to_set.cached_descriptors) {
-            descriptor_set_manager_.PutBackDescriptorSet(cached_descriptor.desc_pool, cached_descriptor.desc_set);
+            gpuav_.desc_set_manager_->PutBackDescriptorSet(cached_descriptor.desc_pool, cached_descriptor.desc_set);
         }
         layout_to_set.cached_descriptors.clear();
     }
     cache_layouts_to_sets_.clear();
 
-    for (CachedBuffer &cached_buffer : cached_buffers_) {
-        cached_buffer.buffer.Destroy();
-    }
-    cached_buffers_.clear();
+    host_visible_buffer_cache_.DestroyBuffers();
+    host_cached_buffer_cache_.DestroyBuffers();
+    device_local_indirect_buffer_cache_.DestroyBuffers();
 }
+
+void GpuResourcesManager::BufferCache::Create(VkBufferUsageFlags buffer_usage_flags, const VmaAllocationCreateInfo allocation_ci) {
+    buffer_usage_flags_ = buffer_usage_flags;
+    allocation_ci_ = allocation_ci;
+}
+
+GpuResourcesManager::BufferCache::~BufferCache() { DestroyBuffers(); }
+
+vko::BufferRange GpuResourcesManager::BufferCache::GetBufferRange(Validator &gpuav, const Location &loc, VkDeviceSize byte_size,
+                                                                  VkDeviceSize alignment, VkDeviceSize min_buffer_block_byte_size) {
+    // Try to find a cached buffer block big enough to sub-allocate from it
+    if (total_available_byte_size_ >= byte_size) {
+        for (size_t i = 0; i < cached_buffers_blocks_.size(); ++i) {
+            const size_t cached_buffer_i = (next_avail_buffer_pos_hint_ + i) % cached_buffers_blocks_.size();
+            CachedBufferBlock &cached_buffer = cached_buffers_blocks_[cached_buffer_i];
+
+            // Is there enough space in the current cached buffer to fit the aligned sub-allocation?
+            const VkDeviceSize aligned_free_range_begin = Align(cached_buffer.used_range.end, alignment);
+            const vvl::range<VkDeviceSize> aligned_free_range = {aligned_free_range_begin, cached_buffer.total_range.end};
+            if (aligned_free_range.non_empty() && aligned_free_range.size() >= byte_size) {
+                // There is enough space, sub-allocate
+                const vvl::range<VkDeviceSize> returned_range = {aligned_free_range_begin, aligned_free_range_begin + byte_size};
+                assert(returned_range.non_empty());
+                const vvl::range<VkDeviceSize> pad_range = {cached_buffer.used_range.end, aligned_free_range.begin};
+                assert(pad_range.valid());
+                total_available_byte_size_ -= returned_range.size() + pad_range.size();
+
+                cached_buffer.used_range.end = returned_range.end;
+
+                // Heuristic: next call to the cache will ask for the same size and alignment.
+                // => If current block is big enough, hint at it. Else, hint at next block.
+                const vvl::range<VkDeviceSize> available_aligned_byte_range = {Align(cached_buffer.used_range.end, alignment),
+                                                                               cached_buffer.total_range.end};
+                if (available_aligned_byte_range.non_empty() && available_aligned_byte_range.size() >= byte_size) {
+                    next_avail_buffer_pos_hint_ = cached_buffer_i;
+                } else {
+                    next_avail_buffer_pos_hint_ = (cached_buffer_i + 1) % cached_buffers_blocks_.size();
+                }
+                uint8_t *offset_mapped_ptr = nullptr;
+                if (cached_buffer.buffer.GetMappedPtr()) {
+                    offset_mapped_ptr = (uint8_t *)cached_buffer.buffer.GetMappedPtr() + returned_range.begin;
+                }
+
+                return {cached_buffer.buffer.VkHandle(), returned_range.begin, returned_range.size(), offset_mapped_ptr};
+            }
+        }
+    }
+
+    // Did not find a cached buffer, create one, cache it and return its handle
+    Buffer buffer(gpuav);
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
+    buffer_ci.size = std::max(min_buffer_block_byte_size, byte_size);
+    buffer_ci.usage = buffer_usage_flags_;
+    const bool success = buffer.Create(loc, &buffer_ci, &allocation_ci_);
+    if (!success) {
+        return {VK_NULL_HANDLE, 0, 0, nullptr};
+    }
+    CachedBufferBlock cached_buffer_block{buffer, {0, buffer_ci.size}, {0, byte_size}};
+    cached_buffers_blocks_.emplace_back(cached_buffer_block);
+
+    total_available_byte_size_ += buffer_ci.size;
+
+    return {buffer.VkHandle(), cached_buffer_block.used_range.begin, cached_buffer_block.used_range.size(),
+            cached_buffer_block.buffer.GetMappedPtr()};
+}
+
+void GpuResourcesManager::BufferCache::ReturnBuffers() {
+    total_available_byte_size_ = 0;
+    for (CachedBufferBlock &cached_buffer_block : cached_buffers_blocks_) {
+        cached_buffer_block.used_range = {0, cached_buffer_block.total_range.end};
+        total_available_byte_size_ += cached_buffer_block.total_range.size();
+    }
+}
+
+void GpuResourcesManager::BufferCache::DestroyBuffers() {
+    for (CachedBufferBlock &cached_buffer_block : cached_buffers_blocks_) {
+        cached_buffer_block.buffer.Destroy();
+    }
+    cached_buffers_blocks_.clear();
+}
+
 }  // namespace vko
 }  // namespace gpuav


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9786

For small allocations, sub-allocate in buffers

Stole the test from https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/9974 🥷