### PR TITLE
layers: Better entrypoint error message

### DIFF
--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -1749,6 +1749,11 @@ bool CoreChecks::ValidateShaderStage(const ShaderStageState &stage_state, const 
             if (entry_point) {
                 err << " (The only entry point found was \"" << entry_point->name << "\" for "
                     << string_VkShaderStageFlagBits(entry_point->stage) << ")";
+                if (entry_point->name == "main") {
+                    err << "\nSome shading languages will let you name the main function something else, but when "
+                           "compiled to SPIR-V, it will keep it as 'main' to match defaults found in other shading langauges such "
+                           "as GLSL. It is also valid in a single SPIR-V binary to have 'main' for two different stages.";
+                }
             }
         } else {
             err << " The following entry points were found in the SPIR-V module:\n";


### PR DESCRIPTION
Found people easily get tripped up that Slang will let you name the function `fragmentMain` but will output `"main"` in the SPIR-V as that has basically become the "default"

This adds an extra level of information in the error message if users are messing this up
