### PR TITLE
tests: Remove ds pool AllocateSets

### DIFF
--- a/tests/framework/binding.cpp
+++ b/tests/framework/binding.cpp
@@ -1783,40 +1783,6 @@ void DescriptorPool::init(const Device &dev, const VkDescriptorPoolCreateInfo &i
 
 void DescriptorPool::Reset() { ASSERT_EQ(VK_SUCCESS, vk::ResetDescriptorPool(device(), handle(), 0)); }
 
-std::vector<DescriptorSet *> DescriptorPool::AllocateSets(const Device &dev,
-                                                          const std::vector<const DescriptorSetLayout *> &layouts) {
-    std::vector<VkDescriptorSetLayout> layout_handles;
-    layout_handles.reserve(layouts.size());
-    std::transform(layouts.begin(), layouts.end(), std::back_inserter(layout_handles),
-                   [](const DescriptorSetLayout *o) { return (o) ? o->handle() : VK_NULL_HANDLE; });
-
-    std::vector<VkDescriptorSet> set_handles;
-    set_handles.resize(layout_handles.size());
-
-    VkDescriptorSetAllocateInfo alloc_info = vku::InitStructHelper();
-    alloc_info.descriptorSetCount = static_cast<uint32_t>(layout_handles.size());
-    alloc_info.descriptorPool = handle();
-    alloc_info.pSetLayouts = layout_handles.data();
-    VkResult err = vk::AllocateDescriptorSets(device(), &alloc_info, set_handles.data());
-    EXPECT_EQ(VK_SUCCESS, err);
-
-    std::vector<DescriptorSet *> sets;
-    for (std::vector<VkDescriptorSet>::const_iterator it = set_handles.begin(); it != set_handles.end(); it++) {
-        // do descriptor sets need memories bound?
-        DescriptorSet *descriptorSet = new DescriptorSet(dev, this, *it);
-        sets.push_back(descriptorSet);
-    }
-    return sets;
-}
-
-std::vector<DescriptorSet *> DescriptorPool::AllocateSets(const Device &dev, const DescriptorSetLayout &layout, uint32_t count) {
-    return AllocateSets(dev, std::vector<const DescriptorSetLayout *>(count, &layout));
-}
-
-DescriptorSet *DescriptorPool::AllocateSets(const Device &dev, const DescriptorSetLayout &layout) {
-    std::vector<DescriptorSet *> set = AllocateSets(dev, layout, 1);
-    return (set.empty()) ? NULL : set[0];
-}
 void DescriptorSet::destroy() noexcept {
     if (!initialized()) {
         return;

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -1006,13 +1006,7 @@ class DescriptorPool : public internal::NonDispHandle<VkDescriptorPool> {
     // vkResetDescriptorPool()
     void Reset();
 
-    // vkFreeDescriptorSet()
     bool GetDynamicUsage() { return dynamic_usage_; }
-
-    // vkAllocateDescriptorSets()
-    std::vector<DescriptorSet *> AllocateSets(const Device &dev, const std::vector<const DescriptorSetLayout *> &layouts);
-    std::vector<DescriptorSet *> AllocateSets(const Device &dev, const DescriptorSetLayout &layout, uint32_t count);
-    DescriptorSet *AllocateSets(const Device &dev, const DescriptorSetLayout &layout);
 
     template <typename PoolSizes>
     static VkDescriptorPoolCreateInfo CreateInfo(VkDescriptorPoolCreateFlags flags, uint32_t max_sets, const PoolSizes &pool_sizes);


### PR DESCRIPTION
Remove `AllocateSets` (in the 2 spots we had it) for `OneOffDescriptorSet`