### PR TITLE
layers: Add top/bottom  to the list of graphics meta stages

### DIFF
--- a/layers/stateless/sl_render_pass.cpp
+++ b/layers/stateless/sl_render_pass.cpp
@@ -30,9 +30,11 @@ bool Device::ValidateSubpassGraphicsFlags(VkDevice device, const VkRenderPassCre
                                 VK_PIPELINE_STAGE_2_RESOLVE_BIT | VK_PIPELINE_STAGE_2_BLIT_BIT | VK_PIPELINE_STAGE_2_CLEAR_BIT;
     const auto kMetaGraphicsStages = VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT | VK_PIPELINE_STAGE_2_VERTEX_INPUT_BIT |
                                      VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT |
-                                     // ALL_COMMANDS means only graphics in graphics only context
+                                     // ALL_COMMANDS means only graphics in graphics only context,
+                                     // TOP_OF_PIPE/BOTTOM_OF_PIPE are also always valid
                                      // https://gitlab.khronos.org/vulkan/vulkan/-/issues/4257
-                                     VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
+                                     VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT | VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT |
+                                     VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT;
     const auto kGraphicsStages =
         (sync_utils::ExpandPipelineStages(VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, VK_QUEUE_GRAPHICS_BIT) | kMetaGraphicsStages) &
         ~kExcludeStages;

--- a/tests/unit/subpass_positive.cpp
+++ b/tests/unit/subpass_positive.cpp
@@ -267,3 +267,37 @@ TEST_F(PositiveSubpass, AllCommandsInSubpassDependency) {
     rp.AddSubpassDependency(subpass_dep);
     rp.CreateRenderPass();
 }
+
+TEST_F(PositiveSubpass, TopOfPipeInSubpassDependency) {
+    TEST_DESCRIPTION("Test TOP_OF_PIPE is allowed in subpass dependency");
+    RETURN_IF_SKIP(Init());
+
+    VkSubpassDependency subpass_dep{};
+    subpass_dep.srcSubpass = VK_SUBPASS_EXTERNAL;
+    subpass_dep.dstSubpass = 0;
+    subpass_dep.srcStageMask = VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
+    subpass_dep.dstStageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;  // Here!
+    subpass_dep.srcAccessMask = VK_ACCESS_NONE;
+    subpass_dep.dstAccessMask = VK_ACCESS_NONE;
+
+    RenderPassSingleSubpass rp(*this);
+    rp.AddSubpassDependency(subpass_dep);
+    rp.CreateRenderPass();
+}
+
+TEST_F(PositiveSubpass, BottomOfPipeInSubpassDependency) {
+    TEST_DESCRIPTION("Test BOTTOM_OF_PIPE is allowed in subpass dependency");
+    RETURN_IF_SKIP(Init());
+
+    VkSubpassDependency subpass_dep{};
+    subpass_dep.srcSubpass = 0;
+    subpass_dep.dstSubpass = VK_SUBPASS_EXTERNAL;
+    subpass_dep.srcStageMask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;  // Here!
+    subpass_dep.dstStageMask = VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
+    subpass_dep.srcAccessMask = VK_ACCESS_NONE;
+    subpass_dep.dstAccessMask = VK_ACCESS_NONE;
+
+    RenderPassSingleSubpass rp(*this);
+    rp.AddSubpassDependency(subpass_dep);
+    rp.CreateRenderPass();
+}


### PR DESCRIPTION
Update related to confirmation that TOP/BOTTOM are valid in subpass 
dependencies: https://gitlab.khronos.org/vulkan/vulkan/-/issues/4257#note_530233

So far it worked correctly even without this change because generated
code lists top/bottom meta stages for graphics pipe and
`syncAllCommandStagesByQueueFlags()` returns them. That probably will
change in the future and generated code will report only atomic stages. 
So changed code with that assusmption and added regression tests.

Also top/bottom are deprecated so their usage will be minimized in the
internal details and only added explicitly when it's necessary, similar
to how it's done in this PR.
