### PR TITLE
layers: Misc image layout map cleanup

### DIFF
--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1117,8 +1117,7 @@ void CommandBuffer::ExecuteCommands(vvl::span<const VkCommandBuffer> secondary_c
                 image_state->GetId() != image_layout_registry->GetImageId()) {
                 continue;
             }
-            auto cb_image_layout_registry = GetOrCreateImageLayoutRegistry(*image_state);
-            if (cb_image_layout_registry) {
+            if (auto cb_image_layout_registry = GetOrCreateImageLayoutRegistry(*image_state)) {
                 cb_image_layout_registry->UpdateFrom(*image_layout_registry);
             }
         }

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -189,8 +189,7 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     CbState state;           // Track cmd buffer update state
     uint64_t command_count;  // Number of commands recorded. Currently only used with VK_KHR_performance_query
     uint64_t submit_count;   // Number of times CB has been submitted
-    typedef uint64_t ImageLayoutUpdateCount;
-    ImageLayoutUpdateCount image_layout_change_count;  // The sequence number for changes to image layout (for cached validation)
+    uint64_t image_layout_change_count;  // The sequence number for changes to image layout (for cached validation)
 
     // Track status of all vkCmdSet* calls, if 1, means it was set
     struct DynamicStateStatus {

--- a/layers/state_tracker/image_layout_map.cpp
+++ b/layers/state_tracker/image_layout_map.cpp
@@ -126,19 +126,9 @@ void ImageLayoutRegistry::SetSubresourceRangeInitialLayout(VkImageLayout layout,
     }
 }
 
-// TODO: make sure this paranoia check is sufficient and not too much.
-uintptr_t ImageLayoutRegistry::CompatibilityKey() const {
-    return (reinterpret_cast<uintptr_t>(&image_state_) ^ image_state_.subresource_encoder.AspectMask());
-}
-
 uint32_t ImageLayoutRegistry::GetImageId() const { return image_state_.GetId(); }
 
 bool ImageLayoutRegistry::UpdateFrom(const ImageLayoutRegistry& other) {
-    // Must be from matching images for the reinterpret cast to be valid
-    assert(CompatibilityKey() == other.CompatibilityKey());
-    if (CompatibilityKey() != other.CompatibilityKey()) {
-        return false;
-    }
     return sparse_container::splice(layout_map_, other.layout_map_, LayoutEntry::Updater());
 }
 

--- a/layers/state_tracker/image_layout_map.cpp
+++ b/layers/state_tracker/image_layout_map.cpp
@@ -45,7 +45,7 @@ static bool UpdateLayoutStateImpl(LayoutsMap& layouts, const IndexRange& range, 
             auto intersected_range = pos->lower_bound->first & range;
             if (!intersected_range.empty() && pos->lower_bound->second.CurrentWillChange(new_entry.current_layout)) {
                 LayoutEntry orig_entry = pos->lower_bound->second;  // intentional copy
-                orig_entry.Update(new_entry);                       // this returns true because of CurrentWillChange check above
+                orig_entry.Update(new_entry);
                 updated_current = true;
                 auto overwrite_result = layouts.overwrite_range(pos->lower_bound, std::make_pair(intersected_range, orig_entry));
                 // If we didn't cover the whole range, we'll need to go around again
@@ -128,8 +128,8 @@ void ImageLayoutRegistry::SetSubresourceRangeInitialLayout(VkImageLayout layout,
 
 uint32_t ImageLayoutRegistry::GetImageId() const { return image_state_.GetId(); }
 
-bool ImageLayoutRegistry::UpdateFrom(const ImageLayoutRegistry& other) {
-    return sparse_container::splice(layout_map_, other.layout_map_, LayoutEntry::Updater());
+void ImageLayoutRegistry::UpdateFrom(const ImageLayoutRegistry& other) {
+    sparse_container::splice(layout_map_, other.layout_map_, LayoutEntry::Updater());
 }
 
 VkImageSubresource ImageLayoutRegistry::Decode(IndexType index) const {
@@ -180,13 +180,10 @@ bool ImageLayoutRegistry::LayoutEntry::CurrentWillChange(VkImageLayout new_layou
     return new_layout != kInvalidLayout && current_layout != new_layout;
 }
 
-bool ImageLayoutRegistry::LayoutEntry::Update(const LayoutEntry& src) {
-    bool updated_current = false;
+void ImageLayoutRegistry::LayoutEntry::Update(const LayoutEntry& src) {
     if (CurrentWillChange(src.current_layout)) {
         current_layout = src.current_layout;
-        updated_current = true;
     }
-    return updated_current;
 }
 
 }  // namespace image_layout_map

--- a/layers/state_tracker/image_layout_map.h
+++ b/layers/state_tracker/image_layout_map.h
@@ -69,15 +69,6 @@ class ImageLayoutRegistry {
         static LayoutEntry ForExpectedLayout(VkImageLayout expected_layout, VkImageAspectFlags aspect_mask = 0);
 
         bool CurrentWillChange(VkImageLayout new_layout) const;
-        void Update(const LayoutEntry& src);
-
-        // updater for splice()
-        struct Updater {
-            void update(LayoutEntry& dst, const LayoutEntry& src) const { dst.Update(src); }
-            std::optional<LayoutEntry> insert(const LayoutEntry& src) const {
-                return std::optional<LayoutEntry>(vvl::in_place, src);
-            }
-        };
     };
     using LayoutMap = subresource_adapter::BothRangeMap<LayoutEntry, 16>;
     using RangeType = LayoutMap::key_type;

--- a/layers/state_tracker/image_layout_map.h
+++ b/layers/state_tracker/image_layout_map.h
@@ -69,11 +69,11 @@ class ImageLayoutRegistry {
         static LayoutEntry ForExpectedLayout(VkImageLayout expected_layout, VkImageAspectFlags aspect_mask = 0);
 
         bool CurrentWillChange(VkImageLayout new_layout) const;
-        bool Update(const LayoutEntry& src);
+        void Update(const LayoutEntry& src);
 
         // updater for splice()
         struct Updater {
-            bool update(LayoutEntry& dst, const LayoutEntry& src) const { return dst.Update(src); }
+            void update(LayoutEntry& dst, const LayoutEntry& src) const { dst.Update(src); }
             std::optional<LayoutEntry> insert(const LayoutEntry& src) const {
                 return std::optional<LayoutEntry>(vvl::in_place, src);
             }
@@ -86,7 +86,7 @@ class ImageLayoutRegistry {
                                    VkImageLayout expected_layout = kInvalidLayout);
     void SetSubresourceRangeInitialLayout(const VkImageSubresourceRange& range, VkImageLayout layout);
     void SetSubresourceRangeInitialLayout(VkImageLayout layout, const vvl::ImageView& view_state);
-    bool UpdateFrom(const ImageLayoutRegistry& from);
+    void UpdateFrom(const ImageLayoutRegistry& from);
     const LayoutMap& GetLayoutMap() const { return layout_map_; }
     ImageLayoutRegistry(const vvl::Image& image_state);
     ~ImageLayoutRegistry() {}

--- a/layers/state_tracker/image_layout_map.h
+++ b/layers/state_tracker/image_layout_map.h
@@ -87,7 +87,6 @@ class ImageLayoutRegistry {
     void SetSubresourceRangeInitialLayout(const VkImageSubresourceRange& range, VkImageLayout layout);
     void SetSubresourceRangeInitialLayout(VkImageLayout layout, const vvl::ImageView& view_state);
     bool UpdateFrom(const ImageLayoutRegistry& from);
-    uintptr_t CompatibilityKey() const;
     const LayoutMap& GetLayoutMap() const { return layout_map_; }
     ImageLayoutRegistry(const vvl::Image& image_state);
     ~ImageLayoutRegistry() {}


### PR DESCRIPTION
* Remove layout map compatibility check
* Do not return update status from splice
* Misc cleanup of layout map interface

There are few commits and comments explain reasoning behind some changes, but in general that's still small changes that make things a bit simpler.
