### PR TITLE
layers: Update VUID from 316 spec

### DIFF
--- a/layers/stateless/sl_spirv.cpp
+++ b/layers/stateless/sl_spirv.cpp
@@ -661,8 +661,7 @@ bool SpirvValidator::ValidateRelaxedExtendedInstruction(const spirv::Module &mod
                                                         const spirv::StatelessData &stateless_data, const Location &loc) const {
     bool skip = false;
     if (!enabled_features.shaderRelaxedExtendedInstruction && stateless_data.has_ext_inst_with_forward_refs) {
-        // VUID being added in https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/7336
-        skip |= LogError("UNASSIGNED-RuntimeSpirv-shaderRelaxedExtendedInstruction", module_state.handle(), loc,
+        skip |= LogError("VUID-RuntimeSpirv-shaderRelaxedExtendedInstruction-10773", module_state.handle(), loc,
                          "SPIR-V uses OpExtInstWithForwardRefsKHR but shaderRelaxedExtendedInstruction was not enabled.\nWhen "
                          "using VK_KHR_shader_non_semantic_info (how you can map SPIR-V back to your source language) this "
                          "instruction is required when dealing with forward reference to a pointer.");

--- a/tests/unit/shader_spirv.cpp
+++ b/tests/unit/shader_spirv.cpp
@@ -2754,7 +2754,7 @@ TEST_F(NegativeShaderSpirv, ShaderRelaxedExtendedInstruction) {
                OpFunctionEnd
         )";
 
-    m_errorMonitor->SetDesiredError("UNASSIGNED-RuntimeSpirv-shaderRelaxedExtendedInstruction");
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-shaderRelaxedExtendedInstruction-10773");
     VkShaderObj cs(this, spv_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
     m_errorMonitor->VerifyFound();
 }


### PR DESCRIPTION
Adds `VUID-RuntimeSpirv-shaderRelaxedExtendedInstruction-10773` (for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9905)