### PR TITLE
gpuav: Misc changes

### DIFF
--- a/layers/gpuav/core/gpuav.h
+++ b/layers/gpuav/core/gpuav.h
@@ -72,7 +72,7 @@ class Validator : public GpuShaderInstrumentor {
   public:
     void FinishDeviceSetup(const VkDeviceCreateInfo* pCreateInfo, const Location& loc) final;
 
-    void InternalVmaError(LogObjectList objlist, const Location& loc, const char* const specific_message) const;
+    void InternalVmaError(LogObjectList objlist, const Location& loc, VkResult result, const char* const specific_message) const;
 
   private:
     void InitSettings(const Location& loc);

--- a/layers/gpuav/descriptor_validation/gpuav_descriptor_validation.cpp
+++ b/layers/gpuav/descriptor_validation/gpuav_descriptor_validation.cpp
@@ -195,13 +195,13 @@ void UpdateBoundDescriptors(Validator &gpuav, CommandBufferSubState &cb_state, V
                       << set_index
                       << "].HasPostProcessBuffer() was false. This should not happen. GPU-AV is in a bad state, aborting.";
 
-                state_.InternalError(state_.device, loc, error.str().c_str());
+                gpuav_.InternalError(gpuav_.device, loc, error.str().c_str());
                 return false;
             }
             validated_desc_sets.emplace(bound_desc_set->VkHandle());
 
             // We build once here, but will update the set_index and shader_handle when found
-            vvl::DescriptorValidator context(state_, base, *bound_desc_set, 0, VK_NULL_HANDLE, nullptr, draw_loc);
+            vvl::DescriptorValidator context(gpuav_, base, *bound_desc_set, 0, VK_NULL_HANDLE, nullptr, draw_loc);
 
             DescriptorAccessMap descriptor_access_map = ds_sub_state.GetDescriptorAccesses(loc);
             // Once we have accessed everything and created the DescriptorAccess, we can clear this buffer
@@ -209,8 +209,8 @@ void UpdateBoundDescriptors(Validator &gpuav, CommandBufferSubState &cb_state, V
 
             // For each shader ID we can do the state object lookup once, then validate all the accesses inside of it
             for (const auto &[shader_id, descriptor_accesses] : descriptor_access_map) {
-                auto it = state_.instrumented_shaders_map_.find(shader_id);
-                if (it == state_.instrumented_shaders_map_.end()) {
+                auto it = gpuav_.instrumented_shaders_map_.find(shader_id);
+                if (it == gpuav_.instrumented_shaders_map_.end()) {
                     assert(false);
                     continue;
                 }
@@ -220,10 +220,10 @@ void UpdateBoundDescriptors(Validator &gpuav, CommandBufferSubState &cb_state, V
 
                 if (it->second.pipeline != VK_NULL_HANDLE) {
                     // We use pipeline over vkShaderModule as likely they will have been destroyed by now
-                    pipeline_state = state_.Get<vvl::Pipeline>(it->second.pipeline).get();
+                    pipeline_state = gpuav_.Get<vvl::Pipeline>(it->second.pipeline).get();
                     context.SetShaderHandleForGpuAv(&pipeline_state->Handle());
                 } else if (it->second.shader_object != VK_NULL_HANDLE) {
-                    shader_object_state = state_.Get<vvl::ShaderObject>(it->second.shader_object).get();
+                    shader_object_state = gpuav_.Get<vvl::ShaderObject>(it->second.shader_object).get();
                     ASSERT_AND_CONTINUE(shader_object_state->entrypoint);
                     context.SetShaderHandleForGpuAv(&shader_object_state->Handle());
                 } else {

--- a/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
@@ -276,9 +276,9 @@ void UpdateInstrumentationDescSet(Validator &gpuav, CommandBufferSubState &cb_st
     // Error output buffer
     VkDescriptorBufferInfo error_output_desc_buffer_info = {};
     {
-        error_output_desc_buffer_info.range = VK_WHOLE_SIZE;
-        error_output_desc_buffer_info.buffer = cb_state.GetErrorOutputBuffer();
-        error_output_desc_buffer_info.offset = 0;
+        error_output_desc_buffer_info.buffer = cb_state.GetErrorOutputBufferRange().buffer;
+        error_output_desc_buffer_info.offset = cb_state.GetErrorOutputBufferRange().offset;
+        error_output_desc_buffer_info.range = cb_state.GetErrorOutputBufferRange().size;
 
         VkWriteDescriptorSet wds = vku::InitStructHelper();
         wds.dstBinding = glsl::kBindingInstErrorBuffer;

--- a/layers/gpuav/resources/gpuav_state_trackers.h
+++ b/layers/gpuav/resources/gpuav_state_trackers.h
@@ -99,9 +99,9 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
 
     uint32_t GetValidationErrorBufferDescSetIndex() const { return 0; }
 
-    const VkBuffer &GetErrorOutputBuffer() const {
-        assert(error_output_buffer_.VkHandle() != VK_NULL_HANDLE);
-        return error_output_buffer_.VkHandle();
+    const vko::BufferRange &GetErrorOutputBufferRange() const {
+        assert(error_output_buffer_range_.buffer != VK_NULL_HANDLE);
+        return error_output_buffer_range_;
     }
 
     VkDeviceSize GetCmdErrorsCountsBufferByteSize() const { return 8192 * sizeof(uint32_t); }
@@ -143,7 +143,7 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     VkDeviceSize GetBdaRangesBufferByteSize() const;
     [[nodiscard]] bool UpdateBdaRangesBuffer(const Location &loc);
 
-    Validator &state_;
+    Validator &gpuav_;
     VkDescriptorSetLayout instrumentation_desc_set_layout_ = VK_NULL_HANDLE;
 
     VkDescriptorSetLayout error_logging_desc_set_layout_ = VK_NULL_HANDLE;
@@ -151,7 +151,7 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     VkDescriptorPool validation_cmd_desc_pool_ = VK_NULL_HANDLE;
 
     // Buffer storing GPU-AV errors
-    vko::Buffer error_output_buffer_;
+    vko::BufferRange error_output_buffer_range_;
     // Buffer storing an error count per validated commands.
     // Used to limit the number of errors a single command can emit.
     vko::Buffer cmd_errors_counts_buffer_;
@@ -176,7 +176,7 @@ class QueueSubState : public vvl::QueueSubState {
   protected:
     void SubmitBarrier(const Location &loc, uint64_t seq);
 
-    Validator &state_;
+    Validator &gpuav_;
     VkCommandPool barrier_command_pool_{VK_NULL_HANDLE};
     VkCommandBuffer barrier_command_buffer_{VK_NULL_HANDLE};
     VkSemaphore barrier_sem_{VK_NULL_HANDLE};

--- a/layers/gpuav/resources/gpuav_vulkan_objects.h
+++ b/layers/gpuav/resources/gpuav_vulkan_objects.h
@@ -87,10 +87,10 @@ class Buffer {
 };
 
 struct BufferRange {
-    VkBuffer buffer;
-    VkDeviceSize offset;
-    VkDeviceSize size;
-    void *offset_mapped_ptr;
+    VkBuffer buffer = VK_NULL_HANDLE;
+    VkDeviceSize offset = 0;
+    VkDeviceSize size = 0;
+    void *offset_mapped_ptr = nullptr;
 };
 
 // Register/Create and register GPU resources, all to be destroyed upon a call to DestroyResources
@@ -100,7 +100,6 @@ class GpuResourcesManager {
 
     VkDescriptorSet GetManagedDescriptorSet(VkDescriptorSetLayout desc_set_layout);
 
-    vko::BufferRange GetHostCachedBuffer(const Location &loc, VkDeviceSize size);
     vko::BufferRange GetHostVisibleBufferRange(const Location &loc, VkDeviceSize size);
     vko::BufferRange GetDeviceLocalIndirectBufferRange(const Location &loc, VkDeviceSize size);
 
@@ -148,7 +147,6 @@ class GpuResourcesManager {
 
     // One cache per buffer type: having them mixed in just one would worse cache lookups
     BufferCache host_visible_buffer_cache_;
-    BufferCache host_cached_buffer_cache_;
     BufferCache device_local_indirect_buffer_cache_;
 };
 


### PR DESCRIPTION
Remove device local flag for error buffer, and allocate it using `gpu_resources_manager`
rename `state_` to the more accurate `gpuav_`
Upon CB reset, prevent destruction of resources that can be re-used Log VkResult when getting a VMA error