### PR TITLE
layers: Combine vvl::AllocateDescriptorSetsData

### DIFF
--- a/layers/best_practices/bp_descriptor.cpp
+++ b/layers/best_practices/bp_descriptor.cpp
@@ -24,9 +24,6 @@ bool BestPractices::PreCallValidateAllocateDescriptorSets(VkDevice device, const
                                                           VkDescriptorSet* pDescriptorSets, const ErrorObject& error_obj,
                                                           vvl::AllocateDescriptorSetsData& ads_state_data) const {
     bool skip = false;
-    skip |= BaseClass::PreCallValidateAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets, error_obj, ads_state_data);
-    if (skip) return skip;
-
     const auto pool_state = Get<vvl::DescriptorPool>(pAllocateInfo->descriptorPool);
     ASSERT_AND_RETURN_SKIP(pool_state);
 

--- a/layers/chassis/chassis_manual.cpp
+++ b/layers/chassis/chassis_manual.cpp
@@ -958,6 +958,9 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateDescriptorSets(VkDevice device, const VkD
     bool skip = false;
     ErrorObject error_obj(vvl::Func::vkAllocateDescriptorSets, VulkanTypedHandle(device, kVulkanObjectTypeDevice));
 
+    // Because this is a high frequency function call and want to save time and populate this struct once.
+    // Both CoreCheck and Best Practice need this information during PreCallValidate time.
+    // During State Tracker PreCallValidate (instead of PreCallRecord), we populate this so that everyone else can use it.
     vvl::AllocateDescriptorSetsData ads_state;
 
     {
@@ -966,7 +969,6 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateDescriptorSets(VkDevice device, const VkD
             if (!vo) {
                 continue;
             }
-            ads_state.Init(pAllocateInfo->descriptorSetCount);
             auto lock = vo->ReadLock();
             skip |= vo->PreCallValidateAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets, error_obj, ads_state);
             if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -3334,8 +3334,6 @@ bool CoreChecks::PreCallValidateDestroyDescriptorPool(VkDevice device, VkDescrip
 bool CoreChecks::PreCallValidateAllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo *pAllocateInfo,
                                                        VkDescriptorSet *pDescriptorSets, const ErrorObject &error_obj,
                                                        vvl::AllocateDescriptorSetsData &ds_data) const {
-    BaseClass::PreCallValidateAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets, error_obj, ds_data);
-
     bool skip = false;
     auto ds_pool_state = Get<vvl::DescriptorPool>(pAllocateInfo->descriptorPool);
     ASSERT_AND_RETURN_SKIP(ds_pool_state);

--- a/layers/state_tracker/descriptor_sets.cpp
+++ b/layers/state_tracker/descriptor_sets.cpp
@@ -480,8 +480,6 @@ vvl::DescriptorSetLayout::DescriptorSetLayout(const VkDescriptorSetLayoutCreateI
                                               const VkDescriptorSetLayout handle)
     : StateObject(handle, kVulkanObjectTypeDescriptorSetLayout), layout_id_(GetCanonicalId(pCreateInfo)) {}
 
-void vvl::AllocateDescriptorSetsData::Init(uint32_t count) { layout_nodes.resize(count); }
-
 vvl::DescriptorSet::DescriptorSet(const VkDescriptorSet handle, vvl::DescriptorPool *pool_state,
                                   const std::shared_ptr<DescriptorSetLayout const> &layout, uint32_t variable_count,
                                   vvl::DeviceState *state_data)

--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -671,13 +671,12 @@ class MutableDescriptor : public Descriptor {
     std::shared_ptr<vvl::AccelerationStructureNV> acc_state_nv_;
 };
 
-// Structs to contain common elements that need to be shared between Validate* and Perform* calls below
+// We will want to build this map and list of layouts once in order to record in the state tracker at PostCallRecord time.
 struct AllocateDescriptorSetsData {
     std::map<uint32_t, uint32_t> required_descriptors_by_type;
     std::vector<std::shared_ptr<DescriptorSetLayout const>> layout_nodes;
-    void Init(uint32_t);
-    AllocateDescriptorSetsData(){};
 };
+
 // "Perform" does the update with the assumption that ValidateUpdateDescriptorSets() has passed for the given update
 void PerformUpdateDescriptorSets(DeviceState &, uint32_t, const VkWriteDescriptorSet *, uint32_t, const VkCopyDescriptorSet *);
 

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -1629,7 +1629,6 @@ class DeviceState : public vvl::base::Device {
     void RecordMappedMemory(VkDeviceMemory mem, VkDeviceSize offset, VkDeviceSize size, void** ppData);
     void UpdateBindBufferMemoryState(const VkBindBufferMemoryInfo& bind_info);
     void UpdateBindImageMemoryState(const VkBindImageMemoryInfo& bind_info);
-    void UpdateAllocateDescriptorSetsData(const VkDescriptorSetAllocateInfo*, vvl::AllocateDescriptorSetsData&) const;
 
     void PostCallRecordCopyAccelerationStructureKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                     const VkCopyAccelerationStructureInfoKHR* pInfo,


### PR DESCRIPTION
Noticed we still have `BaseClass::PreCallValidate` for `vkAllocateDescriptorSets` but don't need it anymore

The order is

- Pre Call Validate | State Tracker | Populates `vvl::AllocateDescriptorSetsData`
- Pre Call Validate | Core Checks  | uses `vvl::AllocateDescriptorSetsData`
- Pre Call Record ... nothing
- Dispatch
- Post Call Record | State Tracker | uses `vvl::AllocateDescriptorSetsData` to create `vvl::DescriptorSet`