### PR TITLE
layers: Improve 00184 00173 error message

### DIFF
--- a/layers/state_tracker/device_memory_state.h
+++ b/layers/state_tracker/device_memory_state.h
@@ -306,11 +306,6 @@ class Bindable : public StateObject {
         const BindableMemoryTracker::MemoryRange &memory_region, const Bindable *other_resource,
         const BindableMemoryTracker::MemoryRange &other_memory_region) const;
 
-    bool DoesResourceMemoryOverlap(const BindableMemoryTracker::MemoryRange &memory_region, const Bindable *other_resource,
-                                   const BindableMemoryTracker::MemoryRange &other_memory_region) const {
-        return GetResourceMemoryOverlap(memory_region, other_resource, other_memory_region).first != VK_NULL_HANDLE;
-    }
-
     BindableMemoryTracker::BoundMemoryRange GetBoundMemoryRange(const BindableMemoryTracker::MemoryRange &range) const {
         return memory_tracker_->GetBoundMemoryRange(range);
     }


### PR DESCRIPTION
Probably one of our worst messages

```
vkCmdCopyImageToBuffer(): pRegions[0] Detected overlap between source and dest regions in memory.
```

now actually tells you how it found that and where the regions overlapping are

```
vkCmdCopyImageToBuffer(): pRegions[0] Detected overlap between src and dst regions in memory while trying to copy 0x64 bytes.
Overlapped memory is (VkDeviceMemory 0x60000000006) on range [48, 64).
bufferOffset (48) creates region of [48, 112)
imageOffset (x = 1, y = 1, z = 0) creates region of [0, 64).
```

The `imageOffset (x = 1, y = 1, z = 0) creates region of [0, 64).` feels wrong, because it currently takes the offset.z as everything being zero when dealing with OPTIMAL layout, looking into fixing that, but it doesn't effect this change itself