### PR TITLE
gpuav: Add missing NotifyUpdate

### DIFF
--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -850,6 +850,7 @@ class DescriptorSet : public StateObject, public SubStateManager<DescriptorSetSu
     // Return true if given binding is present in this set
     bool HasBinding(const uint32_t binding) const { return layout_->HasBinding(binding); };
 
+    void NotifyUpdate();
     // Perform a push update whose contents were just validated using ValidatePushDescriptorsUpdate
     virtual void PerformPushDescriptorsUpdate(uint32_t write_count, const VkWriteDescriptorSet *write_descs);
     // Perform a WriteUpdate whose contents were just validated using ValidateWriteUpdate


### PR DESCRIPTION
found in https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/9651 we missed adding back `NotifyUpdate()` and since then, if you re-updated your descriptor set we never were updating the buffer in GPU-AV 