### PR TITLE
layers: Add missing state to DestroyObjectMaps

### DIFF
--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -923,8 +923,12 @@ void DeviceState::DestroyObjectMaps() {
     command_pool_map_.clear();
     assert(command_buffer_map_.empty());
     pipeline_map_.clear();
+    pipeline_cache_map_.clear();
+    pipeline_layout_map_.clear();
     shader_object_map_.clear();
     render_pass_map_.clear();
+    shader_module_map_.clear();
+    frame_buffer_map_.clear();
 
     // This will also delete all sets in the pool & remove them from setMap
     descriptor_pool_map_.clear();
@@ -943,11 +947,25 @@ void DeviceState::DestroyObjectMaps() {
     image_map_.clear();
     buffer_view_map_.clear();
     buffer_map_.clear();
+    sampler_map_.clear();
+    sampler_ycbcr_conversion_map_.clear();
+    acceleration_structure_nv_map_.clear();
+    acceleration_structure_khr_map_.clear();
+    mem_obj_map_.clear();
+
     // Queues persist until device is destroyed
     for (auto &entry : queue_map_.snapshot()) {
         entry.second->Destroy();
     }
     queue_map_.clear();
+    fence_map_.clear();
+    semaphore_map_.clear();
+    event_map_.clear();
+    indirect_execution_set_ext_map_.clear();
+    indirect_commands_layout_ext_map_.clear();
+    query_pool_map_.clear();
+    video_session_map_.clear();
+    video_session_parameters_map_.clear();
 }
 
 void DeviceState::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks *pAllocator,

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -1971,7 +1971,6 @@ class DeviceState : public vvl::base::Device {
 
   private:
     VALSTATETRACK_MAP_AND_TRAITS(VkQueue, vvl::Queue, queue_map_)
-    VALSTATETRACK_MAP_AND_TRAITS(VkAccelerationStructureNV, vvl::AccelerationStructureNV, acceleration_structure_nv_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkRenderPass, vvl::RenderPass, render_pass_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkDescriptorSetLayout, vvl::DescriptorSetLayout, descriptor_set_layout_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkSampler, vvl::Sampler, sampler_map_)
@@ -1999,9 +1998,11 @@ class DeviceState : public vvl::base::Device {
     VALSTATETRACK_MAP_AND_TRAITS(VkSamplerYcbcrConversion, vvl::SamplerYcbcrConversion, sampler_ycbcr_conversion_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkVideoSessionKHR, vvl::VideoSession, video_session_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkVideoSessionParametersKHR, vvl::VideoSessionParameters, video_session_parameters_map_)
+    VALSTATETRACK_MAP_AND_TRAITS(VkAccelerationStructureNV, vvl::AccelerationStructureNV, acceleration_structure_nv_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkAccelerationStructureKHR, vvl::AccelerationStructureKHR, acceleration_structure_khr_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkIndirectExecutionSetEXT, vvl::IndirectExecutionSet, indirect_execution_set_ext_map_)
     VALSTATETRACK_MAP_AND_TRAITS(VkIndirectCommandsLayoutEXT, vvl::IndirectCommandsLayout, indirect_commands_layout_ext_map_)
+    // When adding a new state tracker, make sure to add to DestroyObjectMaps()
 
     // For state objects that have sub states.  Requires the definition of DeviceProxy, which is below.
     template <typename State, std::enable_if_t<HasSubStates<State>::value, bool> = true>

--- a/tests/unit/object_lifetime.cpp
+++ b/tests/unit/object_lifetime.cpp
@@ -1291,6 +1291,22 @@ TEST_F(NegativeObjectLifetime, LeakABuffer) {
     m_errorMonitor->SetUnexpectedError("VUID-vkDestroyInstance-instance-00629");
 }
 
+TEST_F(NegativeObjectLifetime, LeakImageAndSampler) {
+    RETURN_IF_SKIP(Init());
+
+    VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
+    VkSampler sampler;
+    vk::CreateSampler(device(), &sampler_ci, nullptr, &sampler);
+
+    VkImageCreateInfo image_ci =
+        vkt::Image::ImageCreateInfo2D(32, 32, 1, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    VkImage image;
+    vk::CreateImage(device(), &image_ci, nullptr, &image);
+
+    m_errorMonitor->SetUnexpectedError("VUID-vkDestroyDevice-device-05137");
+    m_errorMonitor->SetUnexpectedError("VUID-vkDestroyDevice-device-05137");
+}
+
 TEST_F(NegativeObjectLifetime, FreeCommandBuffersNull) {
     TEST_DESCRIPTION("Can pass NULL for vkFreeCommandBuffers");
     RETURN_IF_SKIP(Init());


### PR DESCRIPTION
noticed that `DestroyObjectMaps()` was missing clearing some state tracking

the only things that would happen is between creating/destroying devices we would could have ever growing state tracking for the things missing