### PR TITLE
tests: Add Slang

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -32,6 +32,9 @@ if (UPDATE_DEPS)
         list(APPEND update_dep_command "${CMAKE_GENERATOR_PLATFORM}")
     endif()
 
+    list(APPEND update_dep_command "--pointer_size")
+    list(APPEND update_dep_command "${CMAKE_SIZEOF_VOID_P}")
+
     if (NOT CMAKE_BUILD_TYPE)
         message(WARNING "CMAKE_BUILD_TYPE not set. Using Debug for dependency build type")
         set(_build_type Debug)

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -117,10 +117,13 @@
             "optional": [
                 "tests"
             ]
+        },
+        {
+            "name": "slang",
+            "repo_binaries_url": "https://github.com/shader-slang/slang/releases/tag/v2025.12.1",
+            "build_dir": "slang/download",
+            "install_dir": "slang/install"
         }
-    ],
-    "repo_binaries_version": [
-       { "slang": "2025.12.1" }
     ],
     "install_names": {
         "glslang": "GLSLANG_INSTALL_DIR",
@@ -129,6 +132,7 @@
         "SPIRV-Headers": "SPIRV_HEADERS_INSTALL_DIR",
         "SPIRV-Tools": "SPIRV_TOOLS_INSTALL_DIR",
         "googletest": "GOOGLETEST_INSTALL_DIR",
-        "mimalloc": "MIMALLOC_INSTALL_DIR"
+        "mimalloc": "MIMALLOC_INSTALL_DIR",
+        "slang": "SLANG_INSTALL_DIR"
     }
 }

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -119,6 +119,9 @@
             ]
         }
     ],
+    "repo_binaries_version": [
+       { "slang": "2025.12.1" }
+    ],
     "install_names": {
         "glslang": "GLSLANG_INSTALL_DIR",
         "Vulkan-Headers": "VULKAN_HEADERS_INSTALL_DIR",

--- a/scripts/update_deps.py
+++ b/scripts/update_deps.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
 # Copyright 2017 The Glslang Authors. All rights reserved.
-# Copyright (c) 2018-2024 Valve Corporation
-# Copyright (c) 2018-2024 LunarG, Inc.
+# Copyright (c) 2018-2025 Valve Corporation
+# Copyright (c) 2018-2025 LunarG, Inc.
 # Copyright (c) 2023-2023 RasterGrid Kft.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -623,6 +623,21 @@ def GetInstallNames(args):
         else:
             return None
 
+def GetRepoBinaries(args):
+    """Returns the repo binaries version list.       
+    """
+    if args.known_good_dir:
+        known_good_file = os.path.join(os.path.abspath(args.known_good_dir),
+            KNOWN_GOOD_FILE_NAME)
+    else:
+        known_good_file = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), KNOWN_GOOD_FILE_NAME)
+    with open(known_good_file) as known_good:
+        json_data = json.loads(known_good.read())
+        if json_data.get('repo_binaries_version'):
+            return json_data['repo_binaries_version']
+        else:
+            return []
 
 def CreateHelper(args, repos, filename):
     """Create a CMake config helper file.
@@ -648,6 +663,12 @@ def CreateHelper(args, repos, filename):
                                       var=install_names[repo.name],
                                       dir=escape(repo.install_dir)))
 
+        repo_binaries_version = GetRepoBinaries(args)
+        for binary_entry in repo_binaries_version:
+            for binary_name, binary_version in binary_entry.items():
+                helper_file.write(f'set({binary_name.upper()}_VERSION "{binary_version}" CACHE STRING "{binary_name} version to use")\n')
+                if VERBOSE:
+                    print(f'Added {binary_name} version {binary_version} to helper.cmake')
 
 def GetDefaultArch():
     machine = platform.machine().lower()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -330,70 +330,26 @@ find_package(SPIRV-Tools CONFIG)
 
 # Slang
 # ---
-# Due to issues Slang in tests is not supported on Apple,
-# and not 32 bits platforms for lack of pre-built 32 bit binaries
-if(NOT APPLE AND NOT ANDROID AND CMAKE_SIZEOF_VOID_P EQUAL 8)
-    if(NOT DEFINED SLANG_VERSION)
-        message(FATAL_ERROR "Could not retrieve Slang version from helper.cmake")
-    endif()
-
-    set(SLANG_BINARY_DIR "${CMAKE_BINARY_DIR}/slang")
-    set(SLANG_DOWNLOAD_DIR "${SLANG_BINARY_DIR}/download")
-    set(SLANG_EXTRACT_DIR "${SLANG_BINARY_DIR}/extract")
-
-    # Function to determine the correct binary URL based on platform
-    function(get_slang_binary_url RESULT_VAR)
-        if(WIN32 AND CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
-            set(${RESULT_VAR} "https://github.com/shader-slang/slang/releases/download/v${SLANG_VERSION}/slang-${SLANG_VERSION}-windows-aarch64.zip" PARENT_SCOPE)
-        elseif(WIN32)
-            set(${RESULT_VAR} "https://github.com/shader-slang/slang/releases/download/v${SLANG_VERSION}/slang-${SLANG_VERSION}-windows-x86_64.zip" PARENT_SCOPE)
-        elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|aarch64linux|arm64|ARM64")
-            set(${RESULT_VAR} "https://github.com/shader-slang/slang/releases/download/v${SLANG_VERSION}/slang-${SLANG_VERSION}-linux-aarch64.zip" PARENT_SCOPE)
-        elseif(UNIX)
-            set(${RESULT_VAR} "https://github.com/shader-slang/slang/releases/download/v${SLANG_VERSION}/slang-${SLANG_VERSION}-linux-x86_64.zip" PARENT_SCOPE)
-        else()
-            message(FATAL_ERROR "Unsupported platform for Slang prebuilt binaries")
-        endif()
-    endfunction()
-
-    get_slang_binary_url(SLANG_URL)
-    message(STATUS "Using Slang version: ${SLANG_VERSION}")
-    message(STATUS "Downloading from: ${SLANG_URL}")
-
-    # Download and extract the ZIP file
-    file(DOWNLOAD "${SLANG_URL}" "${SLANG_DOWNLOAD_DIR}/slang-${SLANG_VERSION}.zip"
-         STATUS DOWNLOAD_STATUS
-    )
-    list(GET DOWNLOAD_STATUS 0 STATUS_CODE)
-    if(NOT STATUS_CODE EQUAL 0)
-        list(GET DOWNLOAD_STATUS 1 ERROR_MESSAGE)
-        message(FATAL_ERROR "Failed to download Slang: ${ERROR_MESSAGE}")
-    endif()
-    file(MAKE_DIRECTORY "${SLANG_EXTRACT_DIR}")
-    file(ARCHIVE_EXTRACT 
-         INPUT "${SLANG_DOWNLOAD_DIR}/slang-${SLANG_VERSION}.zip"
-         DESTINATION "${SLANG_EXTRACT_DIR}"
-    )
-
+if(DEFINED SLANG_INSTALL_DIR)
     # Define paths based on actual structure
     if(WIN32)
-        if(EXISTS "${SLANG_EXTRACT_DIR}/bin")
-            set(SLANG_BIN_DIR "${SLANG_EXTRACT_DIR}/bin")
+        if(EXISTS "${SLANG_INSTALL_DIR}/bin")
+            set(SLANG_BIN_DIR "${SLANG_INSTALL_DIR}/bin")
         endif()
 
-        if(EXISTS "${SLANG_EXTRACT_DIR}/lib")
-            set(SLANG_LIB_DIR "${SLANG_EXTRACT_DIR}/lib")
+        if(EXISTS "${SLANG_INSTALL_DIR}/lib")
+            set(SLANG_LIB_DIR "${SLANG_INSTALL_DIR}/lib")
         else()
-            set(SLANG_LIB_DIR "${SLANG_EXTRACT_DIR}/bin")
+            set(SLANG_LIB_DIR "${SLANG_INSTALL_DIR}/bin")
         endif()
 
-        set(SLANG_INCLUDE_DIR "${SLANG_EXTRACT_DIR}/include")
+        set(SLANG_INCLUDE_DIR "${SLANG_INSTALL_DIR}/include")
 
         # Find slang.lib
         if(EXISTS "${SLANG_LIB_DIR}/slang.lib")
             set(SLANG_LIBRARY "${SLANG_LIB_DIR}/slang.lib")
         else()
-            file(GLOB SLANG_LIB_FILES "${SLANG_EXTRACT_DIR}/**/slang.lib")
+            file(GLOB SLANG_LIB_FILES "${SLANG_INSTALL_DIR}/**/slang.lib")
             if(SLANG_LIB_FILES)
                 list(GET SLANG_LIB_FILES 0 SLANG_LIBRARY)
             else()
@@ -402,7 +358,7 @@ if(NOT APPLE AND NOT ANDROID AND CMAKE_SIZEOF_VOID_P EQUAL 8)
         endif()
 
         # Find slang.dll
-        file(GLOB SLANG_DLL_FILES "${SLANG_EXTRACT_DIR}/**/slang.dll")
+        file(GLOB SLANG_DLL_FILES "${SLANG_INSTALL_DIR}/**/slang.dll")
         if(SLANG_DLL_FILES)
             list(GET SLANG_DLL_FILES 0 SLANG_DLL)
         elseif(EXISTS "${SLANG_BIN_DIR}/slang.dll")
@@ -422,17 +378,17 @@ if(NOT APPLE AND NOT ANDROID AND CMAKE_SIZEOF_VOID_P EQUAL 8)
         endforeach()
 
     else()
-        set(SLANG_INCLUDE_DIR "${SLANG_EXTRACT_DIR}/include")
+        set(SLANG_INCLUDE_DIR "${SLANG_INSTALL_DIR}/include")
 
-        if(EXISTS "${SLANG_EXTRACT_DIR}/lib")
-            set(SLANG_LIB_DIR "${SLANG_EXTRACT_DIR}/lib")
+        if(EXISTS "${SLANG_INSTALL_DIR}/lib")
+            set(SLANG_LIB_DIR "${SLANG_INSTALL_DIR}/lib")
         else()
             # Some releases might put libraries in a different location
-            file(GLOB LIB_DIRS "${SLANG_EXTRACT_DIR}/**/lib")
+            file(GLOB LIB_DIRS "${SLANG_INSTALL_DIR}/**/lib")
             if(LIB_DIRS)
                 list(GET LIB_DIRS 0 SLANG_LIB_DIR)
             else()
-                set(SLANG_LIB_DIR "${SLANG_EXTRACT_DIR}")
+                set(SLANG_LIB_DIR "${SLANG_INSTALL_DIR}")
             endif()
         endif()
 
@@ -441,7 +397,7 @@ if(NOT APPLE AND NOT ANDROID AND CMAKE_SIZEOF_VOID_P EQUAL 8)
             set(SLANG_LIBRARY "${SLANG_LIB_DIR}/libslang.so")
             message(STATUS "Found libslang.so at: ${SLANG_LIBRARY}")
         else()
-            file(GLOB SLANG_LIB_FILES "${SLANG_EXTRACT_DIR}/**/libslang.so")
+            file(GLOB SLANG_LIB_FILES "${SLANG_INSTALL_DIR}/**/libslang.so")
             if(SLANG_LIB_FILES)
                 list(GET SLANG_LIB_FILES 0 SLANG_LIBRARY)
                 message(STATUS "Found libslang.so via glob at: ${SLANG_LIBRARY}")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -328,8 +328,250 @@ find_package(GTest CONFIG)
 find_package(glslang CONFIG)
 find_package(SPIRV-Tools CONFIG)
 
+# Slang
+# ---
+# Due to issues Slang in tests is not supported on Apple,
+# and not 32 bits platforms for lack of pre-built 32 bit binaries
+if(NOT APPLE AND NOT ANDROID AND CMAKE_SIZEOF_VOID_P EQUAL 8)
+    if(NOT DEFINED SLANG_VERSION)
+        message(FATAL_ERROR "Could not retrieve Slang version from helper.cmake")
+    endif()
+
+    set(SLANG_BINARY_DIR "${CMAKE_BINARY_DIR}/slang")
+    set(SLANG_DOWNLOAD_DIR "${SLANG_BINARY_DIR}/download")
+    set(SLANG_EXTRACT_DIR "${SLANG_BINARY_DIR}/extract")
+
+    # Function to determine the correct binary URL based on platform
+    function(get_slang_binary_url RESULT_VAR)
+        if(WIN32 AND CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64|ARM64")
+            set(${RESULT_VAR} "https://github.com/shader-slang/slang/releases/download/v${SLANG_VERSION}/slang-${SLANG_VERSION}-windows-aarch64.zip" PARENT_SCOPE)
+        elseif(WIN32)
+            set(${RESULT_VAR} "https://github.com/shader-slang/slang/releases/download/v${SLANG_VERSION}/slang-${SLANG_VERSION}-windows-x86_64.zip" PARENT_SCOPE)
+        elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|aarch64linux|arm64|ARM64")
+            set(${RESULT_VAR} "https://github.com/shader-slang/slang/releases/download/v${SLANG_VERSION}/slang-${SLANG_VERSION}-linux-aarch64.zip" PARENT_SCOPE)
+        elseif(UNIX)
+            set(${RESULT_VAR} "https://github.com/shader-slang/slang/releases/download/v${SLANG_VERSION}/slang-${SLANG_VERSION}-linux-x86_64.zip" PARENT_SCOPE)
+        else()
+            message(FATAL_ERROR "Unsupported platform for Slang prebuilt binaries")
+        endif()
+    endfunction()
+
+    get_slang_binary_url(SLANG_URL)
+    message(STATUS "Using Slang version: ${SLANG_VERSION}")
+    message(STATUS "Downloading from: ${SLANG_URL}")
+
+    # Download and extract the ZIP file
+    file(DOWNLOAD "${SLANG_URL}" "${SLANG_DOWNLOAD_DIR}/slang-${SLANG_VERSION}.zip"
+         STATUS DOWNLOAD_STATUS
+    )
+    list(GET DOWNLOAD_STATUS 0 STATUS_CODE)
+    if(NOT STATUS_CODE EQUAL 0)
+        list(GET DOWNLOAD_STATUS 1 ERROR_MESSAGE)
+        message(FATAL_ERROR "Failed to download Slang: ${ERROR_MESSAGE}")
+    endif()
+    file(MAKE_DIRECTORY "${SLANG_EXTRACT_DIR}")
+    file(ARCHIVE_EXTRACT 
+         INPUT "${SLANG_DOWNLOAD_DIR}/slang-${SLANG_VERSION}.zip"
+         DESTINATION "${SLANG_EXTRACT_DIR}"
+    )
+
+    # Define paths based on actual structure
+    if(WIN32)
+        if(EXISTS "${SLANG_EXTRACT_DIR}/bin")
+            set(SLANG_BIN_DIR "${SLANG_EXTRACT_DIR}/bin")
+        endif()
+
+        if(EXISTS "${SLANG_EXTRACT_DIR}/lib")
+            set(SLANG_LIB_DIR "${SLANG_EXTRACT_DIR}/lib")
+        else()
+            set(SLANG_LIB_DIR "${SLANG_EXTRACT_DIR}/bin")
+        endif()
+
+        set(SLANG_INCLUDE_DIR "${SLANG_EXTRACT_DIR}/include")
+
+        # Find slang.lib
+        if(EXISTS "${SLANG_LIB_DIR}/slang.lib")
+            set(SLANG_LIBRARY "${SLANG_LIB_DIR}/slang.lib")
+        else()
+            file(GLOB SLANG_LIB_FILES "${SLANG_EXTRACT_DIR}/**/slang.lib")
+            if(SLANG_LIB_FILES)
+                list(GET SLANG_LIB_FILES 0 SLANG_LIBRARY)
+            else()
+                message(FATAL_ERROR "Could not locate slang.lib in extracted directory")
+            endif()
+        endif()
+
+        # Find slang.dll
+        file(GLOB SLANG_DLL_FILES "${SLANG_EXTRACT_DIR}/**/slang.dll")
+        if(SLANG_DLL_FILES)
+            list(GET SLANG_DLL_FILES 0 SLANG_DLL)
+        elseif(EXISTS "${SLANG_BIN_DIR}/slang.dll")
+            set(SLANG_DLL "${SLANG_BIN_DIR}/slang.dll")
+        else()
+            message(FATAL_ERROR "Could not locate slang.dll in extracted directory")
+        endif()
+
+        # On Windows, also check for any other DLLs in the same directory
+        # as slang.dll and add them to a list for copying
+        get_filename_component(SLANG_DLL_DIR "${SLANG_DLL}" DIRECTORY)
+        file(GLOB ADDITIONAL_DLLS "${SLANG_DLL_DIR}/*.dll")
+        foreach(DLL ${ADDITIONAL_DLLS})
+            if(NOT DLL STREQUAL SLANG_DLL)
+                list(APPEND SLANG_DEPENDENCY_DLLS ${DLL})
+            endif()
+        endforeach()
+
+    else()
+        set(SLANG_INCLUDE_DIR "${SLANG_EXTRACT_DIR}/include")
+
+        if(EXISTS "${SLANG_EXTRACT_DIR}/lib")
+            set(SLANG_LIB_DIR "${SLANG_EXTRACT_DIR}/lib")
+        else()
+            # Some releases might put libraries in a different location
+            file(GLOB LIB_DIRS "${SLANG_EXTRACT_DIR}/**/lib")
+            if(LIB_DIRS)
+                list(GET LIB_DIRS 0 SLANG_LIB_DIR)
+            else()
+                set(SLANG_LIB_DIR "${SLANG_EXTRACT_DIR}")
+            endif()
+        endif()
+
+        # Find libslang.so
+        if(EXISTS "${SLANG_LIB_DIR}/libslang.so")
+            set(SLANG_LIBRARY "${SLANG_LIB_DIR}/libslang.so")
+            message(STATUS "Found libslang.so at: ${SLANG_LIBRARY}")
+        else()
+            file(GLOB SLANG_LIB_FILES "${SLANG_EXTRACT_DIR}/**/libslang.so")
+            if(SLANG_LIB_FILES)
+                list(GET SLANG_LIB_FILES 0 SLANG_LIBRARY)
+                message(STATUS "Found libslang.so via glob at: ${SLANG_LIBRARY}")
+            else()
+                message(FATAL_ERROR "Could not locate libslang.so in extracted directory")
+            endif()
+        endif()
+
+        # Check if we have other shared libraries that might be dependencies
+        get_filename_component(SLANG_LIB_DIR_REAL "${SLANG_LIBRARY}" DIRECTORY)
+        file(GLOB ADDITIONAL_LIBS "${SLANG_LIB_DIR_REAL}/*.so*")
+        foreach(LIB ${ADDITIONAL_LIBS})
+            if(NOT LIB STREQUAL SLANG_LIBRARY)
+                list(APPEND SLANG_DEPENDENCY_LIBS ${LIB})
+            endif()
+        endforeach()
+    endif()
+
+    # Create an imported target for easier usage
+    add_library(slang SHARED IMPORTED GLOBAL)
+
+    set_target_properties(slang PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES ${SLANG_INCLUDE_DIR}
+    )
+
+    if(WIN32)
+        set_target_properties(slang PROPERTIES
+            IMPORTED_IMPLIB ${SLANG_LIBRARY}
+            IMPORTED_LOCATION ${SLANG_DLL}
+        )
+    else()
+        set_target_properties(slang PROPERTIES
+            IMPORTED_LOCATION ${SLANG_LIBRARY}
+        )
+    endif()
+
+    # For specific target directories (adds to the common destinations above)
+    function(configure_slang_for_target TARGET_NAME)
+        if(WIN32)
+            add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    ${SLANG_DLL}
+                    $<TARGET_FILE_DIR:${TARGET_NAME}>
+                COMMENT "Copying Slang DLL to output directory for ${TARGET_NAME}"
+            )
+
+            get_target_property(TARGET_OUTPUT_DIR ${TARGET_NAME} RUNTIME_OUTPUT_DIRECTORY)
+            if(NOT TARGET_OUTPUT_DIR)
+                set(TARGET_OUTPUT_DIR "$<TARGET_FILE_DIR:${TARGET_NAME}>")
+            endif()
+
+            foreach(DEP_DLL ${SLANG_DEPENDENCY_DLLS})
+                get_filename_component(DEP_DLL_NAME ${DEP_DLL} NAME)
+                add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
+                    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                        ${DEP_DLL}
+                        $<TARGET_FILE_DIR:${TARGET_NAME}>
+                    COMMENT "Copying dependency DLL ${DEP_DLL_NAME} to output directory for ${TARGET_NAME}"
+                )
+            endforeach()
+        else()
+            get_filename_component(SLANG_SONAME ${SLANG_LIBRARY} NAME)
+            add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    ${SLANG_LIBRARY}
+                    $<TARGET_FILE_DIR:${TARGET_NAME}>/${SLANG_SONAME}
+                COMMENT "Copying Slang shared library to output directory for ${TARGET_NAME}"
+            )
+
+            get_target_property(TARGET_OUTPUT_DIR ${TARGET_NAME} RUNTIME_OUTPUT_DIRECTORY)
+            if(NOT TARGET_OUTPUT_DIR)
+                set(TARGET_OUTPUT_DIR "$<TARGET_FILE_DIR:${TARGET_NAME}>")
+            endif()
+
+            # Copy any dependency libraries
+            foreach(DEP_LIB ${SLANG_DEPENDENCY_LIBS})
+                get_filename_component(DEP_LIB_NAME ${DEP_LIB} NAME)
+                add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
+                    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                        ${DEP_LIB}
+                        $<TARGET_FILE_DIR:${TARGET_NAME}>/${DEP_LIB_NAME}
+                    COMMENT "Copying dependency library ${DEP_LIB_NAME} to output directory for ${TARGET_NAME}"
+                )
+            endforeach()
+
+            # Set RPATH to look in the same directory as the executable
+            set_target_properties(${TARGET_NAME} PROPERTIES
+                INSTALL_RPATH "$ORIGIN"
+                BUILD_WITH_INSTALL_RPATH TRUE
+            )
+
+            # Add post-build step to verify the library was copied and is executable
+            add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E echo "Verifying shared libraries in $<TARGET_FILE_DIR:${TARGET_NAME}>"
+                COMMAND ${CMAKE_COMMAND} -E echo "Slang library path: $<TARGET_FILE_DIR:${TARGET_NAME}>/${SLANG_SONAME}"
+                COMMAND test -f "$<TARGET_FILE_DIR:${TARGET_NAME}>/${SLANG_SONAME}" || echo "Library not copied correctly"
+                COMMAND chmod +x "$<TARGET_FILE_DIR:${TARGET_NAME}>/${SLANG_SONAME}"
+                COMMAND echo "Library permissions:" && ls -la "$<TARGET_FILE_DIR:${TARGET_NAME}>/${SLANG_SONAME}"
+            )
+        endif()
+    endfunction()
+
+    function(install_slang_with_target TARGET_NAME DESTINATION)
+        if(NOT WIN32)
+            get_filename_component(SLANG_SONAME ${SLANG_LIBRARY} NAME)
+            install(FILES ${SLANG_LIBRARY} DESTINATION ${DESTINATION})
+
+            foreach(DEP_LIB ${SLANG_DEPENDENCY_LIBS})
+                get_filename_component(DEP_LIB_NAME ${DEP_LIB} NAME)
+                install(FILES ${DEP_LIB} DESTINATION ${DESTINATION})
+            endforeach()
+
+            set_target_properties(${TARGET_NAME} PROPERTIES INSTALL_RPATH "$ORIGIN")
+
+            # Add install-time command to set executable permissions
+            install(CODE "message(STATUS \"Setting executable permissions on ${CMAKE_INSTALL_PREFIX}/${DESTINATION}/${SLANG_SONAME}\")
+                         execute_process(COMMAND chmod +x \"${CMAKE_INSTALL_PREFIX}/${DESTINATION}/${SLANG_SONAME}\")")
+         endif()
+    endfunction()
+
+    set(USE_SLANG TRUE)
+    configure_slang_for_target(vk_layer_validation_tests)
+else()
+    message(STATUS "Skipping Slang setup for 32-bit architecture")
+    set(USE_SLANG FALSE)
+endif()
+
 target_link_libraries(vk_layer_validation_tests PRIVATE
     VkLayer_utils
+    $<$<BOOL:${USE_SLANG}>:slang>
     glslang::SPIRV
     glslang::SPVRemapper
     SPIRV-Tools-static
@@ -366,6 +608,10 @@ elseif (ANDROID)
 endif()
 
 install(TARGETS vk_layer_validation_tests)
+if(USE_SLANG)
+    target_compile_definitions(vk_layer_validation_tests PRIVATE VVL_USE_SLANG)
+    install_slang_with_target(vk_layer_validation_tests lib)
+endif()
 
 include(GoogleTest)
 gtest_discover_tests(vk_layer_validation_tests DISCOVERY_TIMEOUT 100)

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -241,8 +241,8 @@ class GpuAVDescriptorIndexingTest : public GpuAVTest {
 
 class GpuAVDescriptorClassGeneralBuffer : public GpuAVTest {
   public:
-    void ComputeStorageBufferTest(const char *shader, bool is_glsl, VkDeviceSize buffer_size, const char *expected_error = nullptr,
-                                  uint32_t error_count = 1);
+    void ComputeStorageBufferTest(const char *shader, int source_type, VkDeviceSize buffer_size,
+                                  const char *expected_error = nullptr, uint32_t error_count = 1);
 };
 
 class GpuAVRayQueryTest : public GpuAVTest {

--- a/tests/framework/ray_tracing_objects.cpp
+++ b/tests/framework/ray_tracing_objects.cpp
@@ -1429,6 +1429,11 @@ void Pipeline::AddSpirvRayGenShader(const char *spirv, const char *entry_point) 
                                                                 SPV_SOURCE_ASM, nullptr, entry_point));
 }
 
+void Pipeline::AddSlangRayGenShader(const char *slang, const char *entry_point) {
+    ray_gen_shaders_.emplace_back(std::make_unique<VkShaderObj>(&test_, slang, VK_SHADER_STAGE_RAYGEN_BIT_KHR, SPV_ENV_VULKAN_1_2,
+                                                                SPV_SOURCE_SLANG, nullptr, entry_point));
+}
+
 void Pipeline::AddGlslMissShader(const char *glsl) {
     miss_shaders_.emplace_back(std::make_unique<VkShaderObj>(&test_, glsl, VK_SHADER_STAGE_MISS_BIT_KHR, SPV_ENV_VULKAN_1_2));
 }
@@ -1436,6 +1441,11 @@ void Pipeline::AddGlslMissShader(const char *glsl) {
 void Pipeline::AddSpirvMissShader(const char *spirv, const char *entry_point) {
     miss_shaders_.emplace_back(std::make_unique<VkShaderObj>(&test_, spirv, VK_SHADER_STAGE_MISS_BIT_KHR, SPV_ENV_VULKAN_1_2,
                                                              SPV_SOURCE_ASM, nullptr, entry_point));
+}
+
+void Pipeline::AddSlangMissShader(const char *slang, const char *entry_point) {
+    miss_shaders_.emplace_back(std::make_unique<VkShaderObj>(&test_, slang, VK_SHADER_STAGE_MISS_BIT_KHR, SPV_ENV_VULKAN_1_2,
+                                                             SPV_SOURCE_SLANG, nullptr, entry_point));
 }
 
 void Pipeline::AddGlslClosestHitShader(const char *glsl) {
@@ -1446,6 +1456,11 @@ void Pipeline::AddGlslClosestHitShader(const char *glsl) {
 void Pipeline::AddSpirvClosestHitShader(const char *spirv, const char *entry_point) {
     closest_hit_shaders_.emplace_back(std::make_unique<VkShaderObj>(&test_, spirv, VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR,
                                                                     SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM, nullptr, entry_point));
+}
+
+void Pipeline::AddSlangClosestHitShader(const char *slang, const char *entry_point) {
+    closest_hit_shaders_.emplace_back(std::make_unique<VkShaderObj>(&test_, slang, VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR,
+                                                                    SPV_ENV_VULKAN_1_2, SPV_SOURCE_SLANG, nullptr, entry_point));
 }
 
 void Pipeline::AddLibrary(const Pipeline &library) {

--- a/tests/framework/ray_tracing_objects.h
+++ b/tests/framework/ray_tracing_objects.h
@@ -323,10 +323,13 @@ class Pipeline {
     void SetPushConstantRangeSize(uint32_t byte_size);
     void SetGlslRayGenShader(const char* glsl);
     void AddSpirvRayGenShader(const char* spirv, const char* entry_point);
+    void AddSlangRayGenShader(const char* slang, const char* entry_point);
     void AddGlslMissShader(const char* glsl);
     void AddSpirvMissShader(const char* spirv, const char* entry_point);
+    void AddSlangMissShader(const char* slang, const char* entry_point);
     void AddGlslClosestHitShader(const char* glsl);
     void AddSpirvClosestHitShader(const char* spirv, const char* entry_point);
+    void AddSlangClosestHitShader(const char* slang, const char* entry_point);
     void AddLibrary(const Pipeline& library);
     void AddDynamicState(VkDynamicState dynamic_state);
 

--- a/tests/framework/shader_helper.h
+++ b/tests/framework/shader_helper.h
@@ -31,14 +31,18 @@ class VkRenderFramework;
 typedef enum {
     SPV_SOURCE_GLSL,
     SPV_SOURCE_ASM,
+    SPV_SOURCE_SLANG,
     // TRY == Won't try in contructor as need to be called as function that can return the VkResult
     SPV_SOURCE_GLSL_TRY,
     SPV_SOURCE_ASM_TRY,
 } SpvSourceType;
 
 bool GLSLtoSPV(const VkPhysicalDeviceLimits &device_limits, const VkShaderStageFlagBits shader_type, const char *p_shader,
-               std::vector<uint32_t> &spv, const spv_target_env spv_env = SPV_ENV_VULKAN_1_0);
-bool ASMtoSPV(const spv_target_env target_env, const uint32_t options, const char *p_asm, std::vector<uint32_t> &spv);
+               std::vector<uint32_t> &out_spv, const spv_target_env spv_env = SPV_ENV_VULKAN_1_0);
+bool ASMtoSPV(const spv_target_env target_env, const uint32_t options, const char *p_asm, std::vector<uint32_t> &out_spv);
+// We don't support installation of Slang on some platforms
+void CheckSlangSupport();
+bool SlangToSPV(const char *slang_shader, const char *entry_point_name, std::vector<uint8_t> &out_bytes);
 
 // VkShaderObj is really just the Shader Module, but we named before VK_EXT_shader_object
 // TODO - move all of VkShaderObj to vkt::ShaderModule
@@ -64,6 +68,7 @@ class VkShaderObj : public vkt::ShaderModule {
     VkResult InitFromGLSLTry(const vkt::Device *custom_device = nullptr);
     bool InitFromASM();
     VkResult InitFromASMTry();
+    bool InitFromSlang();
 
     // These functions return a pointer to a newly created _and initialized_ VkShaderObj if initialization was successful.
     // Otherwise, {} is returned.

--- a/tests/unit/debug_printf_ray_tracing.cpp
+++ b/tests/unit/debug_printf_ray_tracing.cpp
@@ -134,736 +134,6 @@ class NegativeDebugPrintfRayTracing : public DebugPrintfTests {
     }
 };
 
-const char* GetSlangShader1() {
-    // slang shader. Compiled with:
-    // slangc.exe -capability GL_EXT_debug_printf .\ray_tracing.slang -target spirv-asm -profile glsl_460 -O0 -o ray_tracing.spv
-    // /!\ /!\ /!\ you need to manually edit the OpEntryPoint in the resulting spir-v to match the slang shader
-    /*
-[[vk::binding(0, 0)]] uniform RaytracingAccelerationStructure tlas;
-[[vk::binding(1, 0)]] RWStructuredBuffer<uint32_t> debug_buffer;
-
-struct RayPayload {
-    float3 hit;
-};
-
-[shader("raygeneration")]
-void rayGenShader()
-{
-    printf("In Raygen 1");
-    InterlockedAdd(debug_buffer[0], 1);
-    RayPayload ray_payload = { float3(0) };
-    RayDesc ray;
-    ray.TMin = 0.01;
-    ray.TMax = 1000.0;
-
-    // Will miss
-    ray.Origin = float3(0,0,0);
-    ray.Direction = float3(0,0,-1);
-    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
-
-    // Will hit cube 1
-    ray.Origin = float3(0,0,0);
-    ray.Direction = float3(1,0,0);
-    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
-
-    // Will miss
-    ray.Origin = float3(0,0,0);
-    ray.Direction = float3(-1,0,0);
-    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
-}
-
-[shader("raygeneration")]
-void rayGenShader2()
-{
-    printf("In Raygen 2");
-    InterlockedAdd(debug_buffer[1], 1);
-    RayPayload ray_payload = { float3(0) };
-    RayDesc ray;
-    ray.TMin = 0.01;
-    ray.TMax = 1000.0;
-
-    // Will hit cube 1
-    ray.Origin = float3(-50,0,0);
-    ray.Direction = float3(1,0,0);
-    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
-
-    // Will hit cube 2
-    ray.Origin = float3(0,0,0);
-    ray.Direction = float3(0,0,1);
-    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
-}
-
-[shader("miss")]
-void missShader(inout RayPayload payload)
-{
-    printf("In Miss 1");
-    InterlockedAdd(debug_buffer[2], 1);
-    payload.hit = float3(0.1, 0.2, 0.3);
-}
-
-[shader("miss")]
-void missShader2(inout RayPayload payload)
-{
-    printf("In Miss 2");
-    InterlockedAdd(debug_buffer[3], 1);
-    payload.hit = float3(42, 42, 42);
-}
-
-[shader("closesthit")]
-void closestHitShader(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attr)
-{
-    printf("In Closest Hit 1");
-    InterlockedAdd(debug_buffer[4], 1);
-    const float3 barycentric_coords = float3(1.0f - attr.barycentrics.x - attr.barycentrics.y, attr.barycentrics.x,
-attr.barycentrics.y); payload.hit = barycentric_coords;
-
-    RayPayload ray_payload = { float3(0) };
-    RayDesc ray;
-
-    ray.TMin = 0.01;
-    ray.TMax = 1000.0;
-    const uint32_t miss_shader_i = 1;
-
-    // Supposed to hit cube 2, and invoke closestHitShader2
-    ray.Origin = float3(0,0,0);
-    ray.Direction = float3(0,0,1);
-    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, miss_shader_i, ray, ray_payload);
-
-    // Supposed to miss, and call missShader2
-    ray.Origin = float3(0,0,0);
-    ray.Direction = float3(0,1,0);
-    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, miss_shader_i, ray, ray_payload);
-}
-
-[shader("closesthit")]
-void closestHitShader2(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attr)
-{
-    printf("In Closest Hit 2");
-    InterlockedAdd(debug_buffer[5], 1);
-    const float3 barycentric_coords = float3(1.0f - attr.barycentrics.x - attr.barycentrics.y, attr.barycentrics.x,
-attr.barycentrics.y); payload.hit = 999 * barycentric_coords;
-}
-    */
-    const char* ray_tracing_pipeline_spv = R"asm(
-; SPIR-V
-; Version: 1.5
-; Generator: Khronos; 40
-; Bound: 236
-; Schema: 0
-OpCapability RayTracingKHR
-OpCapability Shader
-OpExtension "SPV_KHR_non_semantic_info"
-OpExtension "SPV_KHR_storage_buffer_storage_class"
-OpExtension "SPV_KHR_ray_tracing"
-%11 = OpExtInstImport "NonSemantic.DebugPrintf"
-OpMemoryModel Logical GLSL450
-OpEntryPoint RayGenerationKHR %rayGenShader "rayGenShader" %p %debug_buffer %tlas
-OpEntryPoint RayGenerationKHR %rayGenShader2 "rayGenShader2" %p %debug_buffer %tlas
-OpEntryPoint MissKHR %missShader "missShader" %debug_buffer %136
-OpEntryPoint MissKHR %missShader2 "missShader2" %debug_buffer %151
-OpEntryPoint ClosestHitKHR %closestHitShader "closestHitShader" %p %debug_buffer %tlas %178 %168
-OpEntryPoint ClosestHitKHR %closestHitShader2 "closestHitShader2" %debug_buffer %230 %221
-
-; Debug Information
-OpSource Slang 1
-%12 = OpString "In Raygen 1"
-%91 = OpString "In Raygen 2"
-%132 = OpString "In Miss 1"
-%148 = OpString "In Miss 2"
-%161 = OpString "In Closest Hit 1"
-%217 = OpString "In Closest Hit 2"
-OpName %RayDesc "RayDesc"                           ; id %5
-OpMemberName %RayDesc 0 "Origin"
-OpMemberName %RayDesc 1 "TMin"
-OpMemberName %RayDesc 2 "Direction"
-OpMemberName %RayDesc 3 "TMax"
-OpName %ray "ray"                                   ; id %9
-OpName %ray "ray"                                   ; id %9
-OpName %RWStructuredBuffer "RWStructuredBuffer"     ; id %18
-OpName %debug_buffer "debug_buffer"                 ; id %21
-OpName %RayPayload "RayPayload"                     ; id %27
-OpMemberName %RayPayload 0 "hit"
-OpName %ray_payload "ray_payload"                   ; id %28
-OpName %p "p"                                       ; id %49
-OpName %tlas "tlas"                                 ; id %58
-OpName %ray_payload_0 "ray_payload"                 ; id %61
-OpName %ray_payload_1 "ray_payload"                 ; id %74
-OpName %rayGenShader "rayGenShader"                 ; id %2
-OpName %ray_0 "ray"                                 ; id %89
-OpName %ray_0 "ray"                                 ; id %89
-OpName %ray_payload_2 "ray_payload"                 ; id %95
-OpName %ray_payload_3 "ray_payload"                 ; id %115
-OpName %rayGenShader2 "rayGenShader2"               ; id %87
-OpName %missShader "missShader"                     ; id %129
-OpName %missShader2 "missShader2"                   ; id %145
-OpName %ray_1 "ray"                                 ; id %159
-OpName %ray_1 "ray"                                 ; id %159
-OpName %BuiltInTriangleIntersectionAttributes "BuiltInTriangleIntersectionAttributes"   ; id %165
-OpMemberName %BuiltInTriangleIntersectionAttributes 0 "barycentrics"
-OpName %barycentric_coords "barycentric_coords"     ; id %177
-OpName %ray_payload_4 "ray_payload"                 ; id %182
-OpName %ray_payload_5 "ray_payload"                 ; id %201
-OpName %closestHitShader "closestHitShader"         ; id %157
-OpName %barycentric_coords_0 "barycentric_coords"   ; id %229
-OpName %closestHitShader2 "closestHitShader2"       ; id %214
-
-; Annotations
-OpMemberDecorate %RayDesc 0 Offset 0
-OpMemberDecorate %RayDesc 1 Offset 12
-OpMemberDecorate %RayDesc 2 Offset 16
-OpMemberDecorate %RayDesc 3 Offset 28
-OpDecorate %_runtimearr_uint ArrayStride 4
-OpDecorate %RWStructuredBuffer Block
-OpMemberDecorate %RWStructuredBuffer 0 Offset 0
-OpDecorate %debug_buffer Binding 1
-OpDecorate %debug_buffer DescriptorSet 0
-OpMemberDecorate %RayPayload 0 Offset 0
-OpDecorate %p Location 0
-OpDecorate %tlas Binding 0
-OpDecorate %tlas DescriptorSet 0
-OpMemberDecorate %BuiltInTriangleIntersectionAttributes 0 Offset 0
-
-; Types, variables and constants
-%void = OpTypeVoid
-%3 = OpTypeFunction %void
-%float = OpTypeFloat 32
-%v3float = OpTypeVector %float 3
-%RayDesc = OpTypeStruct %v3float %float %v3float %float
-%_ptr_Function_RayDesc = OpTypePointer Function %RayDesc
-%int = OpTypeInt 32 1
-%int_0 = OpConstant %int 0
-%uint = OpTypeInt 32 0
-%_ptr_StorageBuffer_uint = OpTypePointer StorageBuffer %uint
-%_runtimearr_uint = OpTypeRuntimeArray %uint        ; ArrayStride 4
-%RWStructuredBuffer = OpTypeStruct %_runtimearr_uint    ; Block
-%_ptr_StorageBuffer_RWStructuredBuffer = OpTypePointer StorageBuffer %RWStructuredBuffer
-%uint_1 = OpConstant %uint 1
-%uint_0 = OpConstant %uint 0
-%float_0 = OpConstant %float 0
-%25 = OpConstantComposite %v3float %float_0 %float_0 %float_0
-%RayPayload = OpTypeStruct %v3float
-%int_1 = OpConstant %int 1
-%_ptr_Function_float = OpTypePointer Function %float
-%float_0_00999999978 = OpConstant %float 0.00999999978
-%int_3 = OpConstant %int 3
-%float_1000 = OpConstant %float 1000
-%_ptr_Function_v3float = OpTypePointer Function %v3float
-%40 = OpConstantComposite %v3float %float_0 %float_0 %float_0
-%int_2 = OpConstant %int 2
-%float_n1 = OpConstant %float -1
-%44 = OpConstantComposite %v3float %float_0 %float_0 %float_n1
-%_ptr_RayPayloadKHR_RayPayload = OpTypePointer RayPayloadKHR %RayPayload
-%55 = OpTypeAccelerationStructureKHR
-%_ptr_UniformConstant_55 = OpTypePointer UniformConstant %55
-%uint_255 = OpConstant %uint 255
-%float_1 = OpConstant %float 1
-%63 = OpConstantComposite %v3float %float_1 %float_0 %float_0
-%76 = OpConstantComposite %v3float %float_n1 %float_0 %float_0
-%94 = OpConstantComposite %v3float %float_0 %float_0 %float_0
-%float_n50 = OpConstant %float -50
-%101 = OpConstantComposite %v3float %float_n50 %float_0 %float_0
-%105 = OpConstantComposite %v3float %float_1 %float_0 %float_0
-%116 = OpConstantComposite %v3float %float_0 %float_0 %float_0
-%118 = OpConstantComposite %v3float %float_0 %float_0 %float_1
-%_ptr_IncomingRayPayloadKHR_RayPayload = OpTypePointer IncomingRayPayloadKHR %RayPayload
-%_ptr_IncomingRayPayloadKHR_v3float = OpTypePointer IncomingRayPayloadKHR %v3float
-%float_0_100000001 = OpConstant %float 0.100000001
-%float_0_200000003 = OpConstant %float 0.200000003
-%float_0_300000012 = OpConstant %float 0.300000012
-%139 = OpConstantComposite %v3float %float_0_100000001 %float_0_200000003 %float_0_300000012
-%float_42 = OpConstant %float 42
-%153 = OpConstantComposite %v3float %float_42 %float_42 %float_42
-%int_4 = OpConstant %int 4
-%v2float = OpTypeVector %float 2
-%BuiltInTriangleIntersectionAttributes = OpTypeStruct %v2float
-%_ptr_HitAttributeKHR_BuiltInTriangleIntersectionAttributes = OpTypePointer HitAttributeKHR %BuiltInTriangleIntersectionAttributes
-%_ptr_HitAttributeKHR_v2float = OpTypePointer HitAttributeKHR %v2float
-%181 = OpConstantComposite %v3float %float_0 %float_0 %float_0
-%188 = OpConstantComposite %v3float %float_0 %float_0 %float_0
-%191 = OpConstantComposite %v3float %float_0 %float_0 %float_1
-%203 = OpConstantComposite %v3float %float_0 %float_1 %float_0
-%int_5 = OpConstant %int 5
-%float_999 = OpConstant %float 999
-%debug_buffer = OpVariable %_ptr_StorageBuffer_RWStructuredBuffer StorageBuffer     ; Binding 1, DescriptorSet 0
-%p = OpVariable %_ptr_RayPayloadKHR_RayPayload RayPayloadKHR                        ; Location 0
-%tlas = OpVariable %_ptr_UniformConstant_55 UniformConstant                         ; Binding 0, DescriptorSet 0
-%136 = OpVariable %_ptr_IncomingRayPayloadKHR_RayPayload IncomingRayPayloadKHR
-%151 = OpVariable %_ptr_IncomingRayPayloadKHR_RayPayload IncomingRayPayloadKHR
-%168 = OpVariable %_ptr_HitAttributeKHR_BuiltInTriangleIntersectionAttributes HitAttributeKHR
-%178 = OpVariable %_ptr_IncomingRayPayloadKHR_RayPayload IncomingRayPayloadKHR
-%221 = OpVariable %_ptr_HitAttributeKHR_BuiltInTriangleIntersectionAttributes HitAttributeKHR
-%230 = OpVariable %_ptr_IncomingRayPayloadKHR_RayPayload IncomingRayPayloadKHR
-
-; Function rayGenShader
-%rayGenShader = OpFunction %void None %3
-%4 = OpLabel
-%ray = OpVariable %_ptr_Function_RayDesc Function
-%10 = OpExtInst %void %11 1 %12
-%17 = OpAccessChain %_ptr_StorageBuffer_uint %debug_buffer %int_0 %int_0
-%22 = OpAtomicIAdd %uint %17 %uint_1 %uint_0 %uint_1
-%ray_payload = OpCompositeConstruct %RayPayload %25
-%31 = OpAccessChain %_ptr_Function_float %ray %int_1
-OpStore %31 %float_0_00999999978
-%35 = OpAccessChain %_ptr_Function_float %ray %int_3
-OpStore %35 %float_1000
-%39 = OpAccessChain %_ptr_Function_v3float %ray %int_0
-OpStore %39 %40
-%43 = OpAccessChain %_ptr_Function_v3float %ray %int_2
-OpStore %43 %44
-%47 = OpLoad %RayDesc %ray
-OpStore %p %ray_payload
-%51 = OpCompositeExtract %v3float %47 0
-%52 = OpCompositeExtract %v3float %47 2
-%53 = OpCompositeExtract %float %47 1
-%54 = OpCompositeExtract %float %47 3
-%56 = OpLoad %55 %tlas
-OpTraceRayKHR %56 %uint_0 %uint_255 %uint_0 %uint_0 %uint_0 %51 %53 %52 %54 %p
-%ray_payload_0 = OpLoad %RayPayload %p
-OpStore %39 %40
-OpStore %43 %63
-%66 = OpLoad %RayDesc %ray
-OpStore %p %ray_payload_0
-%68 = OpCompositeExtract %v3float %66 0
-%69 = OpCompositeExtract %v3float %66 2
-%70 = OpCompositeExtract %float %66 1
-%71 = OpCompositeExtract %float %66 3
-%72 = OpLoad %55 %tlas
-OpTraceRayKHR %72 %uint_0 %uint_255 %uint_0 %uint_0 %uint_0 %68 %70 %69 %71 %p
-%ray_payload_1 = OpLoad %RayPayload %p
-OpStore %39 %40
-OpStore %43 %76
-%78 = OpLoad %RayDesc %ray
-OpStore %p %ray_payload_1
-%80 = OpCompositeExtract %v3float %78 0
-%81 = OpCompositeExtract %v3float %78 2
-%82 = OpCompositeExtract %float %78 1
-%83 = OpCompositeExtract %float %78 3
-%84 = OpLoad %55 %tlas
-OpTraceRayKHR %84 %uint_0 %uint_255 %uint_0 %uint_0 %uint_0 %80 %82 %81 %83 %p
-OpReturn
-OpFunctionEnd
-
-; Function rayGenShader2
-%rayGenShader2 = OpFunction %void None %3
-%88 = OpLabel
-%ray_0 = OpVariable %_ptr_Function_RayDesc Function
-%90 = OpExtInst %void %11 1 %91
-%92 = OpAccessChain %_ptr_StorageBuffer_uint %debug_buffer %int_0 %int_1
-%93 = OpAtomicIAdd %uint %92 %uint_1 %uint_0 %uint_1
-%ray_payload_2 = OpCompositeConstruct %RayPayload %94
-%96 = OpAccessChain %_ptr_Function_float %ray_0 %int_1
-OpStore %96 %float_0_00999999978
-%98 = OpAccessChain %_ptr_Function_float %ray_0 %int_3
-OpStore %98 %float_1000
-%100 = OpAccessChain %_ptr_Function_v3float %ray_0 %int_0
-OpStore %100 %101
-%104 = OpAccessChain %_ptr_Function_v3float %ray_0 %int_2
-OpStore %104 %105
-%107 = OpLoad %RayDesc %ray_0
-OpStore %p %ray_payload_2
-%109 = OpCompositeExtract %v3float %107 0
-%110 = OpCompositeExtract %v3float %107 2
-%111 = OpCompositeExtract %float %107 1
-%112 = OpCompositeExtract %float %107 3
-%113 = OpLoad %55 %tlas
-OpTraceRayKHR %113 %uint_0 %uint_255 %uint_0 %uint_0 %uint_0 %109 %111 %110 %112 %p
-%ray_payload_3 = OpLoad %RayPayload %p
-OpStore %100 %116
-OpStore %104 %118
-%120 = OpLoad %RayDesc %ray_0
-OpStore %p %ray_payload_3
-%122 = OpCompositeExtract %v3float %120 0
-%123 = OpCompositeExtract %v3float %120 2
-%124 = OpCompositeExtract %float %120 1
-%125 = OpCompositeExtract %float %120 3
-%126 = OpLoad %55 %tlas
-OpTraceRayKHR %126 %uint_0 %uint_255 %uint_0 %uint_0 %uint_0 %122 %124 %123 %125 %p
-OpReturn
-OpFunctionEnd
-
-; Function missShader
-%missShader = OpFunction %void None %3
-%130 = OpLabel
-%131 = OpExtInst %void %11 1 %132
-%133 = OpAccessChain %_ptr_StorageBuffer_uint %debug_buffer %int_0 %int_2
-%134 = OpAtomicIAdd %uint %133 %uint_1 %uint_0 %uint_1
-%138 = OpAccessChain %_ptr_IncomingRayPayloadKHR_v3float %136 %int_0
-OpStore %138 %139
-OpReturn
-OpFunctionEnd
-
-; Function missShader2
-%missShader2 = OpFunction %void None %3
-%146 = OpLabel
-%147 = OpExtInst %void %11 1 %148
-%149 = OpAccessChain %_ptr_StorageBuffer_uint %debug_buffer %int_0 %int_3
-%150 = OpAtomicIAdd %uint %149 %uint_1 %uint_0 %uint_1
-%152 = OpAccessChain %_ptr_IncomingRayPayloadKHR_v3float %151 %int_0
-OpStore %152 %153
-OpReturn
-OpFunctionEnd
-
-; Function closestHitShader
-%closestHitShader = OpFunction %void None %3
-%158 = OpLabel
-%ray_1 = OpVariable %_ptr_Function_RayDesc Function
-%160 = OpExtInst %void %11 1 %161
-%163 = OpAccessChain %_ptr_StorageBuffer_uint %debug_buffer %int_0 %int_4
-%164 = OpAtomicIAdd %uint %163 %uint_1 %uint_0 %uint_1
-%170 = OpAccessChain %_ptr_HitAttributeKHR_v2float %168 %int_0
-%171 = OpLoad %v2float %170
-%172 = OpCompositeExtract %float %171 0
-%173 = OpFSub %float %float_1 %172
-%174 = OpLoad %v2float %170
-%175 = OpCompositeExtract %float %174 1
-%176 = OpFSub %float %173 %175
-%barycentric_coords = OpCompositeConstruct %v3float %176 %172 %175
-%179 = OpAccessChain %_ptr_IncomingRayPayloadKHR_v3float %178 %int_0
-OpStore %179 %barycentric_coords
-%ray_payload_4 = OpCompositeConstruct %RayPayload %181
-%183 = OpAccessChain %_ptr_Function_float %ray_1 %int_1
-OpStore %183 %float_0_00999999978
-%185 = OpAccessChain %_ptr_Function_float %ray_1 %int_3
-OpStore %185 %float_1000
-%187 = OpAccessChain %_ptr_Function_v3float %ray_1 %int_0
-OpStore %187 %188
-%190 = OpAccessChain %_ptr_Function_v3float %ray_1 %int_2
-OpStore %190 %191
-%193 = OpLoad %RayDesc %ray_1
-OpStore %p %ray_payload_4
-%195 = OpCompositeExtract %v3float %193 0
-%196 = OpCompositeExtract %v3float %193 2
-%197 = OpCompositeExtract %float %193 1
-%198 = OpCompositeExtract %float %193 3
-%199 = OpLoad %55 %tlas
-OpTraceRayKHR %199 %uint_0 %uint_255 %uint_0 %uint_0 %uint_1 %195 %197 %196 %198 %p
-%ray_payload_5 = OpLoad %RayPayload %p
-OpStore %187 %188
-OpStore %190 %203
-%205 = OpLoad %RayDesc %ray_1
-OpStore %p %ray_payload_5
-%207 = OpCompositeExtract %v3float %205 0
-%208 = OpCompositeExtract %v3float %205 2
-%209 = OpCompositeExtract %float %205 1
-%210 = OpCompositeExtract %float %205 3
-%211 = OpLoad %55 %tlas
-OpTraceRayKHR %211 %uint_0 %uint_255 %uint_0 %uint_0 %uint_1 %207 %209 %208 %210 %p
-OpReturn
-OpFunctionEnd
-
-; Function closestHitShader2
-%closestHitShader2 = OpFunction %void None %3
-%215 = OpLabel
-%216 = OpExtInst %void %11 1 %217
-%219 = OpAccessChain %_ptr_StorageBuffer_uint %debug_buffer %int_0 %int_5
-%220 = OpAtomicIAdd %uint %219 %uint_1 %uint_0 %uint_1
-%222 = OpAccessChain %_ptr_HitAttributeKHR_v2float %221 %int_0
-%223 = OpLoad %v2float %222
-%224 = OpCompositeExtract %float %223 0
-%225 = OpFSub %float %float_1 %224
-%226 = OpLoad %v2float %222
-%227 = OpCompositeExtract %float %226 1
-%228 = OpFSub %float %225 %227
-%barycentric_coords_0 = OpCompositeConstruct %v3float %228 %224 %227
-%231 = OpAccessChain %_ptr_IncomingRayPayloadKHR_v3float %230 %int_0
-%232 = OpVectorTimesScalar %v3float %barycentric_coords_0 %float_999
-OpStore %231 %232
-OpReturn
-OpFunctionEnd
-    )asm";
-
-    return ray_tracing_pipeline_spv;
-}
-
-const char* GetSlangShader2() {
-    // slang shader. Compiled with:
-    // slangc.exe -capability GL_EXT_debug_printf .\ray_tracing.slang -target spirv-asm -profile glsl_460 -O0 -o ray_tracing.spv
-    /*
-[[vk::binding(0, 0)]] uniform RaytracingAccelerationStructure tlas;
-[[vk::binding(1, 0)]] RWStructuredBuffer<uint32_t> debug_buffer;
-
-struct RayPayload {
-    float3 hit;
-};
-
-[shader("raygeneration")]
-void rayGenShader()
-{
-    printf("In Raygen");
-    InterlockedAdd(debug_buffer[0], 1);
-    RayPayload ray_payload = { float3(0) };
-    RayDesc ray;
-    ray.TMin = 0.01;
-    ray.TMax = 1000.0;
-
-    // Will hit
-    ray.Origin = float3(0,0,-50);
-    ray.Direction = float3(0,0,1);
-    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
-
-    // Will miss
-    ray.Origin = float3(0,0,-50);
-    ray.Direction = float3(0,0,-1);
-    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
-
-    // Will miss
-    ray.Origin = float3(0,0,50);
-    ray.Direction = float3(0,0,1);
-    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
-
-    // Will miss
-    ray.Origin = float3(0,0,50);
-    ray.Direction = float3(0,0,-1);
-    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
-
-    // Will miss
-    ray.Origin = float3(0,0,0);
-    ray.Direction = float3(0,0,1);
-    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
-
-}
-
-[shader("miss")]
-void missShader(inout RayPayload payload)
-{
-    printf("In Miss");
-    InterlockedAdd(debug_buffer[1], 1);
-    payload.hit = float3(0.1, 0.2, 0.3);
-}
-
-[shader("closesthit")]
-void closestHitShader(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attr)
-{
-    printf("In Closest Hit");
-    InterlockedAdd(debug_buffer[2], 1);
-    const float3 barycentric_coords = float3(1.0f - attr.barycentrics.x - attr.barycentrics.y, attr.barycentrics.x,
-attr.barycentrics.y); payload.hit = barycentric_coords;
-}
-    */
-    const char* ray_tracing_pipeline_spv = R"asm(
-; SPIR-V
-; Version: 1.5
-; Generator: Khronos; 40
-; Bound: 151
-; Schema: 0
-OpCapability RayTracingKHR
-OpCapability Shader
-OpExtension "SPV_KHR_non_semantic_info"
-OpExtension "SPV_KHR_storage_buffer_storage_class"
-OpExtension "SPV_KHR_ray_tracing"
-%11 = OpExtInstImport "NonSemantic.DebugPrintf"
-OpMemoryModel Logical GLSL450
-OpEntryPoint RayGenerationKHR %rayGenShader "main" %p %debug_buffer %tlas
-OpEntryPoint MissKHR %missShader "main" %debug_buffer %119
-OpEntryPoint ClosestHitKHR %closestHitShader "main" %debug_buffer %147 %137
-
-; Debug Information
-OpSource Slang 1
-%12 = OpString "In Raygen"
-%115 = OpString "In Miss"
-%131 = OpString "In Closest Hit"
-OpName %RayDesc "RayDesc"                           ; id %5
-OpMemberName %RayDesc 0 "Origin"
-OpMemberName %RayDesc 1 "TMin"
-OpMemberName %RayDesc 2 "Direction"
-OpMemberName %RayDesc 3 "TMax"
-OpName %ray "ray"                                   ; id %9
-OpName %ray "ray"                                   ; id %9
-OpName %RWStructuredBuffer "RWStructuredBuffer"     ; id %18
-OpName %debug_buffer "debug_buffer"                 ; id %21
-OpName %RayPayload "RayPayload"                     ; id %27
-OpMemberName %RayPayload 0 "hit"
-OpName %ray_payload "ray_payload"                   ; id %28
-OpName %p "p"                                       ; id %50
-OpName %tlas "tlas"                                 ; id %59
-OpName %ray_payload_0 "ray_payload"                 ; id %62
-OpName %ray_payload_1 "ray_payload"                 ; id %75
-OpName %ray_payload_2 "ray_payload"                 ; id %88
-OpName %ray_payload_3 "ray_payload"                 ; id %99
-OpName %rayGenShader "rayGenShader"                 ; id %2
-OpName %missShader "missShader"                     ; id %112
-OpName %BuiltInTriangleIntersectionAttributes "BuiltInTriangleIntersectionAttributes"   ; id %134
-OpMemberName %BuiltInTriangleIntersectionAttributes 0 "barycentrics"
-OpName %barycentric_coords "barycentric_coords"     ; id %146
-OpName %closestHitShader "closestHitShader"         ; id %128
-
-; Annotations
-OpMemberDecorate %RayDesc 0 Offset 0
-OpMemberDecorate %RayDesc 1 Offset 12
-OpMemberDecorate %RayDesc 2 Offset 16
-OpMemberDecorate %RayDesc 3 Offset 28
-OpDecorate %_runtimearr_uint ArrayStride 4
-OpDecorate %RWStructuredBuffer Block
-OpMemberDecorate %RWStructuredBuffer 0 Offset 0
-OpDecorate %debug_buffer Binding 1
-OpDecorate %debug_buffer DescriptorSet 0
-OpMemberDecorate %RayPayload 0 Offset 0
-OpDecorate %p Location 0
-OpDecorate %tlas Binding 0
-OpDecorate %tlas DescriptorSet 0
-OpMemberDecorate %BuiltInTriangleIntersectionAttributes 0 Offset 0
-
-; Types, variables and constants
-%void = OpTypeVoid
-%3 = OpTypeFunction %void
-%float = OpTypeFloat 32
-%v3float = OpTypeVector %float 3
-%RayDesc = OpTypeStruct %v3float %float %v3float %float
-%_ptr_Function_RayDesc = OpTypePointer Function %RayDesc
-%int = OpTypeInt 32 1
-%int_0 = OpConstant %int 0
-%uint = OpTypeInt 32 0
-%_ptr_StorageBuffer_uint = OpTypePointer StorageBuffer %uint
-%_runtimearr_uint = OpTypeRuntimeArray %uint        ; ArrayStride 4
-%RWStructuredBuffer = OpTypeStruct %_runtimearr_uint    ; Block
-%_ptr_StorageBuffer_RWStructuredBuffer = OpTypePointer StorageBuffer %RWStructuredBuffer
-%uint_1 = OpConstant %uint 1
-%uint_0 = OpConstant %uint 0
-%float_0 = OpConstant %float 0
-%25 = OpConstantComposite %v3float %float_0 %float_0 %float_0
-%RayPayload = OpTypeStruct %v3float
-%int_1 = OpConstant %int 1
-%_ptr_Function_float = OpTypePointer Function %float
-%float_0_00999999978 = OpConstant %float 0.00999999978
-%int_3 = OpConstant %int 3
-%float_1000 = OpConstant %float 1000
-%_ptr_Function_v3float = OpTypePointer Function %v3float
-%float_n50 = OpConstant %float -50
-%40 = OpConstantComposite %v3float %float_0 %float_0 %float_n50
-%int_2 = OpConstant %int 2
-%float_1 = OpConstant %float 1
-%45 = OpConstantComposite %v3float %float_0 %float_0 %float_1
-%_ptr_RayPayloadKHR_RayPayload = OpTypePointer RayPayloadKHR %RayPayload
-%56 = OpTypeAccelerationStructureKHR
-%_ptr_UniformConstant_56 = OpTypePointer UniformConstant %56
-%uint_255 = OpConstant %uint 255
-%float_n1 = OpConstant %float -1
-%64 = OpConstantComposite %v3float %float_0 %float_0 %float_n1
-%float_50 = OpConstant %float 50
-%76 = OpConstantComposite %v3float %float_0 %float_0 %float_50
-%100 = OpConstantComposite %v3float %float_0 %float_0 %float_0
-%_ptr_IncomingRayPayloadKHR_RayPayload = OpTypePointer IncomingRayPayloadKHR %RayPayload
-%_ptr_IncomingRayPayloadKHR_v3float = OpTypePointer IncomingRayPayloadKHR %v3float
-%float_0_100000001 = OpConstant %float 0.100000001
-%float_0_200000003 = OpConstant %float 0.200000003
-%float_0_300000012 = OpConstant %float 0.300000012
-%122 = OpConstantComposite %v3float %float_0_100000001 %float_0_200000003 %float_0_300000012
-%v2float = OpTypeVector %float 2
-%BuiltInTriangleIntersectionAttributes = OpTypeStruct %v2float
-%_ptr_HitAttributeKHR_BuiltInTriangleIntersectionAttributes = OpTypePointer HitAttributeKHR %BuiltInTriangleIntersectionAttributes
-%_ptr_HitAttributeKHR_v2float = OpTypePointer HitAttributeKHR %v2float
-%debug_buffer = OpVariable %_ptr_StorageBuffer_RWStructuredBuffer StorageBuffer     ; Binding 1, DescriptorSet 0
-%p = OpVariable %_ptr_RayPayloadKHR_RayPayload RayPayloadKHR                        ; Location 0
-%tlas = OpVariable %_ptr_UniformConstant_56 UniformConstant                         ; Binding 0, DescriptorSet 0
-%119 = OpVariable %_ptr_IncomingRayPayloadKHR_RayPayload IncomingRayPayloadKHR
-%137 = OpVariable %_ptr_HitAttributeKHR_BuiltInTriangleIntersectionAttributes HitAttributeKHR
-%147 = OpVariable %_ptr_IncomingRayPayloadKHR_RayPayload IncomingRayPayloadKHR
-
-; Function rayGenShader
-%rayGenShader = OpFunction %void None %3
-%4 = OpLabel
-%ray = OpVariable %_ptr_Function_RayDesc Function
-%10 = OpExtInst %void %11 1 %12
-%17 = OpAccessChain %_ptr_StorageBuffer_uint %debug_buffer %int_0 %int_0
-%22 = OpAtomicIAdd %uint %17 %uint_1 %uint_0 %uint_1
-%ray_payload = OpCompositeConstruct %RayPayload %25
-%31 = OpAccessChain %_ptr_Function_float %ray %int_1
-OpStore %31 %float_0_00999999978
-%35 = OpAccessChain %_ptr_Function_float %ray %int_3
-OpStore %35 %float_1000
-%39 = OpAccessChain %_ptr_Function_v3float %ray %int_0
-OpStore %39 %40
-%44 = OpAccessChain %_ptr_Function_v3float %ray %int_2
-OpStore %44 %45
-%48 = OpLoad %RayDesc %ray
-OpStore %p %ray_payload
-%52 = OpCompositeExtract %v3float %48 0
-%53 = OpCompositeExtract %v3float %48 2
-%54 = OpCompositeExtract %float %48 1
-%55 = OpCompositeExtract %float %48 3
-%57 = OpLoad %56 %tlas
-OpTraceRayKHR %57 %uint_0 %uint_255 %uint_0 %uint_0 %uint_0 %52 %54 %53 %55 %p
-%ray_payload_0 = OpLoad %RayPayload %p
-OpStore %39 %40
-OpStore %44 %64
-%67 = OpLoad %RayDesc %ray
-OpStore %p %ray_payload_0
-%69 = OpCompositeExtract %v3float %67 0
-%70 = OpCompositeExtract %v3float %67 2
-%71 = OpCompositeExtract %float %67 1
-%72 = OpCompositeExtract %float %67 3
-%73 = OpLoad %56 %tlas
-OpTraceRayKHR %73 %uint_0 %uint_255 %uint_0 %uint_0 %uint_0 %69 %71 %70 %72 %p
-%ray_payload_1 = OpLoad %RayPayload %p
-OpStore %39 %76
-OpStore %44 %45
-%80 = OpLoad %RayDesc %ray
-OpStore %p %ray_payload_1
-%82 = OpCompositeExtract %v3float %80 0
-%83 = OpCompositeExtract %v3float %80 2
-%84 = OpCompositeExtract %float %80 1
-%85 = OpCompositeExtract %float %80 3
-%86 = OpLoad %56 %tlas
-OpTraceRayKHR %86 %uint_0 %uint_255 %uint_0 %uint_0 %uint_0 %82 %84 %83 %85 %p
-%ray_payload_2 = OpLoad %RayPayload %p
-OpStore %39 %76
-OpStore %44 %64
-%91 = OpLoad %RayDesc %ray
-OpStore %p %ray_payload_2
-%93 = OpCompositeExtract %v3float %91 0
-%94 = OpCompositeExtract %v3float %91 2
-%95 = OpCompositeExtract %float %91 1
-%96 = OpCompositeExtract %float %91 3
-%97 = OpLoad %56 %tlas
-OpTraceRayKHR %97 %uint_0 %uint_255 %uint_0 %uint_0 %uint_0 %93 %95 %94 %96 %p
-%ray_payload_3 = OpLoad %RayPayload %p
-OpStore %39 %100
-OpStore %44 %45
-%103 = OpLoad %RayDesc %ray
-OpStore %p %ray_payload_3
-%105 = OpCompositeExtract %v3float %103 0
-%106 = OpCompositeExtract %v3float %103 2
-%107 = OpCompositeExtract %float %103 1
-%108 = OpCompositeExtract %float %103 3
-%109 = OpLoad %56 %tlas
-OpTraceRayKHR %109 %uint_0 %uint_255 %uint_0 %uint_0 %uint_0 %105 %107 %106 %108 %p
-OpReturn
-OpFunctionEnd
-
-; Function missShader
-%missShader = OpFunction %void None %3
-%113 = OpLabel
-%114 = OpExtInst %void %11 1 %115
-%116 = OpAccessChain %_ptr_StorageBuffer_uint %debug_buffer %int_0 %int_1
-%117 = OpAtomicIAdd %uint %116 %uint_1 %uint_0 %uint_1
-%121 = OpAccessChain %_ptr_IncomingRayPayloadKHR_v3float %119 %int_0
-OpStore %121 %122
-OpReturn
-OpFunctionEnd
-
-; Function closestHitShader
-%closestHitShader = OpFunction %void None %3
-%129 = OpLabel
-%130 = OpExtInst %void %11 1 %131
-%132 = OpAccessChain %_ptr_StorageBuffer_uint %debug_buffer %int_0 %int_2
-%133 = OpAtomicIAdd %uint %132 %uint_1 %uint_0 %uint_1
-%139 = OpAccessChain %_ptr_HitAttributeKHR_v2float %137 %int_0
-%140 = OpLoad %v2float %139
-%141 = OpCompositeExtract %float %140 0
-%142 = OpFSub %float %float_1 %141
-%143 = OpLoad %v2float %139
-%144 = OpCompositeExtract %float %143 1
-%145 = OpFSub %float %142 %144
-%barycentric_coords = OpCompositeConstruct %v3float %145 %141 %144
-%148 = OpAccessChain %_ptr_IncomingRayPayloadKHR_v3float %147 %int_0
-OpStore %148 %barycentric_coords
-OpReturn
-OpFunctionEnd
-    )asm";
-
-    return ray_tracing_pipeline_spv;
-}
-
 TEST_F(NegativeDebugPrintfRayTracing, Raygen) {
     TEST_DESCRIPTION("Test debug printf in raygen shader.");
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -1090,9 +360,11 @@ TEST_F(NegativeDebugPrintfRayTracing, RaygenOneMissShaderOneClosestHitShader) {
 }
 
 // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9559
-TEST_F(NegativeDebugPrintfRayTracing, DISABLED_OneMultiEntryPointsShader) {
+TEST_F(NegativeDebugPrintfRayTracing, OneMultiEntryPointsShader) {
     TEST_DESCRIPTION(
         "Test debug printf in a multi entry points shader. 1 ray generation shader, 1 miss shader, 1 closest hit shader");
+
+    RETURN_IF_SKIP(CheckSlangSupport());
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
@@ -1135,9 +407,72 @@ TEST_F(NegativeDebugPrintfRayTracing, DISABLED_OneMultiEntryPointsShader) {
 
     vkt::rt::Pipeline pipeline(*this, m_device);
 
-    pipeline.AddSpirvRayGenShader(GetSlangShader2(), "main");
-    pipeline.AddSpirvMissShader(GetSlangShader2(), "main");
-    pipeline.AddSpirvClosestHitShader(GetSlangShader2(), "main");
+    const char* slang_shader = R"slang(
+        [[vk::binding(0, 0)]] uniform RaytracingAccelerationStructure tlas;
+        [[vk::binding(1, 0)]] RWStructuredBuffer<uint32_t> debug_buffer;
+        
+        struct RayPayload {
+            float3 hit;
+        };
+        
+        [shader("raygeneration")]
+        void rayGenShader()
+        {
+            printf("In Raygen");
+            InterlockedAdd(debug_buffer[0], 1);
+            RayPayload ray_payload = { float3(0) };
+            RayDesc ray;
+            ray.TMin = 0.01;
+            ray.TMax = 1000.0;
+        
+            // Will hit
+            ray.Origin = float3(0,0,-50);
+            ray.Direction = float3(0,0,1);
+            TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+        
+            // Will miss
+            ray.Origin = float3(0,0,-50);
+            ray.Direction = float3(0,0,-1);
+            TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+        
+            // Will miss
+            ray.Origin = float3(0,0,50);
+            ray.Direction = float3(0,0,1);
+            TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+        
+            // Will miss
+            ray.Origin = float3(0,0,50);
+            ray.Direction = float3(0,0,-1);
+            TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+        
+            // Will miss
+            ray.Origin = float3(0,0,0);
+            ray.Direction = float3(0,0,1);
+            TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+        
+        }
+        
+        [shader("miss")]
+        void missShader(inout RayPayload payload)
+        {
+            printf("In Miss");
+            InterlockedAdd(debug_buffer[1], 1);
+            payload.hit = float3(0.1, 0.2, 0.3);
+        }
+        
+        [shader("closesthit")]
+        void closestHitShader(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attr)
+        {
+            printf("In Closest Hit");
+            InterlockedAdd(debug_buffer[2], 1);
+            const float3 barycentric_coords = float3(1.0f - attr.barycentrics.x - attr.barycentrics.y, attr.barycentrics.x,
+        attr.barycentrics.y); payload.hit = barycentric_coords;
+        }        
+    )slang";
+
+    pipeline.AddSlangRayGenShader(slang_shader, "rayGenShader");
+    pipeline.AddSlangMissShader(slang_shader, "missShader");
+    pipeline.AddSlangClosestHitShader(slang_shader, "closestHitShader");
 
     pipeline.AddBinding(VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, 0);
     pipeline.AddBinding(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);
@@ -1174,10 +509,13 @@ TEST_F(NegativeDebugPrintfRayTracing, DISABLED_OneMultiEntryPointsShader) {
 }
 
 // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9559
-TEST_F(NegativeDebugPrintfRayTracing, DISABLED_OneMultiEntryPointsShader2CmdTraceRays) {
+TEST_F(NegativeDebugPrintfRayTracing, OneMultiEntryPointsShader2CmdTraceRays) {
     TEST_DESCRIPTION(
         "Test debug printf in a multi entry points shader. 2 ray generation shaders, 2 miss shaders, 2 closest hit shaders."
         "Trace rays using vkCmdTraceRaysKHR");
+
+    RETURN_IF_SKIP(CheckSlangSupport());
+
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::rayTracingPipeline);
@@ -1199,12 +537,119 @@ TEST_F(NegativeDebugPrintfRayTracing, DISABLED_OneMultiEntryPointsShader2CmdTrac
 
     vkt::rt::Pipeline pipeline(*this, m_device);
 
-    pipeline.AddSpirvRayGenShader(GetSlangShader1(), "rayGenShader");
-    pipeline.AddSpirvRayGenShader(GetSlangShader1(), "rayGenShader2");
-    pipeline.AddSpirvMissShader(GetSlangShader1(), "missShader");
-    pipeline.AddSpirvMissShader(GetSlangShader1(), "missShader2");
-    pipeline.AddSpirvClosestHitShader(GetSlangShader1(), "closestHitShader");
-    pipeline.AddSpirvClosestHitShader(GetSlangShader1(), "closestHitShader2");
+    const char* slang_shader = R"slang(
+        [[vk::binding(0, 0)]] uniform RaytracingAccelerationStructure tlas;
+        [[vk::binding(1, 0)]] RWStructuredBuffer<uint32_t> debug_buffer;
+        
+        struct RayPayload {
+            float3 hit;
+        };
+        
+        [shader("raygeneration")]
+        void rayGenShader()
+        {
+            printf("In Raygen 1");
+            InterlockedAdd(debug_buffer[0], 1);
+            RayPayload ray_payload = { float3(0) };
+            RayDesc ray;
+            ray.TMin = 0.01;
+            ray.TMax = 1000.0;
+        
+            // Will miss
+            ray.Origin = float3(0,0,0);
+            ray.Direction = float3(0,0,-1);
+            TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+        
+            // Will hit cube 1
+            ray.Origin = float3(0,0,0);
+            ray.Direction = float3(1,0,0);
+            TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+        
+            // Will miss
+            ray.Origin = float3(0,0,0);
+            ray.Direction = float3(-1,0,0);
+            TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+        }
+        
+        [shader("raygeneration")]
+        void rayGenShader2()
+        {
+            printf("In Raygen 2");
+            InterlockedAdd(debug_buffer[1], 1);
+            RayPayload ray_payload = { float3(0) };
+            RayDesc ray;
+            ray.TMin = 0.01;
+            ray.TMax = 1000.0;
+        
+            // Will hit cube 1
+            ray.Origin = float3(-50,0,0);
+            ray.Direction = float3(1,0,0);
+            TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+        
+            // Will hit cube 2
+            ray.Origin = float3(0,0,0);
+            ray.Direction = float3(0,0,1);
+            TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+        }
+        
+        [shader("miss")]
+        void missShader(inout RayPayload payload)
+        {
+            printf("In Miss 1");
+            InterlockedAdd(debug_buffer[2], 1);
+            payload.hit = float3(0.1, 0.2, 0.3);
+        }
+        
+        [shader("miss")]
+        void missShader2(inout RayPayload payload)
+        {
+            printf("In Miss 2");
+            InterlockedAdd(debug_buffer[3], 1);
+            payload.hit = float3(42, 42, 42);
+        }
+        
+        [shader("closesthit")]
+        void closestHitShader(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attr)
+        {
+            printf("In Closest Hit 1");
+            InterlockedAdd(debug_buffer[4], 1);
+            const float3 barycentric_coords = float3(1.0f - attr.barycentrics.x - attr.barycentrics.y, attr.barycentrics.x,
+                attr.barycentrics.y); payload.hit = barycentric_coords;
+        
+            RayPayload ray_payload = { float3(0) };
+            RayDesc ray;
+        
+            ray.TMin = 0.01;
+            ray.TMax = 1000.0;
+            const uint32_t miss_shader_i = 1;
+        
+            // Supposed to hit cube 2, and invoke closestHitShader2
+            ray.Origin = float3(0,0,0);
+            ray.Direction = float3(0,0,1);
+            TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, miss_shader_i, ray, ray_payload);
+        
+            // Supposed to miss, and call missShader2
+            ray.Origin = float3(0,0,0);
+            ray.Direction = float3(0,1,0);
+            TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, miss_shader_i, ray, ray_payload);
+        }
+        
+        [shader("closesthit")]
+        void closestHitShader2(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attr)
+        {
+            printf("In Closest Hit 2");
+            InterlockedAdd(debug_buffer[5], 1);
+            const float3 barycentric_coords = float3(1.0f - attr.barycentrics.x - attr.barycentrics.y, attr.barycentrics.x,
+        attr.barycentrics.y); payload.hit = 999 * barycentric_coords;
+        }    
+    )slang";
+
+    pipeline.AddSlangRayGenShader(slang_shader, "rayGenShader");
+    pipeline.AddSlangRayGenShader(slang_shader, "rayGenShader2");
+    pipeline.AddSlangMissShader(slang_shader, "missShader");
+    pipeline.AddSlangMissShader(slang_shader, "missShader2");
+    pipeline.AddSlangClosestHitShader(slang_shader, "closestHitShader");
+    pipeline.AddSlangClosestHitShader(slang_shader, "closestHitShader2");
 
     pipeline.AddBinding(VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, 0);
     pipeline.AddBinding(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);
@@ -1254,10 +699,13 @@ TEST_F(NegativeDebugPrintfRayTracing, DISABLED_OneMultiEntryPointsShader2CmdTrac
 }
 
 // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9559
-TEST_F(NegativeDebugPrintfRayTracing, DISABLED_OneMultiEntryPointsShader2CmdTraceRaysIndirect) {
+TEST_F(NegativeDebugPrintfRayTracing, OneMultiEntryPointsShader2CmdTraceRaysIndirect) {
     TEST_DESCRIPTION(
         "Test debug printf in a multi entry points shader. 2 ray generation shaders, 2 miss shaders, 2 closest hit shaders."
         "Trace rays using vkCmdTraceRaysIndirect2KHR");
+
+    RETURN_IF_SKIP(CheckSlangSupport());
+
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_RAY_TRACING_MAINTENANCE_1_EXTENSION_NAME);
@@ -1281,12 +729,119 @@ TEST_F(NegativeDebugPrintfRayTracing, DISABLED_OneMultiEntryPointsShader2CmdTrac
 
     vkt::rt::Pipeline pipeline(*this, m_device);
 
-    pipeline.AddSpirvRayGenShader(GetSlangShader1(), "rayGenShader");
-    pipeline.AddSpirvRayGenShader(GetSlangShader1(), "rayGenShader2");
-    pipeline.AddSpirvMissShader(GetSlangShader1(), "missShader");
-    pipeline.AddSpirvMissShader(GetSlangShader1(), "missShader2");
-    pipeline.AddSpirvClosestHitShader(GetSlangShader1(), "closestHitShader");
-    pipeline.AddSpirvClosestHitShader(GetSlangShader1(), "closestHitShader2");
+    const char* slang_shader = R"slang(
+        [[vk::binding(0, 0)]] uniform RaytracingAccelerationStructure tlas;
+        [[vk::binding(1, 0)]] RWStructuredBuffer<uint32_t> debug_buffer;
+        
+        struct RayPayload {
+            float3 hit;
+        };
+        
+        [shader("raygeneration")]
+        void rayGenShader()
+        {
+            printf("In Raygen 1");
+            InterlockedAdd(debug_buffer[0], 1);
+            RayPayload ray_payload = { float3(0) };
+            RayDesc ray;
+            ray.TMin = 0.01;
+            ray.TMax = 1000.0;
+        
+            // Will miss
+            ray.Origin = float3(0,0,0);
+            ray.Direction = float3(0,0,-1);
+            TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+        
+            // Will hit cube 1
+            ray.Origin = float3(0,0,0);
+            ray.Direction = float3(1,0,0);
+            TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+        
+            // Will miss
+            ray.Origin = float3(0,0,0);
+            ray.Direction = float3(-1,0,0);
+            TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+        }
+        
+        [shader("raygeneration")]
+        void rayGenShader2()
+        {
+            printf("In Raygen 2");
+            InterlockedAdd(debug_buffer[1], 1);
+            RayPayload ray_payload = { float3(0) };
+            RayDesc ray;
+            ray.TMin = 0.01;
+            ray.TMax = 1000.0;
+        
+            // Will hit cube 1
+            ray.Origin = float3(-50,0,0);
+            ray.Direction = float3(1,0,0);
+            TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+        
+            // Will hit cube 2
+            ray.Origin = float3(0,0,0);
+            ray.Direction = float3(0,0,1);
+            TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+        }
+        
+        [shader("miss")]
+        void missShader(inout RayPayload payload)
+        {
+            printf("In Miss 1");
+            InterlockedAdd(debug_buffer[2], 1);
+            payload.hit = float3(0.1, 0.2, 0.3);
+        }
+        
+        [shader("miss")]
+        void missShader2(inout RayPayload payload)
+        {
+            printf("In Miss 2");
+            InterlockedAdd(debug_buffer[3], 1);
+            payload.hit = float3(42, 42, 42);
+        }
+        
+        [shader("closesthit")]
+        void closestHitShader(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attr)
+        {
+            printf("In Closest Hit 1");
+            InterlockedAdd(debug_buffer[4], 1);
+            const float3 barycentric_coords = float3(1.0f - attr.barycentrics.x - attr.barycentrics.y, attr.barycentrics.x,
+                attr.barycentrics.y); payload.hit = barycentric_coords;
+        
+            RayPayload ray_payload = { float3(0) };
+            RayDesc ray;
+        
+            ray.TMin = 0.01;
+            ray.TMax = 1000.0;
+            const uint32_t miss_shader_i = 1;
+        
+            // Supposed to hit cube 2, and invoke closestHitShader2
+            ray.Origin = float3(0,0,0);
+            ray.Direction = float3(0,0,1);
+            TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, miss_shader_i, ray, ray_payload);
+        
+            // Supposed to miss, and call missShader2
+            ray.Origin = float3(0,0,0);
+            ray.Direction = float3(0,1,0);
+            TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, miss_shader_i, ray, ray_payload);
+        }
+        
+        [shader("closesthit")]
+        void closestHitShader2(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attr)
+        {
+            printf("In Closest Hit 2");
+            InterlockedAdd(debug_buffer[5], 1);
+            const float3 barycentric_coords = float3(1.0f - attr.barycentrics.x - attr.barycentrics.y, attr.barycentrics.x,
+        attr.barycentrics.y); payload.hit = 999 * barycentric_coords;
+        }    
+    )slang";
+
+    pipeline.AddSlangRayGenShader(slang_shader, "rayGenShader");
+    pipeline.AddSlangRayGenShader(slang_shader, "rayGenShader2");
+    pipeline.AddSlangMissShader(slang_shader, "missShader");
+    pipeline.AddSlangMissShader(slang_shader, "missShader2");
+    pipeline.AddSlangClosestHitShader(slang_shader, "closestHitShader");
+    pipeline.AddSlangClosestHitShader(slang_shader, "closestHitShader2");
 
     pipeline.AddBinding(VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, 0);
     pipeline.AddBinding(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);
@@ -1335,10 +890,13 @@ TEST_F(NegativeDebugPrintfRayTracing, DISABLED_OneMultiEntryPointsShader2CmdTrac
 }
 
 // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9559
-TEST_F(NegativeDebugPrintfRayTracing, DISABLED_OneMultiEntryPointsShader2CmdTraceRaysIndirectDeferredBuild) {
+TEST_F(NegativeDebugPrintfRayTracing, OneMultiEntryPointsShader2CmdTraceRaysIndirectDeferredBuild) {
     TEST_DESCRIPTION(
         "Test debug printf in a multi entry points shader. 2 ray generation shaders, 2 miss shaders, 2 closest hit shaders."
         "Trace rays using vkCmdTraceRaysIndirect2KHR");
+
+    RETURN_IF_SKIP(CheckSlangSupport());
+
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_RAY_TRACING_MAINTENANCE_1_EXTENSION_NAME);
@@ -1362,12 +920,119 @@ TEST_F(NegativeDebugPrintfRayTracing, DISABLED_OneMultiEntryPointsShader2CmdTrac
 
     vkt::rt::Pipeline pipeline(*this, m_device);
 
-    pipeline.AddSpirvRayGenShader(GetSlangShader1(), "rayGenShader");
-    pipeline.AddSpirvRayGenShader(GetSlangShader1(), "rayGenShader2");
-    pipeline.AddSpirvMissShader(GetSlangShader1(), "missShader");
-    pipeline.AddSpirvMissShader(GetSlangShader1(), "missShader2");
-    pipeline.AddSpirvClosestHitShader(GetSlangShader1(), "closestHitShader");
-    pipeline.AddSpirvClosestHitShader(GetSlangShader1(), "closestHitShader2");
+    const char* slang_shader = R"slang(
+        [[vk::binding(0, 0)]] uniform RaytracingAccelerationStructure tlas;
+        [[vk::binding(1, 0)]] RWStructuredBuffer<uint32_t> debug_buffer;
+        
+        struct RayPayload {
+            float3 hit;
+        };
+        
+        [shader("raygeneration")]
+        void rayGenShader()
+        {
+            printf("In Raygen 1");
+            InterlockedAdd(debug_buffer[0], 1);
+            RayPayload ray_payload = { float3(0) };
+            RayDesc ray;
+            ray.TMin = 0.01;
+            ray.TMax = 1000.0;
+        
+            // Will miss
+            ray.Origin = float3(0,0,0);
+            ray.Direction = float3(0,0,-1);
+            TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+        
+            // Will hit cube 1
+            ray.Origin = float3(0,0,0);
+            ray.Direction = float3(1,0,0);
+            TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+        
+            // Will miss
+            ray.Origin = float3(0,0,0);
+            ray.Direction = float3(-1,0,0);
+            TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+        }
+        
+        [shader("raygeneration")]
+        void rayGenShader2()
+        {
+            printf("In Raygen 2");
+            InterlockedAdd(debug_buffer[1], 1);
+            RayPayload ray_payload = { float3(0) };
+            RayDesc ray;
+            ray.TMin = 0.01;
+            ray.TMax = 1000.0;
+        
+            // Will hit cube 1
+            ray.Origin = float3(-50,0,0);
+            ray.Direction = float3(1,0,0);
+            TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+        
+            // Will hit cube 2
+            ray.Origin = float3(0,0,0);
+            ray.Direction = float3(0,0,1);
+            TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+        }
+        
+        [shader("miss")]
+        void missShader(inout RayPayload payload)
+        {
+            printf("In Miss 1");
+            InterlockedAdd(debug_buffer[2], 1);
+            payload.hit = float3(0.1, 0.2, 0.3);
+        }
+        
+        [shader("miss")]
+        void missShader2(inout RayPayload payload)
+        {
+            printf("In Miss 2");
+            InterlockedAdd(debug_buffer[3], 1);
+            payload.hit = float3(42, 42, 42);
+        }
+        
+        [shader("closesthit")]
+        void closestHitShader(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attr)
+        {
+            printf("In Closest Hit 1");
+            InterlockedAdd(debug_buffer[4], 1);
+            const float3 barycentric_coords = float3(1.0f - attr.barycentrics.x - attr.barycentrics.y, attr.barycentrics.x,
+                attr.barycentrics.y); payload.hit = barycentric_coords;
+        
+            RayPayload ray_payload = { float3(0) };
+            RayDesc ray;
+        
+            ray.TMin = 0.01;
+            ray.TMax = 1000.0;
+            const uint32_t miss_shader_i = 1;
+        
+            // Supposed to hit cube 2, and invoke closestHitShader2
+            ray.Origin = float3(0,0,0);
+            ray.Direction = float3(0,0,1);
+            TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, miss_shader_i, ray, ray_payload);
+        
+            // Supposed to miss, and call missShader2
+            ray.Origin = float3(0,0,0);
+            ray.Direction = float3(0,1,0);
+            TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, miss_shader_i, ray, ray_payload);
+        }
+        
+        [shader("closesthit")]
+        void closestHitShader2(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attr)
+        {
+            printf("In Closest Hit 2");
+            InterlockedAdd(debug_buffer[5], 1);
+            const float3 barycentric_coords = float3(1.0f - attr.barycentrics.x - attr.barycentrics.y, attr.barycentrics.x,
+        attr.barycentrics.y); payload.hit = 999 * barycentric_coords;
+        }    
+    )slang";
+
+    pipeline.AddSlangRayGenShader(slang_shader, "rayGenShader");
+    pipeline.AddSlangRayGenShader(slang_shader, "rayGenShader2");
+    pipeline.AddSlangMissShader(slang_shader, "missShader");
+    pipeline.AddSlangMissShader(slang_shader, "missShader2");
+    pipeline.AddSlangClosestHitShader(slang_shader, "closestHitShader");
+    pipeline.AddSlangClosestHitShader(slang_shader, "closestHitShader2");
 
     pipeline.AddBinding(VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, 0);
     pipeline.AddBinding(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);

--- a/tests/unit/gpu_av_descriptor_class_general_buffer_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_class_general_buffer_positive.cpp
@@ -18,7 +18,7 @@
 
 class PositiveGpuAVDescriptorClassGeneralBuffer : public GpuAVDescriptorClassGeneralBuffer {};
 
-void GpuAVDescriptorClassGeneralBuffer::ComputeStorageBufferTest(const char *shader, bool is_glsl, VkDeviceSize buffer_size,
+void GpuAVDescriptorClassGeneralBuffer::ComputeStorageBufferTest(const char *shader, int source_type, VkDeviceSize buffer_size,
                                                                  const char *expected_error, uint32_t error_count) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitGpuAvFramework());
@@ -26,8 +26,8 @@ void GpuAVDescriptorClassGeneralBuffer::ComputeStorageBufferTest(const char *sha
 
     CreateComputePipelineHelper pipe(*this);
     pipe.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr};
-    pipe.cs_ = VkShaderObj(this, shader, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2,
-                                             is_glsl ? SPV_SOURCE_GLSL : SPV_SOURCE_ASM);
+    pipe.cs_ = VkShaderObj(this, shader, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, 
+    						(SpvSourceType)source_type);
     pipe.CreateComputePipeline();
 
     vkt::Buffer in_buffer(*m_device, buffer_size, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
@@ -780,7 +780,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, VectorArray) {
         }
     )glsl";
 
-    ComputeStorageBufferTest(cs_source, true, 64);
+    ComputeStorageBufferTest(cs_source, SPV_SOURCE_GLSL, 64);
 }
 
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, ArrayCopyGLSL) {
@@ -797,73 +797,32 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, ArrayCopyGLSL) {
             b = d;
         }
     )glsl";
-    ComputeStorageBufferTest(cs_source, true, 32);
+    ComputeStorageBufferTest(cs_source, SPV_SOURCE_GLSL, 32);
 }
 
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, ArrayCopySlang) {
     TEST_DESCRIPTION("Note that in slang and array copy is really a struct copy");
-    // struct Bar {
-    //     uint4 a;
-    //     uint b[4];
-    //     uint c;
-    // };
-    //
-    // [[vk::binding(0, 0)]]
-    // RWStructuredBuffer<Bar> foo;
-    //
-    // [shader("compute")]
-    // void main() {
-    //     uint d[4] = {4, 5, 6, 7};
-    //     foo[0].b = d;
-    // }
-    char const *cs_source = R"(
-               OpCapability Shader
-               OpExtension "SPV_KHR_storage_buffer_storage_class"
-               OpMemoryModel Logical GLSL450
-               OpEntryPoint GLCompute %main "main" %foo
-               OpExecutionMode %main LocalSize 1 1 1
-               OpDecorate %_arr_uint_int_4 ArrayStride 4
-               OpMemberDecorate %_Array_std430_uint4 0 Offset 0
-               OpMemberDecorate %Bar_std430 0 Offset 0
-               OpMemberDecorate %Bar_std430 1 Offset 16
-               OpMemberDecorate %Bar_std430 2 Offset 32
-               OpDecorate %_runtimearr_Bar_std430 ArrayStride 48
-               OpDecorate %RWStructuredBuffer Block
-               OpMemberDecorate %RWStructuredBuffer 0 Offset 0
-               OpDecorate %foo Binding 0
-               OpDecorate %foo DescriptorSet 0
-       %void = OpTypeVoid
-          %3 = OpTypeFunction %void
-        %int = OpTypeInt 32 1
-      %int_0 = OpConstant %int 0
-       %uint = OpTypeInt 32 0
-     %v4uint = OpTypeVector %uint 4
-      %int_4 = OpConstant %int 4
-%_arr_uint_int_4 = OpTypeArray %uint %int_4
-%_Array_std430_uint4 = OpTypeStruct %_arr_uint_int_4
- %Bar_std430 = OpTypeStruct %v4uint %_Array_std430_uint4 %uint
-%_ptr_StorageBuffer_Bar_std430 = OpTypePointer StorageBuffer %Bar_std430
-%_runtimearr_Bar_std430 = OpTypeRuntimeArray %Bar_std430
-%RWStructuredBuffer = OpTypeStruct %_runtimearr_Bar_std430
-%_ptr_StorageBuffer_RWStructuredBuffer = OpTypePointer StorageBuffer %RWStructuredBuffer
-      %int_1 = OpConstant %int 1
-%_ptr_StorageBuffer__Array_std430_uint4 = OpTypePointer StorageBuffer %_Array_std430_uint4
-     %uint_4 = OpConstant %uint 4
-     %uint_5 = OpConstant %uint 5
-     %uint_6 = OpConstant %uint 6
-     %uint_7 = OpConstant %uint 7
-        %foo = OpVariable %_ptr_StorageBuffer_RWStructuredBuffer StorageBuffer
-       %main = OpFunction %void None %3
-          %4 = OpLabel
-         %14 = OpAccessChain %_ptr_StorageBuffer_Bar_std430 %foo %int_0 %int_0
-         %21 = OpAccessChain %_ptr_StorageBuffer__Array_std430_uint4 %14 %int_1
-         %69 = OpCompositeConstruct %_arr_uint_int_4 %uint_4 %uint_5 %uint_6 %uint_7
-         %55 = OpCompositeConstruct %_Array_std430_uint4 %69
-               OpStore %21 %55
-               OpReturn
-               OpFunctionEnd
-    )";
-    ComputeStorageBufferTest(cs_source, false, 32);
+
+    RETURN_IF_SKIP(CheckSlangSupport());
+
+    const char *slang_shader = R"slang(
+        struct Bar {
+            uint4 a;
+            uint b[4];
+            uint c;
+        };
+        
+        [[vk::binding(0, 0)]]
+        RWStructuredBuffer<Bar> foo;
+        
+        [shader("compute")]
+        void main() {
+            uint d[4] = {4, 5, 6, 7};
+            foo[0].b = d;
+        }
+    )slang";
+
+    ComputeStorageBufferTest(slang_shader, SPV_SOURCE_SLANG, 32);
 }
 
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, ArrayStrideEnd) {
@@ -905,7 +864,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, ArrayStrideEnd) {
                OpFunctionEnd
     )";
 
-    ComputeStorageBufferTest(cs_source, false, 52);
+    ComputeStorageBufferTest(cs_source, SPV_SOURCE_ASM, 52);
 }
 
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, ArrayCopyTwoBindingsGLSL) {
@@ -955,102 +914,42 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, ArrayCopyTwoBindingsGLSL) {
 
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, ArrayCopyTwoBindingsSlang) {
     TEST_DESCRIPTION("Note that in slang and array copy is really a struct copy");
+
+    RETURN_IF_SKIP(CheckSlangSupport());
+
     SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    // struct Bar1 {
-    //     uint4 a;
-    //     uint b[4];
-    //     uint c;
-    // };
-    //
-    // struct Bar2 {
-    //     uint4 d;
-    //     uint e[4];
-    //     uint f;
-    // };
-    //
-    // [[vk::binding(0, 0)]]
-    // RWStructuredBuffer<Bar1> foo1;
-    //
-    // [[vk::binding(1, 0)]]
-    // RWStructuredBuffer<Bar2> foo2;
-    //
-    // [shader("compute")]
-    // void main() {
-    //     foo1[0].b = foo2[0].e;
-    // }
-    char const *cs_source = R"(
-               OpCapability Shader
-               OpExtension "SPV_KHR_storage_buffer_storage_class"
-               OpMemoryModel Logical GLSL450
-               OpEntryPoint GLCompute %main "main" %foo1 %foo2
-               OpExecutionMode %main LocalSize 1 1 1
-               OpDecorate %_arr_uint_int_4 ArrayStride 4
-               OpMemberDecorate %_Array_std430_uint4 0 Offset 0
-               OpMemberDecorate %Bar1_std430 0 Offset 0
-               OpMemberDecorate %Bar1_std430 1 Offset 16
-               OpMemberDecorate %Bar1_std430 2 Offset 32
-               OpDecorate %_runtimearr_Bar1_std430 ArrayStride 48
-               OpDecorate %RWStructuredBuffer Block
-               OpMemberDecorate %RWStructuredBuffer 0 Offset 0
-               OpDecorate %foo1 Binding 0
-               OpDecorate %foo1 DescriptorSet 0
-               OpMemberDecorate %Bar2_std430 0 Offset 0
-               OpMemberDecorate %Bar2_std430 1 Offset 16
-               OpMemberDecorate %Bar2_std430 2 Offset 32
-               OpDecorate %_runtimearr_Bar2_std430 ArrayStride 48
-               OpDecorate %RWStructuredBuffer_0 Block
-               OpMemberDecorate %RWStructuredBuffer_0 0 Offset 0
-               OpDecorate %foo2 Binding 1
-               OpDecorate %foo2 DescriptorSet 0
-       %void = OpTypeVoid
-          %3 = OpTypeFunction %void
-       %uint = OpTypeInt 32 0
-        %int = OpTypeInt 32 1
-      %int_4 = OpConstant %int 4
-      %int_0 = OpConstant %int 0
-     %v4uint = OpTypeVector %uint 4
-%_arr_uint_int_4 = OpTypeArray %uint %int_4
-%_Array_std430_uint4 = OpTypeStruct %_arr_uint_int_4
-%Bar1_std430 = OpTypeStruct %v4uint %_Array_std430_uint4 %uint
-%_ptr_StorageBuffer_Bar1_std430 = OpTypePointer StorageBuffer %Bar1_std430
-%_runtimearr_Bar1_std430 = OpTypeRuntimeArray %Bar1_std430
-%RWStructuredBuffer = OpTypeStruct %_runtimearr_Bar1_std430
-%_ptr_StorageBuffer_RWStructuredBuffer = OpTypePointer StorageBuffer %RWStructuredBuffer
-      %int_1 = OpConstant %int 1
-%_ptr_StorageBuffer__Array_std430_uint4 = OpTypePointer StorageBuffer %_Array_std430_uint4
-%Bar2_std430 = OpTypeStruct %v4uint %_Array_std430_uint4 %uint
-%_ptr_StorageBuffer_Bar2_std430 = OpTypePointer StorageBuffer %Bar2_std430
-%_runtimearr_Bar2_std430 = OpTypeRuntimeArray %Bar2_std430
-%RWStructuredBuffer_0 = OpTypeStruct %_runtimearr_Bar2_std430
-%_ptr_StorageBuffer_RWStructuredBuffer_0 = OpTypePointer StorageBuffer %RWStructuredBuffer_0
-       %foo1 = OpVariable %_ptr_StorageBuffer_RWStructuredBuffer StorageBuffer
-       %foo2 = OpVariable %_ptr_StorageBuffer_RWStructuredBuffer_0 StorageBuffer
-       %main = OpFunction %void None %3
-          %4 = OpLabel
-         %17 = OpAccessChain %_ptr_StorageBuffer_Bar1_std430 %foo1 %int_0 %int_0
-         %24 = OpAccessChain %_ptr_StorageBuffer__Array_std430_uint4 %17 %int_1
-         %27 = OpAccessChain %_ptr_StorageBuffer_Bar2_std430 %foo2 %int_0 %int_0
-         %32 = OpAccessChain %_ptr_StorageBuffer__Array_std430_uint4 %27 %int_1
-         %33 = OpLoad %_Array_std430_uint4 %32
-         %64 = OpCompositeExtract %_arr_uint_int_4 %33 0
-         %65 = OpCompositeExtract %uint %64 0
-         %66 = OpCompositeExtract %uint %64 1
-         %67 = OpCompositeExtract %uint %64 2
-         %68 = OpCompositeExtract %uint %64 3
-        %110 = OpCompositeConstruct %_arr_uint_int_4 %65 %66 %67 %68
-         %83 = OpCompositeConstruct %_Array_std430_uint4 %110
-               OpStore %24 %83
-               OpReturn
-               OpFunctionEnd
-    )";
+    const char *slang_shader = R"slang(
+        struct Bar1 {
+            uint4 a;
+            uint b[4];
+            uint c;
+        };
+        
+        struct Bar2 {
+            uint4 d;
+            uint e[4];
+            uint f;
+        };
+        
+        [[vk::binding(0, 0)]]
+        RWStructuredBuffer<Bar1> foo1;
+        
+        [[vk::binding(1, 0)]]
+        RWStructuredBuffer<Bar2> foo2;
+        
+        [shader("compute")]
+        void main() {
+            foo1[0].b = foo2[0].e;
+        }
+    )slang";
 
     CreateComputePipelineHelper pipe(*this);
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
                           {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};
-    pipe.cs_ = VkShaderObj(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
+    pipe.cs_ = VkShaderObj(this, slang_shader, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_SLANG);
     pipe.CreateComputePipeline();
 
     vkt::Buffer in_buffer(*m_device, 256, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
@@ -1090,7 +989,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, DISABLED_StructCopyGLSL) {
             b = new_bar;
         }
     )glsl";
-    ComputeStorageBufferTest(cs_source, true, 32);
+    ComputeStorageBufferTest(cs_source, SPV_SOURCE_GLSL, 32);
 }
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, StructCopyGLSL2) {
     char const *cs_source = R"glsl(
@@ -1111,7 +1010,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, StructCopyGLSL2) {
             b = new_bar;
         }
     )glsl";
-    ComputeStorageBufferTest(cs_source, true, 32);
+    ComputeStorageBufferTest(cs_source, SPV_SOURCE_GLSL, 32);
 }
 
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, StructCopyGLSL3) {
@@ -1139,151 +1038,57 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, StructCopyGLSL3) {
             b = new_bar;
         }
     )glsl";
-    ComputeStorageBufferTest(cs_source, true, 64);
+    ComputeStorageBufferTest(cs_source, SPV_SOURCE_GLSL, 64);
 }
 
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, StructCopySlang) {
-    // struct Bar {
-    //   uint x;
-    //   uint y;
-    //   uint z[2];
-    // };
-    //
-    // struct FooBuffer {
-    //   float4 a;
-    //   Bar b;
-    //   uint c;
-    // };
-    //
-    // [[vk::binding(0, 0)]]
-    // RWStructuredBuffer<FooBuffer> foo;
-    //
-    // [shader("compute")]
-    // void main() {
-    //   foo[1].b = foo[0].b;
-    // }
-    char const *cs_source = R"(
-               OpCapability Shader
-               OpExtension "SPV_KHR_storage_buffer_storage_class"
-               OpMemoryModel Logical GLSL450
-               OpEntryPoint GLCompute %main "main" %foo
-               OpExecutionMode %main LocalSize 1 1 1
-               OpDecorate %_arr_uint_int_2 ArrayStride 4
-               OpMemberDecorate %_Array_std430_uint2 0 Offset 0
-               OpMemberDecorate %Bar_std430 0 Offset 0
-               OpMemberDecorate %Bar_std430 1 Offset 4
-               OpMemberDecorate %Bar_std430 2 Offset 8
-               OpMemberDecorate %FooBuffer_std430 0 Offset 0
-               OpMemberDecorate %FooBuffer_std430 1 Offset 16
-               OpMemberDecorate %FooBuffer_std430 2 Offset 32
-               OpDecorate %_runtimearr_FooBuffer_std430 ArrayStride 48
-               OpDecorate %RWStructuredBuffer Block
-               OpMemberDecorate %RWStructuredBuffer 0 Offset 0
-               OpDecorate %foo Binding 0
-               OpDecorate %foo DescriptorSet 0
-       %void = OpTypeVoid
-          %3 = OpTypeFunction %void
-        %int = OpTypeInt 32 1
-      %int_1 = OpConstant %int 1
-      %int_0 = OpConstant %int 0
-      %float = OpTypeFloat 32
-    %v4float = OpTypeVector %float 4
-       %uint = OpTypeInt 32 0
-      %int_2 = OpConstant %int 2
-%_arr_uint_int_2 = OpTypeArray %uint %int_2
-%_Array_std430_uint2 = OpTypeStruct %_arr_uint_int_2
- %Bar_std430 = OpTypeStruct %uint %uint %_Array_std430_uint2
-%FooBuffer_std430 = OpTypeStruct %v4float %Bar_std430 %uint
-%_ptr_StorageBuffer_FooBuffer_std430 = OpTypePointer StorageBuffer %FooBuffer_std430
-%_runtimearr_FooBuffer_std430 = OpTypeRuntimeArray %FooBuffer_std430
-%RWStructuredBuffer = OpTypeStruct %_runtimearr_FooBuffer_std430
-%_ptr_StorageBuffer_RWStructuredBuffer = OpTypePointer StorageBuffer %RWStructuredBuffer
-%_ptr_StorageBuffer_Bar_std430 = OpTypePointer StorageBuffer %Bar_std430
-        %foo = OpVariable %_ptr_StorageBuffer_RWStructuredBuffer StorageBuffer
-       %main = OpFunction %void None %3
-          %4 = OpLabel
-         %17 = OpAccessChain %_ptr_StorageBuffer_FooBuffer_std430 %foo %int_0 %int_1
-         %23 = OpAccessChain %_ptr_StorageBuffer_Bar_std430 %17 %int_1
-         %24 = OpAccessChain %_ptr_StorageBuffer_FooBuffer_std430 %foo %int_0 %int_0
-         %25 = OpAccessChain %_ptr_StorageBuffer_Bar_std430 %24 %int_1
-         %26 = OpLoad %Bar_std430 %25
-         %80 = OpCompositeExtract %uint %26 0
-         %81 = OpCompositeExtract %uint %26 1
-         %82 = OpCompositeExtract %_Array_std430_uint2 %26 2
-         %87 = OpCompositeExtract %_arr_uint_int_2 %82 0
-         %88 = OpCompositeExtract %uint %87 0
-         %89 = OpCompositeExtract %uint %87 1
-        %163 = OpCompositeConstruct %_arr_uint_int_2 %88 %89
-        %149 = OpCompositeConstruct %_Array_std430_uint2 %163
-        %121 = OpCompositeConstruct %Bar_std430 %80 %81 %149
-               OpStore %23 %121
-               OpReturn
-               OpFunctionEnd
-    )";
-    ComputeStorageBufferTest(cs_source, false, 80);
+    RETURN_IF_SKIP(CheckSlangSupport());
+
+    const char *slang_shader = R"slang(
+        struct Bar {
+          uint x;
+          uint y;
+          uint z[2];
+        };
+        
+        struct FooBuffer {
+          float4 a;
+          Bar b;
+          uint c;
+        };
+        
+        [[vk::binding(0, 0)]]
+        RWStructuredBuffer<FooBuffer> foo;
+        
+        [shader("compute")]
+        void main() {
+          foo[1].b = foo[0].b;
+        }
+    )slang";
+
+    ComputeStorageBufferTest(slang_shader, SPV_SOURCE_SLANG, 80);
 }
 
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, ChainOfAccessChains) {
     TEST_DESCRIPTION("Slang can sometimes generate a single OpAccessChain like GLSL/HLSL");
 
-    // struct Bar {
-    //     uint a;
-    //     uint d[4];
-    // };
-    //
-    // [[vk::binding(0, 0)]]
-    // RWStructuredBuffer<Bar> foo; // 20 byte stride
-    //
-    // [shader("compute")]
-    // void main() {
-    //     foo[1].d[3] = 44;
-    // }
-    char const *cs_source = R"(
-               OpCapability Shader
-               OpExtension "SPV_KHR_storage_buffer_storage_class"
-               OpMemoryModel Logical GLSL450
-               OpEntryPoint GLCompute %main "main" %foo
-               OpExecutionMode %main LocalSize 1 1 1
-               OpDecorate %_arr_uint_int_4 ArrayStride 4
-               OpMemberDecorate %_Array_std430_uint4 0 Offset 0
-               OpMemberDecorate %Bar_std430 0 Offset 0
-               OpMemberDecorate %Bar_std430 1 Offset 4
-               OpDecorate %_runtimearr_Bar_std430 ArrayStride 20
-               OpDecorate %RWStructuredBuffer Block
-               OpMemberDecorate %RWStructuredBuffer 0 Offset 0
-               OpDecorate %foo Binding 0
-               OpDecorate %foo DescriptorSet 0
-       %void = OpTypeVoid
-          %3 = OpTypeFunction %void
-        %int = OpTypeInt 32 1
-      %int_0 = OpConstant %int 0
-      %int_1 = OpConstant %int 1
-       %uint = OpTypeInt 32 0
-      %int_4 = OpConstant %int 4
-%_arr_uint_int_4 = OpTypeArray %uint %int_4
-%_Array_std430_uint4 = OpTypeStruct %_arr_uint_int_4
- %Bar_std430 = OpTypeStruct %uint %_Array_std430_uint4
-%_ptr_StorageBuffer_Bar_std430 = OpTypePointer StorageBuffer %Bar_std430
-%_runtimearr_Bar_std430 = OpTypeRuntimeArray %Bar_std430
-%RWStructuredBuffer = OpTypeStruct %_runtimearr_Bar_std430
-%_ptr_StorageBuffer_RWStructuredBuffer = OpTypePointer StorageBuffer %RWStructuredBuffer
-%_ptr_StorageBuffer__Array_std430_uint4 = OpTypePointer StorageBuffer %_Array_std430_uint4
-%_ptr_StorageBuffer__arr_uint_int_4 = OpTypePointer StorageBuffer %_arr_uint_int_4
-%_ptr_StorageBuffer_uint = OpTypePointer StorageBuffer %uint
-      %int_3 = OpConstant %int 3
-    %uint_44 = OpConstant %uint 44
-        %foo = OpVariable %_ptr_StorageBuffer_RWStructuredBuffer StorageBuffer
-       %main = OpFunction %void None %3
-          %4 = OpLabel
-         %14 = OpAccessChain %_ptr_StorageBuffer_Bar_std430 %foo %int_0 %int_1
-         %20 = OpAccessChain %_ptr_StorageBuffer__Array_std430_uint4 %14 %int_1
-         %22 = OpAccessChain %_ptr_StorageBuffer__arr_uint_int_4 %20 %int_0
-         %24 = OpAccessChain %_ptr_StorageBuffer_uint %22 %int_3
-               OpStore %24 %uint_44
-               OpReturn
-               OpFunctionEnd
-    )";
-    ComputeStorageBufferTest(cs_source, false, 48);
+    RETURN_IF_SKIP(CheckSlangSupport());
+
+    const char *slang_shader = R"slang(
+        struct Bar {
+            uint a;
+            uint d[4];
+        };
+        
+        [[vk::binding(0, 0)]]
+        RWStructuredBuffer<Bar> foo; // 20 byte stride
+        
+        [shader("compute")]
+        void main() {
+            foo[1].d[3] = 44;
+        }
+    )slang";
+    ComputeStorageBufferTest(slang_shader, SPV_SOURCE_SLANG, 48);
 }
 
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, Atomics) {
@@ -1302,7 +1107,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, Atomics) {
             atomicExchange(c.z, x);
         }
     )glsl";
-    ComputeStorageBufferTest(cs_source, true, 64);
+    ComputeStorageBufferTest(cs_source, SPV_SOURCE_GLSL, 64);
 }
 
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, AtomicsDescriptorIndex) {
@@ -1348,76 +1153,32 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, AtomicsDescriptorIndex) {
 }
 
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, DescriptorIndexSlang) {
+    RETURN_IF_SKIP(CheckSlangSupport());
+
     SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    // struct Bar {
-    //   uint4 a;
-    //   uint b[4];
-    //   uint c;
-    //   uint d;
-    // };
-    //
-    // [[vk::binding(0, 0)]]
-    // RWStructuredBuffer<Bar> foo[2]; // stride of 48 bytes
-    //
-    // [shader("compute")]
-    // void main() {
-    //   foo[1][1].d = 0;
-    // }
-    char const *cs_source = R"(
-               OpCapability Shader
-               OpExtension "SPV_KHR_storage_buffer_storage_class"
-               OpMemoryModel Logical GLSL450
-               OpEntryPoint GLCompute %main "main" %foo
-               OpExecutionMode %main LocalSize 1 1 1
-               OpDecorate %_arr_uint_int_4 ArrayStride 4
-               OpMemberDecorate %_Array_std430_uint4 0 Offset 0
-               OpMemberDecorate %Bar_std430 0 Offset 0
-               OpMemberDecorate %Bar_std430 1 Offset 16
-               OpMemberDecorate %Bar_std430 2 Offset 32
-               OpMemberDecorate %Bar_std430 3 Offset 36
-               OpDecorate %_runtimearr_Bar_std430 ArrayStride 48
-               OpDecorate %RWStructuredBuffer Block
-               OpMemberDecorate %RWStructuredBuffer 0 Offset 0
-               OpDecorate %foo Binding 0
-               OpDecorate %foo DescriptorSet 0
-       %void = OpTypeVoid
-          %3 = OpTypeFunction %void
-       %uint = OpTypeInt 32 0
-     %v4uint = OpTypeVector %uint 4
-        %int = OpTypeInt 32 1
-      %int_4 = OpConstant %int 4
-%_arr_uint_int_4 = OpTypeArray %uint %int_4
-%_Array_std430_uint4 = OpTypeStruct %_arr_uint_int_4
- %Bar_std430 = OpTypeStruct %v4uint %_Array_std430_uint4 %uint %uint
-%_runtimearr_Bar_std430 = OpTypeRuntimeArray %Bar_std430
-%RWStructuredBuffer = OpTypeStruct %_runtimearr_Bar_std430
-      %int_2 = OpConstant %int 2
-%_arr_RWStructuredBuffer_int_2 = OpTypeArray %RWStructuredBuffer %int_2
-%_ptr_StorageBuffer__arr_RWStructuredBuffer_int_2 = OpTypePointer StorageBuffer %_arr_RWStructuredBuffer_int_2
-%_ptr_StorageBuffer_RWStructuredBuffer = OpTypePointer StorageBuffer %RWStructuredBuffer
-      %int_1 = OpConstant %int 1
-      %int_0 = OpConstant %int 0
-%_ptr_StorageBuffer_Bar_std430 = OpTypePointer StorageBuffer %Bar_std430
-      %int_3 = OpConstant %int 3
-%_ptr_StorageBuffer_uint = OpTypePointer StorageBuffer %uint
-     %uint_0 = OpConstant %uint 0
-        %foo = OpVariable %_ptr_StorageBuffer__arr_RWStructuredBuffer_int_2 StorageBuffer
-       %main = OpFunction %void None %3
-          %4 = OpLabel
-         %19 = OpAccessChain %_ptr_StorageBuffer_RWStructuredBuffer %foo %int_1
-         %23 = OpAccessChain %_ptr_StorageBuffer_Bar_std430 %19 %int_0 %int_1
-         %26 = OpAccessChain %_ptr_StorageBuffer_uint %23 %int_3
-               OpStore %26 %uint_0
-               OpReturn
-               OpFunctionEnd
-    )";
+    const char *slang_shader = R"slang(
+        struct Bar {
+          uint4 a;
+          uint b[4];
+          uint c;
+          uint d;
+        };
+        
+        [[vk::binding(0, 0)]]
+        RWStructuredBuffer<Bar> foo[2]; // stride of 48 bytes
+        
+        [shader("compute")]
+        void main() {
+          foo[1][1].d = 0;
+        }
+    )slang";
 
     CreateComputePipelineHelper pipe(*this);
     pipe.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 2, VK_SHADER_STAGE_ALL, nullptr};
-    pipe.cs_ = VkShaderObj(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
+    pipe.cs_ = VkShaderObj(this, slang_shader, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_SLANG);
     pipe.CreateComputePipeline();
 
     vkt::Buffer in_buffer(*m_device, 96, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
@@ -1511,7 +1272,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, Loops) {
             result = x;
         }
     )glsl";
-    ComputeStorageBufferTest(cs_source, true, 256);
+    ComputeStorageBufferTest(cs_source, SPV_SOURCE_GLSL, 256);
 }
 
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, LoopsEarlyBranch) {
@@ -1533,7 +1294,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, LoopsEarlyBranch) {
             result = x;
         }
     )glsl";
-    ComputeStorageBufferTest(cs_source, true, 256);
+    ComputeStorageBufferTest(cs_source, SPV_SOURCE_GLSL, 256);
 }
 
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, MeshTaskIndirect) {

--- a/tests/unit/gpu_av_descriptor_post_process_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_post_process_positive.cpp
@@ -740,93 +740,35 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, SharedDescriptorDifferentOpVariableId
 }
 
 TEST_F(PositiveGpuAVDescriptorPostProcess, DescriptorIndexingSlang) {
+    RETURN_IF_SKIP(CheckSlangSupport());
+
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::runtimeDescriptorArray);
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    // [[vk::binding(0, 0)]]
-    // Texture2D texture[];
-    // [[vk::binding(1, 0)]]
-    // SamplerState sampler;
-    //
-    // struct StorageBuffer {
-    //     uint data; // Will be zero
-    //     float4 color;
-    // };
-    //
-    // [[vk::binding(2, 0)]]
-    // RWStructuredBuffer<StorageBuffer> storageBuffer;
-    //
-    // [shader("compute")]
-    // void main() {
-    //     uint dataIndex = storageBuffer[0].data;
-    //     float4 sampledColor = texture[dataIndex].SampleLevel(sampler, float2(0), 0);
-    //     storageBuffer[0].color = sampledColor;
-    // }
-    char const *cs_source = R"(
-               OpCapability RuntimeDescriptorArray
-               OpCapability Shader
-               OpExtension "SPV_KHR_storage_buffer_storage_class"
-               OpMemoryModel Logical GLSL450
-               OpEntryPoint GLCompute %main "main" %storageBuffer %texture %sampler
-               OpExecutionMode %main LocalSize 1 1 1
-               OpMemberDecorate %StorageBuffer_std430 0 Offset 0
-               OpMemberDecorate %StorageBuffer_std430 1 Offset 16
-               OpDecorate %_runtimearr_StorageBuffer_std430 ArrayStride 32
-               OpDecorate %RWStructuredBuffer Block
-               OpMemberDecorate %RWStructuredBuffer 0 Offset 0
-               OpDecorate %storageBuffer Binding 2
-               OpDecorate %storageBuffer DescriptorSet 0
-               OpDecorate %texture Binding 0
-               OpDecorate %texture DescriptorSet 0
-               OpDecorate %sampler Binding 1
-               OpDecorate %sampler DescriptorSet 0
-       %void = OpTypeVoid
-          %3 = OpTypeFunction %void
-        %int = OpTypeInt 32 1
-      %int_0 = OpConstant %int 0
-       %uint = OpTypeInt 32 0
-      %float = OpTypeFloat 32
-    %v4float = OpTypeVector %float 4
-%StorageBuffer_std430 = OpTypeStruct %uint %v4float
-%_ptr_StorageBuffer_StorageBuffer_std430 = OpTypePointer StorageBuffer %StorageBuffer_std430
-%_runtimearr_StorageBuffer_std430 = OpTypeRuntimeArray %StorageBuffer_std430
-%RWStructuredBuffer = OpTypeStruct %_runtimearr_StorageBuffer_std430
-%_ptr_StorageBuffer_RWStructuredBuffer = OpTypePointer StorageBuffer %RWStructuredBuffer
-%_ptr_StorageBuffer_uint = OpTypePointer StorageBuffer %uint
-         %21 = OpTypeImage %float 2D 2 0 0 1 Unknown
-%_runtimearr_21 = OpTypeRuntimeArray %21
-%_ptr_UniformConstant__runtimearr_21 = OpTypePointer UniformConstant %_runtimearr_21
-%_ptr_UniformConstant_21 = OpTypePointer UniformConstant %21
-    %v2float = OpTypeVector %float 2
-         %32 = OpTypeSampler
-%_ptr_UniformConstant_32 = OpTypePointer UniformConstant %32
-         %36 = OpTypeSampledImage %21
-    %float_0 = OpConstant %float 0
-      %int_1 = OpConstant %int 1
-%_ptr_StorageBuffer_v4float = OpTypePointer StorageBuffer %v4float
-%storageBuffer = OpVariable %_ptr_StorageBuffer_RWStructuredBuffer StorageBuffer
-    %texture = OpVariable %_ptr_UniformConstant__runtimearr_21 UniformConstant
-    %sampler = OpVariable %_ptr_UniformConstant_32 UniformConstant
-         %47 = OpConstantComposite %v2float %float_0 %float_0
-       %main = OpFunction %void None %3
-          %4 = OpLabel
-         %12 = OpAccessChain %_ptr_StorageBuffer_StorageBuffer_std430 %storageBuffer %int_0 %int_0
-         %18 = OpAccessChain %_ptr_StorageBuffer_uint %12 %int_0
-  %dataIndex = OpLoad %uint %18
-         %25 = OpAccessChain %_ptr_UniformConstant_21 %texture %dataIndex
-         %31 = OpLoad %21 %25
-         %33 = OpLoad %32 %sampler
-%sampledImage = OpSampledImage %36 %31 %33
-    %sampled = OpImageSampleExplicitLod %v4float %sampledImage %47 Lod %float_0
-         %41 = OpAccessChain %_ptr_StorageBuffer_StorageBuffer_std430 %storageBuffer %int_0 %int_0
-         %44 = OpAccessChain %_ptr_StorageBuffer_v4float %41 %int_1
-               OpStore %44 %sampled
-               OpReturn
-               OpFunctionEnd
-    )";
+    const char *slang_shader = R"slang(
+        [[vk::binding(0, 0)]]
+        Texture2D texture[];
+        [[vk::binding(1, 0)]]
+        SamplerState sampler;
+        
+        struct StorageBuffer {
+            uint data; // Will be zero
+            float4 color;
+        };
+        
+        [[vk::binding(2, 0)]]
+        RWStructuredBuffer<StorageBuffer> storageBuffer;
+        
+        [shader("compute")]
+        void main() {
+            uint dataIndex = storageBuffer[0].data;
+            float4 sampledColor = texture[dataIndex].SampleLevel(sampler, float2(0), 0);
+            storageBuffer[0].color = sampledColor;
+        }
+    )slang";
 
     vkt::Buffer buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
     uint32_t *buffer_ptr = (uint32_t *)buffer.Memory().Map();
@@ -850,7 +792,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, DescriptorIndexingSlang) {
     descriptor_set.UpdateDescriptorSets();
 
     CreateComputePipelineHelper pipe(*this);
-    pipe.cs_ = VkShaderObj(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
+    pipe.cs_ = VkShaderObj(this, slang_shader, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_SLANG);
     pipe.cp_ci_.layout = pipeline_layout;
     pipe.CreateComputePipeline();
 


### PR DESCRIPTION
![wordart](https://github.com/user-attachments/assets/e9f02fae-47bc-4f75-9b5e-275ee8852c15)

Caveats: Building from source is quite slow (~10 minutes, more than all other dependencies combined), so I opted to download the pre-built binaries instead.
32 bits binaries are not provided, so tests relying on slang shaders will be skipped on such platforms.

EDIT: Too much messing with the build system for now, I gave up on having slang for Mac and Android. For Android I think I am close, I had green github actions but was getting "slang.so not found" errors in our CI.

closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9454