### PR TITLE
gpuav: Warn users to use robustness feature

### DIFF
--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
@@ -1284,7 +1284,7 @@ bool GpuShaderInstrumentor::InstrumentShader(const vvl::span<const uint32_t> &in
         DumpSpirvToFile(non_instrumented_spirv_file.string(), input_spirv.data(), input_spirv.size());
     }
 
-    spirv::Settings module_settings{};
+    spirv::Settings module_settings(loc);
     // Use the unique_shader_id as a shader ID so we can look up its handle later in the shader_map.
     module_settings.shader_id = unique_shader_id;
     module_settings.output_buffer_descriptor_set = instrumentation_desc_set_bind_index_;

--- a/layers/gpuav/spirv/descriptor_class_general_buffer_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_class_general_buffer_pass.cpp
@@ -224,6 +224,14 @@ bool DescriptorClassGeneralBufferPass::Instrument() {
         }
     }
 
+    if (instrumentations_count_ > 75) {
+        module_.InternalWarning(
+            "GPUAV-Compile-time-general-buffer",
+            "This shader will be very slow to compile and runtime performance may also be slow. This is due to the number of OOB "
+            "checks for storage/uniform "
+            "buffers. Turn on the |gpuav_force_on_robustness| setting to skip these checks and improve GPU-AV performance.");
+    }
+
     return instrumentations_count_ != 0;
 }
 

--- a/layers/gpuav/spirv/descriptor_class_texel_buffer_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_class_texel_buffer_pass.cpp
@@ -197,6 +197,14 @@ bool DescriptorClassTexelBufferPass::Instrument() {
         }
     }
 
+    if (instrumentations_count_ > 75) {
+        module_.InternalWarning(
+            "GPUAV-Compile-time-texel-buffer",
+            "This shader will be very slow to compile and runtime performance may also be slow. This is due to the number of OOB "
+            "checks for texel "
+            "buffers. Turn on the |gpuav_force_on_robustness| setting to skip these checks and improve GPU-AV performance.");
+    }
+
     return instrumentations_count_ != 0;
 }
 

--- a/layers/gpuav/spirv/module.cpp
+++ b/layers/gpuav/spirv/module.cpp
@@ -20,7 +20,6 @@
 #include "generated/spirv_grammar_helper.h"
 #include "gpuav/shaders/gpuav_shaders_constants.h"
 #include "error_message/logging.h"
-#include "error_message/error_location.h"
 #include "error_message/log_message_type.h"
 
 #include <iostream>
@@ -771,8 +770,7 @@ void Module::PostProcess() {
 
 void Module::InternalWarning(const char* tag, const std::string& message) {
     if (debug_report_) {
-        Location loc(vvl::Func::Empty);
-        debug_report_->LogMessage(kWarningBit, tag, {}, loc, message);
+        debug_report_->LogMessage(kWarningBit, tag, {}, settings_.loc, message);
     } else {
         std::cout << "[" << tag << "] " << message << '\n';
     }
@@ -780,8 +778,7 @@ void Module::InternalWarning(const char* tag, const std::string& message) {
 
 void Module::InternalError(const char* tag, const std::string& message) {
     if (debug_report_) {
-        Location loc(vvl::Func::Empty);
-        debug_report_->LogMessage(kErrorBit, tag, {}, loc, message);
+        debug_report_->LogMessage(kErrorBit, tag, {}, settings_.loc, message);
     } else {
         std::cerr << "[" << tag << "] " << message << '\n';
     }

--- a/layers/gpuav/spirv/module.h
+++ b/layers/gpuav/spirv/module.h
@@ -17,6 +17,7 @@
 #include <stdint.h>
 #include <vector>
 #include "containers/custom_containers.h"
+#include "error_message/error_location.h"
 #include "link.h"
 #include "interface.h"
 #include "function_basic_block.h"
@@ -52,6 +53,11 @@ struct Settings {
     uint32_t max_instrumentations_count;
     bool support_non_semantic_info;
     bool has_bindless_descriptors;
+
+    // Used if need to report error/warning
+    const Location& loc;
+
+    explicit Settings(const Location& loc) : loc(loc) {}
 };
 
 // This is the "brain" of SPIR-V logic, it stores the memory of all the Instructions and is the main context.


### PR DESCRIPTION
Looking at Godot shaders, they have these massive SSBO structs used to bring everything in (ubershader) and found that turning on `VK_LAYER_GPUAV_FORCE_ON_ROBUSTNESS` makes everything fast again

```
// normal
109 graphics pipelines took 5.861 seconds
170 compute pipelines took 6.151 seconds

// with GPU-AV
109 graphics pipelines took 38.744 seconds
170 compute pipelines took 16.230 seconds

// with GPU-AV and VK_LAYER_GPUAV_FORCE_ON_ROBUSTNESS
109 graphics pipelines took 18.208 seconds
170 compute pipelines took 8.837 seconds
```

This is just the compile time, but the runtime was also much faster!