### PR TITLE
tests: Fix testing 02722

### DIFF
--- a/tests/unit/pipeline.cpp
+++ b/tests/unit/pipeline.cpp
@@ -1402,7 +1402,7 @@ TEST_F(NegativePipeline, FramebufferMixedSamplesCoverageReduction) {
                     bool combination_found = false;
                     for (const auto &combination : combinations) {
                         if (mode == combination.coverageReductionMode && rs == combination.rasterizationSamples &&
-                            ds & combination.depthStencilSamples && cs & combination.colorSamples) {
+                            (ds & combination.depthStencilSamples || ds == 0) && (cs & combination.colorSamples || cs == 0)) {
                             combination_found = true;
                             break;
                         }


### PR DESCRIPTION
The issue was for example if `ds` is `0`, then the check `ds & combination.depthStencilSamples` will be `0 & 0`, which will return false, but this should count as combination found.