### PR TITLE
tests: Add missing barriers from tests

### DIFF
--- a/tests/unit/gpu_av_descriptor_post_process.cpp
+++ b/tests/unit/gpu_av_descriptor_post_process.cpp
@@ -1299,6 +1299,8 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, AliasImageMultisampleDescriptorSetsPa
                               nullptr);
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
 
+    m_command_buffer.FullMemoryBarrier();
+
     // Forgot to set descriptor set
     // need to make sure GPU-AV is patching last descriptor set even though there was a dispatch inbetween
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe_ms);

--- a/tests/unit/gpu_av_descriptor_post_process_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_post_process_positive.cpp
@@ -365,6 +365,8 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, AliasImageMultisampleDescriptorSets) 
                               nullptr);
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
 
+    m_command_buffer.FullMemoryBarrier();
+
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe_ms);
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout1, 0, 1, &descriptor_set1.set_, 0,
                               nullptr);
@@ -448,10 +450,14 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, AliasImageMultisampleDescriptorSetsPa
                               nullptr);
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
 
+    m_command_buffer.FullMemoryBarrier();
+
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe_ms);
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout1, 0, 1, &descriptor_set1.set_, 0,
                               nullptr);
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+
+    m_command_buffer.FullMemoryBarrier();
 
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout0, 0, 1, &descriptor_set0.set_, 0,


### PR DESCRIPTION
@artem-lunarg helped narrow down why we had to blacklist these tests, taking a closer look, I am testing that two separate draws/dispatch work and the tests assume the order they are recorded in, so was a matter of missing the barrier