### PR TITLE
gpuav: Fix maxUpdateAfterBindDescriptorsInAllPools

### DIFF
--- a/layers/gpuav/core/gpuav_record.cpp
+++ b/layers/gpuav/core/gpuav_record.cpp
@@ -121,21 +121,21 @@ void Instance::PostCallRecordGetPhysicalDeviceProperties2(VkPhysicalDevice physi
     // override all possible places maxUpdateAfterBindDescriptorsInAllPools can be set
     auto *desc_indexing_props = vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingProperties>(device_props2->pNext);
     if (desc_indexing_props &&
-        desc_indexing_props->maxUpdateAfterBindDescriptorsInAllPools > glsl::kDebugInputBindlessMaxDescSets) {
+        desc_indexing_props->maxUpdateAfterBindDescriptorsInAllPools > glsl::kDebugInputBindlessMaxDescriptors) {
         std::stringstream ss;
         ss << "Setting VkPhysicalDeviceDescriptorIndexingProperties::maxUpdateAfterBindDescriptorsInAllPools to "
-           << glsl::kDebugInputBindlessMaxDescSets;
+           << glsl::kDebugInputBindlessMaxDescriptors;
         InternalWarning(physicalDevice, record_obj.location, ss.str().c_str());
-        desc_indexing_props->maxUpdateAfterBindDescriptorsInAllPools = glsl::kDebugInputBindlessMaxDescSets;
+        desc_indexing_props->maxUpdateAfterBindDescriptorsInAllPools = glsl::kDebugInputBindlessMaxDescriptors;
     }
 
     auto *vk12_props = vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Properties>(device_props2->pNext);
-    if (vk12_props && vk12_props->maxUpdateAfterBindDescriptorsInAllPools > glsl::kDebugInputBindlessMaxDescSets) {
+    if (vk12_props && vk12_props->maxUpdateAfterBindDescriptorsInAllPools > glsl::kDebugInputBindlessMaxDescriptors) {
         std::stringstream ss;
         ss << "Setting VkPhysicalDeviceVulkan12Properties::maxUpdateAfterBindDescriptorsInAllPools to "
-           << glsl::kDebugInputBindlessMaxDescSets;
+           << glsl::kDebugInputBindlessMaxDescriptors;
         InternalWarning(physicalDevice, record_obj.location, ss.str().c_str());
-        vk12_props->maxUpdateAfterBindDescriptorsInAllPools = glsl::kDebugInputBindlessMaxDescSets;
+        vk12_props->maxUpdateAfterBindDescriptorsInAllPools = glsl::kDebugInputBindlessMaxDescriptors;
     }
 
     ReserveBindingSlot(physicalDevice, device_props2->properties.limits, record_obj.location);


### PR DESCRIPTION
we added this in https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/6527 (and even added tests) but seems we mixed up `kDebugInputBindlessMaxDescriptors` (which is 4 million) for `kDebugInputBindlessMaxDescSets` (which is 32)