### PR TITLE
layers: Fix unused variable build error

### DIFF
--- a/layers/core_checks/cc_video.cpp
+++ b/layers/core_checks/cc_video.cpp
@@ -854,6 +854,7 @@ bool core::ValidateVideoProfileInfo(const StateObject &state, const VkVideoProfi
 
     const char *profile_pnext_msg = "chain does not contain a %s structure.";
     const char *codec_feature_not_enabled_msg = "is %s but the %s device feature is not enabled.";
+    (void)codec_feature_not_enabled_msg;
 
     if (GetBitSetCount(profile->chromaSubsampling) != 1) {
         skip |= state.LogError("VUID-VkVideoProfileInfoKHR-chromaSubsampling-07013", error_obj.objlist,


### PR DESCRIPTION
Not sure how nobody else got this, but for me the build was failing with:
```
/home/nnn/Projects/Vulkan-ValidationLayers/layers/core_checks/cc_video.cpp: In instantiation of ‘bool core::ValidateVideoProfileInfo(const StateObject&, const VkVideoProfileInfoKHR*, const ErrorObject&, const Location&) [with StateObject = core::Instance; VkVideoProfileInfoKHR = VkVideoProfileInfoKHR]’:
/home/nnn/Projects/Vulkan-ValidationLayers/layers/core_checks/cc_video.cpp:1004:111:   required from here
/home/nnn/Projects/Vulkan-ValidationLayers/layers/core_checks/cc_video.cpp:856:17: error: variable ‘codec_feature_not_enabled_msg’ set but not used [-Werror=unused-but-set-variable]
  856 |     const char *codec_feature_not_enabled_msg = "is %s but the %s device feature is not enabled.";
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```