### PR TITLE
tests: Add missing shaderRelaxedExtendedInstruction

### DIFF
--- a/tests/unit/gpu_av_shader_debug_info.cpp
+++ b/tests/unit/gpu_av_shader_debug_info.cpp
@@ -434,6 +434,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, BasicGlslangShaderDebugInfo) {
     TEST_DESCRIPTION("Make sure basic glslang with ShaderDebugInfo works");
     AddRequiredExtensions(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_SHADER_RELAXED_EXTENDED_INSTRUCTION_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::shaderRelaxedExtendedInstruction);
 
     // Manually ran:
     //   glslangValidator -V -gV in.comp -o out.spv --target-env vulkan1.2
@@ -668,6 +669,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, BasicGlslangShaderDebugInfoWithSource) {
     TEST_DESCRIPTION("Make sure basic glslang with ShaderDebugInfo works");
     AddRequiredExtensions(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_SHADER_RELAXED_EXTENDED_INSTRUCTION_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::shaderRelaxedExtendedInstruction);
 
     BasicSingleStorageBufferComputeOOB(
         kBasicGlslShaderSource,
@@ -684,6 +686,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, BasicGlslangShaderDebugInfoWithSourceShader
     AddRequiredFeature(vkt::Feature::shaderObject);
     AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
     AddRequiredFeature(vkt::Feature::shaderInt64);
+    AddRequiredFeature(vkt::Feature::shaderRelaxedExtendedInstruction);
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 


### PR DESCRIPTION
If running Self Val with latest changes, noticed we missed these `shaderRelaxedExtendedInstruction` features