### PR TITLE
layers: Print out pipeline in draw spirv VUs

### DIFF
--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -849,9 +849,9 @@ bool CoreChecks::ValidateDrawState(const vvl::DescriptorSet &descriptor_set, uin
 
         const vvl::DescriptorBinding *binding = descriptor_set.GetBinding(binding_index);
         if (!binding) {  //  End at construction is the condition for an invalid binding.
-            auto set = descriptor_set.Handle();
-            result |= LogError(vuids.descriptor_buffer_bit_set_08114, set, loc, "%s %s is invalid.", FormatHandle(set).c_str(),
-                               resource_variable.DescribeDescriptor().c_str());
+            const LogObjectList objlist(cb_state.Handle(), shader_handle, descriptor_set.Handle());
+            result |= LogError(vuids.descriptor_buffer_bit_set_08114, objlist, loc, "%s %s is invalid.",
+                               FormatHandle(descriptor_set).c_str(), resource_variable.DescribeDescriptor().c_str());
             return result;
         }
 

--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -2152,7 +2152,7 @@ bool CoreChecks::ValidateGeometryNV(const VkGeometryNV &geometry, const Location
     return skip;
 }
 
-bool CoreChecks::ValidateRaytracingShaderBindingTable(VkCommandBuffer commandBuffer, const Location &table_loc,
+bool CoreChecks::ValidateRaytracingShaderBindingTable(const vvl::CommandBuffer &cb_state, const Location &table_loc,
                                                       const char *vuid_single_device_memory, const char *vuid_binding_table_flag,
                                                       const VkStridedDeviceAddressRegionKHR &binding_table) const {
     bool skip = false;
@@ -2163,7 +2163,8 @@ bool CoreChecks::ValidateRaytracingShaderBindingTable(VkCommandBuffer commandBuf
 
     const auto buffer_states = GetBuffersByAddress(binding_table.deviceAddress);
     if (buffer_states.empty()) {
-        skip |= LogError("VUID-VkStridedDeviceAddressRegionKHR-size-04631", commandBuffer, table_loc.dot(Field::deviceAddress),
+        skip |= LogError("VUID-VkStridedDeviceAddressRegionKHR-size-04631",
+                         cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR), table_loc.dot(Field::deviceAddress),
                          "(0x%" PRIx64 ") has no buffer associated with it.", binding_table.deviceAddress);
     } else {
         const vvl::range<VkDeviceSize> requested_range(binding_table.deviceAddress,
@@ -2226,7 +2227,8 @@ bool CoreChecks::ValidateRaytracingShaderBindingTable(VkCommandBuffer commandBuf
         }}};
 
         skip |= buffer_address_validator.LogErrorsIfNoValidBuffer(*this, buffer_states, table_loc.dot(Field::deviceAddress),
-                                                                  LogObjectList(commandBuffer), binding_table.deviceAddress);
+                                                                  cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR),
+                                                                  binding_table.deviceAddress);
     }
 
     return skip;

--- a/layers/core_checks/cc_shader_object.cpp
+++ b/layers/core_checks/cc_shader_object.cpp
@@ -655,7 +655,7 @@ bool CoreChecks::ValidateDrawShaderObject(const LastBound& last_bound_state, con
     const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
 
     if (cb_state.active_render_pass && !cb_state.active_render_pass->UsesDynamicRendering()) {
-        skip |= LogError(vuid.render_pass_began_08876, cb_state.Handle(), vuid.loc(),
+        skip |= LogError(vuid.render_pass_began_08876, cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS), vuid.loc(),
                          "Shader objects must be used with dynamic rendering, but VkRenderPass %s is active.",
                          FormatHandle(cb_state.active_render_pass->Handle()).c_str());
     }

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1450,7 +1450,7 @@ class CoreChecks : public vvl::DeviceProxy {
                                        VkDeviceSize callableShaderBindingOffset, VkDeviceSize callableShaderBindingStride,
                                        uint32_t width, uint32_t height, uint32_t depth,
                                        const ErrorObject& error_obj) const override;
-    bool ValidateRaytracingShaderBindingTable(VkCommandBuffer commandBuffer, const Location& table_loc,
+    bool ValidateRaytracingShaderBindingTable(const vvl::CommandBuffer& cb_state, const Location& table_loc,
                                               const char* vuid_single_device_memory, const char* vuid_binding_table_flag,
                                               const VkStridedDeviceAddressRegionKHR& binding_table) const;
     bool ValidateCmdTraceRaysKHR(const Location& loc, const vvl::CommandBuffer& cb_state,

--- a/layers/drawdispatch/descriptor_validator.cpp
+++ b/layers/drawdispatch/descriptor_validator.cpp
@@ -1069,7 +1069,7 @@ bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVaria
             // the AccelerationStructure could be null via nullDescriptor and accessing it is legal
             if (acc != VK_NULL_HANDLE || !dev_proxy.enabled_features.nullDescriptor) {
                 const LogObjectList objlist(cb_state.Handle(), *shader_handle, descriptor_set.Handle());
-                skip |= LogError(vuids.descriptor_buffer_bit_set_08114, descriptor_set.Handle(), loc.Get(),
+                skip |= LogError(vuids.descriptor_buffer_bit_set_08114, objlist, loc.Get(),
                                  "the %s is using acceleration structure %s that is invalid or has been destroyed.",
                                  DescribeDescriptor(resource_variable, index, descriptor_type).c_str(), FormatHandle(acc).c_str());
             }

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1845,6 +1845,12 @@ LogObjectList CommandBuffer::GetObjectList(VkPipelineBindPoint pipeline_bind_poi
             objlist.add(shader);
         }
     }
+
+    // If using dynamic rendering, will just not add anything
+    if (pipeline_bind_point == VK_PIPELINE_BIND_POINT_GRAPHICS && active_render_pass) {
+        objlist.add(active_render_pass->Handle());
+    }
+
     return objlist;
 }
 


### PR DESCRIPTION
Add `cb_state.GetObjectList` in more places that were missing it so we make sure to print the pipeline/shaderObject for a draw/dispatch VU