### PR TITLE
layers: Rename many image layout names

### DIFF
--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -647,17 +647,16 @@ bool CoreChecks::ValidateSecondaryCommandBufferLayout(const vvl::CommandBuffer &
     // Validate initial layout uses vs. the primary cmd buffer state
     // Novel Valid usage: "UNASSIGNED-vkCmdExecuteCommands-commandBuffer-00001"
     // initial layout usage of secondary command buffers resources must match parent command buffer
-    for (const auto &sub_layout_map_entry : secondary_cb_state.image_layout_map) {
+    for (const auto &sub_layout_map_entry : secondary_cb_state.image_layout_registry) {
         const VkImage image = sub_layout_map_entry.first;
 
-        const auto cb_image_layout_registry = cb_state.GetImageLayoutRegistry(image);
+        const auto cb_layout_map = cb_state.GetImageLayoutMap(image);
         // Const getter can be null in which case we have nothing to check against for this image...
-        if (!cb_image_layout_registry) continue;
+        if (!cb_layout_map) continue;
         if (!sub_layout_map_entry.second) continue;
 
-        const auto &sub_layout_map = sub_layout_map_entry.second->GetLayoutMap();
-        const auto &cb_layout_map = cb_image_layout_registry->GetLayoutMap();
-        for (sparse_container::parallel_iterator<const ImageLayoutRegistry::LayoutMap> iter(sub_layout_map, cb_layout_map, 0);
+        const auto &sub_layout_map = *sub_layout_map_entry.second;
+        for (sparse_container::parallel_iterator<const CommandBufferImageLayoutMap> iter(sub_layout_map, *cb_layout_map, 0);
              !iter->range.empty(); ++iter) {
             VkImageLayout cb_layout = kInvalidLayout, sub_layout = kInvalidLayout;
             const char *layout_type;

--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -42,9 +42,9 @@ struct CommandBufferSubmitState {
     std::string last_closed_cmdbuf_label;
     bool found_unbalanced_cmdbuf_label;
 
-    // The "local" prefix is about tracking state accross all command buffers of a *single* QueueSubmit command.
-    // This does not track global state based on all previous submissions.
-    SubmissionImageLayoutMap local_image_layout_map;
+    // The "local" prefix is about tracking state accross command buffers of a *single* QueueSubmit command.
+    // This does not accumulate state from the previous submissions.
+    ImageLayoutRegistry local_image_layout_registry;
     QueryMap local_query_to_state_map;
     EventMap local_event_signal_info;
     vvl::unordered_map<VkVideoSessionKHR, vvl::VideoSessionDeviceState> local_video_session_state{};
@@ -59,7 +59,7 @@ struct CommandBufferSubmitState {
 
     bool Validate(const Location &loc, const vvl::CommandBuffer &cb_state, uint32_t perf_pass) {
         bool skip = false;
-        skip |= core.ValidateCmdBufImageLayouts(loc, cb_state, local_image_layout_map);
+        skip |= core.ValidateCmdBufImageLayouts(loc, cb_state, local_image_layout_registry);
         const VkCommandBuffer cmd = cb_state.VkHandle();
         current_cmds.push_back(cmd);
         skip |= core.ValidatePrimaryCommandBufferState(

--- a/layers/core_checks/cc_state_tracker.cpp
+++ b/layers/core_checks/cc_state_tracker.cpp
@@ -86,15 +86,15 @@ void CommandBufferSubState::SubmitTimeValidate() {
         if (!image_state) {
             continue;
         }
-        const auto global_layout_map = image_state->layout_range_map.get();
+        const auto global_layout_map = image_state->layout_map.get();
         ASSERT_AND_CONTINUE(global_layout_map);
         auto global_layout_map_guard = global_layout_map->ReadLock();
 
         for (const std::pair<VkImageSubresourceRange, vvl::LocationCapture>& entry : subresources) {
             const VkImageSubresourceRange& subresource = entry.first;
             const Location& barrier_loc = entry.second.Get();
-            ImageLayoutRangeMap::RangeGenerator range_gen(image_state->subresource_encoder, subresource);
-            global_layout_map->AnyInRange(range_gen, [this, &barrier_loc, &image_state](const ImageLayoutRangeMap::key_type& range,
+            ImageLayoutMap::RangeGenerator range_gen(image_state->subresource_encoder, subresource);
+            global_layout_map->AnyInRange(range_gen, [this, &barrier_loc, &image_state](const ImageLayoutMap::key_type& range,
                                                                                         const VkImageLayout& layout) {
                 if (layout != VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ && layout != VK_IMAGE_LAYOUT_GENERAL) {
                     const auto& vuid = sync_vuid_maps::GetDynamicRenderingBarrierVUID(

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -337,7 +337,7 @@ class CoreChecks : public vvl::DeviceProxy {
                                const BufferBarrier& barrier) const;
 
     bool ValidateImageBarrier(const LogObjectList& objlist, const vvl::CommandBuffer& cb_state, const ImageBarrier& barrier,
-                              const Location& barrier_loc, CommandBufferImageLayoutMap& layout_updates_state) const;
+                              const Location& barrier_loc, CommandBufferImageLayoutRegistry& local_layout_registry) const;
 
     bool ValidateBarriers(const Location& loc, const vvl::CommandBuffer& cb_state, VkPipelineStageFlags src_stage_mask,
                           VkPipelineStageFlags dst_stage_mask, uint32_t memBarrierCount, const VkMemoryBarrier* pMemBarriers,
@@ -1029,7 +1029,7 @@ class CoreChecks : public vvl::DeviceProxy {
                                 const VkImageSubresourceRange& range, VkImageLayout dest_image_layout, const Location& loc) const;
 
     bool VerifyImageLayoutRange(const vvl::CommandBuffer& cb_state, const vvl::Image& image_state, VkImageAspectFlags aspect_mask,
-                                VkImageLayout explicit_layout, const image_layout_map::ImageLayoutRegistry& cb_layout_map,
+                                VkImageLayout explicit_layout, const CommandBufferImageLayoutMap& cb_layout_map,
                                 subresource_adapter::RangeGenerator&& range_gen, const Location& image_loc,
                                 const char* mismatch_layout_vuid, bool* error) const;
 
@@ -1087,7 +1087,8 @@ class CoreChecks : public vvl::DeviceProxy {
     void TransitionBeginRenderPassLayouts(vvl::CommandBuffer& cb_state, const vvl::RenderPass& render_pass_state);
 
     bool VerifyImageBarrierLayouts(const vvl::CommandBuffer& cb_state, const vvl::Image& image_state, const Location& image_loc,
-                                   const ImageBarrier& image_barrier, CommandBufferImageLayoutMap& local_layout_map) const;
+                                   const ImageBarrier& image_barrier,
+                                   CommandBufferImageLayoutRegistry& local_layout_registry) const;
 
     bool VerifyDynamicRenderingImageBarrierLayouts(const vvl::CommandBuffer& cb_state, const vvl::Image& image_state,
                                                    const VkRenderingInfo& rendering_info, const Location& barrier_loc) const;
@@ -1097,7 +1098,7 @@ class CoreChecks : public vvl::DeviceProxy {
 
     bool ValidateImageBarrierAgainstImage(const vvl::CommandBuffer& cb_state, const ImageBarrier& barrier,
                                           const Location& barrier_loc, const vvl::Image& image_state,
-                                          CommandBufferImageLayoutMap& layout_updates_state) const;
+                                          CommandBufferImageLayoutRegistry& local_layout_registry) const;
     bool ValidateImageBarrierZeroInitializedSubresourceRange(const vvl::CommandBuffer& cb_state, const ImageBarrier& barrier,
                                                              const vvl::Image& image_state, const Location& barrier_loc) const;
 
@@ -1186,7 +1187,7 @@ class CoreChecks : public vvl::DeviceProxy {
                                      const RecordObject& record_obj) override;
 
     bool ValidateCmdBufImageLayouts(const Location& loc, const vvl::CommandBuffer& cb_state,
-                                    SubmissionImageLayoutMap& submission_image_layout_map) const;
+                                    ImageLayoutRegistry& local_layout_registry) const;
 
     void UpdateCmdBufImageLayouts(const vvl::CommandBuffer& cb_state);
 

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -106,18 +106,17 @@ class Image : public Bindable, public SubStateManager<ImageSubState> {
     const bool metal_io_surface_export;
 #endif  // VK_USE_PLATFORM_METAL
 
-    const image_layout_map::Encoder subresource_encoder;                             // Subresource resolution encoder
-    const VkDevice store_device_as_workaround;                                       // TODO REMOVE WHEN encoder can be const
+    const subresource_adapter::RangeEncoder subresource_encoder;  // Subresource resolution encoder
+    const VkDevice store_device_as_workaround;                    // TODO REMOVE WHEN encoder can be const
 
     // This map is used to validate/update image layouts during submit time processing.
-    // Record time validation can't use this, because global image layout is undefined
-    // at record time (depends on the previous submissions, which are unknown at record time).
-    std::shared_ptr<ImageLayoutRangeMap> layout_range_map;
+    // Record time validation can't use this, because global image layout is undefined at record time
+    std::shared_ptr<ImageLayoutMap> layout_map;
 
-    // If there is no aliasing this mutex protects this->layout_range_map.
+    // If there is no aliasing this mutex protects this->layout_map.
     // With aliasing one of the images shares a mutex with other aliases,
     // so for some aliased images this mutex can be unused.
-    mutable std::shared_mutex layout_range_map_lock;
+    mutable std::shared_mutex layout_map_lock;
 
     vvl::unordered_set<std::shared_ptr<const vvl::VideoProfileDesc>> supported_video_profiles;
 
@@ -288,7 +287,7 @@ class ImageView : public StateObject, public SubStateManager<ImageViewSubState> 
 
     const bool is_depth_sliced;
     const VkImageSubresourceRange normalized_subresource_range;
-    const image_layout_map::RangeGenerator range_generator;
+    const subresource_adapter::RangeGenerator range_generator;
     const VkSampleCountFlagBits samples;
     const VkSamplerYcbcrConversion samplerConversion;  // Handle of the ycbcr sampler conversion the image was created with, if any
     const VkFilterCubicImageViewImageFormatPropertiesEXT filter_cubic_props;

--- a/layers/state_tracker/render_pass_state.cpp
+++ b/layers/state_tracker/render_pass_state.cpp
@@ -22,8 +22,6 @@
 #include "state_tracker/image_state.h"
 #include "containers/span.h"
 
-static const VkImageLayout kInvalidLayout = VK_IMAGE_LAYOUT_MAX_ENUM;
-
 static VkSubpassDependency2 ImplicitDependencyFromExternal(uint32_t subpass) {
     VkSubpassDependency2 from_external = {VK_STRUCTURE_TYPE_SUBPASS_DEPENDENCY_2,
                                           nullptr,


### PR DESCRIPTION
The first part of changes is that I started moving types in `image_layout_map.h` to represent directly maps rather than additional abstractions over maps (still in progress). We have two image layout map types:
* `CommandBufferImageLayoutMap` - tracks layouts of image subresources during command buffer recording, and in addition to the current layout also tracks the first layout used by the command buffer
* `ImageLayoutMap` - directly stores layouts of image subresources

The second part is related to `Registry` naming (yes, I remember we discussed this... I realized too late). `Registry` was used to represent per-image layout information, but this name is better suited to represent global storage, that collects information for all images (so that's the registry). So `Registry` is a collection of all images, and `LayoutMap` is about a single image (maps each subresource to its layout).
