### PR TITLE
tests: Use TestICD for MockAHB

### DIFF
--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -117,19 +117,6 @@
             "optional": [
                 "tests"
             ]
-        },
-        {
-            "name": "Vulkan-Tools",
-            "api": "vulkan",
-            "url": "https://github.com/KhronosGroup/Vulkan-Tools.git",
-            "sub_dir": "Vulkan-Tools",
-            "build_dir": "Vulkan-Tools/build",
-            "install_dir": "Vulkan-Tools/build/install",
-            "commit": "v1.4.315",
-            "build_step": "skip",
-            "optional": [
-                "tests"
-            ]
         }
     ],
     "install_names": {

--- a/tests/icd/CMakeLists.txt
+++ b/tests/icd/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ~~~
-# Copyright (c) 2024 LunarG, Inc.
+# Copyright (c) 2024-2025 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,6 +39,8 @@ elseif(CMAKE_SYSTEM_NAME MATCHES "Linux|BSD|GNU")
     if(BUILD_WSI_WAYLAND_SUPPORT)
         add_definitions(-DVK_USE_PLATFORM_WAYLAND_KHR -DVK_USE_PLATFORM_WAYLAND_KHX)
     endif()
+elseif(VVL_MOCK_ANDROID)
+    add_definitions(-DVK_USE_PLATFORM_ANDROID_KHR)
 else()
     message(FATAL_ERROR "Unsupported Platform!")
 endif()


### PR DESCRIPTION
Seems just never took time to check, but the MockAHB test do run on TestICD, so we can safely remove `Vulkan-Tools` now in `known_goods.json`