### PR TITLE
tests: Fix surface caching related issue

### DIFF
--- a/tests/unit/wsi_positive.cpp
+++ b/tests/unit/wsi_positive.cpp
@@ -1595,8 +1595,7 @@ TEST_F(PositiveWsi, PresentFenceRetiresPresentSemaphores) {
     vk::WaitForFences(*m_device, 1, &present_fences_handles[1], VK_TRUE, kWaitTimeout);
 }
 
-// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10285
-TEST_F(PositiveWsi, DISABLED_DifferentPerPresentModeImageCount) {
+TEST_F(PositiveWsi, DifferentPerPresentModeImageCount) {
     TEST_DESCRIPTION("Create swapchain with per present mode minImageCount that is less than surface's general minImageCount");
 #ifndef VK_USE_PLATFORM_WAYLAND_KHR
     GTEST_SKIP() << "Test requires wayland platform support";
@@ -1619,6 +1618,7 @@ TEST_F(PositiveWsi, DISABLED_DifferentPerPresentModeImageCount) {
 
     VkSurfaceKHR surface;
     vk::CreateWaylandSurfaceKHR(instance(), &surface_create_info, nullptr, &surface);
+    auto info = GetSwapchainInfo(surface);
 
     const auto present_mode = VK_PRESENT_MODE_FIFO_KHR;  // Implementations must support
 
@@ -1639,8 +1639,6 @@ TEST_F(PositiveWsi, DISABLED_DifferentPerPresentModeImageCount) {
         wayland_ctx.Release();
         GTEST_SKIP() << "Can't find present mode that uses less images than a general case";
     }
-
-    auto info = GetSwapchainInfo(surface);
 
     VkSwapchainPresentModesCreateInfoEXT swapchain_present_mode_create_info = vku::InitStructHelper();
     swapchain_present_mode_create_info.presentModeCount = 1;


### PR DESCRIPTION
TL;DR We mixed two type of queries generic and per-present mode. The implementation assumes that the last query is the one that was used to decide on swapchain parameters.

Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10285

`minImageCount validation` takes into account per-present mode limits if we used surface caps queries that specify per-present mode parameters. It is part of surface caching (implemented here https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/8794/files, `IsLastCapabilityQueryUsedPresentMode` check).

If application mixes both generic queries and per-present queries then validation does not have a way to decide based on which query we made decision how to initialize swapchain parameters (one of the gaps of Vulkan swapchain api design):
* it is possible that *generic query* was inteded to be used as the main mechanism to query surface caps. In this case too small minImageCount value indicates bug in a program and validation error should be reported.
*  it is also possible that *per-present mode query*  was intended to be used as the main mechanims. In this case minImageCount which is smaller than generic value can be a valid situation.

Current solution implemented by VVL is that the last query has priority (that's why `IsLastCapabilityQueryUsedPresentMode` name).

The issue we had with the `DifferentPerPresentModeImageCount` test is that we made both generic and per-present mode queries, but we need to initialize swapchain based on per-present mode queries. The solution is to make generic queries first, so per-present mode queries go just before swapchain creation.

This is also related to the reasons why we use surface caps caching. These are known swapchain design issues, this comment explains why caching was introduced https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/69e6081acb3d2f55cb98ae1d5faa17b6db2044c7/layers/state_tracker/wsi_state.h#L198.
