### PR TITLE
tests: Add missing cmath includes

### DIFF
--- a/tests/framework/video_objects.h
+++ b/tests/framework/video_objects.h
@@ -27,6 +27,7 @@
 
 #include <vector>
 #include <unordered_set>
+#include <cmath>
 
 class VideoConfig {
   public:

--- a/tests/unit/dynamic_state.cpp
+++ b/tests/unit/dynamic_state.cpp
@@ -18,6 +18,8 @@
 #include "../framework/pipeline_helper.h"
 #include "../framework/render_pass_helper.h"
 
+#include <cmath>
+
 class NegativeDynamicState : public DynamicStateTest {
     // helper functions for tests in this file
   public:


### PR DESCRIPTION
Fixes build errors when building the unittests with gcc 11.0 on Ubuntu 22.04