### PR TITLE
layers: Update vertex data efficient size computation

### DIFF
--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -5180,10 +5180,7 @@ void DeviceState::PostCallRecordCmdBindVertexBuffers2(VkCommandBuffer commandBuf
         vertex_buffer_binding.bound = true;
         vertex_buffer_binding.buffer = pBuffers[i];
         vertex_buffer_binding.offset = pOffsets[i];
-        vertex_buffer_binding.effective_size = pSizes ? pSizes[i] : VK_WHOLE_SIZE;
-        if (vertex_buffer_binding.effective_size == VK_WHOLE_SIZE) {
-            vertex_buffer_binding.effective_size = Buffer::GetRegionSize(buffer_state, pOffsets[i], VK_WHOLE_SIZE);
-        }
+        vertex_buffer_binding.effective_size = Buffer::GetRegionSize(buffer_state, pOffsets[i], pSizes ? pSizes[i] : VK_WHOLE_SIZE);
 
         if (pStrides) {
             vertex_buffer_binding.stride = pStrides[i];


### PR DESCRIPTION
This makes computations for CmdBindVertexBuffer2 consistent with v1.

Here is the original code that was replaced (with two sections X and Y to refer to):
```
// X
vertex_buffer_binding.effective_size = pSizes ? pSizes[i] : VK_WHOLE_SIZE;
// Y
if (vertex_buffer_binding.effective_size == VK_WHOLE_SIZE) {
       vertex_buffer_binding.effective_size = Buffer::GetRegionSize(buffer_state, pOffsets[i], VK_WHOLE_SIZE);
}
```

and it was replaced by Z:
```
// Z
vertex_buffer_binding.effective_size = Buffer::GetRegionSize(buffer_state, pOffsets[i], pSizes ? pSizes[i] : VK_WHOLE_SIZE);
```

In the old code `vertex_buffer_binding.effective_size` in the line X could be evaluated either to a) VK_WHOLE_SIZE or b) to something else. Lets check both cases:
a) X evaluates to VK_WHOLE_SIZE . It's easy to see that Z evaluates to the same value as Y, no difference here.
b) X evaluates to something else. The Y is skipped and `vertex_buffer_binding.effective_size` remains equal to `pSizes[i]`.

So in case b)  `vertex_buffer_binding.effective_size` is equal to pSizes[i] and can be any value, even that crosses boundary of the buffer. Then if we check other places (index/vertex bindings), for example, v1 `PostCallRecordCmdBindIndexBuffer` they use:
```
vertex_buffer_binding.effective_size = Buffer::GetRegionSize(buffer_state, vertex_buffer_binding.offset, VK_WHOLE_SIZE);
```

so effective size never goes out of bounds and will be set to zero in case of error. Computation Z now does the same for CmdBindVertexBuffer2, so we have unified computation for BindVertexBuffer(v1/v2) and BindIndexBuffer(v1/v2) .



