### PR TITLE
layers: Add CooperativeMatrix version check

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -52,6 +52,7 @@ class Bindable;
 
 namespace spirv {
 struct StatelessData;
+struct LocalSize;
 }  // namespace spirv
 
 namespace core {
@@ -892,8 +893,8 @@ class CoreChecks : public vvl::DeviceProxy {
 
     bool ValidateShaderStageMaxResources(VkShaderStageFlagBits stage, const vvl::Pipeline& pipeline, const Location& loc) const;
     bool ValidateCooperativeMatrix(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
-                                   const ShaderStageState& stage_state, const uint32_t local_size_x, const uint32_t local_size_y,
-                                   const uint32_t local_size_z, const Location& loc) const;
+                                   const ShaderStageState& stage_state, const spirv::LocalSize& local_size,
+                                   const Location& loc) const;
     bool ValidateCooperativeVector(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
                                    const ShaderStageState& stage_state, const Location& loc) const;
     bool ValidateShaderResolveQCOM(const spirv::Module& module_state, VkShaderStageFlagBits stage, const vvl::Pipeline& pipeline,
@@ -2279,14 +2280,12 @@ class CoreChecks : public vvl::DeviceProxy {
     bool PreCallValidateGetSemaphoreCounterValue(VkDevice device, VkSemaphore sempahore, uint64_t* pValue,
                                                  const ErrorObject& error_obj) const override;
     bool ValidateRequiredSubgroupSize(const spirv::Module& module_state, const ShaderStageState& stage_state, uint64_t invocations,
-                                      uint32_t local_size_x, uint32_t local_size_y, uint32_t local_size_z,
-                                      const Location& loc) const;
+                                      const spirv::LocalSize& local_size, const Location& loc) const;
     bool ValidateComputeWorkGroupSizes(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
-                                       const ShaderStageState& stage_state, uint32_t local_size_x, uint32_t local_size_y,
-                                       uint32_t local_size_z, const Location& loc) const;
+                                       const ShaderStageState& stage_state, const spirv::LocalSize& local_size,
+                                       const Location& loc) const;
     bool ValidateTaskMeshWorkGroupSizes(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
-                                        uint32_t local_size_x, uint32_t local_size_y, uint32_t local_size_z,
-                                        const Location& loc) const;
+                                        const spirv::LocalSize& local_size, const Location& loc) const;
     bool ValidateEmitMeshTasksSize(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
                                    const ShaderStageState& stage_state, const Location& loc) const;
     bool ValidateMeshMemorySize(const spirv::Module& module_state, uint32_t total_workgroup_shared_memory,

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -187,15 +187,15 @@ void ExecutionModeSet::Add(const Instruction& insn) {
         case spv::ExecutionModeLocalSizeId:
             flags |= local_size_id_bit;
             // Store ID here, will use flag to know to pull then out
-            local_size_x = insn.Word(3);
-            local_size_y = insn.Word(4);
-            local_size_z = insn.Word(5);
+            local_size.x = insn.Word(3);
+            local_size.y = insn.Word(4);
+            local_size.z = insn.Word(5);
             break;
         case spv::ExecutionModeLocalSize:
             flags |= local_size_bit;
-            local_size_x = insn.Word(3);
-            local_size_y = insn.Word(4);
-            local_size_z = insn.Word(5);
+            local_size.x = insn.Word(3);
+            local_size.y = insn.Word(4);
+            local_size.z = insn.Word(5);
             break;
         case spv::ExecutionModeOutputVertices:
             output_vertices = value;
@@ -1097,6 +1097,9 @@ Module::StaticData::StaticData(const Module& module_state, StatelessData* statel
             case spv::OpTypeCooperativeMatrixNV:
             case spv::OpCooperativeMatrixMulAddNV:
             case spv::OpTypeCooperativeMatrixKHR:
+            case spv::OpCooperativeMatrixLoadKHR:
+            case spv::OpCooperativeMatrixStoreKHR:
+            case spv::OpCooperativeMatrixLengthKHR:
             case spv::OpCooperativeMatrixMulAddKHR: {
                 cooperative_matrix_inst.push_back(&insn);
                 break;
@@ -1464,35 +1467,31 @@ std::shared_ptr<const EntryPoint> Module::FindEntrypoint(char const* name, VkSha
 //    OpEntryPoint GLCompute %main "name_a"
 //    OpEntryPoint GLCompute %main "name_b"
 // Assumes shader module contains no spec constants used to set the local size values
-bool Module::FindLocalSize(const EntryPoint& entrypoint, uint32_t& local_size_x, uint32_t& local_size_y,
-                           uint32_t& local_size_z) const {
+LocalSize Module::FindLocalSize(const EntryPoint& entrypoint) const {
+    LocalSize local_size;
     // "If an object is decorated with the WorkgroupSize decoration, this takes precedence over any LocalSize or LocalSizeId
     // execution mode."
     if (static_data_.has_builtin_workgroup_size) {
         const Instruction* composite_def = FindDef(static_data_.builtin_workgroup_size_id);
         if (composite_def->Opcode() == spv::OpConstantComposite) {
             // VUID-WorkgroupSize-WorkgroupSize-04427 makes sure this is a OpTypeVector of int32
-            local_size_x = GetConstantValueById(composite_def->Word(3));
-            local_size_y = GetConstantValueById(composite_def->Word(4));
-            local_size_z = GetConstantValueById(composite_def->Word(5));
-            return true;
+            local_size.x = GetConstantValueById(composite_def->Word(3));
+            local_size.y = GetConstantValueById(composite_def->Word(4));
+            local_size.z = GetConstantValueById(composite_def->Word(5));
+            return local_size;
         }
     }
 
     if (entrypoint.execution_mode.Has(ExecutionModeSet::local_size_bit)) {
-        local_size_x = entrypoint.execution_mode.local_size_x;
-        local_size_y = entrypoint.execution_mode.local_size_y;
-        local_size_z = entrypoint.execution_mode.local_size_z;
-        return true;
+        local_size = entrypoint.execution_mode.local_size;
     } else if (entrypoint.execution_mode.Has(ExecutionModeSet::local_size_id_bit)) {
         // Uses ExecutionModeLocalSizeId so need to resolve ID value
-        local_size_x = GetConstantValueById(entrypoint.execution_mode.local_size_x);
-        local_size_y = GetConstantValueById(entrypoint.execution_mode.local_size_y);
-        local_size_z = GetConstantValueById(entrypoint.execution_mode.local_size_z);
-        return true;
+        local_size.x = GetConstantValueById(entrypoint.execution_mode.local_size.x);
+        local_size.y = GetConstantValueById(entrypoint.execution_mode.local_size.y);
+        local_size.z = GetConstantValueById(entrypoint.execution_mode.local_size.z);
     }
 
-    return false;  // not found
+    return local_size;
 }
 
 uint32_t Module::CalculateWorkgroupSharedMemory() const {

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -21,6 +21,7 @@
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
+#include <string>
 #include <vector>
 #include <optional>
 
@@ -43,6 +44,16 @@ static constexpr uint32_t kInvalidValue = std::numeric_limits<uint32_t>::max();
 
 // Need to find a way to know if actually array length of zero, or a runtime array.
 static constexpr uint32_t kRuntimeArray = std::numeric_limits<uint32_t>::max();
+
+struct LocalSize {
+    uint32_t x = 0;
+    uint32_t y = 0;
+    uint32_t z = 0;
+
+    std::string ToString() const {
+        return "x = " + std::to_string(x) + ", y = " + std::to_string(y) + ", z = " + std::to_string(z);
+    }
+};
 
 // This is the common info for both OpDecorate and OpMemberDecorate
 // Used to keep track of all decorations applied to any instruction
@@ -143,9 +154,7 @@ struct ExecutionModeSet {
     VkPrimitiveTopology primitive_topology = VK_PRIMITIVE_TOPOLOGY_MAX_ENUM;
 
     // SPIR-V spec says only LocalSize or LocalSizeId can be used, so can share
-    uint32_t local_size_x = kInvalidValue;
-    uint32_t local_size_y = kInvalidValue;
-    uint32_t local_size_z = kInvalidValue;
+    LocalSize local_size = {kInvalidValue, kInvalidValue, kInvalidValue};
 
     uint32_t output_vertices = vvl::kU32Max;
     uint32_t output_primitives = 0;
@@ -712,7 +721,7 @@ struct Module {
     std::optional<VkPrimitiveTopology> GetTopology(const EntryPoint &entrypoint) const;
 
     std::shared_ptr<const EntryPoint> FindEntrypoint(char const *name, VkShaderStageFlagBits stageBits) const;
-    bool FindLocalSize(const EntryPoint &entrypoint, uint32_t &local_size_x, uint32_t &local_size_y, uint32_t &local_size_z) const;
+    LocalSize FindLocalSize(const EntryPoint &entrypoint) const;
 
     uint32_t CalculateWorkgroupSharedMemory() const;
     uint32_t CalculateTaskPayloadMemory() const;

--- a/tests/unit/shader_cooperative_matrix.cpp
+++ b/tests/unit/shader_cooperative_matrix.cpp
@@ -14,6 +14,7 @@
 
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
+#include "../framework/shader_object_helper.h"
 
 class NegativeShaderCooperativeMatrix : public CooperativeMatrixTest {};
 
@@ -700,4 +701,95 @@ TEST_F(NegativeShaderCooperativeMatrix, SignedCheck) {
 
         m_errorMonitor->VerifyFound();
     }
+}
+
+TEST_F(NegativeShaderCooperativeMatrix, RequiredVulkanVersionPipeline) {
+    TEST_DESCRIPTION("https://gitlab.khronos.org/spirv/SPIR-V/-/issues/847");
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_SUBGROUP_SIZE_CONTROL_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_16BIT_STORAGE_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::shaderFloat16);
+    AddRequiredFeature(vkt::Feature::storageBuffer16BitAccess);
+    AddRequiredFeature(vkt::Feature::subgroupSizeControl);
+    RETURN_IF_SKIP(InitCooperativeMatrixKHR());
+    if (!IsPlatformMockICD()) {
+        GTEST_SKIP() << "This makes assumption about possible coop matrix subgroup size and support.";
+    }
+
+    const std::vector<VkDescriptorSetLayoutBinding> bindings = {
+        {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+    };
+    const vkt::DescriptorSetLayout dsl(*m_device, bindings);
+    const vkt::PipelineLayout pipeline_layout(*m_device, {&dsl});
+
+    const char *cs_source = R"glsl(
+         #version 450 core
+         #pragma use_vulkan_memory_model
+         #extension GL_KHR_shader_subgroup_basic : enable
+         #extension GL_KHR_memory_scope_semantics : enable
+         #extension GL_KHR_cooperative_matrix : enable
+         #extension GL_EXT_shader_explicit_arithmetic_types : enable
+         #extension GL_EXT_shader_explicit_arithmetic_types_float16 : enable
+         layout(local_size_x = 32) in;
+         layout(set=0, binding=0) coherent buffer InputA { uint32_t x[]; } inputA;
+         coopmat<uint32_t, gl_ScopeSubgroup, 16, 16, gl_MatrixUseA> matA;
+         void main() {
+             coopMatLoad(matA, inputA.x, 0, 16, gl_CooperativeMatrixLayoutRowMajor);
+         }
+    )glsl";
+    VkShaderObj cs(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1);
+
+    CreateComputePipelineHelper pipe(*this);
+    pipe.cp_ci_.stage = cs.GetStageCreateInfo();
+    pipe.cp_ci_.layout = pipeline_layout;
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-OpTypeCooperativeMatrixKHR-10770");
+    pipe.CreateComputePipeline(false);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeShaderCooperativeMatrix, RequiredVulkanVersionShaderObject) {
+    TEST_DESCRIPTION("https://gitlab.khronos.org/spirv/SPIR-V/-/issues/847");
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_SUBGROUP_SIZE_CONTROL_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_16BIT_STORAGE_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_SHADER_OBJECT_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::shaderObject);
+    AddRequiredFeature(vkt::Feature::shaderFloat16);
+    AddRequiredFeature(vkt::Feature::storageBuffer16BitAccess);
+    AddRequiredFeature(vkt::Feature::subgroupSizeControl);
+    RETURN_IF_SKIP(InitCooperativeMatrixKHR());
+    if (!IsPlatformMockICD()) {
+        GTEST_SKIP() << "This makes assumption about possible coop matrix subgroup size and support.";
+    }
+
+    const std::vector<VkDescriptorSetLayoutBinding> bindings = {
+        {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
+    };
+    const vkt::DescriptorSetLayout dsl(*m_device, bindings);
+    const vkt::PipelineLayout pipeline_layout(*m_device, {&dsl});
+
+    const char *cs_source = R"glsl(
+         #version 450 core
+         #pragma use_vulkan_memory_model
+         #extension GL_KHR_shader_subgroup_basic : enable
+         #extension GL_KHR_memory_scope_semantics : enable
+         #extension GL_KHR_cooperative_matrix : enable
+         #extension GL_EXT_shader_explicit_arithmetic_types : enable
+         #extension GL_EXT_shader_explicit_arithmetic_types_float16 : enable
+         layout(local_size_x = 32) in;
+         layout(set=0, binding=0) coherent buffer InputA { uint32_t x[]; } inputA;
+         coopmat<uint32_t, gl_ScopeSubgroup, 16, 16, gl_MatrixUseA> matA;
+         void main() {
+             coopMatLoad(matA, inputA.x, 0, 16, gl_CooperativeMatrixLayoutRowMajor);
+         }
+    )glsl";
+
+    const auto spv = GLSLToSPV(VK_SHADER_STAGE_COMPUTE_BIT, cs_source, SPV_ENV_VULKAN_1_1);
+    auto shader_ci = ShaderCreateInfoNoNextStage(spv, VK_SHADER_STAGE_COMPUTE_BIT, 1, &dsl.handle());
+
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-OpTypeCooperativeMatrixKHR-10771");
+    const vkt::Shader comp_shader(*m_device, shader_ci);
+    m_errorMonitor->VerifyFound();
 }


### PR DESCRIPTION
From https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/7308

adds `VUID-RuntimeSpirv-OpTypeCooperativeMatrixKHR-10770` and `VUID-RuntimeSpirv-OpTypeCooperativeMatrixKHR-10771`

originally thought I would need `LocalSize` so made the change, but just kept it and made a separate commit