### PR TITLE
layers: Improve error message for copies

### DIFF
--- a/layers/core_checks/cc_copy_blit_resolve.cpp
+++ b/layers/core_checks/cc_copy_blit_resolve.cpp
@@ -522,9 +522,9 @@ bool CoreChecks::ValidateHeterogeneousCopyData(const RegionType &region, const v
                              "(%" PRIu32
                              ") must be a multiple of the image format (%s) texel block width "
                              "(%" PRIu32 "), or when added to imageOffset.x (%" PRId32
-                             ") must equal the image subresource width (%" PRIu32 ").",
+                             ") must equal the image subresource width (%" PRIu32 ").\n%s",
                              region.imageExtent.width, string_VkFormat(image_format), block_extent.width, region.imageOffset.x,
-                             effective_image_extent.width);
+                             effective_image_extent.width, image_state.DescribeSubresourceLayers(region.imageSubresource).c_str());
         } else if ((SafeModulo(region.imageExtent.height, block_extent.height) != 0) &&
                    (region.imageExtent.height + region.imageOffset.y != effective_image_extent.height)) {
             skip |= LogError(GetCopyBufferImageVUID(region_loc, vvl::CopyError::TexelBlockExtentHeight_00208), objlist,
@@ -532,9 +532,9 @@ bool CoreChecks::ValidateHeterogeneousCopyData(const RegionType &region, const v
                              "(%" PRIu32
                              ") must be a multiple of the image format (%s) texel block height "
                              "(%" PRIu32 "), or when added to imageOffset.y (%" PRId32
-                             ") must equal the image subresource height (%" PRIu32 ").",
+                             ") must equal the image subresource height (%" PRIu32 ").\n%s",
                              region.imageExtent.height, string_VkFormat(image_format), block_extent.height, region.imageOffset.y,
-                             effective_image_extent.height);
+                             effective_image_extent.height, image_state.DescribeSubresourceLayers(region.imageSubresource).c_str());
         } else if ((SafeModulo(region.imageExtent.depth, block_extent.depth) != 0) &&
                    (region.imageExtent.depth + region.imageOffset.z != effective_image_extent.depth)) {
             skip |= LogError(GetCopyBufferImageVUID(region_loc, vvl::CopyError::TexelBlockExtentDepth_00209), objlist,
@@ -542,9 +542,9 @@ bool CoreChecks::ValidateHeterogeneousCopyData(const RegionType &region, const v
                              "(%" PRIu32
                              ") must be a multiple of the image format (%s) texel block depth "
                              "(%" PRIu32 "), or when added to imageOffset.z (%" PRId32
-                             ") must equal the image subresource depth (%" PRIu32 ").",
+                             ") must equal the image subresource depth (%" PRIu32 ").\n%s",
                              region.imageExtent.depth, string_VkFormat(image_format), block_extent.depth, region.imageOffset.z,
-                             effective_image_extent.depth);
+                             effective_image_extent.depth, image_state.DescribeSubresourceLayers(region.imageSubresource).c_str());
         }
 
         if (SafeModulo(region.imageOffset.x, block_extent.width) != 0) {

--- a/tests/unit/copy_buffer_image_positive.cpp
+++ b/tests/unit/copy_buffer_image_positive.cpp
@@ -1109,6 +1109,38 @@ TEST_F(PositiveCopyBufferImage, DISABLED_CopyCompressToCompress) {
     m_command_buffer.End();
 }
 
+TEST_F(PositiveCopyBufferImage, CopyBufferToCompressedNonFullTexelBlock) {
+    RETURN_IF_SKIP(Init());
+
+    VkImageCreateInfo image_ci = vku::InitStructHelper();
+    image_ci.imageType = VK_IMAGE_TYPE_2D;
+    image_ci.format = VK_FORMAT_BC1_RGBA_UNORM_BLOCK;
+    image_ci.extent = {22u, 22u, 1u};
+    image_ci.mipLevels = 3u;
+    image_ci.arrayLayers = 3u;
+    image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
+    image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
+    image_ci.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+    image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    if (!ImageFormatIsSupported(instance(), Gpu(), image_ci, VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
+        GTEST_SKIP() << "image format not supported";
+    }
+    vkt::Image dst_image(*m_device, image_ci);
+    vkt::Buffer buffer(*m_device, 4096, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
+
+    VkBufferImageCopy buffer_image_copy;
+    buffer_image_copy.bufferOffset = 0u;
+    buffer_image_copy.bufferRowLength = 24u;
+    buffer_image_copy.bufferImageHeight = 24u;
+    buffer_image_copy.imageSubresource = {1u, 0u, 0u, 1u};
+    buffer_image_copy.imageOffset = {0, 0, 0};
+    buffer_image_copy.imageExtent = {22u, 22u, 1u};
+
+    m_command_buffer.Begin();
+    vk::CmdCopyBufferToImage(m_command_buffer, buffer, dst_image, VK_IMAGE_LAYOUT_GENERAL, 1u, &buffer_image_copy);
+    m_command_buffer.End();
+}
+
 TEST_F(PositiveCopyBufferImage, CopyBufferToCompressedMipLevels) {
     RETURN_IF_SKIP(Init());
 


### PR DESCRIPTION
missed `DescribeSubresourceLayers` for one group of checks and added tests @ziga-lunarg gave me to reproduce