### PR TITLE
tests: Give RenderPassSingleSubpass implicit handle

### DIFF
--- a/tests/framework/render_pass_helper.h
+++ b/tests/framework/render_pass_helper.h
@@ -35,7 +35,8 @@ class InterfaceRenderPassSingleSubpass {
     InterfaceRenderPassSingleSubpass(VkLayerTest &test, vkt::Device *device = nullptr);
     virtual ~InterfaceRenderPassSingleSubpass() { Destroy(); }
 
-    VkRenderPass Handle() { return render_pass_; }
+    const VkRenderPass &Handle() const { return render_pass_.handle(); }
+    operator VkRenderPass() const { return render_pass_; }
 
     // Parameters are ordered from most likely to be custom values
     // Most tests don't need to worry about the Load/Store ops as we never read the values

--- a/tests/unit/android_external_resolve.cpp
+++ b/tests/unit/android_external_resolve.cpp
@@ -342,7 +342,7 @@ TEST_F(NegativeAndroidExternalResolve, Framebuffer) {
     attachments[1] = resolve_view.handle();
 
     m_errorMonitor->SetDesiredError("VUID-VkFramebufferCreateInfo-pAttachments-09350");
-    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 2, attachments);
+    vkt::Framebuffer framebuffer(*m_device, rp, 2, attachments);
     m_errorMonitor->VerifyFound();
 }
 
@@ -441,7 +441,7 @@ TEST_F(NegativeAndroidExternalResolve, ImagelessFramebuffer) {
     fb_ci.height = 32;
     fb_ci.layers = 1;
     fb_ci.attachmentCount = 2;
-    fb_ci.renderPass = rp.Handle();
+    fb_ci.renderPass = rp;
     m_errorMonitor->SetAllowedFailureMsg("VUID-VkFramebufferCreateInfo-flags-03201");
     vkt::Framebuffer framebuffer(*m_device, fb_ci);
 
@@ -453,7 +453,7 @@ TEST_F(NegativeAndroidExternalResolve, ImagelessFramebuffer) {
     render_pass_attachment_bi.pAttachments = attachments;
 
     VkRenderPassBeginInfo render_pass_bi = vku::InitStructHelper(&render_pass_attachment_bi);
-    render_pass_bi.renderPass = rp.Handle();
+    render_pass_bi.renderPass = rp;
     render_pass_bi.framebuffer = framebuffer;
     render_pass_bi.renderArea.extent = {1, 1};
     render_pass_bi.clearValueCount = 1;
@@ -563,7 +563,7 @@ TEST_F(NegativeAndroidExternalResolve, ImagelessFramebufferFormat) {
     fb_ci.height = 32;
     fb_ci.layers = 1;
     fb_ci.attachmentCount = 2;
-    fb_ci.renderPass = rp.Handle();
+    fb_ci.renderPass = rp;
     m_errorMonitor->SetAllowedFailureMsg("VUID-VkFramebufferCreateInfo-flags-03201");
     vkt::Framebuffer framebuffer(*m_device, fb_ci);
 
@@ -575,7 +575,7 @@ TEST_F(NegativeAndroidExternalResolve, ImagelessFramebufferFormat) {
     render_pass_attachment_bi.pAttachments = attachments;
 
     VkRenderPassBeginInfo render_pass_bi = vku::InitStructHelper(&render_pass_attachment_bi);
-    render_pass_bi.renderPass = rp.Handle();
+    render_pass_bi.renderPass = rp;
     render_pass_bi.framebuffer = framebuffer;
     render_pass_bi.renderArea.extent = {1, 1};
     render_pass_bi.clearValueCount = 1;
@@ -801,7 +801,7 @@ TEST_F(NegativeAndroidExternalResolve, PipelineRasterizationSamples) {
 
     CreatePipelineHelper pipe(*this, &external_format);
     pipe.ms_ci_.rasterizationSamples = VK_SAMPLE_COUNT_2_BIT;
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-multisampledRenderToSingleSampled-06853");
     m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-externalFormatResolve-09313");
     pipe.CreateGraphicsPipeline();
@@ -1157,10 +1157,10 @@ TEST_F(NegativeAndroidExternalResolve, PipelineBarrier) {
     attachments[0] = color_view.handle();
     attachments[1] = resolve_view.handle();
 
-    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 2, attachments);
+    vkt::Framebuffer framebuffer(*m_device, rp, 2, attachments);
 
     CreatePipelineHelper pipe(*this);
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.CreateGraphicsPipeline();
 
     m_command_buffer.Begin();
@@ -1184,7 +1184,7 @@ TEST_F(NegativeAndroidExternalResolve, PipelineBarrier) {
     // Valid because outside renderpass
     vk::CmdPipelineBarrier2KHR(m_command_buffer, &dependency_info);
 
-    m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer, 32, 32);
+    m_command_buffer.BeginRenderPass(rp, framebuffer, 32, 32);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdPipelineBarrier2-image-09374");
     barrier.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
@@ -1264,14 +1264,14 @@ TEST_F(NegativeAndroidExternalResolve, PipelineBarrierUnused) {
     attachments[0] = color_view.handle();
     attachments[1] = resolve_view.handle();
 
-    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 2, attachments);
+    vkt::Framebuffer framebuffer(*m_device, rp, 2, attachments);
 
     CreatePipelineHelper pipe(*this, &external_format);
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.CreateGraphicsPipeline();
 
     m_command_buffer.Begin();
-    m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer);
+    m_command_buffer.BeginRenderPass(rp, framebuffer);
 
     VkImageMemoryBarrier image_barrier = vku::InitStructHelper();
     image_barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
@@ -1365,7 +1365,7 @@ TEST_F(NegativeAndroidExternalResolve, RenderPassAndFramebuffer) {
     attachments[1] = resolve_view.handle();
 
     m_errorMonitor->SetDesiredError("VUID-VkFramebufferCreateInfo-nullColorAttachmentWithExternalFormatResolve-09349");
-    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 2, attachments);
+    vkt::Framebuffer framebuffer(*m_device, rp, 2, attachments);
     m_errorMonitor->VerifyFound();
 }
 

--- a/tests/unit/android_external_resolve_positive.cpp
+++ b/tests/unit/android_external_resolve_positive.cpp
@@ -109,10 +109,10 @@ TEST_F(PositiveAndroidExternalResolve, RenderPassAndFramebuffer) {
     attachments[0] = color_view.handle();
     attachments[1] = resolve_view.handle();
 
-    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 2, attachments);
+    vkt::Framebuffer framebuffer(*m_device, rp, 2, attachments);
 
     CreatePipelineHelper pipe(*this, &external_format);
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.CreateGraphicsPipeline();
 }
 
@@ -209,7 +209,7 @@ TEST_F(PositiveAndroidExternalResolve, ImagelessFramebuffer) {
     fb_ci.height = 32;
     fb_ci.layers = 1;
     fb_ci.attachmentCount = 2;
-    fb_ci.renderPass = rp.Handle();
+    fb_ci.renderPass = rp;
     m_errorMonitor->SetAllowedFailureMsg("VUID-VkFramebufferCreateInfo-flags-03201");
     vkt::Framebuffer framebuffer(*m_device, fb_ci);
 
@@ -221,7 +221,7 @@ TEST_F(PositiveAndroidExternalResolve, ImagelessFramebuffer) {
     render_pass_attachment_bi.pAttachments = attachments;
 
     VkRenderPassBeginInfo render_pass_bi = vku::InitStructHelper(&render_pass_attachment_bi);
-    render_pass_bi.renderPass = rp.Handle();
+    render_pass_bi.renderPass = rp;
     render_pass_bi.framebuffer = framebuffer;
     render_pass_bi.renderArea.extent = {1, 1};
     render_pass_bi.clearValueCount = 1;
@@ -379,14 +379,14 @@ TEST_F(PositiveAndroidExternalResolve, PipelineBarrier) {
     attachments[0] = color_view.handle();
     attachments[1] = resolve_view.handle();
 
-    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 2, attachments);
+    vkt::Framebuffer framebuffer(*m_device, rp, 2, attachments);
 
     CreatePipelineHelper pipe(*this, &external_format);
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.CreateGraphicsPipeline();
 
     m_command_buffer.Begin();
-    m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer);
+    m_command_buffer.BeginRenderPass(rp, framebuffer);
 
     VkImageMemoryBarrier image_barrier = vku::InitStructHelper();
     image_barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;

--- a/tests/unit/arm_best_practices.cpp
+++ b/tests/unit/arm_best_practices.cpp
@@ -240,14 +240,14 @@ TEST_F(VkArmBestPracticesLayerTest, AttachmentNeedsReadback) {
     rp.AddAttachmentReference({0, VK_IMAGE_LAYOUT_GENERAL});
     rp.AddColorAttachment(0);
     rp.CreateRenderPass();
-    vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &image_view.handle());
+    vkt::Framebuffer fb(*m_device, rp, 1, &image_view.handle());
 
     m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-vkCmdBeginRenderPass-attachment-needs-readback");
 
     // NOTE: VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT should be set for all tests in this file because
     // otherwise BestPractices-vkBeginCommandBuffer-one-time-submit will be triggered.
     m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
-    m_command_buffer.BeginRenderPass(rp.Handle(), fb);
+    m_command_buffer.BeginRenderPass(rp, fb);
 
     m_errorMonitor->VerifyFound();
 }

--- a/tests/unit/best_practices.cpp
+++ b/tests/unit/best_practices.cpp
@@ -529,7 +529,7 @@ TEST_F(VkBestPracticesLayerTest, ClearAttachmentsAfterLoad) {
     rp.AddAttachmentReference({0, VK_IMAGE_LAYOUT_GENERAL});
     rp.AddColorAttachment(0);
     rp.CreateRenderPass();
-    vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &image_view.handle(), m_width, m_height);
+    vkt::Framebuffer fb(*m_device, rp, 1, &image_view.handle(), m_width, m_height);
 
     m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-vkCmdClearAttachments-clear-after-load-color");
 
@@ -541,7 +541,7 @@ TEST_F(VkBestPracticesLayerTest, ClearAttachmentsAfterLoad) {
     m_errorMonitor->SetAllowedFailureMsg("BestPractices-RenderPass-inefficient-clear");
 
     m_command_buffer.Begin();
-    m_command_buffer.BeginRenderPass(rp.Handle(), fb, m_width, m_height);
+    m_command_buffer.BeginRenderPass(rp, fb, m_width, m_height);
 
     VkClearAttachment color_attachment;
     color_attachment.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -578,15 +578,15 @@ TEST_F(VkBestPracticesLayerTest, ClearAttachmentsAfterLoadSecondary) {
     rp.AddAttachmentReference({0, VK_IMAGE_LAYOUT_GENERAL});
     rp.AddColorAttachment(0);
     rp.CreateRenderPass();
-    vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &image_view.handle(), m_width, m_height);
+    vkt::Framebuffer fb(*m_device, rp, 1, &image_view.handle(), m_width, m_height);
 
     CreatePipelineHelper pipe_masked(*this);
-    pipe_masked.gp_ci_.renderPass = rp.Handle();
+    pipe_masked.gp_ci_.renderPass = rp;
     pipe_masked.cb_attachments_.colorWriteMask = 0;
     pipe_masked.CreateGraphicsPipeline();
 
     CreatePipelineHelper pipe_writes(*this);
-    pipe_writes.gp_ci_.renderPass = rp.Handle();
+    pipe_writes.gp_ci_.renderPass = rp;
     pipe_writes.cb_attachments_.colorWriteMask = 0xf;
     pipe_writes.CreateGraphicsPipeline();
 
@@ -602,7 +602,7 @@ TEST_F(VkBestPracticesLayerTest, ClearAttachmentsAfterLoadSecondary) {
     VkClearRect clear_rect = {{{0, 0}, {m_width, m_height}}, 0, 1};
 
     VkRenderPassBeginInfo render_pass_begin_info = vku::InitStructHelper();
-    render_pass_begin_info.renderPass = rp.Handle();
+    render_pass_begin_info.renderPass = rp;
     render_pass_begin_info.framebuffer = fb;
     // need full clear
     render_pass_begin_info.renderArea.extent.width = m_width;
@@ -644,7 +644,7 @@ TEST_F(VkBestPracticesLayerTest, ClearAttachmentsAfterLoadSecondary) {
     VkCommandBufferInheritanceInfo inherit_info = {VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO};
     begin_info.pInheritanceInfo = &inherit_info;
     inherit_info.subpass = 0;
-    inherit_info.renderPass = rp.Handle();
+    inherit_info.renderPass = rp;
 
     vkt::CommandBuffer secondary_clear(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
     vkt::CommandBuffer secondary_draw_masked(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);

--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -211,10 +211,10 @@ TEST_F(NegativeCommand, ClearAttachment64Bit) {
     rp.AddAttachmentReference({0, VK_IMAGE_LAYOUT_GENERAL});
     rp.AddColorAttachment(0);
     rp.CreateRenderPass();
-    vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &image_view.handle());
+    vkt::Framebuffer fb(*m_device, rp, 1, &image_view.handle());
 
     m_command_buffer.Begin();
-    m_command_buffer.BeginRenderPass(rp.Handle(), fb);
+    m_command_buffer.BeginRenderPass(rp, fb);
 
     VkClearAttachment attachment;
     attachment.colorAttachment = 0;
@@ -2968,33 +2968,33 @@ TEST_F(NegativeCommand, DepthStencilStateForReadOnlyLayout) {
 
     CreatePipelineHelper depth_pipe(*this);
     depth_pipe.LateBindPipelineInfo();
-    depth_pipe.gp_ci_.renderPass = rp.Handle();
+    depth_pipe.gp_ci_.renderPass = rp;
     depth_pipe.gp_ci_.pDepthStencilState = &depth_state_info;
     depth_pipe.CreateGraphicsPipeline(false);
 
     CreatePipelineHelper stencil_pipe(*this);
     stencil_pipe.LateBindPipelineInfo();
-    stencil_pipe.gp_ci_.renderPass = rp.Handle();
+    stencil_pipe.gp_ci_.renderPass = rp;
     stencil_pipe.gp_ci_.pDepthStencilState = &stencil_state_info;
     stencil_pipe.CreateGraphicsPipeline(false);
 
     CreatePipelineHelper stencil_disabled_pipe(*this);
     stencil_disabled_pipe.LateBindPipelineInfo();
-    stencil_disabled_pipe.gp_ci_.renderPass = rp.Handle();
+    stencil_disabled_pipe.gp_ci_.renderPass = rp;
     stencil_disabled_pipe.gp_ci_.pDepthStencilState = &stencil_disabled_state_info;
     stencil_disabled_pipe.CreateGraphicsPipeline(false);
 
     CreatePipelineHelper stencil_dynamic_pipe(*this);
     stencil_dynamic_pipe.AddDynamicState(VK_DYNAMIC_STATE_STENCIL_WRITE_MASK);
     stencil_dynamic_pipe.LateBindPipelineInfo();
-    stencil_dynamic_pipe.gp_ci_.renderPass = rp.Handle();
+    stencil_dynamic_pipe.gp_ci_.renderPass = rp;
     stencil_dynamic_pipe.gp_ci_.pDepthStencilState = &stencil_state_info;
     stencil_dynamic_pipe.CreateGraphicsPipeline(false);
 
-    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view.handle());
+    vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view.handle());
 
     m_command_buffer.Begin();
-    m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer, 32, 32);
+    m_command_buffer.BeginRenderPass(rp, framebuffer, 32, 32);
 
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, depth_pipe);
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-06886");
@@ -3654,7 +3654,7 @@ TEST_F(NegativeCommand, ClearDsImageWithInvalidAspect) {
         rp.AddDepthStencilAttachment(0);
         rp.CreateRenderPass();
 
-        vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view.handle());
+        vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view.handle());
 
         VkClearValue clear_value = {};
         clear_value.depthStencil = {0};
@@ -3669,7 +3669,7 @@ TEST_F(NegativeCommand, ClearDsImageWithInvalidAspect) {
         clear_rect.layerCount = 1u;
 
         m_command_buffer.Begin();
-        m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer, 32, 32, 1, &clear_value);
+        m_command_buffer.BeginRenderPass(rp, framebuffer, 32, 32, 1, &clear_value);
         if (missing_depth) {
             m_errorMonitor->SetDesiredError("VUID-vkCmdClearAttachments-aspectMask-07884");
         } else {

--- a/tests/unit/command_positive.cpp
+++ b/tests/unit/command_positive.cpp
@@ -182,7 +182,7 @@ TEST_F(PositiveCommand, FramebufferBindingDestroyCommandPool) {
     vkt::Image image(*m_device, 32, 32, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
 
     vkt::ImageView view = image.CreateView();
-    vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &view.handle());
+    vkt::Framebuffer fb(*m_device, rp, 1, &view.handle());
 
     // Explicitly create a command buffer to bind the FB to so that we can then
     //  destroy the command pool in order to implicitly free command buffer
@@ -242,7 +242,7 @@ TEST_F(PositiveCommand, ClearRectWith2DArray) {
         rp.CreateRenderPass();
 
         VkFramebufferCreateInfo fbci = vku::InitStructHelper();
-        fbci.renderPass = rp.Handle();
+        fbci.renderPass = rp;
         fbci.attachmentCount = 1;
         fbci.pAttachments = &image_view.handle();
         fbci.width = image_ci.extent.width;
@@ -263,7 +263,7 @@ TEST_F(PositiveCommand, ClearRectWith2DArray) {
         clearValue.color = {{0, 0, 0, 0}};
 
         VkRenderPassBeginInfo rpbi = vku::InitStructHelper();
-        rpbi.renderPass = rp.Handle();
+        rpbi.renderPass = rp;
         rpbi.framebuffer = framebuffer;
         rpbi.renderArea = {{0, 0}, {image_ci.extent.width, image_ci.extent.height}};
         rpbi.clearValueCount = 1;

--- a/tests/unit/descriptors.cpp
+++ b/tests/unit/descriptors.cpp
@@ -3695,7 +3695,7 @@ TEST_F(NegativeDescriptors, DISABLED_ImageSubresourceOverlapBetweenAttachmentsAn
     rp.AddDepthStencilAttachment(1);
     rp.CreateRenderPass();
 
-    vkt::Framebuffer fb(*m_device, rp.Handle(), 2u, attachments, 64, 64);
+    vkt::Framebuffer fb(*m_device, rp, 2u, attachments, 64, 64);
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
     char const *fsSource = R"glsl(
@@ -3729,7 +3729,7 @@ TEST_F(NegativeDescriptors, DISABLED_ImageSubresourceOverlapBetweenAttachmentsAn
     pipe_ds_state_ci.stencilTestEnable = VK_FALSE;
 
     g_pipe.gp_ci_.pDepthStencilState = &pipe_ds_state_ci;
-    g_pipe.gp_ci_.renderPass = rp.Handle();
+    g_pipe.gp_ci_.renderPass = rp;
     g_pipe.CreateGraphicsPipeline();
 
     g_pipe.descriptor_set_->WriteDescriptorImageInfo(0, view_input, sampler, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT);
@@ -3747,7 +3747,7 @@ TEST_F(NegativeDescriptors, DISABLED_ImageSubresourceOverlapBetweenAttachmentsAn
 
     m_command_buffer.Begin();
     m_renderPassBeginInfo.renderArea = {{0, 0}, {64, 64}};
-    m_renderPassBeginInfo.renderPass = rp.Handle();
+    m_renderPassBeginInfo.renderPass = rp;
     m_renderPassBeginInfo.framebuffer = fb;
 
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
@@ -4332,7 +4332,7 @@ TEST_F(NegativeDescriptors, ImageSubresourceOverlapBetweenRenderPassAndDescripto
     vkt::ImageView image_view = image.CreateView();
     VkImageView image_view_handle = image_view;
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
-    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view_handle);
+    vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view_handle);
 
     char const *fsSource = R"glsl(
             #version 450
@@ -4353,7 +4353,7 @@ TEST_F(NegativeDescriptors, ImageSubresourceOverlapBetweenRenderPassAndDescripto
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout;
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.CreateGraphicsPipeline();
 
     descriptor_set.WriteDescriptorImageInfo(0, image_view, sampler, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_IMAGE_LAYOUT_GENERAL);
@@ -4362,7 +4362,7 @@ TEST_F(NegativeDescriptors, ImageSubresourceOverlapBetweenRenderPassAndDescripto
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-06537");
 
     m_command_buffer.Begin();
-    m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer, 32, 32, 1, m_renderPassClearValues.data());
+    m_command_buffer.BeginRenderPass(rp, framebuffer, 32, 32, 1, m_renderPassClearValues.data());
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0, 1, &descriptor_set.set_, 0,
                               nullptr);
@@ -4393,7 +4393,7 @@ TEST_F(NegativeDescriptors, ImageSubresourceOverlapBetweenRenderPassAndDescripto
     vkt::ImageView image_view = image.CreateView();
     VkImageView image_view_handle = image_view;
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
-    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view_handle);
+    vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view_handle);
 
     // used as a "would be valid" image
     vkt::Image image_2(*m_device, image_create_info, vkt::set_layout);
@@ -4466,7 +4466,7 @@ TEST_F(NegativeDescriptors, ImageSubresourceOverlapBetweenRenderPassAndDescripto
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout;
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.CreateGraphicsPipeline();
 
     descriptor_set.WriteDescriptorImageInfo(0, image_view, sampler, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_IMAGE_LAYOUT_GENERAL);
@@ -4476,7 +4476,7 @@ TEST_F(NegativeDescriptors, ImageSubresourceOverlapBetweenRenderPassAndDescripto
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-06537");
 
     m_command_buffer.Begin();
-    m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer, 32, 32, 1, m_renderPassClearValues.data());
+    m_command_buffer.BeginRenderPass(rp, framebuffer, 32, 32, 1, m_renderPassClearValues.data());
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0, 1, &descriptor_set.set_, 0,
                               nullptr);
@@ -4511,7 +4511,7 @@ TEST_F(NegativeDescriptors, DISABLED_DescriptorReadFromWriteAttachment) {
     VkImageView image_view_handle = image_view;
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
-    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view_handle, width, height);
+    vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view_handle, width, height);
 
     char const *fsSource = R"glsl(
             #version 450
@@ -4536,7 +4536,7 @@ TEST_F(NegativeDescriptors, DISABLED_DescriptorReadFromWriteAttachment) {
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout;
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.CreateGraphicsPipeline();
 
     OneOffDescriptorSet descriptor_set(m_device,
@@ -4558,7 +4558,7 @@ TEST_F(NegativeDescriptors, DISABLED_DescriptorReadFromWriteAttachment) {
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-09000");
 
     m_command_buffer.Begin();
-    m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer, width, height, 1, m_renderPassClearValues.data());
+    m_command_buffer.BeginRenderPass(rp, framebuffer, width, height, 1, m_renderPassClearValues.data());
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0, 1, &descriptor_set.set_, 0,
                               nullptr);
@@ -4592,7 +4592,7 @@ TEST_F(NegativeDescriptors, DescriptorWriteFromReadAttachment) {
     VkImageView image_view_handle = image_view;
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
-    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view_handle, width, height);
+    vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view_handle, width, height);
 
     char const *fsSource = R"glsl(
             #version 450
@@ -4625,7 +4625,7 @@ TEST_F(NegativeDescriptors, DescriptorWriteFromReadAttachment) {
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout;
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.CreateGraphicsPipeline();
 
     OneOffDescriptorSet descriptor_set_storage_image(
@@ -4644,7 +4644,7 @@ TEST_F(NegativeDescriptors, DescriptorWriteFromReadAttachment) {
     descriptor_set_input_attachment.UpdateDescriptorSets();
 
     m_command_buffer.Begin();
-    m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer, width, height, 1, m_renderPassClearValues.data());
+    m_command_buffer.BeginRenderPass(rp, framebuffer, width, height, 1, m_renderPassClearValues.data());
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0, 1,
                               &descriptor_set_storage_image.set_, 0, nullptr);

--- a/tests/unit/descriptors_positive.cpp
+++ b/tests/unit/descriptors_positive.cpp
@@ -706,7 +706,7 @@ TEST_F(PositiveDescriptors, ImageViewAsDescriptorReadAndInputAttachment) {
     VkImageView image_view_handle = image_view;
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
-    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view_handle);
+    vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view_handle);
 
     char const *fsSource = R"glsl(
             #version 450
@@ -734,7 +734,7 @@ TEST_F(PositiveDescriptors, ImageViewAsDescriptorReadAndInputAttachment) {
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout;
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.CreateGraphicsPipeline();
 
     OneOffDescriptorSet descriptor_set(m_device,
@@ -751,7 +751,7 @@ TEST_F(PositiveDescriptors, ImageViewAsDescriptorReadAndInputAttachment) {
     descriptor_set2.UpdateDescriptorSets();
 
     m_command_buffer.Begin();
-    m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer, 32, 32, 1, m_renderPassClearValues.data());
+    m_command_buffer.BeginRenderPass(rp, framebuffer, 32, 32, 1, m_renderPassClearValues.data());
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0, 1, &descriptor_set.set_, 0,
                               nullptr);
@@ -873,7 +873,7 @@ TEST_F(PositiveDescriptors, DrawingWithUnboundUnusedSetWithInputAttachments) {
     rp.AddInputAttachment(0);
     rp.CreateRenderPass();
 
-    vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &view_input.handle(), width, height);
+    vkt::Framebuffer fb(*m_device, rp, 1, &view_input.handle(), width, height);
 
     char const *fsSource = R"glsl(
         #version 450
@@ -895,11 +895,11 @@ TEST_F(PositiveDescriptors, DrawingWithUnboundUnusedSetWithInputAttachments) {
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout;
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.CreateGraphicsPipeline();
 
     m_command_buffer.Begin();
-    m_renderPassBeginInfo.renderPass = rp.Handle();
+    m_renderPassBeginInfo.renderPass = rp;
     m_renderPassBeginInfo.framebuffer = fb;
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
@@ -1107,7 +1107,7 @@ TEST_F(PositiveDescriptors, AttachmentFeedbackLoopLayout) {
     VkClearValue clear_value;
     clear_value.color = {{0.0f, 0.0f, 0.0f, 0.0f}};
 
-    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view.handle());
+    vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view.handle());
 
     OneOffDescriptorSet descriptor_set(m_device,
                                        {
@@ -1131,12 +1131,12 @@ TEST_F(PositiveDescriptors, AttachmentFeedbackLoopLayout) {
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.gp_ci_.flags = VK_PIPELINE_CREATE_COLOR_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT;
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&descriptor_set.layout_});
     pipe.CreateGraphicsPipeline();
 
     m_command_buffer.Begin();
-    m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer, 32, 32, 1, &clear_value);
+    m_command_buffer.BeginRenderPass(rp, framebuffer, 32, 32, 1, &clear_value);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_, 0u, 1u,
                               &descriptor_set.set_, 0u, nullptr);
@@ -1242,7 +1242,7 @@ TEST_F(PositiveDescriptors, ImageSubresourceOverlapBetweenRenderPassAndDescripto
     vkt::ImageView image_view = image.CreateView();
     VkImageView image_view_handle = image_view;
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
-    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view_handle);
+    vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view_handle);
 
     // used as a "would be valid" image
     vkt::Image image_2(*m_device, image_create_info, vkt::set_layout);
@@ -1315,7 +1315,7 @@ TEST_F(PositiveDescriptors, ImageSubresourceOverlapBetweenRenderPassAndDescripto
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout;
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.CreateGraphicsPipeline();
 
     descriptor_set.WriteDescriptorImageInfo(0, image_view, sampler, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_IMAGE_LAYOUT_GENERAL);
@@ -1323,7 +1323,7 @@ TEST_F(PositiveDescriptors, ImageSubresourceOverlapBetweenRenderPassAndDescripto
     descriptor_set.UpdateDescriptorSets();
 
     m_command_buffer.Begin();
-    m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer, 32, 32, 1, m_renderPassClearValues.data());
+    m_command_buffer.BeginRenderPass(rp, framebuffer, 32, 32, 1, m_renderPassClearValues.data());
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0, 1, &descriptor_set.set_, 0,
                               nullptr);

--- a/tests/unit/dynamic_rendering_positive.cpp
+++ b/tests/unit/dynamic_rendering_positive.cpp
@@ -341,7 +341,7 @@ TEST_F(PositiveDynamicRendering, CreateGraphicsPipeline) {
     CreatePipelineHelper pipe(*this, &rendering_info);
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pl.handle();
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.CreateGraphicsPipeline();
 }
 
@@ -372,7 +372,7 @@ TEST_F(PositiveDynamicRendering, CreateGraphicsPipelineNoInfo) {
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pl.handle();
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.CreateGraphicsPipeline();
 }
 

--- a/tests/unit/dynamic_state.cpp
+++ b/tests/unit/dynamic_state.cpp
@@ -3248,7 +3248,7 @@ TEST_F(NegativeDynamicState, SampleLocations) {
     vkt::ImageView depth_view = depth_image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT);
     const std::array<VkImageView, 2> attachments = {color_view, depth_view};
 
-    vkt::Framebuffer fb(*m_device, rp.Handle(), static_cast<uint32_t>(attachments.size()), attachments.data(), 128, 128);
+    vkt::Framebuffer fb(*m_device, rp, static_cast<uint32_t>(attachments.size()), attachments.data(), 128, 128);
 
     VkMultisamplePropertiesEXT multisample_prop = vku::InitStructHelper();
     vk::GetPhysicalDeviceMultisamplePropertiesEXT(Gpu(), VK_SAMPLE_COUNT_1_BIT, &multisample_prop);
@@ -3284,7 +3284,7 @@ TEST_F(NegativeDynamicState, SampleLocations) {
     {
         CreatePipelineHelper pipe(*this);
         pipe.ms_ci_ = pipe_ms_state_ci;
-        pipe.gp_ci_.renderPass = rp.Handle();
+        pipe.gp_ci_.renderPass = rp;
         pipe.gp_ci_.pDepthStencilState = &pipe_ds_state_ci;
 
         // Set invalid grid size width
@@ -3341,14 +3341,14 @@ TEST_F(NegativeDynamicState, SampleLocations) {
     CreatePipelineHelper dynamic_pipe(*this);
     dynamic_pipe.ms_ci_ = pipe_ms_state_ci;
     dynamic_pipe.AddDynamicState(VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT);
-    dynamic_pipe.gp_ci_.renderPass = rp.Handle();
+    dynamic_pipe.gp_ci_.renderPass = rp;
     dynamic_pipe.gp_ci_.pDepthStencilState = &pipe_ds_state_ci;
     dynamic_pipe.CreateGraphicsPipeline();
 
     vkt::Buffer vbo(*m_device, sizeof(float) * 3, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
 
     m_command_buffer.Begin();
-    m_command_buffer.BeginRenderPass(rp.Handle(), fb, 128, 128);
+    m_command_buffer.BeginRenderPass(rp, fb, 128, 128);
     vk::CmdBindVertexBuffers(m_command_buffer, 1, 1, &vbo.handle(), &kZeroDeviceSize);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, dynamic_pipe);
 
@@ -5101,15 +5101,15 @@ TEST_F(NegativeDynamicState, MissingColorAttachmentBlendBit) {
     rp.AddColorAttachment(0);
     rp.CreateRenderPass();
 
-    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view.handle());
+    vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view.handle());
 
     CreatePipelineHelper pipe(*this);
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT);
     pipe.CreateGraphicsPipeline();
 
     m_command_buffer.Begin();
-    m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer);
+    m_command_buffer.BeginRenderPass(rp, framebuffer);
     VkBool32 enable = VK_TRUE;
     vk::CmdSetColorBlendEnableEXT(m_command_buffer, 0u, 1u, &enable);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
@@ -5361,7 +5361,7 @@ TEST_F(NegativeDynamicState, InvalidSampleMaskSamples) {
     rp.AddColorAttachment(0);
     rp.CreateRenderPass();
 
-    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view.handle());
+    vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view.handle());
 
     VkPipelineMultisampleStateCreateInfo ms_state_ci = vku::InitStructHelper();
     ms_state_ci.rasterizationSamples = VK_SAMPLE_COUNT_2_BIT;
@@ -5369,14 +5369,14 @@ TEST_F(NegativeDynamicState, InvalidSampleMaskSamples) {
     CreatePipelineHelper pipe1(*this);
     pipe1.AddDynamicState(VK_DYNAMIC_STATE_SAMPLE_MASK_EXT);
     pipe1.ms_ci_ = ms_state_ci;
-    pipe1.gp_ci_.renderPass = rp.Handle();
+    pipe1.gp_ci_.renderPass = rp;
     pipe1.CreateGraphicsPipeline();
 
     CreatePipelineHelper pipe2(*this);
     pipe2.AddDynamicState(VK_DYNAMIC_STATE_SAMPLE_MASK_EXT);
     pipe2.AddDynamicState(VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT);
     pipe2.ms_ci_ = ms_state_ci;
-    pipe2.gp_ci_.renderPass = rp.Handle();
+    pipe2.gp_ci_.renderPass = rp;
     pipe2.CreateGraphicsPipeline();
 
     VkSampleMask sample_mask = 1u;
@@ -5385,7 +5385,7 @@ TEST_F(NegativeDynamicState, InvalidSampleMaskSamples) {
     clear_value.color = {{0, 0, 0, 0}};
 
     m_command_buffer.Begin();
-    m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer, 32, 32, 1, &clear_value);
+    m_command_buffer.BeginRenderPass(rp, framebuffer, 32, 32, 1, &clear_value);
     vk::CmdSetSampleMaskEXT(m_command_buffer, VK_SAMPLE_COUNT_1_BIT, &sample_mask);
 
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe1);
@@ -5469,7 +5469,7 @@ TEST_F(NegativeDynamicState, DynamicSampleLocationsEnable) {
     rp.AddDepthStencilAttachment(0);
     rp.CreateRenderPass();
 
-    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view.handle());
+    vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view.handle());
 
     VkClearValue clear_value;
     clear_value.depthStencil = {1.0f, 0u};
@@ -5477,7 +5477,7 @@ TEST_F(NegativeDynamicState, DynamicSampleLocationsEnable) {
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_ENABLE_EXT);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT);
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.ds_ci_ = vku::InitStructHelper();
     pipe.CreateGraphicsPipeline();
 
@@ -5489,7 +5489,7 @@ TEST_F(NegativeDynamicState, DynamicSampleLocationsEnable) {
     sample_locations_info.pSampleLocations = &sample_location;
 
     m_command_buffer.Begin();
-    m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer, 32, 32, 1, &clear_value);
+    m_command_buffer.BeginRenderPass(rp, framebuffer, 32, 32, 1, &clear_value);
     vk::CmdSetSampleLocationsEnableEXT(m_command_buffer, VK_TRUE);
     vk::CmdSetSampleLocationsEXT(m_command_buffer, &sample_locations_info);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
@@ -5809,15 +5809,15 @@ TEST_F(NegativeDynamicState, ColorBlendEnableNotSet) {
 
     vkt::Image image(*m_device, 32u, 32u, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     vkt::ImageView image_view = image.CreateView();
-    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view.handle());
+    vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view.handle());
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT);
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.CreateGraphicsPipeline();
 
     m_command_buffer.Begin();
-    m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer, 32u, 32u);
+    m_command_buffer.BeginRenderPass(rp, framebuffer, 32u, 32u);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-07627");
     vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
@@ -5871,15 +5871,15 @@ TEST_F(NegativeDynamicState, ColorWriteMaskNotSet) {
 
     vkt::Image image(*m_device, 32u, 32u, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     vkt::ImageView image_view = image.CreateView();
-    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view.handle());
+    vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view.handle());
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT);
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.CreateGraphicsPipeline();
 
     m_command_buffer.Begin();
-    m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer, 32u, 32u);
+    m_command_buffer.BeginRenderPass(rp, framebuffer, 32u, 32u);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-07629");
     vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);

--- a/tests/unit/dynamic_state_positive.cpp
+++ b/tests/unit/dynamic_state_positive.cpp
@@ -274,20 +274,20 @@ TEST_F(PositiveDynamicState, DepthTestEnableOverridesPipelineDepthWriteEnable) {
     rp.AddDepthStencilAttachment(1);
     rp.CreateRenderPass();
     VkImageView views[2] = {color_view.handle(), ds_view.handle()};
-    vkt::Framebuffer fb(*m_device, rp.Handle(), 2, views);
+    vkt::Framebuffer fb(*m_device, rp, 2, views);
 
     VkPipelineDepthStencilStateCreateInfo ds_state = vku::InitStructHelper();
     ds_state.depthWriteEnable = VK_TRUE;
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_TEST_ENABLE);
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.ds_ci_ = ds_state;
     pipe.CreateGraphicsPipeline();
 
     m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
-    m_command_buffer.BeginRenderPass(rp.Handle(), fb);
+    m_command_buffer.BeginRenderPass(rp, fb);
 
     vk::CmdSetDepthTestEnableEXT(m_command_buffer, VK_FALSE);
 
@@ -317,19 +317,19 @@ TEST_F(PositiveDynamicState, DepthTestEnableOverridesDynamicDepthWriteEnable) {
     rp.AddDepthStencilAttachment(1);
     rp.CreateRenderPass();
     VkImageView views[2] = {color_view.handle(), ds_view.handle()};
-    vkt::Framebuffer fb(*m_device, rp.Handle(), 2, views);
+    vkt::Framebuffer fb(*m_device, rp, 2, views);
 
     VkPipelineDepthStencilStateCreateInfo ds_state = vku::InitStructHelper();
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_TEST_ENABLE);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_WRITE_ENABLE);
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.ds_ci_ = ds_state;
     pipe.CreateGraphicsPipeline();
 
     m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
-    m_command_buffer.BeginRenderPass(rp.Handle(), fb);
+    m_command_buffer.BeginRenderPass(rp, fb);
 
     vk::CmdSetDepthTestEnableEXT(m_command_buffer, VK_FALSE);
     vk::CmdSetDepthWriteEnableEXT(m_command_buffer, VK_TRUE);
@@ -360,19 +360,19 @@ TEST_F(PositiveDynamicState, DepthTestEnableDepthWriteEnable) {
     rp.AddDepthStencilAttachment(1);
     rp.CreateRenderPass();
     VkImageView views[2] = {color_view.handle(), ds_view.handle()};
-    vkt::Framebuffer fb(*m_device, rp.Handle(), 2, views);
+    vkt::Framebuffer fb(*m_device, rp, 2, views);
 
     VkPipelineDepthStencilStateCreateInfo ds_state = vku::InitStructHelper();
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_TEST_ENABLE);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_WRITE_ENABLE);
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.ds_ci_ = ds_state;
     pipe.CreateGraphicsPipeline();
 
     m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
-    m_command_buffer.BeginRenderPass(rp.Handle(), fb.handle());
+    m_command_buffer.BeginRenderPass(rp, fb.handle());
 
     vk::CmdSetDepthTestEnableEXT(m_command_buffer.handle(), VK_FALSE);
     // never call vkCmdSetDepthWriteEnableEXT as not needed
@@ -928,15 +928,15 @@ TEST_F(PositiveDynamicState, RasterizationSamples) {
     rp.CreateRenderPass();
 
     VkImageView attachments[2] = {image_view, resolve_image_view};
-    const vkt::Framebuffer fb(*m_device, rp.Handle(), 2, attachments);
+    const vkt::Framebuffer fb(*m_device, rp, 2, attachments);
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT);
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.CreateGraphicsPipeline();
 
     m_command_buffer.Begin();
-    m_command_buffer.BeginRenderPass(rp.Handle(), fb, 32u, 32u);
+    m_command_buffer.BeginRenderPass(rp, fb, 32u, 32u);
     vk::CmdSetRasterizationSamplesEXT(m_command_buffer, VK_SAMPLE_COUNT_4_BIT);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
     vk::CmdDraw(m_command_buffer, 4u, 1u, 0u, 0u);

--- a/tests/unit/fragment_shading_rate.cpp
+++ b/tests/unit/fragment_shading_rate.cpp
@@ -789,7 +789,7 @@ TEST_F(NegativeFragmentShadingRate, FramebufferUsage) {
     vkt::ImageView imageView = image.CreateView();
 
     m_errorMonitor->SetDesiredError("VUID-VkFramebufferCreateInfo-flags-04548");
-    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &imageView.handle(),
+    vkt::Framebuffer framebuffer(*m_device, rp, 1, &imageView.handle(),
                                  fsr_properties.minFragmentShadingRateAttachmentTexelSize.width,
                                  fsr_properties.minFragmentShadingRateAttachmentTexelSize.height);
     m_errorMonitor->VerifyFound();
@@ -823,7 +823,7 @@ TEST_F(NegativeFragmentShadingRate, FramebufferDimensions) {
     const auto imageView = vkt::ImageView(*m_device, image_view_ci);
 
     VkFramebufferCreateInfo fb_info = vku::InitStructHelper();
-    fb_info.renderPass = rp.Handle();
+    fb_info.renderPass = rp;
     fb_info.attachmentCount = 1;
     fb_info.pAttachments = &imageView.handle();
     fb_info.width = fsr_properties.minFragmentShadingRateAttachmentTexelSize.width * 2;
@@ -879,7 +879,7 @@ TEST_F(NegativeFragmentShadingRate, FramebufferDimensionsMultiview) {
     const auto imageView = vkt::ImageView(*m_device, image_view_ci);
 
     VkFramebufferCreateInfo fb_info = vku::InitStructHelper();
-    fb_info.renderPass = rp.Handle();
+    fb_info.renderPass = rp;
     fb_info.attachmentCount = 1;
     fb_info.pAttachments = &imageView.handle();
     fb_info.width = fsr_properties.minFragmentShadingRateAttachmentTexelSize.width;
@@ -3625,7 +3625,7 @@ TEST_F(NegativeFragmentShadingRate, MaxFragmentDensityMapLayers) {
         vkt::ImageView image_view = image.CreateView(VK_IMAGE_VIEW_TYPE_2D_ARRAY, 0, 1, 0, VK_REMAINING_ARRAY_LAYERS);
 
         VkFramebufferCreateInfo fb_info = vku::InitStructHelper();
-        fb_info.renderPass = rp.Handle();
+        fb_info.renderPass = rp;
         fb_info.attachmentCount = 1;
         fb_info.pAttachments = &image_view.handle();
         fb_info.width = 32;

--- a/tests/unit/fragment_shading_rate_positive.cpp
+++ b/tests/unit/fragment_shading_rate_positive.cpp
@@ -95,7 +95,7 @@ TEST_F(PositiveFragmentShadingRate, Attachments) {
     vkt::Image image(*m_device, 1, 1, VK_FORMAT_R8_UINT, VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR);
     vkt::ImageView imageView = image.CreateView();
 
-    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &imageView.handle(),
+    vkt::Framebuffer framebuffer(*m_device, rp, 1, &imageView.handle(),
                                  fsr_properties.minFragmentShadingRateAttachmentTexelSize.width,
                                  fsr_properties.minFragmentShadingRateAttachmentTexelSize.height);
     ASSERT_TRUE(framebuffer.initialized());

--- a/tests/unit/image_layout.cpp
+++ b/tests/unit/image_layout.cpp
@@ -966,7 +966,7 @@ TEST_F(NegativeImageLayout, LayoutTransitionRenderPassObject) {
 
     vkt::Image image(*m_device, 64, 64, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     vkt::ImageView view = image.CreateView();
-    vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &view.handle());
+    vkt::Framebuffer fb(*m_device, rp, 1, &view.handle());
 
     VkImageMemoryBarrier render_pass_barrier = vku::InitStructHelper();
     render_pass_barrier.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
@@ -979,7 +979,7 @@ TEST_F(NegativeImageLayout, LayoutTransitionRenderPassObject) {
     render_pass_barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
 
     m_command_buffer.Begin();
-    m_command_buffer.BeginRenderPass(rp.Handle(), fb);
+    m_command_buffer.BeginRenderPass(rp, fb);
     m_errorMonitor->SetDesiredError("VUID-vkCmdPipelineBarrier-oldLayout-01181");
     vk::CmdPipelineBarrier(m_command_buffer, VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT,
                            VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT, VK_DEPENDENCY_BY_REGION_BIT, 0, nullptr, 0, nullptr, 1,
@@ -1013,7 +1013,7 @@ TEST_F(NegativeImageLayout, LayoutTransitionRenderPassObject2) {
 
     vkt::Image image(*m_device, 64, 64, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     vkt::ImageView view = image.CreateView();
-    vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &view.handle());
+    vkt::Framebuffer fb(*m_device, rp, 1, &view.handle());
 
     VkImageMemoryBarrier2 render_pass_barrier = vku::InitStructHelper();
     render_pass_barrier.srcStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
@@ -1028,7 +1028,7 @@ TEST_F(NegativeImageLayout, LayoutTransitionRenderPassObject2) {
     render_pass_barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
 
     m_command_buffer.Begin();
-    m_command_buffer.BeginRenderPass(rp.Handle(), fb);
+    m_command_buffer.BeginRenderPass(rp, fb);
     m_errorMonitor->SetDesiredError("VUID-vkCmdPipelineBarrier2-oldLayout-01181");
     m_command_buffer.Barrier(render_pass_barrier, VK_DEPENDENCY_BY_REGION_BIT);
     m_errorMonitor->VerifyFound();

--- a/tests/unit/image_layout_positive.cpp
+++ b/tests/unit/image_layout_positive.cpp
@@ -172,7 +172,7 @@ TEST_F(PositiveImageLayout, ImagelessTracking) {
     VkFramebufferCreateInfo framebufferCreateInfo = {VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
                                                      &framebufferAttachmentsCreateInfo,
                                                      VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT,
-                                                     rp.Handle(),
+                                                     rp,
                                                      1,
                                                      reinterpret_cast<const VkImageView *>(1),
                                                      attachmentWidth,

--- a/tests/unit/imageless_framebuffer.cpp
+++ b/tests/unit/imageless_framebuffer.cpp
@@ -59,7 +59,7 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
     framebufferCreateInfo.layers = 1;
     framebufferCreateInfo.attachmentCount = 1;
     framebufferCreateInfo.pAttachments = nullptr;
-    framebufferCreateInfo.renderPass = rp.Handle();
+    framebufferCreateInfo.renderPass = rp;
 
     VkImageFormatListCreateInfo imageFormatListCreateInfo = vku::InitStructHelper();
     imageFormatListCreateInfo.viewFormatCount = 2;
@@ -100,7 +100,7 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
     renderPassAttachmentBeginInfo.attachmentCount = 1;
     renderPassAttachmentBeginInfo.pAttachments = image_views;
     VkRenderPassBeginInfo renderPassBeginInfo = vku::InitStructHelper(&renderPassAttachmentBeginInfo);
-    renderPassBeginInfo.renderPass = rp.Handle();
+    renderPassBeginInfo.renderPass = rp;
     renderPassBeginInfo.renderArea.extent.width = attachmentWidth;
     renderPassBeginInfo.renderArea.extent.height = attachmentHeight;
 
@@ -342,7 +342,7 @@ TEST_F(NegativeImagelessFramebuffer, FeatureEnable) {
     framebufferCreateInfo.width = attachmentWidth;
     framebufferCreateInfo.height = attachmentHeight;
     framebufferCreateInfo.layers = 1;
-    framebufferCreateInfo.renderPass = rp.Handle();
+    framebufferCreateInfo.renderPass = rp;
     framebufferCreateInfo.attachmentCount = 1;
 
     // Imageless framebuffer creation bit not present
@@ -388,7 +388,7 @@ TEST_F(NegativeImagelessFramebuffer, BasicUsage) {
     framebufferCreateInfo.width = attachmentWidth;
     framebufferCreateInfo.height = attachmentHeight;
     framebufferCreateInfo.layers = 1;
-    framebufferCreateInfo.renderPass = rp.Handle();
+    framebufferCreateInfo.renderPass = rp;
     framebufferCreateInfo.attachmentCount = 1;
     VkFramebuffer framebuffer = VK_NULL_HANDLE;
 
@@ -515,7 +515,7 @@ TEST_F(NegativeImagelessFramebuffer, AttachmentImageUsageMismatch) {
     framebufferCreateInfo.width = attachmentWidth;
     framebufferCreateInfo.height = attachmentHeight;
     framebufferCreateInfo.layers = 1;
-    framebufferCreateInfo.renderPass = rp.Handle();
+    framebufferCreateInfo.renderPass = rp;
     framebufferCreateInfo.attachmentCount = 4;
     VkFramebuffer framebuffer = VK_NULL_HANDLE;
 
@@ -624,7 +624,7 @@ TEST_F(NegativeImagelessFramebuffer, AttachmentMultiviewImageLayerCountMismatch)
     framebufferCreateInfo.width = attachmentWidth;
     framebufferCreateInfo.height = attachmentHeight;
     framebufferCreateInfo.layers = 1;
-    framebufferCreateInfo.renderPass = rp.Handle();
+    framebufferCreateInfo.renderPass = rp;
     framebufferCreateInfo.attachmentCount = 4;
     VkFramebuffer framebuffer = VK_NULL_HANDLE;
 
@@ -708,7 +708,7 @@ TEST_F(NegativeImagelessFramebuffer, DepthStencilResolveAttachment) {
     framebufferCreateInfo.width = attachmentWidth;
     framebufferCreateInfo.height = attachmentHeight;
     framebufferCreateInfo.layers = 1;
-    framebufferCreateInfo.renderPass = rp.Handle();
+    framebufferCreateInfo.renderPass = rp;
     framebufferCreateInfo.attachmentCount = 2;
     framebufferCreateInfo.pAttachments = nullptr;
     VkFramebuffer framebuffer = VK_NULL_HANDLE;
@@ -767,7 +767,7 @@ TEST_F(NegativeImagelessFramebuffer, FragmentShadingRateUsage) {
 
     VkFramebufferCreateInfo fb_info = vku::InitStructHelper(&fba_info);
     fb_info.flags = VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT;
-    fb_info.renderPass = rp.Handle();
+    fb_info.renderPass = rp;
     fb_info.attachmentCount = 1;
     fb_info.pAttachments = NULL;
     fb_info.width = fsr_properties.minFragmentShadingRateAttachmentTexelSize.width;
@@ -813,7 +813,7 @@ TEST_F(NegativeImagelessFramebuffer, FragmentShadingRateDimensions) {
 
     VkFramebufferCreateInfo fb_info = vku::InitStructHelper(&fba_info);
     fb_info.flags = VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT;
-    fb_info.renderPass = rp.Handle();
+    fb_info.renderPass = rp;
     fb_info.attachmentCount = 1;
     fb_info.pAttachments = NULL;
     fb_info.width = fsr_properties.minFragmentShadingRateAttachmentTexelSize.width;
@@ -881,7 +881,7 @@ TEST_F(NegativeImagelessFramebuffer, FragmentShadingRateDimensionsMultiview) {
 
     VkFramebufferCreateInfo fb_info = vku::InitStructHelper(&fba_info);
     fb_info.flags = VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT;
-    fb_info.renderPass = rp.Handle();
+    fb_info.renderPass = rp;
     fb_info.attachmentCount = 1;
     fb_info.pAttachments = NULL;
     fb_info.width = fsr_properties.minFragmentShadingRateAttachmentTexelSize.width;
@@ -947,7 +947,7 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageView3D) {
     framebufferCreateInfo.height = attachmentHeight;
     framebufferCreateInfo.layers = 1;
     framebufferCreateInfo.attachmentCount = 1;
-    framebufferCreateInfo.renderPass = rp.Handle();
+    framebufferCreateInfo.renderPass = rp;
 
     // Try to use 3D Image View without imageless flag
     {
@@ -969,7 +969,7 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageView3D) {
     renderPassAttachmentBeginInfo.attachmentCount = 1;
     renderPassAttachmentBeginInfo.pAttachments = &imageView3D.handle();
     VkRenderPassBeginInfo renderPassBeginInfo = vku::InitStructHelper(&renderPassAttachmentBeginInfo);
-    renderPassBeginInfo.renderPass = rp.Handle();
+    renderPassBeginInfo.renderPass = rp;
     renderPassBeginInfo.renderArea.extent.width = attachmentWidth;
     renderPassBeginInfo.renderArea.extent.height = attachmentHeight;
     renderPassBeginInfo.framebuffer = framebuffer;
@@ -1115,7 +1115,7 @@ TEST_F(NegativeImagelessFramebuffer, MissingInheritanceRenderingInfo) {
     fb_ci.width = attachment_width;
     fb_ci.height = attachment_height;
     fb_ci.layers = 1;
-    fb_ci.renderPass = rp.Handle();
+    fb_ci.renderPass = rp;
     fb_ci.attachmentCount = 1;
 
     fb_ci.pAttachments = nullptr;

--- a/tests/unit/imageless_framebuffer_positive.cpp
+++ b/tests/unit/imageless_framebuffer_positive.cpp
@@ -48,7 +48,7 @@ TEST_F(PositiveImagelessFramebuffer, BasicUsage) {
     fb_ci.width = attachment_width;
     fb_ci.height = attachment_height;
     fb_ci.layers = 1;
-    fb_ci.renderPass = rp.Handle();
+    fb_ci.renderPass = rp;
     fb_ci.attachmentCount = 1;
 
     fb_ci.pAttachments  = nullptr;
@@ -107,7 +107,7 @@ TEST_F(PositiveImagelessFramebuffer, Image3D) {
 
     VkFramebufferCreateInfo framebuffer_ci = vku::InitStructHelper(&framebuffer_attachments);
     framebuffer_ci.flags = VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT;
-    framebuffer_ci.renderPass = rp.Handle();
+    framebuffer_ci.renderPass = rp;
     framebuffer_ci.attachmentCount = 1;
     framebuffer_ci.pAttachments = &imageView.handle();
     framebuffer_ci.width = 32;
@@ -124,7 +124,7 @@ TEST_F(PositiveImagelessFramebuffer, Image3D) {
     render_pass_attachment_bi.pAttachments = &imageView.handle();
 
     VkRenderPassBeginInfo render_pass_bi = vku::InitStructHelper(&render_pass_attachment_bi);
-    render_pass_bi.renderPass = rp.Handle();
+    render_pass_bi.renderPass = rp;
     render_pass_bi.framebuffer = framebuffer;
     render_pass_bi.renderArea.extent = {1, 1};
     render_pass_bi.clearValueCount = 1;
@@ -172,7 +172,7 @@ TEST_F(PositiveImagelessFramebuffer, SecondaryCmdBuffer) {
     fb_ci.width = attachment_width;
     fb_ci.height = attachment_height;
     fb_ci.layers = 1;
-    fb_ci.renderPass = rp.Handle();
+    fb_ci.renderPass = rp;
     fb_ci.attachmentCount = 1;
 
     fb_ci.pAttachments = nullptr;
@@ -184,7 +184,7 @@ TEST_F(PositiveImagelessFramebuffer, SecondaryCmdBuffer) {
     vkt::Framebuffer framebuffer_bad_image_view(*m_device, fb_ci);
 
     VkCommandBufferInheritanceInfo inheritanceInfo = vku::InitStructHelper();
-    inheritanceInfo.renderPass = rp.Handle();
+    inheritanceInfo.renderPass = rp;
     inheritanceInfo.framebuffer = framebuffer_null;
 
     VkCommandBufferBeginInfo beginInfo = vku::InitStructHelper();

--- a/tests/unit/multiview.cpp
+++ b/tests/unit/multiview.cpp
@@ -59,10 +59,10 @@ TEST_F(NegativeMultiview, MaxInstanceIndex) {
     vkt::Image image(*m_device, image_create_info, vkt::set_layout);
     vkt::ImageView imageView = image.CreateView(VK_IMAGE_VIEW_TYPE_2D_ARRAY);
 
-    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &imageView.handle());
+    vkt::Framebuffer framebuffer(*m_device, rp, 1, &imageView.handle());
 
     VkRenderPassBeginInfo render_pass_bi = vku::InitStructHelper();
-    render_pass_bi.renderPass = rp.Handle();
+    render_pass_bi.renderPass = rp;
     render_pass_bi.framebuffer = framebuffer;
     render_pass_bi.renderArea.extent.width = 32u;
     render_pass_bi.renderArea.extent.height = 32u;
@@ -70,7 +70,7 @@ TEST_F(NegativeMultiview, MaxInstanceIndex) {
     render_pass_bi.pClearValues = m_renderPassClearValues.data();
 
     CreatePipelineHelper pipe(*this);
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.CreateGraphicsPipeline();
 
     m_command_buffer.Begin();
@@ -116,7 +116,7 @@ TEST_F(NegativeMultiview, ClearColorAttachments) {
     vkt::Image image(*m_device, image_create_info, vkt::set_layout);
     vkt::ImageView imageView = image.CreateView(VK_IMAGE_VIEW_TYPE_2D_ARRAY);
 
-    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &imageView.handle());
+    vkt::Framebuffer framebuffer(*m_device, rp, 1, &imageView.handle());
 
     // Start no RenderPass
     m_command_buffer.Begin();
@@ -133,7 +133,7 @@ TEST_F(NegativeMultiview, ClearColorAttachments) {
     clear_rect.rect.extent.width = 32;
     clear_rect.rect.extent.height = 32;
 
-    m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer, 32, 32);
+    m_command_buffer.BeginRenderPass(rp, framebuffer, 32, 32);
     m_errorMonitor->SetDesiredError("VUID-vkCmdClearAttachments-baseArrayLayer-00018");
     m_errorMonitor->SetDesiredError("VUID-vkCmdClearAttachments-pRects-06937");
     clear_rect.layerCount = 2;
@@ -629,14 +629,14 @@ TEST_F(NegativeMultiview, BeginTransformFeedback) {
     image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
     const vkt::ImageView imageView(*m_device, image_view_ci);
 
-    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &imageView.handle());
+    vkt::Framebuffer framebuffer(*m_device, rp, 1, &imageView.handle());
 
     CreatePipelineHelper pipe(*this);
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.CreateGraphicsPipeline();
 
     m_command_buffer.Begin();
-    m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer, 32, 32);
+    m_command_buffer.BeginRenderPass(rp, framebuffer, 32, 32);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
 
     vkt::Buffer buffer(*m_device, 16, VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_BUFFER_BIT_EXT);
@@ -1101,7 +1101,7 @@ TEST_F(NegativeMultiview, FeaturesDisabled) {
         VkPipelineTessellationStateCreateInfo tsci{VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO, nullptr, 0, 3};
 
         CreatePipelineHelper pipe(*this);
-        pipe.gp_ci_.renderPass = rp.Handle();
+        pipe.gp_ci_.renderPass = rp;
         pipe.gp_ci_.subpass = 0;
         pipe.cb_ci_.attachmentCount = 1;
         pipe.gp_ci_.pTessellationState = &tsci;
@@ -1130,7 +1130,7 @@ TEST_F(NegativeMultiview, FeaturesDisabled) {
         VkShaderObj gs(this, gsSource, VK_SHADER_STAGE_GEOMETRY_BIT);
 
         CreatePipelineHelper pipe(*this);
-        pipe.gp_ci_.renderPass = rp.Handle();
+        pipe.gp_ci_.renderPass = rp;
         pipe.gp_ci_.subpass = 0;
         pipe.cb_ci_.attachmentCount = 1;
         pipe.shader_stages_ = {vs.GetStageCreateInfo(), gs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};

--- a/tests/unit/multiview_positive.cpp
+++ b/tests/unit/multiview_positive.cpp
@@ -43,7 +43,7 @@ TEST_F(PositiveMultiview, RenderPassQueries) {
     vkt::Image image(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView view = image.CreateView(VK_IMAGE_VIEW_TYPE_2D_ARRAY, 0, 1, 0, 3);
 
-    vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &view.handle());
+    vkt::Framebuffer fb(*m_device, rp, 1, &view.handle());
 
     vkt::Buffer buffer(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
@@ -52,7 +52,7 @@ TEST_F(PositiveMultiview, RenderPassQueries) {
     m_command_buffer.Begin();
     vk::CmdResetQueryPool(m_command_buffer, query_pool, 0, 2);
 
-    m_command_buffer.BeginRenderPass(rp.Handle(), fb, 32, 32);
+    m_command_buffer.BeginRenderPass(rp, fb, 32, 32);
     vk::CmdBeginQuery(m_command_buffer, query_pool, 0, 0);
     vk::CmdEndQuery(m_command_buffer, query_pool, 0);
     m_command_buffer.EndRenderPass();

--- a/tests/unit/object_lifetime.cpp
+++ b/tests/unit/object_lifetime.cpp
@@ -795,7 +795,7 @@ TEST_F(NegativeObjectLifetime, FramebufferImageInUseDestroyedSignaled) {
     rp.AddAttachmentReference({0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL});
     rp.AddColorAttachment(0);
     rp.CreateRenderPass();
-    vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &view.handle(), 256, 256);
+    vkt::Framebuffer fb(*m_device, rp, 1, &view.handle(), 256, 256);
 
     // Create Null cmd buffer for submit
     m_command_buffer.Begin();

--- a/tests/unit/pipeline.cpp
+++ b/tests/unit/pipeline.cpp
@@ -126,7 +126,7 @@ TEST_F(NegativePipeline, DisabledIndependentBlend) {
     cb_attachments[1].blendEnable = VK_FALSE;
 
     CreatePipelineHelper pipe(*this);
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.cb_ci_.attachmentCount = 2;
     pipe.cb_ci_.pAttachments = cb_attachments;
 
@@ -164,7 +164,7 @@ TEST_F(NegativePipeline, BlendingOnFormatWithoutBlendingSupport) {
     rp.CreateRenderPass();
 
     CreatePipelineHelper pipe(*this);
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.cb_attachments_.dstAlphaBlendFactor = VK_BLEND_FACTOR_CONSTANT_COLOR;
     pipe.cb_attachments_.blendEnable = VK_TRUE;
     pipe.CreateGraphicsPipeline();
@@ -185,7 +185,7 @@ TEST_F(NegativePipeline, ColorWriteMaskE5B9G9R9) {
     rp.CreateRenderPass();
 
     CreatePipelineHelper pipe(*this);
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.cb_attachments_.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_A_BIT;
     m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-None-09043");
     pipe.CreateGraphicsPipeline();
@@ -1070,7 +1070,7 @@ TEST_F(NegativePipeline, DepthStencilRequired) {
     rp.CreateRenderPass();
 
     CreatePipelineHelper pipe(*this);
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.CreateGraphicsPipeline();
 
     m_errorMonitor->VerifyFound();
@@ -1254,7 +1254,7 @@ TEST_F(NegativePipeline, FramebufferMixedSamplesNV) {
             helper.ms_ci_.rasterizationSamples = test_case.raster_samples;
             helper.ms_ci_.sampleShadingEnable = test_case.sample_shading;
 
-            helper.gp_ci_.renderPass = rp.Handle();
+            helper.gp_ci_.renderPass = rp;
             helper.gp_ci_.pDepthStencilState = &ds;
         };
 
@@ -1314,7 +1314,7 @@ TEST_F(NegativePipeline, FramebufferMixedSamples) {
         const auto break_samples = [&rp, &ds, &test_case](CreatePipelineHelper &helper) {
             helper.ms_ci_.rasterizationSamples = test_case.raster_samples;
 
-            helper.gp_ci_.renderPass = rp.Handle();
+            helper.gp_ci_.renderPass = rp;
             helper.gp_ci_.pDepthStencilState = &ds;
         };
 
@@ -1427,7 +1427,7 @@ TEST_F(NegativePipeline, FramebufferMixedSamplesCoverageReduction) {
 
             helper.ms_ci_.pNext = &crs;
             helper.ms_ci_.rasterizationSamples = test_case.raster_samples;
-            helper.gp_ci_.renderPass = rp.Handle();
+            helper.gp_ci_.renderPass = rp;
             helper.gp_ci_.pDepthStencilState = (test_case.depth_samples) ? &dss : nullptr;
         };
 
@@ -3081,7 +3081,7 @@ TEST_F(NegativePipeline, ShaderTileImage) {
         // Check if the colorAttachmentRead capability enable, renderpass should be null
         auto pipeline_createinfo = [&](CreatePipelineHelper &helper) {
             helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
-            helper.gp_ci_.renderPass = rp.Handle();
+            helper.gp_ci_.renderPass = rp;
         };
 
         CreatePipelineHelper::OneshotTest(*this, pipeline_createinfo, kErrorBit,
@@ -3283,7 +3283,7 @@ TEST_F(NegativePipeline, PipelineMissingFeatures) {
     CreatePipelineHelper pipe(*this);
     pipe.ds_ci_ = vku::InitStructHelper();
     pipe.ds_ci_.depthBoundsTestEnable = VK_TRUE;
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     m_errorMonitor->SetDesiredError("VUID-VkPipelineDepthStencilStateCreateInfo-depthBoundsTestEnable-00598");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();

--- a/tests/unit/pipeline_positive.cpp
+++ b/tests/unit/pipeline_positive.cpp
@@ -752,7 +752,7 @@ TEST_F(PositivePipeline, SampleMaskOverrideCoverageNV) {
 
     CreatePipelineHelper pipe(*this);
     pipe.gp_ci_.layout = pl.handle();
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.gp_ci_.pMultisampleState = &msaa;
 
@@ -778,7 +778,7 @@ TEST_F(PositivePipeline, RasterizationDiscardEnableTrue) {
     pipe.gp_ci_.pMultisampleState = nullptr;
     pipe.gp_ci_.pDepthStencilState = nullptr;
     pipe.gp_ci_.pColorBlendState = nullptr;
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
 
     // When rasterizer discard is enabled, fragment shader state must not be present.
     pipe.VertexShaderOnly();
@@ -869,10 +869,10 @@ TEST_F(PositivePipeline, ConditionalRendering) {
     vkt::Image image(*m_device, 32, 32, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     vkt::ImageView imageView = image.CreateView();
 
-    vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &imageView.handle());
+    vkt::Framebuffer fb(*m_device, rp, 1, &imageView.handle());
 
     m_command_buffer.Begin();
-    m_command_buffer.BeginRenderPass(rp.Handle(), fb, 32, 32);
+    m_command_buffer.BeginRenderPass(rp, fb, 32, 32);
 
     VkImageMemoryBarrier imb = vku::InitStructHelper();
     imb.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
@@ -1568,7 +1568,7 @@ TEST_F(PositivePipeline, DepthStencilStateIgnored) {
         CreatePipelineHelper pipe(*this);
         pipe.VertexShaderOnly();
         pipe.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
-        pipe.gp_ci_.renderPass = rp.Handle();
+        pipe.gp_ci_.renderPass = rp;
         pipe.CreateGraphicsPipeline();
     }
 
@@ -1582,7 +1582,7 @@ TEST_F(PositivePipeline, DepthStencilStateIgnored) {
         pipe.AddDynamicState(VK_DYNAMIC_STATE_STENCIL_TEST_ENABLE);
         pipe.AddDynamicState(VK_DYNAMIC_STATE_STENCIL_OP);
         pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_BOUNDS);
-        pipe.gp_ci_.renderPass = rp.Handle();
+        pipe.gp_ci_.renderPass = rp;
         pipe.CreateGraphicsPipeline();
     }
 }
@@ -1852,7 +1852,7 @@ TEST_F(PositivePipeline, PipelineMissingFeaturesDynamic) {
     pipe.rs_state_ci_.depthClampEnable = VK_TRUE;
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_CLAMP_ENABLE_EXT);
 
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.CreateGraphicsPipeline();
 }
 
@@ -1931,7 +1931,7 @@ TEST_F(PositivePipeline, ColorWriteMaskE5B9G9R9) {
     rp.CreateRenderPass();
 
     CreatePipelineHelper pipe(*this);
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.cb_attachments_.colorWriteMask = VK_COLOR_COMPONENT_A_BIT;
     {
         pipe.CreateGraphicsPipeline();

--- a/tests/unit/protected_memory.cpp
+++ b/tests/unit/protected_memory.cpp
@@ -786,7 +786,7 @@ TEST_F(NegativeProtectedMemory, MixingProtectedResources) {
                             VK_ACCESS_SHADER_WRITE_BIT, VK_ACCESS_SHADER_WRITE_BIT);
     rp.CreateRenderPass();
 
-    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 2, image_views, 8, 8);
+    vkt::Framebuffer framebuffer(*m_device, rp, 2, image_views, 8, 8);
 
     // Various structs used for commands
     VkImageSubresourceLayers image_subresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
@@ -834,7 +834,7 @@ TEST_F(NegativeProtectedMemory, MixingProtectedResources) {
     VkPipelineColorBlendAttachmentState cb_attachments[2] = {};
     memset(cb_attachments, 0, sizeof(VkPipelineColorBlendAttachmentState) * 2);
     CreatePipelineHelper g_pipe(*this);
-    g_pipe.gp_ci_.renderPass = rp.Handle();
+    g_pipe.gp_ci_.renderPass = rp;
     g_pipe.shader_stages_ = {g_pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     g_pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
                             {1, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
@@ -914,7 +914,7 @@ TEST_F(NegativeProtectedMemory, MixingProtectedResources) {
         vk::CmdUpdateBuffer(m_command_buffer, buffer_protected, 0, 4, (void *)update_data);
         m_errorMonitor->VerifyFound();
 
-        m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer, render_area.extent.width, render_area.extent.height);
+        m_command_buffer.BeginRenderPass(rp, framebuffer, render_area.extent.width, render_area.extent.height);
 
         m_errorMonitor->SetDesiredError("VUID-vkCmdClearAttachments-commandBuffer-02504");
         vk::CmdClearAttachments(m_command_buffer, 2, clear_attachments, 2, clear_rect);
@@ -985,7 +985,7 @@ TEST_F(NegativeProtectedMemory, MixingProtectedResources) {
         vk::CmdUpdateBuffer(protectedCommandBuffer, buffer_unprotected, 0, 4, (void *)update_data);
         m_errorMonitor->VerifyFound();
 
-        protectedCommandBuffer.BeginRenderPass(rp.Handle(), framebuffer, render_area.extent.width, render_area.extent.height);
+        protectedCommandBuffer.BeginRenderPass(rp, framebuffer, render_area.extent.width, render_area.extent.height);
 
         m_errorMonitor->SetDesiredError("VUID-vkCmdClearAttachments-commandBuffer-02505");
         vk::CmdClearAttachments(protectedCommandBuffer, 2, clear_attachments, 2, clear_rect);

--- a/tests/unit/secondary_command_buffer.cpp
+++ b/tests/unit/secondary_command_buffer.cpp
@@ -51,7 +51,7 @@ TEST_F(NegativeSecondaryCommandBuffer, Barrier) {
     // Second image that img_barrier will incorrectly use
     vkt::Image image2(*m_device, 32, 32, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
 
-    vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &imageView.handle());
+    vkt::Framebuffer fb(*m_device, rp, 1, &imageView.handle());
 
     m_command_buffer.Begin();
 
@@ -64,7 +64,7 @@ TEST_F(NegativeSecondaryCommandBuffer, Barrier) {
 
     VkCommandBufferInheritanceInfo cbii = {VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO,
                                            nullptr,
-                                           rp.Handle(),
+                                           rp,
                                            0,
                                            VK_NULL_HANDLE,  // Set to NULL FB handle intentionally to flesh out any errors
                                            VK_FALSE,

--- a/tests/unit/secondary_command_buffer_positive.cpp
+++ b/tests/unit/secondary_command_buffer_positive.cpp
@@ -35,7 +35,7 @@ TEST_F(PositiveSecondaryCommandBuffer, Barrier) {
     image.SetLayout(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
     vkt::ImageView imageView = image.CreateView();
 
-    vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &imageView.handle());
+    vkt::Framebuffer fb(*m_device, rp, 1, &imageView.handle());
 
     m_command_buffer.Begin();
     VkRenderPassBeginInfo rpbi =
@@ -47,7 +47,7 @@ TEST_F(PositiveSecondaryCommandBuffer, Barrier) {
 
     VkCommandBufferInheritanceInfo cbii = {VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO,
                                            nullptr,
-                                           rp.Handle(),
+                                           rp,
                                            0,
                                            VK_NULL_HANDLE,  // Set to NULL FB handle intentionally to flesh out any errors
                                            VK_FALSE,

--- a/tests/unit/shader_interface.cpp
+++ b/tests/unit/shader_interface.cpp
@@ -1839,7 +1839,7 @@ TEST_F(NegativeShaderInterface, DISABLED_FragmentOutputNotWrittenArray) {
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.cb_ci_.attachmentCount = 2;
     pipe.cb_ci_.pAttachments = color_blends;
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     m_errorMonitor->SetDesiredWarning("Undefined-Value-ShaderOutputNotProduced");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
@@ -2280,7 +2280,7 @@ TEST_F(NegativeShaderInterface, DISABLED_MultipleFragmentAttachment) {
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.cb_ci_.attachmentCount = 3;
     pipe.cb_ci_.pAttachments = color_blends;
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     m_errorMonitor->SetDesiredWarning("Undefined-Value-ShaderOutputNotProduced");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
@@ -2399,7 +2399,7 @@ TEST_F(NegativeShaderInterface, MissingInputAttachmentIndex) {
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-None-09558");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();

--- a/tests/unit/shader_interface_positive.cpp
+++ b/tests/unit/shader_interface_positive.cpp
@@ -467,7 +467,7 @@ TEST_F(PositiveShaderInterface, InputAttachment) {
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pl.handle();
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.CreateGraphicsPipeline();
 }
 
@@ -560,7 +560,7 @@ TEST_F(PositiveShaderInterface, InputAttachmentArray) {
         const auto set_info = [&](CreatePipelineHelper &helper) {
             helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
             helper.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 2, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
-            helper.gp_ci_.renderPass = rp.Handle();
+            helper.gp_ci_.renderPass = rp;
         };
         CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
     }
@@ -580,7 +580,7 @@ TEST_F(PositiveShaderInterface, InputAttachmentArray) {
         const auto set_info = [&](CreatePipelineHelper &helper) {
             helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
             helper.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 2, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
-            helper.gp_ci_.renderPass = rp.Handle();
+            helper.gp_ci_.renderPass = rp;
         };
         CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
     }
@@ -601,7 +601,7 @@ TEST_F(PositiveShaderInterface, InputAttachmentArray) {
         const auto set_info = [&](CreatePipelineHelper &helper) {
             helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
             helper.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 2, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
-            helper.gp_ci_.renderPass = rp.Handle();
+            helper.gp_ci_.renderPass = rp;
         };
         CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
     }
@@ -621,7 +621,7 @@ TEST_F(PositiveShaderInterface, InputAttachmentArray) {
         const auto set_info = [&](CreatePipelineHelper &helper) {
             helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
             helper.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 2, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
-            helper.gp_ci_.renderPass = rp.Handle();
+            helper.gp_ci_.renderPass = rp;
         };
         CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
     }
@@ -669,7 +669,7 @@ TEST_F(PositiveShaderInterface, InputAttachmentRuntimeArray) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
         helper.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 2, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
                                 {3, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
-        helper.gp_ci_.renderPass = rp.Handle();
+        helper.gp_ci_.renderPass = rp;
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
 
@@ -717,7 +717,7 @@ TEST_F(PositiveShaderInterface, InputAttachmentDepthStencil) {
         helper.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
                                 {1, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
                                 {2, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
-        helper.gp_ci_.renderPass = rp.Handle();
+        helper.gp_ci_.renderPass = rp;
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
 }
@@ -1359,7 +1359,7 @@ TEST_F(PositiveShaderInterface, MultipleFragmentAttachment) {
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.cb_ci_.attachmentCount = 2;
     pipe.cb_ci_.pAttachments = cb_as;
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.CreateGraphicsPipeline();
 }
 
@@ -1421,7 +1421,7 @@ TEST_F(PositiveShaderInterface, MissingInputAttachmentIndex) {
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.CreateGraphicsPipeline();
 }
 

--- a/tests/unit/shader_object.cpp
+++ b/tests/unit/shader_object.cpp
@@ -1059,7 +1059,7 @@ TEST_F(NegativeShaderObject, DrawWithShadersInNonDynamicRenderPass) {
 
     vkt::Image image(*m_device, 32, 32, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     vkt::ImageView image_view = image.CreateView();
-    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view.handle());
+    vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view.handle());
 
     VkClearValue clear_value;
     clear_value.color.float32[0] = 0.25f;
@@ -1068,7 +1068,7 @@ TEST_F(NegativeShaderObject, DrawWithShadersInNonDynamicRenderPass) {
     clear_value.color.float32[3] = 0.0f;
 
     m_command_buffer.Begin();
-    m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer, 32, 32, 1, &clear_value);
+    m_command_buffer.BeginRenderPass(rp, framebuffer, 32, 32, 1, &clear_value);
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindShaders(m_vert_shader, m_frag_shader);
 

--- a/tests/unit/subpass.cpp
+++ b/tests/unit/subpass.cpp
@@ -1204,7 +1204,7 @@ TEST_F(NegativeSubpass, FramebufferNoAttachmentsSampleCounts) {
     ms_state.alphaToOneEnable = VK_FALSE;
 
     CreatePipelineHelper pipe(*this);
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.ms_ci_ = ms_state;
     m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-subpass-00758");
     pipe.CreateGraphicsPipeline();

--- a/tests/unit/sync_object.cpp
+++ b/tests/unit/sync_object.cpp
@@ -255,7 +255,7 @@ TEST_F(NegativeSyncObject, Barriers) {
     // Add a token self-dependency for this test to avoid unexpected errors
     rp.AddSubpassDependency(stage_flags, stage_flags, access_flags, access_flags);
     rp.CreateRenderPass();
-    vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &color_view.handle());
+    vkt::Framebuffer fb(*m_device, rp, 1, &color_view.handle());
 
     auto depth_format = FindSupportedDepthStencilFormat(Gpu());
 
@@ -296,7 +296,7 @@ TEST_F(NegativeSyncObject, Barriers) {
     conc_test("");
 
     m_command_buffer.Begin();
-    m_command_buffer.BeginRenderPass(rp.Handle(), fb);
+    m_command_buffer.BeginRenderPass(rp, fb);
 
     // Can't send buffer memory barrier during a render pass
     m_command_buffer.EndRenderPass();
@@ -774,7 +774,7 @@ TEST_F(NegativeSyncObject, Sync2Barriers) {
     // Add a token self-dependency for this test to avoid unexpected errors
     rp.AddSubpassDependency(stage_flags, stage_flags, access_flags, access_flags);
     rp.CreateRenderPass();
-    vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &color_view.handle());
+    vkt::Framebuffer fb(*m_device, rp, 1, &color_view.handle());
 
     const uint32_t submit_family = m_device->graphics_queue_node_index_;
     const uint32_t invalid = static_cast<uint32_t>(m_device->Physical().queue_properties_.size());
@@ -812,7 +812,7 @@ TEST_F(NegativeSyncObject, Sync2Barriers) {
     conc_test("");
 
     m_command_buffer.Begin();
-    m_command_buffer.BeginRenderPass(rp.Handle(), fb);
+    m_command_buffer.BeginRenderPass(rp, fb);
 
     // Can't send buffer memory barrier during a render pass
     m_command_buffer.EndRenderPass();
@@ -3834,10 +3834,10 @@ TEST_F(NegativeSyncObject, RenderPassPipelineBarrierGraphicsStage) {
 
     vkt::Image image(*m_device, 32, 32, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     vkt::ImageView view = image.CreateView();
-    vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &view.handle());
+    vkt::Framebuffer fb(*m_device, rp, 1, &view.handle());
 
     m_command_buffer.Begin();
-    m_command_buffer.BeginRenderPass(rp.Handle(), fb);
+    m_command_buffer.BeginRenderPass(rp, fb);
     m_errorMonitor->SetDesiredError("VUID-vkCmdPipelineBarrier-None-07889");
     m_errorMonitor->SetDesiredError("VUID-vkCmdPipelineBarrier-None-07889");
     m_errorMonitor->SetDesiredError("VUID-vkCmdPipelineBarrier-None-07892");

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -253,7 +253,7 @@ TEST_F(PositiveSyncVal, LoadOpImplicitOrdering) {
     vkt::Image image(*m_device, 64, 64, VK_FORMAT_R8G8B8A8_UNORM,
                      VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
     vkt::ImageView image_view = image.CreateView();
-    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view.handle(), 64, 64);
+    vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view.handle(), 64, 64);
 
     VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs_read(this, kFragmentSubpassLoadGlsl, VK_SHADER_STAGE_FRAGMENT_BIT);
@@ -261,7 +261,7 @@ TEST_F(PositiveSyncVal, LoadOpImplicitOrdering) {
     CreatePipelineHelper pipe_read(*this);
     pipe_read.shader_stages_ = {vs.GetStageCreateInfo(), fs_read.GetStageCreateInfo()};
     pipe_read.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 1, VK_SHADER_STAGE_FRAGMENT_BIT};
-    pipe_read.gp_ci_.renderPass = rp.Handle();
+    pipe_read.gp_ci_.renderPass = rp;
     pipe_read.CreateGraphicsPipeline();
     pipe_read.descriptor_set_->WriteDescriptorImageInfo(0, image_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT,
                                                         VK_IMAGE_LAYOUT_GENERAL);
@@ -270,7 +270,7 @@ TEST_F(PositiveSyncVal, LoadOpImplicitOrdering) {
     VkClearValue clear_value{};
 
     m_command_buffer.Begin();
-    m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer, 64, 64, 1, &clear_value);
+    m_command_buffer.BeginRenderPass(rp, framebuffer, 64, 64, 1, &clear_value);
 
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe_read);
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe_read.pipeline_layout_, 0, 1,
@@ -295,7 +295,7 @@ TEST_F(PositiveSyncVal, StoreOpImplicitOrdering) {
     vkt::Image input_image(*m_device, 64, 64, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
     vkt::ImageView input_image_view = input_image.CreateView();
 
-    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &input_image_view.handle(), 64, 64);
+    vkt::Framebuffer framebuffer(*m_device, rp, 1, &input_image_view.handle(), 64, 64);
 
     VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(this, kFragmentSubpassLoadGlsl, VK_SHADER_STAGE_FRAGMENT_BIT);
@@ -303,7 +303,7 @@ TEST_F(PositiveSyncVal, StoreOpImplicitOrdering) {
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 1, VK_SHADER_STAGE_FRAGMENT_BIT};
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.CreateGraphicsPipeline();
     pipe.descriptor_set_->WriteDescriptorImageInfo(0, input_image_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT);
     pipe.descriptor_set_->UpdateDescriptorSets();
@@ -312,7 +312,7 @@ TEST_F(PositiveSyncVal, StoreOpImplicitOrdering) {
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_, 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
-    m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer, 64, 64);
+    m_command_buffer.BeginRenderPass(rp, framebuffer, 64, 64);
 
     vk::CmdDraw(m_command_buffer, 1, 0, 0, 0);
 
@@ -343,7 +343,7 @@ TEST_F(PositiveSyncVal, SubpassWithBarrier) {
                      VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
     vkt::ImageView image_view = image.CreateView();
 
-    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view.handle(), 64, 64);
+    vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view.handle(), 64, 64);
 
     VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs_write(this, kFragmentMinimalGlsl, VK_SHADER_STAGE_FRAGMENT_BIT);
@@ -351,13 +351,13 @@ TEST_F(PositiveSyncVal, SubpassWithBarrier) {
 
     CreatePipelineHelper pipe_write(*this);
     pipe_write.shader_stages_ = {vs.GetStageCreateInfo(), fs_write.GetStageCreateInfo()};
-    pipe_write.gp_ci_.renderPass = rp.Handle();
+    pipe_write.gp_ci_.renderPass = rp;
     pipe_write.CreateGraphicsPipeline();
 
     CreatePipelineHelper pipe_read(*this);
     pipe_read.shader_stages_ = {vs.GetStageCreateInfo(), fs_read.GetStageCreateInfo()};
     pipe_read.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 1, VK_SHADER_STAGE_FRAGMENT_BIT};
-    pipe_read.gp_ci_.renderPass = rp.Handle();
+    pipe_read.gp_ci_.renderPass = rp;
     pipe_read.CreateGraphicsPipeline();
     pipe_read.descriptor_set_->WriteDescriptorImageInfo(0, image_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT,
                                                         VK_IMAGE_LAYOUT_GENERAL);
@@ -370,7 +370,7 @@ TEST_F(PositiveSyncVal, SubpassWithBarrier) {
     barrier.dstAccessMask = VK_ACCESS_2_INPUT_ATTACHMENT_READ_BIT;
 
     m_command_buffer.Begin();
-    m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer, 64, 64);
+    m_command_buffer.BeginRenderPass(rp, framebuffer, 64, 64);
 
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe_write);
     vk::CmdDraw(m_command_buffer, 1, 0, 0, 0);
@@ -408,7 +408,7 @@ TEST_F(PositiveSyncVal, SubpassWithBarrier2) {
                      VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
     vkt::ImageView image_view = image.CreateView();
 
-    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view.handle(), 64, 64);
+    vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view.handle(), 64, 64);
 
     VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs_read(this, kFragmentSubpassLoadGlsl, VK_SHADER_STAGE_FRAGMENT_BIT);
@@ -417,7 +417,7 @@ TEST_F(PositiveSyncVal, SubpassWithBarrier2) {
     CreatePipelineHelper pipe_read(*this);
     pipe_read.shader_stages_ = {vs.GetStageCreateInfo(), fs_read.GetStageCreateInfo()};
     pipe_read.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 1, VK_SHADER_STAGE_FRAGMENT_BIT};
-    pipe_read.gp_ci_.renderPass = rp.Handle();
+    pipe_read.gp_ci_.renderPass = rp;
     pipe_read.CreateGraphicsPipeline();
     pipe_read.descriptor_set_->WriteDescriptorImageInfo(0, image_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT,
                                                         VK_IMAGE_LAYOUT_GENERAL);
@@ -425,7 +425,7 @@ TEST_F(PositiveSyncVal, SubpassWithBarrier2) {
 
     CreatePipelineHelper pipe_write(*this);
     pipe_write.shader_stages_ = {vs.GetStageCreateInfo(), fs_write.GetStageCreateInfo()};
-    pipe_write.gp_ci_.renderPass = rp.Handle();
+    pipe_write.gp_ci_.renderPass = rp;
     pipe_write.CreateGraphicsPipeline();
 
     VkMemoryBarrier2 barrier = vku::InitStructHelper();
@@ -435,7 +435,7 @@ TEST_F(PositiveSyncVal, SubpassWithBarrier2) {
     barrier.dstAccessMask = VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT;
 
     m_command_buffer.Begin();
-    m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer, 64, 64);
+    m_command_buffer.BeginRenderPass(rp, framebuffer, 64, 64);
 
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe_read);
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe_read.pipeline_layout_, 0, 1,
@@ -1595,7 +1595,7 @@ TEST_F(PositiveSyncVal, DISABLED_RenderPassStoreOpNone) {
 
     vkt::Image image(*m_device, 32, 32, format, VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
     vkt::ImageView image_view = image.CreateView();
-    vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &image_view.handle());
+    vkt::Framebuffer fb(*m_device, rp, 1, &image_view.handle());
 
     VkImageMemoryBarrier2 layout_transition = vku::InitStructHelper();
     // Form an execution dependency with draw command (FRAGMENT_SHADER). Execution dependency is enough to sync with READ.
@@ -1620,11 +1620,11 @@ TEST_F(PositiveSyncVal, DISABLED_RenderPassStoreOpNone) {
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout;
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.CreateGraphicsPipeline();
 
     m_command_buffer.Begin();
-    m_command_buffer.BeginRenderPass(rp.Handle(), fb);
+    m_command_buffer.BeginRenderPass(rp, fb);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0, 1, &descriptor_set.set_, 0,
                               nullptr);
@@ -2526,7 +2526,7 @@ TEST_F(PositiveSyncVal, DynamicRenderingDSWithOnlyStencilAspect) {
         rp.CreateRenderPass();
 
         VkImageView image_views[] = {color_image_view, depth_image_view};
-        vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 2u, image_views);
+        vkt::Framebuffer framebuffer(*m_device, rp, 2u, image_views);
 
         VkClearValue color_clear_value;
         color_clear_value.color.float32[0] = 0.0f;
@@ -2535,7 +2535,7 @@ TEST_F(PositiveSyncVal, DynamicRenderingDSWithOnlyStencilAspect) {
         color_clear_value.color.float32[3] = 1.0f;
 
         VkRenderPassBeginInfo render_pass_begin_info = vku::InitStructHelper();
-        render_pass_begin_info.renderPass = rp.Handle();
+        render_pass_begin_info.renderPass = rp;
         render_pass_begin_info.framebuffer = framebuffer;
         render_pass_begin_info.renderArea = {{0, 0}, {32u, 32u}};
         render_pass_begin_info.clearValueCount = 1u;

--- a/tests/unit/vertex_input_positive.cpp
+++ b/tests/unit/vertex_input_positive.cpp
@@ -368,7 +368,7 @@ TEST_F(PositiveVertexInput, AttributeComponents) {
 
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.gp_ci_.renderPass = rp.Handle();
+    pipe.gp_ci_.renderPass = rp;
     pipe.cb_ci_.attachmentCount = 2;
     pipe.cb_ci_.pAttachments = cb_attachments;
     pipe.vi_ci_.pVertexBindingDescriptions = &input_binding;


### PR DESCRIPTION
Small quality of life improvement when using `RenderPassSingleSubpass`