### PR TITLE
layers: Fix image layout comparison for secondary cmdbuf

### DIFF
--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -32,6 +32,7 @@
 #include "state_tracker/pipeline_state.h"
 #include "core_validation.h"
 #include "generated/enum_flag_bits.h"
+#include "utils/image_layout_utils.h"
 #include "utils/math_utils.h"
 
 bool CoreChecks::ReportInvalidCommandBuffer(const vvl::CommandBuffer &cb_state, const Location &loc, const char *vuid) const {
@@ -681,7 +682,11 @@ bool CoreChecks::ValidateSecondaryCommandBufferLayout(const vvl::CommandBuffer &
             } else {
                 continue;
             }
-            if (sub_layout != cb_layout) {
+
+            const VkImageLayout normalized_sub_layout =
+                NormalizeSynchronization2Layout(iter->pos_A->lower_bound->second.aspect_mask, sub_layout);
+            const VkImageLayout normalized_cb_layout = NormalizeSynchronization2Layout(cb_layout_state.aspect_mask, cb_layout);
+            if (normalized_sub_layout != normalized_cb_layout) {
                 // We can report all the errors for the intersected range directly
                 for (auto index = iter->range.begin; index < iter->range.end; index++) {
                     const LogObjectList objlist(cb_state.Handle(), secondary_cb_state.Handle());

--- a/tests/unit/secondary_command_buffer.cpp
+++ b/tests/unit/secondary_command_buffer.cpp
@@ -353,9 +353,9 @@ TEST_F(NegativeSecondaryCommandBuffer, ExecuteWithLayoutMismatch) {
     pipeline(secondary, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
     secondary.End();
 
-    m_errorMonitor->SetDesiredError("UNASSIGNED-vkCmdExecuteCommands-commandBuffer-00001");
     m_command_buffer.Begin();
     pipeline(m_command_buffer, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
+    m_errorMonitor->SetDesiredError("UNASSIGNED-vkCmdExecuteCommands-commandBuffer-00001");
     vk::CmdExecuteCommands(m_command_buffer, 1, &secondary.handle());
     m_errorMonitor->VerifyFound();
 


### PR DESCRIPTION
This fixes false positive part of https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7896.
Need also another PR to fix that error message can print normalized layout instead of original one.

The regression test reproduces the same message as in the issue:
> Validation Error: [ UNASSIGNED-vkCmdExecuteCommands-commandBuffer-00001 ] | MessageID = 0xfa96ea8e
vkCmdExecuteCommands(): pCommandBuffers[0] was executed using VkImage 0x40000000004 (subresource: aspectMask VK_IMAGE_ASPECT_COLOR_BIT, array layer 0, mip level 0) which expects layout VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL--instead, image current layout is VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL.

