### PR TITLE
gpuav: More more stuff to descriptor_checks

### DIFF
--- a/layers/gpuav/core/gpuav.h
+++ b/layers/gpuav/core/gpuav.h
@@ -432,8 +432,6 @@ class Validator : public GpuShaderInstrumentor {
     void DebugCapture() final;
 
   public:
-    std::optional<DescriptorHeap> desc_heap_{};  // optional only to defer construction
-
     // We find ourselves constantly needing to create some resource for the "lifetime of GPU-AV"
     // We don't want a messy global space to managae it and use this to allow each check to manage the resource where it is used.
     // The goal is the first time we need the resource, we create it then, and afterwards, its cached and we can regain

--- a/layers/gpuav/core/gpuav_record.cpp
+++ b/layers/gpuav/core/gpuav_record.cpp
@@ -139,8 +139,6 @@ void Instance::PostCallRecordGetPhysicalDeviceProperties2(VkPhysicalDevice physi
 // Clean up device-related resources
 void Validator::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks *pAllocator,
                                            const RecordObject &record_obj) {
-    desc_heap_.reset();
-
     shared_resources_manager.Clear();
 
     indices_buffer_.Destroy();

--- a/layers/gpuav/descriptor_validation/gpuav_descriptor_set.cpp
+++ b/layers/gpuav/descriptor_validation/gpuav_descriptor_set.cpp
@@ -30,12 +30,6 @@ using vvl::DescriptorClass;
 
 namespace gpuav {
 
-// Returns the number of bytes to hold 32 bit aligned array of bits.
-static uint32_t BitBufferSize(uint32_t num_bits) {
-    static constexpr uint32_t kBitsPerWord = 32;
-    return (((num_bits + (kBitsPerWord - 1)) & ~(kBitsPerWord - 1)) / kBitsPerWord) * sizeof(uint32_t);
-}
-
 DescriptorSetSubState::DescriptorSetSubState(const vvl::DescriptorSet &set, Validator &state_data)
     : vvl::DescriptorSetSubState(set), input_buffer_(state_data) {
     BuildBindingLayouts();
@@ -238,67 +232,5 @@ VkDeviceAddress DescriptorSetSubState::GetTypeAddress(Validator &gpuav, const Lo
 }
 
 void DescriptorSetSubState::NotifyUpdate() { current_version_++; }
-
-DescriptorHeap::DescriptorHeap(Validator &gpuav, uint32_t max_descriptors, const Location &loc)
-    : max_descriptors_(max_descriptors), buffer_(gpuav) {
-    // If max_descriptors_ is 0, GPU-AV aborted during vkCreateDevice(). We still need to
-    // support calls into this class as no-ops if this happens.
-    if (max_descriptors_ == 0) {
-        return;
-    }
-
-    VkBufferCreateInfo buffer_info = vku::InitStruct<VkBufferCreateInfo>();
-    buffer_info.size = BitBufferSize(max_descriptors_ + 1);  // add extra entry since 0 is the invalid id.
-    buffer_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
-
-    VmaAllocationCreateInfo alloc_info{};
-    alloc_info.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-    const bool success = buffer_.Create(&buffer_info, &alloc_info);
-    if (!success) {
-        return;
-    }
-
-    gpu_heap_state_ = (uint32_t *)buffer_.GetMappedPtr();
-    memset(gpu_heap_state_, 0, static_cast<size_t>(buffer_info.size));
-}
-
-DescriptorHeap::~DescriptorHeap() {
-    if (max_descriptors_ > 0) {
-        buffer_.Destroy();
-        gpu_heap_state_ = nullptr;
-    }
-}
-
-DescriptorId DescriptorHeap::NextId(const VulkanTypedHandle &handle) {
-    if (max_descriptors_ == 0) {
-        return 0;
-    }
-    DescriptorId result;
-
-    // NOTE: valid ids are in the range [1, max_descriptors_] (inclusive)
-    // 0 is the invalid id.
-    auto guard = Lock();
-    if (alloc_map_.size() >= max_descriptors_) {
-        return 0;
-    }
-    do {
-        result = next_id_++;
-        if (next_id_ > max_descriptors_) {
-            next_id_ = 1;
-        }
-    } while (alloc_map_.count(result) > 0);
-    alloc_map_[result] = handle;
-    gpu_heap_state_[result / 32] |= 1u << (result & 31);
-    return result;
-}
-
-void DescriptorHeap::DeleteId(DescriptorId id) {
-    if (max_descriptors_ > 0) {
-        auto guard = Lock();
-        // Note: We don't mess with next_id_ here because ids should be assigned in LRU order.
-        gpu_heap_state_[id / 32] &= ~(1u << (id & 31));
-        alloc_map_.erase(id);
-    }
-}
 
 }  // namespace gpuav

--- a/layers/gpuav/instrumentation/post_process_descriptor_indexing.cpp
+++ b/layers/gpuav/instrumentation/post_process_descriptor_indexing.cpp
@@ -174,6 +174,10 @@ void RegisterPostProcessingValidation(Validator& gpuav, CommandBufferSubState& c
             // We build once here, but will update the set_index and shader_handle when found
             vvl::DescriptorValidator context(gpuav, cb.base, *desc_set, 0, VK_NULL_HANDLE, nullptr, draw_loc);
 
+            // We create a map with the |unique_shader_id| as the key so we can only do the state object lookup once per
+            // pipeline/shaderModule/shaderObject
+
+            using DescriptorAccessMap = vvl::unordered_map<uint32_t, std::vector<DescriptorAccess>>;
             DescriptorAccessMap descriptor_access_map;
             {
                 VVL_ZoneScoped;

--- a/layers/gpuav/resources/gpuav_state_trackers.h
+++ b/layers/gpuav/resources/gpuav_state_trackers.h
@@ -20,7 +20,7 @@
 #include <vector>
 
 #include "external/inplace_function.h"
-#include "gpuav/descriptor_validation/gpuav_descriptor_set.h"
+#include "gpuav/instrumentation/descriptor_checks.h"
 #include "gpuav/resources/gpuav_vulkan_objects.h"
 
 // We pull in most the core state tracking files
@@ -206,23 +206,6 @@ class QueueSubState : public vvl::QueueSubState {
     VkSemaphore barrier_sem_{VK_NULL_HANDLE};
     std::deque<std::vector<vvl::CommandBufferSubmission>> retiring_;
     const bool timeline_khr_;
-};
-
-// Descriptor Ids are used on the GPU to identify if a given descriptor is valid.
-// In some applications there are very large bindless descriptor arrays where it isn't feasible to track validity
-// via the StateObject::parent_nodes_ map as usual. Instead, these ids are stored in a giant GPU accessible bitmap
-// so that the instrumentation can decide if a descriptor is actually valid when it is used in a shader.
-class DescriptorIdTracker {
-  public:
-    DescriptorIdTracker(DescriptorHeap &heap_, VulkanTypedHandle handle) : heap(heap_), id(heap_.NextId(handle)) {}
-
-    DescriptorIdTracker(const DescriptorIdTracker &) = delete;
-    DescriptorIdTracker &operator=(const DescriptorIdTracker &) = delete;
-
-    ~DescriptorIdTracker() { heap.DeleteId(id); }
-
-    DescriptorHeap &heap;
-    const DescriptorId id{};
 };
 
 class ImageSubState : public vvl::ImageSubState {

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -168,7 +168,7 @@ const char *VK_LAYER_CUSTOM_STYPE_LIST = "custom_stype_list";
 const char *VK_LAYER_ENABLE_MESSAGE_LIMIT = "enable_message_limit";
 const char *VK_LAYER_DUPLICATE_MESSAGE_LIMIT = "duplicate_message_limit";
 
-// GloablSettings
+// Global settings
 // ---
 const char *VK_LAYER_FINE_GRAINED_LOCKING = "fine_grained_locking";
 // Debug settings used for internal development
@@ -193,8 +193,6 @@ const char *VK_LAYER_GPUAV_DESCRIPTOR_CHECKS = "gpuav_descriptor_checks";
 const char *VK_LAYER_GPUAV_BUFFER_ADDRESS_OOB = "gpuav_buffer_address_oob";
 const char *VK_LAYER_GPUAV_MAX_BUFFER_DEVICE_ADDRESSES = "gpuav_max_buffer_device_addresses";
 const char *VK_LAYER_GPUAV_VALIDATE_RAY_QUERY = "gpuav_validate_ray_query";
-// Post Process are designed to allow the user to "assume" the access is valid and want to know after the GPU executes what
-// happened. These are much lighter checks and can be used while the rest of GPU-AV is turned off
 const char *VK_LAYER_GPUAV_POST_PROCESS_DESCRIPTOR_INDEXING = "gpuav_post_process_descriptor_indexing";
 const char *VK_LAYER_GPUAV_VERTEX_ATTRIBUTE_FETCH_OOB = "gpuav_vertex_attribute_fetch_oob";
 const char *VK_LAYER_GPUAV_SELECT_INSTRUMENTED_SHADERS = "gpuav_select_instrumented_shaders";


### PR DESCRIPTION
`desc_heap_` is no more explicitly in `Validator`, and now is indirectly managed by `gpuav.shared_resources_manager`