### PR TITLE
layers: Cleanup image layout code

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1028,9 +1028,9 @@ class CoreChecks : public vvl::DeviceProxy {
     bool VerifyClearImageLayout(const vvl::CommandBuffer& cb_state, const vvl::Image& image_state,
                                 const VkImageSubresourceRange& range, VkImageLayout dest_image_layout, const Location& loc) const;
 
-    template <typename RangeFactory>
     bool VerifyImageLayoutRange(const vvl::CommandBuffer& cb_state, const vvl::Image& image_state, VkImageAspectFlags aspect_mask,
-                                VkImageLayout explicit_layout, const RangeFactory& range_factory, const Location& image_loc,
+                                VkImageLayout explicit_layout, const image_layout_map::ImageLayoutRegistry& cb_layout_map,
+                                subresource_adapter::RangeGenerator&& range_gen, const Location& image_loc,
                                 const char* mismatch_layout_vuid, bool* error) const;
 
     bool VerifyImageLayoutSubresource(const vvl::CommandBuffer& cb_state, const vvl::Image& image_state,
@@ -1041,9 +1041,9 @@ class CoreChecks : public vvl::DeviceProxy {
                            VkImageLayout explicit_layout, const Location& image_loc, const char* mismatch_layout_vuid,
                            bool* error) const override;
 
-    bool VerifyImageLayout(const vvl::CommandBuffer& cb_state, const vvl::Image& image_state, const VkImageSubresourceRange& range,
-                           VkImageLayout explicit_layout, const Location& image_loc, const char* mismatch_layout_vuid,
-                           bool* error) const;
+    bool VerifyImageLayout(const vvl::CommandBuffer& cb_state, const vvl::Image& image_state,
+                           const VkImageSubresourceRange& normalized_subresource_range, VkImageLayout explicit_layout,
+                           const Location& image_loc, const char* mismatch_layout_vuid, bool* error) const;
 
     bool ValidateTransferGranularityExtent(const LogObjectList& objlist, const VkExtent3D& extent, const VkOffset3D& offset,
                                            const VkExtent3D& granularity, const VkExtent3D& subresource_extent,

--- a/layers/state_tracker/image_layout_map.h
+++ b/layers/state_tracker/image_layout_map.h
@@ -93,47 +93,14 @@ class ImageLayoutRegistry {
     ~ImageLayoutRegistry() {}
     uint32_t GetImageId() const;
 
-    // This looks a bit ponderous but kAspectCount is a compile time constant
-    VkImageSubresource Decode(IndexType index) const {
-        const auto subres = encoder_.Decode(index);
-        return encoder_.MakeVkSubresource(subres);
-    }
+    VkImageSubresource Decode(IndexType index) const;
 
-    RangeGenerator RangeGen(const VkImageSubresourceRange& subres_range) const {
-        if (encoder_.InRange(subres_range)) {
-            return (RangeGenerator(encoder_, subres_range));
-        }
-        // Return empty range generator
-        return RangeGenerator();
-    }
-
-    bool AnyInRange(const VkImageSubresourceRange& normalized_range,
-                    std::function<bool(const RangeType& range, const LayoutEntry& state)>&& func) const {
-        return AnyInRange(RangeGen(normalized_range), std::move(func));
-    }
-
-    bool AnyInRange(const RangeGenerator& gen, std::function<bool(const RangeType& range, const LayoutEntry& state)>&& func) const {
-        return AnyInRange(RangeGenerator(gen), std::move(func));
-    }
-
-    bool AnyInRange(RangeGenerator&& gen, std::function<bool(const RangeType& range, const LayoutEntry& state)>&& func) const {
-        for (; gen->non_empty(); ++gen) {
-            for (auto pos = layout_map_.lower_bound(*gen); (pos != layout_map_.end()) && (gen->intersects(pos->first)); ++pos) {
-                if (func(pos->first, pos->second)) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-  protected:
-    bool InRange(const VkImageSubresource& subres) const { return encoder_.InRange(subres); }
-    bool InRange(const VkImageSubresourceRange& range) const { return encoder_.InRange(range); }
+    bool AnyInRange(const VkImageSubresourceRange& normalized_subresource_range,
+                    std::function<bool(const RangeType& range, const LayoutEntry& state)>&& func) const;
+    bool AnyInRange(RangeGenerator&& gen, std::function<bool(const RangeType& range, const LayoutEntry& state)>&& func) const;
 
   private:
     const vvl::Image& image_state_;
-    const Encoder& encoder_;
     LayoutMap layout_map_;
 };
 }  // namespace image_layout_map


### PR DESCRIPTION
That's a minor cleanup that makes `VerifyImageLayoutRange` more explicit (no factory template parameters), but also cleans up a bit `ImageLayoutRegistry`.

The goal for the next PRs is to represent layout information in a more unified way, with a central range map type, instead of using 3 range map types depending on the context (command buffer, submit, global).