### PR TITLE
layers: Move PushConstant state tracking out of Core

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -276,6 +276,7 @@ vvl_sources = [
   "layers/state_tracker/pipeline_state.h",
   "layers/state_tracker/pipeline_sub_state.cpp",
   "layers/state_tracker/pipeline_sub_state.h",
+  "layers/state_tracker/push_constant_data.h",
   "layers/state_tracker/query_state.h",
   "layers/state_tracker/queue_state.cpp",
   "layers/state_tracker/queue_state.h",

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -361,6 +361,7 @@ target_sources(vvl PRIVATE
     state_tracker/pipeline_state.h
     state_tracker/pipeline_sub_state.cpp
     state_tracker/pipeline_sub_state.h
+    state_tracker/push_constant_data.h
     state_tracker/query_state.h
     state_tracker/semaphore_state.cpp
     state_tracker/semaphore_state.h

--- a/layers/best_practices/best_practices_validation.h
+++ b/layers/best_practices/best_practices_validation.h
@@ -148,11 +148,11 @@ class BestPractices : public vvl::DeviceProxy {
 
     std::string GetAPIVersionName(uint32_t version) const;
 
-    bool ValidateCmdDrawType(VkCommandBuffer cmd_buffer, const Location& loc) const;
+    bool ValidateCmdDrawType(const bp_state::CommandBufferSubState& cb_state, const Location& loc) const;
 
-    bool ValidateCmdDispatchType(VkCommandBuffer cmd_buffer, const Location& loc) const;
+    bool ValidateCmdDispatchType(const bp_state::CommandBufferSubState& cb_state, const Location& loc) const;
 
-    bool ValidatePushConstants(VkCommandBuffer cmd_buffer, const Location& loc) const;
+    bool ValidatePushConstants(const bp_state::CommandBufferSubState& cb_state, const Location& loc) const;
 
     void RecordCmdDrawType(bp_state::CommandBufferSubState& cb_state, uint32_t draw_count);
 
@@ -245,8 +245,6 @@ class BestPractices : public vvl::DeviceProxy {
                                         const ErrorObject& error_obj) const override;
     bool PreCallValidateQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
                                      const ErrorObject& error_obj) const override;
-    void PreCallRecordBeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo* pBeginInfo,
-                                         const RecordObject& record_obj) override;
     bool PreCallValidateBeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo* pBeginInfo,
                                            const ErrorObject& error_obj) const override;
     bool CheckEventSignalingState(const bp_state::CommandBufferSubState& command_buffer, VkEvent event,

--- a/layers/best_practices/bp_cmd_buffer.cpp
+++ b/layers/best_practices/bp_cmd_buffer.cpp
@@ -47,15 +47,6 @@ bool BestPractices::PreCallValidateAllocateCommandBuffers(VkDevice device, const
     return skip;
 }
 
-void BestPractices::PreCallRecordBeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo* pBeginInfo,
-                                                    const RecordObject& record_obj) {
-    auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
-    auto& sub_state = bp_state::SubState(*cb_state);
-    // reset
-    sub_state.num_submits = 0;
-    sub_state.small_indexed_draw_call_count = 0;
-}
-
 bool BestPractices::PreCallValidateBeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo* pBeginInfo,
                                                       const ErrorObject& error_obj) const {
     bool skip = false;

--- a/layers/gpuav/core/gpuav_validation_pipeline.cpp
+++ b/layers/gpuav/core/gpuav_validation_pipeline.cpp
@@ -159,7 +159,7 @@ void RestorablePipelineState::Create(CommandBufferSubState &cb_state, VkPipeline
     desc_set_pipeline_layout_ =
         last_bound.desc_set_pipeline_layout ? last_bound.desc_set_pipeline_layout->VkHandle() : VK_NULL_HANDLE;
 
-    push_constants_data_ = cb_state.base.push_constant_data_chunks;
+    push_constants_data_ = cb_state.push_constant_data_chunks;
 
     descriptor_sets_.reserve(last_bound.ds_slots.size());
     for (std::size_t set_i = 0; set_i < last_bound.ds_slots.size(); set_i++) {

--- a/layers/gpuav/core/gpuav_validation_pipeline.h
+++ b/layers/gpuav/core/gpuav_validation_pipeline.h
@@ -18,7 +18,7 @@
 #pragma once
 
 #include "containers/limits.h"
-#include "state_tracker/cmd_buffer_state.h"
+#include "state_tracker/push_constant_data.h"
 
 #include <vector>
 #include <vulkan/vulkan.h>
@@ -121,7 +121,7 @@ class RestorablePipelineState {
     std::vector<std::vector<uint32_t>> dynamic_offsets_;
     uint32_t push_descriptor_set_index_ = 0;
     std::vector<vku::safe_VkWriteDescriptorSet> push_descriptor_set_writes_;
-    std::vector<vvl::PushConstantData> push_constants_data_;
+    std::vector<PushConstantData> push_constants_data_;
     std::vector<vvl::ShaderObject*> shader_objects_;
 };
 }  // namespace valpipe

--- a/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
@@ -273,7 +273,7 @@ void UpdateInstrumentationDescSet(Validator &gpuav, CommandBufferSubState &cb_st
                                   VkDescriptorSet instrumentation_desc_set, const Location &loc,
                                   InstrumentationErrorBlob &out_instrumentation_error_blob) {
     small_vector<VkWriteDescriptorSet, 8> desc_writes = {};
-    
+
     VkDescriptorBufferInfo error_output_desc_buffer_info = {};
     VkDescriptorBufferInfo vertex_attribute_fetch_limits_buffer_bi = {};
     VkDescriptorBufferInfo indices_desc_buffer_info = {};
@@ -511,9 +511,8 @@ void PreCallSetupShaderInstrumentationResources(Validator &gpuav, CommandBufferS
     } else if (last_bound.desc_set_pipeline_layout) {
         inst_binding_pipe_layout_state = last_bound.desc_set_pipeline_layout;
         inst_binding_pipe_layout_src = PipelineLayoutSource::LastBoundDescriptorSet;
-    } else if (cb_state.base.push_constant_latest_used_layout[lv_bind_point] != VK_NULL_HANDLE) {
-        inst_binding_pipe_layout_state =
-            gpuav.Get<vvl::PipelineLayout>(cb_state.base.push_constant_latest_used_layout[lv_bind_point]);
+    } else if (cb_state.push_constant_latest_used_layout[lv_bind_point] != VK_NULL_HANDLE) {
+        inst_binding_pipe_layout_state = gpuav.Get<vvl::PipelineLayout>(cb_state.push_constant_latest_used_layout[lv_bind_point]);
         inst_binding_pipe_layout_src = PipelineLayoutSource::LastPushedConstants;
     }
 

--- a/layers/gpuav/resources/gpuav_state_trackers.h
+++ b/layers/gpuav/resources/gpuav_state_trackers.h
@@ -32,6 +32,7 @@
 #include "state_tracker/sampler_state.h"
 #include "state_tracker/ray_tracing_state.h"
 #include "state_tracker/shader_object_state.h"
+#include "state_tracker/push_constant_data.h"
 
 namespace gpuav {
 
@@ -73,6 +74,9 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     uint32_t trace_rays_index = 0;
     uint32_t action_command_count = 0;
 
+    std::vector<PushConstantData> push_constant_data_chunks;
+    std::array<VkPipelineLayout, BindPoint_Count> push_constant_latest_used_layout{};
+
     CommandBufferSubState(Validator &gpuav, vvl::CommandBuffer &cb);
     ~CommandBufferSubState();
 
@@ -103,6 +107,10 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
 
     void Destroy() final;
     void Reset(const Location &loc) final;
+
+    void RecordPushConstants(VkPipelineLayout layout, VkShaderStageFlags stage_flags, uint32_t offset, uint32_t size,
+                             const void *values) final;
+    void ClearPushConstants() final;
 
     vko::GpuResourcesManager gpu_resources_manager;
     // Using stdext::inplace_function over std::function to allocate memory in place

--- a/layers/state_tracker/push_constant_data.h
+++ b/layers/state_tracker/push_constant_data.h
@@ -1,0 +1,27 @@
+/* Copyright (c) 2025 The Khronos Group Inc.
+ * Copyright (c) 2025 Valve Corporation
+ * Copyright (c) 2025 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include "vulkan/vulkan.h"
+#include <vector>
+#include <cstddef>
+
+struct PushConstantData {
+    VkPipelineLayout layout = VK_NULL_HANDLE;
+    VkShaderStageFlags stage_flags = 0;
+    uint32_t offset = 0;
+    std::vector<std::byte> values{};
+};


### PR DESCRIPTION
In effort to keep the command buffer recording path fast (for core validation), I realize the `vkCmdPushConstant` path was updating state only used by GPU-AV and BestPractice... so with our new fancy Command Buffer SubState, I moved that state tracking off so when only using core validation, you don't pay any cost or recording that command

similar to https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/10262 - I see a small perf increase, but regardless, not doing the tracking in CoreChecks that is not used by it seems like a win regardless