### PR TITLE
tests: Replace init with Init

### DIFF
--- a/tests/framework/android_hardware_buffer.h
+++ b/tests/framework/android_hardware_buffer.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 Valve Corporation
- * Copyright (c) 2023-2024 LunarG, Inc.
+ * Copyright (c) 2023-2025 Valve Corporation
+ * Copyright (c) 2023-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ inline bool SetAllocationInfoImportAHB(vkt::Device *device, VkAndroidHardwareBuf
 namespace vkt {
 class AHB {
   public:
-    AHB(const AHardwareBuffer_Desc *ahb_desc) { init(ahb_desc); }
+    AHB(const AHardwareBuffer_Desc *ahb_desc) { Init(ahb_desc); }
     AHB(uint32_t format, uint64_t usage, uint32_t width, uint32_t height = 1, uint32_t layers = 1, uint32_t stride = 1) {
         AHardwareBuffer_Desc ahb_desc = {};
         ahb_desc.format = format;
@@ -52,10 +52,10 @@ class AHB {
         ahb_desc.height = height;
         ahb_desc.layers = layers;
         ahb_desc.stride = stride;
-        init(&ahb_desc);
+        Init(&ahb_desc);
     }
 
-    void init(const AHardwareBuffer_Desc *ahb_desc) { AHardwareBuffer_allocate(ahb_desc, &ahb); }
+    void Init(const AHardwareBuffer_Desc *ahb_desc) { AHardwareBuffer_allocate(ahb_desc, &ahb); }
 
     uint64_t GetExternalFormat(const Device &dev, void *pNext = nullptr) const {
         VkAndroidHardwareBufferFormatPropertiesANDROID ahb_fmt_props = vku::InitStructHelper(pNext);

--- a/tests/framework/binding.cpp
+++ b/tests/framework/binding.cpp
@@ -845,7 +845,7 @@ void DeviceMemory::destroy() noexcept {
 
 DeviceMemory::~DeviceMemory() noexcept { destroy(); }
 
-void DeviceMemory::init(const Device &dev, const VkMemoryAllocateInfo &info) {
+void DeviceMemory::Init(const Device &dev, const VkMemoryAllocateInfo &info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::AllocateMemory, dev, &info);
     memory_allocate_info_ = info;
 }
@@ -945,13 +945,13 @@ NON_DISPATCHABLE_HANDLE_DTOR(Semaphore, vk::DestroySemaphore)
 
 Semaphore::Semaphore(const Device &dev, VkSemaphoreType type, uint64_t initial_value) {
     if (type == VK_SEMAPHORE_TYPE_BINARY) {
-        init(dev, vku::InitStruct<VkSemaphoreCreateInfo>());
+        Init(dev, vku::InitStruct<VkSemaphoreCreateInfo>());
     } else {
         VkSemaphoreTypeCreateInfo semaphore_type_ci = vku::InitStructHelper();
         semaphore_type_ci.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
         semaphore_type_ci.initialValue = initial_value;
         VkSemaphoreCreateInfo semaphore_ci = vku::InitStructHelper(&semaphore_type_ci);
-        init(dev, semaphore_ci);
+        Init(dev, semaphore_ci);
     }
 }
 
@@ -961,7 +961,7 @@ Semaphore &Semaphore::operator=(Semaphore &&rhs) noexcept {
     return *this;
 }
 
-void Semaphore::init(const Device &dev, const VkSemaphoreCreateInfo &info) {
+void Semaphore::Init(const Device &dev, const VkSemaphoreCreateInfo &info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateSemaphore, dev, &info);
 }
 
@@ -1049,7 +1049,7 @@ VkResult Semaphore::ImportHandle(int fd_handle, VkExternalSemaphoreHandleTypeFla
 
 NON_DISPATCHABLE_HANDLE_DTOR(Event, vk::DestroyEvent)
 
-void Event::init(const Device &dev, const VkEventCreateInfo &info) { NON_DISPATCHABLE_HANDLE_INIT(vk::CreateEvent, dev, &info); }
+void Event::Init(const Device &dev, const VkEventCreateInfo &info) { NON_DISPATCHABLE_HANDLE_INIT(vk::CreateEvent, dev, &info); }
 
 void Event::Set() { ASSERT_EQ(VK_SUCCESS, vk::SetEvent(device(), handle())); }
 
@@ -1074,7 +1074,7 @@ void Event::Reset() { ASSERT_EQ(VK_SUCCESS, vk::ResetEvent(device(), handle()));
 
 NON_DISPATCHABLE_HANDLE_DTOR(QueryPool, vk::DestroyQueryPool)
 
-void QueryPool::init(const Device &dev, const VkQueryPoolCreateInfo &info) {
+void QueryPool::Init(const Device &dev, const VkQueryPoolCreateInfo &info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateQueryPool, dev, &info);
 }
 
@@ -1104,11 +1104,11 @@ Buffer &Buffer::operator=(Buffer &&rhs) noexcept {
     return *this;
 }
 
-void Buffer::init(const Device &dev, const VkBufferCreateInfo &info, VkMemoryPropertyFlags mem_props, void *alloc_info_pnext) {
+void Buffer::Init(const Device &dev, const VkBufferCreateInfo &info, VkMemoryPropertyFlags mem_props, void *alloc_info_pnext) {
     InitNoMemory(dev, info);
 
     auto alloc_info = DeviceMemory::GetResourceAllocInfo(dev, MemoryRequirements(), mem_props, alloc_info_pnext);
-    internal_mem_.init(dev, alloc_info);
+    internal_mem_.Init(dev, alloc_info);
 
     BindMemory(internal_mem_, 0);
 }
@@ -1125,7 +1125,7 @@ void Buffer::InitHostVisibleWithData(const Device &dev, VkBufferUsageFlags usage
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.allocationSize = memory_requirements.size;
     dev.Physical().SetMemoryType(memory_requirements.memoryTypeBits, &alloc_info, memory_properties);
-    internal_mem_.init(dev, alloc_info);
+    internal_mem_.Init(dev, alloc_info);
     BindMemory(internal_mem_, 0);
 
     void *ptr = internal_mem_.Map();
@@ -1148,7 +1148,7 @@ VkMemoryRequirements Buffer::MemoryRequirements() const {
 
 void Buffer::AllocateAndBindMemory(const Device &dev, VkMemoryPropertyFlags mem_props, void *alloc_info_pnext) {
     assert(!internal_mem_.initialized());
-    internal_mem_.init(dev, DeviceMemory::GetResourceAllocInfo(dev, MemoryRequirements(), mem_props, alloc_info_pnext));
+    internal_mem_.Init(dev, DeviceMemory::GetResourceAllocInfo(dev, MemoryRequirements(), mem_props, alloc_info_pnext));
     BindMemory(internal_mem_, 0);
 }
 
@@ -1171,7 +1171,7 @@ VkDeviceAddress Buffer::Address() const {
 
 NON_DISPATCHABLE_HANDLE_DTOR(BufferView, vk::DestroyBufferView)
 
-void BufferView::init(const Device &dev, const VkBufferViewCreateInfo &info) {
+void BufferView::Init(const Device &dev, const VkBufferViewCreateInfo &info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateBufferView, dev, &info);
 }
 
@@ -1237,7 +1237,7 @@ void Image::Init(const Device &dev, const VkImageCreateInfo &info, VkMemoryPrope
 
     if (initialized()) {
         auto alloc_info = DeviceMemory::GetResourceAllocInfo(dev, MemoryRequirements(), mem_props, alloc_info_pnext);
-        internal_mem_.init(dev, alloc_info);
+        internal_mem_.Init(dev, alloc_info);
         BindMemory(internal_mem_, 0);
     }
 }
@@ -1336,7 +1336,7 @@ VkMemoryRequirements Image::MemoryRequirements() const {
 
 void Image::AllocateAndBindMemory(const Device &dev, VkMemoryPropertyFlags mem_props, void *alloc_info_pnext) {
     assert(!internal_mem_.initialized());
-    internal_mem_.init(dev, DeviceMemory::GetResourceAllocInfo(dev, MemoryRequirements(), mem_props, alloc_info_pnext));
+    internal_mem_.Init(dev, DeviceMemory::GetResourceAllocInfo(dev, MemoryRequirements(), mem_props, alloc_info_pnext));
     BindMemory(internal_mem_, 0);
 }
 
@@ -1482,7 +1482,7 @@ ImageView Image::CreateView(VkImageViewType type, uint32_t baseMipLevel, uint32_
 
 NON_DISPATCHABLE_HANDLE_DTOR(ImageView, vk::DestroyImageView)
 
-void ImageView::init(const Device &dev, const VkImageViewCreateInfo &info) {
+void ImageView::Init(const Device &dev, const VkImageViewCreateInfo &info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateImageView, dev, &info);
 }
 
@@ -1527,7 +1527,7 @@ VkMemoryRequirements2 AccelerationStructureNV::BuildScratchMemoryRequirements() 
     return memory_requirements;
 }
 
-void AccelerationStructureNV::init(const Device &dev, const VkAccelerationStructureCreateInfoNV &info, bool init_memory) {
+void AccelerationStructureNV::Init(const Device &dev, const VkAccelerationStructureCreateInfoNV &info, bool init_memory) {
     PFN_vkCreateAccelerationStructureNV vkCreateAccelerationStructureNV =
         (PFN_vkCreateAccelerationStructureNV)vk::GetDeviceProcAddr(dev.handle(), "vkCreateAccelerationStructureNV");
     assert(vkCreateAccelerationStructureNV != nullptr);
@@ -1537,7 +1537,7 @@ void AccelerationStructureNV::init(const Device &dev, const VkAccelerationStruct
     info_ = info.info;
 
     if (init_memory) {
-        memory_.init(dev, DeviceMemory::GetResourceAllocInfo(dev, MemoryRequirements().memoryRequirements,
+        memory_.Init(dev, DeviceMemory::GetResourceAllocInfo(dev, MemoryRequirements().memoryRequirements,
                                                              VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT));
 
         PFN_vkBindAccelerationStructureMemoryNV vkBindAccelerationStructureMemoryNV =
@@ -1588,7 +1588,7 @@ ShaderModule &ShaderModule::operator=(ShaderModule &&rhs) noexcept {
     return *this;
 }
 
-void ShaderModule::init(const Device &dev, const VkShaderModuleCreateInfo &info) {
+void ShaderModule::Init(const Device &dev, const VkShaderModuleCreateInfo &info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateShaderModule, dev, &info);
 }
 
@@ -1603,7 +1603,7 @@ VkResult ShaderModule::InitTry(const Device &dev, const VkShaderModuleCreateInfo
 
 NON_DISPATCHABLE_HANDLE_DTOR(Shader, vk::DestroyShaderEXT)
 
-void Shader::init(const Device &dev, const VkShaderCreateInfoEXT &info) {
+void Shader::Init(const Device &dev, const VkShaderCreateInfoEXT &info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateShadersEXT, dev, 1u, &info);
 }
 
@@ -1633,7 +1633,7 @@ Shader::Shader(const Device &dev, const VkShaderStageFlagBits stage, const std::
         createInfo.pushConstantRangeCount = 1u;
         createInfo.pPushConstantRanges = pushConstRange;
     }
-    init(dev, createInfo);
+    Init(dev, createInfo);
 }
 
 Shader::Shader(const Device &dev, const VkShaderStageFlagBits stage, const char *code,
@@ -1661,7 +1661,7 @@ Shader::Shader(const Device &dev, const VkShaderStageFlagBits stage, const char 
         createInfo.pushConstantRangeCount = 1u;
         createInfo.pPushConstantRanges = pushConstRange;
     }
-    init(dev, createInfo);
+    Init(dev, createInfo);
 }
 
 Shader::Shader(const Device &dev, const VkShaderStageFlagBits stage, const std::vector<uint8_t> &binary,
@@ -1681,18 +1681,18 @@ Shader::Shader(const Device &dev, const VkShaderStageFlagBits stage, const std::
         createInfo.pushConstantRangeCount = 1u;
         createInfo.pPushConstantRanges = pushConstRange;
     }
-    init(dev, createInfo);
+    Init(dev, createInfo);
 }
 
 NON_DISPATCHABLE_HANDLE_DTOR(PipelineCache, vk::DestroyPipelineCache)
 
-void PipelineCache::init(const Device &dev, const VkPipelineCacheCreateInfo &info) {
+void PipelineCache::Init(const Device &dev, const VkPipelineCacheCreateInfo &info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreatePipelineCache, dev, &info);
 }
 
 NON_DISPATCHABLE_HANDLE_DTOR(Pipeline, vk::DestroyPipeline)
 
-void Pipeline::init(const Device &dev, const VkGraphicsPipelineCreateInfo &info) {
+void Pipeline::Init(const Device &dev, const VkGraphicsPipelineCreateInfo &info) {
     VkPipelineCache cache;
     VkPipelineCacheCreateInfo ci = vku::InitStructHelper();
     VkResult err = vk::CreatePipelineCache(dev.handle(), &ci, NULL, &cache);
@@ -1719,7 +1719,7 @@ VkResult Pipeline::InitTry(const Device &dev, const VkGraphicsPipelineCreateInfo
     return err;
 }
 
-void Pipeline::init(const Device &dev, const VkComputePipelineCreateInfo &info) {
+void Pipeline::Init(const Device &dev, const VkComputePipelineCreateInfo &info) {
     VkPipelineCache cache;
     VkPipelineCacheCreateInfo ci = vku::InitStructHelper();
     VkResult err = vk::CreatePipelineCache(dev.handle(), &ci, NULL, &cache);
@@ -1729,7 +1729,7 @@ void Pipeline::init(const Device &dev, const VkComputePipelineCreateInfo &info) 
     }
 }
 
-void Pipeline::init(const Device &dev, const VkRayTracingPipelineCreateInfoKHR &info) {
+void Pipeline::Init(const Device &dev, const VkRayTracingPipelineCreateInfoKHR &info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateRayTracingPipelinesKHR, dev, VK_NULL_HANDLE, VK_NULL_HANDLE, 1, &info);
 }
 
@@ -1745,7 +1745,7 @@ void Pipeline::InitDeferred(const Device &dev, const VkRayTracingPipelineCreateI
 
 NON_DISPATCHABLE_HANDLE_DTOR(PipelineLayout, vk::DestroyPipelineLayout)
 
-void PipelineLayout::init(const Device &dev, VkPipelineLayoutCreateInfo &info,
+void PipelineLayout::Init(const Device &dev, VkPipelineLayoutCreateInfo &info,
                           const std::vector<const DescriptorSetLayout *> &layouts) {
     std::vector<VkDescriptorSetLayout> layout_handles;
     layout_handles.reserve(layouts.size());
@@ -1755,28 +1755,28 @@ void PipelineLayout::init(const Device &dev, VkPipelineLayoutCreateInfo &info,
     info.setLayoutCount = static_cast<uint32_t>(layout_handles.size());
     info.pSetLayouts = layout_handles.data();
 
-    init(dev, info);
+    Init(dev, info);
 }
 
-void PipelineLayout::init(const Device &dev, VkPipelineLayoutCreateInfo &info) {
+void PipelineLayout::Init(const Device &dev, VkPipelineLayoutCreateInfo &info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreatePipelineLayout, dev, &info);
 }
 
 NON_DISPATCHABLE_HANDLE_DTOR(Sampler, vk::DestroySampler)
 
-void Sampler::init(const Device &dev, const VkSamplerCreateInfo &info) {
+void Sampler::Init(const Device &dev, const VkSamplerCreateInfo &info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateSampler, dev, &info);
 }
 
 NON_DISPATCHABLE_HANDLE_DTOR(DescriptorSetLayout, vk::DestroyDescriptorSetLayout)
 
-void DescriptorSetLayout::init(const Device &dev, const VkDescriptorSetLayoutCreateInfo &info) {
+void DescriptorSetLayout::Init(const Device &dev, const VkDescriptorSetLayoutCreateInfo &info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateDescriptorSetLayout, dev, &info);
 }
 
 NON_DISPATCHABLE_HANDLE_DTOR(DescriptorPool, vk::DestroyDescriptorPool)
 
-void DescriptorPool::init(const Device &dev, const VkDescriptorPoolCreateInfo &info) {
+void DescriptorPool::Init(const Device &dev, const VkDescriptorPoolCreateInfo &info) {
     dynamic_usage_ = (info.flags & VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT) != 0;
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateDescriptorPool, dev, &info);
 }
@@ -1880,7 +1880,7 @@ void CommandBuffer::destroy() noexcept {
 }
 CommandBuffer::~CommandBuffer() noexcept { destroy(); }
 
-void CommandBuffer::init(const Device &dev, const VkCommandBufferAllocateInfo &info) {
+void CommandBuffer::Init(const Device &dev, const VkCommandBufferAllocateInfo &info) {
     VkCommandBuffer cmd;
 
     // Make sure commandPool is set
@@ -1895,7 +1895,7 @@ void CommandBuffer::init(const Device &dev, const VkCommandBufferAllocateInfo &i
 void CommandBuffer::Init(const Device &dev, const CommandPool &pool, VkCommandBufferLevel level) {
     auto create_info = CommandBuffer::CreateInfo(pool.handle());
     create_info.level = level;
-    init(dev, create_info);
+    Init(dev, create_info);
 }
 
 void CommandBuffer::Begin(const VkCommandBufferBeginInfo *info) { ASSERT_EQ(VK_SUCCESS, vk::BeginCommandBuffer(handle(), info)); }
@@ -2109,11 +2109,11 @@ void CommandBuffer::FullMemoryBarrier() {
                            nullptr, 0, nullptr);
 }
 
-void RenderPass::init(const Device &dev, const VkRenderPassCreateInfo &info) {
+void RenderPass::Init(const Device &dev, const VkRenderPassCreateInfo &info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateRenderPass, dev, &info);
 }
 
-void RenderPass::init(const Device &dev, const VkRenderPassCreateInfo2 &info) {
+void RenderPass::Init(const Device &dev, const VkRenderPassCreateInfo2 &info) {
     if (vk::CreateRenderPass2KHR) {
         NON_DISPATCHABLE_HANDLE_INIT(vk::CreateRenderPass2KHR, dev, &info);
     } else {
@@ -2123,13 +2123,13 @@ void RenderPass::init(const Device &dev, const VkRenderPassCreateInfo2 &info) {
 
 NON_DISPATCHABLE_HANDLE_DTOR(RenderPass, vk::DestroyRenderPass)
 
-void Framebuffer::init(const Device &dev, const VkFramebufferCreateInfo &info) {
+void Framebuffer::Init(const Device &dev, const VkFramebufferCreateInfo &info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateFramebuffer, dev, &info);
 }
 
 NON_DISPATCHABLE_HANDLE_DTOR(Framebuffer, vk::DestroyFramebuffer)
 
-void SamplerYcbcrConversion::init(const Device &dev, const VkSamplerYcbcrConversionCreateInfo &info) {
+void SamplerYcbcrConversion::Init(const Device &dev, const VkSamplerYcbcrConversionCreateInfo &info) {
     if (vk::CreateSamplerYcbcrConversionKHR) {
         NON_DISPATCHABLE_HANDLE_INIT(vk::CreateSamplerYcbcrConversionKHR, dev, &info);
     } else {

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -320,14 +320,14 @@ class Device : public internal::Handle<VkDevice> {
 class DeviceMemory : public internal::NonDispHandle<VkDeviceMemory> {
   public:
     DeviceMemory() = default;
-    DeviceMemory(const Device &dev, const VkMemoryAllocateInfo &info) { init(dev, info); }
+    DeviceMemory(const Device &dev, const VkMemoryAllocateInfo &info) { Init(dev, info); }
     ~DeviceMemory() noexcept;
     void destroy() noexcept;
     DeviceMemory &operator=(DeviceMemory &&) = default;
 
     // vkAllocateMemory()
     // Fails the test when allocation is unsuccessful
-    void init(const Device &dev, const VkMemoryAllocateInfo &info);
+    void Init(const Device &dev, const VkMemoryAllocateInfo &info);
     // Does not fail the test when allocation is unsuccessful and instead returns error code
     VkResult TryInit(const Device &dev, const VkMemoryAllocateInfo &info);
     void SetName(const char *name) { NonDispHandle<VkDeviceMemory>::SetName(VK_OBJECT_TYPE_DEVICE_MEMORY, name); }
@@ -383,14 +383,14 @@ class Semaphore : public internal::NonDispHandle<VkSemaphore> {
   public:
     Semaphore() = default;
     Semaphore(const Device &dev, VkSemaphoreType type = VK_SEMAPHORE_TYPE_BINARY, uint64_t initial_value = 0);
-    Semaphore(const Device &dev, const VkSemaphoreCreateInfo &info) { init(dev, info); }
+    Semaphore(const Device &dev, const VkSemaphoreCreateInfo &info) { Init(dev, info); }
     Semaphore(Semaphore &&rhs) noexcept : NonDispHandle(std::move(rhs)) {}
     Semaphore &operator=(Semaphore &&) noexcept;
     ~Semaphore() noexcept;
     void destroy() noexcept;
 
     // vkCreateSemaphore()
-    void init(const Device &dev, const VkSemaphoreCreateInfo &info);
+    void Init(const Device &dev, const VkSemaphoreCreateInfo &info);
     void SetName(const char *name) { NonDispHandle<VkSemaphore>::SetName(VK_OBJECT_TYPE_SEMAPHORE, name); }
 
     VkResult Wait(uint64_t value, uint64_t timeout);
@@ -412,13 +412,13 @@ inline const Semaphore no_semaphore;  // equivalent to vkt::Semaphore{}
 class Event : public internal::NonDispHandle<VkEvent> {
   public:
     Event() = default;
-    Event(const Device &dev) { init(dev, CreateInfo(0)); }
-    Event(const Device &dev, const VkEventCreateInfo &info) { init(dev, info); }
+    Event(const Device &dev) { Init(dev, CreateInfo(0)); }
+    Event(const Device &dev, const VkEventCreateInfo &info) { Init(dev, info); }
     ~Event() noexcept;
     void destroy() noexcept;
 
     // vkCreateEvent()
-    void init(const Device &dev, const VkEventCreateInfo &info);
+    void Init(const Device &dev, const VkEventCreateInfo &info);
     void SetName(const char *name) { NonDispHandle<VkEvent>::SetName(VK_OBJECT_TYPE_EVENT, name); }
 
     // vkGetEventStatus()
@@ -526,16 +526,16 @@ class Queue : public internal::Handle<VkQueue> {
 class QueryPool : public internal::NonDispHandle<VkQueryPool> {
   public:
     QueryPool() = default;
-    QueryPool(const Device &dev, const VkQueryPoolCreateInfo &info) { init(dev, info); }
+    QueryPool(const Device &dev, const VkQueryPoolCreateInfo &info) { Init(dev, info); }
     QueryPool(const Device &dev, VkQueryType query_type, uint32_t query_count) {
         VkQueryPoolCreateInfo info = CreateInfo(query_type, query_count);
-        init(dev, info);
+        Init(dev, info);
     }
     ~QueryPool() noexcept;
     void destroy() noexcept;
 
     // vkCreateQueryPool()
-    void init(const Device &dev, const VkQueryPoolCreateInfo &info);
+    void Init(const Device &dev, const VkQueryPoolCreateInfo &info);
     void SetName(const char *name) { NonDispHandle<VkQueryPool>::SetName(VK_OBJECT_TYPE_QUERY_POOL, name); }
 
     // vkGetQueryPoolResults()
@@ -556,11 +556,11 @@ class Buffer : public internal::NonDispHandle<VkBuffer> {
     explicit Buffer() : NonDispHandle(), create_info_(vku::InitStruct<decltype(create_info_)>()) {}
     explicit Buffer(const Device &dev, const VkBufferCreateInfo &info, VkMemoryPropertyFlags mem_props = 0,
                     void *alloc_info_pnext = nullptr) {
-        init(dev, info, mem_props, alloc_info_pnext);
+        Init(dev, info, mem_props, alloc_info_pnext);
     }
     explicit Buffer(const Device &dev, VkDeviceSize size, VkBufferUsageFlags usage, VkMemoryPropertyFlags mem_props = 0,
                     void *alloc_info_pnext = nullptr) {
-        init(dev, size, usage, mem_props, alloc_info_pnext);
+        Init(dev, size, usage, mem_props, alloc_info_pnext);
     }
     explicit Buffer(const Device &dev, const VkBufferCreateInfo &info, NoMemT) { InitNoMemory(dev, info); }
 
@@ -569,7 +569,7 @@ class Buffer : public internal::NonDispHandle<VkBuffer> {
         usage |= VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;  // always add
         VkMemoryAllocateFlagsInfo allocate_flag_info = vku::InitStructHelper();
         allocate_flag_info.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
-        init(dev, CreateInfo(size, usage), VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+        Init(dev, CreateInfo(size, usage), VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
              &allocate_flag_info);
     }
 
@@ -584,11 +584,11 @@ class Buffer : public internal::NonDispHandle<VkBuffer> {
     void destroy() noexcept;
 
     // vkCreateBuffer()
-    void init(const Device &dev, const VkBufferCreateInfo &info, VkMemoryPropertyFlags mem_props = 0,
+    void Init(const Device &dev, const VkBufferCreateInfo &info, VkMemoryPropertyFlags mem_props = 0,
               void *alloc_info_pnext = nullptr);
-    void init(const Device &dev, VkDeviceSize size, VkBufferUsageFlags usage, VkMemoryPropertyFlags mem_props = 0,
+    void Init(const Device &dev, VkDeviceSize size, VkBufferUsageFlags usage, VkMemoryPropertyFlags mem_props = 0,
               void *alloc_info_pnext = nullptr, const vvl::span<uint32_t> &queue_families = {}) {
-        init(dev, CreateInfo(size, usage, queue_families), mem_props, alloc_info_pnext);
+        Init(dev, CreateInfo(size, usage, queue_families), mem_props, alloc_info_pnext);
     }
     void InitHostVisibleWithData(const Device &dev, VkBufferUsageFlags usage, const void *data, size_t data_size,
                                  const vvl::span<uint32_t> &queue_families = {});
@@ -657,16 +657,16 @@ class Buffer : public internal::NonDispHandle<VkBuffer> {
 class BufferView : public internal::NonDispHandle<VkBufferView> {
   public:
     BufferView() = default;
-    BufferView(const Device &dev, const VkBufferViewCreateInfo &info) { init(dev, info); }
+    BufferView(const Device &dev, const VkBufferViewCreateInfo &info) { Init(dev, info); }
     BufferView(const Device &dev, VkBuffer buffer, VkFormat format, VkDeviceSize offset = 0, VkDeviceSize range = VK_WHOLE_SIZE) {
         VkBufferViewCreateInfo buffer_view_ci = CreateInfo(buffer, format, offset, range);
-        init(dev, buffer_view_ci);
+        Init(dev, buffer_view_ci);
     }
     ~BufferView() noexcept;
     void destroy() noexcept;
 
     // vkCreateBufferView()
-    void init(const Device &dev, const VkBufferViewCreateInfo &info);
+    void Init(const Device &dev, const VkBufferViewCreateInfo &info);
     static VkBufferViewCreateInfo CreateInfo(VkBuffer buffer, VkFormat format, VkDeviceSize offset = 0,
                                              VkDeviceSize range = VK_WHOLE_SIZE);
     void SetName(const char *name) { NonDispHandle<VkBufferView>::SetName(VK_OBJECT_TYPE_BUFFER_VIEW, name); }
@@ -785,7 +785,7 @@ class Image : public internal::NonDispHandle<VkImage> {
 class ImageView : public internal::NonDispHandle<VkImageView> {
   public:
     explicit ImageView() = default;
-    explicit ImageView(const Device &dev, const VkImageViewCreateInfo &info) { init(dev, info); }
+    explicit ImageView(const Device &dev, const VkImageViewCreateInfo &info) { Init(dev, info); }
     ImageView(ImageView &&rhs) noexcept : NonDispHandle(std::move(rhs)) {}
     ImageView &operator=(ImageView &&src) noexcept {
         this->~ImageView();
@@ -796,20 +796,20 @@ class ImageView : public internal::NonDispHandle<VkImageView> {
     void destroy() noexcept;
 
     // vkCreateImageView()
-    void init(const Device &dev, const VkImageViewCreateInfo &info);
+    void Init(const Device &dev, const VkImageViewCreateInfo &info);
     void SetName(const char *name) { NonDispHandle<VkImageView>::SetName(VK_OBJECT_TYPE_IMAGE_VIEW, name); }
 };
 
 class AccelerationStructureNV : public internal::NonDispHandle<VkAccelerationStructureNV> {
   public:
     explicit AccelerationStructureNV(const Device &dev, const VkAccelerationStructureCreateInfoNV &info, bool init_memory = true) {
-        init(dev, info, init_memory);
+        Init(dev, info, init_memory);
     }
     ~AccelerationStructureNV() noexcept;
     void destroy() noexcept;
 
     // vkCreateAccelerationStructureNV
-    void init(const Device &dev, const VkAccelerationStructureCreateInfoNV &info, bool init_memory = true);
+    void Init(const Device &dev, const VkAccelerationStructureCreateInfoNV &info, bool init_memory = true);
     void SetName(const char *name) {
         NonDispHandle<VkAccelerationStructureNV>::SetName(VK_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV, name);
     }
@@ -833,14 +833,14 @@ class AccelerationStructureNV : public internal::NonDispHandle<VkAccelerationStr
 class ShaderModule : public internal::NonDispHandle<VkShaderModule> {
   public:
     ShaderModule() = default;
-    ShaderModule(const Device &dev, const VkShaderModuleCreateInfo &info) { init(dev, info); }
+    ShaderModule(const Device &dev, const VkShaderModuleCreateInfo &info) { Init(dev, info); }
     ShaderModule(ShaderModule &&rhs) noexcept : NonDispHandle(std::move(rhs)) {}
     ShaderModule &operator=(ShaderModule &&rhs) noexcept;
     ~ShaderModule() noexcept;
     void destroy() noexcept;
 
     // vkCreateShaderModule()
-    void init(const Device &dev, const VkShaderModuleCreateInfo &info);
+    void Init(const Device &dev, const VkShaderModuleCreateInfo &info);
     VkResult InitTry(const Device &dev, const VkShaderModuleCreateInfo &info);
     void SetName(const char *name) { NonDispHandle<VkShaderModule>::SetName(VK_OBJECT_TYPE_SHADER_MODULE, name); }
 
@@ -851,7 +851,7 @@ class Shader : public internal::NonDispHandle<VkShaderEXT> {
   public:
     Shader() = default;
     Shader(const Device &dev, VkShaderEXT shader) { NonDispHandle::init(dev.handle(), shader); }
-    Shader(const Device &dev, const VkShaderCreateInfoEXT &info) { init(dev, info); }
+    Shader(const Device &dev, const VkShaderCreateInfoEXT &info) { Init(dev, info); }
     Shader(const Device &dev, const VkShaderStageFlagBits stage, const std::vector<uint32_t> &spv,
            const VkDescriptorSetLayout *descriptorSetLayout = nullptr, const VkPushConstantRange *pushConstRange = nullptr);
     Shader(const Device &dev, const VkShaderStageFlagBits stage, const char* code,
@@ -862,7 +862,7 @@ class Shader : public internal::NonDispHandle<VkShaderEXT> {
     void destroy() noexcept;
 
     // vkCreateShaderModule()
-    void init(const Device &dev, const VkShaderCreateInfoEXT &info);
+    void Init(const Device &dev, const VkShaderCreateInfoEXT &info);
     VkResult InitTry(const Device &dev, const VkShaderCreateInfoEXT &info);
     void SetName(const char *name) { NonDispHandle<VkShaderEXT>::SetName(VK_OBJECT_TYPE_SHADER_EXT, name); }
 };
@@ -870,40 +870,40 @@ class Shader : public internal::NonDispHandle<VkShaderEXT> {
 class PipelineCache : public internal::NonDispHandle<VkPipelineCache> {
   public:
     PipelineCache() = default;
-    PipelineCache(const Device &dev, const VkPipelineCacheCreateInfo &info) { init(dev, info); }
+    PipelineCache(const Device &dev, const VkPipelineCacheCreateInfo &info) { Init(dev, info); }
     ~PipelineCache() noexcept;
     void destroy() noexcept;
 
-    void init(const Device &dev, const VkPipelineCacheCreateInfo &info);
+    void Init(const Device &dev, const VkPipelineCacheCreateInfo &info);
     void SetName(const char *name) { NonDispHandle<VkPipelineCache>::SetName(VK_OBJECT_TYPE_PIPELINE_CACHE, name); }
 };
 
 class Pipeline : public internal::NonDispHandle<VkPipeline> {
   public:
     Pipeline() = default;
-    Pipeline(const Device &dev, const VkGraphicsPipelineCreateInfo &info) { init(dev, info); }
+    Pipeline(const Device &dev, const VkGraphicsPipelineCreateInfo &info) { Init(dev, info); }
     Pipeline(const Device &dev, const VkGraphicsPipelineCreateInfo &info, const VkPipeline basePipeline) {
-        init(dev, info, basePipeline);
+        Init(dev, info, basePipeline);
     }
-    Pipeline(const Device &dev, const VkComputePipelineCreateInfo &info) { init(dev, info); }
-    Pipeline(const Device &dev, const VkRayTracingPipelineCreateInfoKHR &info) { init(dev, info); }
+    Pipeline(const Device &dev, const VkComputePipelineCreateInfo &info) { Init(dev, info); }
+    Pipeline(const Device &dev, const VkRayTracingPipelineCreateInfoKHR &info) { Init(dev, info); }
     ~Pipeline() noexcept;
     void destroy() noexcept;
 
     // vkCreateGraphicsPipeline()
-    void init(const Device &dev, const VkGraphicsPipelineCreateInfo &info);
+    void Init(const Device &dev, const VkGraphicsPipelineCreateInfo &info);
     // vkCreateGraphicsPipelineDerivative()
-    void init(const Device &dev, const VkGraphicsPipelineCreateInfo &info, const VkPipeline basePipeline);
+    void Init(const Device &dev, const VkGraphicsPipelineCreateInfo &info, const VkPipeline basePipeline);
     // vkCreateComputePipeline()
-    void init(const Device &dev, const VkComputePipelineCreateInfo &info);
+    void Init(const Device &dev, const VkComputePipelineCreateInfo &info);
     // vkCreateRayTracingPipelinesKHR
-    void init(const Device &dev, const VkRayTracingPipelineCreateInfoKHR &info);
+    void Init(const Device &dev, const VkRayTracingPipelineCreateInfoKHR &info);
     // vkCreateRayTracingPipelinesKHR with deferredOperation
     void InitDeferred(const Device &dev, const VkRayTracingPipelineCreateInfoKHR &info, VkDeferredOperationKHR deferred_op);
     // vkLoadPipeline()
-    void init(const Device &dev, size_t size, const void *data);
+    void Init(const Device &dev, size_t size, const void *data);
     // vkLoadPipelineDerivative()
-    void init(const Device &dev, size_t size, const void *data, VkPipeline basePipeline);
+    void Init(const Device &dev, size_t size, const void *data, VkPipeline basePipeline);
 
     // vkCreateGraphicsPipeline with error return
     VkResult InitTry(const Device &dev, const VkGraphicsPipelineCreateInfo &info);
@@ -914,9 +914,9 @@ class PipelineLayout : public internal::NonDispHandle<VkPipelineLayout> {
   public:
     PipelineLayout() noexcept : NonDispHandle() {}
     PipelineLayout(const Device &dev, VkPipelineLayoutCreateInfo &info, const std::vector<const DescriptorSetLayout *> &layouts) {
-        init(dev, info, layouts);
+        Init(dev, info, layouts);
     }
-    PipelineLayout(const Device &dev, VkPipelineLayoutCreateInfo &info) { init(dev, info); }
+    PipelineLayout(const Device &dev, VkPipelineLayoutCreateInfo &info) { Init(dev, info); }
     PipelineLayout(const Device &dev, const std::vector<const DescriptorSetLayout *> &layouts = {},
                    const std::vector<VkPushConstantRange> &push_constant_ranges = {},
                    VkPipelineLayoutCreateFlags flags = static_cast<VkPipelineLayoutCreateFlags>(0)) {
@@ -925,7 +925,7 @@ class PipelineLayout : public internal::NonDispHandle<VkPipelineLayout> {
         info.pushConstantRangeCount = static_cast<uint32_t>(push_constant_ranges.size());
         info.pPushConstantRanges = push_constant_ranges.data();
 
-        init(dev, info, layouts);
+        Init(dev, info, layouts);
     }
     ~PipelineLayout() noexcept;
     void destroy() noexcept;
@@ -940,34 +940,34 @@ class PipelineLayout : public internal::NonDispHandle<VkPipelineLayout> {
     };
 
     // vCreatePipelineLayout()
-    void init(const Device &dev, VkPipelineLayoutCreateInfo &info, const std::vector<const DescriptorSetLayout *> &layouts);
-    void init(const Device &dev, VkPipelineLayoutCreateInfo &info);
+    void Init(const Device &dev, VkPipelineLayoutCreateInfo &info, const std::vector<const DescriptorSetLayout *> &layouts);
+    void Init(const Device &dev, VkPipelineLayoutCreateInfo &info);
     void SetName(const char *name) { NonDispHandle<VkPipelineLayout>::SetName(VK_OBJECT_TYPE_PIPELINE_LAYOUT, name); }
 };
 
 class Sampler : public internal::NonDispHandle<VkSampler> {
   public:
     Sampler() = default;
-    Sampler(const Device &dev, const VkSamplerCreateInfo &info) { init(dev, info); }
+    Sampler(const Device &dev, const VkSamplerCreateInfo &info) { Init(dev, info); }
     ~Sampler() noexcept;
     void destroy() noexcept;
 
     // vkCreateSampler()
-    void init(const Device &dev, const VkSamplerCreateInfo &info);
+    void Init(const Device &dev, const VkSamplerCreateInfo &info);
     void SetName(const char *name) { NonDispHandle<VkSampler>::SetName(VK_OBJECT_TYPE_SAMPLER, name); }
 };
 
 class DescriptorSetLayout : public internal::NonDispHandle<VkDescriptorSetLayout> {
   public:
     DescriptorSetLayout() = default;
-    DescriptorSetLayout(const Device &dev, const VkDescriptorSetLayoutCreateInfo &info) { init(dev, info); }
+    DescriptorSetLayout(const Device &dev, const VkDescriptorSetLayoutCreateInfo &info) { Init(dev, info); }
     DescriptorSetLayout(const Device &dev, const std::vector<VkDescriptorSetLayoutBinding> &descriptor_set_bindings = {},
                         VkDescriptorSetLayoutCreateFlags flags = 0, void *pNext = nullptr) {
         VkDescriptorSetLayoutCreateInfo info = vku::InitStructHelper(pNext);
         info.flags = flags;
         info.bindingCount = static_cast<uint32_t>(descriptor_set_bindings.size());
         info.pBindings = descriptor_set_bindings.data();
-        init(dev, info);
+        Init(dev, info);
     }
     DescriptorSetLayout(const Device &dev, const VkDescriptorSetLayoutBinding &descriptor_set_binding,
                         VkDescriptorSetLayoutCreateFlags flags = 0, void *pNext = nullptr) {
@@ -975,7 +975,7 @@ class DescriptorSetLayout : public internal::NonDispHandle<VkDescriptorSetLayout
         info.flags = flags;
         info.bindingCount = 1;
         info.pBindings = &descriptor_set_binding;
-        init(dev, info);
+        Init(dev, info);
     }
     ~DescriptorSetLayout() noexcept;
     void destroy() noexcept;
@@ -989,18 +989,18 @@ class DescriptorSetLayout : public internal::NonDispHandle<VkDescriptorSetLayout
     }
 
     // vkCreateDescriptorSetLayout()
-    void init(const Device &dev, const VkDescriptorSetLayoutCreateInfo &info);
+    void Init(const Device &dev, const VkDescriptorSetLayoutCreateInfo &info);
 };
 
 class DescriptorPool : public internal::NonDispHandle<VkDescriptorPool> {
   public:
     DescriptorPool() = default;
-    DescriptorPool(const Device &dev, const VkDescriptorPoolCreateInfo &info) { init(dev, info); }
+    DescriptorPool(const Device &dev, const VkDescriptorPoolCreateInfo &info) { Init(dev, info); }
     ~DescriptorPool() noexcept;
     void destroy() noexcept;
 
     // vkCreateDescriptorPool()
-    void init(const Device &dev, const VkDescriptorPoolCreateInfo &info);
+    void Init(const Device &dev, const VkDescriptorPoolCreateInfo &info);
     void SetName(const char *name) { NonDispHandle<VkDescriptorPool>::SetName(VK_OBJECT_TYPE_DESCRIPTOR_POOL, name); }
 
     // vkResetDescriptorPool()
@@ -1080,7 +1080,7 @@ class CommandBuffer : public internal::Handle<VkCommandBuffer> {
     void destroy() noexcept;
 
     explicit CommandBuffer() : Handle() {}
-    explicit CommandBuffer(const Device &dev, const VkCommandBufferAllocateInfo &info) { init(dev, info); }
+    explicit CommandBuffer(const Device &dev, const VkCommandBufferAllocateInfo &info) { Init(dev, info); }
     explicit CommandBuffer(const Device &dev, const CommandPool &pool,
                            VkCommandBufferLevel level = VK_COMMAND_BUFFER_LEVEL_PRIMARY) {
         Init(dev, pool, level);
@@ -1093,7 +1093,7 @@ class CommandBuffer : public internal::Handle<VkCommandBuffer> {
     }
 
     // vkAllocateCommandBuffers()
-    void init(const Device &dev, const VkCommandBufferAllocateInfo &info);
+    void Init(const Device &dev, const VkCommandBufferAllocateInfo &info);
     void Init(const Device &dev, const CommandPool &pool, VkCommandBufferLevel level = VK_COMMAND_BUFFER_LEVEL_PRIMARY);
     void SetName(const Device &device, const char *name) {
         Handle<VkCommandBuffer>::SetName(device.handle(), VK_OBJECT_TYPE_COMMAND_BUFFER, name);
@@ -1174,23 +1174,23 @@ class RenderPass : public internal::NonDispHandle<VkRenderPass> {
   public:
     RenderPass() = default;
     // vkCreateRenderPass()
-    RenderPass(const Device &dev, const VkRenderPassCreateInfo &info) { init(dev, info); }
+    RenderPass(const Device &dev, const VkRenderPassCreateInfo &info) { Init(dev, info); }
     // vkCreateRenderPass2()
-    RenderPass(const Device &dev, const VkRenderPassCreateInfo2 &info) { init(dev, info); }
+    RenderPass(const Device &dev, const VkRenderPassCreateInfo2 &info) { Init(dev, info); }
     ~RenderPass() noexcept;
     void destroy() noexcept;
 
     // vkCreateRenderPass()
-    void init(const Device &dev, const VkRenderPassCreateInfo &info);
+    void Init(const Device &dev, const VkRenderPassCreateInfo &info);
     // vkCreateRenderPass2()
-    void init(const Device &dev, const VkRenderPassCreateInfo2 &info);
+    void Init(const Device &dev, const VkRenderPassCreateInfo2 &info);
     void SetName(const char *name) { NonDispHandle<VkRenderPass>::SetName(VK_OBJECT_TYPE_RENDER_PASS, name); }
 };
 
 class Framebuffer : public internal::NonDispHandle<VkFramebuffer> {
   public:
     Framebuffer() = default;
-    Framebuffer(const Device &dev, const VkFramebufferCreateInfo &info) { init(dev, info); }
+    Framebuffer(const Device &dev, const VkFramebufferCreateInfo &info) { Init(dev, info); }
     // The most common case, anything outside of this should create there own VkFramebufferCreateInfo
     Framebuffer(const Device &dev, VkRenderPass rp, uint32_t attchment_count, const VkImageView *attchments, uint32_t width = 32,
                 uint32_t height = 32) {
@@ -1201,25 +1201,25 @@ class Framebuffer : public internal::NonDispHandle<VkFramebuffer> {
         info.width = width;
         info.height = height;
         info.layers = 1;
-        init(dev, info);
+        Init(dev, info);
     }
     ~Framebuffer() noexcept;
     void destroy() noexcept;
 
     // vkCreateFramebuffer()
-    void init(const Device &dev, const VkFramebufferCreateInfo &info);
+    void Init(const Device &dev, const VkFramebufferCreateInfo &info);
     void SetName(const char *name) { NonDispHandle<VkFramebuffer>::SetName(VK_OBJECT_TYPE_FRAMEBUFFER, name); }
 };
 
 class SamplerYcbcrConversion : public internal::NonDispHandle<VkSamplerYcbcrConversion> {
   public:
     SamplerYcbcrConversion() = default;
-    SamplerYcbcrConversion(const Device &dev, VkFormat format) { init(dev, DefaultConversionInfo(format)); }
-    SamplerYcbcrConversion(const Device &dev, const VkSamplerYcbcrConversionCreateInfo &info) { init(dev, info); }
+    SamplerYcbcrConversion(const Device &dev, VkFormat format) { Init(dev, DefaultConversionInfo(format)); }
+    SamplerYcbcrConversion(const Device &dev, const VkSamplerYcbcrConversionCreateInfo &info) { Init(dev, info); }
     ~SamplerYcbcrConversion() noexcept;
     void destroy() noexcept;
 
-    void init(const Device &dev, const VkSamplerYcbcrConversionCreateInfo &info);
+    void Init(const Device &dev, const VkSamplerYcbcrConversionCreateInfo &info);
     void SetName(const char *name) {
         NonDispHandle<VkSamplerYcbcrConversion>::SetName(VK_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION, name);
     }

--- a/tests/framework/descriptor_helper.cpp
+++ b/tests/framework/descriptor_helper.cpp
@@ -68,7 +68,7 @@ OneOffDescriptorIndexingSet::OneOffDescriptorIndexingSet(vkt::Device *device, co
     ds_layout_ci.flags = layout_flags;
     ds_layout_ci.bindingCount = ds_layout_bindings.size();
     ds_layout_ci.pBindings = ds_layout_bindings.data();
-    layout_.init(*device, ds_layout_ci);
+    layout_.Init(*device, ds_layout_ci);
 
     VkDescriptorPoolCreateInfo pool_ci = vku::InitStructHelper(create_pool_pnext);
     pool_ci.flags = pool_flags;

--- a/tests/framework/pipeline_helper.cpp
+++ b/tests/framework/pipeline_helper.cpp
@@ -461,7 +461,7 @@ SimpleGPL::SimpleGPL(VkLayerTest &test, VkPipelineLayout layout, const char *ver
 
     VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = layout;
-    pipe_.init(*device, exe_pipe_ci);
+    pipe_.Init(*device, exe_pipe_ci);
 }
 
 }  // namespace vkt

--- a/tests/framework/queue_submit_context.cpp
+++ b/tests/framework/queue_submit_context.cpp
@@ -51,9 +51,9 @@ QSTestContext::QSTestContext(vkt::Device* device, vkt::Queue* force_q0, vkt::Que
 
     VkMemoryPropertyFlags mem_prop = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
     VkBufferUsageFlags transfer_usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
-    buffer_a.init(*device, 256, transfer_usage, mem_prop);
-    buffer_b.init(*device, 256, transfer_usage, mem_prop);
-    buffer_c.init(*device, 256, transfer_usage, mem_prop);
+    buffer_a.Init(*device, 256, transfer_usage, mem_prop);
+    buffer_b.Init(*device, 256, transfer_usage, mem_prop);
+    buffer_c.Init(*device, 256, transfer_usage, mem_prop);
 
     VkDeviceSize size = 256;
     VkDeviceSize half_size = size / 2;
@@ -70,10 +70,10 @@ QSTestContext::QSTestContext(vkt::Device* device, vkt::Queue* force_q0, vkt::Que
     h_cbc = InitFromPool(cbc);
 
     VkSemaphoreCreateInfo semaphore_ci = vku::InitStructHelper();
-    semaphore.init(*device, semaphore_ci);
+    semaphore.Init(*device, semaphore_ci);
 
     VkEventCreateInfo eci = vku::InitStructHelper();
-    event.init(*device, eci);
+    event.Init(*device, eci);
 }
 
 VkCommandBuffer QSTestContext::InitFromPool(vkt::CommandBuffer& cb_obj) {

--- a/tests/framework/ray_tracing_helper_nv.cpp
+++ b/tests/framework/ray_tracing_helper_nv.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 Valve Corporation
- * Copyright (c) 2023-2024 LunarG, Inc.
+ * Copyright (c) 2023-2025 Valve Corporation
+ * Copyright (c) 2023-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -208,8 +208,8 @@ void GetSimpleGeometryForAccelerationStructureTests(const vkt::Device &device, v
         alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
         alloc_pnext = &alloc_flags;
     }
-    vbo->init(device, 1024, usage, kHostVisibleMemProps, alloc_pnext);
-    ibo->init(device, 1024, usage, kHostVisibleMemProps, alloc_pnext);
+    vbo->Init(device, 1024, usage, kHostVisibleMemProps, alloc_pnext);
+    ibo->Init(device, 1024, usage, kHostVisibleMemProps, alloc_pnext);
 
     constexpr std::array vertices = {1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, -1.0f, 0.0f, 0.0f};
     constexpr std::array<uint32_t, 3> indicies = {{0, 1, 2}};

--- a/tests/framework/ray_tracing_objects.cpp
+++ b/tests/framework/ray_tracing_objects.cpp
@@ -340,7 +340,7 @@ void AccelerationStructureKHR::Create() {
         if (buffer_init_no_mem_) {
             device_buffer_.InitNoMemory(*device_, ci);
         } else {
-            device_buffer_.init(*device_, ci, buffer_memory_property_flags_, &alloc_flags);
+            device_buffer_.Init(*device_, ci, buffer_memory_property_flags_, &alloc_flags);
         }
     }
     vk_info_.buffer = device_buffer_.handle();
@@ -546,7 +546,7 @@ void BuildGeometryInfoKHR::SetupBuild(bool is_on_device_build, bool use_ppGeomet
                 alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
 
                 if (scratch_size > 0) {
-                    device_scratch_->init(*device_, scratch_size + as_props.minAccelerationStructureScratchOffsetAlignment,
+                    device_scratch_->Init(*device_, scratch_size + as_props.minAccelerationStructureScratchOffsetAlignment,
                                           VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT |
                                               device_scratch_additional_flags_,
                                           VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &alloc_flags);
@@ -631,7 +631,7 @@ void BuildGeometryInfoKHR::VkCmdBuildAccelerationStructuresIndirectKHR(VkCommand
     VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
     alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
 
-    indirect_buffer_->init(*device_, 1 * vk_info_.geometryCount * sizeof(VkAccelerationStructureBuildRangeInfoKHR),
+    indirect_buffer_->Init(*device_, 1 * vk_info_.geometryCount * sizeof(VkAccelerationStructureBuildRangeInfoKHR),
                            VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps,
                            &alloc_flags);
 
@@ -1107,7 +1107,7 @@ GeometryKHR GeometrySimpleOnDeviceAABBInfo(const vkt::Device &device, VkBufferUs
                                             VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR |
                                             VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | additional_geometry_buffer_flags;
 
-    aabb_buffer.init(device, aabb_buffer_size, buffer_usage, kHostVisibleMemProps, &alloc_flags);
+    aabb_buffer.Init(device, aabb_buffer_size, buffer_usage, kHostVisibleMemProps, &alloc_flags);
 
     // Fill buffer with one AABB
     aabb_geometry.SetPrimitiveCount(static_cast<uint32_t>(aabbs.size()));
@@ -1480,7 +1480,7 @@ void Pipeline::BuildPipeline() {
             pipeline_layout_ci_.setLayoutCount = 1;
             pipeline_layout_ci_.pSetLayouts = &desc_set_->layout_.handle();
         }
-        pipeline_layout_.init(*device_, pipeline_layout_ci_);
+        pipeline_layout_.Init(*device_, pipeline_layout_ci_);
     }
 
     // Assemble shaders information (stages and groups)
@@ -1554,7 +1554,7 @@ void Pipeline::BuildPipeline() {
     vk_info_.layout = pipeline_layout_;
 
     if (deferred_op_ == VK_NULL_HANDLE) {
-        rt_pipeline_.init(*device_, vk_info_);
+        rt_pipeline_.Init(*device_, vk_info_);
     } else {
         rt_pipeline_.InitDeferred(*device_, vk_info_, deferred_op_);
 
@@ -1604,7 +1604,7 @@ void Pipeline::BuildSbt() {
         VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_SHADER_BINDING_TABLE_BIT_KHR | VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
     VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
     alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
-    sbt_buffer_.init(*device_, sbt_buffer_info, kHostVisibleMemProps, &alloc_flags);
+    sbt_buffer_.Init(*device_, sbt_buffer_info, kHostVisibleMemProps, &alloc_flags);
 
 #ifdef VVL_DEBUG_LOG_SBT
     std::cout << "SBT buffer fill:\n";

--- a/tests/framework/render_pass_helper.cpp
+++ b/tests/framework/render_pass_helper.cpp
@@ -107,7 +107,7 @@ void RenderPassSingleSubpass::CreateRenderPass(void* pNext, VkRenderPassCreateFl
     VkRenderPassCreateInfo rp_create_info = GetCreateInfo();
     rp_create_info.pNext = pNext;
     rp_create_info.flags = flags;
-    render_pass_.init(*device_, rp_create_info);
+    render_pass_.Init(*device_, rp_create_info);
 }
 
 RenderPass2SingleSubpass::RenderPass2SingleSubpass(VkLayerTest& test, vkt::Device* device)
@@ -224,5 +224,5 @@ void RenderPass2SingleSubpass::CreateRenderPass(void* pNext, VkRenderPassCreateF
     VkRenderPassCreateInfo2 rp_create_info = GetCreateInfo();
     rp_create_info.pNext = pNext;
     rp_create_info.flags = flags;
-    render_pass_.init(*device_, rp_create_info);
+    render_pass_.Init(*device_, rp_create_info);
 }

--- a/tests/framework/shader_helper.cpp
+++ b/tests/framework/shader_helper.cpp
@@ -337,7 +337,7 @@ bool VkShaderObj::InitFromGLSL(const void *pNext) {
     moduleCreateInfo.codeSize = spv.size() * sizeof(uint32_t);
     moduleCreateInfo.pCode = spv.data();
 
-    init(*m_device, moduleCreateInfo);
+    Init(*m_device, moduleCreateInfo);
     m_stage_info.module = handle();
     return VK_NULL_HANDLE != handle();
 }
@@ -369,7 +369,7 @@ bool VkShaderObj::InitFromASM() {
     moduleCreateInfo.codeSize = spv.size() * sizeof(uint32_t);
     moduleCreateInfo.pCode = spv.data();
 
-    init(*m_device, moduleCreateInfo);
+    Init(*m_device, moduleCreateInfo);
     m_stage_info.module = handle();
     return VK_NULL_HANDLE != handle();
 }

--- a/tests/framework/sync_helper.cpp
+++ b/tests/framework/sync_helper.cpp
@@ -96,7 +96,7 @@ void BarrierQueueFamilyTestHelper::Init(std::vector<uint32_t> *families, bool im
     auto buffer_ci = vkt::Buffer::CreateInfo(256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
                                              families ? vvl::make_span(families->data(), families->size()) : vvl::span<uint32_t>{});
     if (buffer_memory) {
-        buffer_.init(*device_obj, buffer_ci, mem_prop);
+        buffer_.Init(*device_obj, buffer_ci, mem_prop);
     } else {
         buffer_.InitNoMemory(*device_obj, buffer_ci);
     }
@@ -132,7 +132,7 @@ void Barrier2QueueFamilyTestHelper::Init(bool image_memory, bool buffer_memory) 
     VkMemoryPropertyFlags mem_prop = VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
     auto buffer_ci = vkt::Buffer::CreateInfo(256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT);
     if (buffer_memory) {
-        buffer_.init(*device_obj, buffer_ci, mem_prop);
+        buffer_.Init(*device_obj, buffer_ci, mem_prop);
     } else {
         buffer_.InitNoMemory(*device_obj, buffer_ci);
     }

--- a/tests/unit/amd_best_practices.cpp
+++ b/tests/unit/amd_best_practices.cpp
@@ -475,10 +475,10 @@ TEST_F(VkAmdBestPracticesLayerTest, NumSyncPrimitives) {
     const VkSemaphoreCreateInfo semaphore_ci = vku::InitStructHelper();
     std::vector<vkt::Semaphore> test_semaphores(semaphore_warn_limit);
     for (int i = 0; i < semaphore_warn_limit - 1; ++i) {
-        test_semaphores[i].init(*m_device, semaphore_ci);
+        test_semaphores[i].Init(*m_device, semaphore_ci);
     }
     m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-SyncObjects-HighNumberOfSemaphores");
-    test_semaphores[semaphore_warn_limit - 1].init(*m_device, semaphore_ci);
+    test_semaphores[semaphore_warn_limit - 1].Init(*m_device, semaphore_ci);
     m_errorMonitor->VerifyFound();
 }
 

--- a/tests/unit/android_external_resolve.cpp
+++ b/tests/unit/android_external_resolve.cpp
@@ -328,18 +328,16 @@ TEST_F(NegativeAndroidExternalResolve, Framebuffer) {
     vkt::SamplerYcbcrConversion ycbcr_conv(*m_device, sycci);
 
     VkSamplerYcbcrConversionInfo syci = vku::InitStructHelper();
-    syci.conversion = ycbcr_conv.handle();
+    syci.conversion = ycbcr_conv;
 
     VkImageViewCreateInfo ivci = vku::InitStructHelper(&syci);
-    ivci.image = resolve_image.handle();
+    ivci.image = resolve_image;
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     ivci.format = VK_FORMAT_UNDEFINED;
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     const vkt::ImageView resolve_view(*m_device, ivci);
 
-    VkImageView attachments[2];
-    attachments[0] = color_view.handle();
-    attachments[1] = resolve_view.handle();
+    VkImageView attachments[2] = {color_view, resolve_view};
 
     m_errorMonitor->SetDesiredError("VUID-VkFramebufferCreateInfo-pAttachments-09350");
     vkt::Framebuffer framebuffer(*m_device, rp, 2, attachments);
@@ -405,18 +403,16 @@ TEST_F(NegativeAndroidExternalResolve, ImagelessFramebuffer) {
     vkt::SamplerYcbcrConversion ycbcr_conv(*m_device, sycci);
 
     VkSamplerYcbcrConversionInfo syci = vku::InitStructHelper();
-    syci.conversion = ycbcr_conv.handle();
+    syci.conversion = ycbcr_conv;
 
     VkImageViewCreateInfo ivci = vku::InitStructHelper(&syci);
-    ivci.image = resolve_image.handle();
+    ivci.image = resolve_image;
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     ivci.format = VK_FORMAT_UNDEFINED;
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     const vkt::ImageView resolve_view(*m_device, ivci);
 
-    VkImageView attachments[2];
-    attachments[0] = color_view.handle();
-    attachments[1] = resolve_view.handle();
+    VkImageView attachments[2] = {color_view, resolve_view};
 
     VkFramebufferAttachmentImageInfo framebuffer_attachment_image_info[2];
     framebuffer_attachment_image_info[0] = vku::InitStructHelper();
@@ -527,18 +523,16 @@ TEST_F(NegativeAndroidExternalResolve, ImagelessFramebufferFormat) {
     vkt::SamplerYcbcrConversion ycbcr_conv(*m_device, sycci);
 
     VkSamplerYcbcrConversionInfo syci = vku::InitStructHelper();
-    syci.conversion = ycbcr_conv.handle();
+    syci.conversion = ycbcr_conv;
 
     VkImageViewCreateInfo ivci = vku::InitStructHelper(&syci);
-    ivci.image = resolve_image.handle();
+    ivci.image = resolve_image;
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     ivci.format = VK_FORMAT_UNDEFINED;
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     const vkt::ImageView resolve_view(*m_device, ivci);
 
-    VkImageView attachments[2];
-    attachments[0] = color_view.handle();
-    attachments[1] = resolve_view.handle();
+    VkImageView attachments[2] = {color_view, resolve_view};
 
     VkFramebufferAttachmentImageInfo framebuffer_attachment_image_info[2];
     framebuffer_attachment_image_info[0] = vku::InitStructHelper();
@@ -634,20 +628,20 @@ TEST_F(NegativeAndroidExternalResolve, DynamicRendering) {
     vkt::SamplerYcbcrConversion ycbcr_conv(*m_device, sycci);
 
     VkSamplerYcbcrConversionInfo syci = vku::InitStructHelper();
-    syci.conversion = ycbcr_conv.handle();
+    syci.conversion = ycbcr_conv;
 
     VkImageViewCreateInfo ivci = vku::InitStructHelper(&syci);
-    ivci.image = resolve_image.handle();
+    ivci.image = resolve_image;
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     ivci.format = VK_FORMAT_UNDEFINED;
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     const vkt::ImageView resolve_view(*m_device, ivci);
 
     VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
-    color_attachment.imageView = color_view.handle();
+    color_attachment.imageView = color_view;
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     color_attachment.resolveMode = VK_RESOLVE_MODE_NONE;
-    color_attachment.resolveImageView = resolve_view.handle();
+    color_attachment.resolveImageView = resolve_view;
     color_attachment.resolveImageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
     VkRenderingAttachmentInfo ds_attachment = vku::InitStructHelper();
@@ -731,17 +725,17 @@ TEST_F(NegativeAndroidExternalResolve, DynamicRenderingResolveModeNonNullColor) 
     vkt::SamplerYcbcrConversion ycbcr_conv(*m_device, sycci);
 
     VkSamplerYcbcrConversionInfo syci = vku::InitStructHelper();
-    syci.conversion = ycbcr_conv.handle();
+    syci.conversion = ycbcr_conv;
 
     VkImageViewCreateInfo ivci = vku::InitStructHelper(&syci);
-    ivci.image = resolve_image.handle();
+    ivci.image = resolve_image;
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     ivci.format = VK_FORMAT_UNDEFINED;
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     const vkt::ImageView resolve_view(*m_device, ivci);
 
     VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
-    color_attachment.imageView = color_view.handle();
+    color_attachment.imageView = color_view;
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     color_attachment.resolveMode = VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_ANDROID;
     color_attachment.resolveImageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
@@ -754,15 +748,15 @@ TEST_F(NegativeAndroidExternalResolve, DynamicRenderingResolveModeNonNullColor) 
 
     m_command_buffer.Begin();
 
-    color_attachment.resolveImageView = resolve_view.handle();
+    color_attachment.resolveImageView = resolve_view;
     color_attachment.imageView = VK_NULL_HANDLE;
     m_errorMonitor->SetAllowedFailureMsg("VUID-VkRenderingAttachmentInfo-imageView-06129");
     m_errorMonitor->SetDesiredError("VUID-VkRenderingAttachmentInfo-resolveMode-09329");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    color_attachment.imageView = color_view.handle();
-    color_attachment.resolveImageView = bad_resolve_view.handle();
+    color_attachment.imageView = color_view;
+    color_attachment.resolveImageView = bad_resolve_view;
     m_errorMonitor->SetAllowedFailureMsg("VUID-VkRenderingAttachmentInfo-imageView-06129");
     m_errorMonitor->SetDesiredError("VUID-VkRenderingAttachmentInfo-resolveMode-09326");
     m_errorMonitor->SetDesiredError("VUID-VkRenderingAttachmentInfo-resolveMode-09327");
@@ -886,20 +880,20 @@ TEST_F(NegativeAndroidExternalResolve, MissingImageUsage) {
     vkt::SamplerYcbcrConversion ycbcr_conv(*m_device, sycci);
 
     VkSamplerYcbcrConversionInfo syci = vku::InitStructHelper();
-    syci.conversion = ycbcr_conv.handle();
+    syci.conversion = ycbcr_conv;
 
     VkImageViewCreateInfo ivci = vku::InitStructHelper(&syci);
-    ivci.image = resolve_image.handle();
+    ivci.image = resolve_image;
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     ivci.format = VK_FORMAT_UNDEFINED;
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     const vkt::ImageView resolve_view(*m_device, ivci);
 
     VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
-    color_attachment.imageView = color_view.handle();
+    color_attachment.imageView = color_view;
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     color_attachment.resolveMode = VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_ANDROID;
-    color_attachment.resolveImageView = resolve_view.handle();
+    color_attachment.resolveImageView = resolve_view;
     color_attachment.resolveImageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
     VkRenderingInfo begin_rendering_info = vku::InitStructHelper();
@@ -962,20 +956,20 @@ TEST_F(NegativeAndroidExternalResolve, ClearAttachment) {
     vkt::SamplerYcbcrConversion ycbcr_conv(*m_device, sycci);
 
     VkSamplerYcbcrConversionInfo syci = vku::InitStructHelper();
-    syci.conversion = ycbcr_conv.handle();
+    syci.conversion = ycbcr_conv;
 
     VkImageViewCreateInfo ivci = vku::InitStructHelper(&syci);
-    ivci.image = resolve_image.handle();
+    ivci.image = resolve_image;
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     ivci.format = VK_FORMAT_UNDEFINED;
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     const vkt::ImageView resolve_view(*m_device, ivci);
 
     VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
-    color_attachment.imageView = color_view.handle();
+    color_attachment.imageView = color_view;
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     color_attachment.resolveMode = VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_ANDROID;
-    color_attachment.resolveImageView = resolve_view.handle();
+    color_attachment.resolveImageView = resolve_view;
     color_attachment.resolveImageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
     VkRenderingInfo begin_rendering_info = vku::InitStructHelper();
@@ -1049,20 +1043,20 @@ TEST_F(NegativeAndroidExternalResolve, DrawDynamicRasterizationSamples) {
     vkt::SamplerYcbcrConversion ycbcr_conv(*m_device, sycci);
 
     VkSamplerYcbcrConversionInfo syci = vku::InitStructHelper();
-    syci.conversion = ycbcr_conv.handle();
+    syci.conversion = ycbcr_conv;
 
     VkImageViewCreateInfo ivci = vku::InitStructHelper(&syci);
-    ivci.image = resolve_image.handle();
+    ivci.image = resolve_image;
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     ivci.format = VK_FORMAT_UNDEFINED;
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     const vkt::ImageView resolve_view(*m_device, ivci);
 
     VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
-    color_attachment.imageView = color_view.handle();
+    color_attachment.imageView = color_view;
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     color_attachment.resolveMode = VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_ANDROID;
-    color_attachment.resolveImageView = resolve_view.handle();
+    color_attachment.resolveImageView = resolve_view;
     color_attachment.resolveImageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
     VkRenderingInfo begin_rendering_info = vku::InitStructHelper();
@@ -1148,14 +1142,12 @@ TEST_F(NegativeAndroidExternalResolve, PipelineBarrier) {
     vkt::ImageView resolve_view = resolve_image.CreateView();
 
     VkImageViewCreateInfo ivci = vku::InitStructHelper();
-    ivci.image = resolve_image.handle();
+    ivci.image = resolve_image;
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     ivci.format = format_resolve_prop.colorAttachmentFormat;
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
 
-    VkImageView attachments[2];
-    attachments[0] = color_view.handle();
-    attachments[1] = resolve_view.handle();
+    VkImageView attachments[2] = {color_view, resolve_view};
 
     vkt::Framebuffer framebuffer(*m_device, rp, 2, attachments);
 
@@ -1172,7 +1164,7 @@ TEST_F(NegativeAndroidExternalResolve, PipelineBarrier) {
     barrier.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
     barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     barrier.newLayout = VK_IMAGE_LAYOUT_GENERAL;
-    barrier.image = resolve_image.handle();
+    barrier.image = resolve_image;
     barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
     barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
     barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
@@ -1251,18 +1243,16 @@ TEST_F(NegativeAndroidExternalResolve, PipelineBarrierUnused) {
     vkt::SamplerYcbcrConversion ycbcr_conv(*m_device, sycci);
 
     VkSamplerYcbcrConversionInfo syci = vku::InitStructHelper();
-    syci.conversion = ycbcr_conv.handle();
+    syci.conversion = ycbcr_conv;
 
     VkImageViewCreateInfo ivci = vku::InitStructHelper(&syci);
-    ivci.image = resolve_image.handle();
+    ivci.image = resolve_image;
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     ivci.format = VK_FORMAT_UNDEFINED;
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     const vkt::ImageView resolve_view(*m_device, ivci);
 
-    VkImageView attachments[2];
-    attachments[0] = color_view.handle();
-    attachments[1] = resolve_view.handle();
+    VkImageView attachments[2] = {color_view, resolve_view};
 
     vkt::Framebuffer framebuffer(*m_device, rp, 2, attachments);
 
@@ -1279,7 +1269,7 @@ TEST_F(NegativeAndroidExternalResolve, PipelineBarrierUnused) {
     image_barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     image_barrier.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
     image_barrier.newLayout = VK_IMAGE_LAYOUT_GENERAL;
-    image_barrier.image = resolve_image.handle();
+    image_barrier.image = resolve_image;
     image_barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
     image_barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
 
@@ -1351,18 +1341,16 @@ TEST_F(NegativeAndroidExternalResolve, RenderPassAndFramebuffer) {
     vkt::SamplerYcbcrConversion ycbcr_conv(*m_device, sycci);
 
     VkSamplerYcbcrConversionInfo syci = vku::InitStructHelper();
-    syci.conversion = ycbcr_conv.handle();
+    syci.conversion = ycbcr_conv;
 
     VkImageViewCreateInfo ivci = vku::InitStructHelper(&syci);
-    ivci.image = resolve_image.handle();
+    ivci.image = resolve_image;
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     ivci.format = VK_FORMAT_UNDEFINED;
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     const vkt::ImageView resolve_view(*m_device, ivci);
 
-    VkImageView attachments[2];
-    attachments[0] = color_view.handle();
-    attachments[1] = resolve_view.handle();
+    VkImageView attachments[2] = {color_view, resolve_view};
 
     m_errorMonitor->SetDesiredError("VUID-VkFramebufferCreateInfo-nullColorAttachmentWithExternalFormatResolve-09349");
     vkt::Framebuffer framebuffer(*m_device, rp, 2, attachments);

--- a/tests/unit/android_external_resolve_positive.cpp
+++ b/tests/unit/android_external_resolve_positive.cpp
@@ -96,18 +96,16 @@ TEST_F(PositiveAndroidExternalResolve, RenderPassAndFramebuffer) {
     vkt::SamplerYcbcrConversion ycbcr_conv(*m_device, sycci);
 
     VkSamplerYcbcrConversionInfo syci = vku::InitStructHelper();
-    syci.conversion = ycbcr_conv.handle();
+    syci.conversion = ycbcr_conv;
 
     VkImageViewCreateInfo ivci = vku::InitStructHelper(&syci);
-    ivci.image = resolve_image.handle();
+    ivci.image = resolve_image;
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     ivci.format = VK_FORMAT_UNDEFINED;
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     const vkt::ImageView resolve_view(*m_device, ivci);
 
-    VkImageView attachments[2];
-    attachments[0] = color_view.handle();
-    attachments[1] = resolve_view.handle();
+    VkImageView attachments[2] = {color_view, resolve_view};
 
     vkt::Framebuffer framebuffer(*m_device, rp, 2, attachments);
 
@@ -173,18 +171,16 @@ TEST_F(PositiveAndroidExternalResolve, ImagelessFramebuffer) {
     vkt::SamplerYcbcrConversion ycbcr_conv(*m_device, sycci);
 
     VkSamplerYcbcrConversionInfo syci = vku::InitStructHelper();
-    syci.conversion = ycbcr_conv.handle();
+    syci.conversion = ycbcr_conv;
 
     VkImageViewCreateInfo ivci = vku::InitStructHelper(&syci);
-    ivci.image = resolve_image.handle();
+    ivci.image = resolve_image;
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     ivci.format = VK_FORMAT_UNDEFINED;
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     const vkt::ImageView resolve_view(*m_device, ivci);
 
-    VkImageView attachments[2];
-    attachments[0] = color_view.handle();
-    attachments[1] = resolve_view.handle();
+    VkImageView attachments[2] = {color_view, resolve_view};
 
     VkFramebufferAttachmentImageInfo framebuffer_attachment_image_info[2];
     framebuffer_attachment_image_info[0] = vku::InitStructHelper();
@@ -279,20 +275,20 @@ TEST_F(PositiveAndroidExternalResolve, DynamicRendering) {
     vkt::SamplerYcbcrConversion ycbcr_conv(*m_device, sycci);
 
     VkSamplerYcbcrConversionInfo syci = vku::InitStructHelper();
-    syci.conversion = ycbcr_conv.handle();
+    syci.conversion = ycbcr_conv;
 
     VkImageViewCreateInfo ivci = vku::InitStructHelper(&syci);
-    ivci.image = resolve_image.handle();
+    ivci.image = resolve_image;
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     ivci.format = VK_FORMAT_UNDEFINED;
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     const vkt::ImageView resolve_view(*m_device, ivci);
 
     VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
-    color_attachment.imageView = color_view.handle();
+    color_attachment.imageView = color_view;
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     color_attachment.resolveMode = VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_ANDROID;
-    color_attachment.resolveImageView = resolve_view.handle();
+    color_attachment.resolveImageView = resolve_view;
     color_attachment.resolveImageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
     VkRenderingInfo begin_rendering_info = vku::InitStructHelper();
@@ -366,18 +362,16 @@ TEST_F(PositiveAndroidExternalResolve, PipelineBarrier) {
     vkt::SamplerYcbcrConversion ycbcr_conv(*m_device, sycci);
 
     VkSamplerYcbcrConversionInfo syci = vku::InitStructHelper();
-    syci.conversion = ycbcr_conv.handle();
+    syci.conversion = ycbcr_conv;
 
     VkImageViewCreateInfo ivci = vku::InitStructHelper(&syci);
-    ivci.image = resolve_image.handle();
+    ivci.image = resolve_image;
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
     ivci.format = VK_FORMAT_UNDEFINED;
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     const vkt::ImageView resolve_view(*m_device, ivci);
 
-    VkImageView attachments[2];
-    attachments[0] = color_view.handle();
-    attachments[1] = resolve_view.handle();
+    VkImageView attachments[2] = {color_view, resolve_view};
 
     vkt::Framebuffer framebuffer(*m_device, rp, 2, attachments);
 
@@ -394,7 +388,7 @@ TEST_F(PositiveAndroidExternalResolve, PipelineBarrier) {
     image_barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     image_barrier.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
     image_barrier.newLayout = VK_IMAGE_LAYOUT_GENERAL;
-    image_barrier.image = resolve_image.handle();
+    image_barrier.image = resolve_image;
     image_barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
     image_barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
 

--- a/tests/unit/arm_best_practices.cpp
+++ b/tests/unit/arm_best_practices.cpp
@@ -31,7 +31,7 @@ class VkConstantBufferObj : public vkt::Buffer {
   public:
     VkConstantBufferObj(vkt::Device* device, VkDeviceSize size, const void* data,
                         VkBufferUsageFlags usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT) {
-        init(*device, CreateInfo(size, usage), kHostVisibleMemProps);
+        Init(*device, CreateInfo(size, usage), kHostVisibleMemProps);
 
         void* pData = Memory().Map();
         memcpy(pData, data, static_cast<size_t>(size));
@@ -514,7 +514,7 @@ TEST_F(VkArmBestPracticesLayerTest, PostTransformVertexCacheThrashingIndicesTest
     // make sure the worst-case indices throw a warning
     VkConstantBufferObj worst_ibo(m_device, worst_indices.size() * sizeof(uint16_t), worst_indices.data(),
                                   VK_BUFFER_USAGE_INDEX_BUFFER_BIT);
-    vk::CmdBindIndexBuffer(m_command_buffer, worst_ibo.handle(), static_cast<VkDeviceSize>(0), VK_INDEX_TYPE_UINT16);
+    vk::CmdBindIndexBuffer(m_command_buffer, worst_ibo, static_cast<VkDeviceSize>(0), VK_INDEX_TYPE_UINT16);
 
     // the validation layer will only be able to analyse mapped memory, it's too expensive otherwise to do in the layer itself
     worst_ibo.Memory().Map();
@@ -527,7 +527,7 @@ TEST_F(VkArmBestPracticesLayerTest, PostTransformVertexCacheThrashingIndicesTest
     // make sure that the best-case indices don't throw a warning
     VkConstantBufferObj best_ibo(m_device, best_indices.size() * sizeof(uint16_t), best_indices.data(),
                                  VK_BUFFER_USAGE_INDEX_BUFFER_BIT);
-    vk::CmdBindIndexBuffer(m_command_buffer, best_ibo.handle(), static_cast<VkDeviceSize>(0), VK_INDEX_TYPE_UINT16);
+    vk::CmdBindIndexBuffer(m_command_buffer, best_ibo, static_cast<VkDeviceSize>(0), VK_INDEX_TYPE_UINT16);
 
     best_ibo.Memory().Map();
     vk::CmdDrawIndexed(m_command_buffer, best_indices.size(), 0, 0, 0, 0);

--- a/tests/unit/best_practices.cpp
+++ b/tests/unit/best_practices.cpp
@@ -385,9 +385,8 @@ TEST_F(VkBestPracticesLayerTest, SmallDedicatedAllocation) {
     // Create a small image with a dedicated allocation
     vkt::Image image(*m_device, image_info, vkt::no_mem);
 
-    vkt::DeviceMemory mem;
-    mem.init(*m_device,
-             vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image.MemoryRequirements(), VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT));
+    vkt::DeviceMemory mem(*m_device, vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image.MemoryRequirements(),
+                                                                             VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT));
     vk::BindImageMemory(device(), image, mem, 0);
 
     m_errorMonitor->VerifyFound();

--- a/tests/unit/buffer.cpp
+++ b/tests/unit/buffer.cpp
@@ -262,7 +262,7 @@ TEST_F(NegativeBuffer, BufferViewMaxTexelBufferElements) {
     VkBufferViewCreateInfo buff_view_ci = vku::InitStructHelper();
     buff_view_ci.offset = dev_limits.minTexelBufferOffsetAlignment;
     buff_view_ci.format = format_with_uniform_texel_support;
-    buff_view_ci.buffer = large_buffer.handle();
+    buff_view_ci.buffer = large_buffer;
     buff_view_ci.range = VK_WHOLE_SIZE;
 
     // For VK_WHOLE_SIZE, the buffer size - offset must be less than VkPhysicalDeviceLimits::maxTexelBufferElements
@@ -442,7 +442,7 @@ TEST_F(NegativeBuffer, BindNull) {
 
     vk::DestroyBuffer(device(), buffer, nullptr);
     m_errorMonitor->SetDesiredError("VUID-vkBindBufferMemory-buffer-parameter");
-    vk::BindBufferMemory(device(), buffer, memory.handle(), 0);
+    vk::BindBufferMemory(device(), buffer, memory, 0);
     m_errorMonitor->VerifyFound();
 }
 

--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -2017,9 +2017,8 @@ TEST_F(NegativeCommand, DrawIndirectCountKHR) {
 
     vkt::Buffer count_buffer_unbound(*m_device, count_buffer_create_info, vkt::no_mem);
 
-    vkt::Buffer count_buffer_wrong;
     count_buffer_create_info.usage = VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
-    count_buffer_wrong.init(*m_device, count_buffer_create_info);
+    vkt::Buffer count_buffer_wrong(*m_device, count_buffer_create_info);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDrawIndirectCount-countBuffer-02714");
     vk::CmdDrawIndirectCountKHR(m_command_buffer, draw_buffer, 0, count_buffer_unbound, 0, 1, sizeof(VkDrawIndirectCommand));
@@ -2098,9 +2097,8 @@ TEST_F(NegativeCommand, DrawIndexedIndirectCountKHR) {
 
     vkt::Buffer count_buffer_unbound(*m_device, count_buffer_create_info, vkt::no_mem);
 
-    vkt::Buffer count_buffer_wrong;
     count_buffer_create_info.usage = VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
-    count_buffer_wrong.init(*m_device, count_buffer_create_info);
+    vkt::Buffer count_buffer_wrong(*m_device, count_buffer_create_info);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDrawIndexedIndirectCount-countBuffer-02714");
     vk::CmdDrawIndexedIndirectCountKHR(m_command_buffer, draw_buffer, 0, count_buffer_unbound, 0, 1,

--- a/tests/unit/command_positive.cpp
+++ b/tests/unit/command_positive.cpp
@@ -49,7 +49,7 @@ TEST_F(PositiveCommand, DrawIndirectCountWithoutFeature) {
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
     vk::CmdDrawIndirectCountKHR(m_command_buffer, indirect_buffer, 0, count_buffer, 0, 1, sizeof(VkDrawIndirectCommand));
     vk::CmdBindIndexBuffer(m_command_buffer, index_buffer, 0, VK_INDEX_TYPE_UINT32);
-    vk::CmdDrawIndexedIndirectCountKHR(m_command_buffer, indexed_indirect_buffer.handle(), 0, count_buffer, 0, 1,
+    vk::CmdDrawIndexedIndirectCountKHR(m_command_buffer, indexed_indirect_buffer, 0, count_buffer, 0, 1,
                                        sizeof(VkDrawIndexedIndirectCommand));
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
@@ -85,7 +85,7 @@ TEST_F(PositiveCommand, DrawIndirectCountWithoutFeature12) {
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
     vk::CmdDrawIndirectCount(m_command_buffer, indirect_buffer, 0, count_buffer, 0, 1, sizeof(VkDrawIndirectCommand));
     vk::CmdBindIndexBuffer(m_command_buffer, index_buffer, 0, VK_INDEX_TYPE_UINT32);
-    vk::CmdDrawIndexedIndirectCount(m_command_buffer, indexed_indirect_buffer.handle(), 0, count_buffer, 0, 1,
+    vk::CmdDrawIndexedIndirectCount(m_command_buffer, indexed_indirect_buffer, 0, count_buffer, 0, 1,
                                     sizeof(VkDrawIndexedIndirectCommand));
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
@@ -118,7 +118,7 @@ TEST_F(PositiveCommand, DrawIndirectCountWithFeature) {
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
     vk::CmdDrawIndirectCount(m_command_buffer, indirect_buffer, 0, count_buffer, 0, 1, sizeof(VkDrawIndirectCommand));
     vk::CmdBindIndexBuffer(m_command_buffer, index_buffer, 0, VK_INDEX_TYPE_UINT32);
-    vk::CmdDrawIndexedIndirectCount(m_command_buffer, indexed_indirect_buffer.handle(), 0, count_buffer, 0, 1,
+    vk::CmdDrawIndexedIndirectCount(m_command_buffer, indexed_indirect_buffer, 0, count_buffer, 0, 1,
                                     sizeof(VkDrawIndexedIndirectCommand));
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();

--- a/tests/unit/copy_buffer_image.cpp
+++ b/tests/unit/copy_buffer_image.cpp
@@ -2469,7 +2469,6 @@ TEST_F(NegativeCopyBufferImage, DISABLED_ImageOverlappingMemory) {
     vkt::Image image(*m_device, image_ci, vkt::no_mem);
     const auto image_memory_requirements = image.MemoryRequirements();
 
-    vkt::DeviceMemory mem;
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.allocationSize = (std::max)(buffer_memory_requirements.size, image_memory_requirements.size);
     bool has_memtype = m_device->Physical().SetMemoryType(
@@ -2477,7 +2476,7 @@ TEST_F(NegativeCopyBufferImage, DISABLED_ImageOverlappingMemory) {
     if (!has_memtype) {
         GTEST_SKIP() << "Failed to find a memory type for both a buffer and an image";
     }
-    mem.init(*m_device, alloc_info);
+    vkt::DeviceMemory mem(*m_device, alloc_info);
 
     buffer.BindMemory(mem, 0);
     image.BindMemory(mem, 0);
@@ -2540,7 +2539,6 @@ TEST_F(NegativeCopyBufferImage, DISABLED_ImageOverlappingMemoryOffsets) {
     vkt::Image image(*m_device, image_ci, vkt::no_mem);
     const auto image_memory_requirements = image.MemoryRequirements();
 
-    vkt::DeviceMemory mem;
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.allocationSize = (std::max)(buffer_memory_requirements.size, image_memory_requirements.size);
     bool has_memtype = m_device->Physical().SetMemoryType(
@@ -2548,7 +2546,7 @@ TEST_F(NegativeCopyBufferImage, DISABLED_ImageOverlappingMemoryOffsets) {
     if (!has_memtype) {
         GTEST_SKIP() << "Failed to find a memory type for both a buffer and an image";
     }
-    mem.init(*m_device, alloc_info);
+    vkt::DeviceMemory mem(*m_device, alloc_info);
 
     buffer.BindMemory(mem, 0);
     image.BindMemory(mem, 0);

--- a/tests/unit/copy_buffer_image_positive.cpp
+++ b/tests/unit/copy_buffer_image_positive.cpp
@@ -176,7 +176,6 @@ TEST_F(PositiveCopyBufferImage, ImageOverlappingMemory) {
     vkt::Image image(*m_device, image_ci, vkt::no_mem);
     auto image_memory_requirements = image.MemoryRequirements();
 
-    vkt::DeviceMemory mem;
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.allocationSize = buffer_memory_requirements.size + image_memory_requirements.size;
     bool has_memtype = m_device->Physical().SetMemoryType(
@@ -184,7 +183,7 @@ TEST_F(PositiveCopyBufferImage, ImageOverlappingMemory) {
     if (!has_memtype) {
         GTEST_SKIP() << "Failed to find a memory type for both a buffer and an image";
     }
-    mem.init(*m_device, alloc_info);
+    vkt::DeviceMemory mem(*m_device, alloc_info);
 
     buffer.BindMemory(mem, 0);
     image.BindMemory(mem, buffer_memory_requirements.size);
@@ -236,7 +235,6 @@ TEST_F(PositiveCopyBufferImage, ImageOverlappingMemoryCompressed) {
     vkt::Image image(*m_device, image_ci, vkt::no_mem);
     auto image_memory_requirements = image.MemoryRequirements();
 
-    vkt::DeviceMemory mem;
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.allocationSize = buffer_memory_requirements.size + image_memory_requirements.size;
     bool has_memtype = m_device->Physical().SetMemoryType(
@@ -245,7 +243,7 @@ TEST_F(PositiveCopyBufferImage, ImageOverlappingMemoryCompressed) {
         GTEST_SKIP() << "Failed to find a memory type for both a buffer and an image";
     }
 
-    mem.init(*m_device, alloc_info);
+    vkt::DeviceMemory mem(*m_device, alloc_info);
 
     buffer.BindMemory(mem, 0);
     image.BindMemory(mem, buffer_memory_requirements.size);

--- a/tests/unit/debug_extensions.cpp
+++ b/tests/unit/debug_extensions.cpp
@@ -48,11 +48,11 @@ TEST_F(NegativeDebugExtensions, DebugMarkerName) {
     name_info.pObjectName = memory_name.c_str();
     vk::DebugMarkerSetObjectNameEXT(device(), &name_info);
 
-    vk::BindBufferMemory(device(), buffer, memory_1.handle(), 0);
+    vk::BindBufferMemory(device(), buffer, memory_1, 0);
 
     // Test core_validation layer
     m_errorMonitor->SetDesiredError(memory_name.c_str());
-    vk::BindBufferMemory(device(), buffer, memory_2.handle(), 0);
+    vk::BindBufferMemory(device(), buffer, memory_2, 0);
     m_errorMonitor->VerifyFound();
 
     VkCommandBuffer commandBuffer;
@@ -64,7 +64,7 @@ TEST_F(NegativeDebugExtensions, DebugMarkerName) {
     vkt::CommandPool command_pool_2(*m_device, pool_create_info);
 
     VkCommandBufferAllocateInfo command_buffer_allocate_info = vku::InitStructHelper();
-    command_buffer_allocate_info.commandPool = command_pool_1.handle();
+    command_buffer_allocate_info.commandPool = command_pool_1;
     command_buffer_allocate_info.commandBufferCount = 1;
     command_buffer_allocate_info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
     vk::AllocateCommandBuffers(device(), &command_buffer_allocate_info, &commandBuffer);
@@ -88,7 +88,7 @@ TEST_F(NegativeDebugExtensions, DebugMarkerName) {
 
     // Test object_tracker layer
     m_errorMonitor->SetDesiredError(commandBuffer_name.c_str());
-    vk::FreeCommandBuffers(device(), command_pool_2.handle(), 1, &commandBuffer);
+    vk::FreeCommandBuffers(device(), command_pool_2, 1, &commandBuffer);
     m_errorMonitor->VerifyFound();
 }
 
@@ -197,11 +197,11 @@ TEST_F(NegativeDebugExtensions, DebugUtilsName) {
     name_info.objectType = VK_OBJECT_TYPE_DEVICE_MEMORY;
     vk::SetDebugUtilsObjectNameEXT(device(), &name_info);
 
-    vk::BindBufferMemory(device(), buffer, memory_1.handle(), 0);
+    vk::BindBufferMemory(device(), buffer, memory_1, 0);
 
     // Test core_validation layer
     m_errorMonitor->SetDesiredError(memory_name.c_str());
-    vk::BindBufferMemory(device(), buffer, memory_2.handle(), 0);
+    vk::BindBufferMemory(device(), buffer, memory_2, 0);
     m_errorMonitor->VerifyFound();
 
     VkCommandBuffer commandBuffer;
@@ -213,7 +213,7 @@ TEST_F(NegativeDebugExtensions, DebugUtilsName) {
     vkt::CommandPool command_pool_2(*m_device, pool_create_info);
 
     VkCommandBufferAllocateInfo command_buffer_allocate_info = vku::InitStructHelper();
-    command_buffer_allocate_info.commandPool = command_pool_1.handle();
+    command_buffer_allocate_info.commandPool = command_pool_1;
     command_buffer_allocate_info.commandBufferCount = 1;
     command_buffer_allocate_info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
     vk::AllocateCommandBuffers(device(), &command_buffer_allocate_info, &commandBuffer);
@@ -260,7 +260,7 @@ TEST_F(NegativeDebugExtensions, DebugUtilsName) {
 
     // Test object_tracker layer
     m_errorMonitor->SetDesiredError(commandBuffer_name.c_str());
-    vk::FreeCommandBuffers(device(), command_pool_2.handle(), 1, &commandBuffer);
+    vk::FreeCommandBuffers(device(), command_pool_2, 1, &commandBuffer);
     m_errorMonitor->VerifyFound();
 
     vk::DestroyDebugUtilsMessengerEXT(instance(), my_messenger, nullptr);

--- a/tests/unit/descriptor_buffer.cpp
+++ b/tests/unit/descriptor_buffer.cpp
@@ -1053,7 +1053,7 @@ TEST_F(NegativeDescriptorBuffer, BindPoint) {
         plci.setLayoutCount = 2;
         plci.pSetLayouts = set_layouts;
 
-        pipeline_layout.init(*m_device, plci);
+        pipeline_layout.Init(*m_device, plci);
     }
 
     {

--- a/tests/unit/descriptor_buffer_positive.cpp
+++ b/tests/unit/descriptor_buffer_positive.cpp
@@ -282,7 +282,7 @@ TEST_F(PositiveDescriptorBuffer, MultipleSet) {
     VkDescriptorSetLayoutBinding binding = {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr};
     vkt::DescriptorSetLayout ds_layout(*m_device, binding, VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT);
 
-    const VkDescriptorSetLayout set_layouts[3] = {ds_layout.handle(), ds_layout, ds_layout};
+    const VkDescriptorSetLayout set_layouts[3] = {ds_layout, ds_layout, ds_layout};
     VkPipelineLayoutCreateInfo pipe_layout_ci = vku::InitStructHelper();
     pipe_layout_ci.setLayoutCount = 3;
     pipe_layout_ci.pSetLayouts = set_layouts;

--- a/tests/unit/descriptors.cpp
+++ b/tests/unit/descriptors.cpp
@@ -3959,7 +3959,7 @@ TEST_F(NegativeDescriptors, DescriptorUpdateOfMultipleBindingWithOneUpdateCall) 
             GTEST_SKIP() << "DescriptorCount exceeds InlineUniformBlockSize limit";
         }
 
-        descLayout.init(*m_device, layoutCreate);
+        descLayout.Init(*m_device, layoutCreate);
 
         ASSERT_TRUE(descLayout.initialized());
     }
@@ -3980,7 +3980,7 @@ TEST_F(NegativeDescriptors, DescriptorUpdateOfMultipleBindingWithOneUpdateCall) 
         poolCreate.pPoolSizes = poolSize;
         poolCreate.maxSets = 1;
 
-        descPool.init(*m_device, poolCreate);
+        descPool.Init(*m_device, poolCreate);
         ASSERT_TRUE(descPool.initialized());
     }
 

--- a/tests/unit/device_generated_commands_positive.cpp
+++ b/tests/unit/device_generated_commands_positive.cpp
@@ -56,7 +56,7 @@ void DeviceGeneratedCommandsTest::SetPreProcessBuffer(VkGeneratedCommandsInfoEXT
         buffer_usage_flags.usage = VK_BUFFER_USAGE_2_PREPROCESS_BUFFER_BIT_EXT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
         VkBufferCreateInfo buffer_ci = vku::InitStructHelper(&buffer_usage_flags);
         buffer_ci.size = pre_process_size;
-        pre_process_buffer_->init(*m_device, buffer_ci, 0, &allocate_flag_info);
+        pre_process_buffer_->Init(*m_device, buffer_ci, 0, &allocate_flag_info);
         pre_process_address = pre_process_buffer_->Address();
     }
 

--- a/tests/unit/device_queue.cpp
+++ b/tests/unit/device_queue.cpp
@@ -81,11 +81,10 @@ TEST_F(NegativeDeviceQueue, FamilyIndexUsage) {
         buffer_ci.queueFamilyIndexCount = 2;
         qfi[0] = 1;
         qfi[1] = 2;
-        vkt::Buffer ib;
-        ib.init(*m_device, buffer_ci);
+        vkt::Buffer ib(*m_device, buffer_ci);
 
         m_command_buffer.Begin();
-        vk::CmdFillBuffer(m_command_buffer, ib.handle(), 0, 16, 5);
+        vk::CmdFillBuffer(m_command_buffer, ib, 0, 16, 5);
         m_command_buffer.End();
         m_default_queue->SubmitAndWait(m_command_buffer);
         m_errorMonitor->VerifyFound();

--- a/tests/unit/dynamic_rendering.cpp
+++ b/tests/unit/dynamic_rendering.cpp
@@ -5750,7 +5750,7 @@ TEST_F(NegativeDynamicRendering, CreateGraphicsPipeline) {
     m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-renderPass-06061");
     CreatePipelineHelper pipe(*this, &rendering_info);
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
-    pipe.gp_ci_.layout = pl.handle();
+    pipe.gp_ci_.layout = pl;
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 }
@@ -5776,7 +5776,7 @@ TEST_F(NegativeDynamicRendering, CreateGraphicsPipelineNoInfo) {
     m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-renderPass-06061");
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
-    pipe.gp_ci_.layout = pl.handle();
+    pipe.gp_ci_.layout = pl;
     pipe.cb_ci_.attachmentCount = 0;
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
@@ -6139,7 +6139,7 @@ TEST_F(NegativeDynamicRendering, ResolveAttachmentUsage) {
     attachment.imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
     attachment.imageView = image_view;
     attachment.resolveImageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-    attachment.resolveImageView = resolve_image_view.handle();
+    attachment.resolveImageView = resolve_image_view;
     attachment.resolveMode = VK_RESOLVE_MODE_SAMPLE_ZERO_BIT;
 
     VkRenderingInfo rendering_info = vku::InitStructHelper();
@@ -6352,10 +6352,10 @@ TEST_F(NegativeDynamicRendering, RenderPassStripeInfoQueueSubmit2) {
 
     for (uint32_t i = 0; i < stripe_count + 1; ++i) {
         VkSemaphoreCreateInfo create_info = i == 4 ? semaphore_timeline_create_info : semaphore_create_info;
-        semaphore[i].init(*m_device, create_info);
+        semaphore[i].Init(*m_device, create_info);
 
         semaphore_submit_infos[i] = vku::InitStructHelper();
-        semaphore_submit_infos[i].semaphore = semaphore[i].handle();
+        semaphore_submit_infos[i].semaphore = semaphore[i];
     }
 
     VkRenderPassStripeSubmitInfoARM rp_stripe_submit_info = vku::InitStructHelper();

--- a/tests/unit/dynamic_rendering_positive.cpp
+++ b/tests/unit/dynamic_rendering_positive.cpp
@@ -375,7 +375,7 @@ TEST_F(PositiveDynamicRendering, CreateGraphicsPipeline) {
 
     CreatePipelineHelper pipe(*this, &rendering_info);
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
-    pipe.gp_ci_.layout = pl.handle();
+    pipe.gp_ci_.layout = pl;
     pipe.gp_ci_.renderPass = rp;
     pipe.CreateGraphicsPipeline();
 }
@@ -406,7 +406,7 @@ TEST_F(PositiveDynamicRendering, CreateGraphicsPipelineNoInfo) {
 
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
-    pipe.gp_ci_.layout = pl.handle();
+    pipe.gp_ci_.layout = pl;
     pipe.gp_ci_.renderPass = rp;
     pipe.CreateGraphicsPipeline();
 }
@@ -899,7 +899,7 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats2) {
 
         // Matching depth format
         const vkt::ImageView depth_view(*m_device, depthStencilImage.BasicViewCreatInfo(VK_IMAGE_ASPECT_DEPTH_BIT));
-        depth_stencil_attachment.imageView = depth_view.handle();
+        depth_stencil_attachment.imageView = depth_view;
         m_command_buffer.BeginRendering(begin_rendering_info);
         vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_depth);
         vk::CmdDraw(m_command_buffer, 1, 1, 0, 0);
@@ -920,7 +920,7 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats2) {
 
         // Matching stencil format
         const vkt::ImageView stencil_view(*m_device, depthStencilImage.BasicViewCreatInfo(VK_IMAGE_ASPECT_STENCIL_BIT));
-        depth_stencil_attachment.imageView = stencil_view.handle();
+        depth_stencil_attachment.imageView = stencil_view;
         m_command_buffer.BeginRendering(begin_rendering_info);
         vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_stencil);
         vk::CmdDraw(m_command_buffer, 1, 1, 0, 0);
@@ -1164,9 +1164,9 @@ TEST_F(PositiveDynamicRendering, BeginRenderingWithRenderPassStriped) {
     VkSemaphoreSubmitInfo semaphore_submit_infos[stripe_count];
 
     for (uint32_t i = 0; i < stripe_count; ++i) {
-        semaphores[i].init(*m_device, semaphore_create_info);
+        semaphores[i].Init(*m_device, semaphore_create_info);
         semaphore_submit_infos[i] = vku::InitStructHelper();
-        semaphore_submit_infos[i].semaphore = semaphores[i].handle();
+        semaphore_submit_infos[i].semaphore = semaphores[i];
     }
 
     VkRenderPassStripeSubmitInfoARM rp_stripe_submit_info = vku::InitStructHelper();

--- a/tests/unit/dynamic_state.cpp
+++ b/tests/unit/dynamic_state.cpp
@@ -481,25 +481,25 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateDisabled) {
     vkt::CommandBuffer commandBuffer(*m_device, m_command_pool);
     commandBuffer.Begin();
 
-    ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vk::CmdSetCullModeEXT, "VUID-vkCmdSetCullMode-None-08971",
+    ExtendedDynStateCalls(m_errorMonitor, commandBuffer, vk::CmdSetCullModeEXT, "VUID-vkCmdSetCullMode-None-08971",
                           VK_CULL_MODE_NONE);
 
-    ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vk::CmdSetDepthBoundsTestEnableEXT,
+    ExtendedDynStateCalls(m_errorMonitor, commandBuffer, vk::CmdSetDepthBoundsTestEnableEXT,
                           "VUID-vkCmdSetDepthBoundsTestEnable-None-08971", VK_FALSE);
 
-    ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vk::CmdSetDepthCompareOpEXT,
-                          "VUID-vkCmdSetDepthCompareOp-None-08971", VK_COMPARE_OP_NEVER);
+    ExtendedDynStateCalls(m_errorMonitor, commandBuffer, vk::CmdSetDepthCompareOpEXT, "VUID-vkCmdSetDepthCompareOp-None-08971",
+                          VK_COMPARE_OP_NEVER);
 
-    ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vk::CmdSetDepthTestEnableEXT,
-                          "VUID-vkCmdSetDepthTestEnable-None-08971", VK_FALSE);
+    ExtendedDynStateCalls(m_errorMonitor, commandBuffer, vk::CmdSetDepthTestEnableEXT, "VUID-vkCmdSetDepthTestEnable-None-08971",
+                          VK_FALSE);
 
-    ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vk::CmdSetDepthWriteEnableEXT,
-                          "VUID-vkCmdSetDepthWriteEnable-None-08971", VK_FALSE);
+    ExtendedDynStateCalls(m_errorMonitor, commandBuffer, vk::CmdSetDepthWriteEnableEXT, "VUID-vkCmdSetDepthWriteEnable-None-08971",
+                          VK_FALSE);
 
-    ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vk::CmdSetFrontFaceEXT, "VUID-vkCmdSetFrontFace-None-08971",
+    ExtendedDynStateCalls(m_errorMonitor, commandBuffer, vk::CmdSetFrontFaceEXT, "VUID-vkCmdSetFrontFace-None-08971",
                           VK_FRONT_FACE_CLOCKWISE);
 
-    ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vk::CmdSetPrimitiveTopologyEXT,
+    ExtendedDynStateCalls(m_errorMonitor, commandBuffer, vk::CmdSetPrimitiveTopologyEXT,
                           "VUID-vkCmdSetPrimitiveTopology-None-08971", VK_PRIMITIVE_TOPOLOGY_POINT_LIST);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetScissorWithCount-None-08971");
@@ -512,7 +512,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateDisabled) {
                            VK_COMPARE_OP_NEVER);
     m_errorMonitor->VerifyFound();
 
-    ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vk::CmdSetStencilTestEnableEXT,
+    ExtendedDynStateCalls(m_errorMonitor, commandBuffer, vk::CmdSetStencilTestEnableEXT,
                           "VUID-vkCmdSetStencilTestEnable-None-08971", VK_FALSE);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetViewportWithCount-None-08971");
@@ -644,7 +644,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateBindVertexBuffers) {
     {
         vkt::Buffer bufferWrongUsage(*m_device, 16, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT);
         m_errorMonitor->SetDesiredError("VUID-vkCmdBindVertexBuffers2-pBuffers-03359");
-        VkBuffer buffers2[1] = {bufferWrongUsage.handle()};
+        VkBuffer buffers2[1] = {bufferWrongUsage};
         VkDeviceSize offsets2[1] = {};
         vk::CmdBindVertexBuffers2EXT(commandBuffer, 0, 1, buffers2, offsets2, 0, 0);
         m_errorMonitor->VerifyFound();
@@ -5713,7 +5713,7 @@ TEST_F(NegativeDynamicState, PGQNonZeroRasterizationStreams) {
     pipe.CreateGraphicsPipeline();
 
     m_command_buffer.Begin();
-    vk::CmdBeginQuery(m_command_buffer, pg_query_pool.handle(), 0u, 0u);
+    vk::CmdBeginQuery(m_command_buffer, pg_query_pool, 0u, 0u);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
     vk::CmdSetRasterizationStreamEXT(m_command_buffer, 1u);
@@ -5721,7 +5721,7 @@ TEST_F(NegativeDynamicState, PGQNonZeroRasterizationStreams) {
     vk::CmdDraw(m_command_buffer, 3u, 1u, 0u, 0u);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    vk::CmdEndQuery(m_command_buffer, pg_query_pool.handle(), 0u);
+    vk::CmdEndQuery(m_command_buffer, pg_query_pool, 0u);
     m_command_buffer.End();
 }
 
@@ -5983,7 +5983,7 @@ TEST_F(NegativeDynamicState, RasterizationSamplesDynamicRendering) {
     colorAttachment.imageView = image_view;
     colorAttachment.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
     colorAttachment.resolveMode = VK_RESOLVE_MODE_AVERAGE_BIT;
-    colorAttachment.resolveImageView = resolve_image_view.handle();
+    colorAttachment.resolveImageView = resolve_image_view;
     colorAttachment.resolveImageLayout = VK_IMAGE_LAYOUT_GENERAL;
     colorAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
     colorAttachment.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
@@ -6064,12 +6064,12 @@ TEST_F(NegativeDynamicState, DrawNotSetDepthWriteEnable) {
 
     m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
-    vk::CmdSetRasterizerDiscardEnableEXT(m_command_buffer.handle(), VK_FALSE);
-    vk::CmdSetDepthTestEnableEXT(m_command_buffer.handle(), VK_TRUE);
+    vk::CmdSetRasterizerDiscardEnableEXT(m_command_buffer, VK_FALSE);
+    vk::CmdSetDepthTestEnableEXT(m_command_buffer, VK_TRUE);
 
-    vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-07844");
-    vk::CmdDraw(m_command_buffer.handle(), 1, 1, 0, 0);
+    vk::CmdDraw(m_command_buffer, 1, 1, 0, 0);
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();

--- a/tests/unit/dynamic_state_positive.cpp
+++ b/tests/unit/dynamic_state_positive.cpp
@@ -273,7 +273,7 @@ TEST_F(PositiveDynamicState, DepthTestEnableOverridesPipelineDepthWriteEnable) {
     rp.AddColorAttachment(0);
     rp.AddDepthStencilAttachment(1);
     rp.CreateRenderPass();
-    VkImageView views[2] = {color_view.handle(), ds_view.handle()};
+    VkImageView views[2] = {color_view, ds_view};
     vkt::Framebuffer fb(*m_device, rp, 2, views);
 
     VkPipelineDepthStencilStateCreateInfo ds_state = vku::InitStructHelper();
@@ -316,7 +316,7 @@ TEST_F(PositiveDynamicState, DepthTestEnableOverridesDynamicDepthWriteEnable) {
     rp.AddColorAttachment(0);
     rp.AddDepthStencilAttachment(1);
     rp.CreateRenderPass();
-    VkImageView views[2] = {color_view.handle(), ds_view.handle()};
+    VkImageView views[2] = {color_view, ds_view};
     vkt::Framebuffer fb(*m_device, rp, 2, views);
 
     VkPipelineDepthStencilStateCreateInfo ds_state = vku::InitStructHelper();
@@ -359,7 +359,7 @@ TEST_F(PositiveDynamicState, DepthTestEnableDepthWriteEnable) {
     rp.AddColorAttachment(0);
     rp.AddDepthStencilAttachment(1);
     rp.CreateRenderPass();
-    VkImageView views[2] = {color_view.handle(), ds_view.handle()};
+    VkImageView views[2] = {color_view, ds_view};
     vkt::Framebuffer fb(*m_device, rp, 2, views);
 
     VkPipelineDepthStencilStateCreateInfo ds_state = vku::InitStructHelper();
@@ -371,13 +371,13 @@ TEST_F(PositiveDynamicState, DepthTestEnableDepthWriteEnable) {
     pipe.CreateGraphicsPipeline();
 
     m_command_buffer.Begin();
-    vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
-    m_command_buffer.BeginRenderPass(rp, fb.handle());
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
+    m_command_buffer.BeginRenderPass(rp, fb);
 
-    vk::CmdSetDepthTestEnableEXT(m_command_buffer.handle(), VK_FALSE);
+    vk::CmdSetDepthTestEnableEXT(m_command_buffer, VK_FALSE);
     // never call vkCmdSetDepthWriteEnableEXT as not needed
 
-    vk::CmdDraw(m_command_buffer.handle(), 1, 1, 0, 0);
+    vk::CmdDraw(m_command_buffer, 1, 1, 0, 0);
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
 }
@@ -801,12 +801,12 @@ TEST_F(PositiveDynamicState, ViewportInheritance) {
     info.pInheritanceInfo = &hinfo;
 
     cmd_buffer.Begin(&info);
-    vk::CmdBindPipeline(cmd_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
-    vk::CmdDraw(cmd_buffer.handle(), 3, 1, 0, 0);
+    vk::CmdBindPipeline(cmd_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
+    vk::CmdDraw(cmd_buffer, 3, 1, 0, 0);
     cmd_buffer.End();
 
     set_state.Begin();
-    vk::CmdSetViewport(set_state.handle(), 1u, 1u, &viewports[1]);
+    vk::CmdSetViewport(set_state, 1u, 1u, &viewports[1]);
     set_state.End();
 
     m_command_buffer.Begin();
@@ -875,7 +875,7 @@ TEST_F(PositiveDynamicState, RasterizationSamplesDynamicRendering) {
     colorAttachment.imageView = image_view;
     colorAttachment.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
     colorAttachment.resolveMode = VK_RESOLVE_MODE_AVERAGE_BIT;
-    colorAttachment.resolveImageView = resolve_image_view.handle();
+    colorAttachment.resolveImageView = resolve_image_view;
     colorAttachment.resolveImageLayout = VK_IMAGE_LAYOUT_GENERAL;
     colorAttachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
     colorAttachment.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
@@ -1047,7 +1047,7 @@ TEST_F(PositiveDynamicState, VertexInputMultipleBindings) {
     vkt::Buffer vertex_buffer(*m_device, 1024, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
     vkt::Buffer instance_buffer(*m_device, 1024, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
 
-    VkBuffer buffers[2] = {vertex_buffer.handle(), instance_buffer};
+    VkBuffer buffers[2] = {vertex_buffer, instance_buffer};
     VkDeviceSize offsets[2] = {0u, 0u};
 
     m_command_buffer.Begin();
@@ -1188,12 +1188,12 @@ TEST_F(PositiveDynamicState, DynamicColorBlendEnable) {
 
     VkRenderingAttachmentInfo color_attachments[3];
     color_attachments[0] = vku::InitStructHelper();
-    color_attachments[0].imageView = image_view1.handle();
+    color_attachments[0].imageView = image_view1;
     color_attachments[0].imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     color_attachments[1] = color_attachments[0];
-    color_attachments[1].imageView = image_view2.handle();
+    color_attachments[1].imageView = image_view2;
     color_attachments[2] = color_attachments[0];
-    color_attachments[2].imageView = image_view3.handle();
+    color_attachments[2].imageView = image_view3;
 
     VkRenderingAttachmentInfo depth_attachment = vku::InitStructHelper();
     depth_attachment.imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
@@ -1535,11 +1535,11 @@ TEST_F(PositiveDynamicState, VertexInputLocationMissing) {
 
     m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
-    vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
     vkt::Buffer buffer(*m_device, 16, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
     VkDeviceSize offset = 0u;
-    vk::CmdBindVertexBuffers(m_command_buffer.handle(), 0u, 1u, &buffer.handle(), &offset);
+    vk::CmdBindVertexBuffers(m_command_buffer, 0u, 1u, &buffer.handle(), &offset);
 
     VkVertexInputBindingDescription2EXT vertexInputBindingDescription = vku::InitStructHelper();
     vertexInputBindingDescription.binding = 0u;
@@ -1551,9 +1551,9 @@ TEST_F(PositiveDynamicState, VertexInputLocationMissing) {
     vertexAttributeDescription.binding = 0u;
     vertexAttributeDescription.format = VK_FORMAT_R32G32B32A32_SFLOAT;
     vertexAttributeDescription.offset = 0u;
-    vk::CmdSetVertexInputEXT(m_command_buffer.handle(), 1u, &vertexInputBindingDescription, 1u, &vertexAttributeDescription);
+    vk::CmdSetVertexInputEXT(m_command_buffer, 1u, &vertexInputBindingDescription, 1u, &vertexAttributeDescription);
 
-    vk::CmdDraw(m_command_buffer.handle(), 4u, 1u, 0u, 0u);
+    vk::CmdDraw(m_command_buffer, 4u, 1u, 0u, 0u);
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
 }

--- a/tests/unit/external_memory_sync_positive.cpp
+++ b/tests/unit/external_memory_sync_positive.cpp
@@ -29,8 +29,7 @@ TEST_F(PositiveExternalMemorySync, GetMemoryFdHandle) {
     alloc_info.allocationSize = 1024;
     alloc_info.memoryTypeIndex = 0;
 
-    vkt::DeviceMemory memory;
-    memory.init(*m_device, alloc_info);
+    vkt::DeviceMemory memory(*m_device, alloc_info);
     VkMemoryGetFdInfoKHR get_handle_info = vku::InitStructHelper();
     get_handle_info.memory = memory;
     get_handle_info.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
@@ -73,11 +72,10 @@ TEST_F(PositiveExternalMemorySync, ImportMemoryFd) {
     export_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
     auto alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer.MemoryRequirements(), 0, &export_info);
 
-    vkt::DeviceMemory memory_export;
-    memory_export.init(*m_device, alloc_info);
+    vkt::DeviceMemory memory_export(*m_device, alloc_info);
 
     VkMemoryGetFdInfoKHR mgfi = vku::InitStructHelper();
-    mgfi.memory = memory_export.handle();
+    mgfi.memory = memory_export;
     mgfi.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
 
     int fd;
@@ -242,13 +240,13 @@ TEST_F(PositiveExternalMemorySync, ExternalMemory) {
     // Copy from input buffer to output buffer through the exported/imported memory
     m_command_buffer.Begin();
     VkBufferCopy copy_info = {0, 0, buffer_size};
-    vk::CmdCopyBuffer(m_command_buffer, buffer_input.handle(), buffer_export.handle(), 1, &copy_info);
+    vk::CmdCopyBuffer(m_command_buffer, buffer_input, buffer_export, 1, &copy_info);
     // Insert memory barrier to guarantee copy order
     VkMemoryBarrier mem_barrier = {VK_STRUCTURE_TYPE_MEMORY_BARRIER, nullptr, VK_ACCESS_TRANSFER_WRITE_BIT,
                                    VK_ACCESS_TRANSFER_READ_BIT};
     vk::CmdPipelineBarrier(m_command_buffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 1, &mem_barrier, 0,
                            nullptr, 0, nullptr);
-    vk::CmdCopyBuffer(m_command_buffer, buffer_import.handle(), buffer_output.handle(), 1, &copy_info);
+    vk::CmdCopyBuffer(m_command_buffer, buffer_import, buffer_output, 1, &copy_info);
     m_command_buffer.End();
     m_default_queue->SubmitAndWait(m_command_buffer);
 }
@@ -529,11 +527,10 @@ TEST_F(PositiveExternalMemorySync, ImportMemoryWin32BufferDifferentDedicated) {
     export_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;
     auto alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer.MemoryRequirements(), 0, &export_info);
 
-    vkt::DeviceMemory memory_export;
-    memory_export.init(*m_device, alloc_info);
+    vkt::DeviceMemory memory_export(*m_device, alloc_info);
 
     VkMemoryGetWin32HandleInfoKHR get_handle_info = vku::InitStructHelper();
-    get_handle_info.memory = memory_export.handle();
+    get_handle_info.memory = memory_export;
     get_handle_info.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;
 
     HANDLE handle = NULL;
@@ -615,11 +612,10 @@ TEST_F(PositiveExternalMemorySync, ImportMemoryFdBufferDifferentDedicated) {
     export_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
     auto alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer.MemoryRequirements(), 0, &export_info);
 
-    vkt::DeviceMemory memory_export;
-    memory_export.init(*m_device, alloc_info);
+    vkt::DeviceMemory memory_export(*m_device, alloc_info);
 
     VkMemoryGetFdInfoKHR mgfi = vku::InitStructHelper();
-    mgfi.memory = memory_export.handle();
+    mgfi.memory = memory_export;
     mgfi.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
 
     int fd;

--- a/tests/unit/fragment_shading_rate.cpp
+++ b/tests/unit/fragment_shading_rate.cpp
@@ -838,13 +838,13 @@ TEST_F(NegativeFragmentShadingRate, FramebufferDimensions) {
 
     fb_info.height = fsr_properties.minFragmentShadingRateAttachmentTexelSize.height * 2;
     m_errorMonitor->SetDesiredError("VUID-VkFramebufferCreateInfo-flags-04540");
-    fb.init(*m_device, fb_info);
+    fb.Init(*m_device, fb_info);
     m_errorMonitor->VerifyFound();
     fb_info.height = fsr_properties.minFragmentShadingRateAttachmentTexelSize.height;
 
     fb_info.layers = 3;
     m_errorMonitor->SetDesiredError("VUID-VkFramebufferCreateInfo-flags-04538");
-    fb.init(*m_device, fb_info);
+    fb.Init(*m_device, fb_info);
     m_errorMonitor->VerifyFound();
 }
 

--- a/tests/unit/geometry_tessellation.cpp
+++ b/tests/unit/geometry_tessellation.cpp
@@ -37,7 +37,7 @@ TEST_F(NegativeGeometryTessellation, StageMaskGsTsEnabled) {
     pool_create_info.queueFamilyIndex = test_device.graphics_queue_node_index_;
 
     VkCommandPool command_pool;
-    vk::CreateCommandPool(test_device.handle(), &pool_create_info, nullptr, &command_pool);
+    vk::CreateCommandPool(test_device, &pool_create_info, nullptr, &command_pool);
 
     VkCommandBufferAllocateInfo cmd = vku::InitStructHelper();
     cmd.commandPool = command_pool;
@@ -45,12 +45,12 @@ TEST_F(NegativeGeometryTessellation, StageMaskGsTsEnabled) {
     cmd.commandBufferCount = 1;
 
     VkCommandBuffer cmd_buffer;
-    VkResult err = vk::AllocateCommandBuffers(test_device.handle(), &cmd, &cmd_buffer);
+    VkResult err = vk::AllocateCommandBuffers(test_device, &cmd, &cmd_buffer);
     ASSERT_EQ(VK_SUCCESS, err);
 
     VkEvent event;
     VkEventCreateInfo evci = vku::InitStructHelper();
-    VkResult result = vk::CreateEvent(test_device.handle(), &evci, NULL, &event);
+    VkResult result = vk::CreateEvent(test_device, &evci, NULL, &event);
     ASSERT_EQ(VK_SUCCESS, result);
 
     VkCommandBufferBeginInfo cbbi = vku::InitStructHelper();
@@ -63,8 +63,8 @@ TEST_F(NegativeGeometryTessellation, StageMaskGsTsEnabled) {
     vk::CmdSetEvent(cmd_buffer, event, VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT);
     m_errorMonitor->VerifyFound();
 
-    vk::DestroyEvent(test_device.handle(), event, NULL);
-    vk::DestroyCommandPool(test_device.handle(), command_pool, NULL);
+    vk::DestroyEvent(test_device, event, NULL);
+    vk::DestroyCommandPool(test_device, command_pool, NULL);
 }
 
 TEST_F(NegativeGeometryTessellation, GeometryShaderEnabled) {
@@ -418,7 +418,7 @@ TEST_F(NegativeGeometryTessellation, BuiltinBlockSizeMismatchVsGsShaderObject) {
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT,
                                             VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT, VK_SHADER_STAGE_GEOMETRY_BIT,
                                             VK_SHADER_STAGE_FRAGMENT_BIT};
-    const VkShaderEXT shaders[] = {vertShader.handle(), VK_NULL_HANDLE, VK_NULL_HANDLE, geomShader.handle(), fragShader.handle()};
+    const VkShaderEXT shaders[] = {vertShader, VK_NULL_HANDLE, VK_NULL_HANDLE, geomShader, fragShader};
 
     m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
@@ -995,13 +995,13 @@ VK_DESCRIPTOR_SET_USAGE_NON_FREE, 1, &ds_layout.handle(), &descriptorSet);
 
     shaderStages[0] = vku::InitStructHelper();
     shaderStages[0].stage  = VK_SHADER_STAGE_VERTEX_BIT;
-    shaderStages[0].shader = vs.handle();
+    shaderStages[0].shader = vs;
     shaderStages[1] = vku::InitStructHelper();
     shaderStages[1].stage  = VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT;
-    shaderStages[1].shader = tc.handle();
+    shaderStages[1].shader = tc;
     shaderStages[2] = vku::InitStructHelper();
     shaderStages[2].stage  = VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT;
-    shaderStages[2].shader = te.handle();
+    shaderStages[2].shader = te;
 
     VkPipelineInputAssemblyStateCreateInfo iaCI = vku::InitStructHelper();
         iaCI.topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST;

--- a/tests/unit/gpu_av.cpp
+++ b/tests/unit/gpu_av.cpp
@@ -553,12 +553,12 @@ TEST_F(NegativeGpuAV, UseAllDescriptorSlotsPipelineLayout) {
 
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = VkShaderObj(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1);
-    pipe.cp_ci_.layout = bad_pipe_layout.handle();
+    pipe.cp_ci_.layout = bad_pipe_layout;
     pipe.CreateComputePipeline();
 
     m_command_buffer.Begin();
-    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, bad_pipe_layout.handle(), 0, 1,
-                              &descriptor_set.set_, 0, nullptr);
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, bad_pipe_layout, 0, 1, &descriptor_set.set_, 0,
+                              nullptr);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
     m_command_buffer.End();

--- a/tests/unit/gpu_av_buffer_device_address_positive.cpp
+++ b/tests/unit/gpu_av_buffer_device_address_positive.cpp
@@ -2100,7 +2100,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, SharedPipelineLayoutSubsetGraphicsPushC
 
     CreatePipelineHelper pipe_2(*this);
     pipe_2.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe_2.gp_ci_.layout = pipeline_layout_2.handle();
+    pipe_2.gp_ci_.layout = pipeline_layout_2;
     pipe_2.CreateGraphicsPipeline();
 
     vkt::Buffer out_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);

--- a/tests/unit/gpu_av_descriptor_class_general_buffer_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_class_general_buffer_positive.cpp
@@ -145,7 +145,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, GPL) {
     descriptor_set.WriteDescriptorBufferInfo(0, offset_buffer, 0, 4);
     descriptor_set.WriteDescriptorBufferInfo(1, write_buffer, 0, 16, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.WriteDescriptorBufferInfo(2, VK_NULL_HANDLE, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
-    descriptor_set.WriteDescriptorBufferView(3, uniform_buffer_view.handle(), VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER);
+    descriptor_set.WriteDescriptorBufferView(3, uniform_buffer_view, VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER);
     descriptor_set.WriteDescriptorBufferView(4, storage_buffer_view, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER);
     descriptor_set.UpdateDescriptorSets();
     const char vs_source[] = R"glsl(

--- a/tests/unit/gpu_av_descriptor_class_texel_buffer.cpp
+++ b/tests/unit/gpu_av_descriptor_class_texel_buffer.cpp
@@ -34,7 +34,7 @@ TEST_F(NegativeGpuAVDescriptorClassTexelBuffer, GPLTexelFetch) {
     OneOffDescriptorSet descriptor_set(m_device, {{0, VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
                                                   {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}});
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
-    descriptor_set.WriteDescriptorBufferView(0, uniform_buffer_view.handle(), VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER);
+    descriptor_set.WriteDescriptorBufferView(0, uniform_buffer_view, VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER);
     descriptor_set.WriteDescriptorBufferInfo(1, write_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
@@ -179,7 +179,7 @@ TEST_F(NegativeGpuAVDescriptorClassTexelBuffer, GPLTexelFetchIndependentSets) {
     vertex_set.UpdateDescriptorSets();
     common_set.WriteDescriptorBufferInfo(0, offset_buffer, 0, VK_WHOLE_SIZE);
     common_set.UpdateDescriptorSets();
-    fragment_set.WriteDescriptorBufferView(1, uniform_buffer_view.handle(), VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER);
+    fragment_set.WriteDescriptorBufferView(1, uniform_buffer_view, VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER);
     fragment_set.UpdateDescriptorSets();
 
     const std::array<VkDescriptorSet, 3> desc_sets = {vertex_set.set_, common_set.set_, fragment_set.set_};
@@ -337,7 +337,7 @@ TEST_F(NegativeGpuAVDescriptorClassTexelBuffer, TexelFetch) {
     vkt::BufferView uniform_buffer_view(*m_device, uniform_texel_buffer, VK_FORMAT_R32_SFLOAT);
 
     pipe.descriptor_set_.WriteDescriptorBufferInfo(0, out_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
-    pipe.descriptor_set_.WriteDescriptorBufferView(1, uniform_buffer_view.handle(), VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER);
+    pipe.descriptor_set_.WriteDescriptorBufferView(1, uniform_buffer_view, VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER);
     pipe.descriptor_set_.UpdateDescriptorSets();
 
     m_command_buffer.Begin();
@@ -384,7 +384,7 @@ TEST_F(NegativeGpuAVDescriptorClassTexelBuffer, TexelFetchArray) {
 
     vkt::Buffer uniform_texel_buffer(*m_device, 1024, VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT, kHostVisibleMemProps);
     VkBufferViewCreateInfo bvci = vku::InitStructHelper();
-    bvci.buffer = uniform_texel_buffer.handle();
+    bvci.buffer = uniform_texel_buffer;
     bvci.format = VK_FORMAT_R32_SFLOAT;
     bvci.range = VK_WHOLE_SIZE;
     vkt::BufferView full_buffer_view(*m_device, bvci);
@@ -392,8 +392,8 @@ TEST_F(NegativeGpuAVDescriptorClassTexelBuffer, TexelFetchArray) {
     vkt::BufferView partial_buffer_view(*m_device, bvci);
 
     pipe.descriptor_set_.WriteDescriptorBufferInfo(0, out_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
-    pipe.descriptor_set_.WriteDescriptorBufferView(1, full_buffer_view.handle(), VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 0);
-    pipe.descriptor_set_.WriteDescriptorBufferView(1, partial_buffer_view.handle(), VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 1);
+    pipe.descriptor_set_.WriteDescriptorBufferView(1, full_buffer_view, VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 0);
+    pipe.descriptor_set_.WriteDescriptorBufferView(1, partial_buffer_view, VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 1);
     pipe.descriptor_set_.UpdateDescriptorSets();
 
     m_command_buffer.Begin();
@@ -482,7 +482,7 @@ TEST_F(NegativeGpuAVDescriptorClassTexelBuffer, ImageStore) {
     // 16 bytes only holds 4 indexes
     vkt::Buffer storage_texel_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT, kHostVisibleMemProps);
     VkBufferViewCreateInfo bvci = vku::InitStructHelper();
-    bvci.buffer = storage_texel_buffer.handle();
+    bvci.buffer = storage_texel_buffer;
     bvci.format = VK_FORMAT_R32_SFLOAT;
     bvci.range = VK_WHOLE_SIZE;
     vkt::BufferView storage_buffer_view(*m_device, bvci);

--- a/tests/unit/gpu_av_descriptor_class_texel_buffer_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_class_texel_buffer_positive.cpp
@@ -49,7 +49,7 @@ TEST_F(PositiveGpuAVDescriptorClassTexelBuffer, ImageLoadStoreTexelFetch) {
     vkt::Buffer storage_texel_buffer(*m_device, 24, VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT, kHostVisibleMemProps);
     vkt::BufferView storage_buffer_view(*m_device, storage_texel_buffer, VK_FORMAT_R32_SFLOAT);
 
-    pipe.descriptor_set_.WriteDescriptorBufferView(0, uniform_buffer_view.handle(), VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER);
+    pipe.descriptor_set_.WriteDescriptorBufferView(0, uniform_buffer_view, VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER);
     pipe.descriptor_set_.WriteDescriptorBufferView(1, storage_buffer_view, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER);
     pipe.descriptor_set_.UpdateDescriptorSets();
 
@@ -147,7 +147,7 @@ TEST_F(PositiveGpuAVDescriptorClassTexelBuffer, TexelFetchArray) {
 
     vkt::Buffer uniform_texel_buffer(*m_device, 1024, VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT, kHostVisibleMemProps);
     VkBufferViewCreateInfo bvci = vku::InitStructHelper();
-    bvci.buffer = uniform_texel_buffer.handle();
+    bvci.buffer = uniform_texel_buffer;
     bvci.format = VK_FORMAT_R32_SFLOAT;
     bvci.range = VK_WHOLE_SIZE;
     vkt::BufferView full_buffer_view(*m_device, bvci);
@@ -155,8 +155,8 @@ TEST_F(PositiveGpuAVDescriptorClassTexelBuffer, TexelFetchArray) {
     vkt::BufferView partial_buffer_view(*m_device, bvci);
 
     pipe.descriptor_set_.WriteDescriptorBufferInfo(0, out_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
-    pipe.descriptor_set_.WriteDescriptorBufferView(1, full_buffer_view.handle(), VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 0);
-    pipe.descriptor_set_.WriteDescriptorBufferView(1, partial_buffer_view.handle(), VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 1);
+    pipe.descriptor_set_.WriteDescriptorBufferView(1, full_buffer_view, VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 0);
+    pipe.descriptor_set_.WriteDescriptorBufferView(1, partial_buffer_view, VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 1);
     pipe.descriptor_set_.UpdateDescriptorSets();
 
     m_command_buffer.Begin();

--- a/tests/unit/gpu_av_descriptor_indexing_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_indexing_positive.cpp
@@ -1292,10 +1292,10 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetGraphics) {
     vkt::DescriptorSetLayout dsl_1(*m_device, binding, VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT,
                                    &flags_create_info);
 
-    std::array set_layouts = {dsl_1.handle(), dsl_1.handle()};
+    VkDescriptorSetLayout set_layouts[2] = {dsl_1, dsl_1};
 
     VkPipelineLayoutCreateInfo pipeline_layout_ci = vku::InitStructHelper();
-    pipeline_layout_ci.pSetLayouts = set_layouts.data();
+    pipeline_layout_ci.pSetLayouts = set_layouts;
 
     pipeline_layout_ci.setLayoutCount = 1;
     auto pipeline_layout_1 = std::make_unique<vkt::PipelineLayout>(*m_device, pipeline_layout_ci);
@@ -1342,7 +1342,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetGraphics) {
     VkDescriptorSetAllocateInfo allocate_info = vku::InitStructHelper();
     allocate_info.descriptorPool = pool;
     allocate_info.descriptorSetCount = 2;
-    allocate_info.pSetLayouts = set_layouts.data();
+    allocate_info.pSetLayouts = set_layouts;
 
     std::array<VkDescriptorSet, 2> descriptor_sets{};
     vk::AllocateDescriptorSets(device(), &allocate_info, descriptor_sets.data());
@@ -1424,10 +1424,10 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetGraphicsGPL) {
     vkt::DescriptorSetLayout dsl_1(*m_device, binding, VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT,
                                    &flags_create_info);
 
-    std::array set_layouts = {dsl_1.handle(), dsl_1.handle()};
+    VkDescriptorSetLayout set_layouts[2] = {dsl_1, dsl_1};
 
     VkPipelineLayoutCreateInfo pipeline_layout_ci = vku::InitStructHelper();
-    pipeline_layout_ci.pSetLayouts = set_layouts.data();
+    pipeline_layout_ci.pSetLayouts = set_layouts;
 
     pipeline_layout_ci.setLayoutCount = 1;
     const vkt::PipelineLayout pipeline_layout_1(*m_device, pipeline_layout_ci);
@@ -1465,7 +1465,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetGraphicsGPL) {
     VkDescriptorSetAllocateInfo allocate_info = vku::InitStructHelper();
     allocate_info.descriptorPool = pool;
     allocate_info.descriptorSetCount = 2;
-    allocate_info.pSetLayouts = set_layouts.data();
+    allocate_info.pSetLayouts = set_layouts;
 
     std::array<VkDescriptorSet, 2> descriptor_sets{};
     vk::AllocateDescriptorSets(device(), &allocate_info, descriptor_sets.data());
@@ -1548,10 +1548,10 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetGraphicsShader
     vkt::DescriptorSetLayout dsl_1(*m_device, binding, VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT,
                                    &flags_create_info);
 
-    std::array set_layouts = {dsl_1.handle(), dsl_1.handle()};
+    VkDescriptorSetLayout set_layouts[2] = {dsl_1, dsl_1};
 
     VkPipelineLayoutCreateInfo pipeline_layout_ci = vku::InitStructHelper();
-    pipeline_layout_ci.pSetLayouts = set_layouts.data();
+    pipeline_layout_ci.pSetLayouts = set_layouts;
     pipeline_layout_ci.setLayoutCount = 2;
     const vkt::PipelineLayout pipeline_layout(*m_device, pipeline_layout_ci);
 
@@ -1580,7 +1580,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetGraphicsShader
     shader_obj_ci.pCode = vs_spv_1.data();
     shader_obj_ci.pName = "main";
     shader_obj_ci.setLayoutCount = 1u;
-    shader_obj_ci.pSetLayouts = set_layouts.data();
+    shader_obj_ci.pSetLayouts = set_layouts;
     vkt::Shader vs_1(*m_device, shader_obj_ci);
     shader_obj_ci.codeSize = vs_spv_2.size() * sizeof(uint32_t);
     shader_obj_ci.pCode = vs_spv_2.data();
@@ -1604,7 +1604,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetGraphicsShader
     VkDescriptorSetAllocateInfo allocate_info = vku::InitStructHelper();
     allocate_info.descriptorPool = pool;
     allocate_info.descriptorSetCount = 2;
-    allocate_info.pSetLayouts = set_layouts.data();
+    allocate_info.pSetLayouts = set_layouts;
 
     std::array<VkDescriptorSet, 2> descriptor_sets{};
     vk::AllocateDescriptorSets(device(), &allocate_info, descriptor_sets.data());

--- a/tests/unit/gpu_av_descriptor_post_process_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_post_process_positive.cpp
@@ -47,7 +47,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, MixingProtectedResources) {
         GTEST_SKIP() << "Memory type not found";
     }
     vkt::DeviceMemory memory_image_protected(*m_device, alloc_info);
-    vk::BindImageMemory(device(), image_protected, memory_image_protected.handle(), 0);
+    vk::BindImageMemory(device(), image_protected, memory_image_protected, 0);
     image_protected.SetLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     vkt::ImageView image_view_protected = image_protected.CreateView();
 
@@ -218,10 +218,10 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, AliasImageBindingRuntimeArray) {
     uint32_t *data = (uint32_t *)buffer.Memory().Map();
     *data = 0;
 
-    pipe.descriptor_set_.WriteDescriptorImageInfo(0, float_image_view.handle(), VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
-                                                   VK_IMAGE_LAYOUT_GENERAL, 0);
-    pipe.descriptor_set_.WriteDescriptorImageInfo(0, uint_image_view.handle(), VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
-                                                   VK_IMAGE_LAYOUT_GENERAL, 1);
+    pipe.descriptor_set_.WriteDescriptorImageInfo(0, float_image_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
+                                                  VK_IMAGE_LAYOUT_GENERAL, 0);
+    pipe.descriptor_set_.WriteDescriptorImageInfo(0, uint_image_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
+                                                  VK_IMAGE_LAYOUT_GENERAL, 1);
     pipe.descriptor_set_.WriteDescriptorBufferInfo(1, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_.UpdateDescriptorSets();
 
@@ -919,7 +919,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, ZeroBindingDescriptor) {
     pipe1.CreateComputePipeline();
 
     CreateComputePipelineHelper pipe2(*this);
-    pipe2.cp_ci_.layout = pipeline_layout2.handle();
+    pipe2.cp_ci_.layout = pipeline_layout2;
     pipe2.cs_ = VkShaderObj(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT);
     pipe2.CreateComputePipeline();
 

--- a/tests/unit/gpu_av_indirect_buffer_positive.cpp
+++ b/tests/unit/gpu_av_indirect_buffer_positive.cpp
@@ -295,10 +295,10 @@ TEST_F(PositiveGpuAVIndirectBuffer, PipelineAndShaderObjectComputeDispatchIndire
     m_command_buffer.Begin();
 
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
-    vk::CmdDispatchIndirect(m_command_buffer, dispatch_params_buffer.handle(), 0u);
+    vk::CmdDispatchIndirect(m_command_buffer, dispatch_params_buffer, 0u);
 
     vk::CmdBindShadersEXT(m_command_buffer, 1u, &stage, &comp_shader.handle());
-    vk::CmdDispatchIndirect(m_command_buffer, dispatch_params_buffer.handle(), 0u);
+    vk::CmdDispatchIndirect(m_command_buffer, dispatch_params_buffer, 0u);
 
     m_command_buffer.End();
     m_default_queue->SubmitAndWait(m_command_buffer);

--- a/tests/unit/gpu_av_ray_query.cpp
+++ b/tests/unit/gpu_av_ray_query.cpp
@@ -423,7 +423,7 @@ TEST_F(NegativeGpuAVRayQuery, RayGenUseQueryUninit) {
     auto buffer_ptr = static_cast<float *>(ssbo.Memory().Map());
     buffer_ptr[0] = -16.0f;
 
-    pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, ssbo.handle(), 0, 4096, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, ssbo, 0, 4096, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
 
     pipeline.GetDescriptorSet().UpdateDescriptorSets();
 
@@ -500,7 +500,7 @@ TEST_F(NegativeGpuAVRayQuery, RayGenUseQueryUninitSelectShaders) {
     auto buffer_ptr = static_cast<float *>(ssbo.Memory().Map());
     buffer_ptr[0] = -16.0f;
 
-    pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, ssbo.handle(), 0, 4096, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, ssbo, 0, 4096, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
 
     pipeline.GetDescriptorSet().UpdateDescriptorSets();
 

--- a/tests/unit/gpu_av_ray_tracing.cpp
+++ b/tests/unit/gpu_av_ray_tracing.cpp
@@ -239,7 +239,7 @@ TEST_F(NegativeGpuAVRayTracing, DISABLED_BasicTraceRaysDeferredBuild) {
     }
     VkPipelineLayoutCreateInfo pipe_layout_ci = vku::InitStructHelper();
 
-    pipeline.GetPipelineLayout().init(*m_device, pipe_layout_ci, des_set_layouts);
+    pipeline.GetPipelineLayout().Init(*m_device, pipe_layout_ci, des_set_layouts);
 
     // Deferred pipeline build
     RETURN_IF_SKIP(pipeline.DeferBuild());

--- a/tests/unit/gpu_av_shader_object_positive.cpp
+++ b/tests/unit/gpu_av_shader_object_positive.cpp
@@ -148,7 +148,7 @@ TEST_F(PositiveGpuAVShaderObject, RestoreUserPushConstants) {
     vk::CmdPushConstants(m_command_buffer, pipeline_layout, VK_SHADER_STAGE_FRAGMENT_BIT, shader_pcr_byte_size,
                          shader_pcr_byte_size, &push_constants.storage_buffer_ptr_2);
     // Vertex shader will write 8 values to storage buffer, fragment shader another 8
-    vk::CmdDrawIndirect(m_command_buffer, indirect_draw_parameters_buffer.handle(), 0, 1, sizeof(VkDrawIndirectCommand));
+    vk::CmdDrawIndirect(m_command_buffer, indirect_draw_parameters_buffer, 0, 1, sizeof(VkDrawIndirectCommand));
     m_command_buffer.EndRendering();
     m_command_buffer.End();
     m_default_queue->SubmitAndWait(m_command_buffer);
@@ -330,18 +330,17 @@ TEST_F(PositiveGpuAVShaderObject, RestoreUserPushConstants2) {
     m_command_buffer.BindShaders(vs, fs);
     m_command_buffer.BindCompShader(cs);
 
-    vk::CmdPushConstants(m_command_buffer, graphics_pipeline_layout.handle(),
-                         VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT, 0, sizeof(graphics_push_constants),
-                         &graphics_push_constants);
+    vk::CmdPushConstants(m_command_buffer, graphics_pipeline_layout, VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT, 0,
+                         sizeof(graphics_push_constants), &graphics_push_constants);
 
     // Vertex shader will write 4 values to graphics storage buffer, fragment shader another 4
-    vk::CmdDrawIndirect(m_command_buffer, indirect_draw_parameters_buffer.handle(), 0, 1, sizeof(VkDrawIndirectCommand));
+    vk::CmdDrawIndirect(m_command_buffer, indirect_draw_parameters_buffer, 0, 1, sizeof(VkDrawIndirectCommand));
     m_command_buffer.EndRendering();
 
-    vk::CmdPushConstants(m_command_buffer, compute_pipeline_layout.handle(), VK_SHADER_STAGE_COMPUTE_BIT, 0,
-                         sizeof(compute_push_constants), &compute_push_constants);
+    vk::CmdPushConstants(m_command_buffer, compute_pipeline_layout, VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(compute_push_constants),
+                         &compute_push_constants);
     // Compute shaders will write 8 values to compute storage buffer
-    vk::CmdDispatchIndirect(m_command_buffer, indirect_dispatch_parameters_buffer.handle(), 0);
+    vk::CmdDispatchIndirect(m_command_buffer, indirect_dispatch_parameters_buffer, 0);
     m_command_buffer.End();
     m_default_queue->SubmitAndWait(m_command_buffer);
 
@@ -400,10 +399,10 @@ TEST_F(PositiveGpuAVShaderObject, DispatchShaderObjectAndPipeline) {
     m_command_buffer.Begin();
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindCompShader(compShader);
-    vk::CmdDispatchIndirect(m_command_buffer, indirect_dispatch_parameters_buffer.handle(), 0u);
+    vk::CmdDispatchIndirect(m_command_buffer, indirect_dispatch_parameters_buffer, 0u);
 
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, compute_pipe);
-    vk::CmdDispatchIndirect(m_command_buffer, indirect_dispatch_parameters_buffer.handle(), 0u);
+    vk::CmdDispatchIndirect(m_command_buffer, indirect_dispatch_parameters_buffer, 0u);
 
     m_command_buffer.End();
 }

--- a/tests/unit/graphics_library.cpp
+++ b/tests/unit/graphics_library.cpp
@@ -208,7 +208,7 @@ TEST_F(NegativeGraphicsLibrary, LinkWithNonIndependent) {
     link_info.pLibraries = libraries;
 
     VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
-    exe_pipe_ci.layout = pipeline_layout_null.handle();
+    exe_pipe_ci.layout = pipeline_layout_null;
     m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-flags-06730");
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     m_errorMonitor->VerifyFound();
@@ -937,7 +937,7 @@ TEST_F(NegativeGraphicsLibrary, StageCount) {
     vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
     pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
     pre_raster_lib.gp_ci_.stageCount = 0;
-    pre_raster_lib.gp_ci_.layout = pre_raster_lib.pipeline_layout_.handle();
+    pre_raster_lib.gp_ci_.layout = pre_raster_lib.pipeline_layout_;
     m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-flags-06644");
     pre_raster_lib.CreateGraphicsPipeline(false);
     m_errorMonitor->VerifyFound();
@@ -1588,13 +1588,13 @@ TEST_F(NegativeGraphicsLibrary, ShaderModuleIdentifier) {
     m_errorMonitor->VerifyFound();
 
     VkShaderModuleIdentifierEXT get_identifier = vku::InitStructHelper();
-    vk::GetShaderModuleIdentifierEXT(device(), vs.handle(), &get_identifier);
+    vk::GetShaderModuleIdentifierEXT(device(), vs, &get_identifier);
     sm_id_create_info.identifierSize = get_identifier.identifierSize;
     sm_id_create_info.pIdentifier = get_identifier.identifier;
 
     // shader module id ci and module not VK_NULL_HANDLE
     stage_ci.pNext = &sm_id_create_info;
-    stage_ci.module = vs.handle();
+    stage_ci.module = vs;
     m_errorMonitor->SetDesiredError("VUID-VkPipelineShaderStageCreateInfo-stage-06848");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
@@ -1628,11 +1628,11 @@ TEST_F(NegativeGraphicsLibrary, ShaderModuleIdentifierGPL) {
     VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
     VkPipelineShaderStageCreateInfo stage_ci = vku::InitStructHelper();
     stage_ci.stage = VK_SHADER_STAGE_VERTEX_BIT;
-    stage_ci.module = vs.handle();
+    stage_ci.module = vs;
     stage_ci.pName = "main";
 
     VkShaderModuleIdentifierEXT get_identifier = vku::InitStructHelper();
-    vk::GetShaderModuleIdentifierEXT(device(), vs.handle(), &get_identifier);
+    vk::GetShaderModuleIdentifierEXT(device(), vs, &get_identifier);
     VkPipelineShaderStageModuleIdentifierCreateInfoEXT sm_id_create_info = vku::InitStructHelper();
     sm_id_create_info.identifierSize = get_identifier.identifierSize;
     sm_id_create_info.pIdentifier = get_identifier.identifier;
@@ -1773,7 +1773,7 @@ TEST_F(NegativeGraphicsLibrary, IncompatibleLayouts) {
     link_info.pLibraries = libraries;
 
     VkGraphicsPipelineCreateInfo exe_ci = vku::InitStructHelper(&link_info);
-    exe_ci.layout = pipeline_layout_exe.handle();
+    exe_ci.layout = pipeline_layout_exe;
     exe_ci.renderPass = RenderPass();
     m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-layout-07827");  // incompatible with pre-raster state
     m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-layout-07827");  // incompatible with fragment shader state
@@ -1829,7 +1829,7 @@ TEST_F(NegativeGraphicsLibrary, IncompatibleLayoutsMultipleSubsets) {
     link_info.pLibraries = libraries;
 
     VkGraphicsPipelineCreateInfo exe_ci = vku::InitStructHelper(&link_info);
-    exe_ci.layout = pipeline_layout_exe.handle();
+    exe_ci.layout = pipeline_layout_exe;
     exe_ci.renderPass = RenderPass();
     m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-layout-07827");  // incompatible with pre-raster state
     m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-layout-07827");  // incompatible with fragment shader state

--- a/tests/unit/graphics_library_positive.cpp
+++ b/tests/unit/graphics_library_positive.cpp
@@ -264,7 +264,7 @@ TEST_F(PositiveGraphicsLibrary, DrawWithNullDSLs) {
     link_info.pLibraries = libraries;
 
     VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
-    exe_pipe_ci.layout = pipeline_layout_null.handle();
+    exe_pipe_ci.layout = pipeline_layout_null;
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     ASSERT_TRUE(exe_pipe.initialized());
 
@@ -273,7 +273,7 @@ TEST_F(PositiveGraphicsLibrary, DrawWithNullDSLs) {
 
     // Draw with pipeline created with null set
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, exe_pipe);
-    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout_null.handle(), 0,
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout_null, 0,
                               static_cast<uint32_t>(desc_sets.size()), desc_sets.data(), 0, nullptr);
     vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
 
@@ -1037,7 +1037,7 @@ TEST_F(PositiveGraphicsLibrary, GPLDynamicRenderingWithDepthDraw) {
 
     vkt::ImageView depth_stencil_view = m_depthStencil->CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
     VkRenderingAttachmentInfo depth_attachment = vku::InitStructHelper();
-    depth_attachment.imageView = depth_stencil_view.handle();
+    depth_attachment.imageView = depth_stencil_view;
     depth_attachment.imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 
     VkRenderingInfo begin_rendering_info = vku::InitStructHelper();
@@ -1235,7 +1235,7 @@ TEST_F(PositiveGraphicsLibrary, ShaderModuleIdentifier) {
     ASSERT_TRUE(vs.initialized());
 
     VkShaderModuleIdentifierEXT vs_identifier = vku::InitStructHelper();
-    vk::GetShaderModuleIdentifierEXT(device(), vs.handle(), &vs_identifier);
+    vk::GetShaderModuleIdentifierEXT(device(), vs, &vs_identifier);
 
     VkPipelineShaderStageModuleIdentifierCreateInfoEXT sm_id_create_info = vku::InitStructHelper();
     sm_id_create_info.identifierSize = vs_identifier.identifierSize;

--- a/tests/unit/image.cpp
+++ b/tests/unit/image.cpp
@@ -3068,7 +3068,6 @@ TEST_F(NegativeImage, ImageSplitInstanceBindRegionCount) {
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     vkt::Image image(*m_device, image_create_info, vkt::no_mem);
 
-    vkt::DeviceMemory image_mem;
     VkMemoryRequirements mem_reqs;
     vk::GetImageMemoryRequirements(device(), image, &mem_reqs);
     VkMemoryAllocateInfo mem_alloc = vku::InitStructHelper(nullptr);
@@ -3081,7 +3080,7 @@ TEST_F(NegativeImage, ImageSplitInstanceBindRegionCount) {
         }
     }
 
-    image_mem.init(*m_device, mem_alloc);
+    vkt::DeviceMemory image_mem(*m_device, mem_alloc);
 
     std::array<uint32_t, 2> deviceIndices = {{0, 0}};
     VkRect2D splitInstanceBindregion = {{0, 0}, {16, 16}};

--- a/tests/unit/image_drm.cpp
+++ b/tests/unit/image_drm.cpp
@@ -609,9 +609,9 @@ TEST_F(NegativeImageDrm, MultiPlanarBindMemory) {
         bind_info[plane].image = image;
         bind_info[plane].memoryOffset = 0;
     }
-    bind_info[0].memory = p0_mem.handle();
-    bind_info[1].memory = p1_mem.handle();
-    bind_info[2].memory = p2_mem.handle();
+    bind_info[0].memory = p0_mem;
+    bind_info[1].memory = p1_mem;
+    bind_info[2].memory = p2_mem;
     plane_info[0].planeAspect = VK_IMAGE_ASPECT_MEMORY_PLANE_0_BIT_EXT;
     plane_info[1].planeAspect = VK_IMAGE_ASPECT_MEMORY_PLANE_1_BIT_EXT;
     plane_info[2].planeAspect = VK_IMAGE_ASPECT_PLANE_2_BIT;

--- a/tests/unit/image_layout.cpp
+++ b/tests/unit/image_layout.cpp
@@ -44,18 +44,18 @@ TEST_F(NegativeImageLayout, Blit) {
 
     m_command_buffer.Begin();
 
-    vk::CmdBlitImage(m_command_buffer, img_general.handle(), VK_IMAGE_LAYOUT_GENERAL, img_general.handle(), VK_IMAGE_LAYOUT_GENERAL,
-                     1, &blit_region, VK_FILTER_LINEAR);
+    vk::CmdBlitImage(m_command_buffer, img_general, VK_IMAGE_LAYOUT_GENERAL, img_general, VK_IMAGE_LAYOUT_GENERAL, 1, &blit_region,
+                     VK_FILTER_LINEAR);
 
     // Illegal srcImageLayout
     m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-srcImageLayout-01398");
-    vk::CmdBlitImage(m_command_buffer, img_src_transfer.handle(), VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-                     img_dst_transfer.handle(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blit_region, VK_FILTER_LINEAR);
+    vk::CmdBlitImage(m_command_buffer, img_src_transfer, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, img_dst_transfer,
+                     VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blit_region, VK_FILTER_LINEAR);
     m_errorMonitor->VerifyFound();
 
     // Illegal destImageLayout
     m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-dstImageLayout-01399");
-    vk::CmdBlitImage(m_command_buffer, img_src_transfer.handle(), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, img_dst_transfer.handle(),
+    vk::CmdBlitImage(m_command_buffer, img_src_transfer, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, img_dst_transfer,
                      VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, 1, &blit_region, VK_FILTER_LINEAR);
 
     m_command_buffer.End();
@@ -69,8 +69,8 @@ TEST_F(NegativeImageLayout, Blit) {
 
     // Source image in invalid layout at start of the CB
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-09600");
-    vk::CmdBlitImage(m_command_buffer, img_src_transfer.handle(), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, img_color.handle(),
-                     VK_IMAGE_LAYOUT_GENERAL, 1, &blit_region, VK_FILTER_LINEAR);
+    vk::CmdBlitImage(m_command_buffer, img_src_transfer, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, img_color, VK_IMAGE_LAYOUT_GENERAL,
+                     1, &blit_region, VK_FILTER_LINEAR);
 
     m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
@@ -82,8 +82,8 @@ TEST_F(NegativeImageLayout, Blit) {
 
     // Destination image in invalid layout at start of the CB
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-09600");
-    vk::CmdBlitImage(m_command_buffer, img_color.handle(), VK_IMAGE_LAYOUT_GENERAL, img_dst_transfer.handle(),
-                     VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blit_region, VK_FILTER_LINEAR);
+    vk::CmdBlitImage(m_command_buffer, img_color, VK_IMAGE_LAYOUT_GENERAL, img_dst_transfer, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                     1, &blit_region, VK_FILTER_LINEAR);
 
     m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
@@ -99,7 +99,7 @@ TEST_F(NegativeImageLayout, Blit) {
     img_barrier.dstAccessMask = 0;
     img_barrier.oldLayout = VK_IMAGE_LAYOUT_GENERAL;
     img_barrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-    img_barrier.image = img_general.handle();
+    img_barrier.image = img_general;
     img_barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
     img_barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
     img_barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -112,8 +112,8 @@ TEST_F(NegativeImageLayout, Blit) {
                            0, nullptr, 1, &img_barrier);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-srcImageLayout-00221");
-    vk::CmdBlitImage(m_command_buffer, img_general.handle(), VK_IMAGE_LAYOUT_GENERAL, img_dst_transfer.handle(),
-                     VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blit_region, VK_FILTER_LINEAR);
+    vk::CmdBlitImage(m_command_buffer, img_general, VK_IMAGE_LAYOUT_GENERAL, img_dst_transfer, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                     1, &blit_region, VK_FILTER_LINEAR);
 
     m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
@@ -126,13 +126,13 @@ TEST_F(NegativeImageLayout, Blit) {
 
     img_barrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
     img_barrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-    img_barrier.image = img_dst_transfer.handle();
+    img_barrier.image = img_dst_transfer;
 
     vk::CmdPipelineBarrier(m_command_buffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, 0, 0, nullptr,
                            0, nullptr, 1, &img_barrier);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-dstImageLayout-00226");
-    vk::CmdBlitImage(m_command_buffer, img_src_transfer.handle(), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, img_dst_transfer.handle(),
+    vk::CmdBlitImage(m_command_buffer, img_src_transfer, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, img_dst_transfer,
                      VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blit_region, VK_FILTER_LINEAR);
 
     m_command_buffer.End();
@@ -174,10 +174,10 @@ TEST_F(NegativeImageLayout, Compute) {
     {  // Verify invalid image layout with CmdDispatch
         vkt::CommandBuffer cmd(*m_device, m_command_pool);
         cmd.Begin();
-        vk::CmdBindDescriptorSets(cmd.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_, 0, 1,
-                                  &pipe.descriptor_set_.set_, 0, nullptr);
-        vk::CmdBindPipeline(cmd.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
-        vk::CmdDispatch(cmd.handle(), 1, 1, 1);
+        vk::CmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_, 0, 1, &pipe.descriptor_set_.set_, 0,
+                                  nullptr);
+        vk::CmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+        vk::CmdDispatch(cmd, 1, 1, 1);
         cmd.End();
 
         m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-09600");
@@ -189,10 +189,10 @@ TEST_F(NegativeImageLayout, Compute) {
     {  // Verify invalid image layout with CmdDispatchBaseKHR
         vkt::CommandBuffer cmd(*m_device, m_command_pool);
         cmd.Begin();
-        vk::CmdBindDescriptorSets(cmd.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_, 0, 1,
-                                  &pipe.descriptor_set_.set_, 0, nullptr);
-        vk::CmdBindPipeline(cmd.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
-        vk::CmdDispatchBaseKHR(cmd.handle(), 0, 0, 0, 1, 1, 1);
+        vk::CmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_, 0, 1, &pipe.descriptor_set_.set_, 0,
+                                  nullptr);
+        vk::CmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+        vk::CmdDispatchBaseKHR(cmd, 0, 0, 0, 1, 1, 1);
         cmd.End();
 
         m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-09600");

--- a/tests/unit/image_layout_positive.cpp
+++ b/tests/unit/image_layout_positive.cpp
@@ -63,7 +63,7 @@ TEST_F(PositiveImageLayout, BarriersAndImageUsage) {
 
         m_command_buffer.Begin();
         for (uint32_t i = 0; i < layout_count; ++i) {
-            img_barrier.image = buffer_layouts[i].image_obj.handle();
+            img_barrier.image = buffer_layouts[i].image_obj;
             const VkImageUsageFlags usage = buffer_layouts[i].image_obj.Usage();
             img_barrier.subresourceRange.aspectMask = (usage == VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)
                                                           ? (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT)
@@ -289,20 +289,20 @@ TEST_F(PositiveImageLayout, DescriptorSubresource) {
         image_barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
         image_barrier.newLayout = init_layout;
 
-        vk::CmdPipelineBarrier(cmd_buf.handle(), VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, 0, 0,
-                               nullptr, 0, nullptr, 1, &image_barrier);
+        vk::CmdPipelineBarrier(cmd_buf, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, 0, 0, nullptr, 0,
+                               nullptr, 1, &image_barrier);
 
         image_barrier.subresourceRange = first_range;
         image_barrier.oldLayout = init_layout;
         image_barrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-        vk::CmdPipelineBarrier(cmd_buf.handle(), VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, 0, 0,
-                               nullptr, 0, nullptr, 1, &image_barrier);
+        vk::CmdPipelineBarrier(cmd_buf, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, 0, 0, nullptr, 0,
+                               nullptr, 1, &image_barrier);
 
         image_barrier.subresourceRange = view_range;
         image_barrier.oldLayout = init_layout;
         image_barrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-        vk::CmdPipelineBarrier(cmd_buf.handle(), VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, 0, 0,
-                               nullptr, 0, nullptr, 1, &image_barrier);
+        vk::CmdPipelineBarrier(cmd_buf, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, 0, 0, nullptr, 0,
+                               nullptr, 1, &image_barrier);
 
         if (test_type == kExternal) {
             // The image layout is external to the command buffer we are recording to test.  Submit to push to instance scope.
@@ -312,11 +312,11 @@ TEST_F(PositiveImageLayout, DescriptorSubresource) {
         }
 
         cmd_buf.BeginRenderPass(m_renderPassBeginInfo);
-        vk::CmdBindPipeline(cmd_buf.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
-        vk::CmdBindDescriptorSets(cmd_buf.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0, 1, &descriptor_set.set_, 0,
-                                  NULL);
+        vk::CmdBindPipeline(cmd_buf, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
+        vk::CmdBindDescriptorSets(cmd_buf, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0, 1, &descriptor_set.set_, 0,
+                                  nullptr);
 
-        vk::CmdDraw(cmd_buf.handle(), 1, 0, 0, 0);
+        vk::CmdDraw(cmd_buf, 1, 0, 0, 0);
 
         cmd_buf.EndRenderPass();
         cmd_buf.End();
@@ -371,20 +371,17 @@ TEST_F(PositiveImageLayout, Descriptor3D2DSubresource) {
     //    of the selected mip level of the 3D image, automatic layout transitions apply
     //    to the entire subresource referenced which is the entire mip level in this case.
     VkImageSubresourceRange full_range{VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-    vkt::ImageView view_2d, other_view;
     VkImageViewCreateInfo image_view_create_info = vku::InitStructHelper();
     image_view_create_info.image = image_3d;
     image_view_create_info.viewType = VK_IMAGE_VIEW_TYPE_2D;
     image_view_create_info.format = format;
     image_view_create_info.subresourceRange = view_range;
 
-    view_2d.init(*m_device, image_view_create_info);
-    ASSERT_TRUE(view_2d.initialized());
+    vkt::ImageView view_2d(*m_device, image_view_create_info);
 
-    image_view_create_info.image = other_image.handle();
+    image_view_create_info.image = other_image;
     image_view_create_info.subresourceRange = full_range;
-    other_view.init(*m_device, image_view_create_info);
-    ASSERT_TRUE(other_view.initialized());
+    vkt::ImageView other_view(*m_device, image_view_create_info);
 
     std::vector<VkAttachmentDescription> attachments = {
         {0, format, VK_SAMPLE_COUNT_1_BIT, VK_ATTACHMENT_LOAD_OP_LOAD, VK_ATTACHMENT_STORE_OP_STORE,
@@ -459,11 +456,11 @@ TEST_F(PositiveImageLayout, Descriptor3D2DSubresource) {
         image_barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
         image_barrier.newLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
-        vk::CmdPipelineBarrier(cmd_buf.handle(), VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, 0, 0,
-                               nullptr, 0, nullptr, 1, &image_barrier);
-        image_barrier.image = other_image.handle();
-        vk::CmdPipelineBarrier(cmd_buf.handle(), VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, 0, 0,
-                               nullptr, 0, nullptr, 1, &image_barrier);
+        vk::CmdPipelineBarrier(cmd_buf, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, 0, 0, nullptr, 0,
+                               nullptr, 1, &image_barrier);
+        image_barrier.image = other_image;
+        vk::CmdPipelineBarrier(cmd_buf, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, 0, 0, nullptr, 0,
+                               nullptr, 1, &image_barrier);
 
         if (test_type == kExternal) {
             // The image layout is external to the command buffer we are recording to test.  Submit to push to instance scope.
@@ -477,10 +474,10 @@ TEST_F(PositiveImageLayout, Descriptor3D2DSubresource) {
         m_renderPassBeginInfo.renderArea = {{0, 0}, {kWidth, kHeight}};
 
         cmd_buf.BeginRenderPass(m_renderPassBeginInfo);
-        vk::CmdBindPipeline(cmd_buf.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
-        vk::CmdBindDescriptorSets(cmd_buf.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0, 1, &descriptor_set.set_, 0,
+        vk::CmdBindPipeline(cmd_buf, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
+        vk::CmdBindDescriptorSets(cmd_buf, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0, 1, &descriptor_set.set_, 0,
                                   nullptr);
-        vk::CmdDraw(cmd_buf.handle(), 1, 0, 0, 0);
+        vk::CmdDraw(cmd_buf, 1, 0, 0, 0);
 
         cmd_buf.EndRenderPass();
         cmd_buf.End();

--- a/tests/unit/image_positive.cpp
+++ b/tests/unit/image_positive.cpp
@@ -102,7 +102,6 @@ TEST_F(PositiveImage, AliasedMemoryTracking) {
     const auto buffer_memory_requirements = buffer->MemoryRequirements();
     const auto image_memory_requirements = image.MemoryRequirements();
 
-    vkt::DeviceMemory mem;
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.allocationSize = (std::max)(buffer_memory_requirements.size, image_memory_requirements.size);
     bool has_memtype =
@@ -111,7 +110,7 @@ TEST_F(PositiveImage, AliasedMemoryTracking) {
     if (!has_memtype) {
         GTEST_SKIP() << "Failed to find a host visible memory type for both a buffer and an image";
     }
-    mem.init(*m_device, alloc_info);
+    vkt::DeviceMemory mem(*m_device, alloc_info);
 
     auto pData = mem.Map();
     std::memset(pData, 0xCADECADE, static_cast<size_t>(buff_size));

--- a/tests/unit/imageless_framebuffer.cpp
+++ b/tests/unit/imageless_framebuffer.cpp
@@ -1127,7 +1127,7 @@ TEST_F(NegativeImagelessFramebuffer, MissingInheritanceRenderingInfo) {
     vkt::Framebuffer framebuffer_bad_image_view(*m_device, fb_ci);
 
     VkCommandBufferInheritanceInfo inheritanceInfo = vku::InitStructHelper();
-    inheritanceInfo.framebuffer = framebuffer_null.handle();
+    inheritanceInfo.framebuffer = framebuffer_null;
 
     VkCommandBufferBeginInfo beginInfo = vku::InitStructHelper();
     beginInfo.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT | VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;

--- a/tests/unit/memory.cpp
+++ b/tests/unit/memory.cpp
@@ -274,7 +274,7 @@ TEST_F(NegativeMemory, MapMemoryNullppData) {
     vkt::DeviceMemory memory(*m_device, memory_info);
 
     m_errorMonitor->SetDesiredError("VUID-vkMapMemory-ppData-parameter");
-    vk::MapMemory(device(), memory.handle(), 0, VK_WHOLE_SIZE, 0, nullptr);
+    vk::MapMemory(device(), memory, 0, VK_WHOLE_SIZE, 0, nullptr);
     m_errorMonitor->VerifyFound();
 }
 
@@ -296,12 +296,12 @@ TEST_F(NegativeMemory, MapMemWithoutHostVisibleBit) {
 
     m_errorMonitor->SetDesiredError("VUID-vkMapMemory-memory-00682");
     m_errorMonitor->SetUnexpectedError("VUID-vkMapMemory-memory-00683");
-    vk::MapMemory(device(), memory.handle(), 0, VK_WHOLE_SIZE, 0, &mapped_address);
+    vk::MapMemory(device(), memory, 0, VK_WHOLE_SIZE, 0, &mapped_address);
     m_errorMonitor->VerifyFound();
 
     // Attempt to flush and invalidate non-host memory
     VkMappedMemoryRange memory_range = vku::InitStructHelper();
-    memory_range.memory = memory.handle();
+    memory_range.memory = memory;
     memory_range.offset = 0;
     memory_range.size = VK_WHOLE_SIZE;
     m_errorMonitor->SetDesiredError("VUID-VkMappedMemoryRange-memory-00684");
@@ -329,7 +329,7 @@ TEST_F(NegativeMemory, MapMemory2WithoutHostVisibleBit) {
     vkt::DeviceMemory memory(*m_device, mem_alloc);
 
     VkMemoryMapInfo map_info = vku::InitStructHelper();
-    map_info.memory = memory.handle();
+    map_info.memory = memory;
     map_info.offset = 0;
     map_info.size = 32;
     uint8_t *pData;
@@ -680,14 +680,14 @@ TEST_F(NegativeMemory, BindMemory) {
         vkt::DeviceMemory image_mem(*m_device, image_alloc_info);
         vkt::DeviceMemory buffer_mem(*m_device, buffer_alloc_info);
 
-        vk::BindImageMemory(device(), image, image_mem.handle(), 0);
+        vk::BindImageMemory(device(), image, image_mem, 0);
         m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory-image-07460");
-        vk::BindImageMemory(device(), image, image_mem.handle(), 0);
+        vk::BindImageMemory(device(), image, image_mem, 0);
         m_errorMonitor->VerifyFound();
 
-        vk::BindBufferMemory(device(), buffer, buffer_mem.handle(), 0);
+        vk::BindBufferMemory(device(), buffer, buffer_mem, 0);
         m_errorMonitor->SetDesiredError("VUID-vkBindBufferMemory-buffer-07459");
-        vk::BindBufferMemory(device(), buffer, buffer_mem.handle(), 0);
+        vk::BindBufferMemory(device(), buffer, buffer_mem, 0);
         m_errorMonitor->VerifyFound();
     }
 
@@ -714,14 +714,14 @@ TEST_F(NegativeMemory, BindMemory) {
             if (image_mem_reqs.alignment > 1) {
                 VkDeviceSize image_offset = 1;
                 m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory-None-10735");
-                vk::BindImageMemory(device(), image, image_mem.handle(), image_offset);
+                vk::BindImageMemory(device(), image, image_mem, image_offset);
                 m_errorMonitor->VerifyFound();
             }
 
             if (buffer_mem_reqs.alignment > 1) {
                 VkDeviceSize buffer_offset = 1;
                 m_errorMonitor->SetDesiredError("VUID-vkBindBufferMemory-None-10739");
-                vk::BindBufferMemory(device(), buffer, buffer_mem.handle(), buffer_offset);
+                vk::BindBufferMemory(device(), buffer, buffer_mem, buffer_offset);
                 m_errorMonitor->VerifyFound();
             }
         }
@@ -731,13 +731,13 @@ TEST_F(NegativeMemory, BindMemory) {
             VkDeviceSize image_offset =
                 (image_alloc_info.allocationSize + image_mem_reqs.alignment) & ~(image_mem_reqs.alignment - 1);
             m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory-memoryOffset-01046");
-            vk::BindImageMemory(device(), image, image_mem.handle(), image_offset);
+            vk::BindImageMemory(device(), image, image_mem, image_offset);
             m_errorMonitor->VerifyFound();
 
             VkDeviceSize buffer_offset =
                 (buffer_alloc_info.allocationSize + buffer_mem_reqs.alignment) & ~(buffer_mem_reqs.alignment - 1);
             m_errorMonitor->SetDesiredError("VUID-vkBindBufferMemory-memoryOffset-01031");
-            vk::BindBufferMemory(device(), buffer, buffer_mem.handle(), buffer_offset);
+            vk::BindBufferMemory(device(), buffer, buffer_mem, buffer_offset);
             m_errorMonitor->VerifyFound();
         }
 
@@ -747,14 +747,14 @@ TEST_F(NegativeMemory, BindMemory) {
             VkDeviceSize image_offset = (image_mem_reqs.size - 1) & ~(image_mem_reqs.alignment - 1);
             if ((image_offset > 0) && (image_mem_reqs.size < (image_alloc_info.allocationSize - image_mem_reqs.alignment))) {
                 m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory-None-10737");
-                vk::BindImageMemory(device(), image, image_mem.handle(), image_offset);
+                vk::BindImageMemory(device(), image, image_mem, image_offset);
                 m_errorMonitor->VerifyFound();
             }
 
             VkDeviceSize buffer_offset = (buffer_mem_reqs.size - 1) & ~(buffer_mem_reqs.alignment - 1);
             if (buffer_offset > 0) {
                 m_errorMonitor->SetDesiredError("VUID-vkBindBufferMemory-None-10741");
-                vk::BindBufferMemory(device(), buffer, buffer_mem.handle(), buffer_offset);
+                vk::BindBufferMemory(device(), buffer, buffer_mem, buffer_offset);
                 m_errorMonitor->VerifyFound();
             }
         }
@@ -777,7 +777,7 @@ TEST_F(NegativeMemory, BindMemory) {
             } else {
                 vkt::Image sparse_image(*m_device, sparse_image_create_info, vkt::no_mem);
                 VkMemoryRequirements sparse_mem_reqs = {};
-                vk::GetImageMemoryRequirements(device(), sparse_image.handle(), &sparse_mem_reqs);
+                vk::GetImageMemoryRequirements(device(), sparse_image, &sparse_mem_reqs);
                 if (sparse_mem_reqs.memoryTypeBits != 0) {
                     VkMemoryAllocateInfo sparse_mem_alloc = vku::InitStructHelper();
                     sparse_mem_alloc.allocationSize = sparse_mem_reqs.size;
@@ -785,7 +785,7 @@ TEST_F(NegativeMemory, BindMemory) {
                     m_device->Physical().SetMemoryType(sparse_mem_reqs.memoryTypeBits, &sparse_mem_alloc, 0);
                     vkt::DeviceMemory memory(*m_device, sparse_mem_alloc);
                     m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory-image-01045");
-                    vk::BindImageMemory(device(), sparse_image.handle(), memory.handle(), 0);
+                    vk::BindImageMemory(device(), sparse_image, memory, 0);
                     m_errorMonitor->VerifyFound();
                 }
             }
@@ -801,7 +801,7 @@ TEST_F(NegativeMemory, BindMemory) {
         } else {
             vkt::Buffer sparse_buffer(*m_device, sparse_buffer_create_info, vkt::no_mem);
             VkMemoryRequirements sparse_mem_reqs = {};
-            vk::GetBufferMemoryRequirements(device(), sparse_buffer.handle(), &sparse_mem_reqs);
+            vk::GetBufferMemoryRequirements(device(), sparse_buffer, &sparse_mem_reqs);
             if (sparse_mem_reqs.memoryTypeBits != 0) {
                 VkMemoryAllocateInfo sparse_mem_alloc = vku::InitStructHelper();
                 sparse_mem_alloc.allocationSize = sparse_mem_reqs.size;
@@ -809,7 +809,7 @@ TEST_F(NegativeMemory, BindMemory) {
                 m_device->Physical().SetMemoryType(sparse_mem_reqs.memoryTypeBits, &sparse_mem_alloc, 0);
                 vkt::DeviceMemory memory(*m_device, sparse_mem_alloc);
                 m_errorMonitor->SetDesiredError("VUID-vkBindBufferMemory-buffer-01030");
-                vk::BindBufferMemory(device(), sparse_buffer.handle(), memory.handle(), 0);
+                vk::BindBufferMemory(device(), sparse_buffer, memory, 0);
                 m_errorMonitor->VerifyFound();
             }
         }
@@ -846,7 +846,7 @@ TEST_F(NegativeMemory, BindMemoryUnsupported) {
     if (image_unsupported_mem_type_bits != 0 && found_type) {
         vkt::DeviceMemory memory(*m_device, image_alloc_info);
         m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory-memory-01047");
-        vk::BindImageMemory(device(), image, memory.handle(), 0);
+        vk::BindImageMemory(device(), image, memory, 0);
         m_errorMonitor->VerifyFound();
     }
 
@@ -856,7 +856,7 @@ TEST_F(NegativeMemory, BindMemoryUnsupported) {
     if (buffer_unsupported_mem_type_bits != 0 && found_type) {
         vkt::DeviceMemory memory(*m_device, buffer_alloc_info);
         m_errorMonitor->SetDesiredError("VUID-vkBindBufferMemory-memory-01035");
-        vk::BindBufferMemory(device(), buffer, memory.handle(), 0);
+        vk::BindBufferMemory(device(), buffer, memory, 0);
         m_errorMonitor->VerifyFound();
     }
 }
@@ -1358,25 +1358,24 @@ TEST_F(NegativeMemory, DedicatedAllocationBinding) {
     VkMemoryDedicatedAllocateInfo buffer_dedicated_info = vku::InitStructHelper();
     buffer_dedicated_info.buffer = buffer;
     buffer_alloc_info.pNext = &buffer_dedicated_info;
-    vkt::DeviceMemory dedicated_buffer_memory;
-    dedicated_buffer_memory.init(*m_device, buffer_alloc_info);
+    vkt::DeviceMemory dedicated_buffer_memory(*m_device, buffer_alloc_info);
 
     vkt::Buffer wrong_buffer(*m_device, buffer_info, vkt::no_mem);
 
     // Bind with wrong buffer
     m_errorMonitor->SetDesiredError("VUID-vkBindBufferMemory-memory-01508");
-    vk::BindBufferMemory(*m_device, wrong_buffer.handle(), dedicated_buffer_memory.handle(), 0);
+    vk::BindBufferMemory(*m_device, wrong_buffer, dedicated_buffer_memory, 0);
     m_errorMonitor->VerifyFound();
 
     // Bind with non-zero offset (same VUID)
     m_errorMonitor->SetDesiredError("VUID-vkBindBufferMemory-memory-01508");  // offset must be zero
     m_errorMonitor->SetDesiredError("VUID-vkBindBufferMemory-None-10741");    // offset pushes us past size
     auto offset = buffer.MemoryRequirements().alignment;
-    vk::BindBufferMemory(*m_device, buffer, dedicated_buffer_memory.handle(), offset);
+    vk::BindBufferMemory(*m_device, buffer, dedicated_buffer_memory, offset);
     m_errorMonitor->VerifyFound();
 
     // Bind correctly (depends on the "skip" above)
-    vk::BindBufferMemory(*m_device, buffer, dedicated_buffer_memory.handle(), 0);
+    vk::BindBufferMemory(*m_device, buffer, dedicated_buffer_memory, 0);
 
     // And for images...
     auto image_info =
@@ -1388,23 +1387,22 @@ TEST_F(NegativeMemory, DedicatedAllocationBinding) {
     image_dedicated_info.image = image;
     auto image_alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image.MemoryRequirements(), mem_flags);
     image_alloc_info.pNext = &image_dedicated_info;
-    vkt::DeviceMemory dedicated_image_memory;
-    dedicated_image_memory.init(*m_device, image_alloc_info);
+    vkt::DeviceMemory dedicated_image_memory(*m_device, image_alloc_info);
 
     // Bind with wrong image
     m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory-memory-02628");
-    vk::BindImageMemory(*m_device, wrong_image.handle(), dedicated_image_memory.handle(), 0);
+    vk::BindImageMemory(*m_device, wrong_image, dedicated_image_memory, 0);
     m_errorMonitor->VerifyFound();
 
     // Bind with non-zero offset (same VUID)
     m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory-memory-02628");  // offset must be zero
     m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory-None-10737");    // offset pushes us past size
     auto image_offset = image.MemoryRequirements().alignment;
-    vk::BindImageMemory(*m_device, image, dedicated_image_memory.handle(), image_offset);
+    vk::BindImageMemory(*m_device, image, dedicated_image_memory, image_offset);
     m_errorMonitor->VerifyFound();
 
     // Bind correctly (depends on the "skip" above)
-    vk::BindImageMemory(*m_device, image, dedicated_image_memory.handle(), 0);
+    vk::BindImageMemory(*m_device, image, dedicated_image_memory, 0);
 }
 
 TEST_F(NegativeMemory, DedicatedAllocationImageAliasing) {
@@ -1426,18 +1424,17 @@ TEST_F(NegativeMemory, DedicatedAllocationImageAliasing) {
     image_dedicated_info.image = image;
     auto image_alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image.MemoryRequirements(), mem_flags);
     image_alloc_info.pNext = &image_dedicated_info;
-    vkt::DeviceMemory dedicated_image_memory;
-    dedicated_image_memory.init(*m_device, image_alloc_info);
+    vkt::DeviceMemory dedicated_image_memory(*m_device, image_alloc_info);
 
     // Bind with different but identical image
-    vk::BindImageMemory(*m_device, identical_image.handle(), dedicated_image_memory.handle(), 0);
+    vk::BindImageMemory(*m_device, identical_image, dedicated_image_memory, 0);
 
     image_info =
         vkt::Image::ImageCreateInfo2D(resource_size - 1, 1, 1, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
     vkt::Image smaller_image(*m_device, image_info, vkt::no_mem);
 
     // Bind with a smaller image
-    vk::BindImageMemory(*m_device, smaller_image.handle(), dedicated_image_memory.handle(), 0);
+    vk::BindImageMemory(*m_device, smaller_image, dedicated_image_memory, 0);
 
     image_info =
         vkt::Image::ImageCreateInfo2D(resource_size + 1, 1, 1, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
@@ -1448,21 +1445,21 @@ TEST_F(NegativeMemory, DedicatedAllocationImageAliasing) {
     if (larger_image.MemoryRequirements().size > image.MemoryRequirements().size) {
         m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory-None-10737");
     }
-    vk::BindImageMemory(*m_device, larger_image.handle(), dedicated_image_memory.handle(), 0);
+    vk::BindImageMemory(*m_device, larger_image, dedicated_image_memory, 0);
     m_errorMonitor->VerifyFound();
 
     // Bind with non-zero offset
     m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory-memory-02629");  // offset must be zero
     m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory-None-10737");    // offset pushes us past size
     auto image_offset = image.MemoryRequirements().alignment;
-    vk::BindImageMemory(*m_device, image, dedicated_image_memory.handle(), image_offset);
+    vk::BindImageMemory(*m_device, image, dedicated_image_memory, image_offset);
     m_errorMonitor->VerifyFound();
 
     // Bind correctly (depends on the "skip" above)
-    vk::BindImageMemory(*m_device, image, dedicated_image_memory.handle(), 0);
+    vk::BindImageMemory(*m_device, image, dedicated_image_memory, 0);
 
     image.destroy();  // destroy the original image
-    vk::BindImageMemory(*m_device, post_delete_image.handle(), dedicated_image_memory.handle(), 0);
+    vk::BindImageMemory(*m_device, post_delete_image, dedicated_image_memory, 0);
 }
 
 TEST_F(NegativeMemory, BufferDeviceAddressEXT) {
@@ -2193,7 +2190,7 @@ TEST_F(NegativeMemory, BindBufferMemoryDeviceGroup) {
 
     VkBindImageMemoryInfo bind_image_info = vku::InitStructHelper(&bind_image_memory_device_group);
     bind_image_info.image = image;
-    bind_image_info.memory = image_memory.handle();
+    bind_image_info.memory = image_memory;
     bind_image_info.memoryOffset = 0;
 
     m_errorMonitor->SetDesiredError("VUID-VkBindImageMemoryDeviceGroupInfo-deviceIndexCount-01634");
@@ -2226,8 +2223,7 @@ TEST_F(NegativeMemory, SetDeviceMemoryPriority) {
 
     vkt::Buffer buffer(*m_device, vkt::Buffer::CreateInfo(1024, VK_BUFFER_USAGE_TRANSFER_DST_BIT), vkt::no_mem);
 
-    vkt::DeviceMemory buffer_memory;
-    buffer_memory.init(*m_device, vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer.MemoryRequirements(), 0));
+    vkt::DeviceMemory buffer_memory(*m_device, vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer.MemoryRequirements(), 0));
 
     m_errorMonitor->SetDesiredError("VUID-vkSetDeviceMemoryPriorityEXT-priority-06258");
     vk::SetDeviceMemoryPriorityEXT(*m_device, buffer_memory, -0.01f);
@@ -2386,7 +2382,7 @@ TEST_F(NegativeMemory, MapMemoryWithMapPlacedFlag) {
 
     void *data;
     m_errorMonitor->SetDesiredError("VUID-vkMapMemory-flags-09568");
-    vk::MapMemory(device(), memory.handle(), 0u, 4u, VK_MEMORY_MAP_PLACED_BIT_EXT, &data);
+    vk::MapMemory(device(), memory, 0u, 4u, VK_MEMORY_MAP_PLACED_BIT_EXT, &data);
     m_errorMonitor->VerifyFound();
 }
 

--- a/tests/unit/memory_positive.cpp
+++ b/tests/unit/memory_positive.cpp
@@ -166,29 +166,25 @@ TEST_F(PositiveMemory, GetMemoryRequirements2) {
     vkt::Buffer buffer(
         *m_device, vkt::Buffer::CreateInfo(1024, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT), vkt::no_mem);
 
-    // Use extension to get buffer memory requirements
-    VkBufferMemoryRequirementsInfo2 buffer_info = {VK_STRUCTURE_TYPE_BUFFER_MEMORY_REQUIREMENTS_INFO_2_KHR, nullptr, buffer};
-    VkMemoryRequirements2 buffer_reqs = {VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2_KHR};
+    VkBufferMemoryRequirementsInfo2 buffer_info = vku::InitStructHelper();
+    buffer_info.buffer = buffer;
+    VkMemoryRequirements2 buffer_reqs = vku::InitStructHelper();
     vk::GetBufferMemoryRequirements2KHR(device(), &buffer_info, &buffer_reqs);
 
-    // Allocate and bind buffer memory
-    vkt::DeviceMemory buffer_memory;
-    buffer_memory.init(*m_device, vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer_reqs.memoryRequirements, 0));
+    vkt::DeviceMemory buffer_memory(*m_device,
+                                    vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer_reqs.memoryRequirements, 0));
     vk::BindBufferMemory(device(), buffer, buffer_memory, 0);
 
-    // Create a test image
     auto image_ci = vkt::Image::ImageCreateInfo2D(32, 32, 1, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
     vkt::Image image(*m_device, image_ci, vkt::no_mem);
 
-    // Use extension to get image memory requirements
-    VkImageMemoryRequirementsInfo2 image_info = {VK_STRUCTURE_TYPE_IMAGE_MEMORY_REQUIREMENTS_INFO_2_KHR, nullptr, image};
-    VkMemoryRequirements2 image_reqs = {VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2_KHR};
+    VkImageMemoryRequirementsInfo2 image_info = vku::InitStructHelper();
+    image_info.image = image;
+    VkMemoryRequirements2 image_reqs = vku::InitStructHelper();
     vk::GetImageMemoryRequirements2KHR(device(), &image_info, &image_reqs);
 
-    // Allocate and bind image memory
-    vkt::DeviceMemory image_memory;
-    image_memory.init(*m_device, vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image_reqs.memoryRequirements, 0));
-    vk::BindImageMemory(device(), image, image_memory.handle(), 0);
+    vkt::DeviceMemory image_memory(*m_device, vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image_reqs.memoryRequirements, 0));
+    vk::BindImageMemory(device(), image, image_memory, 0);
 
     // Now execute arbitrary commands that use the test buffer and image
     m_command_buffer.Begin();
@@ -220,25 +216,17 @@ TEST_F(PositiveMemory, BindMemory2) {
 
     vkt::Buffer buffer(*m_device, vkt::Buffer::CreateInfo(1024, VK_BUFFER_USAGE_TRANSFER_DST_BIT), vkt::no_mem);
 
-    // Allocate buffer memory
-    vkt::DeviceMemory buffer_memory;
-    buffer_memory.init(*m_device, vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer.MemoryRequirements(), 0));
+    vkt::DeviceMemory buffer_memory(*m_device, vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer.MemoryRequirements(), 0));
 
-    // Bind buffer memory with extension
     VkBindBufferMemoryInfo buffer_bind_info = {VK_STRUCTURE_TYPE_BIND_BUFFER_MEMORY_INFO_KHR, nullptr, buffer, buffer_memory, 0};
     vk::BindBufferMemory2KHR(device(), 1, &buffer_bind_info);
 
-    // Create a test image
     auto image_ci = vkt::Image::ImageCreateInfo2D(32, 32, 1, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
     vkt::Image image(*m_device, image_ci, vkt::no_mem);
 
-    // Allocate image memory
-    vkt::DeviceMemory image_memory;
-    image_memory.init(*m_device, vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image.MemoryRequirements(), 0));
+    vkt::DeviceMemory image_memory(*m_device, vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image.MemoryRequirements(), 0));
 
-    // Bind image memory with extension
-    VkBindImageMemoryInfo image_bind_info = {VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_INFO_KHR, nullptr, image, image_memory.handle(),
-                                             0};
+    VkBindImageMemoryInfo image_bind_info = {VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_INFO_KHR, nullptr, image, image_memory, 0};
     vk::BindImageMemory2KHR(device(), 1, &image_bind_info);
 
     // Now execute arbitrary commands that use the test buffer and image
@@ -591,8 +579,7 @@ TEST_F(PositiveMemory, BindMemoryStatusImage) {
     auto image_ci = vkt::Image::ImageCreateInfo2D(32, 32, 1, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
     vkt::Image image(*m_device, image_ci, vkt::no_mem);
 
-    vkt::DeviceMemory memory;
-    memory.init(*m_device, vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image.MemoryRequirements(), 0));
+    vkt::DeviceMemory memory(*m_device, vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image.MemoryRequirements(), 0));
 
     VkResult result = VK_RESULT_MAX_ENUM;
 

--- a/tests/unit/mesh.cpp
+++ b/tests/unit/mesh.cpp
@@ -632,9 +632,7 @@ TEST_F(NegativeMesh, ExtensionDisabledNV) {
     RETURN_IF_SKIP(InitState(nullptr, &mesh_shader_features));
     InitRenderTarget();
 
-    vkt::Event event_obj(*m_device);
-    const auto event = event_obj.handle();
-    ASSERT_TRUE(event_obj.initialized());
+    vkt::Event event(*m_device);
 
     m_command_buffer.Begin();
 
@@ -656,14 +654,14 @@ TEST_F(NegativeMesh, ExtensionDisabledNV) {
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdWaitEvents-srcStageMask-04095");
     m_errorMonitor->SetDesiredError("VUID-vkCmdWaitEvents-dstStageMask-04095");
-    vk::CmdWaitEvents(m_command_buffer, 1, &event, VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV, VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV, 0,
-                      nullptr, 0, nullptr, 0, nullptr);
+    vk::CmdWaitEvents(m_command_buffer, 1, &event.handle(), VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV,
+                      VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV, 0, nullptr, 0, nullptr, 0, nullptr);
     m_errorMonitor->VerifyFound();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdWaitEvents-srcStageMask-04096");
     m_errorMonitor->SetDesiredError("VUID-vkCmdWaitEvents-dstStageMask-04096");
-    vk::CmdWaitEvents(m_command_buffer, 1, &event, VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV, VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV, 0,
-                      nullptr, 0, nullptr, 0, nullptr);
+    vk::CmdWaitEvents(m_command_buffer, 1, &event.handle(), VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV,
+                      VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV, 0, nullptr, 0, nullptr, 0, nullptr);
     m_errorMonitor->VerifyFound();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdPipelineBarrier-srcStageMask-04095");
@@ -680,22 +678,20 @@ TEST_F(NegativeMesh, ExtensionDisabledNV) {
 
     m_command_buffer.End();
 
-    vkt::Semaphore semaphore_obj(*m_device);
-    const auto semaphore = semaphore_obj.handle();
-    ASSERT_TRUE(semaphore_obj.initialized());
+    vkt::Semaphore semaphore(*m_device);
 
     VkPipelineStageFlags stage_flags = VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV | VK_PIPELINE_STAGE_TASK_SHADER_BIT_NV;
     VkSubmitInfo submit_info = vku::InitStructHelper();
 
     // Signal the semaphore so the next test can wait on it.
     submit_info.signalSemaphoreCount = 1;
-    submit_info.pSignalSemaphores = &semaphore;
+    submit_info.pSignalSemaphores = &semaphore.handle();
     vk::QueueSubmit(m_default_queue->handle(), 1, &submit_info, VK_NULL_HANDLE);
 
     submit_info.signalSemaphoreCount = 0;
     submit_info.pSignalSemaphores = nullptr;
     submit_info.waitSemaphoreCount = 1;
-    submit_info.pWaitSemaphores = &semaphore;
+    submit_info.pWaitSemaphores = &semaphore.handle();
     submit_info.pWaitDstStageMask = &stage_flags;
 
     m_errorMonitor->SetDesiredError("VUID-VkSubmitInfo-pWaitDstStageMask-04095");
@@ -1004,12 +1000,12 @@ TEST_F(NegativeMesh, MultiDrawIndirect) {
     vkt::Buffer count_buffer_wrong_usage(*m_device, count_buffer_create_info);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDrawMeshTasksIndirectCountEXT-countBuffer-02714");
-    vk::CmdDrawMeshTasksIndirectCountEXT(m_command_buffer, draw_buffer, 0, count_buffer_unbound.handle(), 0, 1,
+    vk::CmdDrawMeshTasksIndirectCountEXT(m_command_buffer, draw_buffer, 0, count_buffer_unbound, 0, 1,
                                          sizeof(VkDrawMeshTasksIndirectCommandEXT));
     m_errorMonitor->VerifyFound();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDrawMeshTasksIndirectCountEXT-countBuffer-02715");
-    vk::CmdDrawMeshTasksIndirectCountEXT(m_command_buffer, draw_buffer, 0, count_buffer_wrong_usage.handle(), 0, 1,
+    vk::CmdDrawMeshTasksIndirectCountEXT(m_command_buffer, draw_buffer, 0, count_buffer_wrong_usage, 0, 1,
                                          sizeof(VkDrawMeshTasksIndirectCommandEXT));
     m_errorMonitor->VerifyFound();
 
@@ -1285,17 +1281,17 @@ TEST_F(NegativeMesh, MeshIncompatibleActiveQueries) {
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
 
-    vk::CmdBeginQuery(m_command_buffer, xfb_query_pool.handle(), 0u, 0u);
+    vk::CmdBeginQuery(m_command_buffer, xfb_query_pool, 0u, 0u);
     m_errorMonitor->SetDesiredError("VUID-vkCmdDrawMeshTasksEXT-None-07074");
     vk::CmdDrawMeshTasksEXT(m_command_buffer, 1u, 1u, 1u);
     m_errorMonitor->VerifyFound();
-    vk::CmdEndQuery(m_command_buffer, xfb_query_pool.handle(), 0u);
+    vk::CmdEndQuery(m_command_buffer, xfb_query_pool, 0u);
 
-    vk::CmdBeginQuery(m_command_buffer, pg_query_pool.handle(), 0u, 0u);
+    vk::CmdBeginQuery(m_command_buffer, pg_query_pool, 0u, 0u);
     m_errorMonitor->SetDesiredError("VUID-vkCmdDrawMeshTasksEXT-None-07075");
     vk::CmdDrawMeshTasksEXT(m_command_buffer, 1u, 1u, 1u);
     m_errorMonitor->VerifyFound();
-    vk::CmdEndQuery(m_command_buffer, pg_query_pool.handle(), 0u);
+    vk::CmdEndQuery(m_command_buffer, pg_query_pool, 0u);
 
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();

--- a/tests/unit/multiview.cpp
+++ b/tests/unit/multiview.cpp
@@ -291,7 +291,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         for (unsigned i = 0; i < extra_subpass_count; ++i) {
             auto pipe_info = pipe.gp_ci_;
             pipe_info.subpass = i + 1;
-            pipelines[i].init(*m_device, pipe_info);
+            pipelines[i].Init(*m_device, pipe_info);
         }
 
         m_command_buffer.Begin();
@@ -308,7 +308,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
             // This line width set should not be valid for next subpass
             vk::CmdSetLineWidth(m_command_buffer, 1.0f);
             m_command_buffer.NextSubpass();
-            vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelines[i].handle());
+            vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelines[i]);
 
             m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-07833");
             vk::CmdDraw(m_command_buffer, 1, 0, 0, 0);
@@ -353,7 +353,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         for (unsigned i = 0; i < extra_subpass_count; ++i) {
             auto pipe_info = pipe.gp_ci_;
             pipe_info.subpass = i + 1;
-            pipelines[i].init(*m_device, pipe_info);
+            pipelines[i].Init(*m_device, pipe_info);
         }
         // Set up complete
 
@@ -374,7 +374,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
             vk::CmdPushConstants(m_command_buffer, layout, VK_SHADER_STAGE_VERTEX_BIT, push_constant_range.offset,
                                  push_constant_range.size, dummy_values);
             m_command_buffer.NextSubpass();
-            vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelines[i].handle());
+            vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelines[i]);
 
             m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-maintenance4-08602");
             vk::CmdDraw(m_command_buffer, 1, 0, 0, 0);
@@ -413,7 +413,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         for (unsigned i = 0; i < extra_subpass_count; ++i) {
             auto pipe_info = pipe.gp_ci_;
             pipe_info.subpass = i + 1;
-            pipelines[i].init(*m_device, pipe_info);
+            pipelines[i].Init(*m_device, pipe_info);
         }
         // Set up complete
 
@@ -433,7 +433,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
             vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_, 0, 1,
                                       &descriptor_set.set_, 0, nullptr);
             m_command_buffer.NextSubpass();
-            vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelines[i].handle());
+            vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelines[i]);
 
             m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-08600");
             vk::CmdDraw(m_command_buffer, 1, 0, 0, 0);
@@ -486,7 +486,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         for (unsigned i = 0; i < extra_subpass_count; ++i) {
             auto pipe_info = pipe.gp_ci_;
             pipe_info.subpass = i + 1;
-            pipelines[i].init(*m_device, pipe_info);
+            pipelines[i].Init(*m_device, pipe_info);
         }
         // Set up complete
         VkDeviceSize offset = 0;
@@ -505,7 +505,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
             // This vertex buffer bind should not be counted when next subpass begins
             vk::CmdBindVertexBuffers(m_command_buffer, 0, 1, &vbo.handle(), &offset);
             m_command_buffer.NextSubpass();
-            vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelines[i].handle());
+            vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelines[i]);
 
             m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-04007");
             vk::CmdDraw(m_command_buffer, 1, 0, 0, 0);
@@ -561,7 +561,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         for (unsigned i = 0; i < extra_subpass_count; ++i) {
             auto pipe_info = pipe.gp_ci_;
             pipe_info.subpass = i + 1;
-            pipelines[i].init(*m_device, pipe_info);
+            pipelines[i].Init(*m_device, pipe_info);
         }
         // Set up complete
 
@@ -581,7 +581,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
             // This index buffer bind should not be counted when next subpass begins
             vk::CmdBindIndexBuffer(m_command_buffer, ibo, 0, VK_INDEX_TYPE_UINT32);
             m_command_buffer.NextSubpass();
-            vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelines[i].handle());
+            vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipelines[i]);
             vk::CmdBindVertexBuffers(m_command_buffer, 0, 1, &vbo.handle(), &offset);
 
             m_errorMonitor->SetDesiredError("VUID-vkCmdDrawIndexed-None-07312");
@@ -847,25 +847,25 @@ TEST_F(NegativeMultiview, DrawWithPipelineIncompatibleWithRenderPass) {
     // Create render passes with VK_VERSION_1_0 struct and vkCreateRenderPass call
     // Create rp[0] with Multiview pNext, rp[1] without Multiview pNext, rp[2] with Multiview pNext but another viewMask
     std::array<vkt::RenderPass, 3> rp;
-    rp[0].init(*m_device, rpci);
+    rp[0].Init(*m_device, rpci);
     rpci.pNext = nullptr;
-    rp[1].init(*m_device, rpci);
+    rp[1].Init(*m_device, rpci);
     uint32_t viewMasks2[] = {0x1u};
     rpmvci.pViewMasks = viewMasks2;
     rpci.pNext = &rpmvci;
-    rp[2].init(*m_device, rpci);
+    rp[2].Init(*m_device, rpci);
 
     // Create render passes with VK_VERSION_1_2 struct and vkCreateRenderPass2KHR call
     // Create rp2[0] with Multiview, rp2[1] without Multiview (zero viewMask), rp2[2] with Multiview but another viewMask
     std::array<vkt::RenderPass, 3> rp2;
     if (rp2Supported) {
-        rp2[0].init(*m_device, rpci2);
+        rp2[0].Init(*m_device, rpci2);
         subpass2.viewMask = 0x0u;
         rpci2.pSubpasses = &subpass2;
-        rp2[1].init(*m_device, rpci2);
+        rp2[1].Init(*m_device, rpci2);
         subpass2.viewMask = 0x1u;
         rpci2.pSubpasses = &subpass2;
-        rp2[2].init(*m_device, rpci2);
+        rp2[2].Init(*m_device, rpci2);
     }
 
     auto ici2d = vkt::Image::ImageCreateInfo2D(128, 128, 1, 2, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
@@ -874,7 +874,7 @@ TEST_F(NegativeMultiview, DrawWithPipelineIncompatibleWithRenderPass) {
 
     // Create framebuffers for rp[0] and rp2[0]
     VkFramebufferCreateInfo fbci = vku::InitStructHelper();
-    fbci.renderPass = rp[0].handle();
+    fbci.renderPass = rp[0];
     fbci.attachmentCount = 1;
     fbci.pAttachments = &iv.handle();
     fbci.width = 128;
@@ -884,41 +884,41 @@ TEST_F(NegativeMultiview, DrawWithPipelineIncompatibleWithRenderPass) {
     vkt::Framebuffer fb(*m_device, fbci);
     vkt::Framebuffer fb2;
     if (rp2Supported) {
-        fbci.renderPass = rp2[0].handle();
-        fb2.init(*m_device, fbci);
+        fbci.renderPass = rp2[0];
+        fb2.Init(*m_device, fbci);
     }
 
     VkRenderPassBeginInfo rp_begin = vku::InitStructHelper();
-    rp_begin.renderPass = rp[0].handle();
+    rp_begin.renderPass = rp[0];
     rp_begin.framebuffer = fb;
     rp_begin.renderArea = {{0, 0}, {128, 128}};
 
     // Create a graphics pipeline with rp[1]
     CreatePipelineHelper pipe_1(*this);
     pipe_1.gp_ci_.layout = pipeline_layout;
-    pipe_1.gp_ci_.renderPass = rp[1].handle();
+    pipe_1.gp_ci_.renderPass = rp[1];
     pipe_1.CreateGraphicsPipeline();
 
     // Create a graphics pipeline with rp[2]
     CreatePipelineHelper pipe_2(*this);
     pipe_2.gp_ci_.layout = pipeline_layout;
-    pipe_2.gp_ci_.renderPass = rp[2].handle();
+    pipe_2.gp_ci_.renderPass = rp[2];
     pipe_2.CreateGraphicsPipeline();
 
     CreatePipelineHelper pipe2_1(*this);
     CreatePipelineHelper pipe2_2(*this);
     if (rp2Supported) {
         pipe2_1.gp_ci_.layout = pipeline_layout;
-        pipe2_1.gp_ci_.renderPass = rp[1].handle();
+        pipe2_1.gp_ci_.renderPass = rp[1];
         pipe2_1.CreateGraphicsPipeline();
 
         pipe2_2.gp_ci_.layout = pipeline_layout;
-        pipe2_2.gp_ci_.renderPass = rp[2].handle();
+        pipe2_2.gp_ci_.renderPass = rp[2];
         pipe2_2.CreateGraphicsPipeline();
     }
 
     VkCommandBufferInheritanceInfo cbii = vku::InitStructHelper();
-    cbii.renderPass = rp[0].handle();
+    cbii.renderPass = rp[0];
     cbii.subpass = 0;
     VkCommandBufferBeginInfo cbbi = vku::InitStructHelper();
     cbbi.pInheritanceInfo = &cbii;
@@ -949,9 +949,9 @@ TEST_F(NegativeMultiview, DrawWithPipelineIncompatibleWithRenderPass) {
 
     // Begin rp2[0] for VK_VERSION_1_2 test cases
     if (rp2Supported) {
-        cbii.renderPass = rp2[0].handle();
-        rp_begin.renderPass = rp2[0].handle();
-        rp_begin.framebuffer = fb2.handle();
+        cbii.renderPass = rp2[0];
+        rp_begin.renderPass = rp2[0];
+        rp_begin.framebuffer = fb2;
         vk::BeginCommandBuffer(m_command_buffer, &cbbi);
         vk::CmdBeginRenderPass(m_command_buffer, &rp_begin, VK_SUBPASS_CONTENTS_INLINE);
 

--- a/tests/unit/other_positive.cpp
+++ b/tests/unit/other_positive.cpp
@@ -42,7 +42,7 @@ TEST_F(VkPositiveLayerTest, Maintenance1Tests) {
     cmd_buf.Begin();
     // Set Negative height, should give error if Maintenance 1 is not enabled
     VkViewport viewport = {0, 0, 16, -16, 0, 1};
-    vk::CmdSetViewport(cmd_buf.handle(), 0, 1, &viewport);
+    vk::CmdSetViewport(cmd_buf, 0, 1, &viewport);
     cmd_buf.End();
 }
 

--- a/tests/unit/others.cpp
+++ b/tests/unit/others.cpp
@@ -1292,7 +1292,7 @@ TEST_F(VkLayerTest, DISABLED_DisplayApplicationName) {
 
         // TODO - The second instance is not hooked up to the callback so will crash in corecheck or the driver
         m_errorMonitor->SetDesiredError("AppName: second instance");
-        vk::CreateImage(device2.handle(), nullptr, nullptr, &image);
+        vk::CreateImage(device2, nullptr, nullptr, &image);
         m_errorMonitor->VerifyFound();
     }
     ASSERT_NO_FATAL_FAILURE(vk::DestroyInstance(instance2, nullptr));

--- a/tests/unit/parent.cpp
+++ b/tests/unit/parent.cpp
@@ -64,7 +64,7 @@ TEST_F(NegativeParent, BindBuffer) {
 
     VkBindBufferMemoryInfo bind_buffer_info = vku::InitStructHelper();
     bind_buffer_info.buffer = buffer;
-    bind_buffer_info.memory = memory.handle();
+    bind_buffer_info.memory = memory;
     bind_buffer_info.memoryOffset = 0;
 
     m_errorMonitor->SetDesiredError("VUID-VkBindBufferMemoryInfo-commonparent");
@@ -98,7 +98,7 @@ TEST_F(NegativeParent, DISABLED_BindImage) {
 
     VkBindImageMemoryInfo bind_image_info = vku::InitStructHelper();
     bind_image_info.image = image;
-    bind_image_info.memory = memory.handle();
+    bind_image_info.memory = memory;
     bind_image_info.memoryOffset = 0;
 
     m_errorMonitor->SetDesiredError("VUID-VkBindImageMemoryInfo-commonparent");
@@ -152,7 +152,7 @@ TEST_F(NegativeParent, BindPipeline) {
 
     m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindPipeline-commonparent");
-    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.handle());
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline);
     m_errorMonitor->VerifyFound();
     m_command_buffer.End();
 }

--- a/tests/unit/pipeline.cpp
+++ b/tests/unit/pipeline.cpp
@@ -515,7 +515,7 @@ TEST_F(NegativePipeline, SubpassRasterizationSamples) {
     pipeline_2.CreateGraphicsPipeline();
 
     m_command_buffer.Begin();
-    m_command_buffer.BeginRenderPass(renderpass.handle(), framebuffer, fb_width, fb_height);
+    m_command_buffer.BeginRenderPass(renderpass, framebuffer, fb_width, fb_height);
 
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_1.Handle());
 
@@ -613,7 +613,7 @@ TEST_F(NegativePipeline, RenderPassShaderResolveQCOM) {
 
     ms_state.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
     ms_state.sampleShadingEnable = VK_TRUE;
-    pipe.gp_ci_.renderPass = renderpass2.handle();
+    pipe.gp_ci_.renderPass = renderpass2;
 
     // Create a pipeline with a subpass using VK_SUBPASS_DESCRIPTION_FRAGMENT_REGION_BIT_QCOM,
     // and with sampleShadingEnable enabled in the pipeline
@@ -1759,8 +1759,8 @@ TEST_F(NegativePipeline, NotCompatibleForSet) {
 
     m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
-    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, binding_pipeline_layout.handle(), 0, 1,
-                              &descriptor_set.set_, 0, nullptr);
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, binding_pipeline_layout, 0, 1, &descriptor_set.set_,
+                              0, nullptr);
     m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-None-08600");
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
     m_errorMonitor->VerifyFound();
@@ -2055,10 +2055,10 @@ TEST_F(NegativePipeline, SampledInvalidImageViews) {
     const vkt::PipelineLayout combined_pipeline_layout(*m_device, {&combined_descriptor_set.layout_});
     const vkt::PipelineLayout seperate_pipeline_layout(*m_device, {&seperate_descriptor_set.layout_});
 
-    pipeline_combined.gp_ci_.layout = combined_pipeline_layout.handle();
-    pipeline_seperate.gp_ci_.layout = seperate_pipeline_layout.handle();
-    pipeline_unused.gp_ci_.layout = combined_pipeline_layout.handle();
-    pipeline_function.gp_ci_.layout = combined_pipeline_layout.handle();
+    pipeline_combined.gp_ci_.layout = combined_pipeline_layout;
+    pipeline_seperate.gp_ci_.layout = seperate_pipeline_layout;
+    pipeline_unused.gp_ci_.layout = combined_pipeline_layout;
+    pipeline_function.gp_ci_.layout = combined_pipeline_layout;
 
     pipeline_combined.CreateGraphicsPipeline();
     pipeline_seperate.CreateGraphicsPipeline();
@@ -2091,7 +2091,7 @@ TEST_F(NegativePipeline, SampledInvalidImageViews) {
 
     // Unused is a valid version of the combined pipeline/descriptors
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_unused);
-    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, combined_pipeline_layout.handle(), 0, 1,
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, combined_pipeline_layout, 0, 1,
                               &combined_descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer, 1, 0, 0, 0);
 
@@ -2111,7 +2111,7 @@ TEST_F(NegativePipeline, SampledInvalidImageViews) {
 
         // Same error, but not with seperate descriptors
         vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_seperate);
-        vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, seperate_pipeline_layout.handle(), 0, 1,
+        vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, seperate_pipeline_layout, 0, 1,
                                   &seperate_descriptor_set.set_, 0, nullptr);
         m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-magFilter-04553");
         vk::CmdDraw(m_command_buffer, 1, 0, 0, 0);
@@ -2129,7 +2129,7 @@ TEST_F(NegativePipeline, SampledInvalidImageViews) {
                                                          VK_IMAGE_LAYOUT_UNDEFINED);
         seperate_descriptor_set.UpdateDescriptorSets();
 
-        vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, combined_pipeline_layout.handle(), 0, 1,
+        vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, combined_pipeline_layout, 0, 1,
                                   &combined_descriptor_set.set_, 0, nullptr);
 
         // Same descriptor set as combined test
@@ -2146,7 +2146,7 @@ TEST_F(NegativePipeline, SampledInvalidImageViews) {
 
         // Same error, but not with seperate descriptors
         vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_seperate);
-        vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, seperate_pipeline_layout.handle(), 0, 1,
+        vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, seperate_pipeline_layout, 0, 1,
                                   &seperate_descriptor_set.set_, 0, nullptr);
         m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-mipmapMode-04770");
         vk::CmdDraw(m_command_buffer, 1, 0, 0, 0);
@@ -2409,7 +2409,7 @@ TEST_F(NegativePipeline, CreateComputePipelineWithDerivatives) {
         vkt::Pipeline test_pipeline(*m_device, compute_create_infos[0]);
         if (test_pipeline.initialized()) {
             compute_create_infos[1].flags = VK_PIPELINE_CREATE_DERIVATIVE_BIT;
-            compute_create_infos[1].basePipelineHandle = test_pipeline.handle();
+            compute_create_infos[1].basePipelineHandle = test_pipeline;
             compute_create_infos[1].basePipelineIndex = 0;
 
             m_errorMonitor->SetDesiredError("VUID-VkComputePipelineCreateInfo-flags-07986");
@@ -2865,7 +2865,7 @@ TEST_F(NegativePipeline, RasterizationOrderAttachmentAccessNoSubpassFlags) {
         rpci.subpassCount = 1;
         rpci.pSubpasses = &subpass;
 
-        render_pass.init(*this->m_device, rpci);
+        render_pass.Init(*this->m_device, rpci);
     };
 
     auto set_flgas_pipeline_createinfo = [&](CreatePipelineHelper &helper) {

--- a/tests/unit/pipeline_positive.cpp
+++ b/tests/unit/pipeline_positive.cpp
@@ -320,7 +320,7 @@ TEST_F(PositivePipeline, CreateGraphicsPipelineWithIgnoredPointers) {
             nullptr  // push constants
         };
 
-        pipeline_layout.init(*m_device, pipeline_layout_create_info, {});
+        pipeline_layout.Init(*m_device, pipeline_layout_create_info, {});
     }
 
     // try disabled rasterizer and no tessellation
@@ -354,7 +354,7 @@ TEST_F(PositivePipeline, CreateGraphicsPipelineWithIgnoredPointers) {
         vkt::Pipeline pipeline(*m_device, graphics_pipeline_create_info);
 
         m_command_buffer.Begin();
-        vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline.handle());
+        vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline);
     }
 
     // try enabled rasterizer but no subpass attachments
@@ -391,7 +391,7 @@ TEST_F(PositivePipeline, CreateGraphicsPipelineWithIgnoredPointers) {
                 nullptr  // subpass dependencies
             };
 
-            render_pass.init(*m_device, render_pass_create_info);
+            render_pass.Init(*m_device, render_pass_create_info);
         }
 
         VkGraphicsPipelineCreateInfo graphics_pipeline_create_info{
@@ -751,7 +751,7 @@ TEST_F(PositivePipeline, SampleMaskOverrideCoverageNV) {
     VkShaderObj fs(this, fs_src, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.gp_ci_.layout = pl.handle();
+    pipe.gp_ci_.layout = pl;
     pipe.gp_ci_.renderPass = rp;
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.gp_ci_.pMultisampleState = &msaa;
@@ -1265,7 +1265,7 @@ TEST_F(PositivePipeline, CreateGraphicsPipelineRasterizationOrderAttachmentAcces
         rpci.subpassCount = 1;
         rpci.pSubpasses = &subpass;
 
-        render_pass.init(*this->m_device, rpci);
+        render_pass.Init(*this->m_device, rpci);
     };
 
     auto set_flgas_pipeline_createinfo = [&](CreatePipelineHelper &helper) {
@@ -1404,7 +1404,7 @@ TEST_F(PositivePipeline, ShaderModuleIdentifier) {
     VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
 
     VkShaderModuleIdentifierEXT get_identifier = vku::InitStructHelper();
-    vk::GetShaderModuleIdentifierEXT(device(), vs.handle(), &get_identifier);
+    vk::GetShaderModuleIdentifierEXT(device(), vs, &get_identifier);
     sm_id_create_info.identifierSize = get_identifier.identifierSize;
     sm_id_create_info.pIdentifier = get_identifier.identifier;
 

--- a/tests/unit/push_descriptor.cpp
+++ b/tests/unit/push_descriptor.cpp
@@ -447,7 +447,7 @@ TEST_F(NegativePushDescriptor, CreateDescriptorUpdateTemplate) {
     // Bad pipelineLayout handle, to be ignored if template type is DESCRIPTOR_SET
     {
         create_info.pipelineLayout = CastFromUint64<VkPipelineLayout>(badhandle);
-        create_info.descriptorSetLayout = ds_layout_ub.handle();
+        create_info.descriptorSetLayout = ds_layout_ub;
         VkDescriptorUpdateTemplateKHR dut = VK_NULL_HANDLE;
         if (VK_SUCCESS == vk::CreateDescriptorUpdateTemplateKHR(*m_device, &create_info, nullptr, &dut)) {
             vk::DestroyDescriptorUpdateTemplateKHR(*m_device, dut, nullptr);
@@ -539,7 +539,7 @@ TEST_F(NegativePushDescriptor, CreateDescriptorUpdateTemplate14) {
     // Bad pipelineLayout handle, to be ignored if template type is DESCRIPTOR_SET
     {
         create_info.pipelineLayout = CastFromUint64<VkPipelineLayout>(badhandle);
-        create_info.descriptorSetLayout = ds_layout_ub.handle();
+        create_info.descriptorSetLayout = ds_layout_ub;
         VkDescriptorUpdateTemplateKHR dut = VK_NULL_HANDLE;
         if (VK_SUCCESS == vk::CreateDescriptorUpdateTemplate(*m_device, &create_info, nullptr, &dut)) {
             vk::DestroyDescriptorUpdateTemplate(*m_device, dut, nullptr);
@@ -806,8 +806,7 @@ TEST_F(NegativePushDescriptor, SetCmdPushQueueFamily) {
         m_errorMonitor->SetDesiredError("VUID-vkCmdPushDescriptorSet-pipelineBindPoint-00363");
         m_errorMonitor->SetDesiredError("VUID-VkWriteDescriptorSet-descriptorType-00330");
         m_errorMonitor->SetDesiredError("VUID-vkCmdPushDescriptorSet-commandBuffer-cmdpool");
-        vk::CmdPushDescriptorSetKHR(tran_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0, 1,
-                                    &descriptor_write);
+        vk::CmdPushDescriptorSetKHR(tran_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0, 1, &descriptor_write);
         m_errorMonitor->VerifyFound();
         tran_command_buffer.End();
     }
@@ -1118,8 +1117,8 @@ TEST_F(NegativePushDescriptor, DescriptorTemplateIncompatibleLayout) {
     update_template_ci.pipelineLayout = pipeline_layout;
     vkt::DescriptorUpdateTemplate update_template(*m_device, update_template_ci);
 
-    update_template_ci.descriptorSetLayout = normal_dsl.handle();
-    update_template_ci.pipelineLayout = pipeline_layout3.handle();
+    update_template_ci.descriptorSetLayout = normal_dsl;
+    update_template_ci.pipelineLayout = pipeline_layout3;
     vkt::DescriptorUpdateTemplate update_template2(*m_device, update_template_ci);
 
     SimpleTemplateData update_template_data;

--- a/tests/unit/push_descriptor_positive.cpp
+++ b/tests/unit/push_descriptor_positive.cpp
@@ -60,7 +60,7 @@ TEST_F(PositivePushDescriptor, NullDstSet) {
 
     // In Intel GPU, it needs to bind pipeline before push descriptor set.
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, helper);
-    vk::CmdPushDescriptorSetKHR(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, helper.pipeline_layout_.handle(), 0, 1,
+    vk::CmdPushDescriptorSetKHR(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, helper.pipeline_layout_, 0, 1,
                                 &descriptor_write);
 }
 
@@ -108,8 +108,7 @@ TEST_F(PositivePushDescriptor, NullDstSet14) {
 
     // In Intel GPU, it needs to bind pipeline before push descriptor set.
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, helper);
-    vk::CmdPushDescriptorSet(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, helper.pipeline_layout_.handle(), 0, 1,
-                             &descriptor_write);
+    vk::CmdPushDescriptorSet(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, helper.pipeline_layout_, 0, 1, &descriptor_write);
 }
 
 TEST_F(PositivePushDescriptor, UnboundSet) {

--- a/tests/unit/query.cpp
+++ b/tests/unit/query.cpp
@@ -62,7 +62,7 @@ TEST_F(NegativeQuery, PerformanceCreation) {
 
     // Missing pNext
     m_errorMonitor->SetDesiredError("VUID-VkQueryPoolCreateInfo-queryType-03222");
-    query_pool.init(*m_device, query_pool_ci);
+    query_pool.Init(*m_device, query_pool_ci);
     m_errorMonitor->VerifyFound();
 
     query_pool_ci.pNext = &perf_query_pool_ci;
@@ -72,13 +72,13 @@ TEST_F(NegativeQuery, PerformanceCreation) {
     perf_query_pool_ci.counterIndexCount++;
     perf_query_pool_ci.pCounterIndices = counterIndices.data();
     m_errorMonitor->SetDesiredError("VUID-VkQueryPoolPerformanceCreateInfoKHR-pCounterIndices-03321");
-    query_pool.init(*m_device, query_pool_ci);
+    query_pool.Init(*m_device, query_pool_ci);
     m_errorMonitor->VerifyFound();
     perf_query_pool_ci.counterIndexCount--;
     counterIndices.pop_back();
 
     // Success
-    query_pool.init(*m_device, query_pool_ci);
+    query_pool.Init(*m_device, query_pool_ci);
 
     m_command_buffer.Begin();
 
@@ -1029,46 +1029,46 @@ TEST_F(NegativeQuery, Sizes) {
     // FirstQuery is too large
     m_errorMonitor->SetDesiredError("VUID-vkCmdResetQueryPool-firstQuery-09436");
     m_errorMonitor->SetDesiredError("VUID-vkCmdResetQueryPool-firstQuery-09437");
-    vk::CmdResetQueryPool(m_command_buffer, occlusion_query_pool.handle(), query_pool_size, 1);
+    vk::CmdResetQueryPool(m_command_buffer, occlusion_query_pool, query_pool_size, 1);
     m_errorMonitor->VerifyFound();
 
     // Sum of firstQuery and queryCount is too large
     m_errorMonitor->SetDesiredError("VUID-vkCmdResetQueryPool-firstQuery-09437");
-    vk::CmdResetQueryPool(m_command_buffer, occlusion_query_pool.handle(), 1, query_pool_size);
+    vk::CmdResetQueryPool(m_command_buffer, occlusion_query_pool, 1, query_pool_size);
     m_errorMonitor->VerifyFound();
 
     // Actually reset all queries so they can be used
-    vk::CmdResetQueryPool(m_command_buffer, occlusion_query_pool.handle(), 0, query_pool_size);
+    vk::CmdResetQueryPool(m_command_buffer, occlusion_query_pool, 0, query_pool_size);
 
-    vk::CmdBeginQuery(m_command_buffer, occlusion_query_pool.handle(), 0, 0);
+    vk::CmdBeginQuery(m_command_buffer, occlusion_query_pool, 0, 0);
 
     // Query index to large
     m_errorMonitor->SetDesiredError("VUID-vkCmdEndQuery-query-00810");
-    vk::CmdEndQuery(m_command_buffer, occlusion_query_pool.handle(), query_pool_size);
+    vk::CmdEndQuery(m_command_buffer, occlusion_query_pool, query_pool_size);
     m_errorMonitor->VerifyFound();
 
-    vk::CmdEndQuery(m_command_buffer, occlusion_query_pool.handle(), 0);
+    vk::CmdEndQuery(m_command_buffer, occlusion_query_pool, 0);
 
     // FirstQuery is too large
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyQueryPoolResults-firstQuery-09436");
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyQueryPoolResults-firstQuery-09437");
-    vk::CmdCopyQueryPoolResults(m_command_buffer, occlusion_query_pool.handle(), query_pool_size, 1, buffer, 0, 0, 0);
+    vk::CmdCopyQueryPoolResults(m_command_buffer, occlusion_query_pool, query_pool_size, 1, buffer, 0, 0, 0);
     m_errorMonitor->VerifyFound();
 
     // sum of firstQuery and queryCount is too large
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyQueryPoolResults-firstQuery-09437");
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyQueryPoolResults-queryCount-09438");
-    vk::CmdCopyQueryPoolResults(m_command_buffer, occlusion_query_pool.handle(), 1, query_pool_size, buffer, 0, 0, 0);
+    vk::CmdCopyQueryPoolResults(m_command_buffer, occlusion_query_pool, 1, query_pool_size, buffer, 0, 0, 0);
     m_errorMonitor->VerifyFound();
 
     // Offset larger than buffer size
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyQueryPoolResults-dstOffset-00819");
-    vk::CmdCopyQueryPoolResults(m_command_buffer, occlusion_query_pool.handle(), 0, 1, buffer, buffer_size + 4, 0, 0);
+    vk::CmdCopyQueryPoolResults(m_command_buffer, occlusion_query_pool, 0, 1, buffer, buffer_size + 4, 0, 0);
     m_errorMonitor->VerifyFound();
 
     // Buffer does not have enough storage from offset to contain result of each query
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyQueryPoolResults-dstBuffer-00824");
-    vk::CmdCopyQueryPoolResults(m_command_buffer, occlusion_query_pool.handle(), 0, 2, buffer, buffer_size - 4, 4, 0);
+    vk::CmdCopyQueryPoolResults(m_command_buffer, occlusion_query_pool, 0, 2, buffer, buffer_size - 4, 4, 0);
     m_errorMonitor->VerifyFound();
 
     // Query is not a timestamp type
@@ -1076,7 +1076,7 @@ TEST_F(NegativeQuery, Sizes) {
         m_errorMonitor->SetDesiredError("VUID-vkCmdWriteTimestamp-timestampValidBits-00829");
     }
     m_errorMonitor->SetDesiredError("VUID-vkCmdWriteTimestamp-queryPool-01416");
-    vk::CmdWriteTimestamp(m_command_buffer, VK_PIPELINE_STAGE_VERTEX_INPUT_BIT, occlusion_query_pool.handle(), 0);
+    vk::CmdWriteTimestamp(m_command_buffer, VK_PIPELINE_STAGE_VERTEX_INPUT_BIT, occlusion_query_pool, 0);
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.End();
@@ -1087,12 +1087,12 @@ TEST_F(NegativeQuery, Sizes) {
     // FirstQuery is too large
     m_errorMonitor->SetDesiredError("VUID-vkGetQueryPoolResults-firstQuery-09436");
     m_errorMonitor->SetDesiredError("VUID-vkGetQueryPoolResults-firstQuery-09437");
-    vk::GetQueryPoolResults(device(), occlusion_query_pool.handle(), query_pool_size, 1, out_data_size, &data, 4, 0);
+    vk::GetQueryPoolResults(device(), occlusion_query_pool, query_pool_size, 1, out_data_size, &data, 4, 0);
     m_errorMonitor->VerifyFound();
 
     // Sum of firstQuery and queryCount is too large
     m_errorMonitor->SetDesiredError("VUID-vkGetQueryPoolResults-firstQuery-09437");
-    vk::GetQueryPoolResults(device(), occlusion_query_pool.handle(), 1, query_pool_size, out_data_size, &data, 4, 0);
+    vk::GetQueryPoolResults(device(), occlusion_query_pool, 1, query_pool_size, out_data_size, &data, 4, 0);
     m_errorMonitor->VerifyFound();
 }
 
@@ -1144,7 +1144,7 @@ TEST_F(NegativeQuery, PreciseBit) {
     pool_create_info.queueFamilyIndex = test_device.graphics_queue_node_index_;
 
     VkCommandPool command_pool;
-    vk::CreateCommandPool(test_device.handle(), &pool_create_info, nullptr, &command_pool);
+    vk::CreateCommandPool(test_device, &pool_create_info, nullptr, &command_pool);
 
     VkCommandBufferAllocateInfo cmd = vku::InitStructHelper();
     cmd.commandPool = command_pool;
@@ -1152,16 +1152,16 @@ TEST_F(NegativeQuery, PreciseBit) {
     cmd.commandBufferCount = 1;
 
     VkCommandBuffer cmd_buffer;
-    VkResult err = vk::AllocateCommandBuffers(test_device.handle(), &cmd, &cmd_buffer);
+    VkResult err = vk::AllocateCommandBuffers(test_device, &cmd, &cmd_buffer);
     ASSERT_EQ(VK_SUCCESS, err);
 
     VkCommandBuffer cmd_buffer2;
-    err = vk::AllocateCommandBuffers(test_device.handle(), &cmd, &cmd_buffer2);
+    err = vk::AllocateCommandBuffers(test_device, &cmd, &cmd_buffer2);
     ASSERT_EQ(VK_SUCCESS, err);
 
     VkEvent event;
     VkEventCreateInfo event_create_info = vku::InitStructHelper();
-    vk::CreateEvent(test_device.handle(), &event_create_info, nullptr, &event);
+    vk::CreateEvent(test_device, &event_create_info, nullptr, &event);
 
     VkCommandBufferBeginInfo begin_info = {VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, nullptr,
                                            VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT, nullptr};
@@ -1188,11 +1188,11 @@ TEST_F(NegativeQuery, PreciseBit) {
     uint8_t data[out_data_size];
     // The dataSize is too small to return the data
     m_errorMonitor->SetDesiredError("VUID-vkGetQueryPoolResults-dataSize-00817");
-    vk::GetQueryPoolResults(test_device.handle(), query_pool, 0, 2, 8, &data, out_data_size / 2, 0);
+    vk::GetQueryPoolResults(test_device, query_pool, 0, 2, 8, &data, out_data_size / 2, 0);
     m_errorMonitor->VerifyFound();
 
-    vk::DestroyEvent(test_device.handle(), event, nullptr);
-    vk::DestroyCommandPool(test_device.handle(), command_pool, nullptr);
+    vk::DestroyEvent(test_device, event, nullptr);
+    vk::DestroyCommandPool(test_device, command_pool, nullptr);
 }
 
 TEST_F(NegativeQuery, PoolPartialTimestamp) {
@@ -1326,11 +1326,10 @@ TEST_F(NegativeQuery, CmdEndQueryIndexedEXTIndex) {
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_OCCLUSION, 1);
 
     m_command_buffer.Begin();
-    vk::CmdBeginQueryIndexedEXT(m_command_buffer, tf_query_pool.handle(), 0, 0, 0);
+    vk::CmdBeginQueryIndexedEXT(m_command_buffer, tf_query_pool, 0, 0, 0);
     m_errorMonitor->SetDesiredError("VUID-vkCmdEndQueryIndexedEXT-queryType-06694");
     m_errorMonitor->SetDesiredError("VUID-vkCmdEndQueryIndexedEXT-queryType-06696");
-    vk::CmdEndQueryIndexedEXT(m_command_buffer, tf_query_pool.handle(), 0,
-                              transform_feedback_properties.maxTransformFeedbackStreams);
+    vk::CmdEndQueryIndexedEXT(m_command_buffer, tf_query_pool, 0, transform_feedback_properties.maxTransformFeedbackStreams);
 
     vk::CmdBeginQueryIndexedEXT(m_command_buffer, query_pool, 0, 0, 0);
     m_errorMonitor->SetDesiredError("VUID-vkCmdEndQueryIndexedEXT-queryType-06695");
@@ -1364,21 +1363,18 @@ TEST_F(NegativeQuery, CmdEndQueryIndexedEXTPrimitiveGenerated) {
     m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdBeginQueryIndexedEXT-queryType-02339");
-    vk::CmdBeginQueryIndexedEXT(m_command_buffer, tf_query_pool.handle(), 0, 0,
-                                transform_feedback_properties.maxTransformFeedbackStreams);
+    vk::CmdBeginQueryIndexedEXT(m_command_buffer, tf_query_pool, 0, 0, transform_feedback_properties.maxTransformFeedbackStreams);
     m_errorMonitor->VerifyFound();
 
-    vk::CmdBeginQueryIndexedEXT(m_command_buffer, tf_query_pool.handle(), 0, 0, 0);
+    vk::CmdBeginQueryIndexedEXT(m_command_buffer, tf_query_pool, 0, 0, 0);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdEndQueryIndexedEXT-queryType-06696");
     m_errorMonitor->SetDesiredError("VUID-vkCmdEndQueryIndexedEXT-queryType-06694");
-    vk::CmdEndQueryIndexedEXT(m_command_buffer, tf_query_pool.handle(), 0,
-                              transform_feedback_properties.maxTransformFeedbackStreams);
+    vk::CmdEndQueryIndexedEXT(m_command_buffer, tf_query_pool, 0, transform_feedback_properties.maxTransformFeedbackStreams);
     m_errorMonitor->VerifyFound();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdBeginQueryIndexedEXT-queryType-06690");
-    vk::CmdBeginQueryIndexedEXT(m_command_buffer, pg_query_pool.handle(), 0, 0,
-                                transform_feedback_properties.maxTransformFeedbackStreams);
+    vk::CmdBeginQueryIndexedEXT(m_command_buffer, pg_query_pool, 0, 0, transform_feedback_properties.maxTransformFeedbackStreams);
     m_errorMonitor->VerifyFound();
 
     vk::CmdBeginQueryIndexedEXT(m_command_buffer, query_pool, 0, 0, 0);
@@ -1672,7 +1668,7 @@ TEST_F(NegativeQuery, PrimitivesGenerated) {
 
     vkt::QueryPool occlusion_query_pool(*m_device, VK_QUERY_TYPE_OCCLUSION, 1);
     m_errorMonitor->SetDesiredError("VUID-vkCmdBeginQueryIndexedEXT-queryType-06692");
-    vk::CmdBeginQueryIndexedEXT(m_command_buffer, occlusion_query_pool.handle(), 0, 0, 1);
+    vk::CmdBeginQueryIndexedEXT(m_command_buffer, occlusion_query_pool, 0, 0, 1);
     m_errorMonitor->VerifyFound();
 
     vk::CmdBeginQueryIndexedEXT(m_command_buffer, query_pool, 0, 0, 0);

--- a/tests/unit/query_positive.cpp
+++ b/tests/unit/query_positive.cpp
@@ -248,13 +248,13 @@ TEST_F(PositiveQuery, QueryAndCopySecondaryCommandBuffers) {
         VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
         begin_info.pInheritanceInfo = &hinfo;
         secondary_buffer.Begin(&begin_info);
-        vk::CmdResetQueryPool(secondary_buffer.handle(), query_pool, 0, 1);
-        vk::CmdWriteTimestamp(secondary_buffer.handle(), VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, query_pool, 0);
+        vk::CmdResetQueryPool(secondary_buffer, query_pool, 0, 1);
+        vk::CmdWriteTimestamp(secondary_buffer, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, query_pool, 0);
         secondary_buffer.End();
 
         primary_buffer.Begin();
-        vk::CmdExecuteCommands(primary_buffer.handle(), 1, &secondary_buffer.handle());
-        vk::CmdCopyQueryPoolResults(primary_buffer.handle(), query_pool, 0, 1, buffer, 0, 0, VK_QUERY_RESULT_WAIT_BIT);
+        vk::CmdExecuteCommands(primary_buffer, 1, &secondary_buffer.handle());
+        vk::CmdCopyQueryPoolResults(primary_buffer, query_pool, 0, 1, buffer, 0, 0, VK_QUERY_RESULT_WAIT_BIT);
         primary_buffer.End();
     }
 
@@ -464,12 +464,12 @@ TEST_F(PositiveQuery, PerformanceQueries) {
     VkCommandBufferBeginInfo info = vku::InitStructHelper();
     cmd_buffer.Begin(&info);
 
-    vk::CmdBeginQuery(cmd_buffer.handle(), query_pool, 0u, 0u);
+    vk::CmdBeginQuery(cmd_buffer, query_pool, 0u, 0u);
 
-    vk::CmdPipelineBarrier(cmd_buffer.handle(), VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0u, 0u,
-                           nullptr, 0u, nullptr, 0u, nullptr);
+    vk::CmdPipelineBarrier(cmd_buffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0u, 0u, nullptr,
+                           0u, nullptr, 0u, nullptr);
 
-    vk::CmdEndQuery(cmd_buffer.handle(), query_pool, 0u);
+    vk::CmdEndQuery(cmd_buffer, query_pool, 0u);
 
     cmd_buffer.End();
 
@@ -518,7 +518,7 @@ TEST_F(PositiveQuery, ReuseSecondaryWithQueryCommand) {
 
     vkt::CommandBuffer secondary_buffer(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
     secondary_buffer.Begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
-    vk::CmdWriteTimestamp(secondary_buffer.handle(), VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, query_pool, 0);
+    vk::CmdWriteTimestamp(secondary_buffer, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, query_pool, 0);
     secondary_buffer.End();
 
     m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
@@ -588,12 +588,12 @@ TEST_F(PositiveQuery, PerformanceCountersWithoutEnumeration) {
     VkCommandBufferBeginInfo info = vku::InitStructHelper();
     cmd_buffer.Begin(&info);
 
-    vk::CmdBeginQuery(cmd_buffer.handle(), query_pool, 0u, 0u);
+    vk::CmdBeginQuery(cmd_buffer, query_pool, 0u, 0u);
 
-    vk::CmdPipelineBarrier(cmd_buffer.handle(), VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0u, 0u,
-                           nullptr, 0u, nullptr, 0u, nullptr);
+    vk::CmdPipelineBarrier(cmd_buffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0u, 0u, nullptr,
+                           0u, nullptr, 0u, nullptr);
 
-    vk::CmdEndQuery(cmd_buffer.handle(), query_pool, 0u);
+    vk::CmdEndQuery(cmd_buffer, query_pool, 0u);
 
     cmd_buffer.End();
 
@@ -627,8 +627,8 @@ TEST_F(PositiveQuery, QueryPoolResetBit) {
     vkt::QueryPool query_pool(*m_device, qpci);
 
     m_command_buffer.Begin();
-    vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0, 0);
-    vk::CmdEndQuery(m_command_buffer.handle(), query_pool.handle(), 0);
+    vk::CmdBeginQuery(m_command_buffer, query_pool, 0, 0);
+    vk::CmdEndQuery(m_command_buffer, query_pool, 0);
     m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);

--- a/tests/unit/ray_tracing_nv.cpp
+++ b/tests/unit/ray_tracing_nv.cpp
@@ -105,7 +105,7 @@ void NegativeRayTracingNV::OOBRayTracingShadersTestBodyNV(bool gpu_assisted) {
 
     const VkDeviceSize aabb_buffer_size = sizeof(VkAabbPositionsKHR) * aabbs.size();
     vkt::Buffer aabb_buffer;
-    aabb_buffer.init(*m_device, aabb_buffer_size, VK_BUFFER_USAGE_RAY_TRACING_BIT_NV, kHostVisibleMemProps, nullptr,
+    aabb_buffer.Init(*m_device, aabb_buffer_size, VK_BUFFER_USAGE_RAY_TRACING_BIT_NV, kHostVisibleMemProps, nullptr,
                      vvl::make_span(&ray_tracing_queue_family_index, 1));
 
     uint8_t *mapped_aabb_buffer_data = (uint8_t *)aabb_buffer.Memory().Map();
@@ -155,7 +155,7 @@ void NegativeRayTracingNV::OOBRayTracingShadersTestBodyNV(bool gpu_assisted) {
 
     VkDeviceSize instance_buffer_size = sizeof(instances[0]) * instances.size();
     vkt::Buffer instance_buffer;
-    instance_buffer.init(*m_device, instance_buffer_size, VK_BUFFER_USAGE_RAY_TRACING_BIT_NV, kHostVisibleMemProps, nullptr,
+    instance_buffer.Init(*m_device, instance_buffer_size, VK_BUFFER_USAGE_RAY_TRACING_BIT_NV, kHostVisibleMemProps, nullptr,
                          vvl::make_span(&ray_tracing_queue_family_index, 1));
 
     uint8_t *mapped_instance_buffer_data = (uint8_t *)instance_buffer.Memory().Map();
@@ -206,12 +206,12 @@ void NegativeRayTracingNV::OOBRayTracingShadersTestBodyNV(bool gpu_assisted) {
 
     VkDeviceSize storage_buffer_size = 1024;
     vkt::Buffer storage_buffer;
-    storage_buffer.init(*m_device, storage_buffer_size, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps, nullptr,
+    storage_buffer.Init(*m_device, storage_buffer_size, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps, nullptr,
                         vvl::make_span(&ray_tracing_queue_family_index, 1));
 
     VkDeviceSize shader_binding_table_buffer_size = ray_tracing_properties.shaderGroupBaseAlignment * 4ull;
     vkt::Buffer shader_binding_table_buffer;
-    shader_binding_table_buffer.init(*m_device, shader_binding_table_buffer_size, VK_BUFFER_USAGE_RAY_TRACING_BIT_NV,
+    shader_binding_table_buffer.Init(*m_device, shader_binding_table_buffer_size, VK_BUFFER_USAGE_RAY_TRACING_BIT_NV,
                                      kHostVisibleMemProps, nullptr, vvl::make_span(&ray_tracing_queue_family_index, 1));
 
     // Setup descriptors!
@@ -1046,17 +1046,10 @@ TEST_F(NegativeRayTracingNV, ValidateGeometry) {
     RETURN_IF_SKIP(NvInitFrameworkForRayTracingTest());
     RETURN_IF_SKIP(InitState());
 
-    vkt::Buffer vbo;
-    vbo.init(*m_device, 1024, VK_BUFFER_USAGE_RAY_TRACING_BIT_NV, kHostVisibleMemProps);
-
-    vkt::Buffer ibo;
-    ibo.init(*m_device, 1024, VK_BUFFER_USAGE_RAY_TRACING_BIT_NV, kHostVisibleMemProps);
-
-    vkt::Buffer tbo;
-    tbo.init(*m_device, 1024, VK_BUFFER_USAGE_RAY_TRACING_BIT_NV, kHostVisibleMemProps);
-
-    vkt::Buffer aabbbo;
-    aabbbo.init(*m_device, 1024, VK_BUFFER_USAGE_RAY_TRACING_BIT_NV, kHostVisibleMemProps);
+    vkt::Buffer vbo(*m_device, 1024, VK_BUFFER_USAGE_RAY_TRACING_BIT_NV, kHostVisibleMemProps);
+    vkt::Buffer ibo(*m_device, 1024, VK_BUFFER_USAGE_RAY_TRACING_BIT_NV, kHostVisibleMemProps);
+    vkt::Buffer tbo(*m_device, 1024, VK_BUFFER_USAGE_RAY_TRACING_BIT_NV, kHostVisibleMemProps);
+    vkt::Buffer aabbbo(*m_device, 1024, VK_BUFFER_USAGE_RAY_TRACING_BIT_NV, kHostVisibleMemProps);
 
     VkBufferCreateInfo unbound_buffer_ci = vku::InitStructHelper();
     unbound_buffer_ci.size = 1024;
@@ -1839,7 +1832,7 @@ TEST_F(NegativeRayTracingNV, ValidateCmdCopyAccelerationStructure) {
     m_errorMonitor->VerifyFound();
 
     vkt::DeviceMemory host_memory;
-    host_memory.init(*m_device,
+    host_memory.Init(*m_device,
                      vkt::DeviceMemory::GetResourceAllocInfo(*m_device, dst_as_without_mem.MemoryRequirements().memoryRequirements,
                                                              VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT));
 

--- a/tests/unit/ray_tracing_pipeline_nv.cpp
+++ b/tests/unit/ray_tracing_pipeline_nv.cpp
@@ -54,7 +54,7 @@ TEST_F(NegativeRayTracingPipelineNV, BasicUsage) {
         pipeline_ci.pStages = &stage_create_info;
         pipeline_ci.groupCount = 1;
         pipeline_ci.pGroups = &group_create_info;
-        pipeline_ci.layout = empty_pipeline_layout.handle();
+        pipeline_ci.layout = empty_pipeline_layout;
         pipeline_ci.flags = VK_PIPELINE_CREATE_DERIVATIVE_BIT;
         pipeline_ci.basePipelineIndex = -1;
         constexpr uint64_t fake_pipeline_id = 0xCADECADE;
@@ -76,7 +76,7 @@ TEST_F(NegativeRayTracingPipelineNV, BasicUsage) {
         pipeline_ci.pStages = &stage_create_info;
         pipeline_ci.groupCount = 1;
         pipeline_ci.pGroups = &group_create_info;
-        pipeline_ci.layout = empty_pipeline_layout.handle();
+        pipeline_ci.layout = empty_pipeline_layout;
         pipeline_ci.flags = VK_PIPELINE_CREATE_DEFER_COMPILE_BIT_NV | VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
         m_errorMonitor->SetDesiredError("VUID-VkRayTracingPipelineCreateInfoNV-flags-02957");
         vk::CreateRayTracingPipelinesNV(*m_device, VK_NULL_HANDLE, 1, &pipeline_ci, nullptr, &pipeline);
@@ -88,7 +88,7 @@ TEST_F(NegativeRayTracingPipelineNV, BasicUsage) {
         pipeline_ci.pStages = &stage_create_info;
         pipeline_ci.groupCount = 1;
         pipeline_ci.pGroups = &group_create_info;
-        pipeline_ci.layout = empty_pipeline_layout.handle();
+        pipeline_ci.layout = empty_pipeline_layout;
         pipeline_ci.flags = VK_PIPELINE_CREATE_INDIRECT_BINDABLE_BIT_NV;
         m_errorMonitor->SetDesiredError("VUID-VkRayTracingPipelineCreateInfoNV-None-09497");
         m_errorMonitor->SetDesiredError("VUID-VkRayTracingPipelineCreateInfoNV-flags-02904");
@@ -147,7 +147,7 @@ TEST_F(NegativeRayTracingPipelineNV, BasicUsage) {
         pipeline_ci.pStages = &stage_create_info;
         pipeline_ci.groupCount = 1;
         pipeline_ci.pGroups = &group_create_info;
-        pipeline_ci.layout = empty_pipeline_layout.handle();
+        pipeline_ci.layout = empty_pipeline_layout;
         // appending twice as it is generated twice in auto-validation code
         m_errorMonitor->SetDesiredError("VUID-vkCreateRayTracingPipelinesNV-createInfoCount-arraylength");
         m_errorMonitor->SetDesiredError("VUID-vkCreateRayTracingPipelinesNV-createInfoCount-arraylength");
@@ -212,7 +212,7 @@ TEST_F(NegativeRayTracingPipelineNV, ShaderGroups) {
         pipeline_ci.pStages = &stage_create_info;
         pipeline_ci.groupCount = 1;
         pipeline_ci.pGroups = &group_create_info;
-        pipeline_ci.layout = empty_pipeline_layout.handle();
+        pipeline_ci.layout = empty_pipeline_layout;
 
         m_errorMonitor->SetDesiredError("VUID-VkRayTracingPipelineCreateInfoNV-stage-06232");
         vk::CreateRayTracingPipelinesNV(*m_device, VK_NULL_HANDLE, 1, &pipeline_ci, nullptr, &pipeline);
@@ -252,7 +252,7 @@ TEST_F(NegativeRayTracingPipelineNV, ShaderGroups) {
         pipeline_ci.pStages = stage_create_infos;
         pipeline_ci.groupCount = 2;
         pipeline_ci.pGroups = group_create_infos;
-        pipeline_ci.layout = empty_pipeline_layout.handle();
+        pipeline_ci.layout = empty_pipeline_layout;
 
         vk::CreateRayTracingPipelinesNV(*m_device, VK_NULL_HANDLE, 1, &pipeline_ci, nullptr, &pipeline);
         vk::DestroyPipeline(device(), pipeline, NULL);
@@ -277,7 +277,7 @@ TEST_F(NegativeRayTracingPipelineNV, ShaderGroups) {
         pipeline_ci.pStages = &stage_create_info;
         pipeline_ci.groupCount = 1;
         pipeline_ci.pGroups = &group_create_info;
-        pipeline_ci.layout = empty_pipeline_layout.handle();
+        pipeline_ci.layout = empty_pipeline_layout;
 
         m_errorMonitor->SetDesiredError("VUID-VkRayTracingShaderGroupCreateInfoNV-type-02413");
         vk::CreateRayTracingPipelinesNV(*m_device, VK_NULL_HANDLE, 1, &pipeline_ci, nullptr, &pipeline);
@@ -317,7 +317,7 @@ TEST_F(NegativeRayTracingPipelineNV, ShaderGroups) {
         pipeline_ci.pStages = stage_create_infos;
         pipeline_ci.groupCount = 2;
         pipeline_ci.pGroups = group_create_infos;
-        pipeline_ci.layout = empty_pipeline_layout.handle();
+        pipeline_ci.layout = empty_pipeline_layout;
 
         m_errorMonitor->SetDesiredError("VUID-VkRayTracingShaderGroupCreateInfoNV-type-02413");
         vk::CreateRayTracingPipelinesNV(*m_device, VK_NULL_HANDLE, 1, &pipeline_ci, nullptr, &pipeline);
@@ -357,7 +357,7 @@ TEST_F(NegativeRayTracingPipelineNV, ShaderGroups) {
         pipeline_ci.pStages = stage_create_infos;
         pipeline_ci.groupCount = 2;
         pipeline_ci.pGroups = group_create_infos;
-        pipeline_ci.layout = empty_pipeline_layout.handle();
+        pipeline_ci.layout = empty_pipeline_layout;
 
         m_errorMonitor->SetDesiredError("VUID-VkRayTracingShaderGroupCreateInfoNV-type-02414");
         vk::CreateRayTracingPipelinesNV(*m_device, VK_NULL_HANDLE, 1, &pipeline_ci, nullptr, &pipeline);
@@ -397,7 +397,7 @@ TEST_F(NegativeRayTracingPipelineNV, ShaderGroups) {
         pipeline_ci.pStages = stage_create_infos;
         pipeline_ci.groupCount = 2;
         pipeline_ci.pGroups = group_create_infos;
-        pipeline_ci.layout = empty_pipeline_layout.handle();
+        pipeline_ci.layout = empty_pipeline_layout;
 
         m_errorMonitor->SetDesiredError("VUID-VkRayTracingShaderGroupCreateInfoNV-type-02415");
         vk::CreateRayTracingPipelinesNV(*m_device, VK_NULL_HANDLE, 1, &pipeline_ci, nullptr, &pipeline);
@@ -437,7 +437,7 @@ TEST_F(NegativeRayTracingPipelineNV, ShaderGroups) {
         pipeline_ci.pStages = stage_create_infos;
         pipeline_ci.groupCount = 2;
         pipeline_ci.pGroups = group_create_infos;
-        pipeline_ci.layout = empty_pipeline_layout.handle();
+        pipeline_ci.layout = empty_pipeline_layout;
 
         m_errorMonitor->SetDesiredError("VUID-VkRayTracingShaderGroupCreateInfoNV-type-02415");
         vk::CreateRayTracingPipelinesNV(*m_device, VK_NULL_HANDLE, 1, &pipeline_ci, nullptr, &pipeline);
@@ -477,7 +477,7 @@ TEST_F(NegativeRayTracingPipelineNV, ShaderGroups) {
         pipeline_ci.pStages = stage_create_infos;
         pipeline_ci.groupCount = 2;
         pipeline_ci.pGroups = group_create_infos;
-        pipeline_ci.layout = empty_pipeline_layout.handle();
+        pipeline_ci.layout = empty_pipeline_layout;
 
         m_errorMonitor->SetDesiredError("VUID-VkRayTracingShaderGroupCreateInfoNV-type-02416");
         vk::CreateRayTracingPipelinesNV(*m_device, VK_NULL_HANDLE, 1, &pipeline_ci, nullptr, &pipeline);
@@ -517,7 +517,7 @@ TEST_F(NegativeRayTracingPipelineNV, ShaderGroups) {
         pipeline_ci.pStages = stage_create_infos;
         pipeline_ci.groupCount = 2;
         pipeline_ci.pGroups = group_create_infos;
-        pipeline_ci.layout = empty_pipeline_layout.handle();
+        pipeline_ci.layout = empty_pipeline_layout;
 
         m_errorMonitor->SetDesiredError("VUID-VkRayTracingShaderGroupCreateInfoNV-anyHitShader-02418");
         vk::CreateRayTracingPipelinesNV(*m_device, VK_NULL_HANDLE, 1, &pipeline_ci, nullptr, &pipeline);
@@ -557,7 +557,7 @@ TEST_F(NegativeRayTracingPipelineNV, ShaderGroups) {
         pipeline_ci.pStages = stage_create_infos;
         pipeline_ci.groupCount = 2;
         pipeline_ci.pGroups = group_create_infos;
-        pipeline_ci.layout = empty_pipeline_layout.handle();
+        pipeline_ci.layout = empty_pipeline_layout;
 
         m_errorMonitor->SetDesiredError("VUID-VkRayTracingShaderGroupCreateInfoNV-anyHitShader-02418");
         vk::CreateRayTracingPipelinesNV(*m_device, VK_NULL_HANDLE, 1, &pipeline_ci, nullptr, &pipeline);
@@ -597,7 +597,7 @@ TEST_F(NegativeRayTracingPipelineNV, ShaderGroups) {
         pipeline_ci.pStages = stage_create_infos;
         pipeline_ci.groupCount = 2;
         pipeline_ci.pGroups = group_create_infos;
-        pipeline_ci.layout = empty_pipeline_layout.handle();
+        pipeline_ci.layout = empty_pipeline_layout;
 
         m_errorMonitor->SetDesiredError("VUID-VkRayTracingShaderGroupCreateInfoNV-closestHitShader-02417");
         vk::CreateRayTracingPipelinesNV(*m_device, VK_NULL_HANDLE, 1, &pipeline_ci, nullptr, &pipeline);
@@ -637,7 +637,7 @@ TEST_F(NegativeRayTracingPipelineNV, ShaderGroups) {
         pipeline_ci.pStages = stage_create_infos;
         pipeline_ci.groupCount = 2;
         pipeline_ci.pGroups = group_create_infos;
-        pipeline_ci.layout = empty_pipeline_layout.handle();
+        pipeline_ci.layout = empty_pipeline_layout;
 
         m_errorMonitor->SetDesiredError("VUID-VkRayTracingShaderGroupCreateInfoNV-closestHitShader-02417");
         vk::CreateRayTracingPipelinesNV(*m_device, VK_NULL_HANDLE, 1, &pipeline_ci, nullptr, &pipeline);

--- a/tests/unit/ray_tracing_positive.cpp
+++ b/tests/unit/ray_tracing_positive.cpp
@@ -522,14 +522,14 @@ TEST_F(PositiveRayTracing, AccelerationStructuresReuseScratchMemory) {
         scratch_buffer_frame_0->InitNoMemory(*m_device, scratch_buffer_ci);
 
         // Bind memory to scratch buffer
-        vk::BindBufferMemory(device(), scratch_buffer_frame_0->handle(), common_scratch_memory.handle(), 0);
+        vk::BindBufferMemory(device(), scratch_buffer_frame_0->handle(), common_scratch_memory, 0);
 
         // Build a dummy acceleration structure
         auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
         blas.SetScratchBuffer(scratch_buffer_frame_0);
         blas_vec_frame_0.emplace_back(std::move(blas));
         cmd_buffer_frame_0.Begin();
-        vkt::as::BuildAccelerationStructuresKHR(cmd_buffer_frame_0.handle(), blas_vec_frame_0);
+        vkt::as::BuildAccelerationStructuresKHR(cmd_buffer_frame_0, blas_vec_frame_0);
 
         // Synchronize accesses to scratch buffer memory: next op will be a new acceleration structure build
         VkBufferMemoryBarrier barrier = vku::InitStructHelper();
@@ -537,7 +537,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresReuseScratchMemory) {
         barrier.size = scratch_buffer_ci.size;
         barrier.srcAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR | VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
         barrier.dstAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR | VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
-        vk::CmdPipelineBarrier(cmd_buffer_frame_0.handle(), VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR,
+        vk::CmdPipelineBarrier(cmd_buffer_frame_0, VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR,
                                VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR, 0, 0, nullptr, 1, &barrier, 0, nullptr);
         cmd_buffer_frame_0.End();
         m_default_queue->Submit(cmd_buffer_frame_0, fence_frame_0);
@@ -555,14 +555,14 @@ TEST_F(PositiveRayTracing, AccelerationStructuresReuseScratchMemory) {
         scratch_buffer_frame_1->InitNoMemory(*m_device, scratch_buffer_ci);
 
         // Bind memory to scratch buffer
-        vk::BindBufferMemory(device(), scratch_buffer_frame_1->handle(), common_scratch_memory.handle(), 0);
+        vk::BindBufferMemory(device(), scratch_buffer_frame_1->handle(), common_scratch_memory, 0);
 
         // Build a dummy acceleration structure
         auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
         blas.SetScratchBuffer(scratch_buffer_frame_1);
         blas_vec_frame_1.emplace_back(std::move(blas));
         cmd_buffer_frame_1.Begin();
-        vkt::as::BuildAccelerationStructuresKHR(cmd_buffer_frame_1.handle(), blas_vec_frame_1);
+        vkt::as::BuildAccelerationStructuresKHR(cmd_buffer_frame_1, blas_vec_frame_1);
 
         // Synchronize accesses to scratch buffer memory: next op will be a new acceleration structure build
         VkBufferMemoryBarrier barrier = vku::InitStructHelper();
@@ -570,7 +570,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresReuseScratchMemory) {
         barrier.size = scratch_buffer_ci.size;
         barrier.srcAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR | VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
         barrier.dstAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR | VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
-        vk::CmdPipelineBarrier(cmd_buffer_frame_1.handle(), VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR,
+        vk::CmdPipelineBarrier(cmd_buffer_frame_1, VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR,
                                VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR, 0, 0, nullptr, 1, &barrier, 0, nullptr);
         cmd_buffer_frame_1.End();
         m_default_queue->Submit(cmd_buffer_frame_1, fence_frame_1);
@@ -603,14 +603,14 @@ TEST_F(PositiveRayTracing, AccelerationStructuresReuseScratchMemory) {
         scratch_buffer_frame_2->InitNoMemory(*m_device, scratch_buffer_ci);
 
         // Bind memory to scratch buffer
-        vk::BindBufferMemory(device(), scratch_buffer_frame_2->handle(), common_scratch_memory.handle(), 0);
+        vk::BindBufferMemory(device(), scratch_buffer_frame_2->handle(), common_scratch_memory, 0);
 
         // Build a dummy acceleration structure
         auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
         blas.SetScratchBuffer(scratch_buffer_frame_2);
         blas_vec_frame_2.emplace_back(std::move(blas));
         cmd_buffer_frame_2.Begin();
-        vkt::as::BuildAccelerationStructuresKHR(cmd_buffer_frame_2.handle(), blas_vec_frame_2);
+        vkt::as::BuildAccelerationStructuresKHR(cmd_buffer_frame_2, blas_vec_frame_2);
 
         // Synchronize accesses to scratch buffer memory: next op will be a new acceleration structure build
         VkBufferMemoryBarrier barrier = vku::InitStructHelper();
@@ -618,7 +618,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresReuseScratchMemory) {
         barrier.size = scratch_buffer_ci.size;
         barrier.srcAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR | VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
         barrier.dstAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR | VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
-        vk::CmdPipelineBarrier(cmd_buffer_frame_2.handle(), VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR,
+        vk::CmdPipelineBarrier(cmd_buffer_frame_2, VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR,
                                VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR, 0, 0, nullptr, 1, &barrier, 0, nullptr);
         cmd_buffer_frame_2.End();
         m_default_queue->Submit(cmd_buffer_frame_2, fence_frame_2);
@@ -662,7 +662,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresDedicatedScratchMemory) {
 
         blas_vec_frame_0.emplace_back(std::move(blas));
         cmd_buffer_frame_0.Begin();
-        vkt::as::BuildAccelerationStructuresKHR(cmd_buffer_frame_0.handle(), blas_vec_frame_0);
+        vkt::as::BuildAccelerationStructuresKHR(cmd_buffer_frame_0, blas_vec_frame_0);
 
         // Synchronize accesses to scratch buffer memory: next op will be a new acceleration structure build
         VkBufferMemoryBarrier barrier = vku::InitStructHelper();
@@ -670,7 +670,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresDedicatedScratchMemory) {
         barrier.size = blas_vec_frame_0[0].GetScratchBuffer()->CreateInfo().size;
         barrier.srcAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR | VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
         barrier.dstAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR | VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
-        vk::CmdPipelineBarrier(cmd_buffer_frame_0.handle(), VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR,
+        vk::CmdPipelineBarrier(cmd_buffer_frame_0, VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR,
                                VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR, 0, 0, nullptr, 1, &barrier, 0, nullptr);
         cmd_buffer_frame_0.End();
         m_default_queue->Submit(cmd_buffer_frame_0, fence_frame_0);
@@ -684,7 +684,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresDedicatedScratchMemory) {
         auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
         blas_vec_frame_1.emplace_back(std::move(blas));
         cmd_buffer_frame_1.Begin();
-        vkt::as::BuildAccelerationStructuresKHR(cmd_buffer_frame_1.handle(), blas_vec_frame_1);
+        vkt::as::BuildAccelerationStructuresKHR(cmd_buffer_frame_1, blas_vec_frame_1);
 
         // Synchronize accesses to scratch buffer memory: next op will be a new acceleration structure build
         VkBufferMemoryBarrier barrier = vku::InitStructHelper();
@@ -692,7 +692,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresDedicatedScratchMemory) {
         barrier.size = blas_vec_frame_1[0].GetScratchBuffer()->CreateInfo().size;
         barrier.srcAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR | VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
         barrier.dstAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR | VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
-        vk::CmdPipelineBarrier(cmd_buffer_frame_1.handle(), VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR,
+        vk::CmdPipelineBarrier(cmd_buffer_frame_1, VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR,
                                VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR, 0, 0, nullptr, 1, &barrier, 0, nullptr);
         cmd_buffer_frame_1.End();
         m_default_queue->Submit(cmd_buffer_frame_1, fence_frame_1);
@@ -708,7 +708,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresDedicatedScratchMemory) {
         auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
         blas_vec_frame_2.emplace_back(std::move(blas));
         cmd_buffer_frame_2.Begin();
-        vkt::as::BuildAccelerationStructuresKHR(cmd_buffer_frame_2.handle(), blas_vec_frame_2);
+        vkt::as::BuildAccelerationStructuresKHR(cmd_buffer_frame_2, blas_vec_frame_2);
 
         // Synchronize accesses to scratch buffer memory: next op will be a new acceleration structure build
         VkBufferMemoryBarrier barrier = vku::InitStructHelper();
@@ -716,7 +716,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresDedicatedScratchMemory) {
         barrier.size = blas_vec_frame_2[0].GetScratchBuffer()->CreateInfo().size;
         barrier.srcAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR | VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
         barrier.dstAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR | VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
-        vk::CmdPipelineBarrier(cmd_buffer_frame_2.handle(), VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR,
+        vk::CmdPipelineBarrier(cmd_buffer_frame_2, VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR,
                                VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR, 0, 0, nullptr, 1, &barrier, 0, nullptr);
         cmd_buffer_frame_2.End();
         m_default_queue->Submit(cmd_buffer_frame_2, fence_frame_2);
@@ -1587,10 +1587,10 @@ TEST_F(PositiveRayTracing, SerializeAccelerationStructure) {
 
     m_command_buffer.Begin();
 
-    vk::CmdResetQueryPool(m_command_buffer, serialization_query_pool.handle(), 0, 1);
+    vk::CmdResetQueryPool(m_command_buffer, serialization_query_pool, 0, 1);
     vk::CmdWriteAccelerationStructuresPropertiesKHR(m_command_buffer, 1, &blas.GetDstAS()->handle(),
                                                     VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SERIALIZATION_SIZE_KHR,
-                                                    serialization_query_pool.handle(), 0);
+                                                    serialization_query_pool, 0);
 
     m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
@@ -1695,7 +1695,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresAndScratchBuffersAddressSharing
         VkDeviceAddress ref_address = 0;
         for (size_t i = 0; i < build_info_count; ++i) {
             dst_blas_buffers[i].InitNoMemory(*m_device, dst_blas_buffer_ci);
-            vk::BindBufferMemory(device(), dst_blas_buffers[i].handle(), buffer_memory, 0);
+            vk::BindBufferMemory(device(), dst_blas_buffers[i], buffer_memory, 0);
             scratch_buffers[i] = std::make_shared<vkt::Buffer>();
             scratch_buffers[i]->InitNoMemory(*m_device, scratch_buffer_ci);
             vk::BindBufferMemory(device(), scratch_buffers[i]->handle(), buffer_memory, 0);
@@ -1940,6 +1940,6 @@ TEST_F(PositiveRayTracing, MultipleGeometries) {
     // Build acceleration structure
     const VkAccelerationStructureBuildGeometryInfoKHR* pInfos = &vk_info;
     const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos = pRange_infos.data();
-    vk::CmdBuildAccelerationStructuresKHR(m_command_buffer.handle(), 1u, pInfos, ppBuildRangeInfos);
+    vk::CmdBuildAccelerationStructuresKHR(m_command_buffer, 1u, pInfos, ppBuildRangeInfos);
     m_command_buffer.End();
 }

--- a/tests/unit/render_pass.cpp
+++ b/tests/unit/render_pass.cpp
@@ -1371,9 +1371,8 @@ TEST_F(NegativeRenderPass, BeginLayoutsFramebufferImageUsageMismatches) {
         vkt::Image no_fb_loop_attachment(
             *m_device, 128, 128, VK_FORMAT_R8G8B8A8_UNORM,
             VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
-        vkt::ImageView image_view_no_fb_loop;
         auto image_view_ci = no_fb_loop_attachment.BasicViewCreatInfo();
-        image_view_no_fb_loop.init(*m_device, image_view_ci);
+        vkt::ImageView image_view_no_fb_loop(*m_device, image_view_ci);
         views[0] = image_view_no_fb_loop;
         descriptions[0].format = VK_FORMAT_R8G8B8A8_UNORM;
         descriptions[0].initialLayout = VK_IMAGE_LAYOUT_ATTACHMENT_FEEDBACK_LOOP_OPTIMAL_EXT;
@@ -1387,8 +1386,7 @@ TEST_F(NegativeRenderPass, BeginLayoutsFramebufferImageUsageMismatches) {
             *m_device, 128, 128, VK_FORMAT_R8G8B8A8_UNORM,
             VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT);
         image_view_ci.image = no_usage_sampled_attachment;
-        vkt::ImageView image_view_no_usage_sampled;
-        image_view_no_usage_sampled.init(*m_device, image_view_ci);
+        vkt::ImageView image_view_no_usage_sampled(*m_device, image_view_ci);
         descriptions[1].initialLayout = VK_IMAGE_LAYOUT_ATTACHMENT_FEEDBACK_LOOP_OPTIMAL_EXT;
         views[1] = image_view_no_usage_sampled;
         test_layout_helper("VUID-vkCmdBeginRenderPass-initialLayout-07000", "VUID-vkCmdBeginRenderPass2-initialLayout-07002");
@@ -4295,7 +4293,7 @@ TEST_F(NegativeRenderPass, RenderPassWithRenderPassStripedQueueSubmit2) {
 
     for (uint32_t i = 0; i < stripe_count + 1; ++i) {
         VkSemaphoreCreateInfo create_info = i == 4 ? semaphore_timeline_create_info : semaphore_create_info;
-        semaphore[i].init(*m_device, create_info);
+        semaphore[i].Init(*m_device, create_info);
 
         semaphore_submit_infos[i] = vku::InitStructHelper();
         semaphore_submit_infos[i].semaphore = semaphore[i];

--- a/tests/unit/render_pass_positive.cpp
+++ b/tests/unit/render_pass_positive.cpp
@@ -677,7 +677,7 @@ TEST_F(PositiveRenderPass, FramebufferWithAttachmentsTo3DImageMultipleSubpasses)
     VkImageView views[depth_count] = {VK_NULL_HANDLE};
     for (unsigned i = 0; i < depth_count; ++i) {
         view_info.subresourceRange.baseArrayLayer = i;
-        image_views[i].init(*m_device, view_info);
+        image_views[i].Init(*m_device, view_info);
         views[i] = image_views[i];
     }
 
@@ -776,7 +776,7 @@ TEST_F(PositiveRenderPass, ImageLayoutTransitionOf3dImageWith2dViews) {
     VkImageView views[image_depth] = {VK_NULL_HANDLE};
     for (unsigned i = 0; i < image_depth; ++i) {
         view_info.subresourceRange.baseArrayLayer = i;
-        image_views[i].init(*m_device, view_info);
+        image_views[i].Init(*m_device, view_info);
         views[i] = image_views[i];
     }
 
@@ -1130,7 +1130,7 @@ TEST_F(PositiveRenderPass, BeginRenderPassWithRenderPassStriped) {
     VkSemaphoreSubmitInfo semaphore_submit_infos[stripe_count];
 
     for (uint32_t i = 0; i < stripe_count; ++i) {
-        semaphores[i].init(*m_device, semaphore_create_info);
+        semaphores[i].Init(*m_device, semaphore_create_info);
         semaphore_submit_infos[i] = vku::InitStructHelper();
         semaphore_submit_infos[i].semaphore = semaphores[i];
     }

--- a/tests/unit/secondary_command_buffer_positive.cpp
+++ b/tests/unit/secondary_command_buffer_positive.cpp
@@ -395,17 +395,15 @@ TEST_F(PositiveSecondaryCommandBuffer, EventsIn) {
         GTEST_SKIP() << "VK_KHR_portability_subset enabled, skipping.\n";
     }
 
-    vkt::Event ev(*m_device);
-    VkEvent ev_handle = ev.handle();
+    vkt::Event event(*m_device);
     vkt::CommandBuffer secondary_cb(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
-    VkCommandBuffer scb = secondary_cb.handle();
     secondary_cb.Begin();
-    vk::CmdSetEvent(scb, ev_handle, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT);
-    vk::CmdWaitEvents(scb, 1, &ev_handle, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, nullptr, 0,
-                      nullptr, 0, nullptr);
+    vk::CmdSetEvent(secondary_cb, event, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT);
+    vk::CmdWaitEvents(secondary_cb, 1, &event.handle(), VK_PIPELINE_STAGE_VERTEX_SHADER_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                      0, nullptr, 0, nullptr, 0, nullptr);
     secondary_cb.End();
     m_command_buffer.Begin();
-    vk::CmdExecuteCommands(m_command_buffer, 1, &scb);
+    vk::CmdExecuteCommands(m_command_buffer, 1, &secondary_cb.handle());
     m_command_buffer.End();
 
     m_default_queue->SubmitAndWait(m_command_buffer);
@@ -444,9 +442,9 @@ TEST_F(PositiveSecondaryCommandBuffer, Nested) {
     secondary1.End();
 
     secondary2.Begin(&cbbi);
-    vk::CmdBeginQuery(secondary2.handle(), query_pool, 0, 0);
-    vk::CmdExecuteCommands(secondary2.handle(), 1u, &secondary1.handle());
-    vk::CmdEndQuery(secondary2.handle(), query_pool, 0);
+    vk::CmdBeginQuery(secondary2, query_pool, 0, 0);
+    vk::CmdExecuteCommands(secondary2, 1u, &secondary1.handle());
+    vk::CmdEndQuery(secondary2, query_pool, 0);
     secondary2.End();
 }
 
@@ -488,7 +486,7 @@ TEST_F(PositiveSecondaryCommandBuffer, NestedPrimary) {
     secondary1.End();
 
     secondary2.Begin(&cbbi);
-    vk::CmdExecuteCommands(secondary2.handle(), 1u, &secondary1.handle());
+    vk::CmdExecuteCommands(secondary2, 1u, &secondary1.handle());
     secondary2.End();
 
     // The primary command buffer doesn't count toward nesting

--- a/tests/unit/shader_interface.cpp
+++ b/tests/unit/shader_interface.cpp
@@ -1991,7 +1991,7 @@ TEST_F(NegativeShaderInterface, FragmentOutputDynamicRenderingUnusedAttachments)
 
     VkRenderingAttachmentInfo depth_stencil_attachment = vku::InitStructHelper();
     depth_stencil_attachment.imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-    depth_stencil_attachment.imageView = depth_view.handle();
+    depth_stencil_attachment.imageView = depth_view;
 
     m_command_buffer.Begin();
     VkRenderingInfo begin_rendering_info = vku::InitStructHelper();

--- a/tests/unit/shader_interface_positive.cpp
+++ b/tests/unit/shader_interface_positive.cpp
@@ -466,7 +466,7 @@ TEST_F(PositiveShaderInterface, InputAttachment) {
 
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
-    pipe.gp_ci_.layout = pl.handle();
+    pipe.gp_ci_.layout = pl;
     pipe.gp_ci_.renderPass = rp;
     pipe.CreateGraphicsPipeline();
 }

--- a/tests/unit/shader_object.cpp
+++ b/tests/unit/shader_object.cpp
@@ -418,8 +418,8 @@ TEST_F(NegativeShaderObject, BindVertexAndTaskShaders) {
     vkt::Shader vert_shader(*m_device, ShaderCreateInfo(vert_spv, VK_SHADER_STAGE_VERTEX_BIT));
     vkt::Shader task_shader(*m_device, ShaderCreateInfo(task_spv, VK_SHADER_STAGE_TASK_BIT_EXT));
     VkShaderEXT shaders[] = {
-        vert_shader.handle(),
-        task_shader.handle(),
+        vert_shader,
+        task_shader,
     };
 
     VkShaderStageFlagBits stages[] = {
@@ -446,8 +446,8 @@ TEST_F(NegativeShaderObject, BindVertexAndMeshShaders) {
     vkt::Shader vert_shader(*m_device, ShaderCreateInfo(vert_spv, VK_SHADER_STAGE_VERTEX_BIT));
     vkt::Shader mesh_shader(*m_device, ShaderCreateInfo(mesh_spv, VK_SHADER_STAGE_MESH_BIT_EXT));
     VkShaderEXT shaders[] = {
-        vert_shader.handle(),
-        mesh_shader.handle(),
+        vert_shader,
+        mesh_shader,
     };
 
     VkShaderStageFlagBits stages[] = {
@@ -607,8 +607,8 @@ TEST_F(NegativeShaderObject, NonUniqueShadersBind) {
     vkt::Shader shader2(*m_device, create_info);
 
     VkShaderEXT shaders[] = {
-        shader1.handle(),
-        shader2.handle(),
+        shader1,
+        shader2,
     };
     VkShaderStageFlagBits stages[] = {
         VK_SHADER_STAGE_VERTEX_BIT,
@@ -631,7 +631,6 @@ TEST_F(NegativeShaderObject, InvalidShaderStageBind) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
     vkt::Shader shader(*m_device, ShaderCreateInfo(spv, VK_SHADER_STAGE_VERTEX_BIT));
-    VkShaderEXT shaderHandle = shader.handle();
 
     VkShaderStageFlagBits stage = VK_SHADER_STAGE_ALL_GRAPHICS;
 
@@ -639,7 +638,7 @@ TEST_F(NegativeShaderObject, InvalidShaderStageBind) {
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindShadersEXT-pShaders-08469");
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindShadersEXT-pStages-08464");
-    vk::CmdBindShadersEXT(m_command_buffer, 1u, &stage, &shaderHandle);
+    vk::CmdBindShadersEXT(m_command_buffer, 1u, &stage, &shader.handle());
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.End();
@@ -655,16 +654,15 @@ TEST_F(NegativeShaderObject, GetShaderBinaryDataInvalidPointer) {
 
     const auto spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
     vkt::Shader shader(*m_device, ShaderCreateInfo(spv, VK_SHADER_STAGE_VERTEX_BIT));
-    VkShaderEXT shaderHandle = shader.handle();
 
     size_t dataSize = 0;
-    vk::GetShaderBinaryDataEXT(*m_device, shaderHandle, &dataSize, nullptr);
+    vk::GetShaderBinaryDataEXT(*m_device, shader, &dataSize, nullptr);
     std::vector<uint8_t> data(dataSize + 1u);
     auto ptr = reinterpret_cast<std::uintptr_t>(data.data()) + sizeof(uint8_t);
     void* dataPtr = reinterpret_cast<void*>(ptr);
 
     m_errorMonitor->SetDesiredError("VUID-vkGetShaderBinaryDataEXT-None-08499");
-    vk::GetShaderBinaryDataEXT(*m_device, shaderHandle, &dataSize, dataPtr);
+    vk::GetShaderBinaryDataEXT(*m_device, shader, &dataSize, dataPtr);
     m_errorMonitor->VerifyFound();
 }
 
@@ -2613,7 +2611,7 @@ TEST_F(NegativeShaderObject, MissingTessellationControlBind) {
     SetDefaultDynamicStatesExclude();
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT,
                                             VK_SHADER_STAGE_FRAGMENT_BIT};
-    const VkShaderEXT shaders[] = {m_vert_shader.handle(), VK_NULL_HANDLE, m_frag_shader.handle()};
+    const VkShaderEXT shaders[] = {m_vert_shader, VK_NULL_HANDLE, m_frag_shader};
     vk::CmdBindShadersEXT(m_command_buffer, 3u, stages, shaders);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-08685");
@@ -2641,7 +2639,7 @@ TEST_F(NegativeShaderObject, MissingTessellationEvaluationBind) {
     SetDefaultDynamicStatesExclude();
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT,
                                             VK_SHADER_STAGE_FRAGMENT_BIT};
-    const VkShaderEXT shaders[] = {m_vert_shader.handle(), VK_NULL_HANDLE, m_frag_shader.handle()};
+    const VkShaderEXT shaders[] = {m_vert_shader, VK_NULL_HANDLE, m_frag_shader};
     vk::CmdBindShadersEXT(m_command_buffer, 3u, stages, shaders);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-08686");
@@ -3432,7 +3430,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetDepthWriteEnableEXT) {
     m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_DEPTH_WRITE_ENABLE});
-    vk::CmdSetDepthTestEnableEXT(m_command_buffer.handle(), VK_TRUE);
+    vk::CmdSetDepthTestEnableEXT(m_command_buffer, VK_TRUE);
     m_command_buffer.BindShaders(m_vert_shader, m_frag_shader);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-07844");
@@ -5214,7 +5212,7 @@ TEST_F(NegativeShaderObject, DescriptorNotUpdated) {
     const auto vert_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, vert_src);
     const auto frag_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, frag_src);
 
-    VkDescriptorSetLayout descriptor_set_layouts[] = {vert_descriptor_set.layout_.handle(), frag_descriptor_set.layout_.handle()};
+    VkDescriptorSetLayout descriptor_set_layouts[] = {vert_descriptor_set.layout_, frag_descriptor_set.layout_};
 
     const vkt::Shader vert_shader(*m_device, ShaderCreateInfo(vert_spv, VK_SHADER_STAGE_VERTEX_BIT, 2, descriptor_set_layouts));
     const vkt::Shader frag_shader(*m_device, ShaderCreateInfo(frag_spv, VK_SHADER_STAGE_FRAGMENT_BIT, 2, descriptor_set_layouts));
@@ -6713,8 +6711,7 @@ TEST_F(NegativeShaderObject, DescriptorWrongStageMultipleSets) {
     )glsl";
 
     const auto comp_spv = GLSLToSPV(VK_SHADER_STAGE_COMPUTE_BIT, comp_src);
-    VkDescriptorSetLayout dsl[3] = {descriptor_set0.layout_.handle(), descriptor_set1.layout_.handle(),
-                                    descriptor_set2.layout_.handle()};
+    VkDescriptorSetLayout dsl[3] = {descriptor_set0.layout_, descriptor_set1.layout_, descriptor_set2.layout_};
     VkShaderCreateInfoEXT create_info = ShaderCreateInfo(comp_spv, VK_SHADER_STAGE_COMPUTE_BIT, 3, dsl);
     m_errorMonitor->SetDesiredError("VUID-VkShaderCreateInfoEXT-codeType-10383");
     const vkt::Shader comp_shader(*m_device, create_info);
@@ -6930,7 +6927,7 @@ TEST_F(NegativeShaderObject, TaskMeshShadersDrawWithoutBindingVertex) {
     const vkt::Shader mesh_shader(*m_device, shader_stages[1], mesh_src);
     const vkt::Shader frag_shader(*m_device, shader_stages[2], frag_src);
 
-    VkShaderEXT shaders[3] = {task_shader.handle(), mesh_shader.handle(), frag_shader.handle()};
+    VkShaderEXT shaders[3] = {task_shader, mesh_shader, frag_shader};
 
     vkt::Image image(*m_device, m_width, m_height, VK_FORMAT_R32G32B32A32_SFLOAT,
                      VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
@@ -7025,8 +7022,8 @@ TEST_F(NegativeShaderObject, VertAndMeshShaderBothNotBound) {
                                             VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT,
                                             VK_SHADER_STAGE_GEOMETRY_BIT,
                                             VK_SHADER_STAGE_FRAGMENT_BIT};
-    const VkShaderEXT shaders[] = {VK_NULL_HANDLE, VK_NULL_HANDLE, VK_NULL_HANDLE,      VK_NULL_HANDLE,
-                                   VK_NULL_HANDLE, VK_NULL_HANDLE, frag_shader.handle()};
+    const VkShaderEXT shaders[] = {VK_NULL_HANDLE, VK_NULL_HANDLE, VK_NULL_HANDLE, VK_NULL_HANDLE,
+                                   VK_NULL_HANDLE, VK_NULL_HANDLE, frag_shader};
     vk::CmdBindShadersEXT(m_command_buffer, 7u, stages, shaders);
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-08693");
     vk::CmdDraw(m_command_buffer, 4, 1, 0, 0);

--- a/tests/unit/shader_object_positive.cpp
+++ b/tests/unit/shader_object_positive.cpp
@@ -55,14 +55,14 @@ void ShaderObjectTest::CreateMinimalShaders() {
     create_info.codeSize = vert_spirv.size() * sizeof(uint32_t);
     create_info.pCode = vert_spirv.data();
     create_info.pName = "main";
-    m_vert_shader.init(*m_device, create_info);
+    m_vert_shader.Init(*m_device, create_info);
 
     std::vector<uint32_t> frag_spirv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
     create_info.stage = VK_SHADER_STAGE_FRAGMENT_BIT;
     create_info.nextStage = 0u;
     create_info.codeSize = frag_spirv.size() * sizeof(uint32_t);
     create_info.pCode = frag_spirv.data();
-    m_frag_shader.init(*m_device, create_info);
+    m_frag_shader.Init(*m_device, create_info);
 }
 
 TEST_F(PositiveShaderObject, CreateAndDestroyShaderObject) {
@@ -125,14 +125,14 @@ TEST_F(PositiveShaderObject, DrawWithVertAndFragBinaryShaderObjects) {
     CreateMinimalShaders();
 
     size_t vertDataSize;
-    vk::GetShaderBinaryDataEXT(*m_device, m_vert_shader.handle(), &vertDataSize, nullptr);
+    vk::GetShaderBinaryDataEXT(*m_device, m_vert_shader, &vertDataSize, nullptr);
     std::vector<uint8_t> vertData(vertDataSize);
-    vk::GetShaderBinaryDataEXT(*m_device, m_vert_shader.handle(), &vertDataSize, vertData.data());
+    vk::GetShaderBinaryDataEXT(*m_device, m_vert_shader, &vertDataSize, vertData.data());
 
     size_t fragDataSize;
-    vk::GetShaderBinaryDataEXT(*m_device, m_frag_shader.handle(), &fragDataSize, nullptr);
+    vk::GetShaderBinaryDataEXT(*m_device, m_frag_shader, &fragDataSize, nullptr);
     std::vector<uint8_t> fragData(fragDataSize);
-    vk::GetShaderBinaryDataEXT(*m_device, m_frag_shader.handle(), &fragDataSize, fragData.data());
+    vk::GetShaderBinaryDataEXT(*m_device, m_frag_shader, &fragDataSize, fragData.data());
 
     vkt::Shader binary_vert_shader(*m_device, VK_SHADER_STAGE_VERTEX_BIT, vertData);
     vkt::Shader binary_frag_shader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT, fragData);
@@ -756,7 +756,7 @@ TEST_F(PositiveShaderObject, ShadersDescriptorSets) {
     const auto vert_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, vert_src);
     const auto frag_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, frag_src);
 
-    VkDescriptorSetLayout descriptor_set_layouts[] = {vert_descriptor_set.layout_.handle(), frag_descriptor_set.layout_.handle()};
+    VkDescriptorSetLayout descriptor_set_layouts[] = {vert_descriptor_set.layout_, frag_descriptor_set.layout_};
 
     const vkt::Shader vert_shader(*m_device, ShaderCreateInfo(vert_spv, VK_SHADER_STAGE_VERTEX_BIT, 2, descriptor_set_layouts));
     const vkt::Shader frag_shader(*m_device, ShaderCreateInfo(frag_spv, VK_SHADER_STAGE_FRAGMENT_BIT, 2, descriptor_set_layouts));
@@ -1056,7 +1056,7 @@ TEST_F(PositiveShaderObject, DrawInSecondaryCommandBuffers) {
     command_buffer.Begin();
     command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     command_buffer.BindShaders(m_vert_shader, m_frag_shader);
-    SetDefaultDynamicStatesExclude({}, false, command_buffer.handle());
+    SetDefaultDynamicStatesExclude({}, false, command_buffer);
     vk::CmdDraw(command_buffer, 4, 1, 0, 0);
     command_buffer.EndRendering();
     command_buffer.End();
@@ -1177,7 +1177,7 @@ TEST_F(PositiveShaderObject, DrawInSecondaryCommandBuffersWithRenderPassContinue
     begin_info.pInheritanceInfo = &hinfo;
     command_buffer.Begin(&begin_info);
     command_buffer.BindShaders(m_vert_shader, m_frag_shader);
-    SetDefaultDynamicStatesExclude({}, false, command_buffer.handle());
+    SetDefaultDynamicStatesExclude({}, false, command_buffer);
     vk::CmdDraw(command_buffer, 4, 1, 0, 0);
     command_buffer.End();
 

--- a/tests/unit/shader_push_constants.cpp
+++ b/tests/unit/shader_push_constants.cpp
@@ -134,7 +134,7 @@ TEST_F(NegativeShaderPushConstants, PipelineRangeShaderObject) {
 
     // stageFlags of 0
     m_errorMonitor->SetDesiredError("VUID-VkPushConstantRange-stageFlags-requiredbitmask");
-    shader.init(*m_device, ci_info);
+    shader.Init(*m_device, ci_info);
     m_errorMonitor->VerifyFound();
 
     // will be at least 256 as required from the spec
@@ -144,37 +144,37 @@ TEST_F(NegativeShaderPushConstants, PipelineRangeShaderObject) {
     push_constant_range = {VK_SHADER_STAGE_VERTEX_BIT, maxPushConstantsSize, 8};
     m_errorMonitor->SetDesiredError("VUID-VkPushConstantRange-offset-00294");
     m_errorMonitor->SetDesiredError("VUID-VkPushConstantRange-size-00298");
-    shader.init(*m_device, ci_info);
+    shader.Init(*m_device, ci_info);
     m_errorMonitor->VerifyFound();
 
     // offset not a multiple of 4
     push_constant_range = {VK_SHADER_STAGE_VERTEX_BIT, 1, 8};
     m_errorMonitor->SetDesiredError("VUID-VkPushConstantRange-offset-00295");
-    shader.init(*m_device, ci_info);
+    shader.Init(*m_device, ci_info);
     m_errorMonitor->VerifyFound();
 
     // size of 0
     push_constant_range = {VK_SHADER_STAGE_VERTEX_BIT, 0, 0};
     m_errorMonitor->SetDesiredError("VUID-VkPushConstantRange-size-00296");
-    shader.init(*m_device, ci_info);
+    shader.Init(*m_device, ci_info);
     m_errorMonitor->VerifyFound();
 
     // size not a multiple of 4
     push_constant_range = {VK_SHADER_STAGE_VERTEX_BIT, 0, 7};
     m_errorMonitor->SetDesiredError("VUID-VkPushConstantRange-size-00297");
-    shader.init(*m_device, ci_info);
+    shader.Init(*m_device, ci_info);
     m_errorMonitor->VerifyFound();
 
     // size over limit
     push_constant_range = {VK_SHADER_STAGE_VERTEX_BIT, 0, maxPushConstantsSize + 4};
     m_errorMonitor->SetDesiredError("VUID-VkPushConstantRange-size-00298");
-    shader.init(*m_device, ci_info);
+    shader.Init(*m_device, ci_info);
     m_errorMonitor->VerifyFound();
 
     // size over limit of non-zero offset
     push_constant_range = {VK_SHADER_STAGE_VERTEX_BIT, 4, maxPushConstantsSize};
     m_errorMonitor->SetDesiredError("VUID-VkPushConstantRange-size-00298");
-    shader.init(*m_device, ci_info);
+    shader.Init(*m_device, ci_info);
     m_errorMonitor->VerifyFound();
 
     push_constant_range = {VK_SHADER_STAGE_VERTEX_BIT, 0, maxPushConstantsSize};
@@ -183,7 +183,7 @@ TEST_F(NegativeShaderPushConstants, PipelineRangeShaderObject) {
     ci_info.pushConstantRangeCount = 2;
     ci_info.pPushConstantRanges = push_constant_range_duplicate;
     m_errorMonitor->SetDesiredError("VUID-VkShaderCreateInfoEXT-pPushConstantRanges-10063");
-    shader.init(*m_device, ci_info);
+    shader.Init(*m_device, ci_info);
     m_errorMonitor->VerifyFound();
 }
 

--- a/tests/unit/shader_push_constants_positive.cpp
+++ b/tests/unit/shader_push_constants_positive.cpp
@@ -317,9 +317,9 @@ TEST_F(PositiveShaderPushConstants, CompatibilityGraphicsOnly) {
     pipeline_helper_c.CreateGraphicsPipeline();
 
     // Easier to see in command buffers
-    const VkPipelineLayout layout_a = pipeline_helper_a.pipeline_layout_.handle();
-    const VkPipelineLayout layout_b = pipeline_helper_b.pipeline_layout_.handle();
-    const VkPipelineLayout layout_c = pipeline_helper_c.pipeline_layout_.handle();
+    const VkPipelineLayout layout_a = pipeline_helper_a.pipeline_layout_;
+    const VkPipelineLayout layout_b = pipeline_helper_b.pipeline_layout_;
+    const VkPipelineLayout layout_c = pipeline_helper_c.pipeline_layout_;
     const VkPipeline pipeline_a = pipeline_helper_a;
     const VkPipeline pipeline_b = pipeline_helper_b;
     const VkPipeline pipeline_c = pipeline_helper_c;

--- a/tests/unit/shader_storage_image.cpp
+++ b/tests/unit/shader_storage_image.cpp
@@ -277,8 +277,8 @@ TEST_F(NegativeShaderStorageImage, MissingFormatReadForFormat) {
         }
 
         vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, cs_pipeline);
-        vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, cs_pipeline.pipeline_layout_.handle(), 0, 1,
-                                  &ds.set_, 0, nullptr);
+        vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, cs_pipeline.pipeline_layout_, 0, 1, &ds.set_, 0,
+                                  nullptr);
 
         m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-OpTypeImage-07028");
         vk::CmdDispatch(m_command_buffer, 1, 1, 1);
@@ -421,8 +421,8 @@ TEST_F(NegativeShaderStorageImage, MissingFormatWriteForFormat) {
         }
 
         vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, cs_pipeline);
-        vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, cs_pipeline.pipeline_layout_.handle(), 0, 1,
-                                  &ds.set_, 0, nullptr);
+        vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, cs_pipeline.pipeline_layout_, 0, 1, &ds.set_, 0,
+                                  nullptr);
 
         if ((tests[t].props.optimalTilingFeatures & VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT) == 0) {
             m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-OpTypeImage-07027");

--- a/tests/unit/shader_storage_texel.cpp
+++ b/tests/unit/shader_storage_texel.cpp
@@ -325,8 +325,8 @@ TEST_F(NegativeShaderStorageTexel, MissingFormatWriteForFormat) {
     m_command_buffer.Begin();
 
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, cs_pipeline);
-    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, cs_pipeline.pipeline_layout_.handle(), 0, 1,
-                              &ds.set_, 0, nullptr);
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, cs_pipeline.pipeline_layout_, 0, 1, &ds.set_, 0,
+                              nullptr);
     m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-OpTypeImage-07029");
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
     m_errorMonitor->VerifyFound();

--- a/tests/unit/sparse_buffer.cpp
+++ b/tests/unit/sparse_buffer.cpp
@@ -32,19 +32,18 @@ TEST_F(NegativeSparseBuffer, QueueBindSparseMemoryBindSize) {
     vkt::Buffer buffer_sparse(*m_device, b_info, vkt::no_mem);
 
     VkMemoryRequirements buffer_mem_reqs;
-    vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
+    vk::GetBufferMemoryRequirements(device(), buffer_sparse, &buffer_mem_reqs);
     const auto buffer_mem_alloc =
         vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer_mem_reqs, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
-    vkt::DeviceMemory buffer_mem;
-    buffer_mem.init(*m_device, buffer_mem_alloc);
+    vkt::DeviceMemory buffer_mem(*m_device, buffer_mem_alloc);
 
     VkSparseMemoryBind buffer_memory_bind = {};
     buffer_memory_bind.size = 0u;  // This will trigger the VUID we are testing
-    buffer_memory_bind.memory = buffer_mem.handle();
+    buffer_memory_bind.memory = buffer_mem;
 
     VkSparseBufferMemoryBindInfo buffer_memory_bind_info{};
-    buffer_memory_bind_info.buffer = buffer_sparse.handle();
+    buffer_memory_bind_info.buffer = buffer_sparse;
     buffer_memory_bind_info.bindCount = 1;
     buffer_memory_bind_info.pBinds = &buffer_memory_bind;
 
@@ -74,34 +73,33 @@ TEST_F(NegativeSparseBuffer, QueueBindSparseMemoryBindAlignments) {
     vkt::Buffer buffer_sparse(*m_device, b_info, vkt::no_mem);
 
     VkMemoryRequirements buffer_mem_reqs;
-    vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
+    vk::GetBufferMemoryRequirements(device(), buffer_sparse, &buffer_mem_reqs);
     if (buffer_mem_reqs.alignment == 1) {
         GTEST_SKIP() << "Need buffer memory required alignment to be more than 1";
     }
     const auto buffer_mem_alloc =
         vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer_mem_reqs, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
-    vkt::DeviceMemory buffer_mem;
-    buffer_mem.init(*m_device, buffer_mem_alloc);
+    vkt::DeviceMemory buffer_mem(*m_device, buffer_mem_alloc);
 
     std::array<VkSparseMemoryBind, 3> buffer_memory_binds = {};
     buffer_memory_binds[0].resourceOffset = 0;
     buffer_memory_binds[0].size = 1u;  // Unaligned
-    buffer_memory_binds[0].memory = buffer_mem.handle();
+    buffer_memory_binds[0].memory = buffer_mem;
     buffer_memory_binds[0].memoryOffset = 0;
 
     buffer_memory_binds[1].resourceOffset = 1;  // Unaligned
     buffer_memory_binds[1].size = 0x10000;
-    buffer_memory_binds[1].memory = buffer_mem.handle();
+    buffer_memory_binds[1].memory = buffer_mem;
     buffer_memory_binds[1].memoryOffset = 0;
 
     buffer_memory_binds[2].resourceOffset = 0;
     buffer_memory_binds[2].size = 0x10000;
-    buffer_memory_binds[2].memory = buffer_mem.handle();
+    buffer_memory_binds[2].memory = buffer_mem;
     buffer_memory_binds[2].memoryOffset = 1;  // Unaligned
 
     VkSparseBufferMemoryBindInfo buffer_memory_bind_info{};
-    buffer_memory_bind_info.buffer = buffer_sparse.handle();
+    buffer_memory_bind_info.buffer = buffer_sparse;
     buffer_memory_bind_info.bindCount = size32(buffer_memory_binds);
     buffer_memory_bind_info.pBinds = buffer_memory_binds.data();
 
@@ -134,21 +132,20 @@ TEST_F(NegativeSparseBuffer, QueueBindSparseMemoryBindResourceOffset) {
     vkt::Buffer buffer_sparse(*m_device, b_info, vkt::no_mem);
 
     VkMemoryRequirements buffer_mem_reqs;
-    vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
+    vk::GetBufferMemoryRequirements(device(), buffer_sparse, &buffer_mem_reqs);
     const auto buffer_mem_alloc =
         vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer_mem_reqs, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
-    vkt::DeviceMemory buffer_mem;
-    buffer_mem.init(*m_device, buffer_mem_alloc);
+    vkt::DeviceMemory buffer_mem(*m_device, buffer_mem_alloc);
 
     VkSparseMemoryBind buffer_memory_bind = {};
     buffer_memory_bind.size = buffer_mem_reqs.size;
-    buffer_memory_bind.memory = buffer_mem.handle();
+    buffer_memory_bind.memory = buffer_mem;
     // This will trigger the VUID we are testing
     buffer_memory_bind.resourceOffset = buffer_mem_reqs.size + buffer_mem_reqs.size;
 
     VkSparseBufferMemoryBindInfo buffer_memory_bind_info{};
-    buffer_memory_bind_info.buffer = buffer_sparse.handle();
+    buffer_memory_bind_info.buffer = buffer_sparse;
     buffer_memory_bind_info.bindCount = 1;
     buffer_memory_bind_info.pBinds = &buffer_memory_bind;
 
@@ -178,21 +175,20 @@ TEST_F(NegativeSparseBuffer, QueueBindSparseMemoryBindSizeResourceOffset) {
     vkt::Buffer buffer_sparse(*m_device, b_info, vkt::no_mem);
 
     VkMemoryRequirements buffer_mem_reqs;
-    vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
+    vk::GetBufferMemoryRequirements(device(), buffer_sparse, &buffer_mem_reqs);
     const auto buffer_mem_alloc =
         vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer_mem_reqs, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
-    vkt::DeviceMemory buffer_mem;
-    buffer_mem.init(*m_device, buffer_mem_alloc);
+    vkt::DeviceMemory buffer_mem(*m_device, buffer_mem_alloc);
 
     VkSparseMemoryBind buffer_memory_bind = {};
-    buffer_memory_bind.memory = buffer_mem.handle();
+    buffer_memory_bind.memory = buffer_mem;
     // This will trigger the VUID we are testing
     buffer_memory_bind.resourceOffset = 100;
     buffer_memory_bind.size = buffer_mem_reqs.size;
 
     VkSparseBufferMemoryBindInfo buffer_memory_bind_info{};
-    buffer_memory_bind_info.buffer = buffer_sparse.handle();
+    buffer_memory_bind_info.buffer = buffer_sparse;
     buffer_memory_bind_info.bindCount = 1;
     buffer_memory_bind_info.pBinds = &buffer_memory_bind;
 
@@ -226,21 +222,20 @@ TEST_F(NegativeSparseBuffer, QueueBindSparseMemoryBindSizeMemoryOffset) {
     vkt::Buffer buffer_sparse(*m_device, b_info, vkt::no_mem);
 
     VkMemoryRequirements buffer_mem_reqs;
-    vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
+    vk::GetBufferMemoryRequirements(device(), buffer_sparse, &buffer_mem_reqs);
     const auto buffer_mem_alloc =
         vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer_mem_reqs, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
-    vkt::DeviceMemory buffer_mem;
-    buffer_mem.init(*m_device, buffer_mem_alloc);
+    vkt::DeviceMemory buffer_mem(*m_device, buffer_mem_alloc);
 
     VkSparseMemoryBind buffer_memory_bind = {};
-    buffer_memory_bind.memory = buffer_mem.handle();
+    buffer_memory_bind.memory = buffer_mem;
     // This will trigger the VUID we are testing
     buffer_memory_bind.memoryOffset = buffer_mem_alloc.allocationSize - 1;
     buffer_memory_bind.size = buffer_mem_reqs.size;
 
     VkSparseBufferMemoryBindInfo buffer_memory_bind_info{};
-    buffer_memory_bind_info.buffer = buffer_sparse.handle();
+    buffer_memory_bind_info.buffer = buffer_sparse;
     buffer_memory_bind_info.bindCount = 1;
     buffer_memory_bind_info.pBinds = &buffer_memory_bind;
 
@@ -283,22 +278,21 @@ TEST_F(NegativeSparseBuffer, OverlappingBufferCopy) {
     vkt::Buffer buffer_sparse2(*m_device, b_info, vkt::no_mem);
 
     VkMemoryRequirements buffer_mem_reqs;
-    vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
+    vk::GetBufferMemoryRequirements(device(), buffer_sparse, &buffer_mem_reqs);
     VkMemoryAllocateInfo buffer_mem_alloc =
         vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer_mem_reqs, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
-    vkt::DeviceMemory buffer_mem;
-    buffer_mem.init(*m_device, buffer_mem_alloc);
+    vkt::DeviceMemory buffer_mem(*m_device, buffer_mem_alloc);
 
     VkSparseMemoryBind buffer_memory_bind = {};
     buffer_memory_bind.size = buffer_mem_reqs.size;
-    buffer_memory_bind.memory = buffer_mem.handle();
+    buffer_memory_bind.memory = buffer_mem;
 
     VkSparseBufferMemoryBindInfo buffer_memory_bind_infos[2] = {};
-    buffer_memory_bind_infos[0].buffer = buffer_sparse.handle();
+    buffer_memory_bind_infos[0].buffer = buffer_sparse;
     buffer_memory_bind_infos[0].bindCount = 1;
     buffer_memory_bind_infos[0].pBinds = &buffer_memory_bind;
-    buffer_memory_bind_infos[1].buffer = buffer_sparse2.handle();
+    buffer_memory_bind_infos[1].buffer = buffer_sparse2;
     buffer_memory_bind_infos[1].bindCount = 1;
     buffer_memory_bind_infos[1].pBinds = &buffer_memory_bind;
 
@@ -317,7 +311,7 @@ TEST_F(NegativeSparseBuffer, OverlappingBufferCopy) {
     m_command_buffer.Begin();
     // This copy is not legal since both buffers share same device memory range, and none of them will be rebound
     // to non overlapping device memory ranges. Reported at queue submit
-    vk::CmdCopyBuffer(m_command_buffer, buffer_sparse.handle(), buffer_sparse2.handle(), 1, &copy_info);
+    vk::CmdCopyBuffer(m_command_buffer, buffer_sparse, buffer_sparse2, 1, &copy_info);
     m_command_buffer.End();
 
     // Submitting copy command with overlapping device memory regions
@@ -373,19 +367,18 @@ TEST_F(NegativeSparseBuffer, OverlappingBufferCopy2) {
     vkt::Buffer buffer_sparse(*m_device, b_info, vkt::no_mem);
 
     VkMemoryRequirements buffer_mem_reqs;
-    vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
+    vk::GetBufferMemoryRequirements(device(), buffer_sparse, &buffer_mem_reqs);
     VkMemoryAllocateInfo buffer_mem_alloc =
         vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer_mem_reqs, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
-    vkt::DeviceMemory buffer_mem;
-    buffer_mem.init(*m_device, buffer_mem_alloc);
+    vkt::DeviceMemory buffer_mem(*m_device, buffer_mem_alloc);
 
     VkSparseMemoryBind buffer_memory_bind_1 = {};
     buffer_memory_bind_1.size = buffer_mem_reqs.size;
-    buffer_memory_bind_1.memory = buffer_mem.handle();
+    buffer_memory_bind_1.memory = buffer_mem;
 
     std::array<VkSparseBufferMemoryBindInfo, 1> buffer_memory_bind_infos = {};
-    buffer_memory_bind_infos[0].buffer = buffer_sparse.handle();
+    buffer_memory_bind_infos[0].buffer = buffer_sparse;
     buffer_memory_bind_infos[0].bindCount = 1;
     buffer_memory_bind_infos[0].pBinds = &buffer_memory_bind_1;
 
@@ -402,8 +395,7 @@ TEST_F(NegativeSparseBuffer, OverlappingBufferCopy2) {
     // Set up complete
 
     m_command_buffer.Begin();
-    vk::CmdCopyBuffer(m_command_buffer, buffer_sparse.handle(), buffer_sparse.handle(), size32(copy_info_list),
-                      copy_info_list.data());
+    vk::CmdCopyBuffer(m_command_buffer, buffer_sparse, buffer_sparse, size32(copy_info_list), copy_info_list.data());
     m_command_buffer.End();
 
     // Submitting copy command with overlapping device memory regions
@@ -441,7 +433,7 @@ TEST_F(NegativeSparseBuffer, OverlappingBufferCopy3) {
     vkt::Buffer buffer_sparse(*m_device, buffer_ci, vkt::no_mem);
 
     VkMemoryRequirements buffer_mem_reqs;
-    vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
+    vk::GetBufferMemoryRequirements(device(), buffer_sparse, &buffer_mem_reqs);
     if (buffer_mem_reqs.alignment <= 1) {
         GTEST_SKIP() << "Buffer copy will not work as intended if VkMemoryRequirements::alignment is not superior to 1";
     }
@@ -451,20 +443,18 @@ TEST_F(NegativeSparseBuffer, OverlappingBufferCopy3) {
     VkMemoryAllocateInfo buffer_mem_alloc =
         vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer_mem_reqs, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
-    vkt::DeviceMemory buffer_mem_1;
-    buffer_mem_1.init(*m_device, buffer_mem_alloc);
-    vkt::DeviceMemory buffer_mem_2;
-    buffer_mem_2.init(*m_device, buffer_mem_alloc);
+    vkt::DeviceMemory buffer_mem_1(*m_device, buffer_mem_alloc);
+    vkt::DeviceMemory buffer_mem_2(*m_device, buffer_mem_alloc);
 
     std::array<VkSparseMemoryBind, 2> buffer_memory_binds = {};
     buffer_memory_binds[0].size = buffer_mem_reqs.alignment;
-    buffer_memory_binds[0].memory = buffer_mem_1.handle();
+    buffer_memory_binds[0].memory = buffer_mem_1;
     buffer_memory_binds[1].resourceOffset = buffer_mem_reqs.alignment;
     buffer_memory_binds[1].size = buffer_mem_reqs.alignment;
-    buffer_memory_binds[1].memory = buffer_mem_2.handle();
+    buffer_memory_binds[1].memory = buffer_mem_2;
 
     VkSparseBufferMemoryBindInfo buffer_memory_bind_info = {};
-    buffer_memory_bind_info.buffer = buffer_sparse.handle();
+    buffer_memory_bind_info.buffer = buffer_sparse;
     buffer_memory_bind_info.bindCount = size32(buffer_memory_binds);
     buffer_memory_bind_info.pBinds = buffer_memory_binds.data();
 
@@ -486,7 +476,7 @@ TEST_F(NegativeSparseBuffer, OverlappingBufferCopy3) {
                                                           // => since overlaps are computed in buffer space, none should be detected
     copy_info.size = buffer_mem_reqs.alignment;
     m_command_buffer.Begin();
-    vk::CmdCopyBuffer(m_command_buffer, buffer_sparse.handle(), buffer_sparse.handle(), 1, &copy_info);
+    vk::CmdCopyBuffer(m_command_buffer, buffer_sparse, buffer_sparse, 1, &copy_info);
     m_command_buffer.End();
 
     // Submitting copy command with overlapping device memory regions
@@ -541,17 +531,16 @@ TEST_F(NegativeSparseBuffer, OverlappingBufferCopy4) {
     VkMemoryAllocateInfo buffer_mem_alloc =
         vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer_sparse_mem_reqs, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
-    vkt::DeviceMemory buffer_mem;
-    buffer_mem.init(*m_device, buffer_mem_alloc);
+    vkt::DeviceMemory buffer_mem(*m_device, buffer_mem_alloc);
 
     buffer_not_sparse.BindMemory(buffer_mem, 0);
 
     VkSparseMemoryBind buffer_memory_bind = {};
     buffer_memory_bind.size = buffer_sparse_mem_reqs.size;
-    buffer_memory_bind.memory = buffer_mem.handle();
+    buffer_memory_bind.memory = buffer_mem;
 
     VkSparseBufferMemoryBindInfo buffer_memory_bind_info = {};
-    buffer_memory_bind_info.buffer = buffer_sparse.handle();
+    buffer_memory_bind_info.buffer = buffer_sparse;
     buffer_memory_bind_info.bindCount = 1;
     buffer_memory_bind_info.pBinds = &buffer_memory_bind;
 
@@ -570,7 +559,7 @@ TEST_F(NegativeSparseBuffer, OverlappingBufferCopy4) {
     m_command_buffer.Begin();
     // This copy is not legal since both buffers share same device memory range, and none of them will be rebound
     // to non overlapping device memory ranges. Reported at queue submit
-    vk::CmdCopyBuffer(m_command_buffer, buffer_not_sparse.handle(), buffer_sparse.handle(), 1, &copy_info);
+    vk::CmdCopyBuffer(m_command_buffer, buffer_not_sparse, buffer_sparse, 1, &copy_info);
     m_command_buffer.End();
 
     // Submitting copy command with overlapping device memory regions
@@ -678,12 +667,11 @@ TEST_F(NegativeSparseBuffer, VkSparseMemoryBindFlags) {
     VkMemoryAllocateInfo buffer_mem_alloc =
         vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer_mem_reqs, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
-    vkt::DeviceMemory buffer_mem;
-    buffer_mem.init(*m_device, buffer_mem_alloc);
+    vkt::DeviceMemory buffer_mem(*m_device, buffer_mem_alloc);
 
     VkSparseMemoryBind buffer_memory_bind = {};
     buffer_memory_bind.size = 256;
-    buffer_memory_bind.memory = buffer_mem.handle();
+    buffer_memory_bind.memory = buffer_mem;
     buffer_memory_bind.memoryOffset = 0;
     buffer_memory_bind.flags = 0xBAD00000;
 

--- a/tests/unit/sparse_buffer_positive.cpp
+++ b/tests/unit/sparse_buffer_positive.cpp
@@ -41,24 +41,22 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy) {
     vkt::Buffer buffer_sparse2(*m_device, b_info, vkt::no_mem);
 
     VkMemoryRequirements buffer_mem_reqs;
-    vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
+    vk::GetBufferMemoryRequirements(device(), buffer_sparse, &buffer_mem_reqs);
     VkMemoryAllocateInfo buffer_mem_alloc =
         vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer_mem_reqs, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
-    vkt::DeviceMemory buffer_mem;
-    buffer_mem.init(*m_device, buffer_mem_alloc);
-    vkt::DeviceMemory buffer_mem2;
-    buffer_mem2.init(*m_device, buffer_mem_alloc);
+    vkt::DeviceMemory buffer_mem(*m_device, buffer_mem_alloc);
+    vkt::DeviceMemory buffer_mem2(*m_device, buffer_mem_alloc);
 
     VkSparseMemoryBind buffer_memory_bind = {};
     buffer_memory_bind.size = buffer_mem_reqs.size;
-    buffer_memory_bind.memory = buffer_mem.handle();
+    buffer_memory_bind.memory = buffer_mem;
 
     VkSparseBufferMemoryBindInfo buffer_memory_bind_infos[2] = {};
-    buffer_memory_bind_infos[0].buffer = buffer_sparse.handle();
+    buffer_memory_bind_infos[0].buffer = buffer_sparse;
     buffer_memory_bind_infos[0].bindCount = 1;
     buffer_memory_bind_infos[0].pBinds = &buffer_memory_bind;
-    buffer_memory_bind_infos[1].buffer = buffer_sparse2.handle();
+    buffer_memory_bind_infos[1].buffer = buffer_sparse2;
     buffer_memory_bind_infos[1].bindCount = 1;
     buffer_memory_bind_infos[1].pBinds = &buffer_memory_bind;
 
@@ -76,11 +74,11 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy) {
     m_command_buffer.Begin();
     // This copy is be completely legal as long as we change the memory for buffer_sparse to not overlap with
     // buffer_sparse2's memory on queue submission
-    vk::CmdCopyBuffer(m_command_buffer, buffer_sparse.handle(), buffer_sparse2.handle(), 1, &copy_info);
+    vk::CmdCopyBuffer(m_command_buffer, buffer_sparse, buffer_sparse2, 1, &copy_info);
     m_command_buffer.End();
 
     // Rebind buffer_mem2 so it does not overlap
-    buffer_memory_bind.memory = buffer_mem2.handle();
+    buffer_memory_bind.memory = buffer_mem2;
     bind_info.bufferBindCount = 1;
     bind_info.waitSemaphoreCount = 1;
     bind_info.pWaitSemaphores = &semaphore.handle();
@@ -134,7 +132,7 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy2) {
     vkt::Buffer buffer_sparse(*m_device, b_info, vkt::no_mem);
 
     VkMemoryRequirements buffer_mem_reqs;
-    vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
+    vk::GetBufferMemoryRequirements(device(), buffer_sparse, &buffer_mem_reqs);
     VkMemoryAllocateInfo buffer_mem_alloc =
         vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer_mem_reqs, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
@@ -142,10 +140,10 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy2) {
 
     VkSparseMemoryBind buffer_memory_bind_1 = {};
     buffer_memory_bind_1.size = buffer_mem_reqs.size;
-    buffer_memory_bind_1.memory = buffer_mem.handle();
+    buffer_memory_bind_1.memory = buffer_mem;
 
     std::array<VkSparseBufferMemoryBindInfo, 1> buffer_memory_bind_infos = {};
-    buffer_memory_bind_infos[0].buffer = buffer_sparse.handle();
+    buffer_memory_bind_infos[0].buffer = buffer_sparse;
     buffer_memory_bind_infos[0].bindCount = 1;
     buffer_memory_bind_infos[0].pBinds = &buffer_memory_bind_1;
 
@@ -162,8 +160,7 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy2) {
     // Set up complete
 
     m_command_buffer.Begin();
-    vk::CmdCopyBuffer(m_command_buffer, buffer_sparse.handle(), buffer_sparse.handle(), size32(copy_info_list),
-                      copy_info_list.data());
+    vk::CmdCopyBuffer(m_command_buffer, buffer_sparse, buffer_sparse, size32(copy_info_list), copy_info_list.data());
     m_command_buffer.End();
 
     // Submitting copy command with overlapping device memory regions
@@ -198,7 +195,7 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy3) {
     vkt::Buffer buffer_sparse(*m_device, buffer_ci, vkt::no_mem);
 
     VkMemoryRequirements buffer_mem_reqs;
-    vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
+    vk::GetBufferMemoryRequirements(device(), buffer_sparse, &buffer_mem_reqs);
     buffer_sparse.destroy();
     buffer_ci.size = 2 * buffer_mem_reqs.alignment;
     buffer_sparse.InitNoMemory(*m_device, buffer_ci);
@@ -216,13 +213,13 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy3) {
 
     std::array<VkSparseMemoryBind, 2> buffer_memory_binds = {};
     buffer_memory_binds[0].size = buffer_mem_reqs.alignment;
-    buffer_memory_binds[0].memory = buffer_mem_1.handle();
+    buffer_memory_binds[0].memory = buffer_mem_1;
     buffer_memory_binds[1].resourceOffset = buffer_mem_reqs.alignment;
     buffer_memory_binds[1].size = buffer_mem_reqs.alignment;
-    buffer_memory_binds[1].memory = buffer_mem_2.handle();
+    buffer_memory_binds[1].memory = buffer_mem_2;
 
     VkSparseBufferMemoryBindInfo buffer_memory_bind_info = {};
-    buffer_memory_bind_info.buffer = buffer_sparse.handle();
+    buffer_memory_bind_info.buffer = buffer_sparse;
     buffer_memory_bind_info.bindCount = size32(buffer_memory_binds);
     buffer_memory_bind_info.pBinds = buffer_memory_binds.data();
 
@@ -239,7 +236,7 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy3) {
     // Set up complete
 
     m_command_buffer.Begin();
-    vk::CmdCopyBuffer(m_command_buffer, buffer_sparse.handle(), buffer_sparse.handle(), 1, &copy_info);
+    vk::CmdCopyBuffer(m_command_buffer, buffer_sparse, buffer_sparse, 1, &copy_info);
     m_command_buffer.End();
 
     // Submitting copy command with overlapping device memory regions
@@ -275,7 +272,7 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy4) {
     vkt::Buffer buffer_sparse(*m_device, buffer_ci, vkt::no_mem);
 
     VkMemoryRequirements buffer_mem_reqs;
-    vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
+    vk::GetBufferMemoryRequirements(device(), buffer_sparse, &buffer_mem_reqs);
     if (buffer_mem_reqs.alignment <= 1) {
         GTEST_SKIP() << "Buffer copy will not work as intended if VkMemoryRequirements::alignment is not superior to 1";
     }
@@ -290,13 +287,13 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy4) {
 
     std::array<VkSparseMemoryBind, 2> buffer_memory_binds = {};
     buffer_memory_binds[0].size = buffer_mem_reqs.alignment;
-    buffer_memory_binds[0].memory = buffer_mem_1.handle();
+    buffer_memory_binds[0].memory = buffer_mem_1;
     buffer_memory_binds[1].resourceOffset = buffer_mem_reqs.alignment;
     buffer_memory_binds[1].size = buffer_mem_reqs.alignment;
-    buffer_memory_binds[1].memory = buffer_mem_2.handle();
+    buffer_memory_binds[1].memory = buffer_mem_2;
 
     VkSparseBufferMemoryBindInfo buffer_memory_bind_info = {};
-    buffer_memory_bind_info.buffer = buffer_sparse.handle();
+    buffer_memory_bind_info.buffer = buffer_sparse;
     buffer_memory_bind_info.bindCount = size32(buffer_memory_binds);
     buffer_memory_bind_info.pBinds = buffer_memory_binds.data();
 
@@ -318,7 +315,7 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy4) {
                                                           // => since overlaps are computed in buffer space, none should be detected
     copy_info.size = buffer_mem_reqs.alignment / 2;
     m_command_buffer.Begin();
-    vk::CmdCopyBuffer(m_command_buffer, buffer_sparse.handle(), buffer_sparse.handle(), 1, &copy_info);
+    vk::CmdCopyBuffer(m_command_buffer, buffer_sparse, buffer_sparse, 1, &copy_info);
     m_command_buffer.End();
 
     // Submitting copy command with overlapping device memory regions
@@ -371,18 +368,17 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy5) {
     VkMemoryAllocateInfo buffer_mem_alloc =
         vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer_sparse_mem_reqs, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
-    vkt::DeviceMemory buffer_mem;
-    buffer_mem.init(*m_device, buffer_mem_alloc);
+    vkt::DeviceMemory buffer_mem(*m_device, buffer_mem_alloc);
 
     buffer_not_sparse.BindMemory(buffer_mem, 0);  // Bind not sparse buffer on first part of memory
 
     VkSparseMemoryBind buffer_memory_bind = {};
     buffer_memory_bind.size = 0x10000;
-    buffer_memory_bind.memory = buffer_mem.handle();
+    buffer_memory_bind.memory = buffer_mem;
     buffer_memory_bind.memoryOffset = 0x10000;  // Bind sparse buffer on second part of memory => no overlap
 
     VkSparseBufferMemoryBindInfo buffer_memory_bind_info = {};
-    buffer_memory_bind_info.buffer = buffer_sparse.handle();
+    buffer_memory_bind_info.buffer = buffer_sparse;
     buffer_memory_bind_info.bindCount = 1;
     buffer_memory_bind_info.pBinds = &buffer_memory_bind;
 
@@ -399,7 +395,7 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy5) {
     // Set up complete
 
     m_command_buffer.Begin();
-    vk::CmdCopyBuffer(m_command_buffer, buffer_not_sparse.handle(), buffer_sparse.handle(), 1, &copy_info);
+    vk::CmdCopyBuffer(m_command_buffer, buffer_not_sparse, buffer_sparse, 1, &copy_info);
     m_command_buffer.End();
 
     // Submitting copy command with overlapping device memory regions
@@ -473,19 +469,18 @@ TEST_F(PositiveSparseBuffer, BufferCopiesValidationStressTest) {
     vkt::Buffer buffer_sparse(*m_device, b_info, vkt::no_mem);
 
     VkMemoryRequirements buffer_mem_reqs;
-    vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
+    vk::GetBufferMemoryRequirements(device(), buffer_sparse, &buffer_mem_reqs);
     VkMemoryAllocateInfo buffer_mem_alloc =
         vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer_mem_reqs, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
-    vkt::DeviceMemory buffer_mem;
-    buffer_mem.init(*m_device, buffer_mem_alloc);
+    vkt::DeviceMemory buffer_mem(*m_device, buffer_mem_alloc);
 
     VkSparseMemoryBind buffer_memory_bind_1 = {};
     buffer_memory_bind_1.size = buffer_mem_reqs.size;
-    buffer_memory_bind_1.memory = buffer_mem.handle();
+    buffer_memory_bind_1.memory = buffer_mem;
 
     std::array<VkSparseBufferMemoryBindInfo, 1> buffer_memory_bind_infos = {};
-    buffer_memory_bind_infos[0].buffer = buffer_sparse.handle();
+    buffer_memory_bind_infos[0].buffer = buffer_sparse;
     buffer_memory_bind_infos[0].bindCount = 1;
     buffer_memory_bind_infos[0].pBinds = &buffer_memory_bind_1;
 
@@ -502,8 +497,7 @@ TEST_F(PositiveSparseBuffer, BufferCopiesValidationStressTest) {
     // Set up complete
 
     m_command_buffer.Begin();
-    vk::CmdCopyBuffer(m_command_buffer, buffer_sparse.handle(), buffer_sparse.handle(), size32(copy_info_list),
-                      copy_info_list.data());
+    vk::CmdCopyBuffer(m_command_buffer, buffer_sparse, buffer_sparse, size32(copy_info_list), copy_info_list.data());
     m_command_buffer.End();
 
     VkPipelineStageFlags mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
@@ -566,26 +560,26 @@ TEST_F(PositiveSparseBuffer, BufferCopiesValidationStressTest2) {
     vkt::Buffer buffer_sparse(*m_device, b_info, vkt::no_mem);
 
     VkMemoryRequirements buffer_mem_reqs;
-    vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
+    vk::GetBufferMemoryRequirements(device(), buffer_sparse, &buffer_mem_reqs);
     VkMemoryAllocateInfo buffer_mem_alloc =
         vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer_mem_reqs, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
     std::vector<vkt::DeviceMemory> memory_chunks(memory_chunks_count);
 
     for (auto& mem : memory_chunks) {
-        mem.init(*m_device, buffer_mem_alloc);
+        mem.Init(*m_device, buffer_mem_alloc);
     }
 
     std::vector<VkSparseMemoryBind> buffer_memory_binds(memory_chunks_count);
     for (auto [i, mem_bind] : vvl::enumerate(buffer_memory_binds)) {
         mem_bind.size = memory_size;
-        mem_bind.memory = memory_chunks[i].handle();
+        mem_bind.memory = memory_chunks[i];
         mem_bind.resourceOffset = i * memory_size;
         mem_bind.memoryOffset = 0;
     }
 
     std::array<VkSparseBufferMemoryBindInfo, 1> buffer_memory_bind_infos = {};
-    buffer_memory_bind_infos[0].buffer = buffer_sparse.handle();
+    buffer_memory_bind_infos[0].buffer = buffer_sparse;
     buffer_memory_bind_infos[0].bindCount = size32(buffer_memory_binds);
     buffer_memory_bind_infos[0].pBinds = buffer_memory_binds.data();
 
@@ -602,8 +596,7 @@ TEST_F(PositiveSparseBuffer, BufferCopiesValidationStressTest2) {
     // Set up complete
 
     m_command_buffer.Begin();
-    vk::CmdCopyBuffer(m_command_buffer, buffer_sparse.handle(), buffer_sparse.handle(), size32(copy_info_list),
-                      copy_info_list.data());
+    vk::CmdCopyBuffer(m_command_buffer, buffer_sparse, buffer_sparse, size32(copy_info_list), copy_info_list.data());
     m_command_buffer.End();
 
     VkPipelineStageFlags mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;

--- a/tests/unit/sparse_image.cpp
+++ b/tests/unit/sparse_image.cpp
@@ -420,11 +420,11 @@ TEST_F(NegativeSparseImage, QueueBindSparseMemoryType) {
     /// Specify memory bindings
     VkSparseMemoryBind buffer_memory_bind = {};
     buffer_memory_bind.size = buffer_mem_reqs.size;
-    buffer_memory_bind.memory = buffer_mem.handle();
+    buffer_memory_bind.memory = buffer_mem;
 
     VkSparseMemoryBind image_memory_bind = {};
     image_memory_bind.size = image_mem_reqs.size;
-    image_memory_bind.memory = image_mem.handle();
+    image_memory_bind.memory = image_mem;
 
     VkSparseBufferMemoryBindInfo buffer_memory_bind_info = {};
     buffer_memory_bind_info.buffer = buffer;
@@ -553,11 +553,11 @@ TEST_F(NegativeSparseImage, QueueBindSparseMemoryType2) {
 
     VkSparseMemoryBind buffer_memory_bind = {};
     buffer_memory_bind.size = buffer_mem_reqs.size;
-    buffer_memory_bind.memory = buffer_mem.handle();
+    buffer_memory_bind.memory = buffer_mem;
 
     VkSparseMemoryBind image_memory_bind = {};
     image_memory_bind.size = image_mem_reqs.size;
-    image_memory_bind.memory = image_mem.handle();
+    image_memory_bind.memory = image_mem;
 
     VkSparseBufferMemoryBindInfo buffer_memory_bind_info = {};
     buffer_memory_bind_info.buffer = buffer;
@@ -685,7 +685,7 @@ TEST_F(NegativeSparseImage, QueueBindSparseMemoryType3) {
     // Setup memory bindings
     VkSparseMemoryBind buffer_memory_bind = {};
     buffer_memory_bind.size = buffer_mem_reqs.size;
-    buffer_memory_bind.memory = buffer_mem.handle();
+    buffer_memory_bind.memory = buffer_mem;
 
     VkSparseBufferMemoryBindInfo buffer_memory_bind_info = {};
     buffer_memory_bind_info.buffer = buffer;
@@ -694,7 +694,7 @@ TEST_F(NegativeSparseImage, QueueBindSparseMemoryType3) {
 
     VkSparseMemoryBind image_memory_bind = {};
     image_memory_bind.size = image_mem_reqs.size;
-    image_memory_bind.memory = image_mem.handle();
+    image_memory_bind.memory = image_mem;
 
     VkSparseImageOpaqueMemoryBindInfo image_opaque_memory_bind_info = {};
     image_opaque_memory_bind_info.image = image;
@@ -703,7 +703,7 @@ TEST_F(NegativeSparseImage, QueueBindSparseMemoryType3) {
 
     VkSparseImageMemoryBind image_memory_bind_2 = {};
     image_memory_bind_2.extent = image_create_info.extent;
-    image_memory_bind_2.memory = image_mem.handle();
+    image_memory_bind_2.memory = image_mem;
     image_memory_bind_2.subresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 
     VkSparseImageMemoryBindInfo image_memory_bind_info = {};
@@ -896,7 +896,7 @@ TEST_F(NegativeSparseImage, QueueBindSparseMemoryType4) {
     // Setup memory bindings
     VkSparseMemoryBind buffer_memory_bind = {};
     buffer_memory_bind.size = buffer1.MemoryRequirements().size;
-    buffer_memory_bind.memory = buffer_memory_imported.handle();
+    buffer_memory_bind.memory = buffer_memory_imported;
 
     VkSparseBufferMemoryBindInfo buffer_memory_bind_info = {};
     buffer_memory_bind_info.buffer = buffer1;
@@ -905,7 +905,7 @@ TEST_F(NegativeSparseImage, QueueBindSparseMemoryType4) {
 
     VkSparseMemoryBind image_memory_bind = {};
     image_memory_bind.size = image_mem_reqs.size;
-    image_memory_bind.memory = image_mem.handle();
+    image_memory_bind.memory = image_mem;
 
     VkSparseImageOpaqueMemoryBindInfo image_opaque_memory_bind_info = {};
     image_opaque_memory_bind_info.image = image;
@@ -914,7 +914,7 @@ TEST_F(NegativeSparseImage, QueueBindSparseMemoryType4) {
 
     VkSparseImageMemoryBind image_memory_bind_2 = {};
     image_memory_bind_2.extent = image_create_info.extent;
-    image_memory_bind_2.memory = image_mem.handle();
+    image_memory_bind_2.memory = image_mem;
     image_memory_bind_2.subresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 
     VkSparseImageMemoryBindInfo image_memory_bind_info = {};
@@ -987,8 +987,7 @@ TEST_F(NegativeSparseImage, ImageMemoryBind) {
     const auto image_mem_alloc =
         vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image_mem_reqs, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
-    vkt::DeviceMemory image_mem;
-    image_mem.init(*m_device, image_mem_alloc);
+    vkt::DeviceMemory image_mem(*m_device, image_mem_alloc);
 
     uint32_t requirements_count = 0u;
     vk::GetImageSparseMemoryRequirements(*m_device, image, &requirements_count, nullptr);
@@ -1003,7 +1002,7 @@ TEST_F(NegativeSparseImage, ImageMemoryBind) {
     VkExtent3D granularity = sparse_reqs[0].formatProperties.imageGranularity;
     VkSparseImageMemoryBind image_bind{};
     image_bind.subresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    image_bind.memory = image_mem.handle();
+    image_bind.memory = image_mem;
     image_bind.extent = granularity;
 
     VkSparseImageMemoryBindInfo image_bind_info{};
@@ -1103,14 +1102,13 @@ TEST_F(NegativeSparseImage, ImageMemoryBindInvalidMemory) {
     const auto image_mem_alloc =
         vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image_mem_reqs, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
-    vkt::DeviceMemory image_mem;
-    image_mem.init(*m_device, image_mem_alloc);
+    vkt::DeviceMemory image_mem(*m_device, image_mem_alloc);
 
     VkImageCreateInfo invalid_create_info = create_info;
     vkt::Image invalid_image(*m_device, invalid_create_info, vkt::no_mem);
 
     VkMemoryRequirements invalid_image_mem_reqs;
-    vk::GetImageMemoryRequirements(*m_device, invalid_image.handle(), &invalid_image_mem_reqs);
+    vk::GetImageMemoryRequirements(*m_device, invalid_image, &invalid_image_mem_reqs);
 
     // Make sure that the same memory type is not chosen.
     invalid_image_mem_reqs.memoryTypeBits = ~image_mem_reqs.memoryTypeBits;
@@ -1123,8 +1121,7 @@ TEST_F(NegativeSparseImage, ImageMemoryBindInvalidMemory) {
         GTEST_SKIP() << "Could not find required memory type";
     }
 
-    vkt::DeviceMemory invalid_image_mem;
-    invalid_image_mem.init(*m_device, invalid_image_mem_alloc);
+    vkt::DeviceMemory invalid_image_mem(*m_device, invalid_image_mem_alloc);
 
     uint32_t requirements_count = 0u;
     vk::GetImageSparseMemoryRequirements(*m_device, image, &requirements_count, nullptr);
@@ -1139,7 +1136,7 @@ TEST_F(NegativeSparseImage, ImageMemoryBindInvalidMemory) {
     VkExtent3D granularity = sparse_reqs[0].formatProperties.imageGranularity;
     VkSparseImageMemoryBind image_bind{};
     image_bind.subresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    image_bind.memory = image_mem.handle();
+    image_bind.memory = image_mem;
     image_bind.memoryOffset = 0;
     image_bind.extent = granularity;
 
@@ -1155,7 +1152,7 @@ TEST_F(NegativeSparseImage, ImageMemoryBindInvalidMemory) {
     VkQueue sparse_queue = m_device->QueuesWithSparseCapability()[0]->handle();
 
     // Force invalid device memory
-    image_bind.memory = invalid_image_mem.handle();
+    image_bind.memory = invalid_image_mem;
     m_errorMonitor->SetDesiredError("VUID-VkSparseImageMemoryBind-memory-01105");
     vk::QueueBindSparse(sparse_queue, 1, &bind_info, VK_NULL_HANDLE);
     m_errorMonitor->VerifyFound();
@@ -1187,14 +1184,13 @@ TEST_F(NegativeSparseImage, ImageMemoryBindInvalidAlignment) {
     const auto image_mem_alloc =
         vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image_mem_reqs, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
-    vkt::DeviceMemory image_mem;
-    image_mem.init(*m_device, image_mem_alloc);
+    vkt::DeviceMemory image_mem(*m_device, image_mem_alloc);
 
     VkImageCreateInfo invalid_create_info = create_info;
     vkt::Image invalid_image(*m_device, invalid_create_info, vkt::no_mem);
 
     VkMemoryRequirements invalid_image_mem_reqs;
-    vk::GetImageMemoryRequirements(*m_device, invalid_image.handle(), &invalid_image_mem_reqs);
+    vk::GetImageMemoryRequirements(*m_device, invalid_image, &invalid_image_mem_reqs);
 
     // Make sure that the same memory type is not chosen.
     invalid_image_mem_reqs.memoryTypeBits = ~image_mem_reqs.memoryTypeBits;
@@ -1207,8 +1203,7 @@ TEST_F(NegativeSparseImage, ImageMemoryBindInvalidAlignment) {
         GTEST_SKIP() << "Could not find required memory type";
     }
 
-    vkt::DeviceMemory invalid_image_mem;
-    invalid_image_mem.init(*m_device, invalid_image_mem_alloc);
+    vkt::DeviceMemory invalid_image_mem(*m_device, invalid_image_mem_alloc);
 
     uint32_t requirements_count = 0u;
     vk::GetImageSparseMemoryRequirements(*m_device, image, &requirements_count, nullptr);
@@ -1223,7 +1218,7 @@ TEST_F(NegativeSparseImage, ImageMemoryBindInvalidAlignment) {
     VkExtent3D granularity = sparse_reqs[0].formatProperties.imageGranularity;
     VkSparseImageMemoryBind image_bind{};
     image_bind.subresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    image_bind.memory = image_mem.handle();
+    image_bind.memory = image_mem;
     image_bind.memoryOffset = 0;
     image_bind.extent = granularity;
 
@@ -1269,8 +1264,7 @@ TEST_F(NegativeSparseImage, ImageMemoryBindInvalidExtent) {
     const auto image_mem_alloc =
         vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image_mem_reqs, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
-    vkt::DeviceMemory image_mem;
-    image_mem.init(*m_device, image_mem_alloc);
+    vkt::DeviceMemory image_mem(*m_device, image_mem_alloc);
 
     uint32_t requirements_count = 0u;
     vk::GetImageSparseMemoryRequirements(*m_device, image, &requirements_count, nullptr);
@@ -1285,7 +1279,7 @@ TEST_F(NegativeSparseImage, ImageMemoryBindInvalidExtent) {
     VkExtent3D granularity = sparse_reqs[0].formatProperties.imageGranularity;
     VkSparseImageMemoryBind image_bind{};
     image_bind.subresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    image_bind.memory = image_mem.handle();
+    image_bind.memory = image_mem;
     image_bind.extent = granularity;
 
     VkSparseImageMemoryBindInfo image_bind_info{};

--- a/tests/unit/subgroups.cpp
+++ b/tests/unit/subgroups.cpp
@@ -450,7 +450,7 @@ TEST_F(NegativeSubgroup, SubgroupSizeControlFeaturesWithIdentifierGraphics) {
     VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
 
     VkShaderModuleIdentifierEXT get_identifier = vku::InitStructHelper();
-    vk::GetShaderModuleIdentifierEXT(device(), vs.handle(), &get_identifier);
+    vk::GetShaderModuleIdentifierEXT(device(), vs, &get_identifier);
     sm_id_create_info.identifierSize = get_identifier.identifierSize;
     sm_id_create_info.pIdentifier = get_identifier.identifier;
 
@@ -489,7 +489,7 @@ TEST_F(NegativeSubgroup, SubgroupSizeControlFeaturesWithIdentifierCompute) {
     VkShaderObj cs(this, kMinimalShaderGlsl, VK_SHADER_STAGE_COMPUTE_BIT);
 
     VkShaderModuleIdentifierEXT get_identifier = vku::InitStructHelper();
-    vk::GetShaderModuleIdentifierEXT(device(), cs.handle(), &get_identifier);
+    vk::GetShaderModuleIdentifierEXT(device(), cs, &get_identifier);
     sm_id_create_info.identifierSize = get_identifier.identifierSize;
     sm_id_create_info.pIdentifier = get_identifier.identifier;
 

--- a/tests/unit/sync_object.cpp
+++ b/tests/unit/sync_object.cpp
@@ -1406,7 +1406,7 @@ TEST_F(NegativeSyncObject, ConcurrentBufferBarrierNeedsIgnoredQueue) {
     // Create VK_SHARING_MODE_CONCURRENT buffer by specifying queue families
     uint32_t queue_families[2] = {m_default_queue->family_index, transfer_only_family.value()};
     vkt::Buffer buffer;
-    buffer.init(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT, 0, nullptr, vvl::make_span(queue_families, 2));
+    buffer.Init(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT, 0, nullptr, vvl::make_span(queue_families, 2));
 
     VkBufferMemoryBarrier barrier = vku::InitStructHelper();
     barrier.srcAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
@@ -3036,19 +3036,18 @@ TEST_F(NegativeSyncObject, QueueSubmitBinarySemaphoreNotSignaled) {
     // VUIDs reported change if the extension is enabled, even if the timelineSemaphore feature isn't supported.
 
     {
-        vkt::Semaphore semaphore[3];
-        semaphore[0].init(*m_device, semaphore_create_info);
-        semaphore[1].init(*m_device, semaphore_create_info);
-        semaphore[2].init(*m_device, semaphore_create_info);
+        vkt::Semaphore semaphore_0(*m_device, semaphore_create_info);
+        vkt::Semaphore semaphore_1(*m_device, semaphore_create_info);
+        vkt::Semaphore semaphore_2(*m_device, semaphore_create_info);
 
         VkPipelineStageFlags stage_flags = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
         VkSubmitInfo submit_info[3] = {};
         submit_info[0] = vku::InitStructHelper();
         submit_info[0].pWaitDstStageMask = &stage_flags;
         submit_info[0].waitSemaphoreCount = 1;
-        submit_info[0].pWaitSemaphores = &semaphore[0].handle();
+        submit_info[0].pWaitSemaphores = &semaphore_0.handle();
         submit_info[0].signalSemaphoreCount = 1;
-        submit_info[0].pSignalSemaphores = &semaphore[1].handle();
+        submit_info[0].pSignalSemaphores = &semaphore_1.handle();
         m_errorMonitor->SetDesiredError("VUID-vkQueueSubmit-pWaitSemaphores-03238");
         vk::QueueSubmit(m_default_queue->handle(), 1, submit_info, VK_NULL_HANDLE);
         m_errorMonitor->VerifyFound();
@@ -3056,9 +3055,9 @@ TEST_F(NegativeSyncObject, QueueSubmitBinarySemaphoreNotSignaled) {
         submit_info[1] = vku::InitStructHelper();
         submit_info[1].pWaitDstStageMask = &stage_flags;
         submit_info[1].waitSemaphoreCount = 1;
-        submit_info[1].pWaitSemaphores = &semaphore[1].handle();
+        submit_info[1].pWaitSemaphores = &semaphore_1.handle();
         submit_info[1].signalSemaphoreCount = 1;
-        submit_info[1].pSignalSemaphores = &semaphore[2].handle();
+        submit_info[1].pSignalSemaphores = &semaphore_2.handle();
 
         m_errorMonitor->SetDesiredError("VUID-vkQueueSubmit-pWaitSemaphores-03238");
         vk::QueueSubmit(m_default_queue->handle(), 2, &submit_info[0], VK_NULL_HANDLE);
@@ -3066,25 +3065,24 @@ TEST_F(NegativeSyncObject, QueueSubmitBinarySemaphoreNotSignaled) {
 
         submit_info[2] = vku::InitStructHelper();
         submit_info[2].signalSemaphoreCount = 1;
-        submit_info[2].pSignalSemaphores = &semaphore[0].handle();
+        submit_info[2].pSignalSemaphores = &semaphore_0.handle();
 
         ASSERT_EQ(VK_SUCCESS, vk::QueueSubmit(m_default_queue->handle(), 1, &submit_info[2], VK_NULL_HANDLE));
         ASSERT_EQ(VK_SUCCESS, vk::QueueSubmit(m_default_queue->handle(), 2, submit_info, VK_NULL_HANDLE));
         m_default_queue->Wait();
     }
     if (m_device->Physical().queue_properties_[m_default_queue->family_index].queueFlags & VK_QUEUE_SPARSE_BINDING_BIT) {
-        vkt::Semaphore semaphore[3];
-        semaphore[0].init(*m_device, semaphore_create_info);
-        semaphore[1].init(*m_device, semaphore_create_info);
-        semaphore[2].init(*m_device, semaphore_create_info);
+        vkt::Semaphore semaphore_0(*m_device, semaphore_create_info);
+        vkt::Semaphore semaphore_1(*m_device, semaphore_create_info);
+        vkt::Semaphore semaphore_2(*m_device, semaphore_create_info);
 
         VkBindSparseInfo bind_info[3] = {};
 
         bind_info[0] = vku::InitStructHelper();
         bind_info[0].waitSemaphoreCount = 1;
-        bind_info[0].pWaitSemaphores = &semaphore[0].handle();
+        bind_info[0].pWaitSemaphores = &semaphore_0.handle();
         bind_info[0].signalSemaphoreCount = 1;
-        bind_info[0].pSignalSemaphores = &semaphore[1].handle();
+        bind_info[0].pSignalSemaphores = &semaphore_1.handle();
 
         m_errorMonitor->SetDesiredError("VUID-vkQueueBindSparse-pWaitSemaphores-03245");
         vk::QueueBindSparse(m_default_queue->handle(), 1, &bind_info[0], VK_NULL_HANDLE);
@@ -3092,9 +3090,9 @@ TEST_F(NegativeSyncObject, QueueSubmitBinarySemaphoreNotSignaled) {
 
         bind_info[1] = vku::InitStructHelper();
         bind_info[1].waitSemaphoreCount = 1;
-        bind_info[1].pWaitSemaphores = &semaphore[1].handle();
+        bind_info[1].pWaitSemaphores = &semaphore_1.handle();
         bind_info[1].signalSemaphoreCount = 1;
-        bind_info[1].pSignalSemaphores = &semaphore[2].handle();
+        bind_info[1].pSignalSemaphores = &semaphore_2.handle();
 
         m_errorMonitor->SetDesiredError("VUID-vkQueueBindSparse-pWaitSemaphores-03245");
         vk::QueueBindSparse(m_default_queue->handle(), 2, bind_info, VK_NULL_HANDLE);
@@ -3102,7 +3100,7 @@ TEST_F(NegativeSyncObject, QueueSubmitBinarySemaphoreNotSignaled) {
 
         bind_info[2] = vku::InitStructHelper();
         bind_info[2].signalSemaphoreCount = 1;
-        bind_info[2].pSignalSemaphores = &semaphore[0].handle();
+        bind_info[2].pSignalSemaphores = &semaphore_0.handle();
 
         ASSERT_EQ(VK_SUCCESS, vk::QueueBindSparse(m_default_queue->handle(), 1, &bind_info[2], VK_NULL_HANDLE));
         ASSERT_EQ(VK_SUCCESS, vk::QueueBindSparse(m_default_queue->handle(), 2, bind_info, VK_NULL_HANDLE));
@@ -3111,9 +3109,9 @@ TEST_F(NegativeSyncObject, QueueSubmitBinarySemaphoreNotSignaled) {
 
     {
         vkt::Semaphore semaphore[3];
-        semaphore[0].init(*m_device, semaphore_create_info);
-        semaphore[1].init(*m_device, semaphore_create_info);
-        semaphore[2].init(*m_device, semaphore_create_info);
+        semaphore[0].Init(*m_device, semaphore_create_info);
+        semaphore[1].Init(*m_device, semaphore_create_info);
+        semaphore[2].Init(*m_device, semaphore_create_info);
 
         VkSemaphoreSubmitInfo sem_info[3];
         for (int i = 0; i < 3; i++) {
@@ -3303,20 +3301,19 @@ TEST_F(NegativeSyncObject, Sync2SignalSemaphoreValue) {
 
     VkSemaphoreCreateInfo semaphore_create_info = vku::InitStructHelper(&semaphore_type_create_info);
 
-    vkt::Semaphore semaphore[2];
-    semaphore[0].init(*m_device, semaphore_create_info);
-    semaphore[1].init(*m_device, semaphore_create_info);
+    vkt::Semaphore semaphore_0(*m_device, semaphore_create_info);
+    vkt::Semaphore semaphore_1(*m_device, semaphore_create_info);
 
     VkSemaphoreSignalInfo semaphore_signal_info = vku::InitStructHelper();
-    semaphore_signal_info.semaphore = semaphore[0];
+    semaphore_signal_info.semaphore = semaphore_0;
     semaphore_signal_info.value = 10;
     ASSERT_EQ(VK_SUCCESS, vk::SignalSemaphore(device(), &semaphore_signal_info));
 
     VkSemaphoreSubmitInfo signal_info = vku::InitStructHelper();
-    signal_info.semaphore = semaphore[0];
+    signal_info.semaphore = semaphore_0;
 
     VkSemaphoreSubmitInfo wait_info = vku::InitStructHelper();
-    wait_info.semaphore = semaphore[0];
+    wait_info.semaphore = semaphore_0;
     wait_info.stageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
 
     VkSubmitInfo2 submit_info = vku::InitStructHelper();
@@ -3341,7 +3338,7 @@ TEST_F(NegativeSyncObject, Sync2SignalSemaphoreValue) {
 
     signal_info.value = 20;
     wait_info.value = 15;
-    wait_info.semaphore = semaphore[1];
+    wait_info.semaphore = semaphore_1;
     ASSERT_EQ(VK_SUCCESS, vk::QueueSubmit2KHR(m_default_queue->handle(), 1, &submit_info, VK_NULL_HANDLE));
 
     semaphore_signal_info.value = 25;
@@ -3352,7 +3349,7 @@ TEST_F(NegativeSyncObject, Sync2SignalSemaphoreValue) {
 
     semaphore_signal_info.value = 15;
     ASSERT_EQ(VK_SUCCESS, vk::SignalSemaphore(device(), &semaphore_signal_info));
-    semaphore_signal_info.semaphore = semaphore[1];
+    semaphore_signal_info.semaphore = semaphore_1;
     ASSERT_EQ(VK_SUCCESS, vk::SignalSemaphore(device(), &semaphore_signal_info));
 
     // Check if we can test violations of maxTimelineSemaphoreValueDifference
@@ -5158,7 +5155,7 @@ TEST_F(NegativeSyncObject, Transition3dImageSlice) {
     image_memory_barrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
     image_memory_barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
     image_memory_barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-    image_memory_barrier.image = image.handle();
+    image_memory_barrier.image = image;
     image_memory_barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     image_memory_barrier.subresourceRange.baseMipLevel = 0u;
     image_memory_barrier.subresourceRange.levelCount = 1u;
@@ -5167,15 +5164,15 @@ TEST_F(NegativeSyncObject, Transition3dImageSlice) {
 
     m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkImageMemoryBarrier-maintenance9-10798");
-    vk::CmdPipelineBarrier(m_command_buffer.handle(), VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0u, 0u,
-                           nullptr, 0u, nullptr, 1u, &image_memory_barrier);
+    vk::CmdPipelineBarrier(m_command_buffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0u, 0u, nullptr, 0u,
+                           nullptr, 1u, &image_memory_barrier);
     m_errorMonitor->VerifyFound();
 
     image_memory_barrier.subresourceRange.baseArrayLayer = 0u;
     image_memory_barrier.subresourceRange.layerCount = 5u;
     m_errorMonitor->SetDesiredError("VUID-VkImageMemoryBarrier-maintenance9-10800");
-    vk::CmdPipelineBarrier(m_command_buffer.handle(), VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0u, 0u,
-                           nullptr, 0u, nullptr, 1u, &image_memory_barrier);
+    vk::CmdPipelineBarrier(m_command_buffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0u, 0u, nullptr, 0u,
+                           nullptr, 1u, &image_memory_barrier);
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.End();
@@ -5206,7 +5203,7 @@ TEST_F(NegativeSyncObject, Transition3dImageWithMipLevels) {
     image_memory_barrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
     image_memory_barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
     image_memory_barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-    image_memory_barrier.image = image.handle();
+    image_memory_barrier.image = image;
     image_memory_barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     image_memory_barrier.subresourceRange.baseMipLevel = 0u;
     image_memory_barrier.subresourceRange.levelCount = 2u;
@@ -5215,8 +5212,8 @@ TEST_F(NegativeSyncObject, Transition3dImageWithMipLevels) {
 
     m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkImageMemoryBarrier-maintenance9-10799");
-    vk::CmdPipelineBarrier(m_command_buffer.handle(), VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0u, 0u,
-                           nullptr, 0u, nullptr, 1u, &image_memory_barrier);
+    vk::CmdPipelineBarrier(m_command_buffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0u, 0u, nullptr, 0u,
+                           nullptr, 1u, &image_memory_barrier);
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.End();
@@ -5245,7 +5242,7 @@ TEST_F(NegativeSyncObject, AsymmetricSetEvent2) {
                        VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
 
     VkBufferMemoryBarrier2 buffer_barrier = vku::InitStructHelper();
-    buffer_barrier.buffer = buffer.handle();
+    buffer_barrier.buffer = buffer;
     buffer_barrier.offset = 0u;
     buffer_barrier.size = VK_WHOLE_SIZE;
 

--- a/tests/unit/sync_object_positive.cpp
+++ b/tests/unit/sync_object_positive.cpp
@@ -1478,7 +1478,7 @@ struct SemBufferRaceData {
 
             VkMemoryPropertyFlags reqs = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
             auto buffer = std::make_unique<vkt::Buffer>();
-            buffer->init(dev, 20, VK_BUFFER_USAGE_TRANSFER_DST_BIT, reqs);
+            buffer->Init(dev, 20, VK_BUFFER_USAGE_TRANSFER_DST_BIT, reqs);
 
             // main thread sets up buffer
             // main thread signals 1
@@ -2646,8 +2646,8 @@ TEST_F(PositiveSyncObject, Transition3dImageSlice) {
     image_memory_barrier.subresourceRange.layerCount = 1u;
 
     m_command_buffer.Begin();
-    vk::CmdPipelineBarrier(m_command_buffer.handle(), VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0u, 0u,
-                           nullptr, 0u, nullptr, 1u, &image_memory_barrier);
+    vk::CmdPipelineBarrier(m_command_buffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0u, 0u, nullptr, 0u,
+                           nullptr, 1u, &image_memory_barrier);
     m_command_buffer.End();
 }
 
@@ -2677,7 +2677,7 @@ TEST_F(PositiveSyncObject, Transition3dImageSlices) {
     image_memory_barrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
     image_memory_barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
     image_memory_barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-    image_memory_barrier.image = image.handle();
+    image_memory_barrier.image = image;
     image_memory_barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     image_memory_barrier.subresourceRange.baseMipLevel = 0u;
     image_memory_barrier.subresourceRange.levelCount = 1u;
@@ -2685,26 +2685,26 @@ TEST_F(PositiveSyncObject, Transition3dImageSlices) {
     image_memory_barrier.subresourceRange.layerCount = 4u;
 
     m_command_buffer.Begin();
-    vk::CmdPipelineBarrier(m_command_buffer.handle(), VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0u, 0u,
-                           nullptr, 0u, nullptr, 1u, &image_memory_barrier);
+    vk::CmdPipelineBarrier(m_command_buffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0u, 0u, nullptr, 0u,
+                           nullptr, 1u, &image_memory_barrier);
 
     image_memory_barrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
     image_memory_barrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
     image_memory_barrier.subresourceRange.baseArrayLayer = 1u;
     image_memory_barrier.subresourceRange.layerCount = 1u;
-    vk::CmdPipelineBarrier(m_command_buffer.handle(), VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0u, 0u,
-                           nullptr, 0u, nullptr, 1u, &image_memory_barrier);
+    vk::CmdPipelineBarrier(m_command_buffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0u, 0u, nullptr, 0u,
+                           nullptr, 1u, &image_memory_barrier);
 
     image_memory_barrier.newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     image_memory_barrier.subresourceRange.baseArrayLayer = 2u;
     image_memory_barrier.subresourceRange.layerCount = 1u;
-    vk::CmdPipelineBarrier(m_command_buffer.handle(), VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0u, 0u,
-                           nullptr, 0u, nullptr, 1u, &image_memory_barrier);
+    vk::CmdPipelineBarrier(m_command_buffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0u, 0u, nullptr, 0u,
+                           nullptr, 1u, &image_memory_barrier);
 
     image_memory_barrier.oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     image_memory_barrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-    vk::CmdPipelineBarrier(m_command_buffer.handle(), VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0u, 0u,
-                           nullptr, 0u, nullptr, 1u, &image_memory_barrier);
+    vk::CmdPipelineBarrier(m_command_buffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0u, 0u, nullptr, 0u,
+                           nullptr, 1u, &image_memory_barrier);
     m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
@@ -2742,7 +2742,7 @@ TEST_F(PositiveSyncObject, Transition3dImageWithMipLevels) {
     image_memory_barrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
     image_memory_barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
     image_memory_barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-    image_memory_barrier.image = image.handle();
+    image_memory_barrier.image = image;
     image_memory_barrier.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     image_memory_barrier.subresourceRange.baseMipLevel = 0u;
     image_memory_barrier.subresourceRange.levelCount = 2u;
@@ -2750,8 +2750,8 @@ TEST_F(PositiveSyncObject, Transition3dImageWithMipLevels) {
     image_memory_barrier.subresourceRange.layerCount = VK_REMAINING_ARRAY_LAYERS;
 
     m_command_buffer.Begin();
-    vk::CmdPipelineBarrier(m_command_buffer.handle(), VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0u, 0u,
-                           nullptr, 0u, nullptr, 1u, &image_memory_barrier);
+    vk::CmdPipelineBarrier(m_command_buffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0u, 0u, nullptr, 0u,
+                           nullptr, 1u, &image_memory_barrier);
     m_command_buffer.End();
 }
 
@@ -2772,7 +2772,7 @@ TEST_F(PositiveSyncObject, SetEvent2Flags) {
     dependency_info.pMemoryBarriers = &memory_barrier;
 
     vkt::Event event(*m_device);
-    vk::CmdSetEvent2(m_command_buffer.handle(), event.handle(), &dependency_info);
+    vk::CmdSetEvent2(m_command_buffer, event, &dependency_info);
 }
 
 TEST_F(PositiveSyncObject, TimelineSemaphoreAndExportedCopyCooperation) {

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -2439,7 +2439,7 @@ TEST_F(NegativeSyncVal, RenderPassLoadHazardVsInitialLayout) {
         attachmentDescriptions[0].storeOp = VK_ATTACHMENT_STORE_OP_NONE;
         attachmentDescriptions[1].loadOp = VK_ATTACHMENT_LOAD_OP_NONE;
         attachmentDescriptions[1].storeOp = VK_ATTACHMENT_STORE_OP_NONE;
-        rp_no_load_store.init(*m_device, renderPassInfo);
+        rp_no_load_store.Init(*m_device, renderPassInfo);
         m_renderPassBeginInfo.renderPass = rp_no_load_store;
         m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
         m_command_buffer.EndRenderPass();
@@ -2797,7 +2797,7 @@ struct CreateRenderPassHelper {
         InitSubpasses();
         InitRenderPassInfo();
         render_pass = std::make_shared<vkt::RenderPass>();
-        render_pass->init(*dev, render_pass_create_info);
+        render_pass->Init(*dev, render_pass_create_info);
     }
 
     void InitFramebuffer() {
@@ -2811,7 +2811,7 @@ struct CreateRenderPassHelper {
                                         width,
                                         height,
                                         1u};
-        framebuffer->init(*dev, fbci);
+        framebuffer->Init(*dev, fbci);
     }
 
     void InitBeginInfo() {
@@ -3265,7 +3265,7 @@ TEST_F(NegativeSyncVal, RenderPassAsyncHazard) {
         std::vector<vkt::Pipeline> g_pipes(kNumImages - 1);
         for (size_t i = 0; i < g_pipes.size(); i++) {
             g_pipe_12.gp_ci_.subpass = i + 1;
-            g_pipes[i].init(*m_device, g_pipe_12.gp_ci_);
+            g_pipes[i].Init(*m_device, g_pipe_12.gp_ci_);
         }
 
         g_pipe_12.descriptor_set_->WriteDescriptorImageInfo(0, attachments[0], sampler, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT);
@@ -3344,7 +3344,7 @@ TEST_F(NegativeSyncVal, RenderPassAsyncHazard) {
         std::vector<vkt::Pipeline> g_pipes(kNumImages - 1);
         for (size_t i = 0; i < g_pipes.size(); i++) {
             g_pipe_12.gp_ci_.subpass = i + 1;
-            g_pipes[i].init(*m_device, g_pipe_12.gp_ci_);
+            g_pipes[i].Init(*m_device, g_pipe_12.gp_ci_);
         }
 
         g_pipe_12.descriptor_set_->WriteDescriptorImageInfo(0, attachments[0], sampler, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT);
@@ -3431,7 +3431,7 @@ TEST_F(NegativeSyncVal, RenderPassAsyncHazard) {
         std::vector<vkt::Pipeline> g_pipes(kNumImages - 1);
         for (size_t i = 0; i < g_pipes.size(); i++) {
             g_pipe_12.gp_ci_.subpass = i + 1;
-            g_pipes[i].init(*m_device, g_pipe_12.gp_ci_);
+            g_pipes[i].Init(*m_device, g_pipe_12.gp_ci_);
         }
 
         g_pipe_12.descriptor_set_->WriteDescriptorImageInfo(0, attachments[0], sampler, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT);
@@ -3816,8 +3816,7 @@ TEST_F(NegativeSyncVal, DestroyedUnusedDescriptors) {
     VkBufferCreateInfo buffer_create_info = vku::InitStructHelper();
     buffer_create_info.size = 32;
     buffer_create_info.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
-    auto buffer = std::make_unique<vkt::Buffer>();
-    buffer->init(*m_device, buffer_create_info);
+    auto buffer = std::make_unique<vkt::Buffer>(*m_device, buffer_create_info);
 
     VkDescriptorBufferInfo buffer_info[2] = {};
     buffer_info[0].buffer = doit_buffer;
@@ -3836,23 +3835,20 @@ TEST_F(NegativeSyncVal, DestroyedUnusedDescriptors) {
     bvci.offset = 0;
     bvci.range = VK_WHOLE_SIZE;
 
-    auto texel_bufferview = std::make_unique<vkt::BufferView>();
-    texel_bufferview->init(*m_device, bvci);
+    auto texel_bufferview = std::make_unique<vkt::BufferView>(*m_device, bvci);
 
     vkt::Buffer index_buffer(*m_device, sizeof(uint32_t), VK_BUFFER_USAGE_INDEX_BUFFER_BIT);
 
     VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
     auto image_ci = vkt::Image::ImageCreateInfo2D(128, 128, 1, 1, format, VK_IMAGE_USAGE_SAMPLED_BIT);
     vkt::Image sampled_image(*m_device, image_ci, vkt::set_layout);
-    auto sampled_view = std::make_unique<vkt::ImageView>();
     auto imageview_ci = sampled_image.BasicViewCreatInfo();
-    sampled_view->init(*m_device, imageview_ci);
+    auto sampled_view = std::make_unique<vkt::ImageView>(*m_device, imageview_ci);
 
     image_ci = vkt::Image::ImageCreateInfo2D(128, 128, 1, 1, format, VK_IMAGE_USAGE_SAMPLED_BIT);
     vkt::Image combined_image(*m_device, image_ci, vkt::set_layout);
     imageview_ci = combined_image.BasicViewCreatInfo();
-    auto combined_view = std::make_unique<vkt::ImageView>();
-    combined_view->init(*m_device, imageview_ci);
+    auto combined_view = std::make_unique<vkt::ImageView>(*m_device, imageview_ci);
 
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
@@ -4102,17 +4098,15 @@ TEST_F(NegativeSyncVal, StageAccessExpansion) {
 
     vkt::ImageView imageview_s = image_s_a.CreateView();
 
-    vkt::Sampler sampler_s, sampler_c;
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
-    sampler_s.init(*m_device, sampler_ci);
-    sampler_c.init(*m_device, sampler_ci);
+    vkt::Sampler sampler_s(*m_device, sampler_ci);
+    vkt::Sampler sampler_c(*m_device, sampler_ci);
 
-    vkt::Buffer buffer_a, buffer_b;
     VkMemoryPropertyFlags mem_prop = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
     VkBufferUsageFlags buffer_usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT |
                                       VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
-    buffer_a.init(*m_device, buffer_a.CreateInfo(2048, buffer_usage), mem_prop);
-    buffer_b.init(*m_device, buffer_b.CreateInfo(2048, buffer_usage), mem_prop);
+    vkt::Buffer buffer_a(*m_device, vkt::Buffer::CreateInfo(2048, buffer_usage), mem_prop);
+    vkt::Buffer buffer_b(*m_device, vkt::Buffer::CreateInfo(2048, buffer_usage), mem_prop);
 
     vkt::BufferView buffer_view(*m_device, buffer_a, VK_FORMAT_R32_SFLOAT);
 
@@ -4151,10 +4145,9 @@ TEST_F(NegativeSyncVal, StageAccessExpansion) {
     const float vbo_data[3] = {1.f, 0.f, 1.f};
     VkVertexInputAttributeDescription VertexInputAttributeDescription = {0, 0, VK_FORMAT_R32G32B32_SFLOAT, sizeof(vbo_data)};
     VkVertexInputBindingDescription VertexInputBindingDescription = {0, sizeof(vbo_data), VK_VERTEX_INPUT_RATE_VERTEX};
-    vkt::Buffer vbo, vbo2;
     buffer_usage = VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
-    vbo.init(*m_device, vbo.CreateInfo(sizeof(vbo_data), buffer_usage), mem_prop);
-    vbo2.init(*m_device, vbo2.CreateInfo(sizeof(vbo_data), buffer_usage), mem_prop);
+    vkt::Buffer vbo(*m_device, vkt::Buffer::CreateInfo(sizeof(vbo_data), buffer_usage), mem_prop);
+    vkt::Buffer vbo2(*m_device, vkt::Buffer::CreateInfo(sizeof(vbo_data), buffer_usage), mem_prop);
 
     VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(this, csSource.c_str(), VK_SHADER_STAGE_FRAGMENT_BIT);

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -2723,7 +2723,7 @@ TEST_F(PositiveSyncVal, TwoExternalDependenciesSyncLayoutTransitions) {
     vkt::Image image1(*m_device, w, h, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
     vkt::ImageView image_view1 = image1.CreateView(VK_IMAGE_ASPECT_COLOR_BIT);
 
-    const VkImageView image_views[2] = {image_view0.handle(), image_view1.handle()};
+    const VkImageView image_views[2] = {image_view0, image_view1};
 
     VkAttachmentDescription attachment0 = {};
     attachment0.format = VK_FORMAT_B8G8R8A8_UNORM;

--- a/tests/unit/threading_positive.cpp
+++ b/tests/unit/threading_positive.cpp
@@ -207,7 +207,7 @@ TEST_F(PositiveThreading, DebugObjectNames) {
     vkt::PipelineLayout pipeline_layout(*m_device, {&set_layout2});
 
     VkDescriptorSetAllocateInfo allocate_info = vku::InitStructHelper();
-    allocate_info.descriptorPool = descriptor_pool.handle();
+    allocate_info.descriptorPool = descriptor_pool;
     allocate_info.descriptorSetCount = 1u;
     allocate_info.pSetLayouts = &set_layout.handle();
 

--- a/tests/unit/video_decode_vp9_positive.cpp
+++ b/tests/unit/video_decode_vp9_positive.cpp
@@ -37,8 +37,8 @@ TEST_F(PositiveVideoDecodeVP9, Basic) {
     vkt::CommandBuffer& cb = context.CmdBuffer();
 
     cb.Begin();
-    vk::CmdPipelineBarrier2KHR(cb.handle(), context.DecodeOutput()->LayoutTransition(VK_IMAGE_LAYOUT_VIDEO_DECODE_DST_KHR));
-    vk::CmdPipelineBarrier2KHR(cb.handle(), context.Dpb()->LayoutTransition(VK_IMAGE_LAYOUT_VIDEO_DECODE_DPB_KHR));
+    vk::CmdPipelineBarrier2KHR(cb, context.DecodeOutput()->LayoutTransition(VK_IMAGE_LAYOUT_VIDEO_DECODE_DST_KHR));
+    vk::CmdPipelineBarrier2KHR(cb, context.Dpb()->LayoutTransition(VK_IMAGE_LAYOUT_VIDEO_DECODE_DPB_KHR));
     cb.BeginVideoCoding(context.Begin().AddResource(-1, 0).AddResource(-1, 1).AddResource(-1, 2));
     cb.ControlVideoCoding(context.Control().Reset());
     cb.DecodeVideo(context.DecodeReferenceFrame(0));

--- a/tests/unit/wsi.cpp
+++ b/tests/unit/wsi.cpp
@@ -149,7 +149,7 @@ TEST_F(NegativeWsi, BindImageMemorySwapchain) {
     bool pass = m_device->Physical().SetMemoryType(mem_reqs.memoryRequirements.memoryTypeBits, &alloc_info, 0);
     // some devices don't give us good memory requirements for the swapchain image
     if (pass) {
-        mem.init(*m_device, alloc_info);
+        mem.Init(*m_device, alloc_info);
         ASSERT_TRUE(mem.initialized());
     }
 

--- a/tests/unit/ycbcr.cpp
+++ b/tests/unit/ycbcr.cpp
@@ -556,10 +556,10 @@ TEST_F(NegativeYcbcr, MultiplaneImageCopyBufferToImage) {
     copy.bufferOffset = 16;  // pushes over
 
     for (size_t i = 0; i < aspects.size(); ++i) {
-        buffers[i].init(*m_device, 16 * 16 * 1, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
+        buffers[i].Init(*m_device, 16 * 16 * 1, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
         copy.imageSubresource.aspectMask = aspects[i];
         m_errorMonitor->SetDesiredError("VUID-vkCmdCopyBufferToImage-pRegions-00171");
-        vk::CmdCopyBufferToImage(m_command_buffer, buffers[i].handle(), image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy);
+        vk::CmdCopyBufferToImage(m_command_buffer, buffers[i], image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy);
         m_errorMonitor->VerifyFound();
     }
     m_command_buffer.End();
@@ -1027,8 +1027,8 @@ TEST_F(NegativeYcbcr, BindMemory2Disjoint) {
         mp_image_alloc_info[1].allocationSize = mp_image_mem_reqs2[1].memoryRequirements.size;
         m_device->Physical().SetMemoryType(mp_image_mem_reqs2[1].memoryRequirements.memoryTypeBits, &mp_image_alloc_info[1], 0);
 
-        mp_image_mem[0].init(*m_device, mp_image_alloc_info[0]);
-        mp_image_mem[1].init(*m_device, mp_image_alloc_info[1]);
+        mp_image_mem[0].Init(*m_device, mp_image_alloc_info[0]);
+        mp_image_mem[1].Init(*m_device, mp_image_alloc_info[1]);
     }
 
     // All planes must be bound at once the same here
@@ -1222,8 +1222,8 @@ TEST_F(NegativeYcbcr, BindMemory2DisjointUnsupported) {
         mp_image_alloc_info[1].allocationSize = mp_image_mem_reqs2[1].memoryRequirements.size;
         m_device->Physical().SetMemoryType(mp_image_mem_reqs2[1].memoryRequirements.memoryTypeBits, &mp_image_alloc_info[1], 0);
 
-        mp_image_mem[0].init(*m_device, mp_image_alloc_info[0]);
-        mp_image_mem[1].init(*m_device, mp_image_alloc_info[1]);
+        mp_image_mem[0].Init(*m_device, mp_image_alloc_info[0]);
+        mp_image_mem[1].Init(*m_device, mp_image_alloc_info[1]);
     }
 
     // All planes must be bound at once the same here

--- a/tests/unit/ycbcr_positive.cpp
+++ b/tests/unit/ycbcr_positive.cpp
@@ -111,9 +111,9 @@ TEST_F(PositiveYcbcr, MultiplaneImageCopyBufferToImage) {
     copy.imageExtent = {16, 16, 1};
 
     for (size_t i = 0; i < aspects.size(); ++i) {
-        buffers[i].init(*m_device, 16 * 16 * 1, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
+        buffers[i].Init(*m_device, 16 * 16 * 1, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
         copy.imageSubresource.aspectMask = aspects[i];
-        vk::CmdCopyBufferToImage(m_command_buffer, buffers[i].handle(), image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy);
+        vk::CmdCopyBufferToImage(m_command_buffer, buffers[i], image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy);
     }
     m_command_buffer.End();
 }
@@ -149,8 +149,7 @@ TEST_F(PositiveYcbcr, MultiplaneImageCopy) {
     }
 
     vkt::Image image(*m_device, ci, vkt::no_mem);
-    vkt::DeviceMemory mem_obj;
-    mem_obj.init(*m_device, vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image.MemoryRequirements(), 0));
+    vkt::DeviceMemory mem_obj(*m_device, vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image.MemoryRequirements(), 0));
 
     vk::BindImageMemory(device(), image, mem_obj, 0);
 
@@ -248,9 +247,9 @@ TEST_F(PositiveYcbcr, MultiplaneImageBindDisjoint) {
         bind_info[plane].image = image;
         bind_info[plane].memoryOffset = 0;
     }
-    bind_info[0].memory = p0_mem.handle();
-    bind_info[1].memory = p1_mem.handle();
-    bind_info[2].memory = p2_mem.handle();
+    bind_info[0].memory = p0_mem;
+    bind_info[1].memory = p1_mem;
+    bind_info[2].memory = p2_mem;
     plane_info[0].planeAspect = VK_IMAGE_ASPECT_PLANE_0_BIT;
     plane_info[1].planeAspect = VK_IMAGE_ASPECT_PLANE_1_BIT;
     plane_info[2].planeAspect = VK_IMAGE_ASPECT_PLANE_2_BIT;


### PR DESCRIPTION
remove `init` for `Init` in the tests

cleaned up spots where we could have just used the constructor

removed more `.handle()` where it is implicit