### PR TITLE
layers: Fix null indexed buffer

### DIFF
--- a/layers/gpuav/resources/gpuav_state_trackers.h
+++ b/layers/gpuav/resources/gpuav_state_trackers.h
@@ -125,7 +125,7 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     using ErrorLoggerFunc =
         stdext::inplace_function<bool(const uint32_t *error_record, const LogObjectList &objlist,
                                       const std::vector<std::string> &initial_label_stack),
-                                 280 /*lambda storage size (bytes), large enough to store biggest error lambda*/>;
+                                 288 /*lambda storage size (bytes), large enough to store biggest error lambda*/>;
     std::vector<ErrorLoggerFunc> per_command_error_loggers;
     vvl::unordered_map<uint32_t, uint32_t> action_cmd_i_to_label_cmd_i_map;
 

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -2861,10 +2861,13 @@ void DeviceState::PostCallRecordCmdPushConstants2KHR(VkCommandBuffer commandBuff
 
 void DeviceState::PostCallRecordCmdBindIndexBuffer(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                    VkIndexType indexType, const RecordObject &record_obj) {
-    if (buffer == VK_NULL_HANDLE) {
-        return;  // allowed in maintenance6
-    }
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
+    if (buffer == VK_NULL_HANDLE) {
+        if (enabled_features.maintenance6) {
+            cb_state->index_buffer_binding.bound = true;
+        }
+        return;
+    }
 
     auto buffer_state = Get<Buffer>(buffer);
     // Being able to set the size was added in VK_KHR_maintenance5 via vkCmdBindIndexBuffer2KHR
@@ -2880,10 +2883,13 @@ void DeviceState::PostCallRecordCmdBindIndexBuffer(VkCommandBuffer commandBuffer
 
 void DeviceState::PostCallRecordCmdBindIndexBuffer2(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                     VkDeviceSize size, VkIndexType indexType, const RecordObject &record_obj) {
-    if (buffer == VK_NULL_HANDLE) {
-        return;  // allowed in maintenance6
-    }
     auto cb_state = GetWrite<CommandBuffer>(commandBuffer);
+    if (buffer == VK_NULL_HANDLE) {
+        if (enabled_features.maintenance6) {
+            cb_state->index_buffer_binding.bound = true;
+        }
+        return;
+    }
 
     auto buffer_state = Get<Buffer>(buffer);
     VkDeviceSize buffer_size = Buffer::GetRegionSize(buffer_state, offset, size);

--- a/layers/state_tracker/vertex_index_buffer_state.h
+++ b/layers/state_tracker/vertex_index_buffer_state.h
@@ -42,14 +42,17 @@ struct VertexBufferBinding {
 };
 
 struct IndexBufferBinding {
-    VkBuffer buffer;  // VK_NULL_HANDLE is valid if using nullDescriptor
+    // buffer might be VK_NULL_HANDLE because it was set or by default, we need to actually know if the command buffer binds or not
+    bool bound;
+
+    VkBuffer buffer;  // VK_NULL_HANDLE is valid if using maintenance6
     VkDeviceSize size;
     VkDeviceSize offset;
     VkIndexType index_type;
 
-    IndexBufferBinding() : buffer(VK_NULL_HANDLE), size(0), offset(0), index_type(static_cast<VkIndexType>(0)) {}
+    IndexBufferBinding() : bound(false), buffer(VK_NULL_HANDLE), size(0), offset(0), index_type(static_cast<VkIndexType>(0)) {}
     IndexBufferBinding(VkBuffer buffer_, VkDeviceSize size_, VkDeviceSize offset_, VkIndexType index_type_)
-        : buffer(buffer_), size(size_), offset(offset_), index_type(index_type_) {}
+        : bound(true), buffer(buffer_), size(size_), offset(offset_), index_type(index_type_) {}
 
     void reset() { *this = IndexBufferBinding(); }
 };

--- a/tests/unit/buffer_positive.cpp
+++ b/tests/unit/buffer_positive.cpp
@@ -196,8 +196,6 @@ TEST_F(PositiveBuffer, IndexBufferNull) {
     m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
-    vk::CmdDrawIndexed(m_command_buffer, 0, 1, 0, 0, 0);
-
     vk::CmdBindIndexBuffer(m_command_buffer, VK_NULL_HANDLE, 0, VK_INDEX_TYPE_UINT32);
     vk::CmdDrawIndexed(m_command_buffer, 0, 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10177

We have a `bool bound` for vertex buffer, but didn't for index buffer and would fail to catch cases where you had `maintenance6` enabled, but still didn't call `vkCmdBindIndexBuffer`

basically
- `vkCmdBindIndexBuffer(VK_NULL_HANDLE)`  with `maintenance6` :heavy_check_mark:
- `vkCmdBindIndexBuffer(VK_NULL_HANDLE)`  without `maintenance6` 🙅 (` VUID-vkCmdBindIndexBuffer-None-09493`)
- no `vkCmdBindIndexBuffer` with `maintenance6` 🙅 (`VUID-vkCmdDrawIndexed-None-07312`)