### PR TITLE
gpuav: Reduce post-dominated instructions for PostProcessing

### DIFF
--- a/layers/gpuav/spirv/function_basic_block.h
+++ b/layers/gpuav/spirv/function_basic_block.h
@@ -62,6 +62,13 @@ struct BasicBlock {
     // For blocks that are a Loop hader, points to the Merge Target
     uint32_t loop_header_merge_target_ = 0;
     bool IsLoopHeader() const { return loop_header_merge_target_ != 0; }
+
+    // If block terminates with OpBranchConditional/OpSwtich, mark the ID they point to
+    uint32_t selection_merge_target_ = 0;
+    uint32_t branch_conditional_true_ = 0;
+    uint32_t branch_conditional_false_ = 0;
+    uint32_t switch_default_ = 0;
+    std::vector<uint32_t> switch_cases_;
 };
 
 // Control Flow can be tricky, so having this as a List allows use to easily add/remove/edit blocks around without worrying about

--- a/layers/gpuav/spirv/module.cpp
+++ b/layers/gpuav/spirv/module.cpp
@@ -195,6 +195,22 @@ Module::Module(vvl::span<const uint32_t> words, DebugReport* debug_report, const
             current_block->loop_header_merge_target_ = new_inst->Word(1);
         }
 
+        if (opcode == spv::OpSelectionMerge) {
+            current_block->selection_merge_target_ = new_inst->Word(1);
+        }
+
+        if (opcode == spv::OpSwitch) {
+            current_block->switch_default_ = new_inst->Word(2);
+            for (uint32_t i = 4; i < new_inst->Length(); i++) {
+                current_block->switch_cases_.push_back(new_inst->Word(i));
+            }
+        }
+
+        if (opcode == spv::OpBranchConditional) {
+            current_block->branch_conditional_true_ = new_inst->Word(2);
+            current_block->branch_conditional_false_ = new_inst->Word(3);
+        }
+
         if (opcode == spv::OpLabel) {
             block_found = true;
             auto new_block = std::make_unique<BasicBlock>(std::move(new_inst), *current_function);

--- a/layers/gpuav/spirv/post_process_descriptor_indexing_pass.h
+++ b/layers/gpuav/spirv/post_process_descriptor_indexing_pass.h
@@ -40,9 +40,24 @@ class PostProcessDescriptorIndexingPass : public Pass {
         uint32_t variable_id = 0;
     };
 
-    bool RequiresInstrumentation(const Function& function, const Instruction& inst, InstructionMeta& meta,
-                                 vvl::unordered_set<uint32_t>& found_in_block_set,
-                                 const DescriptroIndexPushConstantAccess& pc_access);
+    // We want to remove redundant instrumentation as it adds overhead to both compile time and runtime
+    // We create a block-scope tracking of all things with instrumentation
+    struct BlockDuplicateTracker {
+        // hash or the arguments making it unique/same
+        vvl::unordered_set<uint32_t> hashes;
+        // Return true if found a duplicate
+        bool FindAndUpdate(std::unordered_map<uint32_t, BlockDuplicateTracker>& duplicate_trackers, uint32_t hash);
+
+        // The current goal is not to remove 100% of things as the trade-off to add something like SPIRV-Tools
+        // PostDominatorAnalysis is high. Just trying to find the "simple" if/else cases removes many spots
+        uint32_t merge_select_predecessor = 0;
+        uint32_t branch_conditional_predecessor = 0;
+        uint32_t switch_cases_predecessor = 0;  // will include default as well
+    };
+
+    BlockDuplicateTracker& GetAndUpdate(std::unordered_map<uint32_t, BlockDuplicateTracker>& duplicate_trackers, BasicBlock& block);
+
+    bool RequiresInstrumentation(const Function& function, const Instruction& inst, InstructionMeta& meta);
     void CreateFunctionCall(BasicBlock& block, InstructionIt* inst_it, const InstructionMeta& meta);
 
     uint32_t GetLinkFunctionId();


### PR DESCRIPTION
While the Post Processing instrumentation is cheap, it is not free. From looking at a lot of shader dumps, I noticed we tend to go

```c
inst_post_process(1, 2, 3);
if (something) 
    inst_post_process(1, 2, 3);
else
    inst_post_process(1, 2, 3);
inst_post_process(1, 2, 3);
```

a lot, so this changes tracks a simple version of Post-Domination in order to detect as much as we can

Using a Godot sample I had running through fossilize with cache off, single threaded, we get quite a good speed up

```
// before
45 graphics pipelines took 23.143 s (accumulated time)
176 compute pipelines took 26.847 s (accumulated time)

// after
45 graphics pipelines took 17.693 s (accumulated time)
176 compute pipelines took 14.548 s (accumulated time)
```

also from the dump we got

```
Function: inst_post_process_descriptor_index
  Max: 215 -> 150
  Mean: 25.88  -> 18.32
  Median: 8.00 -> 7.00
  75th percentile: 15.00 -> 12.00
  95th percentile: 132.10 -> 73.55
```

were you can see for larger shaders we can really reduce quite a bit