### PR TITLE
layers: Add submit validation of dynamic rendering barriers

### DIFF
--- a/layers/core_checks/cc_state_tracker.cpp
+++ b/layers/core_checks/cc_state_tracker.cpp
@@ -20,13 +20,16 @@
 
 #include "cc_state_tracker.h"
 #include "core_validation.h"
+#include "error_message/error_strings.h"
+#include "state_tracker/image_state.h"
 #include "state_tracker/event_map.h"
+#include "sync/sync_vuid_maps.h"
 
 // Location to add per-queue submit debug info if built with -D DEBUG_CAPTURE_KEYBOARD=ON
 void CoreChecks::DebugCapture() {}
 
 void CoreChecks::Created(vvl::CommandBuffer& cb) {
-    cb.SetSubState(container_type, std::make_unique<core::CommandBufferSubState>(cb));
+    cb.SetSubState(container_type, std::make_unique<core::CommandBufferSubState>(cb, *this));
 }
 
 void CoreChecks::Created(vvl::Queue& queue) {
@@ -35,7 +38,10 @@ void CoreChecks::Created(vvl::Queue& queue) {
 
 namespace core {
 
-CommandBufferSubState::CommandBufferSubState(vvl::CommandBuffer& cb) : vvl::CommandBufferSubState(cb) { ResetCBState(); }
+CommandBufferSubState::CommandBufferSubState(vvl::CommandBuffer& cb, CoreChecks& validator)
+    : vvl::CommandBufferSubState(cb), validator(validator) {
+    ResetCBState();
+}
 
 void CommandBufferSubState::RecordWaitEvents(vvl::Func command, uint32_t eventCount, const VkEvent* pEvents,
                                              VkPipelineStageFlags2KHR srcStageMask) {
@@ -62,6 +68,9 @@ void CommandBufferSubState::ResetCBState() {
 
     // VK_EXT_nested_command_buffer
     nesting_level = 0;
+
+    // Submit time validation
+    submit_validate_dynamic_rendering_barrier_subresources.clear();
 }
 
 void CommandBufferSubState::ExecuteCommands(vvl::CommandBuffer& secondary_command_buffer) {
@@ -71,7 +80,50 @@ void CommandBufferSubState::ExecuteCommands(vvl::CommandBuffer& secondary_comman
     }
 }
 
+void CommandBufferSubState::SubmitTimeValidate() {
+    for (const auto& [image, subresources] : submit_validate_dynamic_rendering_barrier_subresources) {
+        const auto image_state = validator.Get<vvl::Image>(image);
+        if (!image_state) {
+            continue;
+        }
+        const auto global_layout_map = image_state->layout_range_map.get();
+        ASSERT_AND_CONTINUE(global_layout_map);
+        auto global_layout_map_guard = global_layout_map->ReadLock();
+
+        for (const std::pair<VkImageSubresourceRange, vvl::LocationCapture>& entry : subresources) {
+            const VkImageSubresourceRange& subresource = entry.first;
+            const Location& barrier_loc = entry.second.Get();
+            ImageLayoutRangeMap::RangeGenerator range_gen(image_state->subresource_encoder, subresource);
+            global_layout_map->AnyInRange(range_gen, [this, &barrier_loc, &image_state](const ImageLayoutRangeMap::key_type& range,
+                                                                                        const VkImageLayout& layout) {
+                if (layout != VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ && layout != VK_IMAGE_LAYOUT_GENERAL) {
+                    const auto& vuid = sync_vuid_maps::GetDynamicRenderingBarrierVUID(
+                        barrier_loc, sync_vuid_maps::DynamicRenderingBarrierError::kImageLayout);
+                    const LogObjectList objlist(base.Handle(), image_state->Handle());
+                    const Location& image_loc = barrier_loc.dot(vvl::Field::image);
+                    const VkImageSubresource subresource =
+                        static_cast<VkImageSubresource>(image_state->subresource_encoder.Decode(range.begin));
+                    return validator.LogError(vuid, objlist, image_loc, "(%s, %s) has layout %s.",
+                                              validator.FormatHandle(image_state->Handle()).c_str(),
+                                              string_VkImageSubresource(subresource).c_str(), string_VkImageLayout(layout));
+                }
+                return false;
+            });
+        }
+    }
+}
+
 QueueSubState::QueueSubState(Logger& logger, vvl::Queue& q) : vvl::QueueSubState(q), queue_submission_validator_(logger) {}
+
+void QueueSubState::PreSubmit(std::vector<vvl::QueueSubmission>& submissions) {
+    for (const auto& submission : submissions) {
+        for (auto& cb : submission.cb_submissions) {
+            auto guard = cb.cb->ReadLock();
+            CommandBufferSubState& cb_substate = SubState(*cb.cb);
+            cb_substate.SubmitTimeValidate();
+        }
+    }
+}
 
 void QueueSubState::Retire(vvl::QueueSubmission& submission) { queue_submission_validator_.Validate(submission); }
 

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -321,8 +321,9 @@ class CoreChecks : public vvl::DeviceProxy {
     bool ValidatePipelineCacheControlFlags(VkPipelineCreateFlags2 flags, const Location& flags_loc, const char* vuid) const;
     bool ValidatePipelineIndirectBindableFlags(VkPipelineCreateFlags2 flags, const Location& flags_loc, const char* vuid) const;
     bool ValidatePipelineProtectedAccessFlags(VkPipelineCreateFlags2 flags, const Location& flags_loc) const;
-    void EnqueueSubmitTimeValidateImageBarrierAttachment(const Location& loc, vvl::CommandBuffer& cb_state,
-                                                         const ImageBarrier& barrier);
+    void EnqueueValidateImageBarrierAttachment(const Location& loc, vvl::CommandBuffer& cb_state, const ImageBarrier& barrier);
+    void EnqueueValidateDynamicRenderingImageBarrierLayouts(const Location barrier_loc, vvl::CommandBuffer& cb_state,
+                                                            const ImageBarrier& image_barrier);
     bool ValidateImageBarrierAttachment(const Location& barrier_loc, vvl::CommandBuffer const& cb_state,
                                         const vvl::Framebuffer& fb_state, uint32_t active_subpass,
                                         const vku::safe_VkSubpassDescription2& sub_desc, const VkRenderPass rp_handle,


### PR DESCRIPTION
This does submit time validation of VUIDs like `VUID-vkCmdPipelineBarrier2-image-09555` when it's not possible to do this at record time (command buffer did not specify layout earlier).
