### PR TITLE
layers: Move has_draw_cmd to BP

### DIFF
--- a/layers/best_practices/bp_copy_blit_resolve.cpp
+++ b/layers/best_practices/bp_copy_blit_resolve.cpp
@@ -146,7 +146,7 @@ bool BestPractices::ValidateClearAttachment(const bp_state::CommandBufferSubStat
     }
 
     // Warn if this is issued prior to Draw Cmd and clearing the entire attachment
-    if (!cb_state.base.has_draw_cmd) {
+    if (!rp_state.has_draw_cmd) {
         const LogObjectList objlist(cb_state.Handle(), rp->Handle());
         skip |= LogPerformanceWarning("BestPractices-DrawState-ClearCmdBeforeDraw", objlist, loc,
                                       "issued on %s prior to any Draw Cmds in current render pass. It is recommended you "

--- a/layers/best_practices/bp_render_pass.cpp
+++ b/layers/best_practices/bp_render_pass.cpp
@@ -656,8 +656,6 @@ void BestPractices::PostCallRecordCmdPushConstants2KHR(VkCommandBuffer commandBu
 void BestPractices::PostRecordCmdBeginRenderPass(bp_state::CommandBufferSubState& cb_state,
                                                  const VkRenderPassBeginInfo* pRenderPassBegin) {
     // Reset the renderpass state
-    // TODO - move this logic to the Render Pass state as cb->has_draw_cmd should stay true for lifetime of command buffer
-    cb_state.base.has_draw_cmd = false;
     auto& render_pass_state = cb_state.render_pass_state;
     render_pass_state.touchesAttachments.clear();
     render_pass_state.earlyClearAttachments.clear();
@@ -666,6 +664,7 @@ void BestPractices::PostRecordCmdBeginRenderPass(bp_state::CommandBufferSubState
     render_pass_state.colorAttachment = false;
     render_pass_state.depthAttachment = false;
     render_pass_state.drawTouchAttachments = true;
+    render_pass_state.has_draw_cmd = false;
     // Don't reset state related to pipeline state.
 
     // Reset NV state

--- a/layers/best_practices/bp_state.cpp
+++ b/layers/best_practices/bp_state.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "best_practices/bp_state.h"
+#include "utils/action_command_utils.h"
 
 namespace bp_state {
 
@@ -60,6 +61,19 @@ void ImageSubState::SetupUsages() {
     usages_.resize(base.create_info.arrayLayers);
     for (auto& mip_vec : usages_) {
         mip_vec.resize(base.create_info.mipLevels, {IMAGE_SUBRESOURCE_USAGE_BP::UNDEFINED, VK_QUEUE_FAMILY_IGNORED});
+    }
+}
+
+void CommandBufferSubState::ExecuteCommands(vvl::CommandBuffer& secondary_command_buffer) {
+    if (secondary_command_buffer.IsSecondary()) {
+        auto& secondary_sub_state = SubState(secondary_command_buffer);
+        render_pass_state.has_draw_cmd |= secondary_sub_state.render_pass_state.has_draw_cmd;
+    }
+}
+
+void CommandBufferSubState::RecordCmd(vvl::Func command) {
+    if (vvl::IsCommandDrawMesh(command) || vvl::IsCommandDrawVertex(command)) {
+        render_pass_state.has_draw_cmd = true;
     }
 }
 

--- a/layers/best_practices/bp_state.h
+++ b/layers/best_practices/bp_state.h
@@ -78,6 +78,7 @@ struct AttachmentInfo {
 };
 
 // used to track state regarding render pass heuristic checks
+// TODO - make vvl::RenderPassSubState instead
 struct RenderPassState {
     bool depthAttachment = false;
     bool colorAttachment = false;
@@ -98,6 +99,8 @@ struct RenderPassState {
     std::vector<AttachmentInfo> touchesAttachments;
     std::vector<AttachmentInfo> nextDrawTouchesAttachments;
     bool drawTouchAttachments = false;
+
+    bool has_draw_cmd = false;
 };
 
 struct CommandBufferStateNV {
@@ -156,6 +159,9 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     // the logic to decide to call this function is not simple, so adding this
     // function back could tedious.
     void UnbindResources() {}
+
+    void ExecuteCommands(vvl::CommandBuffer& secondary_command_buffer) final;
+    void RecordCmd(vvl::Func command) final;
 
     struct SignalingInfo {
         // True, if the event's first state change within a command buffer is a signal (SetEvent)

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -226,7 +226,6 @@ void CommandBuffer::ResetCBState() {
     begin_info_flags = 0;
     has_inheritance = false;
 
-    has_draw_cmd = false;
     has_render_pass_instance = false;
     suspends_render_pass_instance = false;
     resumes_render_pass_instance = false;
@@ -1162,9 +1161,6 @@ void CommandBuffer::ExecuteCommands(vvl::span<const VkCommandBuffer> secondary_c
         scissor.trashed_mask = vvl::MaxTypeValue(scissor.trashed_mask);
         scissor.trashed_count = true;
 
-        // Pass along if any commands are used in the secondary command buffer
-        has_draw_cmd |= secondary_cb_state->has_draw_cmd;
-
         // Handle secondary command buffer updates for dynamic rendering
         if (!has_render_pass_instance) {
             resumes_render_pass_instance = secondary_cb_state->resumes_render_pass_instance;
@@ -1212,10 +1208,7 @@ void CommandBuffer::PushDescriptorSetState(VkPipelineBindPoint pipelineBindPoint
 }
 
 // Generic function to handle state update for all CmdDraw* type functions
-void CommandBuffer::UpdateDrawCmd(Func command) {
-    has_draw_cmd = true;
-    UpdatePipelineState(command, VK_PIPELINE_BIND_POINT_GRAPHICS);
-}
+void CommandBuffer::UpdateDrawCmd(Func command) { UpdatePipelineState(command, VK_PIPELINE_BIND_POINT_GRAPHICS); }
 
 // Generic function to handle state update for all CmdDispatch* type functions
 void CommandBuffer::UpdateDispatchCmd(Func command) { UpdatePipelineState(command, VK_PIPELINE_BIND_POINT_COMPUTE); }

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -186,10 +186,6 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     bool suspends_render_pass_instance;
     bool resumes_render_pass_instance;
 
-    // Track if certain commands have been called at least once in lifetime of the command buffer
-    // primary command buffers values are set true if a secondary command buffer has a command
-    bool has_draw_cmd;
-
     CbState state;           // Track cmd buffer update state
     uint64_t command_count;  // Number of commands recorded. Currently only used with VK_KHR_performance_query
     uint64_t submit_count;   // Number of times CB has been submitted


### PR DESCRIPTION
Move the `has_draw_cmd` only used in Best Practice to its Command Buffer substate