### PR TITLE
tests: More shader interface tests

### DIFF
--- a/tests/unit/shader_interface.cpp
+++ b/tests/unit/shader_interface.cpp
@@ -1712,6 +1712,22 @@ TEST_F(NegativeShaderInterface, PackingInsideArray2) {
     m_errorMonitor->VerifyFound();
 }
 
+TEST_F(NegativeShaderInterface, PackingInsideArray3) {
+    TEST_DESCRIPTION("From https://gitlab.khronos.org/vulkan/vulkan/-/issues/3558");
+    RETURN_IF_SKIP(Init());
+
+    char const *vsSource = R"glsl(
+        #version 450
+        layout(location = 0, component = 0) out float x;
+        layout(location = 0, component = 1) out float[2] y;
+        void main() {}
+    )glsl";
+
+    m_errorMonitor->SetDesiredError("VUID-StandaloneSpirv-OpEntryPoint-08722");
+    VkShaderObj vs(this, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
+    m_errorMonitor->VerifyFound();
+}
+
 // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9616
 TEST_F(NegativeShaderInterface, DISABLED_FragmentOutputNotWritten) {
     TEST_DESCRIPTION(

--- a/tests/unit/shader_interface_positive.cpp
+++ b/tests/unit/shader_interface_positive.cpp
@@ -1472,3 +1472,28 @@ TEST_F(PositiveShaderInterface, FragmentOutputDynamicRenderingUnusedAttachments)
     m_command_buffer.EndRendering();
     m_command_buffer.End();
 }
+
+TEST_F(PositiveShaderInterface, NonZeroComponentArray) {
+    TEST_DESCRIPTION("From https://gitlab.khronos.org/vulkan/vulkan/-/issues/3558");
+    RETURN_IF_SKIP(Init());
+    InitRenderTarget();
+
+    char const *vsSource = R"glsl(
+        #version 450
+        layout(location = 0, component = 1) out float[2] x;
+        void main() {}
+    )glsl";
+
+    char const *fsSource = R"glsl(
+        #version 450
+        layout(location = 0, component = 1) in float[2] x;
+        layout(location=0) out float color;
+        void main(){}
+    )glsl";
+
+    VkShaderObj vs(this, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
+    VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
+    CreatePipelineHelper pipe(*this);
+    pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
+    pipe.CreateGraphicsPipeline();
+}


### PR DESCRIPTION
Basically wanted to confirm (didn't have tests) that this is legal

![Untitled Diagram drawio](https://github.com/user-attachments/assets/c900d968-98b2-406a-ab93-d90ba8b0986a)

but this is still not (until future spec changes are made)

![Untitled Diagram drawio (2)](https://github.com/user-attachments/assets/a63682a6-f7a8-4a1d-b9d2-5f42afbd19cb)
