### PR TITLE
gpuav: Add PushDescriptorTemplate support

### DIFF
--- a/layers/gpuav/core/gpuav.h
+++ b/layers/gpuav/core/gpuav.h
@@ -121,6 +121,19 @@ class Validator : public GpuShaderInstrumentor {
     void PreCallRecordCmdPushDescriptorSet2KHR(VkCommandBuffer commandBuffer,
                                                const VkPushDescriptorSetInfoKHR* pPushDescriptorSetInfo,
                                                const RecordObject& record_obj) final;
+    void PreCallRecordCmdPushDescriptorSetWithTemplate2(
+        VkCommandBuffer commandBuffer, const VkPushDescriptorSetWithTemplateInfoKHR* pPushDescriptorSetWithTemplateInfo,
+        const RecordObject& record_obj) final;
+    void PreCallRecordCmdPushDescriptorSetWithTemplate2KHR(
+        VkCommandBuffer commandBuffer, const VkPushDescriptorSetWithTemplateInfoKHR* pPushDescriptorSetWithTemplateInfo,
+        const RecordObject& record_obj) final;
+    void PreCallRecordCmdPushDescriptorSetWithTemplate(VkCommandBuffer commandBuffer,
+                                                       VkDescriptorUpdateTemplate descriptorUpdateTemplate, VkPipelineLayout layout,
+                                                       uint32_t set, const void* pData, const RecordObject& record_obj) final;
+    void PreCallRecordCmdPushDescriptorSetWithTemplateKHR(VkCommandBuffer commandBuffer,
+                                                          VkDescriptorUpdateTemplate descriptorUpdateTemplate,
+                                                          VkPipelineLayout layout, uint32_t set, const void* pData,
+                                                          const RecordObject& record_obj) final;
     void PreCallRecordCmdBindDescriptorBuffersEXT(VkCommandBuffer commandBuffer, uint32_t bufferCount,
                                                   const VkDescriptorBufferBindingInfoEXT* pBindingInfos,
                                                   const RecordObject& record_obj) final;

--- a/layers/gpuav/core/gpuav_record.cpp
+++ b/layers/gpuav/core/gpuav_record.cpp
@@ -29,6 +29,7 @@
 #include "gpuav/instrumentation/post_process_descriptor_indexing.h"
 #include "gpuav/shaders/gpuav_shaders_constants.h"
 #include "chassis/chassis_modification_state.h"
+#include "utils/assert_utils.h"
 #include "utils/math_utils.h"
 
 namespace gpuav {
@@ -303,6 +304,40 @@ void Validator::PreCallRecordCmdPushDescriptorSet2KHR(VkCommandBuffer commandBuf
                                                       const VkPushDescriptorSetInfoKHR *pPushDescriptorSetInfo,
                                                       const RecordObject &record_obj) {
     PreCallRecordCmdPushDescriptorSet2(commandBuffer, pPushDescriptorSetInfo, record_obj);
+}
+
+void Validator::PreCallRecordCmdPushDescriptorSetWithTemplate2(
+    VkCommandBuffer commandBuffer, const VkPushDescriptorSetWithTemplateInfoKHR *pPushDescriptorSetWithTemplateInfo,
+    const RecordObject &record_obj) {
+    auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
+    auto template_state = Get<vvl::DescriptorUpdateTemplate>(pPushDescriptorSetWithTemplateInfo->descriptorUpdateTemplate);
+    ASSERT_AND_RETURN(template_state);
+    descriptor::UpdateBoundDescriptors(*this, SubState(*cb_state), template_state->create_info.pipelineBindPoint,
+                                       record_obj.location);
+}
+
+void Validator::PreCallRecordCmdPushDescriptorSetWithTemplate2KHR(
+    VkCommandBuffer commandBuffer, const VkPushDescriptorSetWithTemplateInfoKHR *pPushDescriptorSetWithTemplateInfo,
+    const RecordObject &record_obj) {
+    PreCallRecordCmdPushDescriptorSetWithTemplate2(commandBuffer, pPushDescriptorSetWithTemplateInfo, record_obj);
+}
+
+void Validator::PreCallRecordCmdPushDescriptorSetWithTemplate(VkCommandBuffer commandBuffer,
+                                                              VkDescriptorUpdateTemplate descriptorUpdateTemplate,
+                                                              VkPipelineLayout layout, uint32_t set, const void *pData,
+                                                              const RecordObject &record_obj) {
+    auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
+    auto template_state = Get<vvl::DescriptorUpdateTemplate>(descriptorUpdateTemplate);
+    ASSERT_AND_RETURN(template_state);
+    descriptor::UpdateBoundDescriptors(*this, SubState(*cb_state), template_state->create_info.pipelineBindPoint,
+                                       record_obj.location);
+}
+
+void Validator::PreCallRecordCmdPushDescriptorSetWithTemplateKHR(VkCommandBuffer commandBuffer,
+                                                                 VkDescriptorUpdateTemplate descriptorUpdateTemplate,
+                                                                 VkPipelineLayout layout, uint32_t set, const void *pData,
+                                                                 const RecordObject &record_obj) {
+    PreCallRecordCmdPushDescriptorSetWithTemplate(commandBuffer, descriptorUpdateTemplate, layout, set, pData, record_obj);
 }
 
 void Validator::PreCallRecordCmdBindDescriptorBuffersEXT(VkCommandBuffer commandBuffer, uint32_t bufferCount,

--- a/layers/gpuav/descriptor_validation/gpuav_descriptor_set.h
+++ b/layers/gpuav/descriptor_validation/gpuav_descriptor_set.h
@@ -23,7 +23,6 @@
 #include "state_tracker/descriptor_sets.h"
 #include "gpuav/resources/gpuav_vulkan_objects.h"
 #include "gpuav/spirv/interface.h"
-#include "containers/custom_containers.h"
 #include "containers/limits.h"
 
 namespace gpuav {

--- a/layers/gpuav/descriptor_validation/gpuav_descriptor_validation.cpp
+++ b/layers/gpuav/descriptor_validation/gpuav_descriptor_validation.cpp
@@ -17,16 +17,11 @@
 
 #include "gpuav/descriptor_validation/gpuav_descriptor_validation.h"
 
-#include "containers/custom_containers.h"
 #include "drawdispatch/descriptor_validator.h"
 #include "gpuav/core/gpuav.h"
 #include "gpuav/resources/gpuav_state_trackers.h"
-#include "gpuav/resources/gpuav_shader_resources.h"
+#include "gpuav/shaders/gpuav_shaders_constants.h"
 #include "state_tracker/pipeline_state.h"
-#include "state_tracker/shader_module.h"
-
-#include "profiling/profiling.h"
-#include "state_tracker/shader_object_state.h"
 
 namespace gpuav {
 namespace descriptor {

--- a/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
@@ -21,7 +21,7 @@
 #include "containers/small_vector.h"
 #include "gpuav/core/gpuav.h"
 #include "gpuav/error_message/gpuav_vuids.h"
-#include "gpuav/resources/gpuav_shader_resources.h"
+#include "gpuav/shaders/gpuav_shaders_constants.h"
 #include "gpuav/resources/gpuav_state_trackers.h"
 #include "gpuav/shaders/gpuav_error_header.h"
 #include "gpuav/debug_printf/debug_printf.h"

--- a/layers/gpuav/instrumentation/gpuav_instrumentation.h
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation.h
@@ -24,7 +24,6 @@
 #include <string>
 #include <vector>
 #include <optional>
-#include <memory>
 #include <limits>
 
 struct Location;

--- a/layers/gpuav/resources/gpuav_shader_resources.h
+++ b/layers/gpuav/resources/gpuav_shader_resources.h
@@ -19,11 +19,8 @@
 
 #pragma once
 
-#include <vector>
-
 #include "gpuav/descriptor_validation/gpuav_descriptor_set.h"
 #include "gpuav/shaders/gpuav_shaders_constants.h"
-#include "gpuav/resources/gpuav_vulkan_objects.h"
 
 namespace gpuav {
 

--- a/layers/gpuav/resources/gpuav_state_trackers.cpp
+++ b/layers/gpuav/resources/gpuav_state_trackers.cpp
@@ -17,7 +17,7 @@
 
 #include "gpuav/resources/gpuav_state_trackers.h"
 
-#include "gpuav/resources/gpuav_shader_resources.h"
+#include "gpuav/shaders/gpuav_shaders_constants.h"
 #include "gpuav/core/gpuav.h"
 #include "gpuav/core/gpuav_constants.h"
 #include "gpuav/descriptor_validation/gpuav_image_layout.h"

--- a/layers/gpuav/validation_cmd/gpuav_copy_buffer_to_image.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_copy_buffer_to_image.cpp
@@ -21,7 +21,6 @@
 #include "gpuav/validation_cmd/gpuav_validation_cmd_common.h"
 #include "gpuav/resources/gpuav_state_trackers.h"
 #include "gpuav/shaders/gpuav_error_header.h"
-#include "gpuav/shaders/gpuav_shaders_constants.h"
 #include "gpuav/shaders/validation_cmd/push_data.h"
 #include "generated/gpuav_offline_spirv.h"
 #include "containers/limits.h"

--- a/layers/gpuav/validation_cmd/gpuav_dispatch.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_dispatch.cpp
@@ -20,7 +20,6 @@
 #include "gpuav/validation_cmd/gpuav_validation_cmd_common.h"
 #include "gpuav/resources/gpuav_state_trackers.h"
 #include "gpuav/shaders/gpuav_error_header.h"
-#include "gpuav/shaders/gpuav_shaders_constants.h"
 #include "gpuav/shaders/validation_cmd/push_data.h"
 #include "generated/gpuav_offline_spirv.h"
 

--- a/layers/gpuav/validation_cmd/gpuav_draw.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_draw.cpp
@@ -20,17 +20,13 @@
 #include "gpuav/core/gpuav.h"
 #include "gpuav/core/gpuav_validation_pipeline.h"
 #include "gpuav/validation_cmd/gpuav_validation_cmd_common.h"
-#include "gpuav/error_message/gpuav_vuids.h"
 #include "gpuav/resources/gpuav_vulkan_objects.h"
 #include "gpuav/resources/gpuav_state_trackers.h"
 #include "gpuav/shaders/gpuav_error_header.h"
-#include "gpuav/shaders/gpuav_shaders_constants.h"
 
-#include "state_tracker/render_pass_state.h"
 #include "state_tracker/pipeline_state.h"
 #include "containers/limits.h"
 #include "gpuav/shaders/gpuav_error_header.h"
-#include "gpuav/shaders/gpuav_shaders_constants.h"
 #include "gpuav/shaders/validation_cmd/push_data.h"
 #include "generated/gpuav_offline_spirv.h"
 

--- a/tests/unit/debug_printf.cpp
+++ b/tests/unit/debug_printf.cpp
@@ -4811,6 +4811,71 @@ TEST_F(NegativeDebugPrintf, DescriptorTemplates) {
     m_errorMonitor->VerifyFound();
 }
 
+TEST_F(NegativeDebugPrintf, PushDescriptorTemplates) {
+    AddRequiredExtensions(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
+    RETURN_IF_SKIP(InitDebugPrintfFramework());
+    RETURN_IF_SKIP(InitState());
+
+    char const *shader_source = R"glsl(
+        #version 450
+        #extension GL_EXT_debug_printf : enable
+        layout(set = 0, binding = 0) uniform UBO {
+            uint value;
+        };
+        void main() {
+            debugPrintfEXT("value == %u", value);
+        }
+    )glsl";
+
+    vkt::Buffer buffer(*m_device, 8, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
+    auto buffer_ptr = (uint32_t *)buffer.Memory().Map();
+    buffer_ptr[0] = 42;
+
+    vkt::DescriptorSetLayout push_dsl(*m_device, {{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}},
+                                      VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT);
+    vkt::PipelineLayout pipeline_layout(*m_device, {&push_dsl});
+
+    struct SimpleTemplateData {
+        VkDescriptorBufferInfo buffer_info;
+    };
+
+    VkDescriptorUpdateTemplateEntry update_template_entry = {};
+    update_template_entry.dstBinding = 0;
+    update_template_entry.dstArrayElement = 0;
+    update_template_entry.descriptorCount = 1;
+    update_template_entry.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+    update_template_entry.offset = 0;
+    update_template_entry.stride = sizeof(SimpleTemplateData);
+
+    VkDescriptorUpdateTemplateCreateInfo update_template_ci = vku::InitStructHelper();
+    update_template_ci.descriptorUpdateEntryCount = 1;
+    update_template_ci.pDescriptorUpdateEntries = &update_template_entry;
+    update_template_ci.templateType = VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_PUSH_DESCRIPTORS;
+    update_template_ci.descriptorSetLayout = push_dsl;
+    update_template_ci.pipelineBindPoint = VK_PIPELINE_BIND_POINT_COMPUTE;
+    update_template_ci.pipelineLayout = pipeline_layout;
+
+    vkt::DescriptorUpdateTemplate update_template(*m_device, update_template_ci);
+
+    SimpleTemplateData update_template_data;
+    update_template_data.buffer_info = {buffer, 0, VK_WHOLE_SIZE};
+
+    CreateComputePipelineHelper pipe(*this);
+    pipe.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT);
+    pipe.cp_ci_.layout = pipeline_layout;
+    pipe.CreateComputePipeline();
+
+    m_command_buffer.Begin();
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    vk::CmdPushDescriptorSetWithTemplateKHR(m_command_buffer, update_template, pipeline_layout, 0, &update_template_data);
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_command_buffer.End();
+
+    m_errorMonitor->SetDesiredInfo("value == 42");
+    m_default_queue->SubmitAndWait(m_command_buffer);
+    m_errorMonitor->VerifyFound();
+}
+
 TEST_F(NegativeDebugPrintf, DuplicateMessageLimit) {
     TEST_DESCRIPTION("Default settings have a limit of 10, which we want to ignore");
     RETURN_IF_SKIP(InitDebugPrintfFramework());


### PR DESCRIPTION
GPU-AV never tracked the descriptors updated in `vkCmdPushDescriptorSetWithTemplate` (and variations) and would crash

This adds tests (and removes some recent include headers) to go with it