### PR TITLE
layers: Remove BaseClass::PreCallRecord

### DIFF
--- a/layers/best_practices/best_practices_validation.h
+++ b/layers/best_practices/best_practices_validation.h
@@ -337,13 +337,6 @@ class BestPractices : public vvl::DeviceProxy {
                                        const VkSubpassEndInfo* pSubpassEndInfo, const RecordObject& record_obj) override;
     void RecordCmdNextSubpass(bp_state::CommandBufferSubState& cb_state);
 
-    void PostCallRecordCmdPushConstants(VkCommandBuffer commandBuffer, VkPipelineLayout layout, VkShaderStageFlags stageFlags,
-                                        uint32_t offset, uint32_t size, const void* pValues,
-                                        const RecordObject& record_obj) override;
-    void PostCallRecordCmdPushConstants2(VkCommandBuffer commandBuffer, const VkPushConstantsInfo* pPushConstantsInfo,
-                                         const RecordObject& record_obj) override;
-    void PostCallRecordCmdPushConstants2KHR(VkCommandBuffer commandBuffer, const VkPushConstantsInfoKHR* pPushConstantsInfo,
-                                            const RecordObject& record_obj) override;
     void PreCallRecordCmdEndRenderPass(VkCommandBuffer commandBuffer, const RecordObject& record_obj) override;
     void PreCallRecordCmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo,
                                         const RecordObject& record_obj) override;

--- a/layers/best_practices/bp_cmd_buffer.cpp
+++ b/layers/best_practices/bp_cmd_buffer.cpp
@@ -168,8 +168,6 @@ bool BestPractices::PreCallValidateGetQueryPoolResults(VkDevice device, VkQueryP
 
 void BestPractices::PostCallRecordCmdSetDepthCompareOp(VkCommandBuffer commandBuffer, VkCompareOp depthCompareOp,
                                                        const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdSetDepthCompareOp(commandBuffer, depthCompareOp, record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto& sub_state = bp_state::SubState(*cb_state);
 
@@ -185,8 +183,6 @@ void BestPractices::PostCallRecordCmdSetDepthCompareOpEXT(VkCommandBuffer comman
 
 void BestPractices::PostCallRecordCmdSetDepthTestEnable(VkCommandBuffer commandBuffer, VkBool32 depthTestEnable,
                                                         const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdSetDepthTestEnable(commandBuffer, depthTestEnable, record_obj);
-
     if (VendorCheckEnabled(kBPVendorNVIDIA)) {
         auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
         auto& sub_state = bp_state::SubState(*cb_state);

--- a/layers/best_practices/bp_copy_blit_resolve.cpp
+++ b/layers/best_practices/bp_copy_blit_resolve.cpp
@@ -25,9 +25,6 @@
 void BestPractices::PostCallRecordCmdClearAttachments(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
                                                       const VkClearAttachment* pClearAttachments, uint32_t rectCount,
                                                       const VkClearRect* pRects, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdClearAttachments(commandBuffer, attachmentCount, pClearAttachments, rectCount, pRects,
-                                                              record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto* rp_state = cb_state->active_render_pass.get();
     auto* fb_state = cb_state->active_framebuffer.get();
@@ -435,9 +432,6 @@ void BestPractices::PostCallRecordCmdClearDepthStencilImage(VkCommandBuffer comm
                                                             const VkClearDepthStencilValue* pDepthStencil, uint32_t rangeCount,
                                                             const VkImageSubresourceRange* pRanges,
                                                             const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount,
-                                                                    pRanges, record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto& funcs = cb_state->queue_submit_functions;
     auto dst = Get<vvl::Image>(image);
@@ -456,9 +450,6 @@ void BestPractices::PostCallRecordCmdClearDepthStencilImage(VkCommandBuffer comm
 void BestPractices::PostCallRecordCmdCopyImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                                VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
                                                const VkImageCopy* pRegions, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout,
-                                                       regionCount, pRegions, record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto& funcs = cb_state->queue_submit_functions;
     auto src = Get<vvl::Image>(srcImage);

--- a/layers/best_practices/bp_drawdispatch.cpp
+++ b/layers/best_practices/bp_drawdispatch.cpp
@@ -373,8 +373,6 @@ bool BestPractices::ValidateIndexBufferArm(const bp_state::CommandBufferSubState
 void BestPractices::PostCallRecordCmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t indexCount, uint32_t instanceCount,
                                                  uint32_t firstIndex, int32_t vertexOffset, uint32_t firstInstance,
                                                  const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance,
-                                               record_obj);
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto& sub_state = bp_state::SubState(*cb_state);
     RecordCmdDrawType(sub_state, indexCount * instanceCount);
@@ -425,8 +423,6 @@ void BestPractices::PostCallRecordCmdDrawIndexedIndirectCount(VkCommandBuffer co
                                                               VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                               uint32_t maxDrawCount, uint32_t stride,
                                                               const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset,
-                                                            maxDrawCount, stride, record_obj);
     const auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto& sub_state = bp_state::SubState(*cb_state);
     RecordCmdDrawType(sub_state, 0);
@@ -475,8 +471,6 @@ void BestPractices::PostCallRecordCmdDrawIndirectByteCountEXT(VkCommandBuffer co
                                                               uint32_t firstInstance, VkBuffer counterBuffer,
                                                               VkDeviceSize counterBufferOffset, uint32_t counterOffset,
                                                               uint32_t vertexStride, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer,
-                                                            counterBufferOffset, counterOffset, vertexStride, record_obj);
     const auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto& sub_state = bp_state::SubState(*cb_state);
     RecordCmdDrawType(sub_state, 0);
@@ -491,8 +485,6 @@ bool BestPractices::PreCallValidateCmdDrawIndirectCount(VkCommandBuffer commandB
 void BestPractices::PostCallRecordCmdDrawIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                        VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                                        uint32_t stride, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount,
-                                                     stride, record_obj);
     const auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto& sub_state = bp_state::SubState(*cb_state);
     RecordCmdDrawType(sub_state, 0);
@@ -539,8 +531,6 @@ void BestPractices::PostCallRecordCmdDrawMeshTasksIndirectCountNV(VkCommandBuffe
                                                                   VkDeviceSize offset, VkBuffer countBuffer,
                                                                   VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                                                   uint32_t stride, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset,
-                                                                maxDrawCount, stride, record_obj);
     const auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto& sub_state = bp_state::SubState(*cb_state);
     RecordCmdDrawType(sub_state, 0);
@@ -554,7 +544,6 @@ bool BestPractices::PreCallValidateCmdDrawMeshTasksIndirectNV(VkCommandBuffer co
 
 void BestPractices::PostCallRecordCmdDrawMeshTasksIndirectNV(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                              uint32_t drawCount, uint32_t stride, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride, record_obj);
     const auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto& sub_state = bp_state::SubState(*cb_state);
     RecordCmdDrawType(sub_state, 0);
@@ -567,7 +556,6 @@ bool BestPractices::PreCallValidateCmdDrawMeshTasksNV(VkCommandBuffer commandBuf
 
 void BestPractices::PostCallRecordCmdDrawMeshTasksNV(VkCommandBuffer commandBuffer, uint32_t taskCount, uint32_t firstTask,
                                                      const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask, record_obj);
     const auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto& sub_state = bp_state::SubState(*cb_state);
     RecordCmdDrawType(sub_state, 0);
@@ -584,8 +572,6 @@ void BestPractices::PostCallRecordCmdDrawMultiIndexedEXT(VkCommandBuffer command
                                                          const VkMultiDrawIndexedInfoEXT* pIndexInfo, uint32_t instanceCount,
                                                          uint32_t firstInstance, uint32_t stride, const int32_t* pVertexOffset,
                                                          const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdDrawMultiIndexedEXT(commandBuffer, drawCount, pIndexInfo, instanceCount, firstInstance, stride,
-                                                       pVertexOffset, record_obj);
     uint32_t count = 0;
     for (uint32_t i = 0; i < drawCount; ++i) {
         count += pIndexInfo[i].indexCount;
@@ -604,8 +590,6 @@ bool BestPractices::PreCallValidateCmdDrawMultiEXT(VkCommandBuffer commandBuffer
 void BestPractices::PostCallRecordCmdDrawMultiEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
                                                   const VkMultiDrawInfoEXT* pVertexInfo, uint32_t instanceCount,
                                                   uint32_t firstInstance, uint32_t stride, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdDrawMultiEXT(commandBuffer, drawCount, pVertexInfo, instanceCount, firstInstance, stride,
-                                                record_obj);
     uint32_t count = 0;
     for (uint32_t i = 0; i < drawCount; ++i) {
         count += pVertexInfo[i].vertexCount;
@@ -668,7 +652,6 @@ void BestPractices::ValidateBoundDescriptorSets(bp_state::CommandBufferSubState&
 
 void BestPractices::PostCallRecordCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount,
                                           uint32_t firstVertex, uint32_t firstInstance, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance, record_obj);
     const auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto& sub_state = bp_state::SubState(*cb_state);
     ValidateBoundDescriptorSets(sub_state, VK_PIPELINE_BIND_POINT_GRAPHICS, record_obj.location.function);
@@ -677,7 +660,6 @@ void BestPractices::PostCallRecordCmdDraw(VkCommandBuffer commandBuffer, uint32_
 
 void BestPractices::PostCallRecordCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                   uint32_t drawCount, uint32_t stride, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride, record_obj);
     const auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto& sub_state = bp_state::SubState(*cb_state);
     ValidateBoundDescriptorSets(sub_state, VK_PIPELINE_BIND_POINT_GRAPHICS, record_obj.location.function);
@@ -686,7 +668,6 @@ void BestPractices::PostCallRecordCmdDrawIndirect(VkCommandBuffer commandBuffer,
 
 void BestPractices::PostCallRecordCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                          uint32_t drawCount, uint32_t stride, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride, record_obj);
     const auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto& sub_state = bp_state::SubState(*cb_state);
     ValidateBoundDescriptorSets(sub_state, VK_PIPELINE_BIND_POINT_GRAPHICS, record_obj.location.function);

--- a/layers/best_practices/bp_pipeline.cpp
+++ b/layers/best_practices/bp_pipeline.cpp
@@ -416,8 +416,6 @@ bool BestPractices::ValidateCreateComputePipelineAmd(const VkComputePipelineCrea
 
 void BestPractices::PostCallRecordCmdBindPipeline(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                                   VkPipeline pipeline, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline, record_obj);
-
     // AMD best practice
     PipelineUsedInFrame(pipeline);
 

--- a/layers/best_practices/bp_render_pass.cpp
+++ b/layers/best_practices/bp_render_pass.cpp
@@ -367,7 +367,6 @@ void BestPractices::PreCallRecordCmdEndRenderingKHR(VkCommandBuffer commandBuffe
 
 void BestPractices::PostCallRecordCmdBeginRendering(VkCommandBuffer commandBuffer, const VkRenderingInfo* pRenderingInfo,
                                                     const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdBeginRendering(commandBuffer, pRenderingInfo, record_obj);
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto& sub_state = bp_state::SubState(*cb_state);
     RecordCmdBeginRenderingCommon(sub_state, nullptr, pRenderingInfo);
@@ -380,7 +379,6 @@ void BestPractices::PostCallRecordCmdBeginRenderingKHR(VkCommandBuffer commandBu
 
 void BestPractices::PostCallRecordCmdNextSubpass(VkCommandBuffer commandBuffer, VkSubpassContents contents,
                                                  const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdNextSubpass(commandBuffer, contents, record_obj);
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto& sub_state = bp_state::SubState(*cb_state);
     RecordCmdNextSubpass(sub_state);
@@ -623,7 +621,6 @@ void BestPractices::PostCallRecordCmdNextSubpass2KHR(VkCommandBuffer commandBuff
 
 void BestPractices::PostCallRecordCmdNextSubpass2(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo* pSubpassBeginInfo,
                                                   const VkSubpassEndInfo* pSubpassEndInfo, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, record_obj);
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto& sub_state = bp_state::SubState(*cb_state);
     RecordCmdNextSubpass(sub_state);
@@ -634,23 +631,6 @@ void BestPractices::RecordCmdNextSubpass(bp_state::CommandBufferSubState& cb_sta
     if (cb_state.base.active_render_pass && cb_state.base.active_render_pass->has_multiview_enabled) {
         cb_state.UnbindResources();
     }
-}
-
-void BestPractices::PostCallRecordCmdPushConstants(VkCommandBuffer commandBuffer, VkPipelineLayout layout,
-                                                   VkShaderStageFlags stageFlags, uint32_t offset, uint32_t size,
-                                                   const void* pValues, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues, record_obj);
-}
-
-void BestPractices::PostCallRecordCmdPushConstants2(VkCommandBuffer commandBuffer, const VkPushConstantsInfo* pPushConstantsInfo,
-                                                    const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdPushConstants2(commandBuffer, pPushConstantsInfo, record_obj);
-}
-
-void BestPractices::PostCallRecordCmdPushConstants2KHR(VkCommandBuffer commandBuffer,
-                                                       const VkPushConstantsInfoKHR* pPushConstantsInfo,
-                                                       const RecordObject& record_obj) {
-    PostCallRecordCmdPushConstants2(commandBuffer, pPushConstantsInfo, record_obj);
 }
 
 void BestPractices::PostRecordCmdBeginRenderPass(bp_state::CommandBufferSubState& cb_state,
@@ -687,7 +667,6 @@ void BestPractices::PostRecordCmdBeginRenderPass(bp_state::CommandBufferSubState
 
 void BestPractices::PostCallRecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
                                                      VkSubpassContents contents, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents, record_obj);
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto& sub_state = bp_state::SubState(*cb_state);
     PostRecordCmdBeginRenderPass(sub_state, pRenderPassBegin);
@@ -697,7 +676,6 @@ void BestPractices::PostCallRecordCmdBeginRenderPass(VkCommandBuffer commandBuff
 
 void BestPractices::PostCallRecordCmdBeginRenderPass2(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
                                                       const VkSubpassBeginInfo* pSubpassBeginInfo, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, record_obj);
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto& sub_state = bp_state::SubState(*cb_state);
     PostRecordCmdBeginRenderPass(sub_state, pRenderPassBegin);

--- a/layers/best_practices/bp_state_tracker.cpp
+++ b/layers/best_practices/bp_state_tracker.cpp
@@ -41,7 +41,6 @@ void BestPractices::RecordGetImageMemoryRequirementsState(vvl::Image& image_stat
 void BestPractices::PostCallRecordGetImageMemoryRequirements(VkDevice device, VkImage image,
                                                              VkMemoryRequirements* pMemoryRequirements,
                                                              const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetImageMemoryRequirements(device, image, pMemoryRequirements, record_obj);
     if (auto image_state = Get<vvl::Image>(image)) {
         RecordGetImageMemoryRequirementsState(*image_state, nullptr);
     }
@@ -50,7 +49,6 @@ void BestPractices::PostCallRecordGetImageMemoryRequirements(VkDevice device, Vk
 void BestPractices::PostCallRecordGetImageMemoryRequirements2(VkDevice device, const VkImageMemoryRequirementsInfo2* pInfo,
                                                               VkMemoryRequirements2* pMemoryRequirements,
                                                               const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetImageMemoryRequirements2(device, pInfo, pMemoryRequirements, record_obj);
     if (auto image_state = Get<vvl::Image>(pInfo->image)) {
         RecordGetImageMemoryRequirementsState(*image_state, pInfo);
     }
@@ -66,8 +64,6 @@ void BestPractices::PostCallRecordGetImageSparseMemoryRequirements(VkDevice devi
                                                                    uint32_t* pSparseMemoryRequirementCount,
                                                                    VkSparseImageMemoryRequirements* pSparseMemoryRequirements,
                                                                    const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount,
-                                                              pSparseMemoryRequirements, record_obj);
     if (auto image_state = Get<vvl::Image>(image)) {
         auto& sub_state = bp_state::SubState(*image_state);
         sub_state.get_sparse_reqs_called = true;
@@ -79,8 +75,6 @@ void BestPractices::PostCallRecordGetImageSparseMemoryRequirements2(VkDevice dev
                                                                     uint32_t* pSparseMemoryRequirementCount,
                                                                     VkSparseImageMemoryRequirements2* pSparseMemoryRequirements,
                                                                     const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetImageSparseMemoryRequirements2(device, pInfo, pSparseMemoryRequirementCount,
-                                                               pSparseMemoryRequirements, record_obj);
     if (auto image_state = Get<vvl::Image>(pInfo->image)) {
         auto& sub_state = bp_state::SubState(*image_state);
         sub_state.get_sparse_reqs_called = true;

--- a/layers/best_practices/bp_synchronization.cpp
+++ b/layers/best_practices/bp_synchronization.cpp
@@ -109,7 +109,6 @@ bool BestPractices::PreCallValidateCmdSetEvent(VkCommandBuffer commandBuffer, Vk
 
 void BestPractices::PostCallRecordCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
                                               const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdSetEvent(commandBuffer, event, stageMask, record_obj);
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto& sub_state = bp_state::SubState(*cb_state);
     RecordCmdSetEvent(sub_state, event);
@@ -137,7 +136,6 @@ void BestPractices::PostCallRecordCmdSetEvent2KHR(VkCommandBuffer commandBuffer,
 
 void BestPractices::PostCallRecordCmdSetEvent2(VkCommandBuffer commandBuffer, VkEvent event,
                                                const VkDependencyInfo* pDependencyInfo, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdSetEvent2(commandBuffer, event, pDependencyInfo, record_obj);
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto& sub_state = bp_state::SubState(*cb_state);
     RecordCmdSetEvent(sub_state, event);
@@ -152,7 +150,6 @@ bool BestPractices::PreCallValidateCmdResetEvent(VkCommandBuffer commandBuffer, 
 
 void BestPractices::PostCallRecordCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
                                                 const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdResetEvent(commandBuffer, event, stageMask, record_obj);
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto& sub_state = bp_state::SubState(*cb_state);
     RecordCmdResetEvent(sub_state, event);
@@ -177,7 +174,6 @@ void BestPractices::PostCallRecordCmdResetEvent2KHR(VkCommandBuffer commandBuffe
 
 void BestPractices::PostCallRecordCmdResetEvent2(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2 stageMask,
                                                  const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdResetEvent2(commandBuffer, event, stageMask, record_obj);
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto& sub_state = bp_state::SubState(*cb_state);
     RecordCmdResetEvent(sub_state, event);
@@ -499,10 +495,6 @@ void BestPractices::PostCallRecordCmdPipelineBarrier(
     VkDependencyFlags dependencyFlags, uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,
     uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier* pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
     const VkImageMemoryBarrier* pImageMemoryBarriers, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdPipelineBarrier(
-        commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers, bufferMemoryBarrierCount,
-        pBufferMemoryBarriers, imageMemoryBarrierCount, pImageMemoryBarriers, record_obj);
-
     num_barriers_objects_ += (memoryBarrierCount + imageMemoryBarrierCount + bufferMemoryBarrierCount);
 
     for (uint32_t i = 0; i < imageMemoryBarrierCount; ++i) {
@@ -512,8 +504,6 @@ void BestPractices::PostCallRecordCmdPipelineBarrier(
 
 void BestPractices::PostCallRecordCmdPipelineBarrier2(VkCommandBuffer commandBuffer, const VkDependencyInfo* pDependencyInfo,
                                                       const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdPipelineBarrier2(commandBuffer, pDependencyInfo, record_obj);
-
     for (uint32_t i = 0; i < pDependencyInfo->imageMemoryBarrierCount; ++i) {
         RecordCmdPipelineBarrierImageBarrier(commandBuffer, pDependencyInfo->pImageMemoryBarriers[i]);
     }

--- a/layers/chassis/layer_object_id.h
+++ b/layers/chassis/layer_object_id.h
@@ -21,6 +21,7 @@
 
 #pragma once
 // Layer object type identifiers
+// While this doesn't enforce the order, we enforce the order in InitValidationObjects() based on this
 enum LayerObjectTypeId {
     LayerObjectTypeParameterValidation,  // Instance or device parameter validation layer object
     LayerObjectTypeThreading,            // Instance or device threading layer object

--- a/layers/core_checks/cc_copy_blit_resolve.cpp
+++ b/layers/core_checks/cc_copy_blit_resolve.cpp
@@ -1939,8 +1939,6 @@ bool CoreChecks::PreCallValidateCmdCopyImage2(VkCommandBuffer commandBuffer, con
 void CoreChecks::PostCallRecordCmdCopyImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                             VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
                                             const VkImageCopy *pRegions, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount,
-                                             pRegions, record_obj);
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto src_image_state = Get<vvl::Image>(srcImage);
     auto dst_image_state = Get<vvl::Image>(dstImage);
@@ -1960,7 +1958,6 @@ void CoreChecks::PostCallRecordCmdCopyImage2KHR(VkCommandBuffer commandBuffer, c
 
 void CoreChecks::PostCallRecordCmdCopyImage2(VkCommandBuffer commandBuffer, const VkCopyImageInfo2 *pCopyImageInfo,
                                              const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdCopyImage2(commandBuffer, pCopyImageInfo, record_obj);
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto src_image_state = Get<vvl::Image>(pCopyImageInfo->srcImage);
     auto dst_image_state = Get<vvl::Image>(pCopyImageInfo->dstImage);
@@ -2060,7 +2057,6 @@ void CoreChecks::RecordCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer src
 
 void CoreChecks::PostCallRecordCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer,
                                              uint32_t regionCount, const VkBufferCopy *pRegions, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions, record_obj);
     RecordCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions, record_obj.location);
 }
 
@@ -2071,7 +2067,6 @@ void CoreChecks::PostCallRecordCmdCopyBuffer2KHR(VkCommandBuffer commandBuffer, 
 
 void CoreChecks::PostCallRecordCmdCopyBuffer2(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2 *pCopyBufferInfo,
                                               const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdCopyBuffer2(commandBuffer, pCopyBufferInfo, record_obj);
     RecordCmdCopyBuffer(commandBuffer, pCopyBufferInfo->srcBuffer, pCopyBufferInfo->dstBuffer, pCopyBufferInfo->regionCount,
                         pCopyBufferInfo->pRegions, record_obj.location);
 }
@@ -2369,9 +2364,6 @@ bool CoreChecks::PreCallValidateCmdCopyImageToBuffer2(VkCommandBuffer commandBuf
 void CoreChecks::PostCallRecordCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                                     VkBuffer dstBuffer, uint32_t regionCount, const VkBufferImageCopy *pRegions,
                                                     const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions,
-                                                     record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto src_image_state = Get<vvl::Image>(srcImage);
     ASSERT_AND_RETURN(src_image_state);
@@ -2391,8 +2383,6 @@ void CoreChecks::PostCallRecordCmdCopyImageToBuffer2KHR(VkCommandBuffer commandB
 void CoreChecks::PostCallRecordCmdCopyImageToBuffer2(VkCommandBuffer commandBuffer,
                                                      const VkCopyImageToBufferInfo2 *pCopyImageToBufferInfo,
                                                      const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdCopyImageToBuffer2(commandBuffer, pCopyImageToBufferInfo, record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto src_image_state = Get<vvl::Image>(pCopyImageToBufferInfo->srcImage);
     ASSERT_AND_RETURN(src_image_state);
@@ -2528,9 +2518,6 @@ bool CoreChecks::PreCallValidateCmdCopyBufferToImage2(VkCommandBuffer commandBuf
 void CoreChecks::PostCallRecordCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkImage dstImage,
                                                     VkImageLayout dstImageLayout, uint32_t regionCount,
                                                     const VkBufferImageCopy *pRegions, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions,
-                                                     record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto dst_image_state = Get<vvl::Image>(dstImage);
     ASSERT_AND_RETURN(dst_image_state);
@@ -2550,8 +2537,6 @@ void CoreChecks::PostCallRecordCmdCopyBufferToImage2KHR(VkCommandBuffer commandB
 void CoreChecks::PostCallRecordCmdCopyBufferToImage2(VkCommandBuffer commandBuffer,
                                                      const VkCopyBufferToImageInfo2 *pCopyBufferToImageInfo,
                                                      const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdCopyBufferToImage2(commandBuffer, pCopyBufferToImageInfo, record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto dst_image_state = Get<vvl::Image>(pCopyBufferToImageInfo->dstImage);
     ASSERT_AND_RETURN(dst_image_state);
@@ -3482,8 +3467,6 @@ void CoreChecks::RecordCmdBlitImage(VkCommandBuffer commandBuffer, VkImage srcIm
 void CoreChecks::PostCallRecordCmdBlitImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                             VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
                                             const VkImageBlit *pRegions, VkFilter filter, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount,
-                                             pRegions, filter, record_obj);
     RecordCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter);
 }
 
@@ -3494,7 +3477,6 @@ void CoreChecks::PostCallRecordCmdBlitImage2KHR(VkCommandBuffer commandBuffer, c
 
 void CoreChecks::PostCallRecordCmdBlitImage2(VkCommandBuffer commandBuffer, const VkBlitImageInfo2KHR *pBlitImageInfo,
                                              const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdBlitImage2(commandBuffer, pBlitImageInfo, record_obj);
     RecordCmdBlitImage(commandBuffer, pBlitImageInfo->srcImage, pBlitImageInfo->srcImageLayout, pBlitImageInfo->dstImage,
                        pBlitImageInfo->dstImageLayout, pBlitImageInfo->regionCount, pBlitImageInfo->pRegions,
                        pBlitImageInfo->filter);

--- a/layers/core_checks/cc_device_memory.cpp
+++ b/layers/core_checks/cc_device_memory.cpp
@@ -2186,7 +2186,6 @@ void CoreChecks::PostCallRecordBindImageMemory(VkDevice device, VkImage image, V
         return;
     }
 
-    BaseClass::PostCallRecordBindImageMemory(device, image, memory, memoryOffset, record_obj);
     if (auto image_state = Get<vvl::Image>(image)) {
         image_state->SetInitialLayoutMap();
     }
@@ -2200,8 +2199,6 @@ bool CoreChecks::PreCallValidateBindImageMemory2(VkDevice device, uint32_t bindI
 void CoreChecks::PostCallRecordBindImageMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo *pBindInfos,
                                                 const RecordObject &record_obj) {
     // Don't check |record_obj.result| as some binds might still be valid
-    BaseClass::PostCallRecordBindImageMemory2(device, bindInfoCount, pBindInfos, record_obj);
-
     for (uint32_t i = 0; i < bindInfoCount; i++) {
         if (auto image_state = Get<vvl::Image>(pBindInfos[i].image)) {
             // Need to protect if some VkBindMemoryStatus are not VK_SUCCESS

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -852,7 +852,6 @@ void CoreChecks::PostCallRecordCreateImage(VkDevice device, const VkImageCreateI
         return;
     }
 
-    BaseClass::PostCallRecordCreateImage(device, pCreateInfo, pAllocator, pImage, record_obj);
     if ((pCreateInfo->flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT) != 0) {
         // non-sparse images set up their layout maps when memory is bound
         if (auto image_state = Get<vvl::Image>(*pImage)) {
@@ -957,8 +956,6 @@ bool CoreChecks::PreCallValidateCmdClearColorImage(VkCommandBuffer commandBuffer
 void CoreChecks::PostCallRecordCmdClearColorImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
                                                   const VkClearColorValue *pColor, uint32_t rangeCount,
                                                   const VkImageSubresourceRange *pRanges, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges, record_obj);
-
     auto cb_state_ptr = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto image_state = Get<vvl::Image>(image);
     if (cb_state_ptr && image_state) {
@@ -1077,9 +1074,6 @@ bool CoreChecks::PreCallValidateCmdClearDepthStencilImage(VkCommandBuffer comman
 void CoreChecks::PostCallRecordCmdClearDepthStencilImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
                                                          const VkClearDepthStencilValue *pDepthStencil, uint32_t rangeCount,
                                                          const VkImageSubresourceRange *pRanges, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges,
-                                                          record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto image_state = Get<vvl::Image>(image);
     ASSERT_AND_RETURN(image_state);
@@ -1347,8 +1341,6 @@ bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffe
 void CoreChecks::PostCallRecordCmdClearAttachments(VkCommandBuffer commandBuffer, uint32_t attachmentCount,
                                                    const VkClearAttachment *pAttachments, uint32_t rectCount,
                                                    const VkClearRect *pRects, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdClearAttachments(commandBuffer, attachmentCount, pAttachments, rectCount, pRects, record_obj);
-
     auto cb_state_ptr = GetWrite<vvl::CommandBuffer>(commandBuffer);
     ASSERT_AND_RETURN(cb_state_ptr);
     const vvl::CommandBuffer &cb_state = *cb_state_ptr;
@@ -2798,8 +2790,6 @@ bool CoreChecks::PreCallValidateTransitionImageLayoutEXT(VkDevice device, uint32
 void CoreChecks::PostCallRecordTransitionImageLayout(VkDevice device, uint32_t transitionCount,
                                                      const VkHostImageLayoutTransitionInfo *pTransitions,
                                                      const RecordObject &record_obj) {
-    BaseClass::PostCallRecordTransitionImageLayout(device, transitionCount, pTransitions, record_obj);
-
     if (record_obj.result != VK_SUCCESS) {
         return;
     }

--- a/layers/core_checks/cc_pipeline.cpp
+++ b/layers/core_checks/cc_pipeline.cpp
@@ -809,7 +809,6 @@ bool CoreChecks::PreCallValidateReleaseCapturedPipelineDataKHR(VkDevice device, 
 void CoreChecks::PostCallRecordReleaseCapturedPipelineDataKHR(VkDevice device, const VkReleaseCapturedPipelineDataInfoKHR *pInfo,
                                                               const VkAllocationCallbacks *pAllocator,
                                                               const RecordObject &record_obj) {
-    BaseClass::PostCallRecordReleaseCapturedPipelineDataKHR(device, pInfo, pAllocator, record_obj);
     if (record_obj.result != VK_SUCCESS) {
         return;
     }

--- a/layers/core_checks/cc_query.cpp
+++ b/layers/core_checks/cc_query.cpp
@@ -1319,7 +1319,7 @@ bool CoreChecks::PreCallValidateCmdWriteTimestamp2KHR(VkCommandBuffer commandBuf
 
 void CoreChecks::RecordCmdWriteTimestamp2(vvl::CommandBuffer &cb_state, VkQueryPool queryPool, uint32_t slot, Func command) const {
     if (disabled[query_validation]) return;
-    // Enqueue the submit time validation check here, before the submit time state update in BaseClass::PostCall...
+    // Enqueue the submit time validation check here, before the submit time state update in StateTracker::PostCall
     QueryObject query_obj = {queryPool, slot};
     cb_state.query_updates.emplace_back([query_obj, command](vvl::CommandBuffer &cb_state_arg, bool do_validate,
                                                              VkQueryPool &firstPerfQueryPool, uint32_t perfPass,

--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -398,7 +398,6 @@ bool CoreChecks::PreCallValidateQueueSubmit2(VkQueue queue, uint32_t submitCount
 
 void CoreChecks::PostCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo *pSubmits, VkFence fence,
                                            const RecordObject &record_obj) {
-    BaseClass::PostCallRecordQueueSubmit(queue, submitCount, pSubmits, fence, record_obj);
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -448,7 +447,6 @@ void CoreChecks::PostCallRecordQueueSubmit2KHR(VkQueue queue, uint32_t submitCou
 
 void CoreChecks::PostCallRecordQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2 *pSubmits, VkFence fence,
                                             const RecordObject &record_obj) {
-    BaseClass::PostCallRecordQueueSubmit2(queue, submitCount, pSubmits, fence, record_obj);
     RecordQueueSubmit2(queue, submitCount, pSubmits, fence, record_obj);
 }
 

--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -1551,7 +1551,7 @@ void CoreChecks::PreCallRecordCmdWriteAccelerationStructuresPropertiesKHR(VkComm
                                                                           VkQueryType queryType, VkQueryPool queryPool,
                                                                           uint32_t firstQuery, const RecordObject &record_obj) {
     if (disabled[query_validation]) return;
-    // Enqueue the submit time validation check here, before the submit time state update in BaseClass::PostCall...
+    // Enqueue the submit time validation check here, before the submit time state update in StateTracker::PostCall
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     cb_state->query_updates.emplace_back([accelerationStructureCount, firstQuery, queryPool](
                                              vvl::CommandBuffer &cb_state_arg, bool do_validate, VkQueryPool &firstPerfQueryPool,

--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -647,7 +647,6 @@ void CoreChecks::RecordCmdBeginRenderPassLayouts(VkCommandBuffer commandBuffer, 
 
 void CoreChecks::PostCallRecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
                                                   VkSubpassContents contents, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents, record_obj);
     RecordCmdBeginRenderPassLayouts(commandBuffer, pRenderPassBegin, contents);
 }
 
@@ -658,7 +657,6 @@ void CoreChecks::PostCallRecordCmdBeginRenderPass2KHR(VkCommandBuffer commandBuf
 
 void CoreChecks::PostCallRecordCmdBeginRenderPass2(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
                                                    const VkSubpassBeginInfo *pSubpassBeginInfo, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, record_obj);
     RecordCmdBeginRenderPassLayouts(commandBuffer, pRenderPassBegin, pSubpassBeginInfo->contents);
 }
 
@@ -4237,7 +4235,6 @@ void CoreChecks::RecordCmdNextSubpassLayouts(VkCommandBuffer commandBuffer, VkSu
 
 void CoreChecks::PostCallRecordCmdNextSubpass(VkCommandBuffer commandBuffer, VkSubpassContents contents,
                                               const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdNextSubpass(commandBuffer, contents, record_obj);
     RecordCmdNextSubpassLayouts(commandBuffer, contents);
 }
 
@@ -4248,7 +4245,6 @@ void CoreChecks::PostCallRecordCmdNextSubpass2KHR(VkCommandBuffer commandBuffer,
 
 void CoreChecks::PostCallRecordCmdNextSubpass2(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo *pSubpassBeginInfo,
                                                const VkSubpassEndInfo *pSubpassEndInfo, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, record_obj);
     RecordCmdNextSubpassLayouts(commandBuffer, pSubpassBeginInfo->contents);
 }
 

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -1362,10 +1362,6 @@ void CoreChecks::PostCallRecordCmdWaitEvents(VkCommandBuffer commandBuffer, uint
                                              uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier *pBufferMemoryBarriers,
                                              uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier *pImageMemoryBarriers,
                                              const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdWaitEvents(commandBuffer, eventCount, pEvents, sourceStageMask, dstStageMask, memoryBarrierCount,
-                                           pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers,
-                                           imageMemoryBarrierCount, pImageMemoryBarriers, record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     TransitionImageLayouts(*cb_state, imageMemoryBarrierCount, pImageMemoryBarriers, sourceStageMask, dstStageMask);
     RecordBarriers(record_obj.location.function, *cb_state, sourceStageMask, dstStageMask, bufferMemoryBarrierCount,
@@ -1379,7 +1375,6 @@ void CoreChecks::PostCallRecordCmdWaitEvents2KHR(VkCommandBuffer commandBuffer, 
 
 void CoreChecks::PostCallRecordCmdWaitEvents2(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,
                                               const VkDependencyInfo *pDependencyInfos, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdWaitEvents2(commandBuffer, eventCount, pEvents, pDependencyInfos, record_obj);
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
 
     for (uint32_t i = 0; i < eventCount; i++) {
@@ -1469,10 +1464,6 @@ void CoreChecks::PostCallRecordCmdPipelineBarrier(
     VkDependencyFlags dependencyFlags, uint32_t memoryBarrierCount, const VkMemoryBarrier *pMemoryBarriers,
     uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier *pBufferMemoryBarriers, uint32_t imageMemoryBarrierCount,
     const VkImageMemoryBarrier *pImageMemoryBarriers, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount,
-                                                pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers,
-                                                imageMemoryBarrierCount, pImageMemoryBarriers, record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
 
     RecordBarriers(record_obj.location.function, *cb_state, srcStageMask, dstStageMask, bufferMemoryBarrierCount,
@@ -1487,8 +1478,6 @@ void CoreChecks::PostCallRecordCmdPipelineBarrier2KHR(VkCommandBuffer commandBuf
 
 void CoreChecks::PostCallRecordCmdPipelineBarrier2(VkCommandBuffer commandBuffer, const VkDependencyInfo *pDependencyInfo,
                                                    const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdPipelineBarrier2(commandBuffer, pDependencyInfo, record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     RecordBarriers(record_obj.location.function, *cb_state, *pDependencyInfo);
     TransitionImageLayouts(*cb_state, pDependencyInfo->imageMemoryBarrierCount, pDependencyInfo->pImageMemoryBarriers);

--- a/layers/gpuav/core/gpuav.h
+++ b/layers/gpuav/core/gpuav.h
@@ -86,8 +86,6 @@ class Validator : public GpuShaderInstrumentor {
     void PreCallRecordDestroyRenderPass(VkDevice device, VkRenderPass renderPass, const VkAllocationCallbacks* pAllocator,
                                         const RecordObject& record_obj) final;
 
-    void RecordCmdEndRenderPassLayouts(vvl::CommandBuffer& cb_state);
-
     void RecordCmdNextSubpassLayouts(vvl::CommandBuffer& cb_state, VkSubpassContents contents);
     void PostCallRecordCmdNextSubpass(VkCommandBuffer commandBuffer, VkSubpassContents contents,
                                       const RecordObject& record_obj) final;
@@ -391,6 +389,12 @@ class Validator : public GpuShaderInstrumentor {
                                               const VkSubpassBeginInfo* pSubpassBeginInfo, const RecordObject&) final;
     void PostCallRecordCmdBeginRenderPass2(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
                                            const VkSubpassBeginInfo* pSubpassBeginInfo, const RecordObject&) final;
+
+    void PreCallRecordCmdEndRenderPass(VkCommandBuffer commandBuffer, const RecordObject& record_obj) final;
+    void PreCallRecordCmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo,
+                                        const RecordObject& record_obj) final;
+    void PreCallRecordCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo,
+                                           const RecordObject& record_obj) final;
 
     void PostCallRecordCmdPipelineBarrier(VkCommandBuffer commandBuffer, VkPipelineStageFlags srcStageMask,
                                           VkPipelineStageFlags dstStageMask, VkDependencyFlags dependencyFlags,

--- a/layers/gpuav/core/gpuav_record.cpp
+++ b/layers/gpuav/core/gpuav_record.cpp
@@ -135,20 +135,7 @@ void Validator::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCa
     desc_set_manager_.reset();
 }
 
-void Validator::RecordCmdEndRenderPassLayouts(vvl::CommandBuffer &cb_state) { TransitionFinalSubpassLayouts(cb_state); }
-
 void Validator::PostCallRecordCmdEndRenderPass(VkCommandBuffer commandBuffer, const RecordObject &record_obj) {
-    // Record the end at the CoreLevel to ensure StateTracker cleanup doesn't step on anything we need.
-    {
-        auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
-        if (!cb_state) {
-            InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
-            return;
-        }
-        RecordCmdEndRenderPassLayouts(*cb_state);
-    }
-    BaseClass::PostCallRecordCmdEndRenderPass(commandBuffer, record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     if (!cb_state) {
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
@@ -164,16 +151,6 @@ void Validator::PostCallRecordCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer
 
 void Validator::PostCallRecordCmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfo *pSubpassEndInfo,
                                                 const RecordObject &record_obj) {
-    {
-        auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
-        if (!cb_state) {
-            InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
-            return;
-        }
-        RecordCmdEndRenderPassLayouts(*cb_state);
-    }
-    BaseClass::PostCallRecordCmdEndRenderPass2(commandBuffer, pSubpassEndInfo, record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     if (!cb_state) {
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
@@ -183,7 +160,6 @@ void Validator::PostCallRecordCmdEndRenderPass2(VkCommandBuffer commandBuffer, c
 }
 
 void Validator::PostCallRecordCmdEndRendering(VkCommandBuffer commandBuffer, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdEndRendering(commandBuffer, record_obj);
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     if (!cb_state) {
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
@@ -203,7 +179,6 @@ void Validator::RecordCmdNextSubpassLayouts(vvl::CommandBuffer &cb_state, VkSubp
 
 void Validator::PostCallRecordCmdNextSubpass(VkCommandBuffer commandBuffer, VkSubpassContents contents,
                                              const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdNextSubpass(commandBuffer, contents, record_obj);
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     if (!cb_state) {
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
@@ -219,7 +194,6 @@ void Validator::PostCallRecordCmdNextSubpass2KHR(VkCommandBuffer commandBuffer, 
 
 void Validator::PostCallRecordCmdNextSubpass2(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo *pSubpassBeginInfo,
                                               const VkSubpassEndInfo *pSubpassEndInfo, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, record_obj);
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     if (!cb_state) {
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
@@ -232,9 +206,6 @@ void Validator::PostCallRecordCmdBindDescriptorSets(VkCommandBuffer commandBuffe
                                                     VkPipelineLayout layout, uint32_t firstSet, uint32_t descriptorSetCount,
                                                     const VkDescriptorSet *pDescriptorSets, uint32_t dynamicOffsetCount,
                                                     const uint32_t *pDynamicOffsets, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdBindDescriptorSets(commandBuffer, pipelineBindPoint, layout, firstSet, descriptorSetCount,
-                                                   pDescriptorSets, dynamicOffsetCount, pDynamicOffsets, record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     if (!cb_state) {
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
@@ -246,8 +217,6 @@ void Validator::PostCallRecordCmdBindDescriptorSets(VkCommandBuffer commandBuffe
 void Validator::PostCallRecordCmdBindDescriptorSets2(VkCommandBuffer commandBuffer,
                                                      const VkBindDescriptorSetsInfo *pBindDescriptorSetsInfo,
                                                      const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdBindDescriptorSets2(commandBuffer, pBindDescriptorSetsInfo, record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     if (!cb_state) {
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
@@ -379,8 +348,6 @@ void Validator::PreCallRecordCmdDraw(VkCommandBuffer commandBuffer, uint32_t ver
 
 void Validator::PostCallRecordCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount,
                                       uint32_t firstVertex, uint32_t firstInstance, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdDraw(commandBuffer, vertexCount, instanceCount, firstVertex, firstInstance, record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     if (!cb_state) {
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
@@ -408,9 +375,6 @@ void Validator::PreCallRecordCmdDrawMultiEXT(VkCommandBuffer commandBuffer, uint
 void Validator::PostCallRecordCmdDrawMultiEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
                                               const VkMultiDrawInfoEXT *pVertexInfo, uint32_t instanceCount, uint32_t firstInstance,
                                               uint32_t stride, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdDrawMultiEXT(commandBuffer, drawCount, pVertexInfo, instanceCount, firstInstance, stride,
-                                             record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     if (!cb_state) {
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
@@ -438,8 +402,6 @@ void Validator::PreCallRecordCmdDrawIndexed(VkCommandBuffer commandBuffer, uint3
 void Validator::PostCallRecordCmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t indexCount, uint32_t instanceCount,
                                              uint32_t firstIndex, int32_t vertexOffset, uint32_t firstInstance,
                                              const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdDrawIndexed(commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance,
-                                            record_obj);
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     if (!cb_state) {
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
@@ -468,8 +430,6 @@ void Validator::PostCallRecordCmdDrawMultiIndexedEXT(VkCommandBuffer commandBuff
                                                      const VkMultiDrawIndexedInfoEXT *pIndexInfo, uint32_t instanceCount,
                                                      uint32_t firstInstance, uint32_t stride, const int32_t *pVertexOffset,
                                                      const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdDrawMultiIndexedEXT(commandBuffer, drawCount, pIndexInfo, instanceCount, firstInstance, stride,
-                                                    pVertexOffset, record_obj);
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     if (!cb_state) {
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
@@ -502,8 +462,6 @@ void Validator::PreCallRecordCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBu
 
 void Validator::PostCallRecordCmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, uint32_t count,
                                               uint32_t stride, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdDrawIndirect(commandBuffer, buffer, offset, count, stride, record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     if (!cb_state) {
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
@@ -534,8 +492,6 @@ void Validator::PreCallRecordCmdDrawIndexedIndirect(VkCommandBuffer commandBuffe
 
 void Validator::PostCallRecordCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                      uint32_t count, uint32_t stride, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdDrawIndexedIndirect(commandBuffer, buffer, offset, count, stride, record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     if (!cb_state) {
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
@@ -588,9 +544,6 @@ void Validator::PreCallRecordCmdDrawIndirectCount(VkCommandBuffer commandBuffer,
 void Validator::PostCallRecordCmdDrawIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                    VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                                    uint32_t stride, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount,
-                                                  stride, record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     if (!cb_state) {
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
@@ -619,8 +572,6 @@ void Validator::PostCallRecordCmdDrawIndirectByteCountEXT(VkCommandBuffer comman
                                                           uint32_t firstInstance, VkBuffer counterBuffer,
                                                           VkDeviceSize counterBufferOffset, uint32_t counterOffset,
                                                           uint32_t vertexStride, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer,
-                                                         counterBufferOffset, counterOffset, vertexStride, record_obj);
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     if (!cb_state) {
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
@@ -674,9 +625,6 @@ void Validator::PreCallRecordCmdDrawIndexedIndirectCount(VkCommandBuffer command
 void Validator::PostCallRecordCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                           VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                           uint32_t maxDrawCount, uint32_t stride, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset,
-                                                         maxDrawCount, stride, record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     if (!cb_state) {
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
@@ -700,7 +648,6 @@ void Validator::PreCallRecordCmdDrawMeshTasksNV(VkCommandBuffer commandBuffer, u
 
 void Validator::PostCallRecordCmdDrawMeshTasksNV(VkCommandBuffer commandBuffer, uint32_t taskCount, uint32_t firstTask,
                                                  const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdDrawMeshTasksNV(commandBuffer, taskCount, firstTask, record_obj);
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     if (!cb_state) {
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
@@ -725,8 +672,6 @@ void Validator::PreCallRecordCmdDrawMeshTasksIndirectNV(VkCommandBuffer commandB
 
 void Validator::PostCallRecordCmdDrawMeshTasksIndirectNV(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                          uint32_t drawCount, uint32_t stride, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride, record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     if (!cb_state) {
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
@@ -766,9 +711,6 @@ void Validator::PostCallRecordCmdDrawMeshTasksIndirectCountNV(VkCommandBuffer co
                                                               VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                               uint32_t maxDrawCount, uint32_t stride,
                                                               const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdDrawMeshTasksIndirectCountNV(commandBuffer, buffer, offset, countBuffer, countBufferOffset,
-                                                             maxDrawCount, stride, record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     if (!cb_state) {
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
@@ -792,7 +734,6 @@ void Validator::PreCallRecordCmdDrawMeshTasksEXT(VkCommandBuffer commandBuffer, 
 
 void Validator::PostCallRecordCmdDrawMeshTasksEXT(VkCommandBuffer commandBuffer, uint32_t groupCountX, uint32_t groupCountY,
                                                   uint32_t groupCountZ, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdDrawMeshTasksEXT(commandBuffer, groupCountX, groupCountY, groupCountZ, record_obj);
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     if (!cb_state) {
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
@@ -818,8 +759,6 @@ void Validator::PreCallRecordCmdDrawMeshTasksIndirectEXT(VkCommandBuffer command
 
 void Validator::PostCallRecordCmdDrawMeshTasksIndirectEXT(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                           uint32_t drawCount, uint32_t stride, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdDrawMeshTasksIndirectEXT(commandBuffer, buffer, offset, drawCount, stride, record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     if (!cb_state) {
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
@@ -861,9 +800,6 @@ void Validator::PostCallRecordCmdDrawMeshTasksIndirectCountEXT(VkCommandBuffer c
                                                                VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                                uint32_t maxDrawCount, uint32_t stride,
                                                                const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdDrawMeshTasksIndirectCountEXT(commandBuffer, buffer, offset, countBuffer, countBufferOffset,
-                                                              maxDrawCount, stride, record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     if (!cb_state) {
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
@@ -888,8 +824,6 @@ void Validator::PreCallRecordCmdDispatch(VkCommandBuffer commandBuffer, uint32_t
 
 void Validator::PostCallRecordCmdDispatch(VkCommandBuffer commandBuffer, uint32_t x, uint32_t y, uint32_t z,
                                           const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdDispatch(commandBuffer, x, y, z, record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     if (!cb_state) {
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
@@ -915,8 +849,6 @@ void Validator::PreCallRecordCmdDispatchIndirect(VkCommandBuffer commandBuffer, 
 
 void Validator::PostCallRecordCmdDispatchIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                   const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdDispatchIndirect(commandBuffer, buffer, offset, record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     if (!cb_state) {
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
@@ -944,9 +876,6 @@ void Validator::PreCallRecordCmdDispatchBase(VkCommandBuffer commandBuffer, uint
 void Validator::PostCallRecordCmdDispatchBase(VkCommandBuffer commandBuffer, uint32_t baseGroupX, uint32_t baseGroupY,
                                               uint32_t baseGroupZ, uint32_t groupCountX, uint32_t groupCountY, uint32_t groupCountZ,
                                               const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY,
-                                             groupCountZ, record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     if (!cb_state) {
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
@@ -999,12 +928,6 @@ void Validator::PostCallRecordCmdTraceRaysNV(VkCommandBuffer commandBuffer, VkBu
                                              VkDeviceSize hitShaderBindingStride, VkBuffer callableShaderBindingTableBuffer,
                                              VkDeviceSize callableShaderBindingOffset, VkDeviceSize callableShaderBindingStride,
                                              uint32_t width, uint32_t height, uint32_t depth, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdTraceRaysNV(commandBuffer, raygenShaderBindingTableBuffer, raygenShaderBindingOffset,
-                                            missShaderBindingTableBuffer, missShaderBindingOffset, missShaderBindingStride,
-                                            hitShaderBindingTableBuffer, hitShaderBindingOffset, hitShaderBindingStride,
-                                            callableShaderBindingTableBuffer, callableShaderBindingOffset,
-                                            callableShaderBindingStride, width, height, depth, record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     if (!cb_state) {
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
@@ -1038,9 +961,6 @@ void Validator::PostCallRecordCmdTraceRaysKHR(VkCommandBuffer commandBuffer,
                                               const VkStridedDeviceAddressRegionKHR *pHitShaderBindingTable,
                                               const VkStridedDeviceAddressRegionKHR *pCallableShaderBindingTable, uint32_t width,
                                               uint32_t height, uint32_t depth, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdTraceRaysKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable,
-                                             pHitShaderBindingTable, pCallableShaderBindingTable, width, height, depth, record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     if (!cb_state) {
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
@@ -1076,10 +996,6 @@ void Validator::PostCallRecordCmdTraceRaysIndirectKHR(VkCommandBuffer commandBuf
                                                       const VkStridedDeviceAddressRegionKHR *pHitShaderBindingTable,
                                                       const VkStridedDeviceAddressRegionKHR *pCallableShaderBindingTable,
                                                       VkDeviceAddress indirectDeviceAddress, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdTraceRaysIndirectKHR(commandBuffer, pRaygenShaderBindingTable, pMissShaderBindingTable,
-                                                     pHitShaderBindingTable, pCallableShaderBindingTable, indirectDeviceAddress,
-                                                     record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     if (!cb_state) {
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
@@ -1104,8 +1020,6 @@ void Validator::PreCallRecordCmdTraceRaysIndirect2KHR(VkCommandBuffer commandBuf
 
 void Validator::PostCallRecordCmdTraceRaysIndirect2KHR(VkCommandBuffer commandBuffer, VkDeviceAddress indirectDeviceAddress,
                                                        const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdTraceRaysIndirect2KHR(commandBuffer, indirectDeviceAddress, record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     if (!cb_state) {
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
@@ -1133,8 +1047,6 @@ void Validator::PreCallRecordCmdExecuteGeneratedCommandsEXT(VkCommandBuffer comm
 void Validator::PostCallRecordCmdExecuteGeneratedCommandsEXT(VkCommandBuffer commandBuffer, VkBool32 isPreprocessed,
                                                              const VkGeneratedCommandsInfoEXT *pGeneratedCommandsInfo,
                                                              const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdExecuteGeneratedCommandsEXT(commandBuffer, isPreprocessed, pGeneratedCommandsInfo, record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     if (!cb_state) {
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");

--- a/layers/gpuav/descriptor_validation/gpuav_image_layout.cpp
+++ b/layers/gpuav/descriptor_validation/gpuav_image_layout.cpp
@@ -400,7 +400,6 @@ bool Validator::ValidateUnprotectedImage(const vvl::CommandBuffer &cb_state, con
 void Validator::PostCallRecordCreateImage(VkDevice device, const VkImageCreateInfo *pCreateInfo,
                                           const VkAllocationCallbacks *pAllocator, VkImage *pImage,
                                           const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCreateImage(device, pCreateInfo, pAllocator, pImage, record_obj);
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -423,8 +422,6 @@ void Validator::PreCallRecordDestroyImage(VkDevice device, VkImage image, const 
 void Validator::PostCallRecordCmdClearColorImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
                                                  const VkClearColorValue *pColor, uint32_t rangeCount,
                                                  const VkImageSubresourceRange *pRanges, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges, record_obj);
-
     auto cb_state_ptr = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto image_state = Get<vvl::Image>(image);
     if (cb_state_ptr && image_state) {
@@ -437,9 +434,6 @@ void Validator::PostCallRecordCmdClearColorImage(VkCommandBuffer commandBuffer, 
 void Validator::PostCallRecordCmdClearDepthStencilImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
                                                         const VkClearDepthStencilValue *pDepthStencil, uint32_t rangeCount,
                                                         const VkImageSubresourceRange *pRanges, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges,
-                                                       record_obj);
-
     auto cb_state_ptr = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto image_state = Get<vvl::Image>(image);
     if (cb_state_ptr && image_state) {
@@ -458,8 +452,6 @@ void Validator::PostCallRecordCmdClearAttachments(VkCommandBuffer commandBuffer,
 void Validator::PostCallRecordTransitionImageLayout(VkDevice device, uint32_t transitionCount,
                                                     const VkHostImageLayoutTransitionInfo *pTransitions,
                                                     const RecordObject &record_obj) {
-    BaseClass::PostCallRecordTransitionImageLayout(device, transitionCount, pTransitions, record_obj);
-
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -481,8 +473,6 @@ void Validator::PostCallRecordTransitionImageLayoutEXT(VkDevice device, uint32_t
 void Validator::PostCallRecordCmdCopyImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                            VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
                                            const VkImageCopy *pRegions, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions,
-                                          record_obj);
     auto cb_state_ptr = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto src_image_state = Get<vvl::Image>(srcImage);
     auto dst_image_state = Get<vvl::Image>(dstImage);
@@ -519,9 +509,6 @@ void Validator::PostCallRecordCmdCopyImage2(VkCommandBuffer commandBuffer, const
 void Validator::PostCallRecordCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                                    VkBuffer dstBuffer, uint32_t regionCount, const VkBufferImageCopy *pRegions,
                                                    const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions,
-                                                  record_obj);
-
     auto cb_state_ptr = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto src_image_state = Get<vvl::Image>(srcImage);
     if (cb_state_ptr && src_image_state) {
@@ -541,8 +528,6 @@ void Validator::PostCallRecordCmdCopyImageToBuffer2KHR(VkCommandBuffer commandBu
 void Validator::PostCallRecordCmdCopyImageToBuffer2(VkCommandBuffer commandBuffer,
                                                     const VkCopyImageToBufferInfo2 *pCopyImageToBufferInfo,
                                                     const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdCopyImageToBuffer2(commandBuffer, pCopyImageToBufferInfo, record_obj);
-
     auto cb_state_ptr = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto src_image_state = Get<vvl::Image>(pCopyImageToBufferInfo->srcImage);
     if (cb_state_ptr && src_image_state) {
@@ -558,9 +543,6 @@ void Validator::PostCallRecordCmdCopyImageToBuffer2(VkCommandBuffer commandBuffe
 void Validator::PostCallRecordCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkImage dstImage,
                                                    VkImageLayout dstImageLayout, uint32_t regionCount,
                                                    const VkBufferImageCopy *pRegions, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions,
-                                                  record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
 
     if (auto dst_image_state = Get<vvl::Image>(dstImage)) {
@@ -580,8 +562,6 @@ void Validator::PostCallRecordCmdCopyBufferToImage2KHR(VkCommandBuffer commandBu
 void Validator::PostCallRecordCmdCopyBufferToImage2(VkCommandBuffer commandBuffer,
                                                     const VkCopyBufferToImageInfo2 *pCopyBufferToImageInfo,
                                                     const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdCopyBufferToImage2(commandBuffer, pCopyBufferToImageInfo, record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
 
     if (auto dst_image_state = Get<vvl::Image>(pCopyBufferToImageInfo->dstImage)) {
@@ -596,8 +576,6 @@ void Validator::PostCallRecordCmdCopyBufferToImage2(VkCommandBuffer commandBuffe
 void Validator::PostCallRecordCmdBlitImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                            VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
                                            const VkImageBlit *pRegions, VkFilter filter, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions,
-                                          filter, record_obj);
     RecordCmdBlitImage(*this, commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter);
 }
 
@@ -608,7 +586,6 @@ void Validator::PostCallRecordCmdBlitImage2KHR(VkCommandBuffer commandBuffer, co
 
 void Validator::PostCallRecordCmdBlitImage2(VkCommandBuffer commandBuffer, const VkBlitImageInfo2KHR *pBlitImageInfo,
                                             const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdBlitImage2(commandBuffer, pBlitImageInfo, record_obj);
     RecordCmdBlitImage(*this, commandBuffer, pBlitImageInfo->srcImage, pBlitImageInfo->srcImageLayout, pBlitImageInfo->dstImage,
                        pBlitImageInfo->dstImageLayout, pBlitImageInfo->regionCount, pBlitImageInfo->pRegions,
                        pBlitImageInfo->filter);
@@ -616,7 +593,6 @@ void Validator::PostCallRecordCmdBlitImage2(VkCommandBuffer commandBuffer, const
 
 void Validator::PostCallRecordBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory memory, VkDeviceSize memoryOffset,
                                               const RecordObject &record_obj) {
-    BaseClass::PostCallRecordBindImageMemory(device, image, memory, memoryOffset, record_obj);
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -629,8 +605,6 @@ void Validator::PostCallRecordBindImageMemory(VkDevice device, VkImage image, Vk
 void Validator::PostCallRecordBindImageMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo *pBindInfos,
                                                const RecordObject &record_obj) {
     // Don't check |record_obj.result| as some binds might still be valid
-    BaseClass::PostCallRecordBindImageMemory2(device, bindInfoCount, pBindInfos, record_obj);
-
     for (uint32_t i = 0; i < bindInfoCount; i++) {
         if (auto image_state = Get<vvl::Image>(pBindInfos[i].image)) {
             // Need to protect if some VkBindMemoryStatus are not VK_SUCCESS
@@ -652,9 +626,6 @@ void Validator::PostCallRecordCmdWaitEvents(VkCommandBuffer commandBuffer, uint3
                                             uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier *pBufferMemoryBarriers,
                                             uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier *pImageMemoryBarriers,
                                             const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdWaitEvents(commandBuffer, eventCount, pEvents, sourceStageMask, dstStageMask, memoryBarrierCount,
-                                           pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers,
-                                           imageMemoryBarrierCount, pImageMemoryBarriers, record_obj);
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     TransitionImageLayouts(*this, *cb_state, imageMemoryBarrierCount, pImageMemoryBarriers, sourceStageMask, dstStageMask);
 }
@@ -666,7 +637,6 @@ void Validator::PostCallRecordCmdWaitEvents2KHR(VkCommandBuffer commandBuffer, u
 
 void Validator::PostCallRecordCmdWaitEvents2(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,
                                              const VkDependencyInfo *pDependencyInfos, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdWaitEvents2(commandBuffer, eventCount, pEvents, pDependencyInfos, record_obj);
     RecordCmdWaitEvents2(*this, commandBuffer, eventCount, pEvents, pDependencyInfos);
 }
 
@@ -685,7 +655,6 @@ void Validator::RecordCmdBeginRenderPassLayouts(VkCommandBuffer commandBuffer, c
 
 void Validator::PostCallRecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
                                                  VkSubpassContents contents, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents, record_obj);
     RecordCmdBeginRenderPassLayouts(commandBuffer, pRenderPassBegin, contents);
 }
 
@@ -696,8 +665,27 @@ void Validator::PostCallRecordCmdBeginRenderPass2KHR(VkCommandBuffer commandBuff
 
 void Validator::PostCallRecordCmdBeginRenderPass2(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
                                                   const VkSubpassBeginInfo *pSubpassBeginInfo, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, record_obj);
     RecordCmdBeginRenderPassLayouts(commandBuffer, pRenderPassBegin, pSubpassBeginInfo->contents);
+}
+
+// Using PreCallRecord because LayerObjectTypeStateTracker will destroy render pass object first in PostCallRecord
+void Validator::PreCallRecordCmdEndRenderPass(VkCommandBuffer commandBuffer, const RecordObject &record_obj) {
+    if (auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer)) {
+        TransitionFinalSubpassLayouts(*cb_state);
+    }
+}
+
+// Using PreCallRecord because LayerObjectTypeStateTracker will destroy render pass object first in PostCallRecord
+void Validator::PreCallRecordCmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfo *pSubpassEndInfo,
+                                               const RecordObject &record_obj) {
+    if (auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer)) {
+        TransitionFinalSubpassLayouts(*cb_state);
+    }
+}
+
+void Validator::PreCallRecordCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfo *pSubpassEndInfo,
+                                                  const RecordObject &record_obj) {
+    PreCallRecordCmdEndRenderPass2(commandBuffer, pSubpassEndInfo, record_obj);
 }
 
 void Validator::PostCallRecordCmdPipelineBarrier(VkCommandBuffer commandBuffer, VkPipelineStageFlags srcStageMask,
@@ -707,10 +695,6 @@ void Validator::PostCallRecordCmdPipelineBarrier(VkCommandBuffer commandBuffer, 
                                                  const VkBufferMemoryBarrier *pBufferMemoryBarriers,
                                                  uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier *pImageMemoryBarriers,
                                                  const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdPipelineBarrier(commandBuffer, srcStageMask, dstStageMask, dependencyFlags, memoryBarrierCount,
-                                                pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers,
-                                                imageMemoryBarrierCount, pImageMemoryBarriers, record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     TransitionImageLayouts(*this, *cb_state, imageMemoryBarrierCount, pImageMemoryBarriers, srcStageMask, dstStageMask);
 }
@@ -722,8 +706,6 @@ void Validator::PostCallRecordCmdPipelineBarrier2KHR(VkCommandBuffer commandBuff
 
 void Validator::PostCallRecordCmdPipelineBarrier2(VkCommandBuffer commandBuffer, const VkDependencyInfo *pDependencyInfo,
                                                   const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdPipelineBarrier2(commandBuffer, pDependencyInfo, record_obj);
-
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     TransitionImageLayouts(*this, *cb_state, pDependencyInfo->imageMemoryBarrierCount, pDependencyInfo->pImageMemoryBarriers);
 }

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
@@ -266,7 +266,6 @@ void GpuShaderInstrumentor::PostCallRecordCreateShaderModule(VkDevice device, co
                                                              const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule,
                                                              const RecordObject &record_obj,
                                                              chassis::CreateShaderModule &chassis_state) {
-    BaseClass::PostCallRecordCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule, record_obj, chassis_state);
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -419,8 +418,6 @@ void GpuShaderInstrumentor::PostCallRecordCreateShadersEXT(VkDevice device, uint
                                                            const VkShaderCreateInfoEXT *pCreateInfos,
                                                            const VkAllocationCallbacks *pAllocator, VkShaderEXT *pShaders,
                                                            const RecordObject &record_obj, chassis::ShaderObject &chassis_state) {
-    BaseClass::PostCallRecordCreateShadersEXT(device, createInfoCount, pCreateInfos, pAllocator, pShaders, record_obj,
-                                              chassis_state);
     if (!gpuav_settings.IsSpirvModified()) {
         return;
     }
@@ -609,8 +606,6 @@ void GpuShaderInstrumentor::PostCallRecordCreateGraphicsPipelines(VkDevice devic
                                                                   const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
                                                                   const RecordObject &record_obj, PipelineStates &pipeline_states,
                                                                   chassis::CreateGraphicsPipelines &chassis_state) {
-    BaseClass::PostCallRecordCreateGraphicsPipelines(device, pipelineCache, count, pCreateInfos, pAllocator, pPipelines, record_obj,
-                                                     pipeline_states, chassis_state);
     if (!gpuav_settings.IsSpirvModified()) return;
     // VK_PIPELINE_COMPILE_REQUIRED means that the current pipeline creation call was used to poke the driver cache,
     // no pipeline is created in this case
@@ -645,8 +640,6 @@ void GpuShaderInstrumentor::PostCallRecordCreateComputePipelines(VkDevice device
                                                                  const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
                                                                  const RecordObject &record_obj, PipelineStates &pipeline_states,
                                                                  chassis::CreateComputePipelines &chassis_state) {
-    BaseClass::PostCallRecordCreateComputePipelines(device, pipelineCache, count, pCreateInfos, pAllocator, pPipelines, record_obj,
-                                                    pipeline_states, chassis_state);
     if (!gpuav_settings.IsSpirvModified()) return;
     // VK_PIPELINE_COMPILE_REQUIRED means that the current pipeline creation call was used to poke the driver cache,
     // no pipeline is created in this case
@@ -674,8 +667,6 @@ void GpuShaderInstrumentor::PostCallRecordCreateRayTracingPipelinesKHR(
     const VkRayTracingPipelineCreateInfoKHR *pCreateInfos, const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
     const RecordObject &record_obj, PipelineStates &pipeline_states,
     std::shared_ptr<chassis::CreateRayTracingPipelinesKHR> chassis_state) {
-    BaseClass::PostCallRecordCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, count, pCreateInfos, pAllocator,
-                                                          pPipelines, record_obj, pipeline_states, chassis_state);
     // This can occur if the driver failed to compile the instrumented shader or if a PreCall step failed
     if (!chassis_state->is_modified) return;
 

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -771,7 +771,6 @@ void SyncValidator::PreCallRecordDestroyDevice(VkDevice device, const VkAllocati
 void SyncValidator::PostCallRecordCreateSemaphore(VkDevice device, const VkSemaphoreCreateInfo *pCreateInfo,
                                                   const VkAllocationCallbacks *pAllocator, VkSemaphore *pSemaphore,
                                                   const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore, record_obj);
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -838,7 +837,6 @@ void SyncValidator::RecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, cons
 
 void SyncValidator::PostCallRecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
                                                      VkSubpassContents contents, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdBeginRenderPass(commandBuffer, pRenderPassBegin, contents, record_obj);
     VkSubpassBeginInfo subpass_begin_info = vku::InitStructHelper();
     subpass_begin_info.contents = contents;
     RecordCmdBeginRenderPass(commandBuffer, pRenderPassBegin, &subpass_begin_info, record_obj.location.function);
@@ -846,7 +844,6 @@ void SyncValidator::PostCallRecordCmdBeginRenderPass(VkCommandBuffer commandBuff
 
 void SyncValidator::PostCallRecordCmdBeginRenderPass2(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
                                                       const VkSubpassBeginInfo *pSubpassBeginInfo, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdBeginRenderPass2(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, record_obj);
     RecordCmdBeginRenderPass(commandBuffer, pRenderPassBegin, pSubpassBeginInfo, record_obj.location.function);
 }
 
@@ -903,7 +900,6 @@ void SyncValidator::RecordCmdNextSubpass(VkCommandBuffer commandBuffer, const Vk
 
 void SyncValidator::PostCallRecordCmdNextSubpass(VkCommandBuffer commandBuffer, VkSubpassContents contents,
                                                  const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdNextSubpass(commandBuffer, contents, record_obj);
     VkSubpassBeginInfo subpass_begin_info = vku::InitStructHelper();
     subpass_begin_info.contents = contents;
     RecordCmdNextSubpass(commandBuffer, &subpass_begin_info, nullptr, record_obj.location.function);
@@ -911,7 +907,6 @@ void SyncValidator::PostCallRecordCmdNextSubpass(VkCommandBuffer commandBuffer, 
 
 void SyncValidator::PostCallRecordCmdNextSubpass2(VkCommandBuffer commandBuffer, const VkSubpassBeginInfo *pSubpassBeginInfo,
                                                   const VkSubpassEndInfo *pSubpassEndInfo, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdNextSubpass2(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, record_obj);
     RecordCmdNextSubpass(commandBuffer, pSubpassBeginInfo, pSubpassEndInfo, record_obj.location.function);
 }
 
@@ -972,13 +967,11 @@ bool SyncValidator::SupressedBoundDescriptorWAW(const HazardResult &hazard) cons
 
 void SyncValidator::PostCallRecordCmdEndRenderPass(VkCommandBuffer commandBuffer, const RecordObject &record_obj) {
     RecordCmdEndRenderPass(commandBuffer, nullptr, record_obj.location.function);
-    BaseClass::PostCallRecordCmdEndRenderPass(commandBuffer, record_obj);
 }
 
 void SyncValidator::PostCallRecordCmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfo *pSubpassEndInfo,
                                                     const RecordObject &record_obj) {
     RecordCmdEndRenderPass(commandBuffer, pSubpassEndInfo, record_obj.location.function);
-    BaseClass::PostCallRecordCmdEndRenderPass2(commandBuffer, pSubpassEndInfo, record_obj);
 }
 
 void SyncValidator::PostCallRecordCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfo *pSubpassEndInfo,
@@ -1013,7 +1006,6 @@ void SyncValidator::PostCallRecordCmdBeginRenderingKHR(VkCommandBuffer commandBu
 
 void SyncValidator::PostCallRecordCmdBeginRendering(VkCommandBuffer commandBuffer, const VkRenderingInfo *pRenderingInfo,
                                                     const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdBeginRendering(commandBuffer, pRenderingInfo, record_obj);
     vvl::TlsGuard<syncval_state::BeginRenderingCmdState> cmd_state;
 
     assert(cmd_state && cmd_state->cb_state && (cmd_state->cb_state->VkHandle() == commandBuffer));
@@ -1159,8 +1151,6 @@ void SyncValidator::RecordCmdCopyBufferToImage(VkCommandBuffer commandBuffer, Vk
 void SyncValidator::PostCallRecordCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkImage dstImage,
                                                        VkImageLayout dstImageLayout, uint32_t regionCount,
                                                        const VkBufferImageCopy *pRegions, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions,
-                                                  record_obj);
     RecordCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions,
                                record_obj.location.function);
 }
@@ -1174,7 +1164,6 @@ void SyncValidator::PostCallRecordCmdCopyBufferToImage2KHR(VkCommandBuffer comma
 void SyncValidator::PostCallRecordCmdCopyBufferToImage2(VkCommandBuffer commandBuffer,
                                                         const VkCopyBufferToImageInfo2 *pCopyBufferToImageInfo,
                                                         const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdCopyBufferToImage2(commandBuffer, pCopyBufferToImageInfo, record_obj);
     RecordCmdCopyBufferToImage(commandBuffer, pCopyBufferToImageInfo->srcBuffer, pCopyBufferToImageInfo->dstImage,
                                pCopyBufferToImageInfo->dstImageLayout, pCopyBufferToImageInfo->regionCount,
                                pCopyBufferToImageInfo->pRegions, record_obj.location.function);
@@ -1285,8 +1274,6 @@ void SyncValidator::RecordCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, Vk
 void SyncValidator::PostCallRecordCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkImage srcImage,
                                                        VkImageLayout srcImageLayout, VkBuffer dstBuffer, uint32_t regionCount,
                                                        const VkBufferImageCopy *pRegions, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions,
-                                                  record_obj);
     RecordCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions,
                                record_obj.location.function);
 }
@@ -1300,7 +1287,6 @@ void SyncValidator::PostCallRecordCmdCopyImageToBuffer2KHR(VkCommandBuffer comma
 void SyncValidator::PostCallRecordCmdCopyImageToBuffer2(VkCommandBuffer commandBuffer,
                                                         const VkCopyImageToBufferInfo2 *pCopyImageToBufferInfo,
                                                         const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdCopyImageToBuffer2(commandBuffer, pCopyImageToBufferInfo, record_obj);
     RecordCmdCopyImageToBuffer(commandBuffer, pCopyImageToBufferInfo->srcImage, pCopyImageToBufferInfo->srcImageLayout,
                                pCopyImageToBufferInfo->dstBuffer, pCopyImageToBufferInfo->regionCount,
                                pCopyImageToBufferInfo->pRegions, record_obj.location.function);
@@ -1429,8 +1415,6 @@ void SyncValidator::RecordCmdBlitImage(VkCommandBuffer commandBuffer, VkImage sr
 void SyncValidator::PostCallRecordCmdBlitImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                                VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
                                                const VkImageBlit *pRegions, VkFilter filter, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions,
-                                          filter, record_obj);
     RecordCmdBlitImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions, filter,
                        record_obj.location.function);
 }
@@ -1442,7 +1426,6 @@ void SyncValidator::PostCallRecordCmdBlitImage2KHR(VkCommandBuffer commandBuffer
 
 void SyncValidator::PostCallRecordCmdBlitImage2(VkCommandBuffer commandBuffer, const VkBlitImageInfo2 *pBlitImageInfo,
                                                 const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdBlitImage2(commandBuffer, pBlitImageInfo, record_obj);
     RecordCmdBlitImage(commandBuffer, pBlitImageInfo->srcImage, pBlitImageInfo->srcImageLayout, pBlitImageInfo->dstImage,
                        pBlitImageInfo->dstImageLayout, pBlitImageInfo->regionCount, pBlitImageInfo->pRegions,
                        pBlitImageInfo->filter, record_obj.location.function);
@@ -1949,7 +1932,6 @@ bool SyncValidator::PreCallValidateCmdClearColorImage(VkCommandBuffer commandBuf
 void SyncValidator::PostCallRecordCmdClearColorImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
                                                      const VkClearColorValue *pColor, uint32_t rangeCount,
                                                      const VkImageSubresourceRange *pRanges, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges, record_obj);
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     assert(cb_state);
     if (!cb_state) return;
@@ -2004,8 +1986,6 @@ void SyncValidator::PostCallRecordCmdClearDepthStencilImage(VkCommandBuffer comm
                                                             const VkClearDepthStencilValue *pDepthStencil, uint32_t rangeCount,
                                                             const VkImageSubresourceRange *pRanges,
                                                             const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges,
-                                                       record_obj);
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     assert(cb_state);
     if (!cb_state) return;
@@ -2144,7 +2124,6 @@ bool SyncValidator::PreCallValidateCmdFillBuffer(VkCommandBuffer commandBuffer, 
 
 void SyncValidator::PostCallRecordCmdFillBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
                                                 VkDeviceSize size, uint32_t data, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data, record_obj);
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     assert(cb_state);
     if (!cb_state) return;
@@ -2212,8 +2191,6 @@ bool SyncValidator::PreCallValidateCmdResolveImage(VkCommandBuffer commandBuffer
 void SyncValidator::PostCallRecordCmdResolveImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                                   VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
                                                   const VkImageResolve *pRegions, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdResolveImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount,
-                                             pRegions, record_obj);
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     assert(cb_state);
     if (!cb_state) return;
@@ -2301,7 +2278,6 @@ bool SyncValidator::PreCallValidateCmdResolveImage2KHR(VkCommandBuffer commandBu
 
 void SyncValidator::PostCallRecordCmdResolveImage2(VkCommandBuffer commandBuffer, const VkResolveImageInfo2 *pResolveImageInfo,
                                                    const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdResolveImage2(commandBuffer, pResolveImageInfo, record_obj);
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     assert(cb_state);
     if (!cb_state) return;
@@ -2368,7 +2344,6 @@ bool SyncValidator::PreCallValidateCmdUpdateBuffer(VkCommandBuffer commandBuffer
 
 void SyncValidator::PostCallRecordCmdUpdateBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
                                                   VkDeviceSize dataSize, const void *pData, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData, record_obj);
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     assert(cb_state);
     if (!cb_state) return;
@@ -2418,7 +2393,6 @@ bool SyncValidator::PreCallValidateCmdWriteBufferMarkerAMD(VkCommandBuffer comma
 void SyncValidator::PostCallRecordCmdWriteBufferMarkerAMD(VkCommandBuffer commandBuffer, VkPipelineStageFlagBits pipelineStage,
                                                           VkBuffer dstBuffer, VkDeviceSize dstOffset, uint32_t marker,
                                                           const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker, record_obj);
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     assert(cb_state);
     if (!cb_state) return;
@@ -2765,7 +2739,6 @@ bool SyncValidator::PreCallValidateCmdSetEvent(VkCommandBuffer commandBuffer, Vk
 
 void SyncValidator::PostCallRecordCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
                                               const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdSetEvent(commandBuffer, event, stageMask, record_obj);
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     assert(cb_state);
     if (!cb_state) return;
@@ -2804,7 +2777,6 @@ void SyncValidator::PostCallRecordCmdSetEvent2KHR(VkCommandBuffer commandBuffer,
 
 void SyncValidator::PostCallRecordCmdSetEvent2(VkCommandBuffer commandBuffer, VkEvent event,
                                                const VkDependencyInfo *pDependencyInfo, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdSetEvent2(commandBuffer, event, pDependencyInfo, record_obj);
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     assert(cb_state);
     if (!cb_state) return;
@@ -2829,7 +2801,6 @@ bool SyncValidator::PreCallValidateCmdResetEvent(VkCommandBuffer commandBuffer, 
 
 void SyncValidator::PostCallRecordCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
                                                 const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdResetEvent(commandBuffer, event, stageMask, record_obj);
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     assert(cb_state);
     if (!cb_state) return;
@@ -2863,7 +2834,6 @@ void SyncValidator::PostCallRecordCmdResetEvent2KHR(VkCommandBuffer commandBuffe
 
 void SyncValidator::PostCallRecordCmdResetEvent2(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2 stageMask,
                                                  const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdResetEvent2(commandBuffer, event, stageMask, record_obj);
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     assert(cb_state);
     if (!cb_state) return;
@@ -2898,10 +2868,6 @@ void SyncValidator::PostCallRecordCmdWaitEvents(VkCommandBuffer commandBuffer, u
                                                 const VkBufferMemoryBarrier *pBufferMemoryBarriers,
                                                 uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier *pImageMemoryBarriers,
                                                 const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdWaitEvents(commandBuffer, eventCount, pEvents, srcStageMask, dstStageMask, memoryBarrierCount,
-                                              pMemoryBarriers, bufferMemoryBarrierCount, pBufferMemoryBarriers,
-                                              imageMemoryBarrierCount, pImageMemoryBarriers, record_obj);
-
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     assert(cb_state);
     if (!cb_state) return;
@@ -2940,8 +2906,6 @@ bool SyncValidator::PreCallValidateCmdWaitEvents2(VkCommandBuffer commandBuffer,
 
 void SyncValidator::PostCallRecordCmdWaitEvents2(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,
                                                  const VkDependencyInfo *pDependencyInfos, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdWaitEvents2(commandBuffer, eventCount, pEvents, pDependencyInfos, record_obj);
-
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     assert(cb_state);
     if (!cb_state) return;
@@ -2983,7 +2947,6 @@ bool SyncValidator::PreCallValidateCmdWriteBufferMarker2AMD(VkCommandBuffer comm
 void SyncValidator::PostCallRecordCmdWriteBufferMarker2AMD(VkCommandBuffer commandBuffer, VkPipelineStageFlags2KHR pipelineStage,
                                                            VkBuffer dstBuffer, VkDeviceSize dstOffset, uint32_t marker,
                                                            const RecordObject &record_obj) {
-    BaseClass::PostCallRecordCmdWriteBufferMarker2AMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker, record_obj);
     auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
     assert(cb_state);
     if (!cb_state) return;
@@ -3068,7 +3031,6 @@ void SyncValidator::PreCallRecordCmdExecuteCommands(VkCommandBuffer commandBuffe
 
 void SyncValidator::PostCallRecordBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory memory, VkDeviceSize memoryOffset,
                                                   const RecordObject &record_obj) {
-    BaseClass::PostCallRecordBindImageMemory(device, image, memory, memoryOffset, record_obj);
     if (record_obj.result != VK_SUCCESS) {
         return;
     }
@@ -3082,8 +3044,6 @@ void SyncValidator::PostCallRecordBindImageMemory(VkDevice device, VkImage image
 void SyncValidator::PostCallRecordBindImageMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo *pBindInfos,
                                                    const RecordObject &record_obj) {
     // Don't check |record_obj.result| as some binds might still be valid
-    BaseClass::PostCallRecordBindImageMemory2(device, bindInfoCount, pBindInfos, record_obj);
-
     UpdateSyncImageMemoryBindState(bindInfoCount, pBindInfos);
 }
 
@@ -3093,7 +3053,6 @@ void SyncValidator::PostCallRecordBindImageMemory2KHR(VkDevice device, uint32_t 
 }
 
 void SyncValidator::PostCallRecordQueueWaitIdle(VkQueue queue, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordQueueWaitIdle(queue, record_obj);
     if (record_obj.result != VK_SUCCESS || !syncval_settings.submit_time_validation || queue == VK_NULL_HANDLE) {
         return;
     }
@@ -3114,8 +3073,6 @@ void SyncValidator::PostCallRecordQueueWaitIdle(VkQueue queue, const RecordObjec
 }
 
 void SyncValidator::PostCallRecordDeviceWaitIdle(VkDevice device, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordDeviceWaitIdle(device, record_obj);
-
     // We need to treat this a fence waits for all queues... noting that present engine ops will be preserved.
     ForAllQueueBatchContexts(
         [](const QueueBatchContext::Ptr &batch) { batch->ApplyTaggedWait(kQueueAny, ResourceUsageRecord::kMaxIndex); });
@@ -3210,7 +3167,6 @@ uint32_t SyncValidator::SetupPresentInfo(const VkPresentInfoKHR &present_info, Q
 
 void SyncValidator::PostCallRecordQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR *pPresentInfo,
                                                   const RecordObject &record_obj) {
-    BaseClass::PostCallRecordQueuePresentKHR(queue, pPresentInfo, record_obj);
     if (!syncval_settings.submit_time_validation) return;
 
     // The earliest return (when enabled), must be *after* the TlsGuard, as it is the TlsGuard that cleans up the cmd_state
@@ -3236,14 +3192,12 @@ void SyncValidator::PostCallRecordQueuePresentKHR(VkQueue queue, const VkPresent
 void SyncValidator::PostCallRecordAcquireNextImageKHR(VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout,
                                                       VkSemaphore semaphore, VkFence fence, uint32_t *pImageIndex,
                                                       const RecordObject &record_obj) {
-    BaseClass::PostCallRecordAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex, record_obj);
     if (!syncval_settings.submit_time_validation) return;
     RecordAcquireNextImageState(device, swapchain, timeout, semaphore, fence, pImageIndex, record_obj);
 }
 
 void SyncValidator::PostCallRecordAcquireNextImage2KHR(VkDevice device, const VkAcquireNextImageInfoKHR *pAcquireInfo,
                                                        uint32_t *pImageIndex, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordAcquireNextImage2KHR(device, pAcquireInfo, pImageIndex, record_obj);
     if (!syncval_settings.submit_time_validation) return;
     RecordAcquireNextImageState(device, pAcquireInfo->swapchain, pAcquireInfo->timeout, pAcquireInfo->semaphore,
                                 pAcquireInfo->fence, pImageIndex, record_obj);
@@ -3557,7 +3511,6 @@ bool SyncValidator::PreCallValidateQueueSubmit2(VkQueue queue, uint32_t submitCo
 }
 
 void SyncValidator::PostCallRecordGetFenceStatus(VkDevice device, VkFence fence, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordGetFenceStatus(device, fence, record_obj);
     if (!syncval_settings.submit_time_validation) return;
     if (record_obj.result == VK_SUCCESS) {
         // fence is signalled, mark it as waited for
@@ -3567,7 +3520,6 @@ void SyncValidator::PostCallRecordGetFenceStatus(VkDevice device, VkFence fence,
 
 void SyncValidator::PostCallRecordWaitForFences(VkDevice device, uint32_t fenceCount, const VkFence *pFences, VkBool32 waitAll,
                                                 uint64_t timeout, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordWaitForFences(device, fenceCount, pFences, waitAll, timeout, record_obj);
     if (!syncval_settings.submit_time_validation) return;
     if ((record_obj.result == VK_SUCCESS) && ((VK_TRUE == waitAll) || (1 == fenceCount))) {
         // We can only know the pFences have signal if we waited for all of them, or there was only one of them
@@ -3611,7 +3563,6 @@ bool SyncValidator::PreCallValidateSignalSemaphoreKHR(VkDevice device, const VkS
 
 void SyncValidator::PostCallRecordSignalSemaphore(VkDevice device, const VkSemaphoreSignalInfo *pSignalInfo,
                                                   const RecordObject &record_obj) {
-    BaseClass::PostCallRecordSignalSemaphore(device, pSignalInfo, record_obj);
     if (!syncval_settings.submit_time_validation) {
         return;
     }
@@ -3637,7 +3588,6 @@ void SyncValidator::PostCallRecordSignalSemaphoreKHR(VkDevice device, const VkSe
 
 void SyncValidator::PostCallRecordWaitSemaphores(VkDevice device, const VkSemaphoreWaitInfo *pWaitInfo, uint64_t timeout,
                                                  const RecordObject &record_obj) {
-    BaseClass::PostCallRecordWaitSemaphores(device, pWaitInfo, timeout, record_obj);
     if (!syncval_settings.submit_time_validation) {
         return;
     }
@@ -3656,7 +3606,6 @@ void SyncValidator::PostCallRecordWaitSemaphoresKHR(VkDevice device, const VkSem
 
 void SyncValidator::PostCallRecordGetSemaphoreCounterValue(VkDevice device, VkSemaphore semaphore, uint64_t *pValue,
                                                            const RecordObject &record_obj) {
-    BaseClass::PostCallRecordGetSemaphoreCounterValue(device, semaphore, pValue, record_obj);
     if (!syncval_settings.submit_time_validation) {
         return;
     }
@@ -3672,7 +3621,6 @@ void SyncValidator::PostCallRecordGetSemaphoreCounterValueKHR(VkDevice device, V
 
 void SyncValidator::PostCallRecordGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain, uint32_t *pSwapchainImageCount,
                                                         VkImage *pSwapchainImages, const RecordObject &record_obj) {
-    BaseClass::PostCallRecordGetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages, record_obj);
     if ((record_obj.result != VK_SUCCESS) && (record_obj.result != VK_INCOMPLETE)) return;
     auto swapchain_state = Get<vvl::Swapchain>(swapchain);
 

--- a/layers/vulkan/generated/best_practices.cpp
+++ b/layers/vulkan/generated/best_practices.cpp
@@ -217,14 +217,12 @@ std::string GetSpecialUse(vvl::Extension extension_name) {
 void bp_state::Instance::PostCallRecordCreateInstance(const VkInstanceCreateInfo* pCreateInfo,
                                                       const VkAllocationCallbacks* pAllocator, VkInstance* pInstance,
                                                       const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateInstance(pCreateInfo, pAllocator, pInstance, record_obj);
     bp_state::LogResult(*this, *pInstance, record_obj);
 }
 
 void bp_state::Instance::PostCallRecordEnumeratePhysicalDevices(VkInstance instance, uint32_t* pPhysicalDeviceCount,
                                                                 VkPhysicalDevice* pPhysicalDevices,
                                                                 const RecordObject& record_obj) {
-    BaseClass::PostCallRecordEnumeratePhysicalDevices(instance, pPhysicalDeviceCount, pPhysicalDevices, record_obj);
     bp_state::LogResult(*this, instance, record_obj);
 }
 
@@ -233,22 +231,18 @@ void bp_state::Instance::PostCallRecordGetPhysicalDeviceImageFormatProperties(Vk
                                                                               VkImageUsageFlags usage, VkImageCreateFlags flags,
                                                                               VkImageFormatProperties* pImageFormatProperties,
                                                                               const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPhysicalDeviceImageFormatProperties(physicalDevice, format, type, tiling, usage, flags,
-                                                                    pImageFormatProperties, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
 void bp_state::Instance::PostCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo,
                                                     const VkAllocationCallbacks* pAllocator, VkDevice* pDevice,
                                                     const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
 void bp_state::Instance::PostCallRecordEnumerateInstanceExtensionProperties(const char* pLayerName, uint32_t* pPropertyCount,
                                                                             VkExtensionProperties* pProperties,
                                                                             const RecordObject& record_obj) {
-    BaseClass::PostCallRecordEnumerateInstanceExtensionProperties(pLayerName, pPropertyCount, pProperties, record_obj);
     bp_state::LogResult(*this, (VkInstance)VK_NULL_HANDLE, record_obj);
 }
 
@@ -256,83 +250,69 @@ void bp_state::Instance::PostCallRecordEnumerateDeviceExtensionProperties(VkPhys
                                                                           uint32_t* pPropertyCount,
                                                                           VkExtensionProperties* pProperties,
                                                                           const RecordObject& record_obj) {
-    BaseClass::PostCallRecordEnumerateDeviceExtensionProperties(physicalDevice, pLayerName, pPropertyCount, pProperties,
-                                                                record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
 void bp_state::Instance::PostCallRecordEnumerateInstanceLayerProperties(uint32_t* pPropertyCount, VkLayerProperties* pProperties,
                                                                         const RecordObject& record_obj) {
-    BaseClass::PostCallRecordEnumerateInstanceLayerProperties(pPropertyCount, pProperties, record_obj);
     bp_state::LogResult(*this, (VkInstance)VK_NULL_HANDLE, record_obj);
 }
 
 void bp_state::Instance::PostCallRecordEnumerateDeviceLayerProperties(VkPhysicalDevice physicalDevice, uint32_t* pPropertyCount,
                                                                       VkLayerProperties* pProperties,
                                                                       const RecordObject& record_obj) {
-    BaseClass::PostCallRecordEnumerateDeviceLayerProperties(physicalDevice, pPropertyCount, pProperties, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
 void BestPractices::PostCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence,
                                               const RecordObject& record_obj) {
-    BaseClass::PostCallRecordQueueSubmit(queue, submitCount, pSubmits, fence, record_obj);
     ManualPostCallRecordQueueSubmit(queue, submitCount, pSubmits, fence, record_obj);
     bp_state::LogResult(*this, queue, record_obj);
 }
 
 void BestPractices::PostCallRecordQueueWaitIdle(VkQueue queue, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordQueueWaitIdle(queue, record_obj);
     bp_state::LogResult(*this, queue, record_obj);
 }
 
 void BestPractices::PostCallRecordDeviceWaitIdle(VkDevice device, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordDeviceWaitIdle(device, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordAllocateMemory(VkDevice device, const VkMemoryAllocateInfo* pAllocateInfo,
                                                  const VkAllocationCallbacks* pAllocator, VkDeviceMemory* pMemory,
                                                  const RecordObject& record_obj) {
-    BaseClass::PostCallRecordAllocateMemory(device, pAllocateInfo, pAllocator, pMemory, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordMapMemory(VkDevice device, VkDeviceMemory memory, VkDeviceSize offset, VkDeviceSize size,
                                             VkMemoryMapFlags flags, void** ppData, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordMapMemory(device, memory, offset, size, flags, ppData, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordFlushMappedMemoryRanges(VkDevice device, uint32_t memoryRangeCount,
                                                           const VkMappedMemoryRange* pMemoryRanges,
                                                           const RecordObject& record_obj) {
-    BaseClass::PostCallRecordFlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordInvalidateMappedMemoryRanges(VkDevice device, uint32_t memoryRangeCount,
                                                                const VkMappedMemoryRange* pMemoryRanges,
                                                                const RecordObject& record_obj) {
-    BaseClass::PostCallRecordInvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordBindBufferMemory(VkDevice device, VkBuffer buffer, VkDeviceMemory memory,
                                                    VkDeviceSize memoryOffset, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordBindBufferMemory(device, buffer, memory, memoryOffset, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory memory, VkDeviceSize memoryOffset,
                                                   const RecordObject& record_obj) {
-    BaseClass::PostCallRecordBindImageMemory(device, image, memory, memoryOffset, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo,
                                                   VkFence fence, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordQueueBindSparse(queue, bindInfoCount, pBindInfo, fence, record_obj);
     ManualPostCallRecordQueueBindSparse(queue, bindInfoCount, pBindInfo, fence, record_obj);
     bp_state::LogResult(*this, queue, record_obj);
 }
@@ -340,122 +320,102 @@ void BestPractices::PostCallRecordQueueBindSparse(VkQueue queue, uint32_t bindIn
 void BestPractices::PostCallRecordCreateFence(VkDevice device, const VkFenceCreateInfo* pCreateInfo,
                                               const VkAllocationCallbacks* pAllocator, VkFence* pFence,
                                               const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateFence(device, pCreateInfo, pAllocator, pFence, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordResetFences(VkDevice device, uint32_t fenceCount, const VkFence* pFences,
                                               const RecordObject& record_obj) {
-    BaseClass::PostCallRecordResetFences(device, fenceCount, pFences, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetFenceStatus(VkDevice device, VkFence fence, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetFenceStatus(device, fence, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordWaitForFences(VkDevice device, uint32_t fenceCount, const VkFence* pFences, VkBool32 waitAll,
                                                 uint64_t timeout, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordWaitForFences(device, fenceCount, pFences, waitAll, timeout, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordCreateSemaphore(VkDevice device, const VkSemaphoreCreateInfo* pCreateInfo,
                                                   const VkAllocationCallbacks* pAllocator, VkSemaphore* pSemaphore,
                                                   const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateSemaphore(device, pCreateInfo, pAllocator, pSemaphore, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordCreateEvent(VkDevice device, const VkEventCreateInfo* pCreateInfo,
                                               const VkAllocationCallbacks* pAllocator, VkEvent* pEvent,
                                               const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateEvent(device, pCreateInfo, pAllocator, pEvent, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetEventStatus(VkDevice device, VkEvent event, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetEventStatus(device, event, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordSetEvent(VkDevice device, VkEvent event, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordSetEvent(device, event, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordResetEvent(VkDevice device, VkEvent event, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordResetEvent(device, event, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordCreateQueryPool(VkDevice device, const VkQueryPoolCreateInfo* pCreateInfo,
                                                   const VkAllocationCallbacks* pAllocator, VkQueryPool* pQueryPool,
                                                   const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateQueryPool(device, pCreateInfo, pAllocator, pQueryPool, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetQueryPoolResults(VkDevice device, VkQueryPool queryPool, uint32_t firstQuery,
                                                       uint32_t queryCount, size_t dataSize, void* pData, VkDeviceSize stride,
                                                       VkQueryResultFlags flags, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags,
-                                                 record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordCreateBuffer(VkDevice device, const VkBufferCreateInfo* pCreateInfo,
                                                const VkAllocationCallbacks* pAllocator, VkBuffer* pBuffer,
                                                const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateBuffer(device, pCreateInfo, pAllocator, pBuffer, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordCreateBufferView(VkDevice device, const VkBufferViewCreateInfo* pCreateInfo,
                                                    const VkAllocationCallbacks* pAllocator, VkBufferView* pView,
                                                    const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateBufferView(device, pCreateInfo, pAllocator, pView, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordCreateImage(VkDevice device, const VkImageCreateInfo* pCreateInfo,
                                               const VkAllocationCallbacks* pAllocator, VkImage* pImage,
                                               const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateImage(device, pCreateInfo, pAllocator, pImage, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordCreateImageView(VkDevice device, const VkImageViewCreateInfo* pCreateInfo,
                                                   const VkAllocationCallbacks* pAllocator, VkImageView* pView,
                                                   const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateImageView(device, pCreateInfo, pAllocator, pView, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
                                                      const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule,
                                                      const RecordObject& record_obj, chassis::CreateShaderModule& chassis_state) {
-    BaseClass::PostCallRecordCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule, record_obj, chassis_state);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordCreatePipelineCache(VkDevice device, const VkPipelineCacheCreateInfo* pCreateInfo,
                                                       const VkAllocationCallbacks* pAllocator, VkPipelineCache* pPipelineCache,
                                                       const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreatePipelineCache(device, pCreateInfo, pAllocator, pPipelineCache, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetPipelineCacheData(VkDevice device, VkPipelineCache pipelineCache, size_t* pDataSize,
                                                        void* pData, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPipelineCacheData(device, pipelineCache, pDataSize, pData, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordMergePipelineCaches(VkDevice device, VkPipelineCache dstCache, uint32_t srcCacheCount,
                                                       const VkPipelineCache* pSrcCaches, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordMergePipelineCaches(device, dstCache, srcCacheCount, pSrcCaches, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -464,8 +424,6 @@ void BestPractices::PostCallRecordCreateGraphicsPipelines(VkDevice device, VkPip
                                                           const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
                                                           const RecordObject& record_obj, PipelineStates& pipeline_states,
                                                           chassis::CreateGraphicsPipelines& chassis_state) {
-    BaseClass::PostCallRecordCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines,
-                                                     record_obj, pipeline_states, chassis_state);
     ManualPostCallRecordCreateGraphicsPipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines,
                                                 record_obj, pipeline_states, chassis_state);
     bp_state::LogResult(*this, device, record_obj);
@@ -476,8 +434,6 @@ void BestPractices::PostCallRecordCreateComputePipelines(VkDevice device, VkPipe
                                                          const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
                                                          const RecordObject& record_obj, PipelineStates& pipeline_states,
                                                          chassis::CreateComputePipelines& chassis_state) {
-    BaseClass::PostCallRecordCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines,
-                                                    record_obj, pipeline_states, chassis_state);
     ManualPostCallRecordCreateComputePipelines(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator, pPipelines,
                                                record_obj, pipeline_states, chassis_state);
     bp_state::LogResult(*this, device, record_obj);
@@ -486,98 +442,83 @@ void BestPractices::PostCallRecordCreateComputePipelines(VkDevice device, VkPipe
 void BestPractices::PostCallRecordCreatePipelineLayout(VkDevice device, const VkPipelineLayoutCreateInfo* pCreateInfo,
                                                        const VkAllocationCallbacks* pAllocator, VkPipelineLayout* pPipelineLayout,
                                                        const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordCreateSampler(VkDevice device, const VkSamplerCreateInfo* pCreateInfo,
                                                 const VkAllocationCallbacks* pAllocator, VkSampler* pSampler,
                                                 const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateSampler(device, pCreateInfo, pAllocator, pSampler, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordCreateDescriptorSetLayout(VkDevice device, const VkDescriptorSetLayoutCreateInfo* pCreateInfo,
                                                             const VkAllocationCallbacks* pAllocator,
                                                             VkDescriptorSetLayout* pSetLayout, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateDescriptorSetLayout(device, pCreateInfo, pAllocator, pSetLayout, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordCreateDescriptorPool(VkDevice device, const VkDescriptorPoolCreateInfo* pCreateInfo,
                                                        const VkAllocationCallbacks* pAllocator, VkDescriptorPool* pDescriptorPool,
                                                        const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateDescriptorPool(device, pCreateInfo, pAllocator, pDescriptorPool, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordAllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo* pAllocateInfo,
                                                          VkDescriptorSet* pDescriptorSets, const RecordObject& record_obj,
                                                          vvl::AllocateDescriptorSetsData& chassis_state) {
-    BaseClass::PostCallRecordAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets, record_obj, chassis_state);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordCreateFramebuffer(VkDevice device, const VkFramebufferCreateInfo* pCreateInfo,
                                                     const VkAllocationCallbacks* pAllocator, VkFramebuffer* pFramebuffer,
                                                     const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateFramebuffer(device, pCreateInfo, pAllocator, pFramebuffer, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo* pCreateInfo,
                                                    const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass,
                                                    const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateRenderPass(device, pCreateInfo, pAllocator, pRenderPass, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordCreateCommandPool(VkDevice device, const VkCommandPoolCreateInfo* pCreateInfo,
                                                     const VkAllocationCallbacks* pAllocator, VkCommandPool* pCommandPool,
                                                     const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordResetCommandPool(VkDevice device, VkCommandPool commandPool, VkCommandPoolResetFlags flags,
                                                    const RecordObject& record_obj) {
-    BaseClass::PostCallRecordResetCommandPool(device, commandPool, flags, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordAllocateCommandBuffers(VkDevice device, const VkCommandBufferAllocateInfo* pAllocateInfo,
                                                          VkCommandBuffer* pCommandBuffers, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordAllocateCommandBuffers(device, pAllocateInfo, pCommandBuffers, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordBeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo* pBeginInfo,
                                                      const RecordObject& record_obj) {
-    BaseClass::PostCallRecordBeginCommandBuffer(commandBuffer, pBeginInfo, record_obj);
     bp_state::LogResult(*this, commandBuffer, record_obj);
 }
 
 void BestPractices::PostCallRecordEndCommandBuffer(VkCommandBuffer commandBuffer, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordEndCommandBuffer(commandBuffer, record_obj);
     bp_state::LogResult(*this, commandBuffer, record_obj);
 }
 
 void BestPractices::PostCallRecordResetCommandBuffer(VkCommandBuffer commandBuffer, VkCommandBufferResetFlags flags,
                                                      const RecordObject& record_obj) {
-    BaseClass::PostCallRecordResetCommandBuffer(commandBuffer, flags, record_obj);
     bp_state::LogResult(*this, commandBuffer, record_obj);
 }
 
 void BestPractices::PostCallRecordBindBufferMemory2(VkDevice device, uint32_t bindInfoCount,
                                                     const VkBindBufferMemoryInfo* pBindInfos, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordBindBufferMemory2(device, bindInfoCount, pBindInfos, record_obj);
     ManualPostCallRecordBindBufferMemory2(device, bindInfoCount, pBindInfos, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordBindImageMemory2(VkDevice device, uint32_t bindInfoCount, const VkBindImageMemoryInfo* pBindInfos,
                                                    const RecordObject& record_obj) {
-    BaseClass::PostCallRecordBindImageMemory2(device, bindInfoCount, pBindInfos, record_obj);
     ManualPostCallRecordBindImageMemory2(device, bindInfoCount, pBindInfos, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
@@ -585,16 +526,12 @@ void BestPractices::PostCallRecordBindImageMemory2(VkDevice device, uint32_t bin
 void bp_state::Instance::PostCallRecordEnumeratePhysicalDeviceGroups(
     VkInstance instance, uint32_t* pPhysicalDeviceGroupCount, VkPhysicalDeviceGroupProperties* pPhysicalDeviceGroupProperties,
     const RecordObject& record_obj) {
-    BaseClass::PostCallRecordEnumeratePhysicalDeviceGroups(instance, pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties,
-                                                           record_obj);
     bp_state::LogResult(*this, instance, record_obj);
 }
 
 void bp_state::Instance::PostCallRecordGetPhysicalDeviceImageFormatProperties2(
     VkPhysicalDevice physicalDevice, const VkPhysicalDeviceImageFormatInfo2* pImageFormatInfo,
     VkImageFormatProperties2* pImageFormatProperties, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties,
-                                                                     record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
@@ -603,7 +540,6 @@ void BestPractices::PostCallRecordCreateSamplerYcbcrConversion(VkDevice device,
                                                                const VkAllocationCallbacks* pAllocator,
                                                                VkSamplerYcbcrConversion* pYcbcrConversion,
                                                                const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateSamplerYcbcrConversion(device, pCreateInfo, pAllocator, pYcbcrConversion, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -612,102 +548,86 @@ void BestPractices::PostCallRecordCreateDescriptorUpdateTemplate(VkDevice device
                                                                  const VkAllocationCallbacks* pAllocator,
                                                                  VkDescriptorUpdateTemplate* pDescriptorUpdateTemplate,
                                                                  const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateDescriptorUpdateTemplate(device, pCreateInfo, pAllocator, pDescriptorUpdateTemplate, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordCreateRenderPass2(VkDevice device, const VkRenderPassCreateInfo2* pCreateInfo,
                                                     const VkAllocationCallbacks* pAllocator, VkRenderPass* pRenderPass,
                                                     const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateRenderPass2(device, pCreateInfo, pAllocator, pRenderPass, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetSemaphoreCounterValue(VkDevice device, VkSemaphore semaphore, uint64_t* pValue,
                                                            const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetSemaphoreCounterValue(device, semaphore, pValue, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordWaitSemaphores(VkDevice device, const VkSemaphoreWaitInfo* pWaitInfo, uint64_t timeout,
                                                  const RecordObject& record_obj) {
-    BaseClass::PostCallRecordWaitSemaphores(device, pWaitInfo, timeout, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordSignalSemaphore(VkDevice device, const VkSemaphoreSignalInfo* pSignalInfo,
                                                   const RecordObject& record_obj) {
-    BaseClass::PostCallRecordSignalSemaphore(device, pSignalInfo, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void bp_state::Instance::PostCallRecordGetPhysicalDeviceToolProperties(VkPhysicalDevice physicalDevice, uint32_t* pToolCount,
                                                                        VkPhysicalDeviceToolProperties* pToolProperties,
                                                                        const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPhysicalDeviceToolProperties(physicalDevice, pToolCount, pToolProperties, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
 void BestPractices::PostCallRecordCreatePrivateDataSlot(VkDevice device, const VkPrivateDataSlotCreateInfo* pCreateInfo,
                                                         const VkAllocationCallbacks* pAllocator,
                                                         VkPrivateDataSlot* pPrivateDataSlot, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreatePrivateDataSlot(device, pCreateInfo, pAllocator, pPrivateDataSlot, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordSetPrivateData(VkDevice device, VkObjectType objectType, uint64_t objectHandle,
                                                  VkPrivateDataSlot privateDataSlot, uint64_t data, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordSetPrivateData(device, objectType, objectHandle, privateDataSlot, data, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
                                                const RecordObject& record_obj) {
-    BaseClass::PostCallRecordQueueSubmit2(queue, submitCount, pSubmits, fence, record_obj);
     bp_state::LogResult(*this, queue, record_obj);
 }
 
 void BestPractices::PostCallRecordMapMemory2(VkDevice device, const VkMemoryMapInfo* pMemoryMapInfo, void** ppData,
                                              const RecordObject& record_obj) {
-    BaseClass::PostCallRecordMapMemory2(device, pMemoryMapInfo, ppData, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordUnmapMemory2(VkDevice device, const VkMemoryUnmapInfo* pMemoryUnmapInfo,
                                                const RecordObject& record_obj) {
-    BaseClass::PostCallRecordUnmapMemory2(device, pMemoryUnmapInfo, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordCopyMemoryToImage(VkDevice device, const VkCopyMemoryToImageInfo* pCopyMemoryToImageInfo,
                                                     const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCopyMemoryToImage(device, pCopyMemoryToImageInfo, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordCopyImageToMemory(VkDevice device, const VkCopyImageToMemoryInfo* pCopyImageToMemoryInfo,
                                                     const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCopyImageToMemory(device, pCopyImageToMemoryInfo, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordCopyImageToImage(VkDevice device, const VkCopyImageToImageInfo* pCopyImageToImageInfo,
                                                    const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCopyImageToImage(device, pCopyImageToImageInfo, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordTransitionImageLayout(VkDevice device, uint32_t transitionCount,
                                                         const VkHostImageLayoutTransitionInfo* pTransitions,
                                                         const RecordObject& record_obj) {
-    BaseClass::PostCallRecordTransitionImageLayout(device, transitionCount, pTransitions, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void bp_state::Instance::PostCallRecordGetPhysicalDeviceSurfaceSupportKHR(VkPhysicalDevice physicalDevice,
                                                                           uint32_t queueFamilyIndex, VkSurfaceKHR surface,
                                                                           VkBool32* pSupported, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
@@ -715,7 +635,6 @@ void bp_state::Instance::PostCallRecordGetPhysicalDeviceSurfaceCapabilitiesKHR(V
                                                                                VkSurfaceKHR surface,
                                                                                VkSurfaceCapabilitiesKHR* pSurfaceCapabilities,
                                                                                const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
@@ -723,8 +642,6 @@ void bp_state::Instance::PostCallRecordGetPhysicalDeviceSurfaceFormatsKHR(VkPhys
                                                                           uint32_t* pSurfaceFormatCount,
                                                                           VkSurfaceFormatKHR* pSurfaceFormats,
                                                                           const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats,
-                                                                record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
@@ -732,61 +649,51 @@ void bp_state::Instance::PostCallRecordGetPhysicalDeviceSurfacePresentModesKHR(V
                                                                                VkSurfaceKHR surface, uint32_t* pPresentModeCount,
                                                                                VkPresentModeKHR* pPresentModes,
                                                                                const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes,
-                                                                     record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
 void BestPractices::PostCallRecordCreateSwapchainKHR(VkDevice device, const VkSwapchainCreateInfoKHR* pCreateInfo,
                                                      const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchain,
                                                      const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain, uint32_t* pSwapchainImageCount,
                                                         VkImage* pSwapchainImages, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetSwapchainImagesKHR(device, swapchain, pSwapchainImageCount, pSwapchainImages, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordAcquireNextImageKHR(VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout,
                                                       VkSemaphore semaphore, VkFence fence, uint32_t* pImageIndex,
                                                       const RecordObject& record_obj) {
-    BaseClass::PostCallRecordAcquireNextImageKHR(device, swapchain, timeout, semaphore, fence, pImageIndex, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo,
                                                   const RecordObject& record_obj) {
-    BaseClass::PostCallRecordQueuePresentKHR(queue, pPresentInfo, record_obj);
     ManualPostCallRecordQueuePresentKHR(queue, pPresentInfo, record_obj);
     bp_state::LogResult(*this, queue, record_obj);
 }
 
 void BestPractices::PostCallRecordGetDeviceGroupPresentCapabilitiesKHR(
     VkDevice device, VkDeviceGroupPresentCapabilitiesKHR* pDeviceGroupPresentCapabilities, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetDeviceGroupPresentCapabilitiesKHR(device, pDeviceGroupPresentCapabilities, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetDeviceGroupSurfacePresentModesKHR(VkDevice device, VkSurfaceKHR surface,
                                                                        VkDeviceGroupPresentModeFlagsKHR* pModes,
                                                                        const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetDeviceGroupSurfacePresentModesKHR(device, surface, pModes, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void bp_state::Instance::PostCallRecordGetPhysicalDevicePresentRectanglesKHR(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
                                                                              uint32_t* pRectCount, VkRect2D* pRects,
                                                                              const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
 void BestPractices::PostCallRecordAcquireNextImage2KHR(VkDevice device, const VkAcquireNextImageInfoKHR* pAcquireInfo,
                                                        uint32_t* pImageIndex, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordAcquireNextImage2KHR(device, pAcquireInfo, pImageIndex, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -794,7 +701,6 @@ void bp_state::Instance::PostCallRecordGetPhysicalDeviceDisplayPropertiesKHR(VkP
                                                                              uint32_t* pPropertyCount,
                                                                              VkDisplayPropertiesKHR* pProperties,
                                                                              const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPhysicalDeviceDisplayPropertiesKHR(physicalDevice, pPropertyCount, pProperties, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
@@ -802,14 +708,12 @@ void bp_state::Instance::PostCallRecordGetPhysicalDeviceDisplayPlanePropertiesKH
                                                                                   uint32_t* pPropertyCount,
                                                                                   VkDisplayPlanePropertiesKHR* pProperties,
                                                                                   const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPhysicalDeviceDisplayPlanePropertiesKHR(physicalDevice, pPropertyCount, pProperties, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
 void bp_state::Instance::PostCallRecordGetDisplayPlaneSupportedDisplaysKHR(VkPhysicalDevice physicalDevice, uint32_t planeIndex,
                                                                            uint32_t* pDisplayCount, VkDisplayKHR* pDisplays,
                                                                            const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetDisplayPlaneSupportedDisplaysKHR(physicalDevice, planeIndex, pDisplayCount, pDisplays, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
@@ -817,7 +721,6 @@ void bp_state::Instance::PostCallRecordGetDisplayModePropertiesKHR(VkPhysicalDev
                                                                    uint32_t* pPropertyCount,
                                                                    VkDisplayModePropertiesKHR* pProperties,
                                                                    const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetDisplayModePropertiesKHR(physicalDevice, display, pPropertyCount, pProperties, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
@@ -825,7 +728,6 @@ void bp_state::Instance::PostCallRecordCreateDisplayModeKHR(VkPhysicalDevice phy
                                                             const VkDisplayModeCreateInfoKHR* pCreateInfo,
                                                             const VkAllocationCallbacks* pAllocator, VkDisplayModeKHR* pMode,
                                                             const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
@@ -833,7 +735,6 @@ void bp_state::Instance::PostCallRecordGetDisplayPlaneCapabilitiesKHR(VkPhysical
                                                                       uint32_t planeIndex,
                                                                       VkDisplayPlaneCapabilitiesKHR* pCapabilities,
                                                                       const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
@@ -841,7 +742,6 @@ void bp_state::Instance::PostCallRecordCreateDisplayPlaneSurfaceKHR(VkInstance i
                                                                     const VkDisplaySurfaceCreateInfoKHR* pCreateInfo,
                                                                     const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                                     const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateDisplayPlaneSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, record_obj);
     bp_state::LogResult(*this, instance, record_obj);
 }
 
@@ -849,7 +749,6 @@ void BestPractices::PostCallRecordCreateSharedSwapchainsKHR(VkDevice device, uin
                                                             const VkSwapchainCreateInfoKHR* pCreateInfos,
                                                             const VkAllocationCallbacks* pAllocator, VkSwapchainKHR* pSwapchains,
                                                             const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateSharedSwapchainsKHR(device, swapchainCount, pCreateInfos, pAllocator, pSwapchains, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -857,7 +756,6 @@ void BestPractices::PostCallRecordCreateSharedSwapchainsKHR(VkDevice device, uin
 void bp_state::Instance::PostCallRecordCreateXlibSurfaceKHR(VkInstance instance, const VkXlibSurfaceCreateInfoKHR* pCreateInfo,
                                                             const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                             const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateXlibSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, record_obj);
     bp_state::LogResult(*this, instance, record_obj);
 }
 #endif  // VK_USE_PLATFORM_XLIB_KHR
@@ -866,7 +764,6 @@ void bp_state::Instance::PostCallRecordCreateXlibSurfaceKHR(VkInstance instance,
 void bp_state::Instance::PostCallRecordCreateXcbSurfaceKHR(VkInstance instance, const VkXcbSurfaceCreateInfoKHR* pCreateInfo,
                                                            const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                            const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateXcbSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, record_obj);
     bp_state::LogResult(*this, instance, record_obj);
 }
 #endif  // VK_USE_PLATFORM_XCB_KHR
@@ -876,7 +773,6 @@ void bp_state::Instance::PostCallRecordCreateWaylandSurfaceKHR(VkInstance instan
                                                                const VkWaylandSurfaceCreateInfoKHR* pCreateInfo,
                                                                const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                                const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateWaylandSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, record_obj);
     bp_state::LogResult(*this, instance, record_obj);
 }
 #endif  // VK_USE_PLATFORM_WAYLAND_KHR
@@ -886,7 +782,6 @@ void bp_state::Instance::PostCallRecordCreateAndroidSurfaceKHR(VkInstance instan
                                                                const VkAndroidSurfaceCreateInfoKHR* pCreateInfo,
                                                                const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                                const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateAndroidSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, record_obj);
     bp_state::LogResult(*this, instance, record_obj);
 }
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
@@ -895,7 +790,6 @@ void bp_state::Instance::PostCallRecordCreateAndroidSurfaceKHR(VkInstance instan
 void bp_state::Instance::PostCallRecordCreateWin32SurfaceKHR(VkInstance instance, const VkWin32SurfaceCreateInfoKHR* pCreateInfo,
                                                              const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                              const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateWin32SurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, record_obj);
     bp_state::LogResult(*this, instance, record_obj);
 }
 #endif  // VK_USE_PLATFORM_WIN32_KHR
@@ -904,22 +798,18 @@ void bp_state::Instance::PostCallRecordGetPhysicalDeviceVideoCapabilitiesKHR(VkP
                                                                              const VkVideoProfileInfoKHR* pVideoProfile,
                                                                              VkVideoCapabilitiesKHR* pCapabilities,
                                                                              const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPhysicalDeviceVideoCapabilitiesKHR(physicalDevice, pVideoProfile, pCapabilities, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
 void bp_state::Instance::PostCallRecordGetPhysicalDeviceVideoFormatPropertiesKHR(
     VkPhysicalDevice physicalDevice, const VkPhysicalDeviceVideoFormatInfoKHR* pVideoFormatInfo,
     uint32_t* pVideoFormatPropertyCount, VkVideoFormatPropertiesKHR* pVideoFormatProperties, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPhysicalDeviceVideoFormatPropertiesKHR(physicalDevice, pVideoFormatInfo, pVideoFormatPropertyCount,
-                                                                       pVideoFormatProperties, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
 void BestPractices::PostCallRecordCreateVideoSessionKHR(VkDevice device, const VkVideoSessionCreateInfoKHR* pCreateInfo,
                                                         const VkAllocationCallbacks* pAllocator, VkVideoSessionKHR* pVideoSession,
                                                         const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateVideoSessionKHR(device, pCreateInfo, pAllocator, pVideoSession, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -927,8 +817,6 @@ void BestPractices::PostCallRecordGetVideoSessionMemoryRequirementsKHR(VkDevice 
                                                                        uint32_t* pMemoryRequirementsCount,
                                                                        VkVideoSessionMemoryRequirementsKHR* pMemoryRequirements,
                                                                        const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetVideoSessionMemoryRequirementsKHR(device, videoSession, pMemoryRequirementsCount,
-                                                                  pMemoryRequirements, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -936,8 +824,6 @@ void BestPractices::PostCallRecordBindVideoSessionMemoryKHR(VkDevice device, VkV
                                                             uint32_t bindSessionMemoryInfoCount,
                                                             const VkBindVideoSessionMemoryInfoKHR* pBindSessionMemoryInfos,
                                                             const RecordObject& record_obj) {
-    BaseClass::PostCallRecordBindVideoSessionMemoryKHR(device, videoSession, bindSessionMemoryInfoCount, pBindSessionMemoryInfos,
-                                                       record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -946,7 +832,6 @@ void BestPractices::PostCallRecordCreateVideoSessionParametersKHR(VkDevice devic
                                                                   const VkAllocationCallbacks* pAllocator,
                                                                   VkVideoSessionParametersKHR* pVideoSessionParameters,
                                                                   const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateVideoSessionParametersKHR(device, pCreateInfo, pAllocator, pVideoSessionParameters, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -954,7 +839,6 @@ void BestPractices::PostCallRecordUpdateVideoSessionParametersKHR(VkDevice devic
                                                                   VkVideoSessionParametersKHR videoSessionParameters,
                                                                   const VkVideoSessionParametersUpdateInfoKHR* pUpdateInfo,
                                                                   const RecordObject& record_obj) {
-    BaseClass::PostCallRecordUpdateVideoSessionParametersKHR(device, videoSessionParameters, pUpdateInfo, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -973,7 +857,6 @@ void bp_state::Instance::PostCallRecordEnumeratePhysicalDeviceGroupsKHR(
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 void BestPractices::PostCallRecordGetMemoryWin32HandleKHR(VkDevice device, const VkMemoryGetWin32HandleInfoKHR* pGetWin32HandleInfo,
                                                           HANDLE* pHandle, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetMemoryWin32HandleKHR(device, pGetWin32HandleInfo, pHandle, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -981,49 +864,41 @@ void BestPractices::PostCallRecordGetMemoryWin32HandlePropertiesKHR(VkDevice dev
                                                                     HANDLE handle,
                                                                     VkMemoryWin32HandlePropertiesKHR* pMemoryWin32HandleProperties,
                                                                     const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetMemoryWin32HandlePropertiesKHR(device, handleType, handle, pMemoryWin32HandleProperties,
-                                                               record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 
 void BestPractices::PostCallRecordGetMemoryFdKHR(VkDevice device, const VkMemoryGetFdInfoKHR* pGetFdInfo, int* pFd,
                                                  const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetMemoryFdKHR(device, pGetFdInfo, pFd, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetMemoryFdPropertiesKHR(VkDevice device, VkExternalMemoryHandleTypeFlagBits handleType, int fd,
                                                            VkMemoryFdPropertiesKHR* pMemoryFdProperties,
                                                            const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetMemoryFdPropertiesKHR(device, handleType, fd, pMemoryFdProperties, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 void BestPractices::PostCallRecordImportSemaphoreWin32HandleKHR(
     VkDevice device, const VkImportSemaphoreWin32HandleInfoKHR* pImportSemaphoreWin32HandleInfo, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordImportSemaphoreWin32HandleKHR(device, pImportSemaphoreWin32HandleInfo, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetSemaphoreWin32HandleKHR(VkDevice device,
                                                              const VkSemaphoreGetWin32HandleInfoKHR* pGetWin32HandleInfo,
                                                              HANDLE* pHandle, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetSemaphoreWin32HandleKHR(device, pGetWin32HandleInfo, pHandle, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 
 void BestPractices::PostCallRecordImportSemaphoreFdKHR(VkDevice device, const VkImportSemaphoreFdInfoKHR* pImportSemaphoreFdInfo,
                                                        const RecordObject& record_obj) {
-    BaseClass::PostCallRecordImportSemaphoreFdKHR(device, pImportSemaphoreFdInfo, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetSemaphoreFdKHR(VkDevice device, const VkSemaphoreGetFdInfoKHR* pGetFdInfo, int* pFd,
                                                     const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetSemaphoreFdKHR(device, pGetFdInfo, pFd, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -1042,7 +917,6 @@ void BestPractices::PostCallRecordCreateRenderPass2KHR(VkDevice device, const Vk
 }
 
 void BestPractices::PostCallRecordGetSwapchainStatusKHR(VkDevice device, VkSwapchainKHR swapchain, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetSwapchainStatusKHR(device, swapchain, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -1050,40 +924,33 @@ void BestPractices::PostCallRecordGetSwapchainStatusKHR(VkDevice device, VkSwapc
 void BestPractices::PostCallRecordImportFenceWin32HandleKHR(VkDevice device,
                                                             const VkImportFenceWin32HandleInfoKHR* pImportFenceWin32HandleInfo,
                                                             const RecordObject& record_obj) {
-    BaseClass::PostCallRecordImportFenceWin32HandleKHR(device, pImportFenceWin32HandleInfo, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetFenceWin32HandleKHR(VkDevice device, const VkFenceGetWin32HandleInfoKHR* pGetWin32HandleInfo,
                                                          HANDLE* pHandle, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetFenceWin32HandleKHR(device, pGetWin32HandleInfo, pHandle, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 
 void BestPractices::PostCallRecordImportFenceFdKHR(VkDevice device, const VkImportFenceFdInfoKHR* pImportFenceFdInfo,
                                                    const RecordObject& record_obj) {
-    BaseClass::PostCallRecordImportFenceFdKHR(device, pImportFenceFdInfo, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetFenceFdKHR(VkDevice device, const VkFenceGetFdInfoKHR* pGetFdInfo, int* pFd,
                                                 const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetFenceFdKHR(device, pGetFdInfo, pFd, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void bp_state::Instance::PostCallRecordEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(
     VkPhysicalDevice physicalDevice, uint32_t queueFamilyIndex, uint32_t* pCounterCount, VkPerformanceCounterKHR* pCounters,
     VkPerformanceCounterDescriptionKHR* pCounterDescriptions, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(
-        physicalDevice, queueFamilyIndex, pCounterCount, pCounters, pCounterDescriptions, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
 void BestPractices::PostCallRecordAcquireProfilingLockKHR(VkDevice device, const VkAcquireProfilingLockInfoKHR* pInfo,
                                                           const RecordObject& record_obj) {
-    BaseClass::PostCallRecordAcquireProfilingLockKHR(device, pInfo, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -1091,8 +958,6 @@ void bp_state::Instance::PostCallRecordGetPhysicalDeviceSurfaceCapabilities2KHR(
                                                                                 const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo,
                                                                                 VkSurfaceCapabilities2KHR* pSurfaceCapabilities,
                                                                                 const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPhysicalDeviceSurfaceCapabilities2KHR(physicalDevice, pSurfaceInfo, pSurfaceCapabilities,
-                                                                      record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
@@ -1101,8 +966,6 @@ void bp_state::Instance::PostCallRecordGetPhysicalDeviceSurfaceFormats2KHR(VkPhy
                                                                            uint32_t* pSurfaceFormatCount,
                                                                            VkSurfaceFormat2KHR* pSurfaceFormats,
                                                                            const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPhysicalDeviceSurfaceFormats2KHR(physicalDevice, pSurfaceInfo, pSurfaceFormatCount, pSurfaceFormats,
-                                                                 record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
@@ -1110,7 +973,6 @@ void bp_state::Instance::PostCallRecordGetPhysicalDeviceDisplayProperties2KHR(Vk
                                                                               uint32_t* pPropertyCount,
                                                                               VkDisplayProperties2KHR* pProperties,
                                                                               const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPhysicalDeviceDisplayProperties2KHR(physicalDevice, pPropertyCount, pProperties, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
@@ -1118,7 +980,6 @@ void bp_state::Instance::PostCallRecordGetPhysicalDeviceDisplayPlaneProperties2K
                                                                                    uint32_t* pPropertyCount,
                                                                                    VkDisplayPlaneProperties2KHR* pProperties,
                                                                                    const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPhysicalDeviceDisplayPlaneProperties2KHR(physicalDevice, pPropertyCount, pProperties, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
@@ -1126,7 +987,6 @@ void bp_state::Instance::PostCallRecordGetDisplayModeProperties2KHR(VkPhysicalDe
                                                                     uint32_t* pPropertyCount,
                                                                     VkDisplayModeProperties2KHR* pProperties,
                                                                     const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetDisplayModeProperties2KHR(physicalDevice, display, pPropertyCount, pProperties, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
@@ -1134,7 +994,6 @@ void bp_state::Instance::PostCallRecordGetDisplayPlaneCapabilities2KHR(VkPhysica
                                                                        const VkDisplayPlaneInfo2KHR* pDisplayPlaneInfo,
                                                                        VkDisplayPlaneCapabilities2KHR* pCapabilities,
                                                                        const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetDisplayPlaneCapabilities2KHR(physicalDevice, pDisplayPlaneInfo, pCapabilities, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
@@ -1174,33 +1033,27 @@ void BestPractices::PostCallRecordSignalSemaphoreKHR(VkDevice device, const VkSe
 void bp_state::Instance::PostCallRecordGetPhysicalDeviceFragmentShadingRatesKHR(
     VkPhysicalDevice physicalDevice, uint32_t* pFragmentShadingRateCount,
     VkPhysicalDeviceFragmentShadingRateKHR* pFragmentShadingRates, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice, pFragmentShadingRateCount,
-                                                                      pFragmentShadingRates, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
 void BestPractices::PostCallRecordWaitForPresentKHR(VkDevice device, VkSwapchainKHR swapchain, uint64_t presentId, uint64_t timeout,
                                                     const RecordObject& record_obj) {
-    BaseClass::PostCallRecordWaitForPresentKHR(device, swapchain, presentId, timeout, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordCreateDeferredOperationKHR(VkDevice device, const VkAllocationCallbacks* pAllocator,
                                                              VkDeferredOperationKHR* pDeferredOperation,
                                                              const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateDeferredOperationKHR(device, pAllocator, pDeferredOperation, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetDeferredOperationResultKHR(VkDevice device, VkDeferredOperationKHR operation,
                                                                 const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetDeferredOperationResultKHR(device, operation, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordDeferredOperationJoinKHR(VkDevice device, VkDeferredOperationKHR operation,
                                                            const RecordObject& record_obj) {
-    BaseClass::PostCallRecordDeferredOperationJoinKHR(device, operation, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -1208,7 +1061,6 @@ void BestPractices::PostCallRecordGetPipelineExecutablePropertiesKHR(VkDevice de
                                                                      uint32_t* pExecutableCount,
                                                                      VkPipelineExecutablePropertiesKHR* pProperties,
                                                                      const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPipelineExecutablePropertiesKHR(device, pPipelineInfo, pExecutableCount, pProperties, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -1217,15 +1069,12 @@ void BestPractices::PostCallRecordGetPipelineExecutableStatisticsKHR(VkDevice de
                                                                      uint32_t* pStatisticCount,
                                                                      VkPipelineExecutableStatisticKHR* pStatistics,
                                                                      const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPipelineExecutableStatisticsKHR(device, pExecutableInfo, pStatisticCount, pStatistics, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetPipelineExecutableInternalRepresentationsKHR(
     VkDevice device, const VkPipelineExecutableInfoKHR* pExecutableInfo, uint32_t* pInternalRepresentationCount,
     VkPipelineExecutableInternalRepresentationKHR* pInternalRepresentations, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPipelineExecutableInternalRepresentationsKHR(device, pExecutableInfo, pInternalRepresentationCount,
-                                                                             pInternalRepresentations, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -1242,16 +1091,12 @@ void BestPractices::PostCallRecordUnmapMemory2KHR(VkDevice device, const VkMemor
 void bp_state::Instance::PostCallRecordGetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR(
     VkPhysicalDevice physicalDevice, const VkPhysicalDeviceVideoEncodeQualityLevelInfoKHR* pQualityLevelInfo,
     VkVideoEncodeQualityLevelPropertiesKHR* pQualityLevelProperties, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR(physicalDevice, pQualityLevelInfo,
-                                                                                   pQualityLevelProperties, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
 void BestPractices::PostCallRecordGetEncodedVideoSessionParametersKHR(
     VkDevice device, const VkVideoEncodeSessionParametersGetInfoKHR* pVideoSessionParametersInfo,
     VkVideoEncodeSessionParametersFeedbackInfoKHR* pFeedbackInfo, size_t* pDataSize, void* pData, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetEncodedVideoSessionParametersKHR(device, pVideoSessionParametersInfo, pFeedbackInfo, pDataSize,
-                                                                 pData, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -1264,13 +1109,11 @@ void BestPractices::PostCallRecordCreatePipelineBinariesKHR(VkDevice device, con
                                                             const VkAllocationCallbacks* pAllocator,
                                                             VkPipelineBinaryHandlesInfoKHR* pBinaries,
                                                             const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreatePipelineBinariesKHR(device, pCreateInfo, pAllocator, pBinaries, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetPipelineKeyKHR(VkDevice device, const VkPipelineCreateInfoKHR* pPipelineCreateInfo,
                                                     VkPipelineBinaryKeyKHR* pPipelineKey, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPipelineKeyKHR(device, pPipelineCreateInfo, pPipelineKey, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -1278,16 +1121,12 @@ void BestPractices::PostCallRecordGetPipelineBinaryDataKHR(VkDevice device, cons
                                                            VkPipelineBinaryKeyKHR* pPipelineBinaryKey,
                                                            size_t* pPipelineBinaryDataSize, void* pPipelineBinaryData,
                                                            const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPipelineBinaryDataKHR(device, pInfo, pPipelineBinaryKey, pPipelineBinaryDataSize,
-                                                      pPipelineBinaryData, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void bp_state::Instance::PostCallRecordGetPhysicalDeviceCooperativeMatrixPropertiesKHR(
     VkPhysicalDevice physicalDevice, uint32_t* pPropertyCount, VkCooperativeMatrixPropertiesKHR* pProperties,
     const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPhysicalDeviceCooperativeMatrixPropertiesKHR(physicalDevice, pPropertyCount, pProperties,
-                                                                             record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
@@ -1295,8 +1134,6 @@ void bp_state::Instance::PostCallRecordGetPhysicalDeviceCalibrateableTimeDomains
                                                                                     uint32_t* pTimeDomainCount,
                                                                                     VkTimeDomainKHR* pTimeDomains,
                                                                                     const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPhysicalDeviceCalibrateableTimeDomainsKHR(physicalDevice, pTimeDomainCount, pTimeDomains,
-                                                                          record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
@@ -1304,8 +1141,6 @@ void BestPractices::PostCallRecordGetCalibratedTimestampsKHR(VkDevice device, ui
                                                              const VkCalibratedTimestampInfoKHR* pTimestampInfos,
                                                              uint64_t* pTimestamps, uint64_t* pMaxDeviation,
                                                              const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetCalibratedTimestampsKHR(device, timestampCount, pTimestampInfos, pTimestamps, pMaxDeviation,
-                                                        record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -1314,47 +1149,40 @@ void bp_state::Instance::PostCallRecordCreateDebugReportCallbackEXT(VkInstance i
                                                                     const VkAllocationCallbacks* pAllocator,
                                                                     VkDebugReportCallbackEXT* pCallback,
                                                                     const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateDebugReportCallbackEXT(instance, pCreateInfo, pAllocator, pCallback, record_obj);
     bp_state::LogResult(*this, instance, record_obj);
 }
 
 void BestPractices::PostCallRecordDebugMarkerSetObjectTagEXT(VkDevice device, const VkDebugMarkerObjectTagInfoEXT* pTagInfo,
                                                              const RecordObject& record_obj) {
-    BaseClass::PostCallRecordDebugMarkerSetObjectTagEXT(device, pTagInfo, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordDebugMarkerSetObjectNameEXT(VkDevice device, const VkDebugMarkerObjectNameInfoEXT* pNameInfo,
                                                               const RecordObject& record_obj) {
-    BaseClass::PostCallRecordDebugMarkerSetObjectNameEXT(device, pNameInfo, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordCreateCuModuleNVX(VkDevice device, const VkCuModuleCreateInfoNVX* pCreateInfo,
                                                     const VkAllocationCallbacks* pAllocator, VkCuModuleNVX* pModule,
                                                     const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateCuModuleNVX(device, pCreateInfo, pAllocator, pModule, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordCreateCuFunctionNVX(VkDevice device, const VkCuFunctionCreateInfoNVX* pCreateInfo,
                                                       const VkAllocationCallbacks* pAllocator, VkCuFunctionNVX* pFunction,
                                                       const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateCuFunctionNVX(device, pCreateInfo, pAllocator, pFunction, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetImageViewAddressNVX(VkDevice device, VkImageView imageView,
                                                          VkImageViewAddressPropertiesNVX* pProperties,
                                                          const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetImageViewAddressNVX(device, imageView, pProperties, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetShaderInfoAMD(VkDevice device, VkPipeline pipeline, VkShaderStageFlagBits shaderStage,
                                                    VkShaderInfoTypeAMD infoType, size_t* pInfoSize, void* pInfo,
                                                    const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, pInfo, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -1363,7 +1191,6 @@ void bp_state::Instance::PostCallRecordCreateStreamDescriptorSurfaceGGP(VkInstan
                                                                         const VkStreamDescriptorSurfaceCreateInfoGGP* pCreateInfo,
                                                                         const VkAllocationCallbacks* pAllocator,
                                                                         VkSurfaceKHR* pSurface, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateStreamDescriptorSurfaceGGP(instance, pCreateInfo, pAllocator, pSurface, record_obj);
     bp_state::LogResult(*this, instance, record_obj);
 }
 #endif  // VK_USE_PLATFORM_GGP
@@ -1372,8 +1199,6 @@ void bp_state::Instance::PostCallRecordGetPhysicalDeviceExternalImageFormatPrope
     VkPhysicalDevice physicalDevice, VkFormat format, VkImageType type, VkImageTiling tiling, VkImageUsageFlags usage,
     VkImageCreateFlags flags, VkExternalMemoryHandleTypeFlagsNV externalHandleType,
     VkExternalImageFormatPropertiesNV* pExternalImageFormatProperties, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPhysicalDeviceExternalImageFormatPropertiesNV(
-        physicalDevice, format, type, tiling, usage, flags, externalHandleType, pExternalImageFormatProperties, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
@@ -1381,7 +1206,6 @@ void bp_state::Instance::PostCallRecordGetPhysicalDeviceExternalImageFormatPrope
 void BestPractices::PostCallRecordGetMemoryWin32HandleNV(VkDevice device, VkDeviceMemory memory,
                                                          VkExternalMemoryHandleTypeFlagsNV handleType, HANDLE* pHandle,
                                                          const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetMemoryWin32HandleNV(device, memory, handleType, pHandle, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 #endif  // VK_USE_PLATFORM_WIN32_KHR
@@ -1390,7 +1214,6 @@ void BestPractices::PostCallRecordGetMemoryWin32HandleNV(VkDevice device, VkDevi
 void bp_state::Instance::PostCallRecordCreateViSurfaceNN(VkInstance instance, const VkViSurfaceCreateInfoNN* pCreateInfo,
                                                          const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                          const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateViSurfaceNN(instance, pCreateInfo, pAllocator, pSurface, record_obj);
     bp_state::LogResult(*this, instance, record_obj);
 }
 #endif  // VK_USE_PLATFORM_VI_NN
@@ -1398,13 +1221,11 @@ void bp_state::Instance::PostCallRecordCreateViSurfaceNN(VkInstance instance, co
 #ifdef VK_USE_PLATFORM_XLIB_XRANDR_EXT
 void bp_state::Instance::PostCallRecordAcquireXlibDisplayEXT(VkPhysicalDevice physicalDevice, Display* dpy, VkDisplayKHR display,
                                                              const RecordObject& record_obj) {
-    BaseClass::PostCallRecordAcquireXlibDisplayEXT(physicalDevice, dpy, display, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
 void bp_state::Instance::PostCallRecordGetRandROutputDisplayEXT(VkPhysicalDevice physicalDevice, Display* dpy, RROutput rrOutput,
                                                                 VkDisplayKHR* pDisplay, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetRandROutputDisplayEXT(physicalDevice, dpy, rrOutput, pDisplay, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 #endif  // VK_USE_PLATFORM_XLIB_XRANDR_EXT
@@ -1413,21 +1234,18 @@ void bp_state::Instance::PostCallRecordGetPhysicalDeviceSurfaceCapabilities2EXT(
                                                                                 VkSurfaceKHR surface,
                                                                                 VkSurfaceCapabilities2EXT* pSurfaceCapabilities,
                                                                                 const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
 void BestPractices::PostCallRecordDisplayPowerControlEXT(VkDevice device, VkDisplayKHR display,
                                                          const VkDisplayPowerInfoEXT* pDisplayPowerInfo,
                                                          const RecordObject& record_obj) {
-    BaseClass::PostCallRecordDisplayPowerControlEXT(device, display, pDisplayPowerInfo, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordRegisterDeviceEventEXT(VkDevice device, const VkDeviceEventInfoEXT* pDeviceEventInfo,
                                                          const VkAllocationCallbacks* pAllocator, VkFence* pFence,
                                                          const RecordObject& record_obj) {
-    BaseClass::PostCallRecordRegisterDeviceEventEXT(device, pDeviceEventInfo, pAllocator, pFence, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -1435,21 +1253,18 @@ void BestPractices::PostCallRecordRegisterDisplayEventEXT(VkDevice device, VkDis
                                                           const VkDisplayEventInfoEXT* pDisplayEventInfo,
                                                           const VkAllocationCallbacks* pAllocator, VkFence* pFence,
                                                           const RecordObject& record_obj) {
-    BaseClass::PostCallRecordRegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetSwapchainCounterEXT(VkDevice device, VkSwapchainKHR swapchain,
                                                          VkSurfaceCounterFlagBitsEXT counter, uint64_t* pCounterValue,
                                                          const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetSwapchainCounterEXT(device, swapchain, counter, pCounterValue, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetRefreshCycleDurationGOOGLE(VkDevice device, VkSwapchainKHR swapchain,
                                                                 VkRefreshCycleDurationGOOGLE* pDisplayTimingProperties,
                                                                 const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProperties, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -1457,8 +1272,6 @@ void BestPractices::PostCallRecordGetPastPresentationTimingGOOGLE(VkDevice devic
                                                                   uint32_t* pPresentationTimingCount,
                                                                   VkPastPresentationTimingGOOGLE* pPresentationTimings,
                                                                   const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings,
-                                                             record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -1466,7 +1279,6 @@ void BestPractices::PostCallRecordGetPastPresentationTimingGOOGLE(VkDevice devic
 void bp_state::Instance::PostCallRecordCreateIOSSurfaceMVK(VkInstance instance, const VkIOSSurfaceCreateInfoMVK* pCreateInfo,
                                                            const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                            const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateIOSSurfaceMVK(instance, pCreateInfo, pAllocator, pSurface, record_obj);
     bp_state::LogResult(*this, instance, record_obj);
 }
 #endif  // VK_USE_PLATFORM_IOS_MVK
@@ -1475,20 +1287,17 @@ void bp_state::Instance::PostCallRecordCreateIOSSurfaceMVK(VkInstance instance, 
 void bp_state::Instance::PostCallRecordCreateMacOSSurfaceMVK(VkInstance instance, const VkMacOSSurfaceCreateInfoMVK* pCreateInfo,
                                                              const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                              const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateMacOSSurfaceMVK(instance, pCreateInfo, pAllocator, pSurface, record_obj);
     bp_state::LogResult(*this, instance, record_obj);
 }
 #endif  // VK_USE_PLATFORM_MACOS_MVK
 
 void BestPractices::PostCallRecordSetDebugUtilsObjectNameEXT(VkDevice device, const VkDebugUtilsObjectNameInfoEXT* pNameInfo,
                                                              const RecordObject& record_obj) {
-    BaseClass::PostCallRecordSetDebugUtilsObjectNameEXT(device, pNameInfo, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordSetDebugUtilsObjectTagEXT(VkDevice device, const VkDebugUtilsObjectTagInfoEXT* pTagInfo,
                                                             const RecordObject& record_obj) {
-    BaseClass::PostCallRecordSetDebugUtilsObjectTagEXT(device, pTagInfo, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -1497,7 +1306,6 @@ void bp_state::Instance::PostCallRecordCreateDebugUtilsMessengerEXT(VkInstance i
                                                                     const VkAllocationCallbacks* pAllocator,
                                                                     VkDebugUtilsMessengerEXT* pMessenger,
                                                                     const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateDebugUtilsMessengerEXT(instance, pCreateInfo, pAllocator, pMessenger, record_obj);
     bp_state::LogResult(*this, instance, record_obj);
 }
 
@@ -1505,7 +1313,6 @@ void bp_state::Instance::PostCallRecordCreateDebugUtilsMessengerEXT(VkInstance i
 void BestPractices::PostCallRecordGetAndroidHardwareBufferPropertiesANDROID(VkDevice device, const struct AHardwareBuffer* buffer,
                                                                             VkAndroidHardwareBufferPropertiesANDROID* pProperties,
                                                                             const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetAndroidHardwareBufferPropertiesANDROID(device, buffer, pProperties, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -1513,7 +1320,6 @@ void BestPractices::PostCallRecordGetMemoryAndroidHardwareBufferANDROID(VkDevice
                                                                         const VkMemoryGetAndroidHardwareBufferInfoANDROID* pInfo,
                                                                         struct AHardwareBuffer** pBuffer,
                                                                         const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetMemoryAndroidHardwareBufferANDROID(device, pInfo, pBuffer, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
@@ -1524,22 +1330,18 @@ void BestPractices::PostCallRecordCreateExecutionGraphPipelinesAMDX(VkDevice dev
                                                                     const VkExecutionGraphPipelineCreateInfoAMDX* pCreateInfos,
                                                                     const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
                                                                     const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateExecutionGraphPipelinesAMDX(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator,
-                                                               pPipelines, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetExecutionGraphPipelineScratchSizeAMDX(VkDevice device, VkPipeline executionGraph,
                                                                            VkExecutionGraphPipelineScratchSizeAMDX* pSizeInfo,
                                                                            const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetExecutionGraphPipelineScratchSizeAMDX(device, executionGraph, pSizeInfo, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetExecutionGraphPipelineNodeIndexAMDX(VkDevice device, VkPipeline executionGraph,
                                                                          const VkPipelineShaderStageNodeCreateInfoAMDX* pNodeInfo,
                                                                          uint32_t* pNodeIndex, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetExecutionGraphPipelineNodeIndexAMDX(device, executionGraph, pNodeInfo, pNodeIndex, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 #endif  // VK_ENABLE_BETA_EXTENSIONS
@@ -1547,7 +1349,6 @@ void BestPractices::PostCallRecordGetExecutionGraphPipelineNodeIndexAMDX(VkDevic
 void BestPractices::PostCallRecordGetImageDrmFormatModifierPropertiesEXT(VkDevice device, VkImage image,
                                                                          VkImageDrmFormatModifierPropertiesEXT* pProperties,
                                                                          const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetImageDrmFormatModifierPropertiesEXT(device, image, pProperties, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -1556,14 +1357,12 @@ void BestPractices::PostCallRecordCreateAccelerationStructureNV(VkDevice device,
                                                                 const VkAllocationCallbacks* pAllocator,
                                                                 VkAccelerationStructureNV* pAccelerationStructure,
                                                                 const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateAccelerationStructureNV(device, pCreateInfo, pAllocator, pAccelerationStructure, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordBindAccelerationStructureMemoryNV(VkDevice device, uint32_t bindInfoCount,
                                                                     const VkBindAccelerationStructureMemoryInfoNV* pBindInfos,
                                                                     const RecordObject& record_obj) {
-    BaseClass::PostCallRecordBindAccelerationStructureMemoryNV(device, bindInfoCount, pBindInfos, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -1572,16 +1371,12 @@ void BestPractices::PostCallRecordCreateRayTracingPipelinesNV(VkDevice device, V
                                                               const VkRayTracingPipelineCreateInfoNV* pCreateInfos,
                                                               const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
                                                               const RecordObject& record_obj, PipelineStates& pipeline_states) {
-    BaseClass::PostCallRecordCreateRayTracingPipelinesNV(device, pipelineCache, createInfoCount, pCreateInfos, pAllocator,
-                                                         pPipelines, record_obj, pipeline_states);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetRayTracingShaderGroupHandlesKHR(VkDevice device, VkPipeline pipeline, uint32_t firstGroup,
                                                                      uint32_t groupCount, size_t dataSize, void* pData,
                                                                      const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData,
-                                                                record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -1593,13 +1388,11 @@ void BestPractices::PostCallRecordGetRayTracingShaderGroupHandlesNV(VkDevice dev
 
 void BestPractices::PostCallRecordGetAccelerationStructureHandleNV(VkDevice device, VkAccelerationStructureNV accelerationStructure,
                                                                    size_t dataSize, void* pData, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordCompileDeferredNV(VkDevice device, VkPipeline pipeline, uint32_t shader,
                                                     const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCompileDeferredNV(device, pipeline, shader, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -1607,8 +1400,6 @@ void BestPractices::PostCallRecordGetMemoryHostPointerPropertiesEXT(VkDevice dev
                                                                     const void* pHostPointer,
                                                                     VkMemoryHostPointerPropertiesEXT* pMemoryHostPointerProperties,
                                                                     const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetMemoryHostPointerPropertiesEXT(device, handleType, pHostPointer, pMemoryHostPointerProperties,
-                                                               record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -1629,55 +1420,47 @@ void BestPractices::PostCallRecordGetCalibratedTimestampsEXT(VkDevice device, ui
 void BestPractices::PostCallRecordInitializePerformanceApiINTEL(VkDevice device,
                                                                 const VkInitializePerformanceApiInfoINTEL* pInitializeInfo,
                                                                 const RecordObject& record_obj) {
-    BaseClass::PostCallRecordInitializePerformanceApiINTEL(device, pInitializeInfo, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordCmdSetPerformanceMarkerINTEL(VkCommandBuffer commandBuffer,
                                                                const VkPerformanceMarkerInfoINTEL* pMarkerInfo,
                                                                const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdSetPerformanceMarkerINTEL(commandBuffer, pMarkerInfo, record_obj);
     bp_state::LogResult(*this, commandBuffer, record_obj);
 }
 
 void BestPractices::PostCallRecordCmdSetPerformanceStreamMarkerINTEL(VkCommandBuffer commandBuffer,
                                                                      const VkPerformanceStreamMarkerInfoINTEL* pMarkerInfo,
                                                                      const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdSetPerformanceStreamMarkerINTEL(commandBuffer, pMarkerInfo, record_obj);
     bp_state::LogResult(*this, commandBuffer, record_obj);
 }
 
 void BestPractices::PostCallRecordCmdSetPerformanceOverrideINTEL(VkCommandBuffer commandBuffer,
                                                                  const VkPerformanceOverrideInfoINTEL* pOverrideInfo,
                                                                  const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCmdSetPerformanceOverrideINTEL(commandBuffer, pOverrideInfo, record_obj);
     bp_state::LogResult(*this, commandBuffer, record_obj);
 }
 
 void BestPractices::PostCallRecordAcquirePerformanceConfigurationINTEL(
     VkDevice device, const VkPerformanceConfigurationAcquireInfoINTEL* pAcquireInfo,
     VkPerformanceConfigurationINTEL* pConfiguration, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordAcquirePerformanceConfigurationINTEL(device, pAcquireInfo, pConfiguration, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordReleasePerformanceConfigurationINTEL(VkDevice device,
                                                                        VkPerformanceConfigurationINTEL configuration,
                                                                        const RecordObject& record_obj) {
-    BaseClass::PostCallRecordReleasePerformanceConfigurationINTEL(device, configuration, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordQueueSetPerformanceConfigurationINTEL(VkQueue queue,
                                                                         VkPerformanceConfigurationINTEL configuration,
                                                                         const RecordObject& record_obj) {
-    BaseClass::PostCallRecordQueueSetPerformanceConfigurationINTEL(queue, configuration, record_obj);
     bp_state::LogResult(*this, queue, record_obj);
 }
 
 void BestPractices::PostCallRecordGetPerformanceParameterINTEL(VkDevice device, VkPerformanceParameterTypeINTEL parameter,
                                                                VkPerformanceValueINTEL* pValue, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPerformanceParameterINTEL(device, parameter, pValue, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -1686,7 +1469,6 @@ void bp_state::Instance::PostCallRecordCreateImagePipeSurfaceFUCHSIA(VkInstance 
                                                                      const VkImagePipeSurfaceCreateInfoFUCHSIA* pCreateInfo,
                                                                      const VkAllocationCallbacks* pAllocator,
                                                                      VkSurfaceKHR* pSurface, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateImagePipeSurfaceFUCHSIA(instance, pCreateInfo, pAllocator, pSurface, record_obj);
     bp_state::LogResult(*this, instance, record_obj);
 }
 #endif  // VK_USE_PLATFORM_FUCHSIA
@@ -1695,7 +1477,6 @@ void bp_state::Instance::PostCallRecordCreateImagePipeSurfaceFUCHSIA(VkInstance 
 void bp_state::Instance::PostCallRecordCreateMetalSurfaceEXT(VkInstance instance, const VkMetalSurfaceCreateInfoEXT* pCreateInfo,
                                                              const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                              const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateMetalSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface, record_obj);
     bp_state::LogResult(*this, instance, record_obj);
 }
 #endif  // VK_USE_PLATFORM_METAL_EXT
@@ -1710,16 +1491,12 @@ void bp_state::Instance::PostCallRecordGetPhysicalDeviceCooperativeMatrixPropert
                                                                                       uint32_t* pPropertyCount,
                                                                                       VkCooperativeMatrixPropertiesNV* pProperties,
                                                                                       const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPhysicalDeviceCooperativeMatrixPropertiesNV(physicalDevice, pPropertyCount, pProperties,
-                                                                            record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
 void bp_state::Instance::PostCallRecordGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(
     VkPhysicalDevice physicalDevice, uint32_t* pCombinationCount, VkFramebufferMixedSamplesCombinationNV* pCombinations,
     const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(physicalDevice, pCombinationCount,
-                                                                                             pCombinations, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
@@ -1729,20 +1506,16 @@ void bp_state::Instance::PostCallRecordGetPhysicalDeviceSurfacePresentModes2EXT(
                                                                                 uint32_t* pPresentModeCount,
                                                                                 VkPresentModeKHR* pPresentModes,
                                                                                 const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPhysicalDeviceSurfacePresentModes2EXT(physicalDevice, pSurfaceInfo, pPresentModeCount,
-                                                                      pPresentModes, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
 void BestPractices::PostCallRecordAcquireFullScreenExclusiveModeEXT(VkDevice device, VkSwapchainKHR swapchain,
                                                                     const RecordObject& record_obj) {
-    BaseClass::PostCallRecordAcquireFullScreenExclusiveModeEXT(device, swapchain, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordReleaseFullScreenExclusiveModeEXT(VkDevice device, VkSwapchainKHR swapchain,
                                                                     const RecordObject& record_obj) {
-    BaseClass::PostCallRecordReleaseFullScreenExclusiveModeEXT(device, swapchain, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -1750,7 +1523,6 @@ void BestPractices::PostCallRecordGetDeviceGroupSurfacePresentModes2EXT(VkDevice
                                                                         const VkPhysicalDeviceSurfaceInfo2KHR* pSurfaceInfo,
                                                                         VkDeviceGroupPresentModeFlagsKHR* pModes,
                                                                         const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetDeviceGroupSurfacePresentModes2EXT(device, pSurfaceInfo, pModes, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 #endif  // VK_USE_PLATFORM_WIN32_KHR
@@ -1759,7 +1531,6 @@ void bp_state::Instance::PostCallRecordCreateHeadlessSurfaceEXT(VkInstance insta
                                                                 const VkHeadlessSurfaceCreateInfoEXT* pCreateInfo,
                                                                 const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                                 const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateHeadlessSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface, record_obj);
     bp_state::LogResult(*this, instance, record_obj);
 }
 
@@ -1786,7 +1557,6 @@ void BestPractices::PostCallRecordTransitionImageLayoutEXT(VkDevice device, uint
 
 void BestPractices::PostCallRecordReleaseSwapchainImagesEXT(VkDevice device, const VkReleaseSwapchainImagesInfoEXT* pReleaseInfo,
                                                             const RecordObject& record_obj) {
-    BaseClass::PostCallRecordReleaseSwapchainImagesEXT(device, pReleaseInfo, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -1795,19 +1565,16 @@ void BestPractices::PostCallRecordCreateIndirectCommandsLayoutNV(VkDevice device
                                                                  const VkAllocationCallbacks* pAllocator,
                                                                  VkIndirectCommandsLayoutNV* pIndirectCommandsLayout,
                                                                  const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateIndirectCommandsLayoutNV(device, pCreateInfo, pAllocator, pIndirectCommandsLayout, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void bp_state::Instance::PostCallRecordAcquireDrmDisplayEXT(VkPhysicalDevice physicalDevice, int32_t drmFd, VkDisplayKHR display,
                                                             const RecordObject& record_obj) {
-    BaseClass::PostCallRecordAcquireDrmDisplayEXT(physicalDevice, drmFd, display, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
 void bp_state::Instance::PostCallRecordGetDrmDisplayEXT(VkPhysicalDevice physicalDevice, int32_t drmFd, uint32_t connectorId,
                                                         VkDisplayKHR* display, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetDrmDisplayEXT(physicalDevice, drmFd, connectorId, display, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
@@ -1827,20 +1594,17 @@ void BestPractices::PostCallRecordSetPrivateDataEXT(VkDevice device, VkObjectTyp
 void BestPractices::PostCallRecordCreateCudaModuleNV(VkDevice device, const VkCudaModuleCreateInfoNV* pCreateInfo,
                                                      const VkAllocationCallbacks* pAllocator, VkCudaModuleNV* pModule,
                                                      const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateCudaModuleNV(device, pCreateInfo, pAllocator, pModule, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetCudaModuleCacheNV(VkDevice device, VkCudaModuleNV module, size_t* pCacheSize, void* pCacheData,
                                                        const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetCudaModuleCacheNV(device, module, pCacheSize, pCacheData, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordCreateCudaFunctionNV(VkDevice device, const VkCudaFunctionCreateInfoNV* pCreateInfo,
                                                        const VkAllocationCallbacks* pAllocator, VkCudaFunctionNV* pFunction,
                                                        const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateCudaFunctionNV(device, pCreateInfo, pAllocator, pFunction, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 #endif  // VK_ENABLE_BETA_EXTENSIONS
@@ -1848,54 +1612,46 @@ void BestPractices::PostCallRecordCreateCudaFunctionNV(VkDevice device, const Vk
 void BestPractices::PostCallRecordGetBufferOpaqueCaptureDescriptorDataEXT(VkDevice device,
                                                                           const VkBufferCaptureDescriptorDataInfoEXT* pInfo,
                                                                           void* pData, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetBufferOpaqueCaptureDescriptorDataEXT(device, pInfo, pData, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetImageOpaqueCaptureDescriptorDataEXT(VkDevice device,
                                                                          const VkImageCaptureDescriptorDataInfoEXT* pInfo,
                                                                          void* pData, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetImageOpaqueCaptureDescriptorDataEXT(device, pInfo, pData, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetImageViewOpaqueCaptureDescriptorDataEXT(VkDevice device,
                                                                              const VkImageViewCaptureDescriptorDataInfoEXT* pInfo,
                                                                              void* pData, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetImageViewOpaqueCaptureDescriptorDataEXT(device, pInfo, pData, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetSamplerOpaqueCaptureDescriptorDataEXT(VkDevice device,
                                                                            const VkSamplerCaptureDescriptorDataInfoEXT* pInfo,
                                                                            void* pData, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetSamplerOpaqueCaptureDescriptorDataEXT(device, pInfo, pData, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetAccelerationStructureOpaqueCaptureDescriptorDataEXT(
     VkDevice device, const VkAccelerationStructureCaptureDescriptorDataInfoEXT* pInfo, void* pData,
     const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetAccelerationStructureOpaqueCaptureDescriptorDataEXT(device, pInfo, pData, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetDeviceFaultInfoEXT(VkDevice device, VkDeviceFaultCountsEXT* pFaultCounts,
                                                         VkDeviceFaultInfoEXT* pFaultInfo, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetDeviceFaultInfoEXT(device, pFaultCounts, pFaultInfo, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 void bp_state::Instance::PostCallRecordAcquireWinrtDisplayNV(VkPhysicalDevice physicalDevice, VkDisplayKHR display,
                                                              const RecordObject& record_obj) {
-    BaseClass::PostCallRecordAcquireWinrtDisplayNV(physicalDevice, display, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
 void bp_state::Instance::PostCallRecordGetWinrtDisplayNV(VkPhysicalDevice physicalDevice, uint32_t deviceRelativeId,
                                                          VkDisplayKHR* pDisplay, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 #endif  // VK_USE_PLATFORM_WIN32_KHR
@@ -1905,7 +1661,6 @@ void bp_state::Instance::PostCallRecordCreateDirectFBSurfaceEXT(VkInstance insta
                                                                 const VkDirectFBSurfaceCreateInfoEXT* pCreateInfo,
                                                                 const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                                 const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateDirectFBSurfaceEXT(instance, pCreateInfo, pAllocator, pSurface, record_obj);
     bp_state::LogResult(*this, instance, record_obj);
 }
 #endif  // VK_USE_PLATFORM_DIRECTFB_EXT
@@ -1914,29 +1669,24 @@ void bp_state::Instance::PostCallRecordCreateDirectFBSurfaceEXT(VkInstance insta
 void BestPractices::PostCallRecordGetMemoryZirconHandleFUCHSIA(VkDevice device,
                                                                const VkMemoryGetZirconHandleInfoFUCHSIA* pGetZirconHandleInfo,
                                                                zx_handle_t* pZirconHandle, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetMemoryZirconHandleFUCHSIA(device, pGetZirconHandleInfo, pZirconHandle, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetMemoryZirconHandlePropertiesFUCHSIA(
     VkDevice device, VkExternalMemoryHandleTypeFlagBits handleType, zx_handle_t zirconHandle,
     VkMemoryZirconHandlePropertiesFUCHSIA* pMemoryZirconHandleProperties, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetMemoryZirconHandlePropertiesFUCHSIA(device, handleType, zirconHandle, pMemoryZirconHandleProperties,
-                                                                    record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordImportSemaphoreZirconHandleFUCHSIA(
     VkDevice device, const VkImportSemaphoreZirconHandleInfoFUCHSIA* pImportSemaphoreZirconHandleInfo,
     const RecordObject& record_obj) {
-    BaseClass::PostCallRecordImportSemaphoreZirconHandleFUCHSIA(device, pImportSemaphoreZirconHandleInfo, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetSemaphoreZirconHandleFUCHSIA(VkDevice device,
                                                                   const VkSemaphoreGetZirconHandleInfoFUCHSIA* pGetZirconHandleInfo,
                                                                   zx_handle_t* pZirconHandle, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetSemaphoreZirconHandleFUCHSIA(device, pGetZirconHandleInfo, pZirconHandle, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -1945,28 +1695,24 @@ void BestPractices::PostCallRecordCreateBufferCollectionFUCHSIA(VkDevice device,
                                                                 const VkAllocationCallbacks* pAllocator,
                                                                 VkBufferCollectionFUCHSIA* pCollection,
                                                                 const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateBufferCollectionFUCHSIA(device, pCreateInfo, pAllocator, pCollection, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordSetBufferCollectionImageConstraintsFUCHSIA(
     VkDevice device, VkBufferCollectionFUCHSIA collection, const VkImageConstraintsInfoFUCHSIA* pImageConstraintsInfo,
     const RecordObject& record_obj) {
-    BaseClass::PostCallRecordSetBufferCollectionImageConstraintsFUCHSIA(device, collection, pImageConstraintsInfo, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordSetBufferCollectionBufferConstraintsFUCHSIA(
     VkDevice device, VkBufferCollectionFUCHSIA collection, const VkBufferConstraintsInfoFUCHSIA* pBufferConstraintsInfo,
     const RecordObject& record_obj) {
-    BaseClass::PostCallRecordSetBufferCollectionBufferConstraintsFUCHSIA(device, collection, pBufferConstraintsInfo, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetBufferCollectionPropertiesFUCHSIA(VkDevice device, VkBufferCollectionFUCHSIA collection,
                                                                        VkBufferCollectionPropertiesFUCHSIA* pProperties,
                                                                        const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetBufferCollectionPropertiesFUCHSIA(device, collection, pProperties, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 #endif  // VK_USE_PLATFORM_FUCHSIA
@@ -1974,21 +1720,18 @@ void BestPractices::PostCallRecordGetBufferCollectionPropertiesFUCHSIA(VkDevice 
 void BestPractices::PostCallRecordGetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI(VkDevice device, VkRenderPass renderpass,
                                                                                 VkExtent2D* pMaxWorkgroupSize,
                                                                                 const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI(device, renderpass, pMaxWorkgroupSize, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetMemoryRemoteAddressNV(VkDevice device,
                                                            const VkMemoryGetRemoteAddressInfoNV* pMemoryGetRemoteAddressInfo,
                                                            VkRemoteAddressNV* pAddress, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetMemoryRemoteAddressNV(device, pMemoryGetRemoteAddressInfo, pAddress, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetPipelinePropertiesEXT(VkDevice device, const VkPipelineInfoEXT* pPipelineInfo,
                                                            VkBaseOutStructure* pPipelineProperties,
                                                            const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPipelinePropertiesEXT(device, pPipelineInfo, pPipelineProperties, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -1996,7 +1739,6 @@ void BestPractices::PostCallRecordGetPipelinePropertiesEXT(VkDevice device, cons
 void bp_state::Instance::PostCallRecordCreateScreenSurfaceQNX(VkInstance instance, const VkScreenSurfaceCreateInfoQNX* pCreateInfo,
                                                               const VkAllocationCallbacks* pAllocator, VkSurfaceKHR* pSurface,
                                                               const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateScreenSurfaceQNX(instance, pCreateInfo, pAllocator, pSurface, record_obj);
     bp_state::LogResult(*this, instance, record_obj);
 }
 #endif  // VK_USE_PLATFORM_SCREEN_QNX
@@ -2004,33 +1746,28 @@ void bp_state::Instance::PostCallRecordCreateScreenSurfaceQNX(VkInstance instanc
 void BestPractices::PostCallRecordCreateMicromapEXT(VkDevice device, const VkMicromapCreateInfoEXT* pCreateInfo,
                                                     const VkAllocationCallbacks* pAllocator, VkMicromapEXT* pMicromap,
                                                     const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateMicromapEXT(device, pCreateInfo, pAllocator, pMicromap, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordBuildMicromapsEXT(VkDevice device, VkDeferredOperationKHR deferredOperation, uint32_t infoCount,
                                                     const VkMicromapBuildInfoEXT* pInfos, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordBuildMicromapsEXT(device, deferredOperation, infoCount, pInfos, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordCopyMicromapEXT(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                   const VkCopyMicromapInfoEXT* pInfo, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCopyMicromapEXT(device, deferredOperation, pInfo, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordCopyMicromapToMemoryEXT(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                           const VkCopyMicromapToMemoryInfoEXT* pInfo,
                                                           const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCopyMicromapToMemoryEXT(device, deferredOperation, pInfo, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordCopyMemoryToMicromapEXT(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                           const VkCopyMemoryToMicromapInfoEXT* pInfo,
                                                           const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCopyMemoryToMicromapEXT(device, deferredOperation, pInfo, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -2038,30 +1775,24 @@ void BestPractices::PostCallRecordWriteMicromapsPropertiesEXT(VkDevice device, u
                                                               const VkMicromapEXT* pMicromaps, VkQueryType queryType,
                                                               size_t dataSize, void* pData, size_t stride,
                                                               const RecordObject& record_obj) {
-    BaseClass::PostCallRecordWriteMicromapsPropertiesEXT(device, micromapCount, pMicromaps, queryType, dataSize, pData, stride,
-                                                         record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void bp_state::Instance::PostCallRecordGetPhysicalDeviceOpticalFlowImageFormatsNV(
     VkPhysicalDevice physicalDevice, const VkOpticalFlowImageFormatInfoNV* pOpticalFlowImageFormatInfo, uint32_t* pFormatCount,
     VkOpticalFlowImageFormatPropertiesNV* pImageFormatProperties, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPhysicalDeviceOpticalFlowImageFormatsNV(physicalDevice, pOpticalFlowImageFormatInfo, pFormatCount,
-                                                                        pImageFormatProperties, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
 void BestPractices::PostCallRecordCreateOpticalFlowSessionNV(VkDevice device, const VkOpticalFlowSessionCreateInfoNV* pCreateInfo,
                                                              const VkAllocationCallbacks* pAllocator,
                                                              VkOpticalFlowSessionNV* pSession, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateOpticalFlowSessionNV(device, pCreateInfo, pAllocator, pSession, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordBindOpticalFlowSessionImageNV(VkDevice device, VkOpticalFlowSessionNV session,
                                                                 VkOpticalFlowSessionBindingPointNV bindingPoint, VkImageView view,
                                                                 VkImageLayout layout, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordBindOpticalFlowSessionImageNV(device, session, bindingPoint, view, layout, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -2069,21 +1800,17 @@ void BestPractices::PostCallRecordCreateShadersEXT(VkDevice device, uint32_t cre
                                                    const VkShaderCreateInfoEXT* pCreateInfos,
                                                    const VkAllocationCallbacks* pAllocator, VkShaderEXT* pShaders,
                                                    const RecordObject& record_obj, chassis::ShaderObject& chassis_state) {
-    BaseClass::PostCallRecordCreateShadersEXT(device, createInfoCount, pCreateInfos, pAllocator, pShaders, record_obj,
-                                              chassis_state);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetShaderBinaryDataEXT(VkDevice device, VkShaderEXT shader, size_t* pDataSize, void* pData,
                                                          const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetShaderBinaryDataEXT(device, shader, pDataSize, pData, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordGetFramebufferTilePropertiesQCOM(VkDevice device, VkFramebuffer framebuffer,
                                                                    uint32_t* pPropertiesCount, VkTilePropertiesQCOM* pProperties,
                                                                    const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetFramebufferTilePropertiesQCOM(device, framebuffer, pPropertiesCount, pProperties, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -2091,22 +1818,18 @@ void bp_state::Instance::PostCallRecordGetPhysicalDeviceCooperativeVectorPropert
                                                                                       uint32_t* pPropertyCount,
                                                                                       VkCooperativeVectorPropertiesNV* pProperties,
                                                                                       const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPhysicalDeviceCooperativeVectorPropertiesNV(physicalDevice, pPropertyCount, pProperties,
-                                                                            record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
 void BestPractices::PostCallRecordConvertCooperativeVectorMatrixNV(VkDevice device,
                                                                    const VkConvertCooperativeVectorMatrixInfoNV* pInfo,
                                                                    const RecordObject& record_obj) {
-    BaseClass::PostCallRecordConvertCooperativeVectorMatrixNV(device, pInfo, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordSetLatencySleepModeNV(VkDevice device, VkSwapchainKHR swapchain,
                                                         const VkLatencySleepModeInfoNV* pSleepModeInfo,
                                                         const RecordObject& record_obj) {
-    BaseClass::PostCallRecordSetLatencySleepModeNV(device, swapchain, pSleepModeInfo, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -2114,7 +1837,6 @@ void BestPractices::PostCallRecordSetLatencySleepModeNV(VkDevice device, VkSwapc
 void BestPractices::PostCallRecordGetScreenBufferPropertiesQNX(VkDevice device, const struct _screen_buffer* buffer,
                                                                VkScreenBufferPropertiesQNX* pProperties,
                                                                const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetScreenBufferPropertiesQNX(device, buffer, pProperties, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 #endif  // VK_USE_PLATFORM_SCREEN_QNX
@@ -2124,7 +1846,6 @@ void BestPractices::PostCallRecordCreateExternalComputeQueueNV(VkDevice device,
                                                                const VkAllocationCallbacks* pAllocator,
                                                                VkExternalComputeQueueNV* pExternalQueue,
                                                                const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateExternalComputeQueueNV(device, pCreateInfo, pAllocator, pExternalQueue, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -2133,7 +1854,6 @@ void BestPractices::PostCallRecordCreateIndirectCommandsLayoutEXT(VkDevice devic
                                                                   const VkAllocationCallbacks* pAllocator,
                                                                   VkIndirectCommandsLayoutEXT* pIndirectCommandsLayout,
                                                                   const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateIndirectCommandsLayoutEXT(device, pCreateInfo, pAllocator, pIndirectCommandsLayout, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -2142,22 +1862,18 @@ void BestPractices::PostCallRecordCreateIndirectExecutionSetEXT(VkDevice device,
                                                                 const VkAllocationCallbacks* pAllocator,
                                                                 VkIndirectExecutionSetEXT* pIndirectExecutionSet,
                                                                 const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateIndirectExecutionSetEXT(device, pCreateInfo, pAllocator, pIndirectExecutionSet, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void bp_state::Instance::PostCallRecordGetPhysicalDeviceCooperativeMatrixFlexibleDimensionsPropertiesNV(
     VkPhysicalDevice physicalDevice, uint32_t* pPropertyCount, VkCooperativeMatrixFlexibleDimensionsPropertiesNV* pProperties,
     const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetPhysicalDeviceCooperativeMatrixFlexibleDimensionsPropertiesNV(physicalDevice, pPropertyCount,
-                                                                                              pProperties, record_obj);
     bp_state::LogResult(*this, physicalDevice, record_obj);
 }
 
 #ifdef VK_USE_PLATFORM_METAL_EXT
 void BestPractices::PostCallRecordGetMemoryMetalHandleEXT(VkDevice device, const VkMemoryGetMetalHandleInfoEXT* pGetMetalHandleInfo,
                                                           void** pHandle, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetMemoryMetalHandleEXT(device, pGetMetalHandleInfo, pHandle, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -2165,8 +1881,6 @@ void BestPractices::PostCallRecordGetMemoryMetalHandlePropertiesEXT(VkDevice dev
                                                                     const void* pHandle,
                                                                     VkMemoryMetalHandlePropertiesEXT* pMemoryMetalHandleProperties,
                                                                     const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetMemoryMetalHandlePropertiesEXT(device, handleType, pHandle, pMemoryMetalHandleProperties,
-                                                               record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 #endif  // VK_USE_PLATFORM_METAL_EXT
@@ -2176,7 +1890,6 @@ void BestPractices::PostCallRecordCreateAccelerationStructureKHR(VkDevice device
                                                                  const VkAllocationCallbacks* pAllocator,
                                                                  VkAccelerationStructureKHR* pAccelerationStructure,
                                                                  const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCreateAccelerationStructureKHR(device, pCreateInfo, pAllocator, pAccelerationStructure, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -2184,37 +1897,30 @@ void BestPractices::PostCallRecordBuildAccelerationStructuresKHR(
     VkDevice device, VkDeferredOperationKHR deferredOperation, uint32_t infoCount,
     const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
     const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordBuildAccelerationStructuresKHR(device, deferredOperation, infoCount, pInfos, ppBuildRangeInfos,
-                                                            record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordCopyAccelerationStructureKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                                const VkCopyAccelerationStructureInfoKHR* pInfo,
                                                                const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCopyAccelerationStructureKHR(device, deferredOperation, pInfo, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordCopyAccelerationStructureToMemoryKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                                        const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo,
                                                                        const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCopyAccelerationStructureToMemoryKHR(device, deferredOperation, pInfo, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordCopyMemoryToAccelerationStructureKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                                        const VkCopyMemoryToAccelerationStructureInfoKHR* pInfo,
                                                                        const RecordObject& record_obj) {
-    BaseClass::PostCallRecordCopyMemoryToAccelerationStructureKHR(device, deferredOperation, pInfo, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
 void BestPractices::PostCallRecordWriteAccelerationStructuresPropertiesKHR(
     VkDevice device, uint32_t accelerationStructureCount, const VkAccelerationStructureKHR* pAccelerationStructures,
     VkQueryType queryType, size_t dataSize, void* pData, size_t stride, const RecordObject& record_obj) {
-    BaseClass::PostCallRecordWriteAccelerationStructuresPropertiesKHR(device, accelerationStructureCount, pAccelerationStructures,
-                                                                      queryType, dataSize, pData, stride, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -2223,8 +1929,6 @@ void BestPractices::PostCallRecordCreateRayTracingPipelinesKHR(
     const VkRayTracingPipelineCreateInfoKHR* pCreateInfos, const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
     const RecordObject& record_obj, PipelineStates& pipeline_states,
     std::shared_ptr<chassis::CreateRayTracingPipelinesKHR> chassis_state) {
-    BaseClass::PostCallRecordCreateRayTracingPipelinesKHR(device, deferredOperation, pipelineCache, createInfoCount, pCreateInfos,
-                                                          pAllocator, pPipelines, record_obj, pipeline_states, chassis_state);
     bp_state::LogResult(*this, device, record_obj);
 }
 
@@ -2232,8 +1936,6 @@ void BestPractices::PostCallRecordGetRayTracingCaptureReplayShaderGroupHandlesKH
                                                                                   uint32_t firstGroup, uint32_t groupCount,
                                                                                   size_t dataSize, void* pData,
                                                                                   const RecordObject& record_obj) {
-    BaseClass::PostCallRecordGetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize,
-                                                                             pData, record_obj);
     bp_state::LogResult(*this, device, record_obj);
 }
 

--- a/scripts/generators/best_practices_generator.py
+++ b/scripts/generators/best_practices_generator.py
@@ -216,7 +216,6 @@ class BestPracticesOutputGenerator(BaseGenerator):
                 params = ', '.join(paramList)
                 out.append(f'PostCallRecord{command.alias[2:]}({params});')
             else:
-                out.append(f'BaseClass::PostCallRecord{command.name[2:]}({params});\n')
                 if command.name in self.manual_postcallrecord_list:
                     out.append(f'ManualPostCallRecord{command.name[2:]}({params});\n')
 


### PR DESCRIPTION
The new order of how things run in the chassis is

- Pre Call LayerObjectTypeStateTracker
- Pre Call CoreCheck
- Pre Call Bp/SyncVal/GPU-AV
- Dispatch
- Post Call LayerObjectTypeStateTracker
- Post Call CoreCheck
- Post Call Bp/SyncVal/GPU-AV

This means `BaseClass::PreCallRecord` is just going to redo work (worst case be a bug)

Just simply removed them all 