### PR TITLE
layers: Combine PostCallRecordCmdBindShadersEXT

### DIFF
--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -1807,8 +1807,6 @@ class DeviceState : public vvl::base::Device {
     void PostCallRecordGetShaderModuleCreateInfoIdentifierEXT(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
                                                               VkShaderModuleIdentifierEXT* pIdentifier,
                                                               const RecordObject& record_obj) override;
-    void PreCallRecordCmdBindShadersEXT(VkCommandBuffer commandBuffer, uint32_t stageCount, const VkShaderStageFlagBits* pStages,
-                                        const VkShaderEXT* pShaders, const RecordObject& record_obj) override;
 
     void PostCallRecordCmdBindTransformFeedbackBuffersEXT(VkCommandBuffer commandBuffer, uint32_t firstBinding,
                                                           uint32_t bindingCount, const VkBuffer* pBuffers,


### PR DESCRIPTION
We had the `BindPipeine()` call in the PreCall but for no reason