### PR TITLE
Reduce redundant look ups at drawtime

### DIFF
--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -611,9 +611,11 @@ bool CoreChecks::PreCallValidateCmdDrawIndirectCount(VkCommandBuffer commandBuff
                          "call this command.");
     }
 
-    auto count_buffer_state = Get<vvl::Buffer>(countBuffer);
-    ASSERT_AND_RETURN_SKIP(count_buffer_state);
-    skip |= ValidateIndirectCountCmd(cb_state, *count_buffer_state, countBufferOffset, vuid);
+    {
+        auto count_buffer_state = Get<vvl::Buffer>(countBuffer);
+        ASSERT_AND_RETURN_SKIP(count_buffer_state);
+        skip |= ValidateIndirectCountCmd(cb_state, *count_buffer_state, countBufferOffset, vuid);
+    }
 
     {
         auto indirect_buffer_state = Get<vvl::Buffer>(buffer);
@@ -667,9 +669,12 @@ bool CoreChecks::PreCallValidateCmdDrawIndexedIndirectCount(VkCommandBuffer comm
                          "call this command.");
     }
 
-    auto count_buffer_state = Get<vvl::Buffer>(countBuffer);
-    ASSERT_AND_RETURN_SKIP(count_buffer_state);
-    skip |= ValidateIndirectCountCmd(cb_state, *count_buffer_state, countBufferOffset, vuid);
+    {
+        auto count_buffer_state = Get<vvl::Buffer>(countBuffer);
+        ASSERT_AND_RETURN_SKIP(count_buffer_state);
+        skip |= ValidateIndirectCountCmd(cb_state, *count_buffer_state, countBufferOffset, vuid);
+    }
+
     {
         const auto index_buffer_state = Get<vvl::Buffer>(cb_state.index_buffer_binding.buffer);
         skip |= ValidateGraphicsIndexedCmd(cb_state, index_buffer_state.get(), vuid);
@@ -1154,8 +1159,11 @@ bool CoreChecks::PreCallValidateCmdDrawMeshTasksIndirectCountNV(VkCommandBuffer 
                          "(%" PRIu64 "), is not a multiple of 4.", countBufferOffset);
     }
 
-    auto count_buffer_state = Get<vvl::Buffer>(countBuffer);
-    ASSERT_AND_RETURN_SKIP(count_buffer_state);
+    {
+        auto count_buffer_state = Get<vvl::Buffer>(countBuffer);
+        ASSERT_AND_RETURN_SKIP(count_buffer_state);
+        skip |= ValidateIndirectCountCmd(cb_state, *count_buffer_state, countBufferOffset, vuid);
+    }
 
     {
         auto indirect_buffer_state = Get<vvl::Buffer>(buffer);
@@ -1173,7 +1181,6 @@ bool CoreChecks::PreCallValidateCmdDrawMeshTasksIndirectCountNV(VkCommandBuffer 
         }
     }
 
-    skip |= ValidateIndirectCountCmd(cb_state, *count_buffer_state, countBufferOffset, vuid);
     return skip;
 }
 

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -434,7 +434,7 @@ class CoreChecks : public vvl::DeviceProxy {
     bool ValidateCmdEndQuery(const vvl::CommandBuffer& cb_state, VkQueryPool queryPool, uint32_t slot, uint32_t index,
                              const Location& loc) const;
 
-    bool ValidateCmdDrawInstance(const vvl::CommandBuffer& cb_state, uint32_t instanceCount, uint32_t firstInstance,
+    bool ValidateCmdDrawInstance(const LastBound& last_bound_state, uint32_t instanceCount, uint32_t firstInstance,
                                  const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateGraphicsIndexedCmd(const vvl::CommandBuffer& cb_state, const vvl::Buffer* index_buffer_state,
                                     const vvl::DrawDispatchVuid& vuid) const;
@@ -715,8 +715,7 @@ class CoreChecks : public vvl::DeviceProxy {
     bool ValidateDrawShaderObjectLinking(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateDrawShaderObjectPushConstantAndLayout(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateDrawShaderObjectMesh(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
-    bool ValidateActionState(const vvl::CommandBuffer& cb_state, const VkPipelineBindPoint bind_point,
-                             const vvl::DrawDispatchVuid& vuid) const;
+    bool ValidateActionState(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateActionStateDescriptorsPipeline(const LastBound& last_bound_state, const VkPipelineBindPoint bind_point,
                                                 const vvl::Pipeline& pipeline, const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateActionStateDescriptorsShaderObject(const LastBound& last_bound_state, const VkPipelineBindPoint bind_point,
@@ -1438,7 +1437,7 @@ class CoreChecks : public vvl::DeviceProxy {
     bool ValidateRaytracingShaderBindingTable(const vvl::CommandBuffer& cb_state, const Location& table_loc,
                                               const char* vuid_single_device_memory, const char* vuid_binding_table_flag,
                                               const VkStridedDeviceAddressRegionKHR& binding_table) const;
-    bool ValidateCmdTraceRaysKHR(const Location& loc, const vvl::CommandBuffer& cb_state,
+    bool ValidateCmdTraceRaysKHR(const Location& loc, const LastBound& last_bound_state,
                                  const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
                                  const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable,
                                  const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -435,9 +435,9 @@ class CoreChecks : public vvl::DeviceProxy {
                              const Location& loc) const;
 
     bool ValidateCmdDrawInstance(const vvl::CommandBuffer& cb_state, uint32_t instanceCount, uint32_t firstInstance,
-                                 const Location& loc) const;
+                                 const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateGraphicsIndexedCmd(const vvl::CommandBuffer& cb_state, const vvl::Buffer* index_buffer_state,
-                                    const Location& loc) const;
+                                    const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateCmdNextSubpass(VkCommandBuffer commandBuffer, const ErrorObject& error_obj) const;
     bool ValidateInsertMemoryRange(const VulkanTypedHandle& typed_handle, const vvl::DeviceMemory& mem_info,
                                    VkDeviceSize memoryOffset, const Location& loc) const;
@@ -629,9 +629,10 @@ class CoreChecks : public vvl::DeviceProxy {
                                     const char* vuid) const;
     bool ValidateCmdSubpassState(const vvl::CommandBuffer& cb_state, const Location& loc, const char* vuid) const;
     bool ValidateCmd(const vvl::CommandBuffer& cb_state, const Location& loc) const;
-    bool ValidateIndirectCmd(const vvl::CommandBuffer& cb_state, const vvl::Buffer& buffer_state, const Location& loc) const;
+    bool ValidateIndirectCmd(const vvl::CommandBuffer& cb_state, const vvl::Buffer& buffer_state,
+                             const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateIndirectCountCmd(const vvl::CommandBuffer& cb_state, const vvl::Buffer& count_buffer_state,
-                                  VkDeviceSize count_buffer_offset, const Location& loc) const;
+                                  VkDeviceSize count_buffer_offset, const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateDrawPipelineFramebuffer(const vvl::CommandBuffer& cb_state, const vvl::Pipeline& pipeline,
                                          const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateDrawPipelineVertexBinding(const vvl::CommandBuffer& cb_state, const vvl::Pipeline& pipeline,
@@ -714,7 +715,8 @@ class CoreChecks : public vvl::DeviceProxy {
     bool ValidateDrawShaderObjectLinking(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateDrawShaderObjectPushConstantAndLayout(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateDrawShaderObjectMesh(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
-    bool ValidateActionState(const vvl::CommandBuffer& cb_state, const VkPipelineBindPoint bind_point, const Location& loc) const;
+    bool ValidateActionState(const vvl::CommandBuffer& cb_state, const VkPipelineBindPoint bind_point,
+                             const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateActionStateDescriptorsPipeline(const LastBound& last_bound_state, const VkPipelineBindPoint bind_point,
                                                 const vvl::Pipeline& pipeline, const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateActionStateDescriptorsShaderObject(const LastBound& last_bound_state, const VkPipelineBindPoint bind_point,
@@ -1795,8 +1797,8 @@ class CoreChecks : public vvl::DeviceProxy {
     bool PreCallValidateCmdBindVertexBuffers(VkCommandBuffer commandBuffer, uint32_t firstBinding, uint32_t bindingCount,
                                              const VkBuffer* pBuffers, const VkDeviceSize* pOffsets,
                                              const ErrorObject& error_obj) const override;
-    bool ValidateVTGShaderStages(const vvl::CommandBuffer& cb_state, const Location& loc) const;
-    bool ValidateMeshShaderStage(const vvl::CommandBuffer& cb_state, const Location& loc, bool is_NV) const;
+    bool ValidateVTGShaderStages(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
+    bool ValidateMeshShaderStage(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid, bool is_NV) const;
     bool PreCallValidateCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex,
                                 uint32_t firstInstance, const ErrorObject& error_obj) const override;
     bool PreCallValidateCmdDrawMultiEXT(VkCommandBuffer commandBuffer, uint32_t drawCount, const VkMultiDrawInfoEXT* pVertexInfo,

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -436,7 +436,8 @@ class CoreChecks : public vvl::DeviceProxy {
 
     bool ValidateCmdDrawInstance(const vvl::CommandBuffer& cb_state, uint32_t instanceCount, uint32_t firstInstance,
                                  const Location& loc) const;
-    bool ValidateGraphicsIndexedCmd(const vvl::CommandBuffer& cb_state, const Location& loc) const;
+    bool ValidateGraphicsIndexedCmd(const vvl::CommandBuffer& cb_state, const vvl::Buffer* index_buffer_state,
+                                    const Location& loc) const;
     bool ValidateCmdNextSubpass(VkCommandBuffer commandBuffer, const ErrorObject& error_obj) const;
     bool ValidateInsertMemoryRange(const VulkanTypedHandle& typed_handle, const vvl::DeviceMemory& mem_info,
                                    VkDeviceSize memoryOffset, const Location& loc) const;
@@ -1801,8 +1802,9 @@ class CoreChecks : public vvl::DeviceProxy {
     bool PreCallValidateCmdDrawMultiEXT(VkCommandBuffer commandBuffer, uint32_t drawCount, const VkMultiDrawInfoEXT* pVertexInfo,
                                         uint32_t instanceCount, uint32_t firstInstance, uint32_t stride,
                                         const ErrorObject& error_obj) const override;
-    bool ValidateCmdDrawIndexedBufferSize(const vvl::CommandBuffer& cb_state, uint32_t indexCount, uint32_t firstIndex,
-                                          const Location& loc, const char* first_index_vuid) const;
+    bool ValidateCmdDrawIndexedBufferSize(const vvl::CommandBuffer& cb_state, const vvl::Buffer& index_buffer_state,
+                                          uint32_t indexCount, uint32_t firstIndex, const Location& loc,
+                                          const char* first_index_vuid) const;
     bool PreCallValidateCmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t indexCount, uint32_t instanceCount,
                                        uint32_t firstIndex, int32_t vertexOffset, uint32_t firstInstance,
                                        const ErrorObject& error_obj) const override;

--- a/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
@@ -39,12 +39,12 @@
 namespace gpuav {
 
 // If application is using shader objects, bindings count will be computed from bound shaders
-static uint32_t LastBoundPipelineOrShaderDescSetBindingsCount(VkPipelineBindPoint bind_point, const LastBound &last_bound) {
+static uint32_t LastBoundPipelineOrShaderDescSetBindingsCount(const LastBound &last_bound) {
     if (last_bound.pipeline_state && last_bound.pipeline_state->PreRasterPipelineLayoutState()) {
         return static_cast<uint32_t>(last_bound.pipeline_state->PreRasterPipelineLayoutState()->set_layouts.size());
     }
 
-    if (const vvl::ShaderObject *main_bound_shader = last_bound.GetFirstShader(bind_point)) {
+    if (const vvl::ShaderObject *main_bound_shader = last_bound.GetFirstShader()) {
         return static_cast<uint32_t>(main_bound_shader->set_layouts.size());
     }
 
@@ -54,13 +54,13 @@ static uint32_t LastBoundPipelineOrShaderDescSetBindingsCount(VkPipelineBindPoin
 }
 
 // If application is using shader objects, bindings count will be computed from bound shaders
-static uint32_t LastBoundPipelineOrShaderPushConstantsRangesCount(VkPipelineBindPoint bind_point, const LastBound &last_bound) {
+static uint32_t LastBoundPipelineOrShaderPushConstantsRangesCount(const LastBound &last_bound) {
     if (last_bound.pipeline_state && last_bound.pipeline_state->PreRasterPipelineLayoutState()) {
         return static_cast<uint32_t>(
             last_bound.pipeline_state->PreRasterPipelineLayoutState()->push_constant_ranges_layout->size());
     }
 
-    if (const vvl::ShaderObject *main_bound_shader = last_bound.GetFirstShader(bind_point)) {
+    if (const vvl::ShaderObject *main_bound_shader = last_bound.GetFirstShader()) {
         return static_cast<uint32_t>(main_bound_shader->push_constant_ranges->size());
     }
 
@@ -69,8 +69,7 @@ static uint32_t LastBoundPipelineOrShaderPushConstantsRangesCount(VkPipelineBind
     return 0;
 }
 
-static VkPipelineLayout CreateInstrumentationPipelineLayout(Validator &gpuav, VkPipelineBindPoint bind_point, const Location &loc,
-                                                            const LastBound &last_bound,
+static VkPipelineLayout CreateInstrumentationPipelineLayout(Validator &gpuav, const Location &loc, const LastBound &last_bound,
                                                             VkDescriptorSetLayout dummy_desc_set_layout,
                                                             VkDescriptorSetLayout instrumentation_desc_set_layout,
                                                             uint32_t inst_desc_set_binding) {
@@ -117,7 +116,7 @@ static VkPipelineLayout CreateInstrumentationPipelineLayout(Validator &gpuav, Vk
         // Application is using shader objects, compose a pipeline layout from bound shaders
         // ---
 
-        const vvl::ShaderObject *main_bound_shader = last_bound.GetFirstShader(bind_point);
+        const vvl::ShaderObject *main_bound_shader = last_bound.GetFirstShader();
         if (!main_bound_shader) {
             // Should not get there, it would mean no pipeline nor shader object was bound
             gpuav.InternalError(gpuav.device, loc, "Could not retrieve last bound computer/vertex/mesh shader");
@@ -273,7 +272,7 @@ void UpdateInstrumentationDescSet(Validator &gpuav, CommandBufferSubState &cb_st
                                   VkDescriptorSet instrumentation_desc_set, const Location &loc,
                                   InstrumentationErrorBlob &out_instrumentation_error_blob) {
     small_vector<VkWriteDescriptorSet, 8> desc_writes = {};
-    
+
     VkDescriptorBufferInfo error_output_desc_buffer_info = {};
     VkDescriptorBufferInfo vertex_attribute_fetch_limits_buffer_bi = {};
     VkDescriptorBufferInfo indices_desc_buffer_info = {};
@@ -549,8 +548,8 @@ void PreCallSetupShaderInstrumentationResources(Validator &gpuav, CommandBufferS
                 // last bound shader objects is created and used.
                 // If will also be cached: heuristic is next action command will likely need the same.
 
-                const uint32_t last_pipe_bindings_count = LastBoundPipelineOrShaderDescSetBindingsCount(bind_point, last_bound);
-                const uint32_t last_pipe_pcr_count = LastBoundPipelineOrShaderPushConstantsRangesCount(bind_point, last_bound);
+                const uint32_t last_pipe_bindings_count = LastBoundPipelineOrShaderDescSetBindingsCount(last_bound);
+                const uint32_t last_pipe_pcr_count = LastBoundPipelineOrShaderPushConstantsRangesCount(last_bound);
 
                 // If the number of binding of the currently bound pipeline's layout (or the equivalent for shader objects) is
                 // less that the number of bindings in the pipeline layout used to bind descriptor sets,
@@ -559,7 +558,7 @@ void PreCallSetupShaderInstrumentationResources(Validator &gpuav, CommandBufferS
                 if (last_pipe_bindings_count < (uint32_t)inst_binding_pipe_layout_state->set_layouts.size() ||
                     last_pipe_pcr_count < (uint32_t)inst_binding_pipe_layout_state->push_constant_ranges_layout->size()) {
                     VkPipelineLayout instrumentation_pipe_layout = CreateInstrumentationPipelineLayout(
-                        gpuav, bind_point, loc, last_bound, gpuav.dummy_desc_layout_, gpuav.GetInstrumentationDescriptorSetLayout(),
+                        gpuav, loc, last_bound, gpuav.dummy_desc_layout_, gpuav.GetInstrumentationDescriptorSetLayout(),
                         gpuav.instrumentation_desc_set_bind_index_);
 
                     if (instrumentation_pipe_layout != VK_NULL_HANDLE) {
@@ -635,8 +634,7 @@ void PostCallSetupShaderInstrumentationResources(Validator &gpuav, CommandBuffer
     // => We create this incompatibility when we add our empty descriptor set.
     // See PositiveGpuAVDescriptorIndexing.SharedPipelineLayoutSubsetGraphics for instance
     if (last_bound.desc_set_pipeline_layout) {
-        const uint32_t desc_set_bindings_counts_from_last_pipeline =
-            LastBoundPipelineOrShaderDescSetBindingsCount(bind_point, last_bound);
+        const uint32_t desc_set_bindings_counts_from_last_pipeline = LastBoundPipelineOrShaderDescSetBindingsCount(last_bound);
 
         const bool any_disturbed_desc_sets_bindings =
             desc_set_bindings_counts_from_last_pipeline <

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -184,7 +184,9 @@ CommandBuffer::CommandBuffer(DeviceState &dev, VkCommandBuffer handle, const VkC
       command_pool(pool),
       dev_data(dev),
       unprotected(pool->unprotected),
-      lastBound({*this, *this, *this}) {
+      lastBound({{{*this, VK_PIPELINE_BIND_POINT_GRAPHICS},
+                  {*this, VK_PIPELINE_BIND_POINT_COMPUTE},
+                  {*this, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR}}}) {
     ResetCBState();
 }
 

--- a/layers/state_tracker/last_bound_state.cpp
+++ b/layers/state_tracker/last_bound_state.cpp
@@ -482,7 +482,7 @@ const vvl::ShaderObject *LastBound::GetShaderStateIfValid(ShaderObjectStage stag
     return shader_object_states[static_cast<uint32_t>(stage)];
 }
 
-const vvl::ShaderObject *LastBound::GetFirstShader(VkPipelineBindPoint bind_point) const {
+const vvl::ShaderObject *LastBound::GetFirstShader() const {
     if (bind_point == VK_PIPELINE_BIND_POINT_COMPUTE) {
         return GetShaderStateIfValid(ShaderObjectStage::COMPUTE);
     } else if (bind_point == VK_PIPELINE_BIND_POINT_GRAPHICS) {

--- a/layers/state_tracker/last_bound_state.h
+++ b/layers/state_tracker/last_bound_state.h
@@ -40,9 +40,11 @@ struct EntryPoint;
 
 // Track last states that are bound per pipeline bind point (Gfx & Compute)
 struct LastBound {
-    LastBound(vvl::CommandBuffer &cb) : cb_state(cb) {}
+    LastBound(vvl::CommandBuffer &cb, const VkPipelineBindPoint bind_point) : cb_state(cb), bind_point(bind_point) {}
 
     vvl::CommandBuffer &cb_state;
+    const VkPipelineBindPoint bind_point;
+
     vvl::Pipeline *pipeline_state = nullptr;
     // All shader stages for a used pipeline bind point must be bound to with a valid shader or VK_NULL_HANDLE
     // We have to track shader_object_bound, because shader_object_states will be nullptr when VK_NULL_HANDLE is used
@@ -120,12 +122,11 @@ struct LastBound {
     VkCoverageModulationModeNV GetCoverageModulationMode() const;
     uint32_t GetViewportSwizzleCount() const;
 
-    bool ValidShaderObjectCombination(const VkPipelineBindPoint bind_point, const DeviceFeatures &device_features) const;
     VkShaderEXT GetShader(ShaderObjectStage stage) const;
     vvl::ShaderObject *GetShaderState(ShaderObjectStage stage) const;
     const vvl::ShaderObject *GetShaderStateIfValid(ShaderObjectStage stage) const;
     // Return compute shader for compute pipeline, vertex or mesh shader for graphics
-    const vvl::ShaderObject *GetFirstShader(VkPipelineBindPoint bind_point) const;
+    const vvl::ShaderObject *GetFirstShader() const;
     bool HasShaderObjects() const;
     bool IsValidShaderBound(ShaderObjectStage stage) const;
     bool IsValidShaderOrNullBound(ShaderObjectStage stage) const;


### PR DESCRIPTION
The core goal was to try and squeeze a few cycles out of `vkCmdDrawIndexed` which I found in my traces get called millions of times

I noticed in the `PreCallValidateCmdDrawIndexed` we were calling a few things multiple times as it went through all the functions

This change mainly

1. sets up `LastBound last_bound_state` right away as it is used all the way through the functions (and you can get `cb_state` out of it easily)
2. Use `vvl::DrawDispatchVuid& vuid` from the start instead of grabbing it multiple times in multiple functions
3. group logic together, I caught we were doing `Get<vvl::Buffer>()` twice for the Indexed Buffer, now its all together so was easy to spot and reduce it to a single state tracking lookup

----

Ran multiple times with and without this change back-to-back and seeing a solid consistent small improvement with this

Trace times average after 4 runs
- 23.8 seconds to  23.2 seconds
- 33.5 seconds to  33.3 seconds