### PR TITLE
layers: Remove extra properties pretty print

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -437,20 +437,6 @@
                                                     { "key": "validate_sync", "value": true }
                                                 ]
                                             }
-                                        },
-                                        {
-                                            "key": "syncval_message_extra_properties_pretty_print",
-                                            "label": "Pretty print extra properties",
-                                            "description": "Enable formatted output of key-value properties. Disabled by default to simplify pattern matching when filtering errors.",
-                                            "type": "BOOL",
-                                            "default": false,
-                                            "dependence": {
-                                                "mode": "ALL",
-                                                "settings": [
-                                                    { "key": "validate_sync", "value": true },
-                                                    { "key": "syncval_message_extra_properties", "value": true }
-                                                ]
-                                            }
                                         }
                                     ]
                                 }

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -223,7 +223,6 @@ const char *VK_LAYER_GPUAV_DEBUG_PRINT_INSTRUMENTATION_INFO = "gpuav_debug_print
 const char *VK_LAYER_SYNCVAL_SUBMIT_TIME_VALIDATION = "syncval_submit_time_validation";
 const char *VK_LAYER_SYNCVAL_SHADER_ACCESSES_HEURISTIC = "syncval_shader_accesses_heuristic";
 const char *VK_LAYER_SYNCVAL_MESSAGE_EXTRA_PROPERTIES = "syncval_message_extra_properties";
-const char *VK_LAYER_SYNCVAL_MESSAGE_EXTRA_PROPERTIES_PRETTY_PRINT = "syncval_message_extra_properties_pretty_print";
 
 // Message Formatting
 // ---
@@ -631,8 +630,6 @@ static void ValidateLayerSettingsProvided(const VkLayerSettingsCreateInfoEXT *la
         } else if (strcmp(VK_LAYER_SYNCVAL_SHADER_ACCESSES_HEURISTIC, setting.pSettingName) == 0) {
             required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
         } else if (strcmp(VK_LAYER_SYNCVAL_MESSAGE_EXTRA_PROPERTIES, setting.pSettingName) == 0) {
-            required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
-        } else if (strcmp(VK_LAYER_SYNCVAL_MESSAGE_EXTRA_PROPERTIES_PRETTY_PRINT, setting.pSettingName) == 0) {
             required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
         } else if (strcmp(VK_LAYER_MESSAGE_FORMAT_JSON, setting.pSettingName) == 0) {
             required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
@@ -1226,9 +1223,11 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
                                 syncval_settings.message_extra_properties);
     }
 
-    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_SYNCVAL_MESSAGE_EXTRA_PROPERTIES_PRETTY_PRINT)) {
-        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_SYNCVAL_MESSAGE_EXTRA_PROPERTIES_PRETTY_PRINT,
-                                syncval_settings.message_extra_properties_pretty_print);
+    const char *REMOVED_VK_LAYER_SYNCVAL_MESSAGE_EXTRA_PROPERTIES_PRETTY_PRINT = "syncval_message_extra_properties_pretty_print";
+    if (vkuHasLayerSetting(layer_setting_set, REMOVED_VK_LAYER_SYNCVAL_MESSAGE_EXTRA_PROPERTIES_PRETTY_PRINT)) {
+        setting_warnings.emplace_back(std::string(REMOVED_VK_LAYER_SYNCVAL_MESSAGE_EXTRA_PROPERTIES_PRETTY_PRINT) +
+                                      " was removed. The main purpose of the extra properties section is to filter syncval error "
+                                      "messages. The priority is to have a fixed and easy-to-parse layout.");
     }
 
     const auto *validation_features_ext = vku::FindStructInPNextChain<VkValidationFeaturesEXT>(settings_data->create_info);

--- a/layers/sync/sync_error_messages.cpp
+++ b/layers/sync/sync_error_messages.cpp
@@ -42,7 +42,7 @@ std::string ErrorMessages::Error(const HazardResult& hazard, const CommandExecut
             message += '\n';
         }
         const ReportProperties properties = GetErrorMessageProperties(hazard, context, command, message_type, additional_info);
-        message += properties.FormatExtraPropertiesSection(validator_.syncval_settings.message_extra_properties_pretty_print);
+        message += properties.FormatExtraPropertiesSection();
     }
     return message;
 }

--- a/layers/sync/sync_reporting.cpp
+++ b/layers/sync/sync_reporting.cpp
@@ -325,11 +325,10 @@ void ReportProperties::Add(std::string_view property_name, uint64_t value) {
     name_values.emplace_back(NameValue{std::string(property_name), std::to_string(value)});
 }
 
-std::string ReportProperties::FormatExtraPropertiesSection(bool pretty_print) const {
+std::string ReportProperties::FormatExtraPropertiesSection() const {
     if (name_values.empty()) {
         return {};
     }
-    const uint32_t pretty_print_alignment = 18;
     const auto sorted = SortKeyValues(name_values);
     std::stringstream ss;
     ss << "[Extra properties]\n";
@@ -339,11 +338,7 @@ std::string ReportProperties::FormatExtraPropertiesSection(bool pretty_print) co
             ss << "\n";
         }
         first = false;
-        uint32_t extra_space_count = 0;
-        if (pretty_print && property.name.length() < pretty_print_alignment) {
-            extra_space_count = pretty_print_alignment - (uint32_t)property.name.length();
-        }
-        ss << property.name << std::string(extra_space_count, ' ') << " = " << property.value;
+        ss << property.name << " = " << property.value;
     }
     return ss.str();
 }

--- a/layers/sync/sync_reporting.h
+++ b/layers/sync/sync_reporting.h
@@ -40,7 +40,7 @@ struct ReportProperties {
 
     void Add(std::string_view property_name, std::string_view value);
     void Add(std::string_view property_name, uint64_t value);
-    std::string FormatExtraPropertiesSection(bool pretty_print) const;
+    std::string FormatExtraPropertiesSection() const;
 };
 
 // Customization options to modify the standard form of the synchronization error message.

--- a/layers/sync/sync_settings.h
+++ b/layers/sync/sync_settings.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2024 The Khronos Group Inc.
- * Copyright (c) 2024 Valve Corporation
- * Copyright (c) 2024 LunarG, Inc.
+/* Copyright (c) 2025 The Khronos Group Inc.
+ * Copyright (c) 2025 Valve Corporation
+ * Copyright (c) 2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,5 +21,4 @@ struct SyncValSettings {
     bool submit_time_validation = true;
     bool shader_accesses_heuristic = false;
     bool message_extra_properties = false;
-    bool message_extra_properties_pretty_print = false;
 };

--- a/tests/unit/layer_settings_positive.cpp
+++ b/tests/unit/layer_settings_positive.cpp
@@ -74,7 +74,6 @@ TEST_F(PositiveLayerSettings, AllSettings) {
         {OBJECT_LAYER_NAME, "syncval_submit_time_validation", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable},
         {OBJECT_LAYER_NAME, "syncval_shader_accesses_heuristic", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable},
         {OBJECT_LAYER_NAME, "syncval_message_extra_properties", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable},
-        {OBJECT_LAYER_NAME, "syncval_message_extra_properties_pretty_print", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable},
         {OBJECT_LAYER_NAME, "message_format_display_application_name", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable},
         {OBJECT_LAYER_NAME, "message_format_json", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &disable},
         {OBJECT_LAYER_NAME, "debug_action", VK_LAYER_SETTING_TYPE_STRING_EXT, 1, &action_ignore},


### PR DESCRIPTION
Prepare "pretty print extra properties" option for removal in future SDKs. The ability to change formatting a bit contradicts with the main feature of extra properties that they are easy to parse and stable, if you change formatting it's easy to break parsing code. Quickly considered this when introduced a feature but unfortunatley decided to add a "nice" feature.

@spencer-lunarg please check if that's the changes that we discussed.