### PR TITLE
tests: Add Slang

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -324,85 +324,141 @@ find_package(SPIRV-Tools CONFIG)
 
 include(ExternalProject)
 
-
 set(SLANG_BINARY_DIR "${CMAKE_BINARY_DIR}/slang")
+set(SLANG_DOWNLOAD_DIR "${SLANG_BINARY_DIR}/download")
+set(SLANG_EXTRACT_DIR "${SLANG_BINARY_DIR}/extract")
 
 # Function to determine the correct binary URL based on platform
-function(get_slang_binary_url RESULT_VAR)
+function(get_slang_binary_url RESULT_VAR VERSION_VAR)
+    set(SLANG_VERSION "2025.8.1" CACHE STRING "Slang version to use")
+    set(${VERSION_VAR} ${SLANG_VERSION} PARENT_SCOPE)
+
     if(WIN32)
-        set(${RESULT_VAR} "https://github.com/shader-slang/slang/releases/download/v2025.8.1/slang-2025.8.1-windows-x86_64.zip" PARENT_SCOPE)
+        set(${RESULT_VAR} "https://github.com/shader-slang/slang/releases/download/v${SLANG_VERSION}/slang-${SLANG_VERSION}-windows-x86_64.zip" PARENT_SCOPE)
     elseif(UNIX AND NOT APPLE)
-        set(${RESULT_VAR} "https://github.com/shader-slang/slang/releases/download/v2025.8.1/slang-2025.8.1-linux-x86_64.zip" PARENT_SCOPE)
+        set(${RESULT_VAR} "https://github.com/shader-slang/slang/releases/download/v${SLANG_VERSION}/slang-${SLANG_VERSION}-linux-x86_64.zip" PARENT_SCOPE)
     elseif(APPLE)
-        set(${RESULT_VAR} "https://github.com/shader-slang/slang/releases/download/v2025.8.1/slang-2025.8.1-macos-aarch64.zip" PARENT_SCOPE)
+        set(${RESULT_VAR} "https://github.com/shader-slang/slang/releases/download/v${SLANG_VERSION}/slang-${SLANG_VERSION}-macos-aarch64.zip" PARENT_SCOPE)
     else()
         message(FATAL_ERROR "Unsupported platform for Slang prebuilt binaries")
     endif()
 endfunction()
 
-get_slang_binary_url(SLANG_URL)
+# Get the URL and version
+get_slang_binary_url(SLANG_URL SLANG_VERSION)
+message(STATUS "Using Slang version: ${SLANG_VERSION}")
+message(STATUS "Downloading from: ${SLANG_URL}")
 
-# Download and extract the binaries
-ExternalProject_Add(slang_binaries
-    URL ${SLANG_URL}
-    DOWNLOAD_DIR ${SLANG_BINARY_DIR}/download
-    SOURCE_DIR ${SLANG_BINARY_DIR}/source
-    BINARY_DIR ${SLANG_BINARY_DIR}/build
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND ""
-    INSTALL_COMMAND ""
-    # Ensure extraction happens
-    UPDATE_COMMAND ""
-    PATCH_COMMAND ""
+# Download the ZIP file directly using file(DOWNLOAD)
+file(DOWNLOAD "${SLANG_URL}" "${SLANG_DOWNLOAD_DIR}/slang-${SLANG_VERSION}.zip"
+     SHOW_PROGRESS
+     STATUS DOWNLOAD_STATUS
+)
+list(GET DOWNLOAD_STATUS 0 STATUS_CODE)
+if(NOT STATUS_CODE EQUAL 0)
+    list(GET DOWNLOAD_STATUS 1 ERROR_MESSAGE)
+    message(FATAL_ERROR "Failed to download Slang: ${ERROR_MESSAGE}")
+endif()
+
+# Extract the ZIP file using CMake's capabilities
+file(MAKE_DIRECTORY "${SLANG_EXTRACT_DIR}")
+file(ARCHIVE_EXTRACT 
+     INPUT "${SLANG_DOWNLOAD_DIR}/slang-${SLANG_VERSION}.zip"
+     DESTINATION "${SLANG_EXTRACT_DIR}"
 )
 
-# Define paths to Slang libraries and includes based on extracted structure
-set(SLANG_INCLUDE_DIR "${SLANG_BINARY_DIR}/source/include")
+# Print the directory structure for debugging
+message(STATUS "Listing contents of extracted directory:")
+file(GLOB_RECURSE EXTRACTED_FILES "${SLANG_EXTRACT_DIR}/*")
+foreach(FILE ${EXTRACTED_FILES})
+    message(STATUS "  ${FILE}")
+endforeach()
+
+# Define paths based on actual structure - these might need adjustment
 if(WIN32)
-    set(SLANG_LIBRARY "${SLANG_BINARY_DIR}/source/lib/slang.lib") 
-    set(SLANG_DLL "${SLANG_BINARY_DIR}/source/lib/slang.dll")
+    # Most Windows releases put files in bin/ directory
+    set(SLANG_BIN_DIR "${SLANG_EXTRACT_DIR}/bin")
+    set(SLANG_LIB_DIR "${SLANG_EXTRACT_DIR}/bin")
+    set(SLANG_INCLUDE_DIR "${SLANG_EXTRACT_DIR}/include")
+
+    # Double-check if lib directory exists separately
+    if(EXISTS "${SLANG_EXTRACT_DIR}/lib")
+        set(SLANG_LIB_DIR "${SLANG_EXTRACT_DIR}/lib")
+    endif()
+
+    # Check for slang.lib in both potential locations
+    if(EXISTS "${SLANG_BIN_DIR}/slang.lib")
+        set(SLANG_LIBRARY "${SLANG_BIN_DIR}/slang.lib")
+    elseif(EXISTS "${SLANG_LIB_DIR}/slang.lib")
+        set(SLANG_LIBRARY "${SLANG_LIB_DIR}/slang.lib")
+    else()
+        # Try to find the file with glob
+        file(GLOB SLANG_LIB_FILES "${SLANG_EXTRACT_DIR}/**/slang.lib")
+        if(SLANG_LIB_FILES)
+            list(GET SLANG_LIB_FILES 0 SLANG_LIBRARY)
+            message(STATUS "Found slang.lib at: ${SLANG_LIBRARY}")
+        else()
+            message(FATAL_ERROR "Could not locate slang.lib in extracted directory")
+        endif()
+    endif()
 else()
-    set(SLANG_LIBRARY "${SLANG_BINARY_DIR}/source/lib/libslang.so")
+    # Unix systems typically have lib/ and include/ directories
+    set(SLANG_INCLUDE_DIR "${SLANG_EXTRACT_DIR}/include")
+    set(SLANG_LIB_DIR "${SLANG_EXTRACT_DIR}/lib")
+
+    if(EXISTS "${SLANG_LIB_DIR}/libslang.so")
+        set(SLANG_LIBRARY "${SLANG_LIB_DIR}/libslang.so")
+    else()
+        file(GLOB SLANG_LIB_FILES "${SLANG_EXTRACT_DIR}/**/libslang.so")
+        if(SLANG_LIB_FILES)
+            list(GET SLANG_LIB_FILES 0 SLANG_LIBRARY)
+            message(STATUS "Found libslang.so at: ${SLANG_LIBRARY}")
+        else()
+            message(FATAL_ERROR "Could not locate libslang.so in extracted directory")
+        endif()
+    endif()
 endif()
 
 # Create an imported target for easier usage
 add_library(slang SHARED IMPORTED GLOBAL)
-add_dependencies(slang slang_binaries) # Ensure binaries are downloaded/extracted before use
 
-# Set properties after extraction is completed
-file(MAKE_DIRECTORY ${SLANG_INCLUDE_DIR}) # Avoid include directory warnings
+# Set properties
+file(MAKE_DIRECTORY ${SLANG_INCLUDE_DIR})
+message(STATUS "Setting Slang include dir: ${SLANG_INCLUDE_DIR}")
+message(STATUS "Setting Slang library: ${SLANG_LIBRARY}")
 
 set_target_properties(slang PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES ${SLANG_INCLUDE_DIR}
 )
 
-# Set platform-specific properties
 if(WIN32)
+    message(STATUS "Setting Slang .lib: ${SLANG_LIBRARY}")
     set_target_properties(slang PROPERTIES
         IMPORTED_IMPLIB ${SLANG_LIBRARY}
-        IMPORTED_LOCATION ${SLANG_DLL}
     )
 else()
     set_target_properties(slang PROPERTIES
         IMPORTED_LOCATION ${SLANG_LIBRARY}
     )
+    add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${SLANG_LIBRARY}
+            $<TARGET_FILE_DIR:${TARGET_NAME}>
+        COMMENT "Copying Slang .so to output directory for ${TARGET_NAME}"
+    )
 endif()
 
 # Function to copy the DLL to the target's output directory (for Windows)
-# function(copy_slang_dll TARGET_NAME)
-#     if(WIN32)
-#         add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
-#             COMMAND ${CMAKE_COMMAND} -E copy_if_different
-#                 ${SLANG_DLL}
-#                 $<TARGET_FILE_DIR:${TARGET_NAME}>
-#             COMMENT "Copying Slang DLL to output directory"
-#         )
-#     endif()
-# endfunction()
-
-# Usage in your project:
-# target_link_libraries(your_target PRIVATE slang)
-# copy_slang_dll(your_target)
+function(copy_slang_dll TARGET_NAME)
+    if(WIN32)
+        add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                ${SLANG_DLL}
+                $<TARGET_FILE_DIR:${TARGET_NAME}>
+            COMMENT "Copying Slang DLL to output directory for ${TARGET_NAME}"
+        )
+    endif()
+endfunction()
 
 target_link_libraries(vk_layer_validation_tests PRIVATE
     VkLayer_utils

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -322,8 +322,91 @@ find_package(GTest CONFIG)
 find_package(glslang CONFIG)
 find_package(SPIRV-Tools CONFIG)
 
+include(ExternalProject)
+
+
+set(SLANG_BINARY_DIR "${CMAKE_BINARY_DIR}/slang")
+
+# Function to determine the correct binary URL based on platform
+function(get_slang_binary_url RESULT_VAR)
+    if(WIN32)
+        set(${RESULT_VAR} "https://github.com/shader-slang/slang/releases/download/v2025.8.1/slang-2025.8.1-windows-x86_64.zip" PARENT_SCOPE)
+    elseif(UNIX AND NOT APPLE)
+        set(${RESULT_VAR} "https://github.com/shader-slang/slang/releases/download/v2025.8.1/slang-2025.8.1-linux-x86_64.zip" PARENT_SCOPE)
+    elseif(APPLE)
+        set(${RESULT_VAR} "https://github.com/shader-slang/slang/releases/download/v2025.8.1/slang-2025.8.1-macos-aarch64.zip" PARENT_SCOPE)
+    else()
+        message(FATAL_ERROR "Unsupported platform for Slang prebuilt binaries")
+    endif()
+endfunction()
+
+get_slang_binary_url(SLANG_URL)
+
+# Download and extract the binaries
+ExternalProject_Add(slang_binaries
+    URL ${SLANG_URL}
+    DOWNLOAD_DIR ${SLANG_BINARY_DIR}/download
+    SOURCE_DIR ${SLANG_BINARY_DIR}/source
+    BINARY_DIR ${SLANG_BINARY_DIR}/build
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
+    INSTALL_COMMAND ""
+    # Ensure extraction happens
+    UPDATE_COMMAND ""
+    PATCH_COMMAND ""
+)
+
+# Define paths to Slang libraries and includes based on extracted structure
+set(SLANG_INCLUDE_DIR "${SLANG_BINARY_DIR}/source/include")
+if(WIN32)
+    set(SLANG_LIBRARY "${SLANG_BINARY_DIR}/source/lib/slang.lib") 
+    set(SLANG_DLL "${SLANG_BINARY_DIR}/source/lib/slang.dll")
+else()
+    set(SLANG_LIBRARY "${SLANG_BINARY_DIR}/source/lib/libslang.so")
+endif()
+
+# Create an imported target for easier usage
+add_library(slang SHARED IMPORTED GLOBAL)
+add_dependencies(slang slang_binaries) # Ensure binaries are downloaded/extracted before use
+
+# Set properties after extraction is completed
+file(MAKE_DIRECTORY ${SLANG_INCLUDE_DIR}) # Avoid include directory warnings
+
+set_target_properties(slang PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES ${SLANG_INCLUDE_DIR}
+)
+
+# Set platform-specific properties
+if(WIN32)
+    set_target_properties(slang PROPERTIES
+        IMPORTED_IMPLIB ${SLANG_LIBRARY}
+        IMPORTED_LOCATION ${SLANG_DLL}
+    )
+else()
+    set_target_properties(slang PROPERTIES
+        IMPORTED_LOCATION ${SLANG_LIBRARY}
+    )
+endif()
+
+# Function to copy the DLL to the target's output directory (for Windows)
+# function(copy_slang_dll TARGET_NAME)
+#     if(WIN32)
+#         add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
+#             COMMAND ${CMAKE_COMMAND} -E copy_if_different
+#                 ${SLANG_DLL}
+#                 $<TARGET_FILE_DIR:${TARGET_NAME}>
+#             COMMENT "Copying Slang DLL to output directory"
+#         )
+#     endif()
+# endfunction()
+
+# Usage in your project:
+# target_link_libraries(your_target PRIVATE slang)
+# copy_slang_dll(your_target)
+
 target_link_libraries(vk_layer_validation_tests PRIVATE
     VkLayer_utils
+    slang
     glslang::SPIRV
     glslang::SPVRemapper
     SPIRV-Tools-static

--- a/tests/framework/ray_tracing_objects.cpp
+++ b/tests/framework/ray_tracing_objects.cpp
@@ -1429,6 +1429,11 @@ void Pipeline::AddSpirvRayGenShader(const char *spirv, const char *entry_point) 
                                                                 SPV_SOURCE_ASM, nullptr, entry_point));
 }
 
+void Pipeline::AddSlangRayGenShader(const char *slang, const char *entry_point) {
+    ray_gen_shaders_.emplace_back(std::make_unique<VkShaderObj>(&test_, slang, VK_SHADER_STAGE_RAYGEN_BIT_KHR, SPV_ENV_VULKAN_1_2,
+                                                                SPV_SOURCE_SLANG, nullptr, entry_point));
+}
+
 void Pipeline::AddGlslMissShader(const char *glsl) {
     miss_shaders_.emplace_back(std::make_unique<VkShaderObj>(&test_, glsl, VK_SHADER_STAGE_MISS_BIT_KHR, SPV_ENV_VULKAN_1_2));
 }
@@ -1436,6 +1441,11 @@ void Pipeline::AddGlslMissShader(const char *glsl) {
 void Pipeline::AddSpirvMissShader(const char *spirv, const char *entry_point) {
     miss_shaders_.emplace_back(std::make_unique<VkShaderObj>(&test_, spirv, VK_SHADER_STAGE_MISS_BIT_KHR, SPV_ENV_VULKAN_1_2,
                                                              SPV_SOURCE_ASM, nullptr, entry_point));
+}
+
+void Pipeline::AddSlangMissShader(const char *slang, const char *entry_point) {
+    miss_shaders_.emplace_back(std::make_unique<VkShaderObj>(&test_, slang, VK_SHADER_STAGE_MISS_BIT_KHR, SPV_ENV_VULKAN_1_2,
+                                                             SPV_SOURCE_SLANG, nullptr, entry_point));
 }
 
 void Pipeline::AddGlslClosestHitShader(const char *glsl) {
@@ -1446,6 +1456,11 @@ void Pipeline::AddGlslClosestHitShader(const char *glsl) {
 void Pipeline::AddSpirvClosestHitShader(const char *spirv, const char *entry_point) {
     closest_hit_shaders_.emplace_back(std::make_unique<VkShaderObj>(&test_, spirv, VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR,
                                                                     SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM, nullptr, entry_point));
+}
+
+void Pipeline::AddSlangClosestHitShader(const char *slang, const char *entry_point) {
+    closest_hit_shaders_.emplace_back(std::make_unique<VkShaderObj>(&test_, slang, VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR,
+                                                                    SPV_ENV_VULKAN_1_2, SPV_SOURCE_SLANG, nullptr, entry_point));
 }
 
 void Pipeline::AddLibrary(const Pipeline &library) {

--- a/tests/framework/ray_tracing_objects.h
+++ b/tests/framework/ray_tracing_objects.h
@@ -323,10 +323,13 @@ class Pipeline {
     void SetPushConstantRangeSize(uint32_t byte_size);
     void SetGlslRayGenShader(const char* glsl);
     void AddSpirvRayGenShader(const char* spirv, const char* entry_point);
+    void AddSlangRayGenShader(const char* slang, const char* entry_point);
     void AddGlslMissShader(const char* glsl);
     void AddSpirvMissShader(const char* spirv, const char* entry_point);
+    void AddSlangMissShader(const char* slang, const char* entry_point);
     void AddGlslClosestHitShader(const char* glsl);
     void AddSpirvClosestHitShader(const char* spirv, const char* entry_point);
+    void AddSlangClosestHitShader(const char* slang, const char* entry_point);
     void AddLibrary(const Pipeline& library);
     void AddDynamicState(VkDynamicState dynamic_state);
 

--- a/tests/framework/shader_helper.cpp
+++ b/tests/framework/shader_helper.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@
 #include "shader_helper.h"
 #include "glslang/SPIRV/GlslangToSpv.h"
 #include <glslang/Public/ShaderLang.h>
+#include "slang.h"
+#include "slang-com-ptr.h"
 
 static void ProcessConfigFile(const VkPhysicalDeviceLimits &device_limits, TBuiltInResource &out_resources) {
     // These are the default resources for TBuiltInResources.
@@ -304,6 +306,124 @@ bool ASMtoSPV(const spv_target_env target_env, const uint32_t options, const cha
     return true;
 }
 
+bool SlangToSPV(const char *slang_shader, const char *entry_point_name, std::vector<uint8_t> &out_bytes) {
+    // Function adapted from
+    // https://github.com/shader-slang/slang/blob/master/examples/hello-world/main.cpp#L114
+    // Used https://github.com/shader-slang/slang/issues/6678 to figure out how to use
+    // `slang::IModule::loadModuleFromSourceString`
+
+    using namespace Slang;
+
+    // First we need to create slang global session with work with the Slang API.
+    ComPtr<slang::IGlobalSession> slang_session;
+    {
+        SlangGlobalSessionDesc slang_session_desc = {};
+        // slang_session_desc.enableGLSL = true; // Could be needed in the future
+        slang::createGlobalSession(&slang_session_desc, slang_session.writeRef());
+    }
+
+    // Next we create a compilation session to generate SPIRV code from Slang source.
+    slang::TargetDesc targetDesc = {};
+    targetDesc.format = SLANG_SPIRV;
+    targetDesc.profile = slang_session->findProfile("glsl_460");  // todo what spirv profile ?
+    targetDesc.flags = 0;
+    slang::SessionDesc sessionDesc = {};
+    sessionDesc.targets = &targetDesc;
+    sessionDesc.targetCount = 1;
+
+    std::vector<slang::CompilerOptionEntry> options;
+    options.push_back(
+        {slang::CompilerOptionName::EmitSpirvDirectly, {slang::CompilerOptionValueKind::Int, 1, 0, nullptr, nullptr}});
+    // https://github.com/shader-slang/slang/issues/6248
+    options.push_back(
+        {slang::CompilerOptionName::VulkanUseEntryPointName, {slang::CompilerOptionValueKind::Int, 1, 0, nullptr, nullptr}});
+    sessionDesc.compilerOptionEntries = options.data();
+    sessionDesc.compilerOptionEntryCount = options.size();
+
+    ComPtr<slang::ISession> session;
+    SlangResult result = slang_session->createSession(sessionDesc, session.writeRef());
+    if (result != 0) {
+        ADD_FAILURE() << "Slang failure: slang_session->createSession()";
+    }
+
+    // Handle errors
+    Slang::ComPtr<ISlangBlob> diagnostics;
+
+    // Compile the source code
+    // Once the session has been obtained, we can start loading code into it.
+    // Here we use `loadModuleFromSourceString` and not `loadModule`.
+    // moduleName and path are just placeholders
+    Slang::ComPtr<slang::IModule> slang_module;
+    slang_module = session->loadModuleFromSourceString("my_shader", "my_shader.slang", slang_shader, diagnostics.writeRef());
+    if (slang_module == NULL) {
+        ADD_FAILURE() << "Slang failure: loadModuleFromSourceString()\n" << ((const char *)diagnostics->getBufferPointer());
+        return false;
+    }
+
+    // Loading the module will compile and check all the shader code in it,
+    // including the shader entry points we want to use. Now that the module is loaded
+    // we can look up those entry points by name.
+    //
+    // Note: If you are using this `loadModule` approach to load your shader code it is
+    // important to tag your entry point functions with the `[shader("...")]` attribute
+    // (e.g., `[shader("compute")] void computeMain(...)`). Without that information there
+    // is no unambiguous way for the compiler to know which functions represent entry
+    // points when it parses your code via `loadModule()`.
+    //
+    ComPtr<slang::IEntryPoint> entry_point;
+    slang_module->findEntryPointByName(entry_point_name, entry_point.writeRef());
+
+    // At this point we have a few different Slang API objects that represent
+    // pieces of our code: `module`, `vertexEntryPoint`, and `fragmentEntryPoint`.
+    //
+    // A single Slang module could contain many different entry points (e.g.,
+    // four vertex entry points, three fragment entry points, and two compute
+    // shaders), and before we try to generate output code for our target API
+    // we need to identify which entry points we plan to use together.
+    //
+    // Modules and entry points are both examples of *component types* in the
+    // Slang API. The API also provides a way to build a *composite* out of
+    // other pieces, and that is what we are going to do with our module
+    // and entry points.
+    //
+    std::vector<slang::IComponentType *> componentTypes;
+    componentTypes.emplace_back(slang_module);
+    componentTypes.emplace_back(entry_point);
+
+    // Actually creating the composite component type is a single operation
+    // on the Slang session, but the operation could potentially fail if
+    // something about the composite was invalid (e.g., you are trying to
+    // combine multiple copies of the same module), so we need to deal
+    // with the possibility of diagnostic output.
+    //
+    ComPtr<slang::IComponentType> composedProgram;
+    {
+        result = session->createCompositeComponentType(componentTypes.data(), (SlangInt)componentTypes.size(),
+                                                       composedProgram.writeRef(), diagnostics.writeRef());
+        if (result != 0) {
+            ADD_FAILURE() << "Slang failure: createCompositeComponentType()\n" << ((const char *)diagnostics->getBufferPointer());
+            return false;
+        }
+    }
+
+    // Now we can call `composedProgram->getEntryPointCode()` to retrieve the
+    // compiled SPIRV code that we will use to create a vulkan compute pipeline.
+    // This will trigger the final Slang compilation and spirv code generation.
+    ComPtr<slang::IBlob> spirvCode;
+    {
+        result = composedProgram->getEntryPointCode(0, 0, spirvCode.writeRef(), diagnostics.writeRef());
+        if (result != 0) {
+            ADD_FAILURE() << "Slang failure: createCompositeComponentType()\n" << ((const char *)diagnostics->getBufferPointer());
+            return false;
+        }
+    }
+
+    out_bytes.resize(spirvCode->getBufferSize());
+    std::memcpy(out_bytes.data(), spirvCode->getBufferPointer(), spirvCode->getBufferSize());
+
+    return true;
+}
+
 VkPipelineShaderStageCreateInfo const &VkShaderObj::GetStageCreateInfo() const { return m_stage_info; }
 
 VkShaderObj::VkShaderObj(VkRenderFramework *framework, const char *source, VkShaderStageFlagBits stage, const spv_target_env env,
@@ -320,6 +440,8 @@ VkShaderObj::VkShaderObj(VkRenderFramework *framework, const char *source, VkSha
         InitFromGLSL(pNext);
     } else if (source_type == SPV_SOURCE_ASM) {
         InitFromASM();
+    } else if (source_type == SPV_SOURCE_SLANG) {
+        InitFromSlang();
     }
 }
 
@@ -380,6 +502,25 @@ VkResult VkShaderObj::InitFromASMTry() {
     const auto result = InitTry(m_device, moduleCreateInfo);
     m_stage_info.module = handle();
     return result;
+}
+
+bool VkShaderObj::InitFromSlang() {
+    std::vector<uint8_t> bytes;
+    if (!SlangToSPV(m_source, m_stage_info.pName, bytes)) {
+        return false;
+    }
+    // Maxi hack: slang always output "main" as OpEntryPoint.
+    // But when compiling slang source, the entry point name provided earlier is expected
+    // => TL;DR: things will work as expeced, as long GetStageCreateInfo().pName is used to access the entry point name
+    // after compiling the shader
+    // m_stage_info.pName = "main";
+    VkShaderModuleCreateInfo module_ci = vku::InitStructHelper();
+    module_ci.codeSize = bytes.size();
+    module_ci.pCode = (uint32_t *)bytes.data();
+
+    init(m_device, module_ci);
+    m_stage_info.module = handle();
+    return VK_NULL_HANDLE != handle();
 }
 
 // static

--- a/tests/framework/shader_helper.cpp
+++ b/tests/framework/shader_helper.cpp
@@ -19,8 +19,17 @@
 #include "shader_helper.h"
 #include "glslang/SPIRV/GlslangToSpv.h"
 #include <glslang/Public/ShaderLang.h>
+
+#pragma push_macro("None")
+#pragma push_macro("Bool")
+#undef None
+#undef Bool
+
 #include "slang.h"
 #include "slang-com-ptr.h"
+
+#pragma pop_macro("None")
+#pragma pop_macro("Bool")
 
 static void ProcessConfigFile(const VkPhysicalDeviceLimits &device_limits, TBuiltInResource &out_resources) {
     // These are the default resources for TBuiltInResources.

--- a/tests/framework/shader_helper.h
+++ b/tests/framework/shader_helper.h
@@ -31,14 +31,17 @@ class VkRenderFramework;
 typedef enum {
     SPV_SOURCE_GLSL,
     SPV_SOURCE_ASM,
+    SPV_SOURCE_SLANG,
     // TRY == Won't try in contructor as need to be called as function that can return the VkResult
     SPV_SOURCE_GLSL_TRY,
     SPV_SOURCE_ASM_TRY,
 } SpvSourceType;
 
 bool GLSLtoSPV(const VkPhysicalDeviceLimits &device_limits, const VkShaderStageFlagBits shader_type, const char *p_shader,
-               std::vector<uint32_t> &spv, const spv_target_env spv_env = SPV_ENV_VULKAN_1_0);
-bool ASMtoSPV(const spv_target_env target_env, const uint32_t options, const char *p_asm, std::vector<uint32_t> &spv);
+               std::vector<uint32_t> &out_spv, const spv_target_env spv_env = SPV_ENV_VULKAN_1_0);
+bool ASMtoSPV(const spv_target_env target_env, const uint32_t options, const char *p_asm, std::vector<uint32_t> &out_spv);
+
+bool SlangToSPV(const char *slang_shader, const char *entry_point_name, std::vector<uint8_t> &out_bytes);
 
 // VkShaderObj is really just the Shader Module, but we named before VK_EXT_shader_object
 // TODO - move all of VkShaderObj to vkt::ShaderModule
@@ -48,12 +51,14 @@ class VkShaderObj : public vkt::ShaderModule {
     VkShaderObj(VkRenderFramework *framework, const char *source, VkShaderStageFlagBits stage,
                 const spv_target_env env = SPV_ENV_VULKAN_1_0, SpvSourceType source_type = SPV_SOURCE_GLSL,
                 const VkSpecializationInfo *spec_info = nullptr, char const *entry_point = "main", const void *pNext = nullptr);
+
     VkPipelineShaderStageCreateInfo const &GetStageCreateInfo() const;
 
     bool InitFromGLSL(const void *pNext = nullptr);
     VkResult InitFromGLSLTry(const vkt::Device *custom_device = nullptr);
     bool InitFromASM();
     VkResult InitFromASMTry();
+    bool InitFromSlang();
 
     // These functions return a pointer to a newly created _and initialized_ VkShaderObj if initialization was successful.
     // Otherwise, {} is returned.


### PR DESCRIPTION
![Cool Text - The Future is Here Slang in VVL 482383561126123](https://github.com/user-attachments/assets/712cc0c9-5869-41ed-99df-1e7ff6651695)

(well almost, CI will likely cry, and probably still need to cleanup the CMake, at least for ARM)

Building Slang from source is painfully slow (7 minutes, more than the other dependencies combined).
So instead I went the "just grab the pre built libs" route, since Slang devs provide builds for pretty much every platform we care about