### PR TITLE
layers: Remove TransitionImageLayouts from corechecks

### DIFF
--- a/layers/core_checks/cc_image_layout.cpp
+++ b/layers/core_checks/cc_image_layout.cpp
@@ -1016,23 +1016,6 @@ void CoreChecks::RecordTransitionImageLayout(vvl::CommandBuffer &cb_state, const
     }
 }
 
-void CoreChecks::TransitionImageLayouts(vvl::CommandBuffer &cb_state, uint32_t barrier_count,
-                                        const VkImageMemoryBarrier2 *image_barriers) {
-    for (uint32_t i = 0; i < barrier_count; i++) {
-        const ImageBarrier barrier(image_barriers[i]);
-        RecordTransitionImageLayout(cb_state, barrier);
-    }
-}
-
-void CoreChecks::TransitionImageLayouts(vvl::CommandBuffer &cb_state, uint32_t barrier_count,
-                                        const VkImageMemoryBarrier *image_barriers, VkPipelineStageFlags src_stage_mask,
-                                        VkPipelineStageFlags dst_stage_mask) {
-    for (uint32_t i = 0; i < barrier_count; i++) {
-        const ImageBarrier barrier(image_barriers[i], src_stage_mask, dst_stage_mask);
-        RecordTransitionImageLayout(cb_state, barrier);
-    }
-}
-
 bool CoreChecks::IsCompliantSubresourceRange(const VkImageSubresourceRange &subres_range, const vvl::Image &image_state) const {
     if (!(subres_range.layerCount) || !(subres_range.levelCount)) return false;
     if (subres_range.baseMipLevel + subres_range.levelCount > image_state.create_info.mipLevels) return false;

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1098,11 +1098,6 @@ class CoreChecks : public vvl::DeviceProxy {
                                           CommandBufferImageLayoutMap& layout_updates_state) const;
 
     void RecordQueuedQFOTransfers(vvl::CommandBuffer& cb_state);
-
-    void TransitionImageLayouts(vvl::CommandBuffer& cb_state, uint32_t barrier_count, const VkImageMemoryBarrier2* image_barriers);
-    void TransitionImageLayouts(vvl::CommandBuffer& cb_state, uint32_t barrier_count, const VkImageMemoryBarrier* image_barriers,
-                                VkPipelineStageFlags src_stage_mask, VkPipelineStageFlags dst_stage_mask);
-
     void RecordTransitionImageLayout(vvl::CommandBuffer& cb_state, const ImageBarrier& image_barrier);
     void RecordBarriers(Func func_name, vvl::CommandBuffer& cb_state, VkPipelineStageFlags src_stage_mask,
                         VkPipelineStageFlags dst_stage_mask, uint32_t bufferBarrierCount,


### PR DESCRIPTION
Inline `RecordTransitionImageLayouts` into `RecordBarriers`. With this change `RecordBarriers` does everything, so no need to think about layout transitions. New version also removes one initialization of `ImageBarrier` object comparing to the  previous version.

For GPU-AV it makes sense to use aggregate `TransitionImageLayouts` because there is no additional barrier code similar to `RecordBarriers`.