### PR TITLE
layers: Print original image layout in the error messages

### DIFF
--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -683,9 +683,11 @@ bool CoreChecks::ValidateSecondaryCommandBufferLayout(const vvl::CommandBuffer &
                 continue;
             }
 
+            // TODO: figure out how to use ImageLayoutMatches instead (need to understand better aspect behavior)
             const VkImageLayout normalized_sub_layout =
                 NormalizeSynchronization2Layout(iter->pos_A->lower_bound->second.aspect_mask, sub_layout);
             const VkImageLayout normalized_cb_layout = NormalizeSynchronization2Layout(cb_layout_state.aspect_mask, cb_layout);
+
             if (normalized_sub_layout != normalized_cb_layout) {
                 // We can report all the errors for the intersected range directly
                 for (auto index = iter->range.begin; index < iter->range.end; index++) {

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1440,12 +1440,13 @@ void CommandBuffer::UpdateLastBoundDescriptorBuffers(VkPipelineBindPoint pipelin
 }
 
 // Set image layout for given subresource range
-void CommandBuffer::SetImageLayout(const vvl::Image &image_state, const VkImageSubresourceRange &subresource_range,
+void CommandBuffer::SetImageLayout(const vvl::Image &image_state, const VkImageSubresourceRange &normalized_subresource_range,
                                    VkImageLayout layout, VkImageLayout expected_layout) {
     if (auto image_layout_map = GetOrCreateImageLayoutMap(image_state)) {
-        if (image_state.subresource_encoder.InRange(subresource_range)) {
-            RangeGenerator range_gen(image_state.subresource_encoder, subresource_range);
-            if (UpdateCurrentLayout(*image_layout_map, std::move(range_gen), layout, expected_layout)) {
+        if (image_state.subresource_encoder.InRange(normalized_subresource_range)) {
+            RangeGenerator range_gen(image_state.subresource_encoder, normalized_subresource_range);
+            if (UpdateCurrentLayout(*image_layout_map, std::move(range_gen), layout, expected_layout,
+                                    normalized_subresource_range.aspectMask)) {
                 image_layout_change_count++;  // Change the version of this data to force revalidation
             }
         }
@@ -1464,13 +1465,13 @@ void CommandBuffer::TrackImageViewFirstLayout(const vvl::ImageView &view_state, 
     }
 }
 
-void CommandBuffer::TrackImageFirstLayout(const vvl::Image &image_state, const VkImageSubresourceRange &range,
-                                            VkImageLayout layout) {
+void CommandBuffer::TrackImageFirstLayout(const vvl::Image &image_state, const VkImageSubresourceRange &subresource_range,
+                                          VkImageLayout layout) {
     if (auto image_layout_map = GetOrCreateImageLayoutMap(image_state)) {
-        const VkImageSubresourceRange normalized_subresource_range = image_state.NormalizeSubresourceRange(range);
+        const VkImageSubresourceRange normalized_subresource_range = image_state.NormalizeSubresourceRange(subresource_range);
         if (image_state.subresource_encoder.InRange(normalized_subresource_range)) {
             RangeGenerator range_gen(image_state.subresource_encoder, normalized_subresource_range);
-            TrackFirstLayout(*image_layout_map, std::move(range_gen), layout);
+            TrackFirstLayout(*image_layout_map, std::move(range_gen), layout, normalized_subresource_range.aspectMask);
         }
     }
 }

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -644,10 +644,11 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     void SetImageViewLayout(const vvl::ImageView &view_state, VkImageLayout layout, VkImageLayout layoutStencil);
     void TrackImageViewFirstLayout(const vvl::ImageView &view_state, VkImageLayout layout);
 
-    void SetImageLayout(const vvl::Image &image_state, const VkImageSubresourceRange &subresource_range, VkImageLayout layout,
-                        VkImageLayout expected_layout = kInvalidLayout);
+    void SetImageLayout(const vvl::Image &image_state, const VkImageSubresourceRange &normalized_subresource_range,
+                        VkImageLayout layout, VkImageLayout expected_layout = kInvalidLayout);
     // This tracks the first known layout of the subresource in the command buffer.
-    void TrackImageFirstLayout(const vvl::Image &image_state, const VkImageSubresourceRange &range, VkImageLayout layout);
+    void TrackImageFirstLayout(const vvl::Image &image_state, const VkImageSubresourceRange &subresource_range,
+                               VkImageLayout layout);
 
     void Submit(Queue &queue_state, uint32_t perf_submit_pass, const Location &loc);
     void Retire(uint32_t perf_submit_pass, const std::function<bool(const QueryObject &)> &is_query_updated_after);

--- a/layers/utils/image_layout_utils.h
+++ b/layers/utils/image_layout_utils.h
@@ -1,5 +1,5 @@
-/* Copyright (c) 2023 Valve Corporation
- * Copyright (c) 2023 LunarG, Inc.
+/* Copyright (c) 2023-2025 Valve Corporation
+ * Copyright (c) 2023-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,5 @@
 #pragma once
 #include <vulkan/vulkan_core.h>
 
-VkImageLayout NormalizeDepthImageLayout(VkImageLayout layout);
-VkImageLayout NormalizeStencilImageLayout(VkImageLayout layout);
 VkImageLayout NormalizeSynchronization2Layout(const VkImageAspectFlags aspect_mask, VkImageLayout layout);
 bool ImageLayoutMatches(const VkImageAspectFlags aspect_mask, VkImageLayout a, VkImageLayout b);

--- a/tests/unit/secondary_command_buffer.cpp
+++ b/tests/unit/secondary_command_buffer.cpp
@@ -13,6 +13,8 @@
  */
 
 #include "../framework/layer_validation_tests.h"
+#include "../framework/descriptor_helper.h"
+#include "../framework/pipeline_helper.h"
 #include "../framework/render_pass_helper.h"
 
 class NegativeSecondaryCommandBuffer : public VkLayerTest {};
@@ -369,6 +371,62 @@ TEST_F(NegativeSecondaryCommandBuffer, ExecuteWithLayoutMismatch) {
     m_command_buffer.Begin();
     pipeline(m_command_buffer, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
     vk::CmdExecuteCommands(m_command_buffer, 1, &secondary.handle());
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeSecondaryCommandBuffer, ExecuteWithLayoutMismatchUseGenericLayout) {
+    // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7896
+    TEST_DESCRIPTION("Check that generic layouts like VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL are reported correctly");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(Init());
+
+    vkt::Image image(*m_device, 32, 32, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    vkt::ImageView image_view = image.CreateView();
+
+    // Main command buffer transitions to READ_ONLY_OPTIMAL
+    VkImageMemoryBarrier2 layout_transition = vku::InitStructHelper();
+    layout_transition.srcStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
+    layout_transition.dstStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
+    layout_transition.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    layout_transition.newLayout = VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL;
+    layout_transition.image = image;
+    layout_transition.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+
+    // Secondary command buffer expects sampled image to be in READ_ONLY_OPTIMAL
+    vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
+    OneOffDescriptorSet descriptor_set(m_device, {{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_COMPUTE_BIT}});
+    descriptor_set.WriteDescriptorImageInfo(0, image_view, sampler, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+                                            VK_IMAGE_LAYOUT_GENERAL);
+    descriptor_set.UpdateDescriptorSets();
+    char const *cs_source = R"glsl(
+        #version 450
+        layout(set=0, binding=0) uniform sampler2D color_image;
+        void main() {
+            vec4 data = texture(color_image, vec2(0));
+        }
+    )glsl";
+    CreateComputePipelineHelper cs_pipe(*this);
+    cs_pipe.cs_ = VkShaderObj(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT);
+    cs_pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&descriptor_set.layout_});
+    cs_pipe.CreateComputePipeline();
+
+    vkt::CommandBuffer secondary(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    secondary.Begin();
+    vk::CmdBindPipeline(secondary, VK_PIPELINE_BIND_POINT_COMPUTE, cs_pipe);
+    vk::CmdBindDescriptorSets(secondary, VK_PIPELINE_BIND_POINT_COMPUTE, cs_pipe.pipeline_layout_, 0, 1, &descriptor_set.set_, 0,
+                              nullptr);
+    vk::CmdDispatch(secondary, 1, 1, 1);
+    secondary.End();
+
+    m_command_buffer.Begin();
+    m_command_buffer.Barrier(layout_transition);
+    // Check that the error message reports image layout exactly as specified by the test (VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL)
+    // and not in the normalized form that is used by the implementation (VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL)
+    m_errorMonitor->SetDesiredErrorRegex("UNASSIGNED-vkCmdExecuteCommands-commandBuffer-00001",
+                                         "VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL");
+    vk::CmdExecuteCommands(m_command_buffer, 1, &secondary.handle());
+    m_errorMonitor->VerifyFound();
     m_command_buffer.End();
 }
 


### PR DESCRIPTION
Previously we could print normalized image used internally by vvl.

It is likely that related requires additional massaging.
Some behavior related to aspect masks is not super well defined.

Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7896
