### PR TITLE
layers: Refactor copy image

### DIFF
--- a/layers/core_checks/cc_vuid_maps.cpp
+++ b/layers/core_checks/cc_vuid_maps.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2024 The Khronos Group Inc.
- * Copyright (c) 2024 Valve Corporation
- * Copyright (c) 2024 LunarG, Inc.
+/* Copyright (c) 2024-2025 The Khronos Group Inc.
+ * Copyright (c) 2024-2025 Valve Corporation
+ * Copyright (c) 2024-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
  */
 #include "cc_vuid_maps.h"
 #include "error_message/error_location.h"
+#include "generated/error_location_helper.h"
 #include "utils/vk_layer_utils.h"
 #include "state_tracker/pipeline_state.h"
 #include <map>

--- a/layers/core_checks/cc_vuid_maps.h
+++ b/layers/core_checks/cc_vuid_maps.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2024 The Khronos Group Inc.
- * Copyright (c) 2024 Valve Corporation
- * Copyright (c) 2024 LunarG, Inc.
+/* Copyright (c) 2024-2025 The Khronos Group Inc.
+ * Copyright (c) 2024-2025 Valve Corporation
+ * Copyright (c) 2024-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,6 +93,7 @@ enum class CopyError {
 const std::string &GetCopyBufferImageDeviceVUID(const Location &loc, CopyError error);
 // contains Host Image Copy
 const std::string &GetCopyBufferImageVUID(const Location &loc, CopyError error);
+// When copying between images
 const std::string &GetCopyImageVUID(const Location &loc, CopyError error);
 const std::string &GetImageMipLevelVUID(const Location &loc);
 const std::string &GetImageArrayLayerRangeVUID(const Location &loc);

--- a/layers/utils/vk_layer_utils.cpp
+++ b/layers/utils/vk_layer_utils.cpp
@@ -83,14 +83,18 @@ VkExtent3D GetEffectiveExtent(const VkImageCreateInfo &ci, const VkImageAspectFl
     {
         const uint32_t corner = (ci.flags & VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV) ? 1 : 0;
         const uint32_t min_size = 1 + corner;
-        const std::array dimensions = {&extent.width, &extent.height, &extent.depth};
-        for (uint32_t *dim : dimensions) {
-            // Don't allow mip adjustment to create 0 dim, but pass along a 0 if that's what subresource specified
-            if (*dim == 0) {
-                continue;
-            }
-            *dim >>= mip_level;
-            *dim = std::max(min_size, *dim);
+
+        if (extent.width != 0) {
+            extent.width >>= mip_level;
+            extent.width = std::max({min_size, extent.width});
+        }
+        if (extent.height != 0) {
+            extent.height >>= mip_level;
+            extent.height = std::max({min_size, extent.height});
+        }
+        if (extent.depth != 0) {
+            extent.depth >>= mip_level;
+            extent.depth = std::max({min_size, extent.depth});
         }
     }
 

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -112,7 +112,7 @@
             "sub_dir": "Vulkan-Profiles",
             "build_dir": "Vulkan-Profiles/build",
             "install_dir": "Vulkan-Profiles/build/install",
-            "commit": "ceef6cd5ed4525c2da4f00abe5b6cf4448af2178",
+            "commit": "79e26a82498b4637a23920cf6b392cb5f4b01c82",
             "build_step": "skip",
             "optional": [
                 "tests"

--- a/tests/device_profiles/max_profile.json
+++ b/tests/device_profiles/max_profile.json
@@ -1847,7 +1847,27 @@
                     "maxPushDescriptors": 4294967000,
                     "blockTexelViewCompatibleMultipleLayers": true,
                     "maxCombinedImageSamplerDescriptorCount": 1073741824,
-                    "identicalMemoryTypeRequirements": true
+                    "identicalMemoryTypeRequirements": true,
+                    "copySrcLayoutCount": 7,
+                    "pCopySrcLayouts": [
+                        "VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL",
+                        "VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL",
+                        "VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL",
+                        "VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL",
+                        "VK_IMAGE_LAYOUT_GENERAL",
+                        "VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL",
+                        "VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL"
+                    ],
+                    "copyDstLayoutCount": 7,
+                    "pCopyDstLayouts": [
+                        "VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL",
+                        "VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL",
+                        "VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL",
+                        "VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL",
+                        "VK_IMAGE_LAYOUT_GENERAL",
+                        "VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL",
+                        "VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL"
+                    ]
                 },
                 "VkPhysicalDeviceCustomBorderColorPropertiesEXT": {
                     "maxCustomBorderColorSamplers": 4294967000

--- a/tests/unit/host_image_copy.cpp
+++ b/tests/unit/host_image_copy.cpp
@@ -271,25 +271,14 @@ TEST_F(NegativeHostImageCopy, ImageSubresource) {
     copy_from_image.regionCount = 1;
     copy_from_image.pRegions = &region_from_image;
 
-    // Bad mipLevel - also throws off multiple size calculations, causing other errors
-    // Also get 07970 - pRegions must be contained within the specified dstSubresource of dstImage
-    // Also get 07971 - imageOffset.x and (imageExtent.width + imageOffset.x) both >= 0 and <= imageSubresource width
-    // Also get 07972 - imageOffset.y and (imageExtent.height + imageOffset.y) both >= 0 and <= imageSubresource height
-    // Also get 09104 - imageOffset.z and (imageExtent.depth + imageOffset.z) both >= 0 and <= imageSubresource depth
     region_to_image.imageSubresource.mipLevel = image_ci.mipLevels + 1;
-    m_errorMonitor->SetUnexpectedError("VUID-VkCopyMemoryToImageInfo-imageSubresource-07970");
-    m_errorMonitor->SetUnexpectedError("VUID-VkCopyMemoryToImageInfo-imageSubresource-07971");
-    m_errorMonitor->SetUnexpectedError("VUID-VkCopyMemoryToImageInfo-imageSubresource-07972");
-    m_errorMonitor->SetUnexpectedError("VUID-VkCopyMemoryToImageInfo-imageOffset-09104");
+    m_errorMonitor->SetDesiredError("VUID-VkCopyMemoryToImageInfo-imageSubresource-07971");
     m_errorMonitor->SetDesiredError("VUID-VkCopyMemoryToImageInfo-imageSubresource-07967");
     vk::CopyMemoryToImageEXT(*m_device, &copy_to_image);
     m_errorMonitor->VerifyFound();
 
     region_from_image.imageSubresource.mipLevel = image_ci.mipLevels + 1;
-    m_errorMonitor->SetUnexpectedError("VUID-VkCopyImageToMemoryInfo-imageSubresource-07970");
-    m_errorMonitor->SetUnexpectedError("VUID-VkCopyImageToMemoryInfo-imageSubresource-07971");
-    m_errorMonitor->SetUnexpectedError("VUID-VkCopyImageToMemoryInfo-imageSubresource-07972");
-    m_errorMonitor->SetUnexpectedError("VUID-VkCopyImageToMemoryInfo-imageOffset-09104");
+    m_errorMonitor->SetDesiredError("VUID-VkCopyImageToMemoryInfo-imageSubresource-07971");
     m_errorMonitor->SetDesiredError("VUID-VkCopyImageToMemoryInfo-imageSubresource-07967");
     vk::CopyImageToMemoryEXT(*m_device, &copy_from_image);
     m_errorMonitor->VerifyFound();
@@ -308,15 +297,13 @@ TEST_F(NegativeHostImageCopy, ImageSubresource) {
     region_to_image.imageSubresource.baseArrayLayer = 0;
     region_from_image.imageSubresource.baseArrayLayer = 0;
 
-    // Extent bigger than image - Can't get 07970 without getting 07971, 07972 or 09104, so test both 07971 and 07970 here
+    // Extent bigger than image
     region_to_image.imageExtent.width = width + 1;
     m_errorMonitor->SetDesiredError("VUID-VkCopyMemoryToImageInfo-imageSubresource-07971");
-    m_errorMonitor->SetDesiredError("VUID-VkCopyMemoryToImageInfo-imageSubresource-07970");
     vk::CopyMemoryToImageEXT(*m_device, &copy_to_image);
     m_errorMonitor->VerifyFound();
     region_from_image.imageExtent.width = width + 1;
     m_errorMonitor->SetDesiredError("VUID-VkCopyImageToMemoryInfo-imageSubresource-07971");
-    m_errorMonitor->SetDesiredError("VUID-VkCopyImageToMemoryInfo-imageSubresource-07970");
     vk::CopyImageToMemoryEXT(*m_device, &copy_from_image);
     m_errorMonitor->VerifyFound();
     region_to_image.imageExtent.width = width;
@@ -325,12 +312,10 @@ TEST_F(NegativeHostImageCopy, ImageSubresource) {
     // imageOffset.y and (imageExtent.height + imageOffset.y) both >= 0 and <= imageSubresource height
     region_to_image.imageOffset.y = -1;
     m_errorMonitor->SetDesiredError("VUID-VkCopyMemoryToImageInfo-imageSubresource-07972");
-    m_errorMonitor->SetUnexpectedError("VUID-VkCopyMemoryToImageInfo-imageSubresource-07970");
     vk::CopyMemoryToImageEXT(*m_device, &copy_to_image);
     m_errorMonitor->VerifyFound();
     region_from_image.imageOffset.y = -1;
     m_errorMonitor->SetDesiredError("VUID-VkCopyImageToMemoryInfo-imageSubresource-07972");
-    m_errorMonitor->SetUnexpectedError("VUID-VkCopyImageToMemoryInfo-imageSubresource-07970");
     vk::CopyImageToMemoryEXT(*m_device, &copy_from_image);
     m_errorMonitor->VerifyFound();
 }
@@ -375,13 +360,11 @@ TEST_F(NegativeHostImageCopy, ImageExtent) {
     copy_to_image.dstImage = image_3d;
     region_to_image.imageOffset.z = 1;
     m_errorMonitor->SetDesiredError("VUID-VkCopyMemoryToImageInfo-imageOffset-09104");
-    m_errorMonitor->SetUnexpectedError("VUID-VkCopyMemoryToImageInfo-imageSubresource-07970");
     vk::CopyMemoryToImageEXT(*m_device, &copy_to_image);
     m_errorMonitor->VerifyFound();
     region_from_image.imageOffset.z = 1;
     copy_from_image.srcImage = image_3d;
     m_errorMonitor->SetDesiredError("VUID-VkCopyImageToMemoryInfo-imageOffset-09104");
-    m_errorMonitor->SetUnexpectedError("VUID-VkCopyImageToMemoryInfo-imageSubresource-07970");
     vk::CopyImageToMemoryEXT(*m_device, &copy_from_image);
     m_errorMonitor->VerifyFound();
     region_to_image.imageOffset.z = 0;
@@ -457,7 +440,6 @@ TEST_F(NegativeHostImageCopy, Image1D) {
     region_to_image.imageExtent.height = 1;
     m_errorMonitor->SetDesiredError("VUID-VkCopyMemoryToImageInfo-dstImage-07979");
     m_errorMonitor->SetUnexpectedError("VUID-VkCopyMemoryToImageInfo-imageSubresource-07972");
-    m_errorMonitor->SetUnexpectedError("VUID-VkCopyMemoryToImageInfo-imageSubresource-07970");
     vk::CopyMemoryToImageEXT(*m_device, &copy_to_image);
     m_errorMonitor->VerifyFound();
     copy_from_image.srcImage = image_1d;
@@ -465,7 +447,6 @@ TEST_F(NegativeHostImageCopy, Image1D) {
     region_from_image.imageExtent.height = 1;
     m_errorMonitor->SetDesiredError("VUID-VkCopyImageToMemoryInfo-srcImage-07979");
     m_errorMonitor->SetUnexpectedError("VUID-VkCopyImageToMemoryInfo-imageSubresource-07972");
-    m_errorMonitor->SetUnexpectedError("VUID-VkCopyImageToMemoryInfo-imageSubresource-07970");
     vk::CopyImageToMemoryEXT(*m_device, &copy_from_image);
     m_errorMonitor->VerifyFound();
     region_to_image.imageOffset.y = 0;
@@ -476,14 +457,12 @@ TEST_F(NegativeHostImageCopy, Image1D) {
     region_to_image.imageExtent.depth = 1;
     m_errorMonitor->SetDesiredError("VUID-VkCopyMemoryToImageInfo-dstImage-07980");
     m_errorMonitor->SetUnexpectedError("VUID-VkCopyMemoryToImageInfo-imageOffset-09104");
-    m_errorMonitor->SetUnexpectedError("VUID-VkCopyMemoryToImageInfo-imageSubresource-07970");
     vk::CopyMemoryToImageEXT(*m_device, &copy_to_image);
     m_errorMonitor->VerifyFound();
     region_from_image.imageOffset.z = 1;
     region_from_image.imageExtent.depth = 1;
     m_errorMonitor->SetDesiredError("VUID-VkCopyImageToMemoryInfo-srcImage-07980");
     m_errorMonitor->SetUnexpectedError("VUID-VkCopyImageToMemoryInfo-imageOffset-09104");
-    m_errorMonitor->SetUnexpectedError("VUID-VkCopyImageToMemoryInfo-imageSubresource-07970");
     vk::CopyImageToMemoryEXT(*m_device, &copy_from_image);
     m_errorMonitor->VerifyFound();
 }
@@ -555,6 +534,11 @@ TEST_F(NegativeHostImageCopy, CompressedFormat) {
     vkt::Image image(*m_device, image_ci);
     image.SetLayout(layout);
 
+    image_ci.format = VK_FORMAT_BC3_SRGB_BLOCK;
+    image_ci.mipLevels = 6;
+    vkt::Image image_compressed(*m_device, image_ci);
+    image_compressed.SetLayout(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+
     std::vector<uint8_t> pixels(width * height * 4);
 
     VkMemoryToImageCopy region_to_image = vku::InitStructHelper();
@@ -579,55 +563,94 @@ TEST_F(NegativeHostImageCopy, CompressedFormat) {
     copy_from_image.regionCount = 1;
     copy_from_image.pRegions = &region_from_image;
 
-    image_ci.format = VK_FORMAT_BC3_SRGB_BLOCK;
-    image_ci.mipLevels = 6;
-    vkt::Image image_compressed(*m_device, image_ci);
-    image_compressed.SetLayout(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
-
     // imageOffset not a multiple of block size
     region_to_image.imageOffset = {1, 1, 0};
     region_to_image.imageExtent = {1, 1, 1};
     region_to_image.imageSubresource.mipLevel = 4;
     copy_to_image.dstImage = image_compressed;
     m_errorMonitor->SetDesiredError("VUID-VkCopyMemoryToImageInfo-dstImage-07274");
-    m_errorMonitor->SetDesiredError("VUID-VkCopyMemoryToImageInfo-dstImage-07275");
     vk::CopyMemoryToImageEXT(*m_device, &copy_to_image);
     m_errorMonitor->VerifyFound();
+
     region_from_image.imageOffset = {1, 1, 0};
     region_from_image.imageExtent = {1, 1, 1};
     region_from_image.imageSubresource.mipLevel = 4;
     copy_from_image.srcImage = image_compressed;
     m_errorMonitor->SetDesiredError("VUID-VkCopyImageToMemoryInfo-srcImage-07274");
-    m_errorMonitor->SetDesiredError("VUID-VkCopyImageToMemoryInfo-srcImage-07275");
     vk::CopyImageToMemoryEXT(*m_device, &copy_from_image);
     m_errorMonitor->VerifyFound();
     region_to_image.imageOffset = {0, 0, 0};
     region_from_image.imageOffset = {0, 0, 0};
 
     // width not a multiple of compressed block width
-    region_to_image.imageExtent = {1, 2, 1};
+    region_to_image.imageExtent = {1, 4, 1};
     m_errorMonitor->SetDesiredError("VUID-VkCopyMemoryToImageInfo-dstImage-00207");
+    m_errorMonitor->SetDesiredError("VUID-VkCopyMemoryToImageInfo-imageSubresource-07972");
     vk::CopyMemoryToImageEXT(*m_device, &copy_to_image);
     m_errorMonitor->VerifyFound();
-    region_from_image.imageExtent = {1, 2, 1};
+    region_from_image.imageExtent = {1, 4, 1};
     m_errorMonitor->SetDesiredError("VUID-VkCopyImageToMemoryInfo-srcImage-00207");
+    m_errorMonitor->SetDesiredError("VUID-VkCopyImageToMemoryInfo-imageSubresource-07972");
     vk::CopyImageToMemoryEXT(*m_device, &copy_from_image);
     m_errorMonitor->VerifyFound();
 
     // Copy height < compressed block size but not the full mip height
-    region_to_image.imageExtent = {2, 1, 1};
+    region_to_image.imageExtent = {4, 1, 1};
     m_errorMonitor->SetDesiredError("VUID-VkCopyMemoryToImageInfo-dstImage-00208");
+    m_errorMonitor->SetDesiredError("VUID-VkCopyMemoryToImageInfo-imageSubresource-07971");
     vk::CopyMemoryToImageEXT(*m_device, &copy_to_image);
     m_errorMonitor->VerifyFound();
-    region_from_image.imageExtent = {2, 1, 1};
+    region_from_image.imageExtent = {4, 1, 1};
     m_errorMonitor->SetDesiredError("VUID-VkCopyImageToMemoryInfo-srcImage-00208");
+    m_errorMonitor->SetDesiredError("VUID-VkCopyImageToMemoryInfo-imageSubresource-07971");
     vk::CopyImageToMemoryEXT(*m_device, &copy_from_image);
     m_errorMonitor->VerifyFound();
+}
 
-    region_to_image.imageSubresource.mipLevel = 0;
-    region_from_image.imageSubresource.mipLevel = 0;
+TEST_F(NegativeHostImageCopy, CompressedFormatMemory) {
+    AddRequiredFeature(vkt::Feature::textureCompressionBC);
+    RETURN_IF_SKIP(InitHostImageCopyTest());
+
+    VkImageFormatProperties img_prop = {};
+    if (VK_SUCCESS != vk::GetPhysicalDeviceImageFormatProperties(m_device->Physical(), VK_FORMAT_BC3_SRGB_BLOCK, image_ci.imageType,
+                                                                 image_ci.tiling, image_ci.usage, image_ci.flags, &img_prop)) {
+        GTEST_SKIP() << "Image format properties not supported";
+    }
+
+    VkImageLayout layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    vkt::Image image(*m_device, image_ci);
+    image.SetLayout(layout);
+
+    image_ci.format = VK_FORMAT_BC3_SRGB_BLOCK;
+    image_ci.mipLevels = 6;
+    vkt::Image image_compressed(*m_device, image_ci);
+    image_compressed.SetLayout(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+
+    std::vector<uint8_t> pixels(width * height * 4);
+
+    VkMemoryToImageCopy region_to_image = vku::InitStructHelper();
+    region_to_image.pHostPointer = pixels.data();
+    region_to_image.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
     region_to_image.imageExtent = {width, height, 1};
+
+    VkCopyMemoryToImageInfo copy_to_image = vku::InitStructHelper();
+    copy_to_image.dstImage = image;
+    copy_to_image.dstImageLayout = layout;
+    copy_to_image.regionCount = 1;
+    copy_to_image.pRegions = &region_to_image;
+    copy_to_image.dstImage = image_compressed;
+
+    VkImageToMemoryCopy region_from_image = vku::InitStructHelper();
+    region_from_image.pHostPointer = pixels.data();
+    region_from_image.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
     region_from_image.imageExtent = {width, height, 1};
+
+    VkCopyImageToMemoryInfo copy_from_image = vku::InitStructHelper();
+    copy_from_image.srcImage = image;
+    copy_from_image.srcImageLayout = layout;
+    copy_from_image.regionCount = 1;
+    copy_from_image.pRegions = &region_from_image;
+    copy_from_image.srcImage = image_compressed;
 
     // memoryRowLength not a multiple of block width (4)
     region_to_image.memoryRowLength = 130;
@@ -1184,11 +1207,7 @@ TEST_F(NegativeHostImageCopy, CopyImageToImageMipLevels) {
     image_copy_2.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
     image_copy_2.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
     image_copy_2.extent = {width, height, 1};
-    // Bad mipLevel - also throws off multiple size calculations, causing other errors
-    // Also get 07970 - pRegions must be contained within the specified dstSubresource of dstImage
-    // Also get 07971 - imageOffset.x and (imageExtent.width + imageOffset.x) both >= 0 and <= imageSubresource width
-    // Also get 07972 - imageOffset.y and (imageExtent.height + imageOffset.y) both >= 0 and <= imageSubresource height
-    // Also get 09104 - imageOffset.z and (imageExtent.depth + imageOffset.z) both >= 0 and <= imageSubresource depth
+    // Bad mipLevel
     image_copy_2.dstSubresource.mipLevel = image_ci.mipLevels + 1;
     image_copy_2.srcSubresource.mipLevel = image_ci.mipLevels + 1;
 
@@ -1200,14 +1219,8 @@ TEST_F(NegativeHostImageCopy, CopyImageToImageMipLevels) {
     copy_image_to_image.dstImage = image1;
     copy_image_to_image.srcImage = image2;
 
-    m_errorMonitor->SetUnexpectedError("VUID-VkCopyImageToImageInfo-srcSubresource-07970");
-    m_errorMonitor->SetUnexpectedError("VUID-VkCopyImageToImageInfo-srcSubresource-07971");
-    m_errorMonitor->SetUnexpectedError("VUID-VkCopyImageToImageInfo-srcSubresource-07972");
-    m_errorMonitor->SetUnexpectedError("VUID-VkCopyImageToImageInfo-srcOffset-09104");
-    m_errorMonitor->SetUnexpectedError("VUID-VkCopyImageToImageInfo-dstSubresource-07970");
-    m_errorMonitor->SetUnexpectedError("VUID-VkCopyImageToImageInfo-dstSubresource-07971");
-    m_errorMonitor->SetUnexpectedError("VUID-VkCopyImageToImageInfo-dstSubresource-07972");
-    m_errorMonitor->SetUnexpectedError("VUID-VkCopyImageToImageInfo-dstOffset-09104");
+    m_errorMonitor->SetDesiredError("VUID-VkCopyImageToImageInfo-srcSubresource-07971");
+    m_errorMonitor->SetDesiredError("VUID-VkCopyImageToImageInfo-dstSubresource-07971");
     m_errorMonitor->SetDesiredError("VUID-VkCopyImageToImageInfo-srcSubresource-07967");
     m_errorMonitor->SetDesiredError("VUID-VkCopyImageToImageInfo-dstSubresource-07967");
     vk::CopyImageToImageEXT(*m_device, &copy_image_to_image);
@@ -1252,7 +1265,7 @@ TEST_F(NegativeHostImageCopy, CopyImageToImageLargeExtent) {
     VkImageCopy2 image_copy_2 = vku::InitStructHelper();
     image_copy_2.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
     image_copy_2.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
-    // Extent bigger than image - Can't get 07970 without getting 07971, 07972 or 09104, so test both 07971 and 07970 here
+    // Extent bigger than image
     image_copy_2.extent = {width + 1, height, 1};
     VkCopyImageToImageInfo copy_image_to_image = vku::InitStructHelper();
     copy_image_to_image.regionCount = 1;
@@ -1262,9 +1275,7 @@ TEST_F(NegativeHostImageCopy, CopyImageToImageLargeExtent) {
     copy_image_to_image.dstImage = image1;
     copy_image_to_image.srcImage = image2;
 
-    m_errorMonitor->SetDesiredError("VUID-VkCopyImageToImageInfo-srcSubresource-07970");
     m_errorMonitor->SetDesiredError("VUID-VkCopyImageToImageInfo-srcSubresource-07971");
-    m_errorMonitor->SetDesiredError("VUID-VkCopyImageToImageInfo-dstSubresource-07970");
     m_errorMonitor->SetDesiredError("VUID-VkCopyImageToImageInfo-dstSubresource-07971");
     vk::CopyImageToImageEXT(*m_device, &copy_image_to_image);
     m_errorMonitor->VerifyFound();
@@ -1281,7 +1292,6 @@ TEST_F(NegativeHostImageCopy, CopyImageToImageOffsetSmall) {
     image_copy_2.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
     image_copy_2.extent = {width, height, 1};
     // imageOffset.y and (imageExtent.height + imageOffset.y) both >= 0 and <= imageSubresource height
-    // Also get 07970 - pRegions must be contained within the specified dstSubresource of dstImage
     image_copy_2.srcOffset.y = -1;
     image_copy_2.dstOffset.y = -1;
 
@@ -1295,8 +1305,6 @@ TEST_F(NegativeHostImageCopy, CopyImageToImageOffsetSmall) {
 
     m_errorMonitor->SetDesiredError("VUID-VkCopyImageToImageInfo-srcSubresource-07972");
     m_errorMonitor->SetDesiredError("VUID-VkCopyImageToImageInfo-dstSubresource-07972");
-    m_errorMonitor->SetUnexpectedError("VUID-VkCopyImageToImageInfo-srcSubresource-07970");
-    m_errorMonitor->SetUnexpectedError("VUID-VkCopyImageToImageInfo-dstSubresource-07970");
     vk::CopyImageToImageEXT(*m_device, &copy_image_to_image);
     m_errorMonitor->VerifyFound();
 }
@@ -1314,7 +1322,6 @@ TEST_F(NegativeHostImageCopy, CopyImageToImagDepth) {
     image_copy_2.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
     image_copy_2.extent = {width, height, 1};
     // imageOffset.z and (imageExtent.depth + imageOffset.z) both >= 0 and <= imageSubresource height
-    // Also get 07970 - pRegions must be contained within the specified dstSubresource of dstImage
     image_copy_2.srcOffset.z = 1;
     image_copy_2.dstOffset.z = 1;
 
@@ -1328,8 +1335,6 @@ TEST_F(NegativeHostImageCopy, CopyImageToImagDepth) {
 
     m_errorMonitor->SetDesiredError("VUID-VkCopyImageToImageInfo-dstOffset-09104");
     m_errorMonitor->SetDesiredError("VUID-VkCopyImageToImageInfo-srcOffset-09104");
-    m_errorMonitor->SetUnexpectedError("VUID-VkCopyImageToImageInfo-srcSubresource-07970");
-    m_errorMonitor->SetUnexpectedError("VUID-VkCopyImageToImageInfo-dstSubresource-07970");
     vk::CopyImageToImageEXT(*m_device, &copy_image_to_image);
     m_errorMonitor->VerifyFound();
 }
@@ -1418,9 +1423,6 @@ TEST_F(NegativeHostImageCopy, CopyImageToImag1D) {
 
     m_errorMonitor->SetDesiredError("VUID-VkCopyImageToImageInfo-srcImage-07979");
     m_errorMonitor->SetDesiredError("VUID-VkCopyImageToImageInfo-dstImage-07979");
-    // Also get 07970 - pRegions must be contained within the specified subresource of image
-    m_errorMonitor->SetUnexpectedError("VUID-VkCopyImageToImageInfo-srcSubresource-07970");
-    m_errorMonitor->SetUnexpectedError("VUID-VkCopyImageToImageInfo-dstSubresource-07970");
     // Also get 07972 - offset.y and (extent.height + offset.y) both >= 0 and <= image subresource height
     m_errorMonitor->SetUnexpectedError("VUID-VkCopyImageToImageInfo-srcSubresource-07972");
     m_errorMonitor->SetUnexpectedError("VUID-VkCopyImageToImageInfo-dstSubresource-07972");
@@ -1454,9 +1456,6 @@ TEST_F(NegativeHostImageCopy, CopyImageToImag1DDpeth) {
 
     m_errorMonitor->SetDesiredError("VUID-VkCopyImageToImageInfo-dstImage-07980");
     m_errorMonitor->SetDesiredError("VUID-VkCopyImageToImageInfo-srcImage-07980");
-    // Also get 07970 - pRegions must be contained within the specified subresource of image
-    m_errorMonitor->SetUnexpectedError("VUID-VkCopyImageToImageInfo-srcSubresource-07970");
-    m_errorMonitor->SetUnexpectedError("VUID-VkCopyImageToImageInfo-dstSubresource-07970");
     // Also get 09104 - imageOffset.z and (imageExtent.depth + imageOffset.z) both >= 0 and <= imageSubresource depth
     m_errorMonitor->SetUnexpectedError("VUID-VkCopyImageToImageInfo-srcOffset-09104");
     m_errorMonitor->SetUnexpectedError("VUID-VkCopyImageToImageInfo-dstOffset-09104");
@@ -1654,8 +1653,6 @@ TEST_F(NegativeHostImageCopy, CopyImageToImageZeroExtent) {
     VkImageCopy2 image_copy_2 = vku::InitStructHelper();
     image_copy_2.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
     image_copy_2.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
-    // Neither width not height can be zero
-    image_copy_2.extent = {0, 0, 1};
     VkCopyImageToImageInfo copy_image_to_image = vku::InitStructHelper();
     copy_image_to_image.regionCount = 1;
     copy_image_to_image.pRegions = &image_copy_2;
@@ -1664,7 +1661,12 @@ TEST_F(NegativeHostImageCopy, CopyImageToImageZeroExtent) {
     copy_image_to_image.dstImage = image1;
     copy_image_to_image.srcImage = image2;
 
+    image_copy_2.extent = {0, 1, 1};
     m_errorMonitor->SetDesiredError("VUID-VkImageCopy2-extent-06668");
+    vk::CopyImageToImageEXT(*m_device, &copy_image_to_image);
+    m_errorMonitor->VerifyFound();
+
+    image_copy_2.extent = {1, 0, 1};
     m_errorMonitor->SetDesiredError("VUID-VkImageCopy2-extent-06669");
     vk::CopyImageToImageEXT(*m_device, &copy_image_to_image);
     m_errorMonitor->VerifyFound();
@@ -1706,14 +1708,14 @@ TEST_F(NegativeHostImageCopy, CopyImageToImageCompressed) {
 
     image_ci.format = VK_FORMAT_BC3_SRGB_BLOCK;
     image_ci.mipLevels = 6;
-    vkt::Image image_compressed1(*m_device, image_ci);
+    vkt::Image image_compressed1(*m_device, image_ci);  // 32x32 images
     vkt::Image image_compressed2(*m_device, image_ci);
     image_compressed1.SetLayout(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
     image_compressed2.SetLayout(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
 
     // imageOffset not a multiple of block size
     VkImageCopy2 image_copy_2 = vku::InitStructHelper();
-    image_copy_2.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 4, 0, 1};
+    image_copy_2.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 4, 0, 1};  // 2x2 mip level
     image_copy_2.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 4, 0, 1};
     image_copy_2.dstOffset = {1, 1, 0};
     image_copy_2.srcOffset = {1, 1, 0};
@@ -1728,24 +1730,22 @@ TEST_F(NegativeHostImageCopy, CopyImageToImageCompressed) {
     copy_image_to_image.srcImage = image_compressed2;
     m_errorMonitor->SetDesiredError("VUID-VkCopyImageToImageInfo-srcImage-07274");
     m_errorMonitor->SetDesiredError("VUID-VkCopyImageToImageInfo-dstImage-07274");
-    m_errorMonitor->SetDesiredError("VUID-VkCopyImageToImageInfo-srcImage-07275");
-    m_errorMonitor->SetDesiredError("VUID-VkCopyImageToImageInfo-dstImage-07275");
     vk::CopyImageToImageEXT(*m_device, &copy_image_to_image);
     m_errorMonitor->VerifyFound();
     image_copy_2.dstOffset = {0, 0, 0};
     image_copy_2.srcOffset = {0, 0, 0};
 
     // width not a multiple of compressed block width
-    image_copy_2.extent = {1, 2, 1};
+    image_copy_2.extent = {1, 4, 1};
     m_errorMonitor->SetDesiredError("VUID-VkCopyImageToImageInfo-srcImage-00207");
-    m_errorMonitor->SetDesiredError("VUID-VkCopyImageToImageInfo-dstImage-00207");
+    m_errorMonitor->SetDesiredError("VUID-VkCopyImageToImageInfo-srcSubresource-07972");
     vk::CopyImageToImageEXT(*m_device, &copy_image_to_image);
     m_errorMonitor->VerifyFound();
 
     // Copy height < compressed block size but not the full mip height
-    image_copy_2.extent = {2, 1, 1};
+    image_copy_2.extent = {4, 1, 1};
     m_errorMonitor->SetDesiredError("VUID-VkCopyImageToImageInfo-srcImage-00208");
-    m_errorMonitor->SetDesiredError("VUID-VkCopyImageToImageInfo-dstImage-00208");
+    m_errorMonitor->SetDesiredError("VUID-VkCopyImageToImageInfo-srcSubresource-07971");
     vk::CopyImageToImageEXT(*m_device, &copy_image_to_image);
     m_errorMonitor->VerifyFound();
     image_copy_2.extent = {width, height, 1};
@@ -2111,7 +2111,8 @@ TEST_F(NegativeHostImageCopy, Features) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeHostImageCopy, ImageMemoryOverlap) {
+// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10125
+TEST_F(NegativeHostImageCopy, DISABLED_ImageMemoryOverlap) {
     TEST_DESCRIPTION("Copy with host memory and image memory overlapping");
     RETURN_IF_SKIP(InitHostImageCopyTest());
 
@@ -2174,9 +2175,13 @@ TEST_F(NegativeHostImageCopy, ImageMemoryOverlap) {
     m_errorMonitor->VerifyFound();
 }
 
-// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8946
+// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10125
 TEST_F(NegativeHostImageCopy, DISABLED_ImageMemoryOverlapCompressed) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8946");
     RETURN_IF_SKIP(InitHostImageCopyTest());
+
+    image_ci = vkt::Image::ImageCreateInfo2D(width, height, 4, 4, VK_FORMAT_BC3_SRGB_BLOCK,
+                                             VK_IMAGE_USAGE_HOST_TRANSFER_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
 
     VkImageFormatProperties img_prop = {};
     if (VK_SUCCESS != vk::GetPhysicalDeviceImageFormatProperties(m_device->Physical(), VK_FORMAT_BC3_SRGB_BLOCK, image_ci.imageType,
@@ -2184,11 +2189,8 @@ TEST_F(NegativeHostImageCopy, DISABLED_ImageMemoryOverlapCompressed) {
         GTEST_SKIP() << "Image format properties not supported";
     }
 
-    image_ci.format = VK_FORMAT_BC3_SRGB_BLOCK;
-    image_ci.extent = {4, 4, 1};
-    VkImageLayout layout = VK_IMAGE_LAYOUT_GENERAL;
     vkt::Image image(*m_device, image_ci, kHostVisibleMemProps);
-    image.SetLayout(layout);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
 
     VkDeviceAddress *data = (VkDeviceAddress *)image.Memory().Map();
 
@@ -2202,7 +2204,7 @@ TEST_F(NegativeHostImageCopy, DISABLED_ImageMemoryOverlapCompressed) {
 
     VkCopyMemoryToImageInfo copy_memory_to_image = vku::InitStructHelper();
     copy_memory_to_image.dstImage = image;
-    copy_memory_to_image.dstImageLayout = layout;
+    copy_memory_to_image.dstImageLayout = VK_IMAGE_LAYOUT_GENERAL;
     copy_memory_to_image.regionCount = 1;
     copy_memory_to_image.pRegions = &region2;
 

--- a/tests/unit/image.cpp
+++ b/tests/unit/image.cpp
@@ -522,14 +522,12 @@ TEST_F(NegativeImage, BlitOffsets) {
     blit_region.dstOffsets[0] = {0, 0, 0};
     blit_region.dstOffsets[1] = {64, 64, 1};
     m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-srcOffset-00243");  // x
-    m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-pRegions-00215");   // src region
     vk::CmdBlitImage(m_command_buffer, image_3D, VK_IMAGE_LAYOUT_GENERAL, image_2D, VK_IMAGE_LAYOUT_GENERAL, 1, &blit_region,
                      VK_FILTER_NEAREST);
     m_errorMonitor->VerifyFound();
 
     blit_region.srcOffsets[1] = {64, 65, 1};                                 // src y
     m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-srcOffset-00244");  // y
-    m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-pRegions-00215");   // src region
     vk::CmdBlitImage(m_command_buffer, image_3D, VK_IMAGE_LAYOUT_GENERAL, image_2D, VK_IMAGE_LAYOUT_GENERAL, 1, &blit_region,
                      VK_FILTER_NEAREST);
     m_errorMonitor->VerifyFound();
@@ -537,7 +535,6 @@ TEST_F(NegativeImage, BlitOffsets) {
     blit_region.srcOffsets[0] = {0, 0, 65};  // src z
     blit_region.srcOffsets[1] = {64, 64, 64};
     m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-srcOffset-00246");  // z
-    m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-pRegions-00215");   // src region
     vk::CmdBlitImage(m_command_buffer, image_3D, VK_IMAGE_LAYOUT_GENERAL, image_2D, VK_IMAGE_LAYOUT_GENERAL, 1, &blit_region,
                      VK_FILTER_NEAREST);
     m_errorMonitor->VerifyFound();
@@ -548,14 +545,12 @@ TEST_F(NegativeImage, BlitOffsets) {
     blit_region.dstOffsets[0] = {96, 64, 32};  // dst x
     blit_region.dstOffsets[1] = {64, 0, 33};
     m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-dstOffset-00248");  // x
-    m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-pRegions-00216");   // dst region
     vk::CmdBlitImage(m_command_buffer, image_2D, VK_IMAGE_LAYOUT_GENERAL, image_3D, VK_IMAGE_LAYOUT_GENERAL, 1, &blit_region,
                      VK_FILTER_NEAREST);
     m_errorMonitor->VerifyFound();
 
     blit_region.dstOffsets[0] = {0, 65, 32};                                 // dst y
     m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-dstOffset-00249");  // y
-    m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-pRegions-00216");   // dst region
     vk::CmdBlitImage(m_command_buffer, image_2D, VK_IMAGE_LAYOUT_GENERAL, image_3D, VK_IMAGE_LAYOUT_GENERAL, 1, &blit_region,
                      VK_FILTER_NEAREST);
     m_errorMonitor->VerifyFound();
@@ -563,7 +558,6 @@ TEST_F(NegativeImage, BlitOffsets) {
     blit_region.dstOffsets[0] = {0, 64, 65};  // dst z
     blit_region.dstOffsets[1] = {64, 0, 64};
     m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-dstOffset-00251");  // z
-    m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-pRegions-00216");   // dst region
     vk::CmdBlitImage(m_command_buffer, image_2D, VK_IMAGE_LAYOUT_GENERAL, image_3D, VK_IMAGE_LAYOUT_GENERAL, 1, &blit_region,
                      VK_FILTER_NEAREST);
     m_errorMonitor->VerifyFound();
@@ -672,9 +666,6 @@ TEST_F(NegativeImage, MiscBlitTests) {
     m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-srcSubresource-01705");  // invalid srcSubresource.mipLevel
     // Redundant unavoidable errors
     m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-srcOffset-00243");  // out-of-bounds srcOffset.x
-    m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-srcOffset-00244");  // out-of-bounds srcOffset.y
-    m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-srcOffset-00246");  // out-of-bounds srcOffset.z
-    m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-pRegions-00215");   // region not contained within src image
     vk::CmdBlitImage(m_command_buffer, color_img, VK_IMAGE_LAYOUT_GENERAL, color_img, VK_IMAGE_LAYOUT_GENERAL, 1, &blitRegion,
                      VK_FILTER_NEAREST);
     m_errorMonitor->VerifyFound();
@@ -685,9 +676,6 @@ TEST_F(NegativeImage, MiscBlitTests) {
     m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-dstSubresource-01706");  // invalid dstSubresource.mipLevel
     // Redundant unavoidable errors
     m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-dstOffset-00248");  // out-of-bounds dstOffset.x
-    m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-dstOffset-00249");  // out-of-bounds dstOffset.y
-    m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-dstOffset-00251");  // out-of-bounds dstOffset.z
-    m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-pRegions-00216");   // region not contained within dst image
     vk::CmdBlitImage(m_command_buffer, color_img, VK_IMAGE_LAYOUT_GENERAL, color_img, VK_IMAGE_LAYOUT_GENERAL, 1, &blitRegion,
                      VK_FILTER_NEAREST);
     m_errorMonitor->VerifyFound();

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -4005,7 +4005,6 @@ TEST_F(NegativeSyncVal, CopyToCompressedImage) {
     copy_regions[1].dstOffset = {4, 0, 0};
     vk::CmdCopyImage(m_command_buffer, src_image, VK_IMAGE_LAYOUT_GENERAL, dst_image, VK_IMAGE_LAYOUT_GENERAL, 1, &copy_regions[1]);
     m_errorMonitor->VerifyFound();
-
     m_command_buffer.End();
 
     if (copy_commands_2) {


### PR DESCRIPTION
This is a complete rework of the `cc_copy_blit_resolve.cpp` file

We had many open issues and the core issue was the lack of fully grasping how image copies work with the many permutations of formats and functions calls

I have a few things I need to do after this PR (which will include getting agreement from the working group on spec issues)

This for the short term is a functionally correct cleanup.

closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/1946
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9209
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6898
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9537
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9276
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8946
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/3925

There will also be a Vulkan Guide article on this soon to help explain this for the people (likely me) who has to maintain this in the future

Also, some VU were remove as they were redundant and will be getting removed in the spec in future change