### PR TITLE
tests: Make semaphore type parameter mandatory

### DIFF
--- a/tests/framework/external_memory_sync.cpp
+++ b/tests/framework/external_memory_sync.cpp
@@ -217,13 +217,17 @@ bool HandleTypeNeedsDedicatedAllocation(VkPhysicalDevice gpu, const VkImageCreat
     return (external_features & VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT) != 0;
 }
 
-bool SemaphoreExportImportSupported(VkPhysicalDevice gpu, VkExternalSemaphoreHandleTypeFlagBits handle_type, void *p_next) {
+bool SemaphoreExportImportSupported(VkPhysicalDevice gpu, VkSemaphoreType semaphore_type,
+                                    VkExternalSemaphoreHandleTypeFlagBits handle_type) {
     constexpr auto export_import_flags =
         VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT | VK_EXTERNAL_SEMAPHORE_FEATURE_IMPORTABLE_BIT;
 
-    VkPhysicalDeviceExternalSemaphoreInfo info = vku::InitStructHelper(p_next);
-    info.handleType = handle_type;
+    VkSemaphoreTypeCreateInfo type_info = vku::InitStructHelper();
+    type_info.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
+
+    VkPhysicalDeviceExternalSemaphoreInfo external_info = vku::InitStructHelper(&type_info);
+    external_info.handleType = handle_type;
     VkExternalSemaphoreProperties properties = vku::InitStructHelper();
-    vk::GetPhysicalDeviceExternalSemaphoreProperties(gpu, &info, &properties);
+    vk::GetPhysicalDeviceExternalSemaphoreProperties(gpu, &external_info, &properties);
     return (properties.externalSemaphoreFeatures & export_import_flags) == export_import_flags;
 }

--- a/tests/framework/external_memory_sync.h
+++ b/tests/framework/external_memory_sync.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 Valve Corporation
- * Copyright (c) 2023-2024 LunarG, Inc.
+ * Copyright (c) 2023-2025 Valve Corporation
+ * Copyright (c) 2023-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,5 +44,5 @@ bool HandleTypeNeedsDedicatedAllocation(VkPhysicalDevice gpu, const VkBufferCrea
 bool HandleTypeNeedsDedicatedAllocation(VkPhysicalDevice gpu, const VkImageCreateInfo &image_create_info,
                                         VkExternalMemoryHandleTypeFlagBits handle_type);
 
-bool SemaphoreExportImportSupported(VkPhysicalDevice gpu, VkExternalSemaphoreHandleTypeFlagBits handle_type,
-                                    void *p_next = nullptr);
+bool SemaphoreExportImportSupported(VkPhysicalDevice gpu, VkSemaphoreType semaphore_type,
+                                    VkExternalSemaphoreHandleTypeFlagBits handle_type);

--- a/tests/unit/external_memory_sync_positive.cpp
+++ b/tests/unit/external_memory_sync_positive.cpp
@@ -653,13 +653,12 @@ TEST_F(PositiveExternalMemorySync, BinarySyncDependsOnExternalTimelineSignal) {
     AddRequiredFeature(vkt::Feature::timelineSemaphore);
     RETURN_IF_SKIP(Init());
 
-    VkSemaphoreTypeCreateInfo semaphore_type_ci = vku::InitStructHelper();
-    semaphore_type_ci.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
-
-    // NOTE: external semaphore support depends on semaphore type so need to provide VkSemaphoreTypeCreateInfo here!
-    if (!SemaphoreExportImportSupported(Gpu(), handle_type, &semaphore_type_ci)) {
+    if (!SemaphoreExportImportSupported(Gpu(), VK_SEMAPHORE_TYPE_TIMELINE, handle_type)) {
         GTEST_SKIP() << "Semaphore does not support export and import through opaque handle";
     }
+
+    VkSemaphoreTypeCreateInfo semaphore_type_ci = vku::InitStructHelper();
+    semaphore_type_ci.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
 
     VkExportSemaphoreCreateInfo export_info = vku::InitStructHelper(&semaphore_type_ci);
     export_info.handleTypes = handle_type;

--- a/tests/unit/object_lifetime.cpp
+++ b/tests/unit/object_lifetime.cpp
@@ -1138,7 +1138,7 @@ TEST_F(NegativeObjectLifetime, ImportFdSemaphoreInUse) {
     AddRequiredExtensions(VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     constexpr auto handle_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
-    if (!SemaphoreExportImportSupported(Gpu(), handle_type)) {
+    if (!SemaphoreExportImportSupported(Gpu(), VK_SEMAPHORE_TYPE_BINARY, handle_type)) {
         GTEST_SKIP() << "Semaphore does not support export and import through fd handle";
     }
 
@@ -1171,7 +1171,7 @@ TEST_F(NegativeObjectLifetime, ImportWin32SemaphoreInUse) {
     AddRequiredExtensions(VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     constexpr auto handle_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT;
-    if (!SemaphoreExportImportSupported(Gpu(), handle_type)) {
+    if (!SemaphoreExportImportSupported(Gpu(), VK_SEMAPHORE_TYPE_BINARY, handle_type)) {
         GTEST_SKIP() << "Semaphore does not support export and import through Win32 handle";
     }
 

--- a/tests/unit/sync_object.cpp
+++ b/tests/unit/sync_object.cpp
@@ -5100,7 +5100,7 @@ TEST_F(NegativeSyncObject, TimelineSemaphoreAndExportedCopyCooperation) {
     if (!m_second_queue) {
         GTEST_SKIP() << "Two queues are needed";
     }
-    if (!SemaphoreExportImportSupported(Gpu(), handle_type)) {
+    if (!SemaphoreExportImportSupported(Gpu(), VK_SEMAPHORE_TYPE_TIMELINE, handle_type)) {
         GTEST_SKIP() << "Semaphore does not support export and import through opaque handle";
     }
 

--- a/tests/unit/sync_object_positive.cpp
+++ b/tests/unit/sync_object_positive.cpp
@@ -1546,15 +1546,15 @@ TEST_F(PositiveSyncObject, WaitTimelineSemaphoreWithWin32HandleRetrieved) {
     }
     constexpr auto handle_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT;
 
-    VkSemaphoreTypeCreateInfo semaphore_type_create_info = vku::InitStructHelper();
-    semaphore_type_create_info.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
-    semaphore_type_create_info.initialValue = 0;
-
-    if (!SemaphoreExportImportSupported(Gpu(), handle_type, &semaphore_type_create_info)) {
+    if (!SemaphoreExportImportSupported(Gpu(), VK_SEMAPHORE_TYPE_TIMELINE, handle_type)) {
         GTEST_SKIP() << "Semaphore does not support export and import through Win32 handle";
     }
 
     // Create exportable timeline semaphore
+    VkSemaphoreTypeCreateInfo semaphore_type_create_info = vku::InitStructHelper();
+    semaphore_type_create_info.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
+    semaphore_type_create_info.initialValue = 0;
+
     VkExportSemaphoreCreateInfo export_info = vku::InitStructHelper(&semaphore_type_create_info);
     export_info.handleTypes = handle_type;
 
@@ -2121,7 +2121,7 @@ TEST_F(PositiveSyncObject, GetCounterValueOfExportedSemaphore) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
     constexpr auto handle_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT;
-    if (!SemaphoreExportImportSupported(Gpu(), handle_type)) {
+    if (!SemaphoreExportImportSupported(Gpu(), VK_SEMAPHORE_TYPE_TIMELINE, handle_type)) {
         GTEST_SKIP() << "Semaphore does not support export and import through Win32 handle";
     }
 
@@ -2158,7 +2158,7 @@ TEST_F(PositiveSyncObject, GetCounterValueOfExportedSemaphore2) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
     constexpr auto handle_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT;
-    if (!SemaphoreExportImportSupported(Gpu(), handle_type)) {
+    if (!SemaphoreExportImportSupported(Gpu(), VK_SEMAPHORE_TYPE_TIMELINE, handle_type)) {
         GTEST_SKIP() << "Semaphore does not support export and import through Win32 handle";
     }
 
@@ -2633,7 +2633,7 @@ TEST_F(PositiveSyncObject, TimelineSemaphoreAndExportedCopyCooperation) {
     if (!m_second_queue) {
         GTEST_SKIP() << "Two queues are needed";
     }
-    if (!SemaphoreExportImportSupported(Gpu(), handle_type)) {
+    if (!SemaphoreExportImportSupported(Gpu(), VK_SEMAPHORE_TYPE_TIMELINE, handle_type)) {
         GTEST_SKIP() << "Semaphore does not support export and import through opaque handle";
     }
 
@@ -2684,7 +2684,7 @@ TEST_F(PositiveSyncObject, TimelineSemaphoreAndExportedCopyCooperation2) {
     if (!m_second_queue) {
         GTEST_SKIP() << "Two queues are needed";
     }
-    if (!SemaphoreExportImportSupported(Gpu(), handle_type)) {
+    if (!SemaphoreExportImportSupported(Gpu(), VK_SEMAPHORE_TYPE_TIMELINE, handle_type)) {
         GTEST_SKIP() << "Semaphore does not support export and import through opaque handle";
     }
 

--- a/tests/unit/sync_val_semaphore_positive.cpp
+++ b/tests/unit/sync_val_semaphore_positive.cpp
@@ -627,7 +627,7 @@ TEST_F(PositiveSyncValTimelineSemaphore, ExternalSemaphoreWaitBeforeSignal) {
     }
 
     constexpr auto handle_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT;
-    if (!SemaphoreExportImportSupported(Gpu(), handle_type)) {
+    if (!SemaphoreExportImportSupported(Gpu(), VK_SEMAPHORE_TYPE_TIMELINE, handle_type)) {
         GTEST_SKIP() << "Semaphore does not support export and import through Win32 handle";
     }
 


### PR DESCRIPTION
`GetPhysicalDeviceExternalSemaphoreProperties` reports based on semaphore type. Currently we have several tests that specify wrong type and still pass because they are lucky. Sometimes this does not work. I did this mistake at least two times and it was quite hard to figure out what's going on.

At the moment of writing ARM drivers report different support depending on semaphore type.