### PR TITLE
layers: Fix crash when oob for descriptor updates

### DIFF
--- a/layers/state_tracker/descriptor_sets.cpp
+++ b/layers/state_tracker/descriptor_sets.cpp
@@ -28,6 +28,7 @@
 #include "state_tracker/shader_module.h"
 #include "state_tracker/state_tracker.h"
 #include "containers/limits.h"
+#include "utils/assert_utils.h"
 
 static vvl::DescriptorPool::TypeCountMap GetMaxTypeCounts(const VkDescriptorPoolCreateInfo *create_info) {
     vvl::DescriptorPool::TypeCountMap counts;
@@ -650,7 +651,7 @@ void vvl::DescriptorSet::PerformWriteUpdate(const VkWriteDescriptorSet &update) 
     // Perform update on a per-binding basis as consecutive updates roll over to next binding
     auto descriptors_remaining = update.descriptorCount;
     auto iter = FindDescriptor(update.dstBinding, update.dstArrayElement);
-    ASSERT_AND_RETURN(!iter.AtEnd());
+    ASSERT_AND_RETURN(!iter.AtEnd() && iter.IsValid());
     auto &orig_binding = iter.CurrentBinding();
 
     // Verify next consecutive binding matches type, stage flags & immutable sampler use and if AtEnd
@@ -675,6 +676,7 @@ void vvl::DescriptorSet::PerformWriteUpdate(const VkWriteDescriptorSet &update) 
 void vvl::DescriptorSet::PerformCopyUpdate(const VkCopyDescriptorSet &update, const DescriptorSet &src_set) {
     auto src_iter = src_set.FindDescriptor(update.srcBinding, update.srcArrayElement);
     auto dst_iter = FindDescriptor(update.dstBinding, update.dstArrayElement);
+    ASSERT_AND_RETURN(src_iter.IsValid() && dst_iter.IsValid());
     // Update parameters all look good so perform update
     for (uint32_t i = 0; i < update.descriptorCount; ++i, ++src_iter, ++dst_iter) {
         auto &src = *src_iter;

--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -944,20 +944,14 @@ class DescriptorSet : public StateObject, public SubStateManager<DescriptorSetSu
         DescriptorIterator &operator=(const DescriptorIterator &rhs) = default;
 
         DescriptorIterator(DescriptorSet &descriptor_set, uint32_t binding, uint32_t index = 0)
-            : iter_(descriptor_set.FindBinding(binding)), end_(descriptor_set.end()), index_(index) {
-            if (!AtEnd()) {
-                assert(index_ < (*iter_)->count);
-            }
-        }
+            : iter_(descriptor_set.FindBinding(binding)), end_(descriptor_set.end()), index_(index) {}
 
         DescriptorIterator(const DescriptorSet &descriptor_set, uint32_t binding, uint32_t index = 0)
-            : iter_(descriptor_set.FindBinding(binding)), end_(descriptor_set.end()), index_(index) {
-            if (!AtEnd()) {
-                assert(index_ < (*iter_)->count);
-            }
-        }
+            : iter_(descriptor_set.FindBinding(binding)), end_(descriptor_set.end()), index_(index) {}
 
         bool AtEnd() const { return iter_ == end_; }
+
+        bool IsValid() const { return *iter_ && index_ < (*iter_)->count; }
 
         bool operator==(const DescriptorIterator &rhs) { return (iter_ == rhs.iter_) && (index_ == rhs.index_); }
 


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10151

Added tests that blew things up

The issue is there is 2 ways to get OOB

1. The `srcArrayElement`/`dstArrayElement` is just too large
2. `descriptorCount` goes over

This makes the few spots calling `FindDescriptor()` all consistent 