### PR TITLE
layers: Check dispatch in renderPass

### DIFF
--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -1295,6 +1295,8 @@ bool CoreChecks::ValidateActionState(const vvl::CommandBuffer &cb_state, const V
         }
 
     } else if (bind_point == VK_PIPELINE_BIND_POINT_COMPUTE) {
+        skip |= InsideRenderPass(cb_state, loc, vuid.compute_inside_rp_10672);
+
         if (!pipeline && !last_bound_state.IsValidShaderBound(ShaderObjectStage::COMPUTE)) {
             const bool is_null_bound = last_bound_state.IsValidShaderOrNullBound(ShaderObjectStage::COMPUTE);
             return LogError(

--- a/layers/drawdispatch/drawdispatch_vuids.cpp
+++ b/layers/drawdispatch/drawdispatch_vuids.cpp
@@ -1657,6 +1657,7 @@ struct DispatchVuidsCmdDispatch : DrawDispatchVuid {
         unprotected_command_buffer_02707         = "VUID-vkCmdDispatch-commandBuffer-02707";
         protected_command_buffer_02712           = "VUID-vkCmdDispatch-commandBuffer-02712";
         compute_not_bound_10743                  = "VUID-vkCmdDispatch-None-10743";
+        compute_inside_rp_10672                  = "VUID-vkCmdDispatch-None-10672";
         ray_query_04617                          = "VUID-vkCmdDispatch-commandBuffer-04617";
         img_filter_cubic_02693                   = "VUID-vkCmdDispatch-None-02693";
         filter_cubic_02694                       = "VUID-vkCmdDispatch-filterCubic-02694";
@@ -1706,6 +1707,7 @@ struct DispatchVuidsCmdDispatchIndirect : DrawDispatchVuid {
         dynamic_state_setting_commands_08608     = "VUID-vkCmdDispatchIndirect-None-08608";
         unprotected_command_buffer_02707         = "VUID-vkCmdDispatchIndirect-commandBuffer-02707";
         compute_not_bound_10743                  = "VUID-vkCmdDispatchIndirect-None-10743";
+        compute_inside_rp_10672                  = "VUID-vkCmdDispatchIndirect-None-10672";
         img_filter_cubic_02693                   = "VUID-vkCmdDispatchIndirect-None-02693";
         filter_cubic_02694                       = "VUID-vkCmdDispatchIndirect-filterCubic-02694";
         filter_cubic_min_max_02695               = "VUID-vkCmdDispatchIndirect-filterCubicMinmax-02695";
@@ -4274,6 +4276,7 @@ struct DispatchVuidsCmdDispatchBase: DrawDispatchVuid {
         dynamic_state_setting_commands_08608     = "VUID-vkCmdDispatchBase-None-08608";
         unprotected_command_buffer_02707         = "VUID-vkCmdDispatchBase-commandBuffer-02707";
         compute_not_bound_10743                  = "VUID-vkCmdDispatchBase-None-10743";
+        compute_inside_rp_10672                  = "VUID-vkCmdDispatchBase-None-10672";
         protected_command_buffer_02712           = "VUID-vkCmdDispatchBase-commandBuffer-02712";
         ray_query_04617                          = "VUID-vkCmdDispatchBase-commandBuffer-04617";
         img_filter_cubic_02693                   = "VUID-vkCmdDispatchBase-None-02693";

--- a/layers/drawdispatch/drawdispatch_vuids.h
+++ b/layers/drawdispatch/drawdispatch_vuids.h
@@ -74,6 +74,7 @@ struct DrawDispatchVuid {
     const char* unprotected_command_buffer_02707 = kVUIDUndefined;
     const char* protected_command_buffer_02712 = kVUIDUndefined;
     const char* compute_not_bound_10743 = kVUIDUndefined;
+    const char* compute_inside_rp_10672 = kVUIDUndefined;
     const char* ray_query_protected_cb_03635 = kVUIDUndefined;
     const char* ray_query_04617 = kVUIDUndefined;
     // TODO: Some instance values are in VkBuffer. The validation in those Cmds is skipped.

--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -751,6 +751,24 @@ TEST_F(NegativeCommand, DrawOutsideRenderPass) {
     m_errorMonitor->VerifyFound();
 }
 
+TEST_F(NegativeCommand, DispatchInsideRenderPass) {
+    TEST_DESCRIPTION("Only allowed with VK_QCOM_tile_shading");
+    RETURN_IF_SKIP(Init());
+    InitRenderTarget();
+
+    CreateComputePipelineHelper pipe(*this);
+    pipe.CreateComputePipeline();
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-None-10672");
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}
+
 TEST_F(NegativeCommand, MultiDrawDrawOutsideRenderPass) {
     AddRequiredExtensions(VK_EXT_MULTI_DRAW_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::multiDraw);


### PR DESCRIPTION
`VK_QCOM_tile_shading` added ability to dispatch in a renderpass, this VU was generated before, but now is explicit