### PR TITLE
layers: Create ImageUtil and improve image errors

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -363,6 +363,8 @@ vvl_sources = [
   "layers/utils/hash_util.cpp",
   "layers/utils/hash_util.h",
   "layers/utils/hash_vk_types.h",
+  "layers/utils/image_utils.cpp",
+  "layers/utils/image_utils.h",
   "layers/utils/image_layout_utils.cpp",
   "layers/utils/image_layout_utils.h",
   "layers/utils/math_utils.h",

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -62,6 +62,8 @@ target_sources(VkLayer_utils PRIVATE
     utils/hash_util.h
     utils/hash_util.cpp
     utils/hash_vk_types.h
+    utils/image_utils.h
+    utils/image_utils.cpp
     utils/image_layout_utils.h
     utils/image_layout_utils.cpp
     utils/math_utils.h

--- a/layers/best_practices/bp_cmd_buffer_nv.cpp
+++ b/layers/best_practices/bp_cmd_buffer_nv.cpp
@@ -19,6 +19,7 @@
 
 #include "best_practices/best_practices_validation.h"
 #include "best_practices/bp_state.h"
+#include <vulkan/utility/vk_format_utils.h>
 
 static std::array<uint32_t, 4> GetRawClearColor(VkFormat format, const VkClearColorValue& clear_value) {
     std::array<uint32_t, 4> raw_color{};

--- a/layers/best_practices/bp_framebuffer.cpp
+++ b/layers/best_practices/bp_framebuffer.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
+/* Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -19,6 +19,7 @@
 
 #include "best_practices/best_practices_validation.h"
 #include "best_practices/bp_state.h"
+#include <vulkan/utility/vk_format_utils.h>
 #include "state_tracker/render_pass_state.h"
 
 bool BestPractices::ValidateAttachments(const VkRenderPassCreateInfo2* rpci, uint32_t attachment_count,

--- a/layers/best_practices/bp_render_pass.cpp
+++ b/layers/best_practices/bp_render_pass.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <vulkan/vk_enum_string_helper.h>
+#include <vulkan/utility/vk_format_utils.h>
 #include "best_practices/best_practices_validation.h"
 #include "error_message/error_strings.h"
 #include "best_practices/bp_state.h"

--- a/layers/core_checks/cc_android.cpp
+++ b/layers/core_checks/cc_android.cpp
@@ -25,6 +25,7 @@
 #include "state_tracker/cmd_buffer_state.h"
 #include "generated/dispatch_functions.h"
 #include "error_message/error_strings.h"
+#include <algorithm>
 
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
 // Android-specific validation that uses types defined only on Android and only for NDK versions
@@ -80,6 +81,11 @@ static inline const char *string_AHardwareBufferGpuUsage(uint64_t usage) {
     } else {
         return "Unknown AHARDWAREBUFFER_USAGE_GPU";
     }
+}
+
+static uint32_t FullMipChainLevels(VkExtent3D extent) {
+    // uint cast applies floor()
+    return 1u + static_cast<uint32_t>(log2(std::max({extent.height, extent.width, extent.depth})));
 }
 
 //

--- a/layers/core_checks/cc_buffer.cpp
+++ b/layers/core_checks/cc_buffer.cpp
@@ -20,11 +20,14 @@
 #include <string>
 
 #include <vulkan/vk_enum_string_helper.h>
+#include <vulkan/utility/vk_format_utils.h>
 #include "error_message/error_location.h"
 #include "core_validation.h"
 #include "state_tracker/buffer_state.h"
 #include "state_tracker/cmd_buffer_state.h"
 #include "generated/dispatch_functions.h"
+#include "utils/math_utils.h"
+#include "utils/image_utils.h"
 
 // Helper function to validate usage flags for buffers. For given buffer_state send actual vs. desired usage off to helper above
 // where an error will be flagged if usage is not correct

--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -22,6 +22,7 @@
 #include <sstream>
 
 #include <vulkan/vk_enum_string_helper.h>
+#include <vulkan/utility/vk_format_utils.h>
 #include "core_checks/cc_state_tracker.h"
 #include "state_tracker/image_state.h"
 #include "state_tracker/buffer_state.h"
@@ -31,6 +32,7 @@
 #include "state_tracker/pipeline_state.h"
 #include "core_validation.h"
 #include "generated/enum_flag_bits.h"
+#include "utils/math_utils.h"
 
 bool CoreChecks::ReportInvalidCommandBuffer(const vvl::CommandBuffer &cb_state, const Location &loc, const char *vuid) const {
     bool skip = false;

--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <vulkan/vk_enum_string_helper.h>
+#include <vulkan/utility/vk_format_utils.h>
 #include <vulkan/vulkan_core.h>
 #include "core_validation.h"
 #include "drawdispatch/drawdispatch_vuids.h"
@@ -30,6 +31,7 @@
 #include "state_tracker/shader_module.h"
 #include "state_tracker/cmd_buffer_state.h"
 #include "state_tracker/pipeline_state.h"
+#include "utils/math_utils.h"
 
 bool CoreChecks::ValidateDynamicStateIsSet(const LastBound& last_bound_state, const CBDynamicFlags& state_status_cb,
                                            CBDynamicState dynamic_state, const vvl::DrawDispatchVuid& vuid) const {

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <vulkan/vk_enum_string_helper.h>
+#include <vulkan/utility/vk_format_utils.h>
 #include <vulkan/vulkan_core.h>
 #include <sstream>
 #include <valarray>
@@ -37,7 +38,6 @@
 #include "cc_buffer_address.h"
 #include "drawdispatch/descriptor_validator.h"
 #include "drawdispatch/drawdispatch_vuids.h"
-#include "utils/vk_layer_utils.h"
 #include "utils/vk_struct_compare.h"
 #include "error_message/error_strings.h"
 

--- a/layers/core_checks/cc_device_memory.cpp
+++ b/layers/core_checks/cc_device_memory.cpp
@@ -20,6 +20,7 @@
 #include <assert.h>
 
 #include <vulkan/vk_enum_string_helper.h>
+#include <vulkan/utility/vk_format_utils.h>
 #include <vulkan/vulkan_core.h>
 #include "generated/pnext_chain_extraction.h"
 #include "core_validation.h"
@@ -31,6 +32,8 @@
 #include "error_message/error_strings.h"
 #include "containers/limits.h"
 #include "generated/dispatch_functions.h"
+#include "utils/image_utils.h"
+#include "utils/math_utils.h"
 
 // For given mem object, verify that it is not null or UNBOUND, if it is, report error. Return skip value.
 bool CoreChecks::VerifyBoundMemoryIsValid(const vvl::DeviceMemory *memory_state, const LogObjectList &objlist,

--- a/layers/core_checks/cc_external_object.cpp
+++ b/layers/core_checks/cc_external_object.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <vulkan/vk_enum_string_helper.h>
+#include <vulkan/utility/vk_format_utils.h>
 #include "core_validation.h"
 #include "state_tracker/image_state.h"
 #include "state_tracker/buffer_state.h"

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -36,7 +36,7 @@
 #include "state_tracker/wsi_state.h"
 #include "sync/sync_vuid_maps.h"
 #include "utils/math_utils.h"
-#include "utils/vk_layer_utils.h"
+#include "utils/image_utils.h"
 
 bool CoreChecks::ValidateImageFormatFeatures(const VkImageCreateInfo &create_info, const Location &loc) const {
     bool skip = false;

--- a/layers/core_checks/cc_image_layout.cpp
+++ b/layers/core_checks/cc_image_layout.cpp
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include <vulkan/vk_enum_string_helper.h>
+#include <vulkan/utility/vk_format_utils.h>
 #include "core_checks/cc_state_tracker.h"
 #include "core_checks/cc_vuid_maps.h"
 #include "core_checks/core_validation.h"
@@ -28,6 +29,7 @@
 #include "generated/error_location_helper.h"
 #include "sync/sync_vuid_maps.h"
 #include "utils/image_layout_utils.h"
+#include "utils/image_utils.h"
 #include "state_tracker/image_state.h"
 #include "state_tracker/render_pass_state.h"
 #include "state_tracker/cmd_buffer_state.h"

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include <vulkan/vk_enum_string_helper.h>
+#include <vulkan/utility/vk_format_utils.h>
 #include <vulkan/vulkan_core.h>
 #include "utils/math_utils.h"
 #include "utils/vk_struct_compare.h"

--- a/layers/core_checks/cc_query.cpp
+++ b/layers/core_checks/cc_query.cpp
@@ -27,6 +27,7 @@
 #include "state_tracker/buffer_state.h"
 #include "state_tracker/render_pass_state.h"
 #include "state_tracker/cmd_buffer_state.h"
+#include "utils/math_utils.h"
 
 static QueryState GetLocalQueryState(const QueryMap *localQueryToStateMap, VkQueryPool queryPool, uint32_t queryIndex,
                                      uint32_t perfPass) {

--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -22,6 +22,7 @@
 #include <string>
 
 #include <vulkan/vk_enum_string_helper.h>
+#include <vulkan/utility/vk_format_utils.h>
 #include "core_validation.h"
 #include "cc_buffer_address.h"
 #include "utils/ray_tracing_utils.h"

--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include <vulkan/vk_enum_string_helper.h>
+#include <vulkan/utility/vk_format_utils.h>
 #include "core_checks/cc_state_tracker.h"
 #include "core_validation.h"
 #include "error_message/error_location.h"
@@ -33,6 +34,7 @@
 #include "state_tracker/render_pass_state.h"
 #include "state_tracker/cmd_buffer_state.h"
 #include "utils/math_utils.h"
+#include "utils/image_utils.h"
 
 namespace vvl {
 template <typename T>

--- a/layers/core_checks/cc_shader_interface.cpp
+++ b/layers/core_checks/cc_shader_interface.cpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include <vulkan/vk_enum_string_helper.h>
+#include <vulkan/utility/vk_format_utils.h>
 #include <vulkan/vulkan_core.h>
 #include "core_validation.h"
 #include "generated/spirv_grammar_helper.h"
@@ -33,7 +34,6 @@
 #include "state_tracker/render_pass_state.h"
 #include "state_tracker/cmd_buffer_state.h"
 #include "state_tracker/pipeline_state.h"
-#include "utils/vk_layer_utils.h"
 #include "containers/limits.h"
 
 bool CoreChecks::ValidateInterfaceVertexInput(const vvl::Pipeline &pipeline, const spirv::Module &module_state,

--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include <vulkan/vk_enum_string_helper.h>
+#include <vulkan/utility/vk_format_utils.h>
 #include <vulkan/vulkan_core.h>
 #include "core_checks/cc_vuid_maps.h"
 #include "core_validation.h"

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -20,9 +20,9 @@
 #include <algorithm>
 #include <assert.h>
 #include <string>
-#include <set>
 
 #include <vulkan/vk_enum_string_helper.h>
+#include <vulkan/utility/vk_format_utils.h>
 #include <vulkan/vulkan_core.h>
 #include "core_checks/cc_synchronization.h"
 #include "core_checks/cc_state_tracker.h"
@@ -43,7 +43,7 @@
 #include "state_tracker/wsi_state.h"
 #include "state_tracker/event_map.h"
 #include "generated/dispatch_functions.h"
-#include "utils/vk_layer_utils.h"
+#include "utils/math_utils.h"
 
 using sync_utils::BufferBarrier;
 using sync_utils::ImageBarrier;

--- a/layers/core_checks/cc_video.cpp
+++ b/layers/core_checks/cc_video.cpp
@@ -27,6 +27,7 @@
 #include "state_tracker/buffer_state.h"
 #include "state_tracker/cmd_buffer_state.h"
 #include "generated/dispatch_functions.h"
+#include "utils/math_utils.h"
 
 // Flags validation error if the associated call is made inside a video coding block.
 // The apiName routine should ONLY be called outside a video coding block.

--- a/layers/core_checks/cc_wsi.cpp
+++ b/layers/core_checks/cc_wsi.cpp
@@ -33,6 +33,7 @@
 #include "state_tracker/device_state.h"
 #include "state_tracker/wsi_state.h"
 #include "generated/dispatch_functions.h"
+#include "utils/math_utils.h"
 
 static bool IsExtentInsideBounds(VkExtent2D extent, VkExtent2D min, VkExtent2D max) {
     if ((extent.width < min.width) || (extent.width > max.width) || (extent.height < min.height) || (extent.height > max.height)) {

--- a/layers/core_checks/cc_ycbcr.cpp
+++ b/layers/core_checks/cc_ycbcr.cpp
@@ -20,6 +20,8 @@
  */
 
 #include "core_validation.h"
+#include <vulkan/utility/vk_format_utils.h>
+#include "utils/image_utils.h"
 
 // There is a table in the Vulkan spec to list all formats that implicitly require YCbCr conversion,
 // but some features/extensions can explicitly turn that restriction off

--- a/layers/drawdispatch/descriptor_validator.cpp
+++ b/layers/drawdispatch/descriptor_validator.cpp
@@ -17,6 +17,7 @@
 
 #include "descriptor_validator.h"
 #include <vulkan/vulkan_core.h>
+#include <vulkan/utility/vk_format_utils.h>
 #include <sstream>
 #include "generated/spirv_grammar_helper.h"
 #include "generated/spirv_validation_helper.h"

--- a/layers/gpuav/core/gpuav_record.cpp
+++ b/layers/gpuav/core/gpuav_record.cpp
@@ -28,6 +28,7 @@
 #include "gpuav/instrumentation/post_process_descriptor_indexing.h"
 #include "gpuav/shaders/gpuav_shaders_constants.h"
 #include "chassis/chassis_modification_state.h"
+#include "utils/math_utils.h"
 
 namespace gpuav {
 

--- a/layers/gpuav/spirv/buffer_device_address_pass.cpp
+++ b/layers/gpuav/spirv/buffer_device_address_pass.cpp
@@ -20,7 +20,6 @@
 #include <iostream>
 #include "utils/math_utils.h"
 #include "utils/vk_layer_utils.h"
-#include "containers/limits.h"
 #include "gpuav/shaders/gpuav_error_header.h"
 
 #include "generated/gpuav_offline_spirv.h"

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -19,13 +19,13 @@
  */
 #include "state_tracker/cmd_buffer_state.h"
 #include <vulkan/vulkan_core.h>
+#include <vulkan/utility/vk_format_utils.h>
 #include "state_tracker/descriptor_sets.h"
 #include "state_tracker/render_pass_state.h"
 #include "state_tracker/pipeline_state.h"
 #include "state_tracker/buffer_state.h"
 #include "state_tracker/image_state.h"
 #include "state_tracker/queue_state.h"
-#include "utils/vk_layer_utils.h"
 
 using RangeGenerator = subresource_adapter::RangeGenerator;
 

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -23,7 +23,6 @@
 
 #include "state_tracker/device_memory_state.h"
 #include "state_tracker/image_layout_map.h"
-#include "utils/vk_layer_utils.h"
 
 namespace vvl {
 class DeviceState;
@@ -189,19 +188,11 @@ class Image : public Bindable, public SubStateManager<ImageSubState> {
     void Destroy() override;
 
     // Returns the effective extent of the provided subresource, adjusted for mip level and array depth.
-    VkExtent3D GetEffectiveSubresourceExtent(const VkImageSubresourceLayers &sub) const {
-        return GetEffectiveExtent(create_info, sub.aspectMask, sub.mipLevel);
-    }
+    VkExtent3D GetEffectiveSubresourceExtent(const VkImageSubresourceLayers &sub) const;
+    VkExtent3D GetEffectiveSubresourceExtent(const VkImageSubresource &sub) const;
+    VkExtent3D GetEffectiveSubresourceExtent(const VkImageSubresourceRange &range) const;
 
-    // Returns the effective extent of the provided subresource, adjusted for mip level and array depth.
-    VkExtent3D GetEffectiveSubresourceExtent(const VkImageSubresource &sub) const {
-        return GetEffectiveExtent(create_info, sub.aspectMask, sub.mipLevel);
-    }
-
-    // Returns the effective extent of the provided subresource, adjusted for mip level and array depth.
-    VkExtent3D GetEffectiveSubresourceExtent(const VkImageSubresourceRange &range) const {
-        return GetEffectiveExtent(create_info, range.aspectMask, range.baseMipLevel);
-    }
+    std::string DescribeSubresourceLayers(const VkImageSubresourceLayers &subresource) const;
 
     VkImageSubresourceRange NormalizeSubresourceRange(const VkImageSubresourceRange &range) const;
     uint32_t NormalizeLayerCount(const VkImageSubresourceLayers &resource) const;

--- a/layers/state_tracker/render_pass_state.cpp
+++ b/layers/state_tracker/render_pass_state.cpp
@@ -19,6 +19,7 @@
 
 #include "state_tracker/render_pass_state.h"
 #include "utils/convert_utils.h"
+#include "utils/math_utils.h"
 #include "state_tracker/image_state.h"
 #include "containers/span.h"
 

--- a/layers/state_tracker/sampler_state.h
+++ b/layers/state_tracker/sampler_state.h
@@ -19,6 +19,7 @@
 #pragma once
 #include "state_tracker/state_object.h"
 #include <vulkan/utility/vk_safe_struct.hpp>
+#include "utils/image_utils.h"
 
 // Note: some of the types in this header are needed by both the DescriptorSet and Pipeline
 // state objects. It is helpful to have a separate header to avoid circular #include madness.

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <queue>
 
+#include <vulkan/utility/vk_format_utils.h>
 #include "utils/hash_util.h"
 #include "generated/spirv_grammar_helper.h"
 #include "generated/spirv_validation_helper.h"

--- a/layers/stateless/sl_buffer.cpp
+++ b/layers/stateless/sl_buffer.cpp
@@ -18,6 +18,8 @@
 
 #include "stateless/stateless_validation.h"
 #include "generated/enum_flag_bits.h"
+#include "utils/image_utils.h"
+#include <vulkan/utility/vk_format_utils.h>
 
 namespace stateless {
 

--- a/layers/stateless/sl_descriptor.cpp
+++ b/layers/stateless/sl_descriptor.cpp
@@ -16,11 +16,13 @@
  * limitations under the License.
  */
 
+#include <vulkan/utility/vk_format_utils.h>
 #include "error_message/error_location.h"
 #include "stateless/stateless_validation.h"
 #include "generated/enum_flag_bits.h"
 #include "error_message/error_strings.h"
 #include "containers/span.h"
+#include "utils/image_utils.h"
 
 namespace stateless {
 bool Device::ValidateCoarseSampleOrderCustomNV(const VkCoarseSampleOrderCustomNV &order, const Location &order_loc) const {

--- a/layers/stateless/sl_device_memory.cpp
+++ b/layers/stateless/sl_device_memory.cpp
@@ -17,6 +17,8 @@
  */
 
 #include "stateless/stateless_validation.h"
+#include <vulkan/utility/vk_format_utils.h>
+#include "utils/image_utils.h"
 
 namespace stateless {
 

--- a/layers/stateless/sl_image.cpp
+++ b/layers/stateless/sl_image.cpp
@@ -17,12 +17,13 @@
  */
 
 #include <vulkan/vk_enum_string_helper.h>
+#include <vulkan/utility/vk_format_utils.h>
 #include <vulkan/vulkan_core.h>
 #include "error_message/error_strings.h"
 #include "stateless/stateless_validation.h"
 #include "generated/enum_flag_bits.h"
 #include "utils/math_utils.h"
-#include "utils/vk_layer_utils.h"
+#include "utils/image_utils.h"
 
 namespace stateless {
 

--- a/layers/stateless/sl_pipeline.cpp
+++ b/layers/stateless/sl_pipeline.cpp
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+#include <vulkan/utility/vk_format_utils.h>
 #include "error_message/error_location.h"
 #include "stateless/stateless_validation.h"
 #include "generated/enum_flag_bits.h"

--- a/layers/stateless/sl_render_pass.cpp
+++ b/layers/stateless/sl_render_pass.cpp
@@ -16,10 +16,12 @@
  * limitations under the License.
  */
 
+#include <vulkan/utility/vk_format_utils.h>
 #include "stateless/stateless_validation.h"
-#include "utils/convert_utils.h"
 #include "error_message/error_strings.h"
-#include "utils/vk_layer_utils.h"
+#include "utils/convert_utils.h"
+#include "utils/math_utils.h"
+#include "utils/image_utils.h"
 
 namespace stateless {
 

--- a/layers/stateless/sl_wsi.cpp
+++ b/layers/stateless/sl_wsi.cpp
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+#include <vulkan/utility/vk_format_utils.h>
 #include "error_message/error_location.h"
 #include "stateless/stateless_validation.h"
 #include "generated/enum_flag_bits.h"

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -22,7 +22,6 @@
 #include <vulkan/utility/vk_struct_helper.hpp>
 #include "generated/error_location_helper.h"
 #include "sync/sync_utils.h"
-#include "utils/vk_layer_utils.h"
 #include "chassis/validation_object.h"
 #include "generated/device_features.h"
 

--- a/layers/sync/sync_access_context.cpp
+++ b/layers/sync/sync_access_context.cpp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+#include <vulkan/utility/vk_format_utils.h>
 #include "state_tracker/buffer_state.h"
 #include "state_tracker/video_session_state.h"
 #include "state_tracker/render_pass_state.h"

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+#include <vulkan/utility/vk_format_utils.h>
 #include "sync/sync_commandbuffer.h"
 #include "sync/sync_op.h"
 #include "sync/sync_reporting.h"
@@ -27,6 +28,7 @@
 #include "state_tracker/render_pass_state.h"
 #include "state_tracker/shader_module.h"
 #include "state_tracker/pipeline_state.h"
+#include "utils/math_utils.h"
 #include "utils/text_utils.h"
 
 SyncAccessIndex GetSyncStageAccessIndexsByDescriptorSet(VkDescriptorType descriptor_type,

--- a/layers/sync/sync_renderpass.cpp
+++ b/layers/sync/sync_renderpass.cpp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+#include <vulkan/utility/vk_format_utils.h>
 #include "sync/sync_renderpass.h"
 #include "sync/sync_validation.h"
 #include "sync/sync_op.h"

--- a/layers/sync/sync_reporting.cpp
+++ b/layers/sync/sync_reporting.cpp
@@ -19,6 +19,7 @@
 #include "sync/sync_image.h"
 #include "sync/sync_validation.h"
 #include "error_message/error_strings.h"
+#include "utils/math_utils.h"
 
 static const char *string_SyncHazard(SyncHazard hazard) {
     switch (hazard) {

--- a/layers/utils/image_utils.cpp
+++ b/layers/utils/image_utils.cpp
@@ -1,0 +1,240 @@
+/* Copyright (c) 2020-2025 The Khronos Group Inc.
+ * Copyright (c) 2020-2025 Valve Corporation
+ * Copyright (c) 2020-2025 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "image_utils.h"
+#include "containers/range.h"
+#include "utils/math_utils.h"
+
+#include <algorithm>
+#include <sstream>
+#include <array>
+
+#include <vulkan/vk_enum_string_helper.h>
+#include <vulkan/utility/vk_format_utils.h>
+#include <vulkan/utility/vk_struct_helper.hpp>
+
+// Returns the effective extent of an image subresource, adjusted for mip level and array depth.
+VkExtent3D GetEffectiveExtent(const VkImageCreateInfo &ci, const VkImageAspectFlags aspect_mask, const uint32_t mip_level) {
+    // Return zero extent if mip level doesn't exist
+    if (mip_level >= ci.mipLevels) {
+        return VkExtent3D{0, 0, 0};
+    }
+
+    VkExtent3D extent = ci.extent;
+
+    // If multi-plane, adjust per-plane extent
+    const VkFormat format = ci.format;
+    if (vkuFormatIsMultiplane(format)) {
+        VkExtent2D divisors = vkuFindMultiplaneExtentDivisors(format, static_cast<VkImageAspectFlagBits>(aspect_mask));
+        extent.width /= divisors.width;
+        extent.height /= divisors.height;
+    }
+
+    // Mip Maps
+    {
+        const uint32_t corner = (ci.flags & VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV) ? 1 : 0;
+        const uint32_t min_size = 1 + corner;
+
+        if (extent.width != 0) {
+            extent.width >>= mip_level;
+            extent.width = std::max({min_size, extent.width});
+        }
+        if (extent.height != 0) {
+            extent.height >>= mip_level;
+            extent.height = std::max({min_size, extent.height});
+        }
+        if (extent.depth != 0) {
+            extent.depth >>= mip_level;
+            extent.depth = std::max({min_size, extent.depth});
+        }
+    }
+
+    // Image arrays have an effective z extent that isn't diminished by mip level
+    if (VK_IMAGE_TYPE_3D != ci.imageType) {
+        extent.depth = ci.arrayLayers;
+    }
+
+    return extent;
+}
+
+// Returns true if [x, x + x_size) and [y, y + y_size) overlap
+bool RangesIntersect(int64_t x, uint64_t x_size, int64_t y, uint64_t y_size) {
+    auto intersection = GetRangeIntersection(x, x_size, y, y_size);
+    return intersection.non_empty();
+}
+
+// Implements the vkspec.html#formats-size-compatibility section of the spec
+bool AreFormatsSizeCompatible(VkFormat a, VkFormat b, VkImageAspectFlags aspect_mask) {
+    const bool is_a_a8 = a == VK_FORMAT_A8_UNORM;
+    const bool is_b_a8 = b == VK_FORMAT_A8_UNORM;
+    if ((is_a_a8 && !is_b_a8) || (!is_a_a8 && is_b_a8)) {
+        return false;
+    }
+
+    const bool is_a_depth_stencil = vkuFormatIsDepthOrStencil(a);
+    const bool is_b_depth_stencil = vkuFormatIsDepthOrStencil(b);
+    if (is_a_depth_stencil && !is_b_depth_stencil) {
+        return vkuFormatIsDepthStencilWithColorSizeCompatible(b, a, aspect_mask);
+    } else if (!is_a_depth_stencil && is_b_depth_stencil) {
+        return vkuFormatIsDepthStencilWithColorSizeCompatible(a, b, aspect_mask);
+    } else if (is_a_depth_stencil && is_b_depth_stencil) {
+        return a == b;
+    }
+
+    // Color formats are considered compatible if their texel block size in bytes is the same
+    return vkuFormatTexelBlockSize(a) == vkuFormatTexelBlockSize(b);
+}
+
+std::string DescribeFormatsSizeCompatible(VkFormat a, VkFormat b) {
+    std::stringstream ss;
+    const bool is_a_a8 = a == VK_FORMAT_A8_UNORM;
+    const bool is_b_a8 = b == VK_FORMAT_A8_UNORM;
+    if ((is_a_a8 && !is_b_a8) || (!is_a_a8 && is_b_a8)) {
+        ss << string_VkFormat(a) << " and " << string_VkFormat(b)
+           << " either both need to be VK_FORMAT_A8_UNORM or neither of them";
+        return ss.str();
+    }
+
+    const bool is_a_depth_stencil = vkuFormatIsDepthOrStencil(a);
+    const bool is_b_depth_stencil = vkuFormatIsDepthOrStencil(b);
+    if (is_a_depth_stencil && is_b_depth_stencil) {
+        ss << string_VkFormat(a) << " and " << string_VkFormat(b)
+           << " are both depth/stencil, therefor they must be the exact same format";
+    } else if (is_a_depth_stencil || is_b_depth_stencil) {
+        if (is_a_depth_stencil && !is_b_depth_stencil) {
+            ss << string_VkFormat(a) << " is a depth/stencil and " << string_VkFormat(b) << " is color";
+        } else if (!is_a_depth_stencil && is_b_depth_stencil) {
+            ss << string_VkFormat(a) << " is a color and " << string_VkFormat(b) << " is depth/stencil";
+        }
+        ss << " (this is only allowed with a certain set of formats during image copy with VK_KHR_maintenance8)";
+    } else {
+        ss << string_VkFormat(a) << " has a texel block size of " << vkuFormatTexelBlockSize(a) << " while " << string_VkFormat(b)
+           << " has a texel block size of " << vkuFormatTexelBlockSize(b);
+    }
+    return ss.str();
+}
+
+uint32_t GetVertexInputFormatSize(VkFormat format) {
+    // Vertex input attributes use VkFormat, but only to make use of how they define sizes, things such as
+    // depth/multi-plane/compressed will never be used here because they would mean nothing. So we can ensure these are "standard"
+    // color formats being used. This function is a wrapper to make it more clear of the intent.
+    return vkuFormatTexelBlockSize(format);
+}
+
+uint32_t GetTexelBufferFormatSize(VkFormat format) {
+    // The spec says "If format is a block-compressed format, then bufferFeatures must not support any features for the format"
+    // For Texel Buffers, we can assume the texel blocks are a 1x1x1 extent
+    // See https://gitlab.khronos.org/vulkan/vulkan/-/issues/4155 for more details
+    return vkuFormatTexelBlockSize(format);
+}
+
+// Used to get the VkExternalFormatANDROID without having to use ifdef in logic
+// Result of zero is same of not having pNext struct
+uint64_t GetExternalFormat(const void *pNext) {
+#if defined(VK_USE_PLATFORM_ANDROID_KHR)
+    if (pNext) {
+        const auto *external_format = vku::FindStructInPNextChain<VkExternalFormatANDROID>(pNext);
+        if (external_format) {
+            return external_format->externalFormat;
+        }
+    }
+#endif
+    (void)pNext;
+    return 0;
+}
+
+// vkspec.html#formats-planes-image-aspect
+bool IsValidPlaneAspect(VkFormat format, VkImageAspectFlags aspect_mask) {
+    const uint32_t planes = vkuFormatPlaneCount(format);
+    constexpr VkImageAspectFlags valid_planes =
+        VK_IMAGE_ASPECT_PLANE_0_BIT | VK_IMAGE_ASPECT_PLANE_1_BIT | VK_IMAGE_ASPECT_PLANE_2_BIT;
+
+    if (((aspect_mask & valid_planes) == aspect_mask) && (aspect_mask != 0)) {
+        if ((planes == 3) || ((planes == 2) && ((aspect_mask & VK_IMAGE_ASPECT_PLANE_2_BIT) == 0))) {
+            return true;
+        }
+    }
+    return false;  // Expects calls to make sure it is a multi-planar format
+}
+
+bool IsOnlyOneValidPlaneAspect(VkFormat format, VkImageAspectFlags aspect_mask) {
+    const bool multiple_bits = aspect_mask != 0 && !IsPowerOfTwo(aspect_mask);
+    return !multiple_bits && IsValidPlaneAspect(format, aspect_mask);
+}
+
+bool IsMultiplePlaneAspect(VkImageAspectFlags aspect_mask) {
+    // If checking for multiple planes, there will already be another check if valid for plane count
+    constexpr VkImageAspectFlags valid_planes =
+        VK_IMAGE_ASPECT_PLANE_0_BIT | VK_IMAGE_ASPECT_PLANE_1_BIT | VK_IMAGE_ASPECT_PLANE_2_BIT;
+    const VkImageAspectFlags planes = aspect_mask & valid_planes;
+    return planes != 0 && !IsPowerOfTwo(planes);
+}
+
+bool IsAnyPlaneAspect(VkImageAspectFlags aspect_mask) {
+    constexpr VkImageAspectFlags valid_planes =
+        VK_IMAGE_ASPECT_PLANE_0_BIT | VK_IMAGE_ASPECT_PLANE_1_BIT | VK_IMAGE_ASPECT_PLANE_2_BIT;
+    return (aspect_mask & valid_planes) != 0;
+}
+
+bool IsImageLayoutReadOnly(VkImageLayout layout) {
+    constexpr std::array read_only_layouts = {
+        VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
+        VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+        VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL,
+        VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL,
+        VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL,
+        VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL,
+        VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL,
+    };
+    return std::any_of(read_only_layouts.begin(), read_only_layouts.end(),
+                       [layout](const VkImageLayout read_only_layout) { return layout == read_only_layout; });
+}
+
+bool IsImageLayoutDepthOnly(VkImageLayout layout) {
+    constexpr std::array depth_only_layouts = {VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL};
+    return std::any_of(depth_only_layouts.begin(), depth_only_layouts.end(),
+                       [layout](const VkImageLayout read_only_layout) { return layout == read_only_layout; });
+}
+
+bool IsImageLayoutDepthReadOnly(VkImageLayout layout) {
+    constexpr std::array read_only_layouts = {
+        VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
+        VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL,
+        VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL,
+        VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL,
+    };
+    return std::any_of(read_only_layouts.begin(), read_only_layouts.end(),
+                       [layout](const VkImageLayout read_only_layout) { return layout == read_only_layout; });
+}
+
+bool IsImageLayoutStencilOnly(VkImageLayout layout) {
+    constexpr std::array depth_only_layouts = {VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL,
+                                               VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL};
+    return std::any_of(depth_only_layouts.begin(), depth_only_layouts.end(),
+                       [layout](const VkImageLayout read_only_layout) { return layout == read_only_layout; });
+}
+
+bool IsImageLayoutStencilReadOnly(VkImageLayout layout) {
+    constexpr std::array read_only_layouts = {
+        VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
+        VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL,
+        VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL,
+        VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL,
+    };
+    return std::any_of(read_only_layouts.begin(), read_only_layouts.end(),
+                       [layout](const VkImageLayout read_only_layout) { return layout == read_only_layout; });
+}

--- a/layers/utils/image_utils.h
+++ b/layers/utils/image_utils.h
@@ -1,0 +1,117 @@
+/* Copyright (c) 2019-2025 The Khronos Group Inc.
+ * Copyright (c) 2019-2025 Valve Corporation
+ * Copyright (c) 2019-2025 LunarG, Inc.
+ * Modifications Copyright (C) 2022 RasterGrid Kft.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cctype>
+#include <cstring>
+#include <string>
+
+#include <vulkan/vulkan_core.h>
+
+VkExtent3D GetEffectiveExtent(const VkImageCreateInfo &ci, const VkImageAspectFlags aspect_mask, const uint32_t mip_level);
+
+// When dealing with a compressed format, we could have a miplevel that is less then a single texel block
+// In that case, we still view (from the API) that you need a full extent for 1 texel block
+// if block extent width is 4,
+//     then {1, 2, 3, 4} texel is 1 texel block
+//     then {5, 6, 7, 8} texel is 2 texel block
+//     .. etc
+static inline VkExtent3D GetTexelBlocks(VkExtent3D texels, VkExtent3D block_extent) {
+    return {
+        ((texels.width - 1) / block_extent.width) + 1,
+        ((texels.height - 1) / block_extent.height) + 1,
+        ((texels.depth - 1) / block_extent.depth) + 1,
+    };
+};
+
+// if block extent width is 4,
+//     then {1, 2, 3, 4} texels is 4 texels
+//     then {5, 6, 7, 8} texels is 8 texels
+//     .. etc
+static inline VkExtent3D RoundUpToFullTexelBlocks(VkExtent3D texels, VkExtent3D block_extent) {
+    return {
+        ((texels.width + block_extent.width - 1) / block_extent.width) * block_extent.width,
+        ((texels.height + block_extent.height - 1) / block_extent.height) * block_extent.height,
+        ((texels.depth + block_extent.depth - 1) / block_extent.depth) * block_extent.depth,
+    };
+};
+
+bool RangesIntersect(int64_t x, uint64_t x_size, int64_t y, uint64_t y_size);
+
+bool AreFormatsSizeCompatible(VkFormat a, VkFormat b,
+                              VkImageAspectFlags aspect_mask = VK_IMAGE_ASPECT_STENCIL_BIT | VK_IMAGE_ASPECT_DEPTH_BIT);
+
+std::string DescribeFormatsSizeCompatible(VkFormat a, VkFormat b);
+
+uint64_t GetExternalFormat(const void *pNext);
+
+uint32_t GetVertexInputFormatSize(VkFormat format);
+uint32_t GetTexelBufferFormatSize(VkFormat format);
+
+bool IsValidPlaneAspect(VkFormat format, VkImageAspectFlags aspect_mask);
+bool IsOnlyOneValidPlaneAspect(VkFormat format, VkImageAspectFlags aspect_mask);
+bool IsMultiplePlaneAspect(VkImageAspectFlags aspect_mask);
+bool IsAnyPlaneAspect(VkImageAspectFlags aspect_mask);
+
+bool IsImageLayoutReadOnly(VkImageLayout layout);
+bool IsImageLayoutDepthOnly(VkImageLayout layout);
+bool IsImageLayoutDepthReadOnly(VkImageLayout layout);
+bool IsImageLayoutStencilOnly(VkImageLayout layout);
+bool IsImageLayoutStencilReadOnly(VkImageLayout layout);
+
+static inline bool IsIdentitySwizzle(VkComponentMapping components) {
+    // clang-format off
+    return (
+        ((components.r == VK_COMPONENT_SWIZZLE_IDENTITY) || (components.r == VK_COMPONENT_SWIZZLE_R)) &&
+        ((components.g == VK_COMPONENT_SWIZZLE_IDENTITY) || (components.g == VK_COMPONENT_SWIZZLE_G)) &&
+        ((components.b == VK_COMPONENT_SWIZZLE_IDENTITY) || (components.b == VK_COMPONENT_SWIZZLE_B)) &&
+        ((components.a == VK_COMPONENT_SWIZZLE_IDENTITY) || (components.a == VK_COMPONENT_SWIZZLE_A))
+    );
+    // clang-format on
+}
+
+static inline uint32_t SampleCountSize(VkSampleCountFlagBits sample_count) {
+    uint32_t size = 0;
+    switch (sample_count) {
+        case VK_SAMPLE_COUNT_1_BIT:
+            size = 1;
+            break;
+        case VK_SAMPLE_COUNT_2_BIT:
+            size = 2;
+            break;
+        case VK_SAMPLE_COUNT_4_BIT:
+            size = 4;
+            break;
+        case VK_SAMPLE_COUNT_8_BIT:
+            size = 8;
+            break;
+        case VK_SAMPLE_COUNT_16_BIT:
+            size = 16;
+            break;
+        case VK_SAMPLE_COUNT_32_BIT:
+            size = 32;
+            break;
+        case VK_SAMPLE_COUNT_64_BIT:
+            size = 64;
+            break;
+        default:
+            size = 0;
+    }
+    return size;
+}

--- a/layers/utils/vk_struct_compare.cpp
+++ b/layers/utils/vk_struct_compare.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2024 The Khronos Group Inc.
- * Copyright (c) 2024 Valve Corporation
- * Copyright (c) 2024 LunarG, Inc.
+/* Copyright (c) 2024-2025 The Khronos Group Inc.
+ * Copyright (c) 2024-2025 Valve Corporation
+ * Copyright (c) 2024-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
  */
 
 #include "utils/vk_struct_compare.h"
-#include "utils/vk_layer_utils.h"
+#include "utils/image_utils.h"
 #include <vulkan/utility/vk_struct_helper.hpp>
 
 static inline bool ComparePipelineSampleLocationsStateCreateInfo(const VkPipelineSampleLocationsStateCreateInfoEXT &a,

--- a/tests/framework/ray_tracing_objects.cpp
+++ b/tests/framework/ray_tracing_objects.cpp
@@ -12,6 +12,7 @@
 #include "ray_tracing_objects.h"
 
 #include "utils/vk_layer_utils.h"
+#include "utils/math_utils.h"
 
 // #define VVL_DEBUG_LOG_SBT
 #ifdef VVL_DEBUG_LOG_SBT

--- a/tests/unit/external_memory_metal.cpp
+++ b/tests/unit/external_memory_metal.cpp
@@ -13,6 +13,7 @@
 
 #ifdef VK_USE_PLATFORM_METAL_EXT
 #include "utils/vk_layer_utils.h"
+#include "utils/math_utils.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/external_memory_sync.h"
 

--- a/tests/unit/external_memory_sync.cpp
+++ b/tests/unit/external_memory_sync.cpp
@@ -16,6 +16,7 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/external_memory_sync.h"
 #include "utils/vk_layer_utils.h"
+#include "utils/math_utils.h"
 
 class NegativeExternalMemorySync : public ExternalMemorySyncTest {};
 

--- a/tests/unit/fragment_shading_rate_positive.cpp
+++ b/tests/unit/fragment_shading_rate_positive.cpp
@@ -11,6 +11,7 @@
 
 #include "../framework/layer_validation_tests.h"
 #include "../framework/render_pass_helper.h"
+#include "utils/math_utils.h"
 
 class PositiveFragmentShadingRate : public VkLayerTest {};
 

--- a/tests/unit/image_positive.cpp
+++ b/tests/unit/image_positive.cpp
@@ -14,7 +14,7 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/sync_helper.h"
 
-#include "utils/vk_layer_utils.h"
+#include "utils/image_utils.h"
 
 // A reasonable well supported default VkImageCreateInfo for image creation
 VkImageCreateInfo ImageTest::DefaultImageInfo() {

--- a/tests/unit/layer_utils_positive.cpp
+++ b/tests/unit/layer_utils_positive.cpp
@@ -1,7 +1,7 @@
 
 /*
- * Copyright (c) 2023-2024 Valve Corporation
- * Copyright (c) 2023-2024 LunarG, Inc.
+ * Copyright (c) 2023-2025 Valve Corporation
+ * Copyright (c) 2023-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -11,7 +11,7 @@
  */
 
 #include "../framework/layer_validation_tests.h"
-#include "utils/vk_layer_utils.h"
+#include "utils/image_utils.h"
 
 class PositiveLayerUtils : public VkLayerTest {};
 


### PR DESCRIPTION
in `cc_copy_blit_resolve.cpp` we do a lot of 

`VkExtent3D effective_image_extent = image_state.GetEffectiveSubresourceExtent(region.imageSubresource);`

and I wanted to add `image_state.DescribeSubresourceLayers(region.imageSubresource).c_str());` to print out better/useful information

In doing so, I had to add more things to `vk_layer_utils.h`, which I refused to and just finally created a `image_utils.h` file