### PR TITLE
gpuva: Remove Object Type spam on warnings

### DIFF
--- a/layers/gpuav/core/gpuav_features.cpp
+++ b/layers/gpuav/core/gpuav_features.cpp
@@ -48,6 +48,10 @@ static bool IsExtensionAvailable(const char *extension_name, const std::vector<V
     return false;
 }
 
+// We end up printing lots of warning for GPU-AV that really have no use for any object.
+// Instead of spamming with a VkInstance, just explicitly don't print anything
+static const VulkanTypedHandle kNoObjects;
+
 // In PreCallRecord we try to turn on as many features as possible on behalf of the app (and warn the user if we are doing it).
 // Later after device creation, we can decide if the required Vulkan feature for each GPU-AV setting is found and report errors
 void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceCreateInfo *modified_create_info,
@@ -81,20 +85,20 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
 
         if (modified_features) {
             if (supported_features.fragmentStoresAndAtomics && !modified_features->fragmentStoresAndAtomics) {
-                InternalWarning(instance, loc, "Forcing fragmentStoresAndAtomics to VK_TRUE");
+                InternalWarning(kNoObjects, loc, "Forcing fragmentStoresAndAtomics to VK_TRUE");
                 modified_features->fragmentStoresAndAtomics = VK_TRUE;
             }
             if (supported_features.vertexPipelineStoresAndAtomics && !modified_features->vertexPipelineStoresAndAtomics) {
-                InternalWarning(instance, loc, "Forcing vertexPipelineStoresAndAtomics to VK_TRUE");
+                InternalWarning(kNoObjects, loc, "Forcing vertexPipelineStoresAndAtomics to VK_TRUE");
                 modified_features->vertexPipelineStoresAndAtomics = VK_TRUE;
             }
             if (supported_features.shaderInt64 && !modified_features->shaderInt64) {
-                InternalWarning(instance, loc, "Forcing shaderInt64 to VK_TRUE");
+                InternalWarning(kNoObjects, loc, "Forcing shaderInt64 to VK_TRUE");
                 modified_features->shaderInt64 = VK_TRUE;
             }
             if (gpuav_settings.force_on_robustness && supported_features.robustBufferAccess &&
                 !modified_features->robustBufferAccess) {
-                InternalWarning(instance, loc, "Forcing robustBufferAccess to VK_TRUE");
+                InternalWarning(kNoObjects, loc, "Forcing robustBufferAccess to VK_TRUE");
                 modified_features->robustBufferAccess = VK_TRUE;
             }
         }
@@ -108,13 +112,13 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
             if (auto *ts_features = const_cast<VkPhysicalDeviceTimelineSemaphoreFeatures *>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceTimelineSemaphoreFeatures>(modified_create_info))) {
                 if (ts_features->timelineSemaphore == VK_FALSE) {
-                    InternalWarning(instance, loc,
+                    InternalWarning(kNoObjects, loc,
                                     "Forcing VkPhysicalDeviceTimelineSemaphoreFeatures::timelineSemaphore to VK_TRUE");
                     ts_features->timelineSemaphore = VK_TRUE;
                 }
             } else {
                 InternalWarning(
-                    instance, loc,
+                    kNoObjects, loc,
                     "Adding a VkPhysicalDeviceTimelineSemaphoreFeatures to pNext with timelineSemaphore set to VK_TRUE");
                 VkPhysicalDeviceTimelineSemaphoreFeatures new_ts_features = vku::InitStructHelper();
                 new_ts_features.timelineSemaphore = VK_TRUE;
@@ -126,7 +130,7 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
             if (auto *features12 = const_cast<VkPhysicalDeviceVulkan12Features *>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(modified_create_info->pNext))) {
                 if (features12->timelineSemaphore == VK_FALSE) {
-                    InternalWarning(instance, loc, "Forcing VkPhysicalDeviceVulkan12Features::timelineSemaphore to VK_TRUE");
+                    InternalWarning(kNoObjects, loc, "Forcing VkPhysicalDeviceVulkan12Features::timelineSemaphore to VK_TRUE");
                     features12->timelineSemaphore = VK_TRUE;
                 }
             } else {
@@ -145,17 +149,17 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
             if (auto *mm_features = const_cast<VkPhysicalDeviceVulkanMemoryModelFeatures *>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkanMemoryModelFeatures>(modified_create_info))) {
                 if (mm_features->vulkanMemoryModel == VK_FALSE) {
-                    InternalWarning(instance, loc,
+                    InternalWarning(kNoObjects, loc,
                                     "Forcing VkPhysicalDeviceVulkanMemoryModelFeatures::vulkanMemoryModel to VK_TRUE");
                     mm_features->vulkanMemoryModel = VK_TRUE;
                 }
                 if (mm_features->vulkanMemoryModelDeviceScope == VK_FALSE) {
-                    InternalWarning(instance, loc,
+                    InternalWarning(kNoObjects, loc,
                                     "Forcing VkPhysicalDeviceVulkanMemoryModelFeatures::vulkanMemoryModelDeviceScope to VK_TRUE");
                     mm_features->vulkanMemoryModelDeviceScope = VK_TRUE;
                 }
             } else {
-                InternalWarning(instance, loc,
+                InternalWarning(kNoObjects, loc,
                                 "Adding a VkPhysicalDeviceVulkanMemoryModelFeatures to pNext with vulkanMemoryModel and "
                                 "vulkanMemoryModelDeviceScope set to VK_TRUE");
                 VkPhysicalDeviceVulkanMemoryModelFeatures new_mm_features = vku::InitStructHelper();
@@ -169,11 +173,11 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
             if (auto *features12 = const_cast<VkPhysicalDeviceVulkan12Features *>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(modified_create_info->pNext))) {
                 if (features12->vulkanMemoryModel == VK_FALSE) {
-                    InternalWarning(instance, loc, "Forcing VkPhysicalDeviceVulkan12Features::vulkanMemoryModel to VK_TRUE");
+                    InternalWarning(kNoObjects, loc, "Forcing VkPhysicalDeviceVulkan12Features::vulkanMemoryModel to VK_TRUE");
                     features12->vulkanMemoryModel = VK_TRUE;
                 }
                 if (features12->vulkanMemoryModelDeviceScope == VK_FALSE) {
-                    InternalWarning(instance, loc,
+                    InternalWarning(kNoObjects, loc,
                                     "Forcing VkPhysicalDeviceVulkan12Features::vulkanMemoryModelDeviceScope to VK_TRUE");
                     features12->vulkanMemoryModelDeviceScope = VK_TRUE;
                 }
@@ -193,13 +197,13 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
             if (auto *bda_features = const_cast<VkPhysicalDeviceBufferDeviceAddressFeatures *>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceBufferDeviceAddressFeatures>(modified_create_info))) {
                 if (!bda_features->bufferDeviceAddress) {
-                    InternalWarning(instance, loc,
+                    InternalWarning(kNoObjects, loc,
                                     "Forcing VkPhysicalDeviceBufferDeviceAddressFeatures::bufferDeviceAddress to VK_TRUE");
                     bda_features->bufferDeviceAddress = VK_TRUE;
                 }
             } else {
                 InternalWarning(
-                    instance, loc,
+                    kNoObjects, loc,
                     "Adding a VkPhysicalDeviceBufferDeviceAddressFeatures to pNext with bufferDeviceAddress set to VK_TRUE");
                 VkPhysicalDeviceBufferDeviceAddressFeatures new_bda_features = vku::InitStructHelper();
                 new_bda_features.bufferDeviceAddress = VK_TRUE;
@@ -211,7 +215,7 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
             if (auto *features12 = const_cast<VkPhysicalDeviceVulkan12Features *>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(modified_create_info->pNext))) {
                 if (!features12->bufferDeviceAddress) {
-                    InternalWarning(instance, loc, "Forcing VkPhysicalDeviceVulkan12Features::bufferDeviceAddress to VK_TRUE");
+                    InternalWarning(kNoObjects, loc, "Forcing VkPhysicalDeviceVulkan12Features::bufferDeviceAddress to VK_TRUE");
                     features12->bufferDeviceAddress = VK_TRUE;
                 }
             } else {
@@ -230,12 +234,12 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
             if (auto *eight_bit_access_feature = const_cast<VkPhysicalDevice8BitStorageFeatures *>(
                     vku::FindStructInPNextChain<VkPhysicalDevice8BitStorageFeatures>(modified_create_info))) {
                 if (!eight_bit_access_feature->storageBuffer8BitAccess) {
-                    InternalWarning(instance, loc,
+                    InternalWarning(kNoObjects, loc,
                                     "Forcing VkPhysicalDevice8BitStorageFeatures::storageBuffer8BitAccess to VK_TRUE");
                     eight_bit_access_feature->storageBuffer8BitAccess = VK_TRUE;
                 }
             } else {
-                InternalWarning(instance, loc,
+                InternalWarning(kNoObjects, loc,
                                 "Adding a VkPhysicalDevice8BitStorageFeatures to pNext with storageBuffer8BitAccess "
                                 "set to VK_TRUE");
                 VkPhysicalDevice8BitStorageFeatures new_8bit_features = vku::InitStructHelper();
@@ -248,7 +252,7 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
             if (auto *features12 = const_cast<VkPhysicalDeviceVulkan12Features *>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(modified_create_info->pNext))) {
                 if (!features12->storageBuffer8BitAccess) {
-                    InternalWarning(instance, loc,
+                    InternalWarning(kNoObjects, loc,
                                     "Forcing VkPhysicalDeviceVulkan12Features::storageBuffer8BitAccess to VK_TRUE");
                     features12->storageBuffer8BitAccess = VK_TRUE;
                 }
@@ -264,7 +268,7 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
 
     if (gpuav_settings.debug_printf_enabled) {
         if (!IsExtensionAvailable(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME, available_extensions)) {
-            InternalWarning(instance, loc,
+            InternalWarning(kNoObjects, loc,
                             "VK_KHR_shader_non_semantic_info is not available on selected device, Debug Printf may produce SPIR-V "
                             "that could fail to compile the shader.");
         } else {
@@ -281,25 +285,26 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
             if (auto *robust_buffer_2_feature = const_cast<VkPhysicalDeviceRobustness2FeaturesEXT *>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceRobustness2FeaturesEXT>(modified_create_info))) {
                 if (!robust_buffer_2_feature->robustBufferAccess2 && supported_robustness2_feature.robustBufferAccess2) {
-                    InternalWarning(instance, loc,
+                    InternalWarning(kNoObjects, loc,
                                     "Forcing VkPhysicalDeviceRobustness2FeaturesEXT::robustBufferAccess2 to VK_TRUE");
                     robust_buffer_2_feature->robustBufferAccess2 = VK_TRUE;
                 }
                 if (!robust_buffer_2_feature->robustImageAccess2 && supported_robustness2_feature.robustImageAccess2) {
-                    InternalWarning(instance, loc, "Forcing VkPhysicalDeviceRobustness2FeaturesEXT::robustImageAccess2 to VK_TRUE");
+                    InternalWarning(kNoObjects, loc,
+                                    "Forcing VkPhysicalDeviceRobustness2FeaturesEXT::robustImageAccess2 to VK_TRUE");
                     robust_buffer_2_feature->robustImageAccess2 = VK_TRUE;
                 }
             } else {
                 VkPhysicalDeviceRobustness2FeaturesEXT new_robust_buffer_2_feature = vku::InitStructHelper();
                 if (supported_robustness2_feature.robustBufferAccess2) {
                     InternalWarning(
-                        instance, loc,
+                        kNoObjects, loc,
                         "Adding a VkPhysicalDeviceRobustness2FeaturesEXT to pNext with robustBufferAccess2 set to VK_TRUE");
                     new_robust_buffer_2_feature.robustBufferAccess2 = VK_TRUE;
                 }
                 if (supported_robustness2_feature.robustImageAccess2) {
                     InternalWarning(
-                        instance, loc,
+                        kNoObjects, loc,
                         "Adding a VkPhysicalDeviceRobustness2FeaturesEXT to pNext with robustImageAccess2 set to VK_TRUE");
                     new_robust_buffer_2_feature.robustImageAccess2 = VK_TRUE;
                 }


### PR DESCRIPTION
```
Validation Warning: [ WARNING-GPU-Assisted-Validation ] | MessageID = 0x24b5c69f
vkCreateDevice(): Internal Warning: Adding a VkPhysicalDeviceTimelineSemaphoreFeatures to pNext with timelineSemaphore set to VK_TRUE
Objects: 1
    [0] VkInstance 0x2a756b30

Validation Warning: [ WARNING-GPU-Assisted-Validation ] | MessageID = 0x24b5c69f
vkCreateDevice(): Internal Warning: Adding a VkPhysicalDeviceVulkanMemoryModelFeatures to pNext with vulkanMemoryModel and vulkanMemoryModelDeviceScope set to VK_TRUE
Objects: 1
    [0] VkInstance 0x2a756b30

Validation Warning: [ WARNING-GPU-Assisted-Validation ] | MessageID = 0x24b5c69f
vkCreateDevice(): Internal Warning: Adding a VkPhysicalDeviceBufferDeviceAddressFeatures to pNext with bufferDeviceAddress set to VK_TRUE
Objects: 1
    [0] VkInstance 0x2a756b30
```

Becomes

```
Validation Warning: [ WARNING-GPU-Assisted-Validation ] | MessageID = 0x24b5c69f
vkCreateDevice(): Internal Warning: Adding a VkPhysicalDeviceTimelineSemaphoreFeatures to pNext with timelineSemaphore set to VK_TRUE

Validation Warning: [ WARNING-GPU-Assisted-Validation ] | MessageID = 0x24b5c69f
vkCreateDevice(): Internal Warning: Adding a VkPhysicalDeviceVulkanMemoryModelFeatures to pNext with vulkanMemoryModel and vulkanMemoryModelDeviceScope set to VK_TRUE

Validation Warning: [ WARNING-GPU-Assisted-Validation ] | MessageID = 0x24b5c69f
vkCreateDevice(): Internal Warning: Adding a VkPhysicalDeviceBufferDeviceAddressFeatures to pNext with bufferDeviceAddress set to VK_TRUE
```