### PR TITLE
layers: Cleanup ImageLayoutRegistry::LayoutEntry

### DIFF
--- a/layers/containers/range.h
+++ b/layers/containers/range.h
@@ -64,7 +64,7 @@ struct range {
         bool result = false;
         if (invalid()) {
             // all invalid < valid, allows map/set validity check by looking at begin()->first
-            // all invalid are equal, thus only equal if this is invalid and rhs is valid
+            // all invalid are equal, thus only less if this is invalid and rhs is valid
             result = rhs.valid();
         } else if (begin < rhs.begin) {
             result = true;

--- a/layers/containers/subresource_adapter.h
+++ b/layers/containers/subresource_adapter.h
@@ -35,7 +35,7 @@ class Image;
 namespace subresource_adapter {
 
 class RangeEncoder;
-using IndexType = uint64_t;
+using IndexType = uint64_t;  // TODO: just update to 32 bit, but before collect memory usage stats, perf stats
 using IndexRange = vvl::range<IndexType>;
 using WritePolicy = sparse_container::value_precedence;
 using split_op_keep_both = sparse_container::split_op_keep_both;

--- a/layers/core_checks/cc_image_layout.cpp
+++ b/layers/core_checks/cc_image_layout.cpp
@@ -58,9 +58,9 @@ struct LayoutUseCheckAndMessage {
             }
         } else if (layout_entry.initial_layout != kInvalidLayout) {
             if (!ImageLayoutMatches(aspect_mask, expected_layout, layout_entry.initial_layout)) {
-                assert(layout_entry.state);  // If we have an initial layout, we better have a state for it
-                if (!((layout_entry.state->aspect_mask & kDepthOrStencil) &&
-                      ImageLayoutMatches(layout_entry.state->aspect_mask, expected_layout, layout_entry.initial_layout))) {
+                assert(layout_entry.aspect_mask.has_value());  // If we have an initial layout, we better have a state for it
+                if (!((*layout_entry.aspect_mask & kDepthOrStencil) &&
+                      ImageLayoutMatches(*layout_entry.aspect_mask, expected_layout, layout_entry.initial_layout))) {
                     message = "previously used";
                     layout = layout_entry.initial_layout;
                 }

--- a/layers/gpuav/descriptor_validation/gpuav_image_layout.cpp
+++ b/layers/gpuav/descriptor_validation/gpuav_image_layout.cpp
@@ -50,9 +50,9 @@ struct LayoutUseCheckAndMessage {
             }
         } else if (layout_entry.initial_layout != kInvalidLayout) {
             if (!ImageLayoutMatches(aspect_mask, expected_layout, layout_entry.initial_layout)) {
-                assert(layout_entry.state);  // If we have an initial layout, we better have a state for it
-                if (!((layout_entry.state->aspect_mask & kDepthOrStencil) &&
-                      ImageLayoutMatches(layout_entry.state->aspect_mask, expected_layout, layout_entry.initial_layout))) {
+                assert(layout_entry.aspect_mask.has_value());  // If we have an initial layout, we better have a state for it
+                if (!((*layout_entry.aspect_mask & kDepthOrStencil) &&
+                      ImageLayoutMatches(*layout_entry.aspect_mask, expected_layout, layout_entry.initial_layout))) {
                     message = "previously used";
                     layout = layout_entry.initial_layout;
                 }


### PR DESCRIPTION
In `InitialLayoutState` only aspect mask member was used. Then remove `InitialLayoutState` altogether and store aspect mask directly inside `LayoutEntry`. For now, it's std::optional to have the same semantics as previous implementation (could be a null pointer), but initial testing shows it should be possible to just use regular field (need to update logic accordingly).

Also removes any possibility to access dangling pointers mentioned here: https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/9992