### PR TITLE
layers: Print better error message for allocation warning

### DIFF
--- a/layers/best_practices/bp_descriptor.cpp
+++ b/layers/best_practices/bp_descriptor.cpp
@@ -57,9 +57,10 @@ bool BestPractices::PreCallValidateAllocateDescriptorSets(VkDevice device, const
                     "BestPractices-vkAllocateDescriptorSets-EmptyDescriptorPoolType", ads_pool_state->Handle(), error_obj.location,
                     "Unable to allocate %" PRIu32
                     " descriptors of type %s from %s"
-                    ". This pool only has %" PRIu32 " descriptors of this type remaining.",
+                    ". This pool only has %" PRIu32 " descriptors of this type remaining.\n%s",
                     ads_state_data.required_descriptors_by_type.at(it->first), string_VkDescriptorType(VkDescriptorType(it->first)),
-                    FormatHandle(*ads_pool_state).c_str(), available_count);
+                    FormatHandle(*ads_pool_state).c_str(), available_count,
+                    device_state->PrintDescriptorAllocation(*pAllocateInfo, *pool_state, VkDescriptorType(it->first)).c_str());
             }
         }
     }

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -3452,9 +3452,11 @@ bool CoreChecks::PreCallValidateAllocateDescriptorSets(VkDevice device, const Vk
                         "WARNING-VkDescriptorSetAllocateInfo-descriptorCount", ds_pool_state->Handle(), error_obj.location,
                         "Trying to allocate %" PRIu32 " of %s descriptors from %s, but this pool only has a total of %" PRIu32
                         " descriptors for this type so you will likely get VK_ERROR_OUT_OF_POOL_MEMORY_KHR. While this might "
-                        "succeed on some implementations, it will fail on others.",
+                        "succeed on some implementations, it will fail on others.\n%s",
                         attempt_allocate, string_VkDescriptorType(VkDescriptorType(it->first)),
-                        FormatHandle(*ds_pool_state).c_str(), max_available_count);
+                        FormatHandle(*ds_pool_state).c_str(), max_available_count,
+                        device_state->PrintDescriptorAllocation(*pAllocateInfo, *ds_pool_state, VkDescriptorType(it->first))
+                            .c_str());
                 }
             }
         }

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -896,6 +896,8 @@ class DeviceState : public vvl::base::Device {
                                               chassis::CreateComputePipelines& chassis_state) override;
     void PostCallRecordResetDescriptorPool(VkDevice device, VkDescriptorPool descriptorPool, VkDescriptorPoolResetFlags flags,
                                            const RecordObject& record_obj) override;
+    std::string PrintDescriptorAllocation(const VkDescriptorSetAllocateInfo& allocate_info, const vvl::DescriptorPool& pool_state,
+                                          VkDescriptorType type) const;
     bool PreCallValidateAllocateDescriptorSets(VkDevice device, const VkDescriptorSetAllocateInfo* pAllocateInfo,
                                                VkDescriptorSet* pDescriptorSets, const ErrorObject& error_obj,
                                                vvl::AllocateDescriptorSetsData& ads_state_data) const override;


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10009

The new error message will include 

```
Where VK_DESCRIPTOR_TYPE_SAMPLER is found in the pool:
  pPoolSizes[1].descriptorCount = 2
Where the allocation are being requested:
  pSetLayouts[0]::pBindings[1].descriptorCount = 2
  pSetLayouts[2]::pBindings[1].descriptorCount = 2
  pSetLayouts[3]::pBindings[1].descriptorCount = 2
```

or 

```
Where VK_DESCRIPTOR_TYPE_STORAGE_BUFFER is found in the pool:
  pPoolSizes[0].descriptorCount = 8
Where the allocation are being requested:
  pSetLayouts[0]::pBindings[0].descriptorCount = 10 (adjusted for VK_DESCRIPTOR_BINDING_VARIABLE_DESCRIPTOR_COUNT_BIT)
```

type message to better show where these 2 totals (what the pool has and whats being asked) are coming from 