### PR TITLE
gpuav: Per cb submission buffers for post process

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -204,6 +204,8 @@ vvl_sources = [
   "layers/gpuav/instrumentation/gpuav_shader_instrumentor.h",
   "layers/gpuav/instrumentation/gpuav_instrumentation.cpp",
   "layers/gpuav/instrumentation/gpuav_instrumentation.h",
+  "layers/gpuav/instrumentation/post_process_descriptor_indexing.cpp",
+  "layers/gpuav/instrumentation/post_process_descriptor_indexing.h",
   "layers/gpuav/resources/gpuav_vulkan_objects.cpp",
   "layers/gpuav/resources/gpuav_vulkan_objects.h",
   "layers/gpuav/resources/gpuav_shader_resources.h",

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -310,6 +310,8 @@ target_sources(vvl PRIVATE
     gpuav/instrumentation/gpuav_shader_instrumentor.h
     gpuav/instrumentation/gpuav_instrumentation.h
     gpuav/instrumentation/gpuav_instrumentation.cpp
+    gpuav/instrumentation/post_process_descriptor_indexing.h
+    gpuav/instrumentation/post_process_descriptor_indexing.cpp
     gpuav/resources/gpuav_state_trackers.cpp
     gpuav/resources/gpuav_state_trackers.h
     gpuav/resources/gpuav_shader_resources.h

--- a/layers/gpuav/core/gpuav.h
+++ b/layers/gpuav/core/gpuav.h
@@ -83,6 +83,8 @@ class Validator : public GpuShaderInstrumentor {
     void PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) final;
     void PreCallRecordCreateBuffer(VkDevice device, const VkBufferCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                    VkBuffer* pBuffer, const RecordObject& record_obj, chassis::CreateBuffer& chassis_state) final;
+    void PreCallRecordBeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo* pBeginInfo,
+                                         const RecordObject& record_obj) final;
     void RecordCmdNextSubpassLayouts(vvl::CommandBuffer& cb_state, VkSubpassContents contents);
     void PostCallRecordCmdNextSubpass(VkCommandBuffer commandBuffer, VkSubpassContents contents,
                                       const RecordObject& record_obj) final;

--- a/layers/gpuav/descriptor_validation/gpuav_descriptor_set.cpp
+++ b/layers/gpuav/descriptor_validation/gpuav_descriptor_set.cpp
@@ -17,13 +17,11 @@
 
 #include "gpuav/descriptor_validation/gpuav_descriptor_set.h"
 
-#include "containers/custom_containers.h"
 #include "gpuav/core/gpuav.h"
 #include "gpuav/resources/gpuav_state_trackers.h"
 #include "gpuav/resources/gpuav_shader_resources.h"
 #include "gpuav/shaders/gpuav_shaders_constants.h"
 #include "state_tracker/descriptor_sets.h"
-#include "state_tracker/shader_module.h"
 #include "containers/limits.h"
 
 #include "profiling/profiling.h"
@@ -39,14 +37,11 @@ static uint32_t BitBufferSize(uint32_t num_bits) {
 }
 
 DescriptorSetSubState::DescriptorSetSubState(const vvl::DescriptorSet &set, Validator &state_data)
-    : vvl::DescriptorSetSubState(set), post_process_buffer_(state_data), input_buffer_(state_data) {
+    : vvl::DescriptorSetSubState(set), input_buffer_(state_data) {
     BuildBindingLayouts();
 }
 
-DescriptorSetSubState::~DescriptorSetSubState() {
-    post_process_buffer_.Destroy();
-    input_buffer_.Destroy();
-}
+DescriptorSetSubState::~DescriptorSetSubState() { input_buffer_.Destroy(); }
 
 void DescriptorSetSubState::BuildBindingLayouts() {
     const uint32_t binding_count = (base.GetBindingCount() > 0) ? base.GetLayout()->GetMaxBinding() + 1 : 0;
@@ -240,80 +235,6 @@ VkDeviceAddress DescriptorSetSubState::GetTypeAddress(Validator &gpuav, const Lo
     input_buffer_.FlushAllocation();
 
     return input_buffer_.Address();
-}
-
-// There are times we need a dummy address because the app is legally using something that doesn't require a post process buffer
-bool DescriptorSetSubState::CanPostProcess() const {
-    // When no descriptors (only inline, zero bindingCount, etc)
-    if (base.GetNonInlineDescriptorCount() == 0) {
-        return false;
-    }
-    return true;
-}
-
-VkDeviceAddress DescriptorSetSubState::GetPostProcessBuffer(Validator &gpuav) {
-    auto guard = Lock();
-    // Each set only needs to create its post process buffer once. It is based on total descriptor count, and even with things like
-    // VARIABLE_DESCRIPTOR_COUNT_BIT, the size will only get smaller afterwards.
-    if (post_process_buffer_.Address() != 0) {
-        return post_process_buffer_.Address();
-    }
-
-    if (!CanPostProcess()) {
-        return post_process_buffer_.Address();
-    }
-
-    const VkDeviceSize slot_size = base.GetNonInlineDescriptorCount() * sizeof(glsl::PostProcessDescriptorIndexSlot);
-    VkBufferCreateInfo buffer_info = vku::InitStructHelper();
-    buffer_info.size = slot_size;
-    buffer_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
-
-    VmaAllocationCreateInfo alloc_info{};
-    // The descriptor state buffer can be very large (4mb+ in some games). Allocating it as HOST_CACHED
-    // and manually flushing it at the end of the state updates is faster than using HOST_COHERENT.
-    alloc_info.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT;
-    const bool success = post_process_buffer_.Create(&buffer_info, &alloc_info);
-    if (!success) {
-        return 0;
-    }
-
-    ClearPostProcess();
-
-    return post_process_buffer_.Address();
-}
-
-// cross checks the two buffers (our layout with the output from the GPU-AV run) and builds a map of which indexes in which binding
-// where accessed
-DescriptorAccessMap DescriptorSetSubState::GetDescriptorAccesses(const Location &loc) const {
-    VVL_ZoneScoped;
-    DescriptorAccessMap descriptor_access_map;
-    if (post_process_buffer_.IsDestroyed()) {
-        return descriptor_access_map;
-    }
-
-    auto slot_ptr = (glsl::PostProcessDescriptorIndexSlot *)post_process_buffer_.GetMappedPtr();
-    post_process_buffer_.InvalidateAllocation();
-
-    for (uint32_t binding = 0; binding < binding_layouts_.size(); binding++) {
-        const gpuav::spirv::BindingLayout &binding_layout = binding_layouts_[binding];
-        for (uint32_t descriptor_i = 0; descriptor_i < binding_layout.count; descriptor_i++) {
-            const glsl::PostProcessDescriptorIndexSlot slot = slot_ptr[binding_layout.start + descriptor_i];
-            if (slot.meta_data & glsl::kPostProcessMetaMaskAccessed) {
-                const uint32_t shader_id = slot.meta_data & glsl::kShaderIdMask;
-                const uint32_t action_index =
-                    (slot.meta_data & glsl::kPostProcessMetaMaskActionIndex) >> glsl::kPostProcessMetaShiftActionIndex;
-                descriptor_access_map[shader_id].emplace_back(
-                    DescriptorAccess{binding, descriptor_i, slot.variable_id, action_index});
-            }
-        }
-    }
-
-    return descriptor_access_map;
-}
-
-void DescriptorSetSubState::ClearPostProcess() const {
-    post_process_buffer_.Clear();
-    post_process_buffer_.FlushAllocation();
 }
 
 void DescriptorSetSubState::NotifyUpdate() { current_version_++; }

--- a/layers/gpuav/descriptor_validation/gpuav_descriptor_set.h
+++ b/layers/gpuav/descriptor_validation/gpuav_descriptor_set.h
@@ -50,18 +50,12 @@ class DescriptorSetSubState : public vvl::DescriptorSetSubState {
     void NotifyUpdate() override;
 
     VkDeviceAddress GetTypeAddress(Validator &gpuav, const Location &loc);
-    VkDeviceAddress GetPostProcessBuffer(Validator &gpuav);
-    bool HasPostProcessBuffer() const { return !post_process_buffer_.IsDestroyed(); }
-    bool CanPostProcess() const;
-    void ClearPostProcess() const;
 
-    DescriptorAccessMap GetDescriptorAccesses(const Location &loc) const;
+    const std::vector<gpuav::spirv::BindingLayout> &GetBindingLayouts() const { return binding_layouts_; }
 
   private:
     void BuildBindingLayouts();
     std::lock_guard<std::mutex> Lock() const { return std::lock_guard<std::mutex>(state_lock_); }
-
-    vko::Buffer post_process_buffer_;
 
     std::vector<gpuav::spirv::BindingLayout> binding_layouts_;
 

--- a/layers/gpuav/descriptor_validation/gpuav_descriptor_validation.cpp
+++ b/layers/gpuav/descriptor_validation/gpuav_descriptor_validation.cpp
@@ -32,40 +32,8 @@
 namespace gpuav {
 namespace descriptor {
 
-void UpdateBoundDescriptorsPostProcess(Validator &gpuav, CommandBufferSubState &cb_state, const LastBound &last_bound,
-                                       DescriptorBindingCommand &descriptor_binding_cmd) {
-    if (!gpuav.gpuav_settings.shader_instrumentation.post_process_descriptor_indexing) return;
-
-    // Create a new buffer to hold our BDA pointers
-    VkBufferCreateInfo buffer_info = vku::InitStructHelper();
-    buffer_info.size = sizeof(glsl::PostProcessSSBO);
-    buffer_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
-    VmaAllocationCreateInfo alloc_info = {};
-    alloc_info.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-    alloc_info.pool = VK_NULL_HANDLE;
-    const bool success = descriptor_binding_cmd.post_process_ssbo_buffer.Create(&buffer_info, &alloc_info);
-    if (!success) {
-        return;
-    }
-
-    descriptor_binding_cmd.post_process_ssbo_buffer.Clear();
-    auto ssbo_buffer_ptr = (glsl::PostProcessSSBO *)descriptor_binding_cmd.post_process_ssbo_buffer.GetMappedPtr();
-
-    cb_state.post_process_buffer_lut = descriptor_binding_cmd.post_process_ssbo_buffer.VkHandle();
-
-    const size_t number_of_sets = last_bound.ds_slots.size();
-    for (uint32_t i = 0; i < number_of_sets; i++) {
-        const auto &ds_slot = last_bound.ds_slots[i];
-        if (!ds_slot.ds_state) {
-            continue;  // can have gaps in descriptor sets
-        }
-
-        ssbo_buffer_ptr->descriptor_index_post_process_buffers[i] = SubState(*ds_slot.ds_state).GetPostProcessBuffer(gpuav);
-    }
-}
-
 void UpdateBoundDescriptorsDescriptorChecks(Validator &gpuav, CommandBufferSubState &cb_state, const LastBound &last_bound,
-                                            DescriptorBindingCommand &descriptor_binding_cmd, const Location &loc) {
+                                            DescriptorSetBindingCommand &descriptor_binding_cmd, const Location &loc) {
     if (!gpuav.gpuav_settings.shader_instrumentation.descriptor_checks) {
         return;
     }
@@ -121,7 +89,7 @@ void UpdateBoundDescriptors(Validator &gpuav, CommandBufferSubState &cb_state, V
         return;
     }
 
-    DescriptorBindingCommand descriptor_binding_cmd(gpuav);
+    DescriptorSetBindingCommand descriptor_binding_cmd(gpuav);
     descriptor_binding_cmd.bound_descriptor_sets.reserve(number_of_sets);
     // Currently we loop through the sets multiple times to reduce complexity and seperate the various parts, can revisit if we find
     // this is actually a perf bottleneck (assume number of sets are low as people we will then to have a single large set)
@@ -130,157 +98,43 @@ void UpdateBoundDescriptors(Validator &gpuav, CommandBufferSubState &cb_state, V
         descriptor_binding_cmd.bound_descriptor_sets.emplace_back(ds_slot.ds_state);
     }
 
-    UpdateBoundDescriptorsPostProcess(gpuav, cb_state, last_bound, descriptor_binding_cmd);
     UpdateBoundDescriptorsDescriptorChecks(gpuav, cb_state, last_bound, descriptor_binding_cmd, loc);
 
-    cb_state.descriptor_binding_commands.emplace_back(std::move(descriptor_binding_cmd));
+    // #ARNO_TODO should not be a GetOrCreate but a TryGet: only care about creating this cache if it is used.
+    // => need to update `UpdateBoundDescriptorsDescriptorChecks` and `UpdateDescriptorStateSSBO` same as I did for post processing
+    DescriptorSetBindings &desc_set_bindings = cb_state.shared_resources_cache.GetOrCreate<DescriptorSetBindings>();
+    for (auto &descriptor_binding_func : desc_set_bindings.on_update_bound_descriptor_sets) {
+        descriptor_binding_func(cb_state, descriptor_binding_cmd);
+    }
+    desc_set_bindings.descriptor_set_binding_commands.emplace_back(std::move(descriptor_binding_cmd));
 }
 
 // For the given command buffer, map its debug data buffers and update the status of any update after bind descriptors
 [[nodiscard]] bool UpdateDescriptorStateSSBO(Validator &gpuav, CommandBufferSubState &cb_state, const Location &loc) {
-    const bool need_descriptor_checks = gpuav.gpuav_settings.shader_instrumentation.descriptor_checks;
-    if (!need_descriptor_checks) return true;
+    const bool need_descriptor_checks_update = gpuav.gpuav_settings.shader_instrumentation.descriptor_checks;
+    if (!need_descriptor_checks_update) {
+        return true;
+    }
 
-    for (auto &descriptor_binding_cmd : cb_state.descriptor_binding_commands) {
-        auto ssbo_buffer_ptr = (glsl::DescriptorStateSSBO *)descriptor_binding_cmd.descritpor_state_ssbo_buffer.GetMappedPtr();
-        for (size_t i = 0; i < descriptor_binding_cmd.bound_descriptor_sets.size(); i++) {
-            auto &bound_desc_set = descriptor_binding_cmd.bound_descriptor_sets[i];
-            // Some descriptor set slots may be unbound
-            if (!bound_desc_set) {
+    DescriptorSetBindings *desc_set_bindings = cb_state.shared_resources_cache.TryGet<DescriptorSetBindings>();
+    if (!desc_set_bindings) {
+        return true;
+    }
+    for (DescriptorSetBindingCommand &descriptor_command_binding : desc_set_bindings->descriptor_set_binding_commands) {
+        glsl::DescriptorStateSSBO *desc_state_ssbo_ptr =
+            (glsl::DescriptorStateSSBO *)descriptor_command_binding.descritpor_state_ssbo_buffer.GetMappedPtr();
+        for (size_t i = 0; i < descriptor_command_binding.bound_descriptor_sets.size(); i++) {
+            // Perfectly can have gaps in descriptor sets bindings
+            if (!descriptor_command_binding.bound_descriptor_sets[i]) {
                 continue;
             }
-            auto &substate = SubState(*bound_desc_set);
-            ssbo_buffer_ptr->descriptor_set_types[i] = substate.GetTypeAddress(gpuav, loc);
+            DescriptorSetSubState &desc_set_state = SubState(*descriptor_command_binding.bound_descriptor_sets[i]);
+            if (need_descriptor_checks_update) {
+                desc_state_ssbo_ptr->descriptor_set_types[i] = desc_set_state.GetTypeAddress(gpuav, loc);
+            }
         }
     }
     return true;
 }
 }  // namespace descriptor
-
-// After the GPU executed, we know which descriptor indexes were accessed and can validate with normal Core Validation logic
-[[nodiscard]] bool CommandBufferSubState::ValidateBindlessDescriptorSets(const Location &loc, const LabelLogging &label_logging) {
-    VVL_ZoneScoped;
-    // Only check a VkDescriptorSet once, might be bound multiple times in a single command buffer
-    vvl::unordered_set<VkDescriptorSet> validated_desc_sets;
-
-    // TODO - Currently we don't know the actual call that triggered this, but without just giving "vkCmdDraw" we will get
-    // VUID_Undefined We now have the DescriptorValidator::action_index, just need to hook it up!
-    Location draw_loc(vvl::Func::vkCmdDraw);
-
-    // We loop each vkCmdBindDescriptorSet, find each VkDescriptorSet that was used in the command buffer, and check its post
-    // process buffer for which descriptor was accessed
-    for (const auto &descriptor_binding_cmd : descriptor_binding_commands) {
-        for (uint32_t set_index = 0; set_index < descriptor_binding_cmd.bound_descriptor_sets.size(); set_index++) {
-            auto &bound_desc_set = descriptor_binding_cmd.bound_descriptor_sets[set_index];
-            // Some descriptor set slots may be unbound
-            if (!bound_desc_set) {
-                continue;
-            }
-            auto &ds_sub_state = SubState(*bound_desc_set);
-
-            // The Post Process buffer is tied to the VkDescriptorSet, so we clear it after and only check it once
-            if (validated_desc_sets.count(bound_desc_set->VkHandle()) > 0) {
-                // TODO - If you share two VkDescriptorSet across two different sets in the SPIR-V, we are not going to be
-                // validating the 2nd instance of it
-                continue;
-            }
-
-            if (!ds_sub_state.HasPostProcessBuffer()) {
-                if (!ds_sub_state.CanPostProcess()) {
-                    continue;  // hit a dummy object used as a placeholder
-                } else if (bound_desc_set->GetBindingCount() == 0) {
-                    continue;  // empty set
-                }
-
-                std::stringstream error;
-                error << "In CommandBuffer::ValidateBindlessDescriptorSets, descriptor_binding_cmd.bound_descriptor_sets["
-                      << set_index
-                      << "].HasPostProcessBuffer() was false. This should not happen. GPU-AV is in a bad state, aborting.";
-
-                gpuav_.InternalError(gpuav_.device, loc, error.str().c_str());
-                return false;
-            }
-            validated_desc_sets.emplace(bound_desc_set->VkHandle());
-
-            // We build once here, but will update the set_index and shader_handle when found
-            vvl::DescriptorValidator context(gpuav_, base, *bound_desc_set, 0, VK_NULL_HANDLE, nullptr, draw_loc);
-
-            DescriptorAccessMap descriptor_access_map = ds_sub_state.GetDescriptorAccesses(loc);
-            // Once we have accessed everything and created the DescriptorAccess, we can clear this buffer
-            ds_sub_state.ClearPostProcess();
-
-            // For each shader ID we can do the state object lookup once, then validate all the accesses inside of it
-            for (const auto &[shader_id, descriptor_accesses] : descriptor_access_map) {
-                auto it = gpuav_.instrumented_shaders_map_.find(shader_id);
-                if (it == gpuav_.instrumented_shaders_map_.end()) {
-                    assert(false);
-                    continue;
-                }
-
-                const vvl::Pipeline *pipeline_state = nullptr;
-                const vvl::ShaderObject *shader_object_state = nullptr;
-
-                if (it->second.pipeline != VK_NULL_HANDLE) {
-                    // We use pipeline over vkShaderModule as likely they will have been destroyed by now
-                    pipeline_state = gpuav_.Get<vvl::Pipeline>(it->second.pipeline).get();
-                    context.SetShaderHandleForGpuAv(&pipeline_state->Handle());
-                } else if (it->second.shader_object != VK_NULL_HANDLE) {
-                    shader_object_state = gpuav_.Get<vvl::ShaderObject>(it->second.shader_object).get();
-                    ASSERT_AND_CONTINUE(shader_object_state->entrypoint);
-                    context.SetShaderHandleForGpuAv(&shader_object_state->Handle());
-                } else {
-                    assert(false);
-                    continue;
-                }
-
-                for (const auto &descriptor_access : descriptor_accesses) {
-                    auto descriptor_binding = bound_desc_set->GetBinding(descriptor_access.binding);
-                    ASSERT_AND_CONTINUE(descriptor_binding);
-
-                    const ::spirv::ResourceInterfaceVariable *resource_variable = nullptr;
-                    if (pipeline_state) {
-                        for (const auto &stage_state : pipeline_state->stage_states) {
-                            ASSERT_AND_CONTINUE(stage_state.entrypoint);
-                            auto variable_it =
-                                stage_state.entrypoint->resource_interface_variable_map.find(descriptor_access.variable_id);
-                            if (variable_it != stage_state.entrypoint->resource_interface_variable_map.end()) {
-                                resource_variable = variable_it->second;
-                                break;  // Only need to find a single entry point
-                            }
-                        }
-                    } else if (shader_object_state) {
-                        ASSERT_AND_CONTINUE(shader_object_state->entrypoint);
-                        auto variable_it =
-                            shader_object_state->entrypoint->resource_interface_variable_map.find(descriptor_access.variable_id);
-                        if (variable_it != shader_object_state->entrypoint->resource_interface_variable_map.end()) {
-                            resource_variable = variable_it->second;
-                        }
-                    }
-                    ASSERT_AND_CONTINUE(resource_variable);
-
-                    // If we already validated/updated the descriptor on the CPU, don't redo it now in GPU-AV Post Processing
-                    if (!bound_desc_set->ValidateBindingOnGPU(*descriptor_binding, *resource_variable)) {
-                        continue;
-                    }
-
-                    // This will represent the Set that was accessed in the shader, which might not match the vkCmdBindDescriptorSet
-                    // index if sets are aliased
-                    context.SetSetIndexForGpuAv(resource_variable->decorations.set);
-
-                    std::string debug_region_name;
-                    if (auto found_label_cmd_i = label_logging.action_cmd_i_to_label_cmd_i_map.find(descriptor_access.action_index);
-                        found_label_cmd_i != label_logging.action_cmd_i_to_label_cmd_i_map.end()) {
-                        debug_region_name = GetDebugLabelRegion(found_label_cmd_i->second, label_logging.initial_label_stack);
-                    }
-
-                    Location access_loc(loc, debug_region_name);
-                    context.SetLocationForGpuAv(access_loc);
-                    context.ValidateBindingDynamic(*resource_variable, *descriptor_binding, descriptor_access.index);
-                }
-            }
-        }
-    }
-
-    return true;
-}
 }  // namespace gpuav

--- a/layers/gpuav/descriptor_validation/gpuav_descriptor_validation.h
+++ b/layers/gpuav/descriptor_validation/gpuav_descriptor_validation.h
@@ -25,13 +25,11 @@ struct LastBound;
 namespace gpuav {
 class CommandBufferSubState;
 class Validator;
-struct DescriptorBindingCommand;
+struct DescriptorSetBindingCommand;
 
 namespace descriptor {
-void UpdateBoundDescriptorsPostProcess(Validator& gpuav, CommandBufferSubState& cb_state, const LastBound& last_bound,
-                                       DescriptorBindingCommand& descriptor_binding_cmd);
 void UpdateBoundDescriptorsDescriptorChecks(Validator& gpuav, CommandBufferSubState& cb_state, const LastBound& last_bound,
-                                            DescriptorBindingCommand& descriptor_binding_cmd, const Location& loc);
+                                            DescriptorSetBindingCommand& descriptor_binding_cmd, const Location& loc);
 void UpdateBoundDescriptors(Validator& gpuav, CommandBufferSubState& cb_state, VkPipelineBindPoint pipeline_bind_point,
                             const Location& loc);
 [[nodiscard]] bool UpdateDescriptorStateSSBO(Validator& gpuav, CommandBufferSubState& cb_state, const Location& loc);

--- a/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
@@ -332,22 +332,6 @@ void UpdateInstrumentationDescSet(Validator &gpuav, CommandBufferSubState &cb_st
         desc_writes.emplace_back(wds);
     }
 
-    // Post Processing Output buffer
-    VkDescriptorBufferInfo post_process_buffer_info = {};
-    if (cb_state.post_process_buffer_lut != VK_NULL_HANDLE) {
-        post_process_buffer_info.range = VK_WHOLE_SIZE;
-        post_process_buffer_info.buffer = cb_state.post_process_buffer_lut;
-        post_process_buffer_info.offset = 0;
-
-        VkWriteDescriptorSet wds = vku::InitStructHelper();
-        wds.dstBinding = glsl::kBindingInstPostProcess;
-        wds.descriptorCount = 1;
-        wds.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-        wds.pBufferInfo = &post_process_buffer_info;
-        wds.dstSet = instrumentation_desc_set;
-        desc_writes.emplace_back(wds);
-    }
-
     // Descriptor Indexing input buffer
     VkDescriptorBufferInfo di_input_desc_buffer_info = {};
     if (cb_state.descriptor_indexing_buffer != VK_NULL_HANDLE) {
@@ -437,6 +421,23 @@ void UpdateInstrumentationDescSet(Validator &gpuav, CommandBufferSubState &cb_st
         wds.descriptorCount = 1;
         wds.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
         wds.pBufferInfo = &vertex_attribute_fetch_limits_buffer_bi;
+        desc_writes.emplace_back(wds);
+    }
+
+    std::vector<VkDescriptorBufferInfo> buffer_infos(cb_state.on_instrumentation_desc_set_update_functions.size());
+    for (size_t func_i = 0; func_i < cb_state.on_instrumentation_desc_set_update_functions.size(); ++func_i) {
+        VkWriteDescriptorSet wds = vku::InitStructHelper();
+        wds.dstSet = instrumentation_desc_set;
+        wds.dstBinding = vvl::kU32Max;
+        wds.descriptorCount = 1;
+        wds.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+        wds.pBufferInfo = &buffer_infos[func_i];
+
+        cb_state.on_instrumentation_desc_set_update_functions[func_i](cb_state, buffer_infos[func_i], wds.dstBinding);
+
+        assert(buffer_infos[func_i].buffer != VK_NULL_HANDLE);
+        assert(wds.dstBinding != vvl::kU32Max);
+
         desc_writes.emplace_back(wds);
     }
 
@@ -625,8 +626,12 @@ void PreCallSetupShaderInstrumentationResources(Validator &gpuav, CommandBufferS
     // We want to grab the last (current) element in descriptor_binding_commands, but as a std::vector, the refernce might be
     // garbage later, so just hold the index for later. It is possible to have no descriptor sets bound, for example if using push
     // constants.
-    instrumentation_error_blob.descriptor_binding_index =
-        !cb_state.descriptor_binding_commands.empty() ? uint32_t(cb_state.descriptor_binding_commands.size()) - 1 : vvl::kU32Max;
+    instrumentation_error_blob.descriptor_binding_index = vvl::kU32Max;
+    DescriptorSetBindings *desc_set_bindings = cb_state.shared_resources_cache.TryGet<DescriptorSetBindings>();
+    if (desc_set_bindings && !desc_set_bindings->descriptor_set_binding_commands.empty()) {
+        instrumentation_error_blob.descriptor_binding_index =
+            uint32_t(desc_set_bindings->descriptor_set_binding_commands.size() - 1);
+    }
 
     instrumentation_error_blob.label_command_i =
         !cb_state.base.GetLabelCommands().empty() ? uint32_t(cb_state.base.GetLabelCommands().size() - 1) : vvl::kU32Max;
@@ -706,8 +711,10 @@ bool LogMessageInstDescriptorIndexingOOB(Validator &gpuav, const CommandBufferSu
         assert(false);  // This means we have hit a situtation where there are no descriptors bound
         return false;
     }
+    const DescriptorSetBindings &desc_set_bindings = cb_state.shared_resources_cache.Get<DescriptorSetBindings>();
     const auto &descriptor_sets =
-        cb_state.descriptor_binding_commands[instrumentation_error_blob.descriptor_binding_index].bound_descriptor_sets;
+        desc_set_bindings.descriptor_set_binding_commands[instrumentation_error_blob.descriptor_binding_index]
+            .bound_descriptor_sets;
 
     // Currently we only encode the descriptor index here and save the binding in a parameter slot
     // The issue becomes if the user has kErrorSubCodeDescriptorIndexingBounds then we can't back track to the exact binding because
@@ -779,8 +786,10 @@ bool LogMessageInstDescriptorClass(Validator &gpuav, const CommandBufferSubState
         assert(false);  // This means we have hit a situtation where there are no descriptors bound
         return false;
     }
+    const DescriptorSetBindings &desc_set_bindings = cb_state.shared_resources_cache.Get<DescriptorSetBindings>();
     const auto &descriptor_sets =
-        cb_state.descriptor_binding_commands[instrumentation_error_blob.descriptor_binding_index].bound_descriptor_sets;
+        desc_set_bindings.descriptor_set_binding_commands[instrumentation_error_blob.descriptor_binding_index]
+            .bound_descriptor_sets;
 
     const uint32_t encoded_set_index = error_record[kInstDescriptorIndexingSetAndIndexOffset];
     const uint32_t set_num = encoded_set_index >> kInstDescriptorIndexingSetShift;

--- a/layers/gpuav/instrumentation/gpuav_instrumentation.h
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation.h
@@ -40,7 +40,6 @@ namespace gpuav {
 class Validator;
 class CommandBufferSubState;
 class Queue;
-struct DescriptorBindingCommand;
 struct InstrumentationErrorBlob;
 
 void UpdateInstrumentationDescSet(Validator& gpuav, CommandBufferSubState& cb_state, VkDescriptorSet instrumentation_desc_set,

--- a/layers/gpuav/instrumentation/post_process_descriptor_indexing.cpp
+++ b/layers/gpuav/instrumentation/post_process_descriptor_indexing.cpp
@@ -1,0 +1,274 @@
+/* Copyright (c) 2024-2025 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gpuav/instrumentation/post_process_descriptor_indexing.h"
+
+#include "drawdispatch/descriptor_validator.h"
+#include "gpuav/core/gpuav.h"
+#include "gpuav/resources/gpuav_shader_resources.h"
+#include "gpuav/resources/gpuav_state_trackers.h"
+#include "state_tracker/pipeline_state.h"
+#include "state_tracker/shader_module.h"
+#include "state_tracker/shader_object_state.h"
+
+#include "profiling/profiling.h"
+
+namespace gpuav {
+
+struct PostProcessingCbState {
+    vko::BufferRange last_desc_set_binding_to_post_process_buffers_lut;
+};
+
+void RegisterPostProcessingValidation(Validator& gpuav, CommandBufferSubState& cb) {
+    if (!gpuav.gpuav_settings.shader_instrumentation.post_process_descriptor_indexing) {
+        return;
+    }
+
+    DescriptorSetBindings& desc_set_bindings = cb.shared_resources_cache.GetOrCreate<DescriptorSetBindings>();
+
+    desc_set_bindings.on_update_bound_descriptor_sets.emplace_back(
+        [](CommandBufferSubState& cb, DescriptorSetBindingCommand& desc_binding_cmd) {
+            PostProcessingCbState& pp_cb_state = cb.shared_resources_cache.GetOrCreate<PostProcessingCbState>();
+
+            pp_cb_state.last_desc_set_binding_to_post_process_buffers_lut =
+                cb.gpu_resources_manager.GetDeviceLocalBufferRange(sizeof(glsl::PostProcessSSBO));
+
+            desc_binding_cmd.desc_set_binding_to_post_process_buffers_lut =
+                pp_cb_state.last_desc_set_binding_to_post_process_buffers_lut;
+        });
+
+    cb.on_instrumentation_desc_set_update_functions.emplace_back(
+        [dummy_buffer_range = vko::BufferRange{}](CommandBufferSubState& cb, VkDescriptorBufferInfo& out_buffer_info,
+                                                  uint32_t& out_dst_binding) mutable {
+            PostProcessingCbState* pp_cb_state = cb.shared_resources_cache.TryGet<PostProcessingCbState>();
+            if (pp_cb_state) {
+                out_buffer_info.buffer = pp_cb_state->last_desc_set_binding_to_post_process_buffers_lut.buffer;
+                out_buffer_info.offset = pp_cb_state->last_desc_set_binding_to_post_process_buffers_lut.offset;
+                out_buffer_info.range = pp_cb_state->last_desc_set_binding_to_post_process_buffers_lut.size;
+            } else {
+                // Eventually, no descriptor set was bound in command buffer.
+                // Instrumenation descriptor set is already defined at this point and needs a binding,
+                // so just provide a dummy buffer
+                if (dummy_buffer_range.buffer == VK_NULL_HANDLE) {
+                    dummy_buffer_range = cb.gpu_resources_manager.GetDeviceLocalBufferRange(64);
+                }
+                out_buffer_info.buffer = dummy_buffer_range.buffer;
+                out_buffer_info.offset = dummy_buffer_range.offset;
+                out_buffer_info.range = dummy_buffer_range.size;
+            }
+
+            out_dst_binding = glsl::kBindingInstPostProcess;
+        });
+
+    auto bound_desc_sets_to_pp_buffer_map =
+        std::make_shared<vvl::unordered_map<std::shared_ptr<vvl::DescriptorSet>, vko::BufferRange>>();
+    cb.on_pre_cb_submission_functions.emplace_back([bound_desc_sets_to_pp_buffer_map](Validator& gpuav, CommandBufferSubState& cb,
+                                                                                      VkCommandBuffer per_submission_cb) {
+        VVL_ZoneScoped;
+        DescriptorSetBindings& desc_set_bindings = cb.shared_resources_cache.Get<DescriptorSetBindings>();
+
+        for (const DescriptorSetBindingCommand& desc_binding_cmd : desc_set_bindings.descriptor_set_binding_commands) {
+            vko::BufferRange desc_set_buffer_lut_buffer_range = cb.gpu_resources_manager.GetHostVisibleBufferRange(
+                32 * sizeof(VkDeviceAddress));  // No driver offers more than 32 descriptor set bindings
+
+            // For each unique bound descriptor set in this command buffer,
+            // create an appropriate post processing buffer,
+            // and update the "per CB submission desciptor set to post process buffers" LUT
+
+            // For each CB submission, and for each descriptor binding command,
+            // a "desciptor set to post process buffers LUT" is allocated and updated in a VkBuffer.
+            // When executing, this CB submission will access its own private
+            // post processing buffers, preventing concurrent use by another CB
+            for (size_t ds_i = 0; ds_i < desc_binding_cmd.bound_descriptor_sets.size(); ds_i++) {
+                // Perfectly can have gaps in descriptor sets bindings
+                if (!desc_binding_cmd.bound_descriptor_sets[ds_i]) {
+                    continue;
+                }
+                DescriptorSetSubState& desc_set_state = SubState(*desc_binding_cmd.bound_descriptor_sets[ds_i]);
+
+                if (auto found = bound_desc_sets_to_pp_buffer_map->find(desc_binding_cmd.bound_descriptor_sets[ds_i]);
+                    found == bound_desc_sets_to_pp_buffer_map->end()) {
+                    // DescriptorSetSubState::GetPostProcessBufferSize() used to do a "auto guard = Lock()"
+                    // But the lock was only guarding againg GPU-AV sub state, not the base state, so
+                    // base.GetNonInlineDescriptorCount() access were not fully protected
+                    const VkDeviceSize pp_buffer_size =
+                        desc_set_state.base.GetNonInlineDescriptorCount() * sizeof(glsl::PostProcessDescriptorIndexSlot);
+
+                    if (pp_buffer_size == 0) {
+                        continue;
+                    }
+
+                    vko::BufferRange pp_buffer_range = cb.gpu_resources_manager.GetHostCachedBufferRange(pp_buffer_size);
+                    memset((std::byte*)pp_buffer_range.offset_mapped_ptr, 0, (size_t)pp_buffer_range.size);
+                    cb.gpu_resources_manager.FlushAllocation(pp_buffer_range);
+
+                    auto desc_set_buffer_lut_ptr = (VkDeviceAddress*)desc_set_buffer_lut_buffer_range.offset_mapped_ptr;
+                    desc_set_buffer_lut_ptr[ds_i] = pp_buffer_range.offset_address;
+                    bound_desc_sets_to_pp_buffer_map->insert({desc_binding_cmd.bound_descriptor_sets[ds_i], pp_buffer_range});
+                } else {
+                    auto desc_set_buffer_lut_ptr = (VkDeviceAddress*)desc_set_buffer_lut_buffer_range.offset_mapped_ptr;
+                    desc_set_buffer_lut_ptr[ds_i] = found->second.offset_address;
+                }
+            }
+
+            // Dispatch a copy command, copying the per CB submission descriptor set LUT to the LUT created at
+            // "bind descriptor set command" record time, aka the one that shaders will ultimately access.
+            {
+                VkBufferMemoryBarrier barrier_write_after_read = vku::InitStructHelper();
+                barrier_write_after_read.srcAccessMask = VK_ACCESS_MEMORY_READ_BIT;
+                barrier_write_after_read.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                barrier_write_after_read.buffer = desc_binding_cmd.desc_set_binding_to_post_process_buffers_lut.buffer;
+                barrier_write_after_read.offset = desc_binding_cmd.desc_set_binding_to_post_process_buffers_lut.offset;
+                barrier_write_after_read.size = desc_binding_cmd.desc_set_binding_to_post_process_buffers_lut.size;
+
+                DispatchCmdPipelineBarrier(per_submission_cb, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                                           VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 1, &barrier_write_after_read, 0,
+                                           nullptr);
+
+                VkBufferCopy copy;
+                copy.srcOffset = desc_set_buffer_lut_buffer_range.offset;
+                copy.dstOffset = desc_binding_cmd.desc_set_binding_to_post_process_buffers_lut.offset;
+                copy.size = desc_binding_cmd.bound_descriptor_sets.size() * sizeof(VkDeviceAddress);
+                DispatchCmdCopyBuffer(per_submission_cb, desc_set_buffer_lut_buffer_range.buffer,
+                                      desc_binding_cmd.desc_set_binding_to_post_process_buffers_lut.buffer, 1, &copy);
+
+                VkBufferMemoryBarrier barrier_read_before_write = vku::InitStructHelper();
+                barrier_read_before_write.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+                barrier_read_before_write.dstAccessMask = VK_ACCESS_MEMORY_READ_BIT;
+                barrier_read_before_write.buffer = desc_binding_cmd.desc_set_binding_to_post_process_buffers_lut.buffer;
+                barrier_read_before_write.offset = desc_binding_cmd.desc_set_binding_to_post_process_buffers_lut.offset;
+                barrier_read_before_write.size = desc_binding_cmd.desc_set_binding_to_post_process_buffers_lut.size;
+
+                DispatchCmdPipelineBarrier(per_submission_cb, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0,
+                                           0, nullptr, 1, &barrier_read_before_write, 0, nullptr);
+            }
+        }
+    });
+
+    // Validate descriptor set accesses done by command buffer submission
+    cb.on_cb_completion_functions.emplace_back([bound_desc_sets_to_pp_buffer_map](
+                                                   Validator& gpuav, CommandBufferSubState& cb,
+                                                   const CommandBufferSubState::LabelLogging& label_logging, const Location& loc) {
+        VVL_ZoneScoped;
+
+        // TODO - Currently we don't know the actual call that triggered this, but without just giving "vkCmdDraw" we
+        // will get VUID_Undefined We now have the DescriptorValidator::action_index, just need to hook it up!
+        Location draw_loc(vvl::Func::vkCmdDraw);
+
+        // We loop each vkCmdBindDescriptorSet, find each VkDescriptorSet that was used in the command buffer, and check
+        // its post process buffer for which descriptor was accessed Only check a VkDescriptorSet once, might be bound
+        // multiple times in a single command buffer
+        for (const auto& [desc_set, pp_buffer_range] : *bound_desc_sets_to_pp_buffer_map) {
+            // We build once here, but will update the set_index and shader_handle when found
+            vvl::DescriptorValidator context(gpuav, cb.base, *desc_set, 0, VK_NULL_HANDLE, nullptr, draw_loc);
+
+            DescriptorAccessMap descriptor_access_map;
+            {
+                VVL_ZoneScoped;
+                cb.gpu_resources_manager.InvalidateAllocation(pp_buffer_range);
+                auto slot_ptr = (glsl::PostProcessDescriptorIndexSlot*)pp_buffer_range.offset_mapped_ptr;
+
+                const std::vector<gpuav::spirv::BindingLayout>& binding_layouts = SubState(*desc_set).GetBindingLayouts();
+                for (uint32_t binding = 0; binding < binding_layouts.size(); binding++) {
+                    const gpuav::spirv::BindingLayout& binding_layout = binding_layouts[binding];
+                    for (uint32_t descriptor_i = 0; descriptor_i < binding_layout.count; descriptor_i++) {
+                        const glsl::PostProcessDescriptorIndexSlot slot = slot_ptr[binding_layout.start + descriptor_i];
+                        if (slot.meta_data & glsl::kPostProcessMetaMaskAccessed) {
+                            const uint32_t shader_id = slot.meta_data & glsl::kShaderIdMask;
+                            const uint32_t action_index =
+                                (slot.meta_data & glsl::kPostProcessMetaMaskActionIndex) >> glsl::kPostProcessMetaShiftActionIndex;
+                            descriptor_access_map[shader_id].emplace_back(
+                                DescriptorAccess{binding, descriptor_i, slot.variable_id, action_index});
+                        }
+                    }
+                }
+            }
+
+            // For each shader ID we can do the state object lookup once, then validate all the accesses inside of it
+            for (const auto& [shader_id, descriptor_accesses] : descriptor_access_map) {
+                auto it = gpuav.instrumented_shaders_map_.find(shader_id);
+                if (it == gpuav.instrumented_shaders_map_.end()) {
+                    assert(false);
+                    continue;
+                }
+
+                const vvl::Pipeline* pipeline_state = nullptr;
+                const vvl::ShaderObject* shader_object_state = nullptr;
+
+                if (it->second.pipeline != VK_NULL_HANDLE) {
+                    // We use pipeline over vkShaderModule as likely they will have been destroyed by now
+                    pipeline_state = gpuav.Get<vvl::Pipeline>(it->second.pipeline).get();
+                    context.SetShaderHandleForGpuAv(&pipeline_state->Handle());
+                } else if (it->second.shader_object != VK_NULL_HANDLE) {
+                    shader_object_state = gpuav.Get<vvl::ShaderObject>(it->second.shader_object).get();
+                    ASSERT_AND_CONTINUE(shader_object_state->entrypoint);
+                    context.SetShaderHandleForGpuAv(&shader_object_state->Handle());
+                } else {
+                    assert(false);
+                    continue;
+                }
+
+                for (const DescriptorAccess& descriptor_access : descriptor_accesses) {
+                    auto descriptor_binding = desc_set->GetBinding(descriptor_access.binding);
+                    ASSERT_AND_CONTINUE(descriptor_binding);
+
+                    const ::spirv::ResourceInterfaceVariable* resource_variable = nullptr;
+                    if (pipeline_state) {
+                        for (const ShaderStageState& stage_state : pipeline_state->stage_states) {
+                            ASSERT_AND_CONTINUE(stage_state.entrypoint);
+                            auto variable_it =
+                                stage_state.entrypoint->resource_interface_variable_map.find(descriptor_access.variable_id);
+                            if (variable_it != stage_state.entrypoint->resource_interface_variable_map.end()) {
+                                resource_variable = variable_it->second;
+                                break;  // Only need to find a single entry point
+                            }
+                        }
+                    } else if (shader_object_state) {
+                        ASSERT_AND_CONTINUE(shader_object_state->entrypoint);
+                        auto variable_it =
+                            shader_object_state->entrypoint->resource_interface_variable_map.find(descriptor_access.variable_id);
+                        if (variable_it != shader_object_state->entrypoint->resource_interface_variable_map.end()) {
+                            resource_variable = variable_it->second;
+                        }
+                    }
+                    ASSERT_AND_CONTINUE(resource_variable);
+
+                    // If we already validated/updated the descriptor on the CPU, don't redo it now in GPU-AV Post
+                    // Processing
+                    if (!desc_set->ValidateBindingOnGPU(*descriptor_binding, *resource_variable)) {
+                        continue;
+                    }
+
+                    // This will represent the Set that was accessed in the shader, which might not match the
+                    // vkCmdBindDescriptorSet index if sets are aliased
+                    context.SetSetIndexForGpuAv(resource_variable->decorations.set);
+
+                    std::string debug_region_name;
+                    if (auto found_label_cmd_i = label_logging.action_cmd_i_to_label_cmd_i_map.find(descriptor_access.action_index);
+                        found_label_cmd_i != label_logging.action_cmd_i_to_label_cmd_i_map.end()) {
+                        debug_region_name = cb.GetDebugLabelRegion(found_label_cmd_i->second, label_logging.initial_label_stack);
+                    }
+
+                    Location access_loc(loc, debug_region_name);
+                    context.SetLocationForGpuAv(access_loc);
+                    context.ValidateBindingDynamic(*resource_variable, *descriptor_binding, descriptor_access.index);
+                }
+            }
+        }
+
+        return true;
+    });
+}
+}  // namespace gpuav

--- a/layers/gpuav/instrumentation/post_process_descriptor_indexing.h
+++ b/layers/gpuav/instrumentation/post_process_descriptor_indexing.h
@@ -1,0 +1,23 @@
+/* Copyright (c) 2024-2025 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+namespace gpuav {
+class Validator;
+class CommandBufferSubState;
+
+void RegisterPostProcessingValidation(Validator& gpuav, CommandBufferSubState& cb);
+
+}  // namespace gpuav

--- a/layers/gpuav/resources/gpuav_shader_resources.h
+++ b/layers/gpuav/resources/gpuav_shader_resources.h
@@ -27,20 +27,6 @@
 
 namespace gpuav {
 
-// "binding" here refers to "binding in the command buffer" and not the "binding in a descriptor set"
-struct DescriptorBindingCommand {
-    // This is where we hold the list of BDA address for a given bound descriptor snapshot.
-    // The size of the SSBO doesn't change on an UpdateAfterBind so we can allocate it once and update its internals later
-    vko::Buffer descritpor_state_ssbo_buffer;  // type DescriptorStateSSBO
-    vko::Buffer post_process_ssbo_buffer;      // type PostProcessSSBO
-
-    // Note: The index here is from vkCmdBindDescriptorSets::firstSet
-    // for each "set" in vkCmdBindDescriptorSets::descriptorSetCount
-    std::vector<std::shared_ptr<vvl::DescriptorSet>> bound_descriptor_sets;
-
-    DescriptorBindingCommand(Validator &gpuav) : descritpor_state_ssbo_buffer(gpuav), post_process_ssbo_buffer(gpuav) {}
-};
-
 // These match the Structures found in the instrumentation GLSL logic
 namespace glsl {
 

--- a/layers/gpuav/resources/gpuav_vulkan_objects.cpp
+++ b/layers/gpuav/resources/gpuav_vulkan_objects.cpp
@@ -215,7 +215,24 @@ GpuResourcesManager::GpuResourcesManager(Validator &gpuav) : gpuav_(gpuav) {
         VmaAllocationCreateInfo alloc_ci = {};
         alloc_ci.usage = VMA_MEMORY_USAGE_AUTO;
         alloc_ci.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT;
-        host_visible_buffer_cache_.Create(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, alloc_ci);
+        host_visible_buffer_cache_.Create(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT |
+                                              VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+                                          alloc_ci);
+    }
+
+    {
+        VmaAllocationCreateInfo alloc_ci = {};
+        alloc_ci.usage = VMA_MEMORY_USAGE_AUTO;
+        alloc_ci.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT | VMA_ALLOCATION_CREATE_MAPPED_BIT;
+        host_cached_buffer_cache_.Create(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT, alloc_ci);
+    }
+
+    {
+        VmaAllocationCreateInfo alloc_ci = {};
+        alloc_ci.usage = VMA_MEMORY_USAGE_AUTO_PREFER_DEVICE;
+        device_local_buffer_cache_.Create(VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT |
+                                              VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+                                          alloc_ci);
     }
 
     {
@@ -256,19 +273,50 @@ VkDescriptorSet GpuResourcesManager::GetManagedDescriptorSet(VkDescriptorSetLayo
     return GetManagedDescriptorSet(desc_set_layout);
 }
 
+// Arbitrary, big enough
+constexpr VkDeviceSize buffer_address_alignment = 128;
+
 vko::BufferRange GpuResourcesManager::GetHostVisibleBufferRange(VkDeviceSize size) {
     // Kind of arbitrary, considered "big enough"
     constexpr VkDeviceSize min_buffer_block_size = 4 * 1024;
     // Buffers are used as storage buffers, align to corresponding limit
-    const VkDeviceSize alignment = gpuav_.phys_dev_props.limits.minStorageBufferOffsetAlignment;
+    const VkDeviceSize alignment =
+        std::max<VkDeviceSize>(gpuav_.phys_dev_props.limits.minStorageBufferOffsetAlignment, buffer_address_alignment);
     return host_visible_buffer_cache_.GetBufferRange(gpuav_, size, alignment, min_buffer_block_size);
+}
+
+vko::BufferRange GpuResourcesManager::GetHostCachedBufferRange(VkDeviceSize size) {
+    // Kind of arbitrary, considered "big enough"
+    constexpr VkDeviceSize min_buffer_block_size = 4 * 1024;
+    // Buffers are used as storage buffers, align to corresponding limit
+    const VkDeviceSize alignment =
+        std::max<VkDeviceSize>(gpuav_.phys_dev_props.limits.minStorageBufferOffsetAlignment, buffer_address_alignment);
+    return host_cached_buffer_cache_.GetBufferRange(gpuav_, size, alignment, min_buffer_block_size);
+}
+
+void GpuResourcesManager::FlushAllocation(const vko::BufferRange &buffer_range) {
+    vmaFlushAllocation(gpuav_.vma_allocator_, buffer_range.vma_alloc, 0, VK_WHOLE_SIZE);
+}
+
+void GpuResourcesManager::InvalidateAllocation(const vko::BufferRange &buffer_range) {
+    vmaInvalidateAllocation(gpuav_.vma_allocator_, buffer_range.vma_alloc, 0, VK_WHOLE_SIZE);
+}
+
+vko::BufferRange GpuResourcesManager::GetDeviceLocalBufferRange(VkDeviceSize size) {
+    // Kind of arbitrary, considered "big enough"
+    constexpr VkDeviceSize min_buffer_block_size = 4 * 1024;
+    // Buffers are used as storage buffers, align to corresponding limit
+    const VkDeviceSize alignment =
+        std::max<VkDeviceSize>(gpuav_.phys_dev_props.limits.minStorageBufferOffsetAlignment, buffer_address_alignment);
+    return device_local_buffer_cache_.GetBufferRange(gpuav_, size, alignment, min_buffer_block_size);
 }
 
 vko::BufferRange GpuResourcesManager::GetDeviceLocalIndirectBufferRange(VkDeviceSize size) {
     // Kind of arbitrary, considered "big enough"
     constexpr VkDeviceSize min_buffer_block_size = 4 * 1024;
     // Buffers are used as storage buffers, align to corresponding limit
-    const VkDeviceSize alignment = gpuav_.phys_dev_props.limits.minStorageBufferOffsetAlignment;
+    const VkDeviceSize alignment =
+        std::max<VkDeviceSize>(gpuav_.phys_dev_props.limits.minStorageBufferOffsetAlignment, buffer_address_alignment);
     return device_local_indirect_buffer_cache_.GetBufferRange(gpuav_, size, alignment, min_buffer_block_size);
 }
 
@@ -278,6 +326,8 @@ void GpuResourcesManager::ReturnResources() {
     }
 
     host_visible_buffer_cache_.ReturnBuffers();
+    host_cached_buffer_cache_.ReturnBuffers();
+    device_local_buffer_cache_.ReturnBuffers();
     device_local_indirect_buffer_cache_.ReturnBuffers();
 }
 
@@ -291,6 +341,8 @@ void GpuResourcesManager::DestroyResources() {
     cache_layouts_to_sets_.clear();
 
     host_visible_buffer_cache_.DestroyBuffers();
+    host_cached_buffer_cache_.DestroyBuffers();
+    device_local_buffer_cache_.DestroyBuffers();
     device_local_indirect_buffer_cache_.DestroyBuffers();
 }
 
@@ -335,8 +387,17 @@ vko::BufferRange GpuResourcesManager::BufferCache::GetBufferRange(Validator &gpu
                 if (cached_buffer.buffer.GetMappedPtr()) {
                     offset_mapped_ptr = (uint8_t *)cached_buffer.buffer.GetMappedPtr() + returned_range.begin;
                 }
+                VkDeviceAddress offset_address = 0;
+                if (cached_buffer.buffer.Address()) {
+                    offset_address = cached_buffer.buffer.Address() + returned_range.begin;
+                }
 
-                return {cached_buffer.buffer.VkHandle(), returned_range.begin, returned_range.size(), offset_mapped_ptr};
+                return {cached_buffer.buffer.VkHandle(),
+                        returned_range.begin,
+                        returned_range.size(),
+                        offset_mapped_ptr,
+                        offset_address,
+                        cached_buffer.buffer.Allocation()};
             }
         }
     }
@@ -348,21 +409,25 @@ vko::BufferRange GpuResourcesManager::BufferCache::GetBufferRange(Validator &gpu
     buffer_ci.usage = buffer_usage_flags_;
     const bool success = buffer.Create(&buffer_ci, &allocation_ci_);
     if (!success) {
-        return {VK_NULL_HANDLE, 0, 0, nullptr};
+        return {};
     }
     CachedBufferBlock cached_buffer_block{buffer, {0, buffer_ci.size}, {0, byte_size}};
     cached_buffers_blocks_.emplace_back(cached_buffer_block);
 
-    total_available_byte_size_ += buffer_ci.size;
+    total_available_byte_size_ += buffer_ci.size - byte_size;
 
-    return {buffer.VkHandle(), cached_buffer_block.used_range.begin, cached_buffer_block.used_range.size(),
-            cached_buffer_block.buffer.GetMappedPtr()};
+    return {buffer.VkHandle(),
+            cached_buffer_block.used_range.begin,
+            cached_buffer_block.used_range.size(),
+            cached_buffer_block.buffer.GetMappedPtr(),
+            cached_buffer_block.buffer.Address(),
+            cached_buffer_block.buffer.Allocation()};
 }
 
 void GpuResourcesManager::BufferCache::ReturnBuffers() {
     total_available_byte_size_ = 0;
     for (CachedBufferBlock &cached_buffer_block : cached_buffers_blocks_) {
-        cached_buffer_block.used_range = {0, cached_buffer_block.total_range.end};
+        cached_buffer_block.used_range = {0, 0};
         total_available_byte_size_ += cached_buffer_block.total_range.size();
     }
 }
@@ -372,6 +437,61 @@ void GpuResourcesManager::BufferCache::DestroyBuffers() {
         cached_buffer_block.buffer.Destroy();
     }
     cached_buffers_blocks_.clear();
+}
+
+CommandPool::CommandPool(Validator &gpuav, uint32_t queue_family_i) : gpuav_(gpuav) {
+    VkCommandPoolCreateInfo cmd_pool_ci = vku::InitStructHelper();
+    cmd_pool_ci.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+    cmd_pool_ci.queueFamilyIndex = queue_family_i;
+    VkResult result = DispatchCreateCommandPool(gpuav_.device, &cmd_pool_ci, nullptr, &cmd_pool_);
+    if (result != VK_SUCCESS) {
+        gpuav_.InternalError(LogObjectList(), Location(vvl::Func::Empty), "Failed to create command buffer pool");
+    }
+
+    VkCommandBufferAllocateInfo cmd_buf_ai = vku::InitStructHelper();
+    cmd_buf_ai.commandPool = cmd_pool_;
+    cmd_buf_ai.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    cmd_buf_ai.commandBufferCount = 128;  // #ARNO_TODO do not hardcode commandBufferCount
+
+    cmd_buffers_.resize(cmd_buf_ai.commandBufferCount);
+    result = DispatchAllocateCommandBuffers(gpuav_.device, &cmd_buf_ai, cmd_buffers_.data());
+    if (result != VK_SUCCESS) {
+        gpuav_.InternalError(LogObjectList(), Location(vvl::Func::Empty), "Failed to create command buffers");
+    }
+
+    for (VkCommandBuffer cb : cmd_buffers_) {
+        gpuav.vk_set_device_loader_data_(gpuav.device, cb);
+    }
+
+    fences_.resize(cmd_buf_ai.commandBufferCount);
+    for (VkFence &fence : fences_) {
+        VkFenceCreateInfo fence_ci = vku::InitStructHelper();
+        fence_ci.flags = VK_FENCE_CREATE_SIGNALED_BIT;
+        result = DispatchCreateFence(gpuav_.device, &fence_ci, nullptr, &fence);
+        if (result != VK_SUCCESS) {
+            gpuav_.InternalError(LogObjectList(), Location(vvl::Func::Empty), "Failed to create fences");
+        }
+    }
+}
+
+CommandPool::~CommandPool() {
+    DispatchDestroyCommandPool(gpuav_.device, cmd_pool_, nullptr);
+    for (VkFence fence : fences_) {
+        DispatchDestroyFence(gpuav_.device, fence, nullptr);
+    }
+}
+
+std::pair<VkCommandBuffer, VkFence> CommandPool::GetCommandBuffer() {
+    const size_t cb_i = cmd_buffer_ring_head_++ % cmd_buffers_.size();
+    VkResult result = DispatchWaitForFences(gpuav_.device, 1, &fences_[cb_i], VK_TRUE, UINT64_MAX);
+    if (result != VK_SUCCESS) {
+        gpuav_.InternalError(LogObjectList(), Location(vvl::Func::Empty), "Failed to wait for fence");
+        return {VK_NULL_HANDLE, VK_NULL_HANDLE};
+    }
+
+    DispatchResetFences(gpuav_.device, 1, &fences_[cb_i]);
+    DispatchResetCommandBuffer(cmd_buffers_[cb_i], 0);
+    return {cmd_buffers_[cb_i], fences_[cb_i]};
 }
 
 }  // namespace vko

--- a/layers/gpuav/spirv/post_process_descriptor_indexing_pass.cpp
+++ b/layers/gpuav/spirv/post_process_descriptor_indexing_pass.cpp
@@ -14,12 +14,13 @@
  */
 
 #include "post_process_descriptor_indexing_pass.h"
-#include "module.h"
-#include <iostream>
 
+#include "module.h"
 #include "generated/gpuav_offline_spirv.h"
 #include "gpuav/shaders/gpuav_shaders_constants.h"
 #include "utils/hash_util.h"
+
+#include <iostream>
 
 namespace gpuav {
 namespace spirv {

--- a/layers/gpuav/spirv/post_process_descriptor_indexing_pass.h
+++ b/layers/gpuav/spirv/post_process_descriptor_indexing_pass.h
@@ -18,6 +18,7 @@
 #include "pass.h"
 
 namespace gpuav {
+
 namespace spirv {
 
 struct Type;

--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -469,6 +469,8 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit(VkQueue queue, uint32_t submitCount, 
     RecordObject record_obj(vvl::Func::vkQueueSubmit);
     {
         VVL_ZoneScopedN("PreCallRecord_vkQueueSubmit");
+        VVL_TracyVkNamedZoneStart(GetTracyVkCtx(), queue, "gpu_PreCallRecordvkQueueSubmit", pre_call_record_gpu_zone);
+
         for (auto& vo : device_dispatch->intercept_vectors[InterceptIdPreCallRecordQueueSubmit]) {
             if (!vo) {
                 continue;
@@ -476,22 +478,23 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit(VkQueue queue, uint32_t submitCount, 
             auto lock = vo->WriteLock();
             vo->PreCallRecordQueueSubmit(queue, submitCount, pSubmits, fence, record_obj);
         }
+
+        VVL_TracyVkNamedZoneEnd(pre_call_record_gpu_zone, queue);
     }
     VkResult result;
     {
         VVL_ZoneScopedN("Dispatch_vkQueueSubmit");
 
-        VVL_TracyVkNamedZoneStart(GetTracyVkCtx(), queue, "gpu_QueueSubmit", submit_gpu_zone);
+        VVL_TracyVkNamedZoneStart(GetTracyVkCtx(), queue, "gpu_vkQueueSubmit", submit_gpu_zone);
         result = device_dispatch->QueueSubmit(queue, submitCount, pSubmits, fence);
 
         VVL_TracyVkNamedZoneEnd(submit_gpu_zone, queue);
-#if defined(VVL_TRACY_GPU)
-        TracyVkCollector::TrySubmitCollectCb(queue);
-#endif
     }
     record_obj.result = result;
     {
         VVL_ZoneScopedN("PostCallRecord_vkQueueSubmit");
+
+        VVL_TracyVkNamedZoneStart(GetTracyVkCtx(), queue, "gpu_PostCallRecordvkQueueSubmit", post_call_record_gpu_zone);
 
         if (result == VK_ERROR_DEVICE_LOST) {
             for (auto& vo : device_dispatch->object_dispatch) {
@@ -505,7 +508,12 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit(VkQueue queue, uint32_t submitCount, 
             auto lock = vo->WriteLock();
             vo->PostCallRecordQueueSubmit(queue, submitCount, pSubmits, fence, record_obj);
         }
+
+        VVL_TracyVkNamedZoneEnd(post_call_record_gpu_zone, queue);
     }
+#if defined(VVL_TRACY_GPU)
+    TracyVkCollector::TrySubmitCollectCb(queue);
+#endif
     return result;
 }
 
@@ -8011,6 +8019,8 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit2(VkQueue queue, uint32_t submitCount,
     RecordObject record_obj(vvl::Func::vkQueueSubmit2);
     {
         VVL_ZoneScopedN("PreCallRecord_vkQueueSubmit2");
+        VVL_TracyVkNamedZoneStart(GetTracyVkCtx(), queue, "gpu_PreCallRecordvkQueueSubmit2", pre_call_record_gpu_zone);
+
         for (auto& vo : device_dispatch->intercept_vectors[InterceptIdPreCallRecordQueueSubmit2]) {
             if (!vo) {
                 continue;
@@ -8018,22 +8028,23 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit2(VkQueue queue, uint32_t submitCount,
             auto lock = vo->WriteLock();
             vo->PreCallRecordQueueSubmit2(queue, submitCount, pSubmits, fence, record_obj);
         }
+
+        VVL_TracyVkNamedZoneEnd(pre_call_record_gpu_zone, queue);
     }
     VkResult result;
     {
         VVL_ZoneScopedN("Dispatch_vkQueueSubmit2");
 
-        VVL_TracyVkNamedZoneStart(GetTracyVkCtx(), queue, "gpu_QueueSubmit", submit_gpu_zone);
+        VVL_TracyVkNamedZoneStart(GetTracyVkCtx(), queue, "gpu_vkQueueSubmit2", submit_gpu_zone);
         result = device_dispatch->QueueSubmit2(queue, submitCount, pSubmits, fence);
 
         VVL_TracyVkNamedZoneEnd(submit_gpu_zone, queue);
-#if defined(VVL_TRACY_GPU)
-        TracyVkCollector::TrySubmitCollectCb(queue);
-#endif
     }
     record_obj.result = result;
     {
         VVL_ZoneScopedN("PostCallRecord_vkQueueSubmit2");
+
+        VVL_TracyVkNamedZoneStart(GetTracyVkCtx(), queue, "gpu_PostCallRecordvkQueueSubmit2", post_call_record_gpu_zone);
 
         if (result == VK_ERROR_DEVICE_LOST) {
             for (auto& vo : device_dispatch->object_dispatch) {
@@ -8047,7 +8058,12 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit2(VkQueue queue, uint32_t submitCount,
             auto lock = vo->WriteLock();
             vo->PostCallRecordQueueSubmit2(queue, submitCount, pSubmits, fence, record_obj);
         }
+
+        VVL_TracyVkNamedZoneEnd(post_call_record_gpu_zone, queue);
     }
+#if defined(VVL_TRACY_GPU)
+    TracyVkCollector::TrySubmitCollectCb(queue);
+#endif
     return result;
 }
 
@@ -16378,6 +16394,8 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit2KHR(VkQueue queue, uint32_t submitCou
     RecordObject record_obj(vvl::Func::vkQueueSubmit2KHR);
     {
         VVL_ZoneScopedN("PreCallRecord_vkQueueSubmit2KHR");
+        VVL_TracyVkNamedZoneStart(GetTracyVkCtx(), queue, "gpu_PreCallRecordvkQueueSubmit2KHR", pre_call_record_gpu_zone);
+
         for (auto& vo : device_dispatch->intercept_vectors[InterceptIdPreCallRecordQueueSubmit2KHR]) {
             if (!vo) {
                 continue;
@@ -16385,22 +16403,23 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit2KHR(VkQueue queue, uint32_t submitCou
             auto lock = vo->WriteLock();
             vo->PreCallRecordQueueSubmit2KHR(queue, submitCount, pSubmits, fence, record_obj);
         }
+
+        VVL_TracyVkNamedZoneEnd(pre_call_record_gpu_zone, queue);
     }
     VkResult result;
     {
         VVL_ZoneScopedN("Dispatch_vkQueueSubmit2KHR");
 
-        VVL_TracyVkNamedZoneStart(GetTracyVkCtx(), queue, "gpu_QueueSubmit", submit_gpu_zone);
+        VVL_TracyVkNamedZoneStart(GetTracyVkCtx(), queue, "gpu_vkQueueSubmit2KHR", submit_gpu_zone);
         result = device_dispatch->QueueSubmit2KHR(queue, submitCount, pSubmits, fence);
 
         VVL_TracyVkNamedZoneEnd(submit_gpu_zone, queue);
-#if defined(VVL_TRACY_GPU)
-        TracyVkCollector::TrySubmitCollectCb(queue);
-#endif
     }
     record_obj.result = result;
     {
         VVL_ZoneScopedN("PostCallRecord_vkQueueSubmit2KHR");
+
+        VVL_TracyVkNamedZoneStart(GetTracyVkCtx(), queue, "gpu_PostCallRecordvkQueueSubmit2KHR", post_call_record_gpu_zone);
 
         if (result == VK_ERROR_DEVICE_LOST) {
             for (auto& vo : device_dispatch->object_dispatch) {
@@ -16414,7 +16433,12 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit2KHR(VkQueue queue, uint32_t submitCou
             auto lock = vo->WriteLock();
             vo->PostCallRecordQueueSubmit2KHR(queue, submitCount, pSubmits, fence, record_obj);
         }
+
+        VVL_TracyVkNamedZoneEnd(post_call_record_gpu_zone, queue);
     }
+#if defined(VVL_TRACY_GPU)
+    TracyVkCollector::TrySubmitCollectCb(queue);
+#endif
     return result;
 }
 

--- a/layers/vulkan/generated/feature_requirements_helper.cpp
+++ b/layers/vulkan/generated/feature_requirements_helper.cpp
@@ -4453,21 +4453,21 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
-                case Feature::constantAlphaColorBlendFactors : {
-                auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
-                    vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
-                if (!vk_struct) {
-                    vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
-                    *vk_struct = vku::InitStructHelper();
-                    if (*inout_pnext_chain) {
-                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
-                    } else {
-                        *inout_pnext_chain = vk_struct;
-                    }
+        case Feature::constantAlphaColorBlendFactors: {
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
                 }
-                return {&vk_struct->constantAlphaColorBlendFactors,
-                        "VkPhysicalDevicePortabilitySubsetFeaturesKHR::constantAlphaColorBlendFactors"};
             }
+            return {&vk_struct->constantAlphaColorBlendFactors,
+                    "VkPhysicalDevicePortabilitySubsetFeaturesKHR::constantAlphaColorBlendFactors"};
+        }
 #endif  // VK_ENABLE_BETA_EXTENSIONS
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 

--- a/scripts/generate_spirv.py
+++ b/scripts/generate_spirv.py
@@ -236,10 +236,10 @@ def main():
     shader_type = ['vert', 'tesc', 'tese', 'geom', 'frag', 'comp', 'mesh', 'task', 'rgen', 'rint', 'rahit', 'rchit', 'rmiss', 'rcall']
     try:
         gpu_shaders_dir = common_ci.RepoRelative('layers/gpuav/shaders')
-        diagnostic_shaders_dir = common_ci.RepoRelative('layers/gpuav/shaders/validation_cmd')
+        validation_cmd_shaders_dir = common_ci.RepoRelative('layers/gpuav/shaders/validation_cmd')
         instrumentation_shaders_dir = common_ci.RepoRelative('layers/gpuav/shaders/instrumentation')
 
-        for dir_path in [diagnostic_shaders_dir, instrumentation_shaders_dir]:
+        for dir_path in [validation_cmd_shaders_dir, instrumentation_shaders_dir]:
              if not os.path.isdir(dir_path):
                  print(f"Warning: Shader directory not found: {dir_path}", file=sys.stderr)
                  continue


### PR DESCRIPTION
VkBuffer used in GPU-AV's "post processing" step to validate correct usage of descriptors were only tied to a descriptor set:
It meant that we could run into synchronization issues where we would read the content of a buffer on the CPU while potentially it was still in use on the GPU.
To avoid needless waits, proposed solution is to move to "per command buffer submission" post processing buffers:
When a command buffer is submitted, post processing buffers are allocated _for this submission_, ensuring that when CPU reads them, at command buffer completion time, no concurrent access can happen.

Doing the necessary changes showed that we have a tendency to clobber functions that should be generic, or internally maintained state objects such as command buffer state, descriptor set state, with functions or data that only really belong to a specific part of validation.

Refactoring this code showed that only really care about inserting custom validation logic at precise spots / events. 
For instance: when a new action command is recorded, when a descriptor set is bound, when a command buffer is submitted, when a command submission is completed...

Knowing that, I moved to an "event registering" approach: when adding new validation, you would only need to subscribe to those events (using lambdas), without having to explicitly go clobber existing generic functions with your validation specific code.
Look at those in `gpuav::CommandBufferSubState`:
```cpp
std::vector<OnInstrumentionDescSetUpdate> on_instrumentation_desc_set_update_functions;
std::vector<OnCommandBufferSubmission> on_cb_submission_functions;
std::vector<OnCommandBufferCompletion> on_cb_completion_functions;
```
Another common problem we face is tying some new object lifespan to a command buffer lifespan. 
`vko::SharedResourcesCache` was created to solve this specific problem, but I was only using it for validation commands. I realized I could spread usage, it allowed to remove post processing specific state from directly clobbering command buffer state. 
This way, post processing state is created only when needed, and you never need to touch the `gpuav::CommandBufferSubstate` class explicitly to correctly manage lifespan of this post processing state: code is clearer and easier to manage.

- I still have some `#ARNO_TODO` that I will address just next. Ultimately we need to move every validation we do to this event registration system, doing everything in this PR does not make sense.

- Post processing performance is still bad, but that's also for an upcoming PR (need to rework GPU memory management)