### PR TITLE
tests: Fix rt serialization size and alignment computations

### DIFF
--- a/tests/unit/ray_tracing_positive.cpp
+++ b/tests/unit/ray_tracing_positive.cpp
@@ -1600,11 +1600,8 @@ TEST_F(PositiveRayTracing, SerializeAccelerationStructure) {
     uint32_t accel_struct_serialization_size = 0;
     serialization_query_pool.Results(0, 1, sizeof(uint32_t), &accel_struct_serialization_size, 0);
 
-    // See https://vkdoc.net/man/vkCmdCopyAccelerationStructureToMemoryKHR
-    const VkDeviceSize serialized_accel_struct_size =
-        Align<VkDeviceSize>(2 * VK_UUID_SIZE + 3 * sizeof(uint64_t) * accel_struct_serialization_size, 256);
     vkt::Buffer serialized_accel_struct_buffer(
-        *m_device, serialized_accel_struct_size,
+        *m_device, accel_struct_serialization_size,
         VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
         vkt::device_address);
 
@@ -1620,14 +1617,14 @@ TEST_F(PositiveRayTracing, SerializeAccelerationStructure) {
     m_device->Wait();
 
     vkt::Buffer de_serialized_accel_struct_buffer(
-        *m_device, serialized_accel_struct_size,
+        *m_device, accel_struct_serialization_size,
         VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
         vkt::device_address);
 
     auto deserialized_blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
     deserialized_blas.AddFlags(
         VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR /*| VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR*/);
-    deserialized_blas.GetDstAS()->SetSize(Align<VkDeviceSize>(serialized_accel_struct_size, 256));
+    deserialized_blas.GetDstAS()->SetSize(accel_struct_serialization_size);
     deserialized_blas.GetDstAS()->Create();
 
     VkCopyMemoryToAccelerationStructureInfoKHR copy_memory_to_accel_struct_info = vku::InitStructHelper();


### PR DESCRIPTION
`vkCmdWriteAccelerationStructuresPropertiesKHR` already includes HEADER size, no need to manually add it. Few places to infer this info:
* The spec says that value returned by `vkCmdWriteAccelerationStructuresPropertiesKHR` is enough to make `vkCmdCopyAccelerationStructureToMemoryKHR` call, without additional requirements: `The memory pointed to by dst must be at least as large as the serialization size of src, as reported by vkWriteAccelerationStructuresPropertiesKHR or vkCmdWriteAccelerationStructuresPropertiesKHR`
* The above is enough but there's more. The spec uses term `semi-opaque format` (`VK_COPY_ACCELERATION_STRUCTURE_MODE_SERIALIZE_KHR serializes the acceleration structure to a semi-opaque format which can be reloaded on a compatible implementation`). The "opaque" part here is acceleration structure binary data which is not  standardized and implementation specific. "semi" is about the HEADER which is documented in the spec, so the entire blob is not 100% opaque. Because the spec says that serialized data is semi-opaque implies that header is also written.
* Testing on NVIDIA/AMD shows that the size of acceleration strcture (BLAS) and the value returned by `vkCmdWriteAccelerationStructuresPropertiesKHR` differs by 56 bytes which is the size of the header.

There is a requirement that `deviceAddress` where to store serialized data should be 256 byte aligned. We don't need to do any computation because the test framework binds buffer to VkDeviceMemory with 0 offset by default, and the spec guarantees that `Allocations returned by vkAllocateMemory are guaranteed to meet any alignment requirement of the implementation`.

The existing alignment computations are also not sufficient to re-use this code for another test where buffer is bound to memory with non-zero offset. If offset is not multiple to 256 the returned deviceAddress would also be not multiple to 256, and the correct solution is to align the returned deviceAddress (existing code aligns size which is also needed but not sufficient). So, no reason to keep this code.