### PR TITLE
layers: Rename initial layout to first layout

### DIFF
--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -664,17 +664,17 @@ bool CoreChecks::ValidateSecondaryCommandBufferLayout(const vvl::CommandBuffer &
             if (!iter->pos_A->valid || !iter->pos_B->valid) continue;
 
             // pos_A denotes the sub CB map in the parallel iterator
-            sub_layout = iter->pos_A->lower_bound->second.initial_layout;
-            if (VK_IMAGE_LAYOUT_UNDEFINED == sub_layout) continue;  // secondary doesn't care about current or initial
+            sub_layout = iter->pos_A->lower_bound->second.first_layout;
+            if (VK_IMAGE_LAYOUT_UNDEFINED == sub_layout) continue;  // secondary doesn't care about current or first
 
             // pos_B denotes the main CB map in the parallel iterator
             const auto &cb_layout_state = iter->pos_B->lower_bound->second;
             if (cb_layout_state.current_layout != kInvalidLayout) {
-                layout_type = "current";
+                layout_type = "current layout";
                 cb_layout = cb_layout_state.current_layout;
-            } else if (cb_layout_state.initial_layout != kInvalidLayout) {
-                layout_type = "initial";
-                cb_layout = cb_layout_state.initial_layout;
+            } else if (cb_layout_state.first_layout != kInvalidLayout) {
+                layout_type = "layout specified by the primary command buffer";
+                cb_layout = cb_layout_state.first_layout;
             } else {
                 continue;
             }
@@ -688,7 +688,7 @@ bool CoreChecks::ValidateSecondaryCommandBufferLayout(const vvl::CommandBuffer &
                     // VU being worked on https://gitlab.khronos.org/vulkan/vulkan/-/issues/2456
                     skip |= LogError("UNASSIGNED-vkCmdExecuteCommands-commandBuffer-00001", objlist, cb_loc,
                                      "was executed using %s (subresource: aspectMask %s, array layer %" PRIu32
-                                     ", mip level %" PRIu32 ") which expects layout %s--instead, image %s layout is %s.",
+                                     ", mip level %" PRIu32 ") which expects layout %s--instead, image %s is %s.",
                                      FormatHandle(image).c_str(), string_VkImageAspectFlags(subresource.aspectMask).c_str(),
                                      subresource.arrayLayer, subresource.mipLevel, string_VkImageLayout(sub_layout), layout_type,
                                      string_VkImageLayout(cb_layout));

--- a/layers/core_checks/cc_copy_blit_resolve.cpp
+++ b/layers/core_checks/cc_copy_blit_resolve.cpp
@@ -1945,8 +1945,8 @@ void CoreChecks::PostCallRecordCmdCopyImage(VkCommandBuffer commandBuffer, VkIma
     ASSERT_AND_RETURN(src_image_state && dst_image_state);
 
     for (uint32_t i = 0; i < regionCount; ++i) {
-        cb_state->TrackImageInitialLayout(*src_image_state, RangeFromLayers(pRegions[i].srcSubresource), srcImageLayout);
-        cb_state->TrackImageInitialLayout(*dst_image_state, RangeFromLayers(pRegions[i].dstSubresource), dstImageLayout);
+        cb_state->TrackImageFirstLayout(*src_image_state, RangeFromLayers(pRegions[i].srcSubresource), srcImageLayout);
+        cb_state->TrackImageFirstLayout(*dst_image_state, RangeFromLayers(pRegions[i].dstSubresource), dstImageLayout);
     }
 }
 
@@ -1963,10 +1963,10 @@ void CoreChecks::PostCallRecordCmdCopyImage2(VkCommandBuffer commandBuffer, cons
     ASSERT_AND_RETURN(src_image_state && dst_image_state);
 
     for (uint32_t i = 0; i < pCopyImageInfo->regionCount; ++i) {
-        cb_state->TrackImageInitialLayout(*src_image_state, RangeFromLayers(pCopyImageInfo->pRegions[i].srcSubresource),
-                                          pCopyImageInfo->srcImageLayout);
-        cb_state->TrackImageInitialLayout(*dst_image_state, RangeFromLayers(pCopyImageInfo->pRegions[i].dstSubresource),
-                                          pCopyImageInfo->dstImageLayout);
+        cb_state->TrackImageFirstLayout(*src_image_state, RangeFromLayers(pCopyImageInfo->pRegions[i].srcSubresource),
+                                        pCopyImageInfo->srcImageLayout);
+        cb_state->TrackImageFirstLayout(*dst_image_state, RangeFromLayers(pCopyImageInfo->pRegions[i].dstSubresource),
+                                        pCopyImageInfo->dstImageLayout);
     }
 }
 
@@ -2373,7 +2373,7 @@ void CoreChecks::PostCallRecordCmdCopyImageToBuffer(VkCommandBuffer commandBuffe
     ASSERT_AND_RETURN(src_image_state);
 
     for (uint32_t i = 0; i < regionCount; ++i) {
-        cb_state->TrackImageInitialLayout(*src_image_state, RangeFromLayers(pRegions[i].imageSubresource), srcImageLayout);
+        cb_state->TrackImageFirstLayout(*src_image_state, RangeFromLayers(pRegions[i].imageSubresource), srcImageLayout);
     }
 }
 
@@ -2391,8 +2391,8 @@ void CoreChecks::PostCallRecordCmdCopyImageToBuffer2(VkCommandBuffer commandBuff
     ASSERT_AND_RETURN(src_image_state);
 
     for (uint32_t i = 0; i < pCopyImageToBufferInfo->regionCount; ++i) {
-        cb_state->TrackImageInitialLayout(*src_image_state, RangeFromLayers(pCopyImageToBufferInfo->pRegions[i].imageSubresource),
-                                          pCopyImageToBufferInfo->srcImageLayout);
+        cb_state->TrackImageFirstLayout(*src_image_state, RangeFromLayers(pCopyImageToBufferInfo->pRegions[i].imageSubresource),
+                                        pCopyImageToBufferInfo->srcImageLayout);
     }
 }
 
@@ -2525,7 +2525,7 @@ void CoreChecks::PostCallRecordCmdCopyBufferToImage(VkCommandBuffer commandBuffe
     ASSERT_AND_RETURN(dst_image_state);
 
     for (uint32_t i = 0; i < regionCount; ++i) {
-        cb_state->TrackImageInitialLayout(*dst_image_state, RangeFromLayers(pRegions[i].imageSubresource), dstImageLayout);
+        cb_state->TrackImageFirstLayout(*dst_image_state, RangeFromLayers(pRegions[i].imageSubresource), dstImageLayout);
     }
 }
 
@@ -2543,8 +2543,8 @@ void CoreChecks::PostCallRecordCmdCopyBufferToImage2(VkCommandBuffer commandBuff
     ASSERT_AND_RETURN(dst_image_state);
 
     for (uint32_t i = 0; i < pCopyBufferToImageInfo->regionCount; ++i) {
-        cb_state->TrackImageInitialLayout(*dst_image_state, RangeFromLayers(pCopyBufferToImageInfo->pRegions[i].imageSubresource),
-                                          pCopyBufferToImageInfo->dstImageLayout);
+        cb_state->TrackImageFirstLayout(*dst_image_state, RangeFromLayers(pCopyBufferToImageInfo->pRegions[i].imageSubresource),
+                                        pCopyBufferToImageInfo->dstImageLayout);
     }
 }
 
@@ -3458,8 +3458,8 @@ void CoreChecks::RecordCmdBlitImage(VkCommandBuffer commandBuffer, VkImage srcIm
     ASSERT_AND_RETURN(src_image_state && dst_image_state);
 
     for (uint32_t i = 0; i < regionCount; ++i) {
-        cb_state->TrackImageInitialLayout(*src_image_state, RangeFromLayers(pRegions[i].srcSubresource), srcImageLayout);
-        cb_state->TrackImageInitialLayout(*dst_image_state, RangeFromLayers(pRegions[i].dstSubresource), dstImageLayout);
+        cb_state->TrackImageFirstLayout(*src_image_state, RangeFromLayers(pRegions[i].srcSubresource), srcImageLayout);
+        cb_state->TrackImageFirstLayout(*dst_image_state, RangeFromLayers(pRegions[i].dstSubresource), dstImageLayout);
     }
 }
 

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -960,7 +960,7 @@ void CoreChecks::PostCallRecordCmdClearColorImage(VkCommandBuffer commandBuffer,
     auto image_state = Get<vvl::Image>(image);
     if (cb_state_ptr && image_state) {
         for (uint32_t i = 0; i < rangeCount; ++i) {
-            cb_state_ptr->TrackImageInitialLayout(*image_state, pRanges[i], imageLayout);
+            cb_state_ptr->TrackImageFirstLayout(*image_state, pRanges[i], imageLayout);
         }
     }
 }
@@ -1079,7 +1079,7 @@ void CoreChecks::PostCallRecordCmdClearDepthStencilImage(VkCommandBuffer command
     ASSERT_AND_RETURN(image_state);
 
     for (uint32_t i = 0; i < rangeCount; ++i) {
-        cb_state->TrackImageInitialLayout(*image_state, pRanges[i], imageLayout);
+        cb_state->TrackImageFirstLayout(*image_state, pRanges[i], imageLayout);
     }
 }
 

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1466,7 +1466,7 @@ void CommandBuffer::SetImageLayout(const vvl::Image &image_state, const VkImageS
     }
 }
 
-void CommandBuffer::TrackImageViewInitialLayout(const vvl::ImageView &view_state, VkImageLayout layout) {
+void CommandBuffer::TrackImageViewFirstLayout(const vvl::ImageView &view_state, VkImageLayout layout) {
     if (dev_data.disabled[image_layout_validation]) {
         return;
     }
@@ -1474,17 +1474,17 @@ void CommandBuffer::TrackImageViewInitialLayout(const vvl::ImageView &view_state
     auto image_layout_map = (image_state && !image_state->Destroyed()) ? GetOrCreateImageLayoutMap(*image_state) : nullptr;
     if (image_layout_map) {
         RangeGenerator range_gen(view_state.range_generator);
-        TrackInitialLayout(*image_layout_map, std::move(range_gen), layout, view_state.normalized_subresource_range.aspectMask);
+        TrackFirstLayout(*image_layout_map, std::move(range_gen), layout, view_state.normalized_subresource_range.aspectMask);
     }
 }
 
-void CommandBuffer::TrackImageInitialLayout(const vvl::Image &image_state, const VkImageSubresourceRange &range,
+void CommandBuffer::TrackImageFirstLayout(const vvl::Image &image_state, const VkImageSubresourceRange &range,
                                             VkImageLayout layout) {
     if (auto image_layout_map = GetOrCreateImageLayoutMap(image_state)) {
         const VkImageSubresourceRange normalized_subresource_range = image_state.NormalizeSubresourceRange(range);
         if (image_state.subresource_encoder.InRange(normalized_subresource_range)) {
             RangeGenerator range_gen(image_state.subresource_encoder, normalized_subresource_range);
-            TrackInitialLayout(*image_layout_map, std::move(range_gen), layout);
+            TrackFirstLayout(*image_layout_map, std::move(range_gen), layout);
         }
     }
 }

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -649,12 +649,12 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     void RecordBarriers(const VkDependencyInfo &dep_info);
 
     void SetImageViewLayout(const vvl::ImageView &view_state, VkImageLayout layout, VkImageLayout layoutStencil);
-    void TrackImageViewInitialLayout(const vvl::ImageView &view_state, VkImageLayout layout);
+    void TrackImageViewFirstLayout(const vvl::ImageView &view_state, VkImageLayout layout);
 
     void SetImageLayout(const vvl::Image &image_state, const VkImageSubresourceRange &subresource_range, VkImageLayout layout,
                         VkImageLayout expected_layout = kInvalidLayout);
-    // This tracks the first known layout of the subresource in the command buffer (that's why initial).
-    void TrackImageInitialLayout(const vvl::Image &image_state, const VkImageSubresourceRange &range, VkImageLayout layout);
+    // This tracks the first known layout of the subresource in the command buffer.
+    void TrackImageFirstLayout(const vvl::Image &image_state, const VkImageSubresourceRange &range, VkImageLayout layout);
 
     void Submit(Queue &queue_state, uint32_t perf_submit_pass, const Location &loc);
     void Retire(uint32_t perf_submit_pass, const std::function<bool(const QueryObject &)> &is_query_updated_after);

--- a/layers/state_tracker/descriptor_sets.cpp
+++ b/layers/state_tracker/descriptor_sets.cpp
@@ -914,7 +914,7 @@ void vvl::ImageDescriptor::CopyUpdate(DescriptorSet &set_state, const vvl::Devic
 void vvl::ImageDescriptor::UpdateImageLayoutDrawState(vvl::CommandBuffer &cb_state) {
     // Add binding for image
     if (auto iv_state = GetImageViewState()) {
-        cb_state.TrackImageViewInitialLayout(*iv_state, image_layout_);
+        cb_state.TrackImageViewFirstLayout(*iv_state, image_layout_);
     }
 }
 
@@ -1323,7 +1323,7 @@ void vvl::MutableDescriptor::UpdateImageLayoutDrawState(vvl::CommandBuffer &cb_s
     const vvl::DescriptorClass active_class = ActiveClass();
     if (active_class == DescriptorClass::Image || active_class == DescriptorClass::ImageSampler) {
         if (image_view_state_) {
-            cb_state.TrackImageViewInitialLayout(*image_view_state_, image_layout_);
+            cb_state.TrackImageViewFirstLayout(*image_view_state_, image_layout_);
         }
     }
 }

--- a/layers/state_tracker/image_layout_map.h
+++ b/layers/state_tracker/image_layout_map.h
@@ -37,11 +37,11 @@ struct LayoutEntry {
     // This tracks current subresource layout as we progress through the command buffer
     VkImageLayout current_layout;
 
-    // This tracks the first known layout of the subresource in the command buffer (that's why initial).
+    // This tracks the first known layout of the subresource in the command buffer.
     // This value is tracked based on the expected layout parameters from various API functions.
     // For example, for vkCmdCopyImageToBuffer the expected layout is the srcImageLayout parameter,
     // and for image barrier it is the oldLayout.
-    VkImageLayout initial_layout;
+    VkImageLayout first_layout;
 
     // For relaxed matching rules
     VkImageAspectFlags aspect_mask;
@@ -58,15 +58,16 @@ using ImageLayoutMap = subresource_adapter::BothRangeMap<VkImageLayout, 16>;
 using CommandBufferImageLayoutRegistry = vvl::unordered_map<VkImage, std::shared_ptr<CommandBufferImageLayoutMap>>;
 using ImageLayoutRegistry = vvl::unordered_map<const vvl::Image*, std::optional<ImageLayoutMap>>;
 
-// Set current layout. If API also defines the expected layout it can be specified too.
+// Set current image layout in the command buffer.
+// If API defines the expected layout it can be specified too.
 bool UpdateCurrentLayout(CommandBufferImageLayoutMap& image_layout_map, subresource_adapter::RangeGenerator&& range_gen,
                          VkImageLayout layout, VkImageLayout expected_layout = kInvalidLayout);
 
-// Tracks image first layout in the command buffer. This is usually used by the APIs that do not perform
+// Tracks image's first layout in the command buffer. This function is usually called by the APIs that do not perform
 // layout transitions but just manifest the expected layout, e.g. srcImageLayout parameter in vkCmdCopyImageToBuffer.
 // The aspect mask is used if API additionally restricts subresource to specific aspect (descriptor image views).
-void TrackInitialLayout(CommandBufferImageLayoutMap& image_layout_map, subresource_adapter::RangeGenerator&& range_gen,
-                        VkImageLayout expected_layout, VkImageAspectFlags aspect_mask = 0);
+void TrackFirstLayout(CommandBufferImageLayoutMap& image_layout_map, subresource_adapter::RangeGenerator&& range_gen,
+                      VkImageLayout expected_layout, VkImageAspectFlags aspect_mask = 0);
 
 // TODO: document and rename me
 bool AnyInRange(const CommandBufferImageLayoutMap& image_layout_map, const vvl::Image& image_state,

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -33,10 +33,6 @@ class Swapchain;
 class VideoProfileDesc;
 }  // namespace vvl
 
-static inline bool operator==(const VkImageSubresource &lhs, const VkImageSubresource &rhs) {
-    return (lhs.aspectMask == rhs.aspectMask) && (lhs.mipLevel == rhs.mipLevel) && (lhs.arrayLayer == rhs.arrayLayer);
-}
-
 // Transfer VkImageSubresourceRange into VkImageSubresourceLayers struct
 static inline VkImageSubresourceLayers LayersFromRange(const VkImageSubresourceRange &subresource_range) {
     VkImageSubresourceLayers subresource_layers;


### PR DESCRIPTION
This is to avoid confusion, as we already use the term "initial layout" to refer both to `VkImageCreateInfo::initialLayout` and also `initialLayout` specified in various render pass structures.

The *"first layout"* is the first detected layout of the image subresource in the command buffer.

The new term has a matching *"first access"* syncval naming, which means that we track the first memory access in the command buffer to use later for submit-time or `CmdExecuteCommands` validation.