### PR TITLE
layers: Add exceptions for duplicate VUID check

### DIFF
--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -870,14 +870,6 @@ static void ProcessDebugReportSettings(ConfigAndEnvSettings *settings_data, VkuL
                 "will not be seen.");
             report_flags |= kInformationBit;
         }
-        // If any non-stdout DebugPrintf is being used, just turn off duplicate_message_limit, it will prevent people thinking
-        // DebugPrintf is broken because nothing is printing.
-        if (!settings_data->gpuav_settings->debug_printf_to_stdout && debug_report->duplicate_message_limit != 0) {
-            debug_report->duplicate_message_limit = 0;
-            setting_warnings.emplace_back("DebugPrintf logs can possibly print many times, but duplicate_message_limit is set to " +
-                                          std::to_string(debug_report->duplicate_message_limit) +
-                                          ", setting enable_message_limit to false so all logs are printed.");
-        }
     }
 
     // Flag as default if these settings are not from a vk_layer_settings.txt file

--- a/tests/unit/debug_printf_shader_debug_info.cpp
+++ b/tests/unit/debug_printf_shader_debug_info.cpp
@@ -16,9 +16,7 @@
 class NegativeDebugPrintfShaderDebugInfo : public DebugPrintfTests {};
 
 // These tests print out the verbose info to make sure that info is correct
-static const VkBool32 verbose_value = true;
-static const VkLayerSettingEXT layer_setting = {OBJECT_LAYER_NAME, "printf_verbose", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1,
-                                                &verbose_value};
+static const VkLayerSettingEXT layer_setting = {OBJECT_LAYER_NAME, "printf_verbose", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkTrue};
 static VkLayerSettingsCreateInfoEXT layer_settings_create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1,
                                                                   &layer_setting};
 

--- a/tests/unit/others.cpp
+++ b/tests/unit/others.cpp
@@ -83,6 +83,7 @@ TEST_F(VkLayerTest, VuidHashStability) {
     ASSERT_TRUE(hash_util::VuidHash("VUID-RayTmaxKHR-RayTmaxKHR-04349") == 0x8e67514c);
     ASSERT_TRUE(hash_util::VuidHash("VUID-RuntimeSpirv-SubgroupUniformControlFlowKHR-06379") == 0x2f574188);
     ASSERT_TRUE(hash_util::VuidHash("VVL-DEBUG-PRINTF") == 0x4fe1fef9);
+    ASSERT_TRUE(hash_util::VuidHash("WARNING-GPU-Assisted-Validation") == 0x24b5c69f);
 }
 
 TEST_F(VkLayerTest, RequiredParameter) {


### PR DESCRIPTION
1. We have zero reason to ever suppress VUID like DebugPrintf or GPUAV-warning
2. Instead of turning off the setting (which they might want for other reasons) just do a quick check if we should ignore the hash or not