### PR TITLE
layers: Make ImageLayoutMap a regular map

### DIFF
--- a/layers/state_tracker/image_layout_map.cpp
+++ b/layers/state_tracker/image_layout_map.cpp
@@ -195,10 +195,11 @@ bool LayoutEntry::CurrentWillChange(VkImageLayout new_layout) const {
     return new_layout != kInvalidLayout && current_layout != new_layout;
 }
 
-bool ImageLayoutMap::AnyInRange(RangeGenerator& gen,
-                                     std::function<bool(const key_type& range, const mapped_type& state)>&& func) const {
+bool AnyInRange(const ImageLayoutMap& image_layout_map, RangeGenerator& gen,
+                std::function<bool(const ImageLayoutMap::key_type& range, VkImageLayout image_layout)>&& func) {
     for (; gen->non_empty(); ++gen) {
-        for (auto pos = lower_bound(*gen); (pos != end()) && (gen->intersects(pos->first)); ++pos) {
+        for (auto pos = image_layout_map.lower_bound(*gen); (pos != image_layout_map.end()) && (gen->intersects(pos->first));
+             ++pos) {
             if (func(pos->first, pos->second)) {
                 return true;
             }

--- a/layers/state_tracker/image_layout_map.h
+++ b/layers/state_tracker/image_layout_map.h
@@ -85,20 +85,11 @@ class CommandBufferImageLayoutMap : public subresource_adapter::BothRangeMap<Lay
     const vvl::Image& image_state_;
 };
 
-class ImageLayoutMap : public subresource_adapter::BothRangeMap<VkImageLayout, 16> {
-  public:
-    using RangeGenerator = subresource_adapter::RangeGenerator;
-
-    ImageLayoutMap(index_type index) : BothRangeMap<VkImageLayout, 16>(index) {}
-    ReadLockGuard ReadLock() const { return ReadLockGuard(*lock); }
-    WriteLockGuard WriteLock() { return WriteLockGuard(*lock); }
-
-    bool AnyInRange(RangeGenerator& gen, std::function<bool(const key_type& range, const mapped_type& state)>&& func) const;
-
-    // Not null if this layout map is owned by the vvl::Image and points to vvl::Image::layout_range_map_lock.
-    // The layout maps that are not owned by the images do not use locking functionality.
-    std::shared_mutex* lock = nullptr;
-};
+using ImageLayoutMap = subresource_adapter::BothRangeMap<VkImageLayout, 16>;
 
 using CommandBufferImageLayoutRegistry = vvl::unordered_map<VkImage, std::shared_ptr<CommandBufferImageLayoutMap>>;
 using ImageLayoutRegistry = vvl::unordered_map<const vvl::Image*, std::optional<ImageLayoutMap>>;
+
+// TODO: document and rename me
+bool AnyInRange(const ImageLayoutMap& image_layout_map, subresource_adapter::RangeGenerator& gen,
+                std::function<bool(const ImageLayoutMap::key_type& range, VkImageLayout image_layout)>&& func);


### PR DESCRIPTION
The lock functionality is moved to `vvl::Image`. This allows to use `BothRangeMap` type directly as layout map. Also not all layout maps need a lock (only for global layout tracking), so without lock inside the map the code is cleaner for such use cases.

In case of aliased images the lock is shared via `shared_ptr` (in the same way as layout map is shared). In the previous implementation the lock existed in each image, and in case of aliasing some locks were unused (there was a chance to use a wrong lock).
