### PR TITLE
layers: Move callbacks to cb substate

### DIFF
--- a/layers/best_practices/best_practices_validation.h
+++ b/layers/best_practices/best_practices_validation.h
@@ -494,7 +494,8 @@ class BestPractices : public vvl::DeviceProxy {
     bool PreCallValidateCmdResolveImage2(VkCommandBuffer commandBuffer, const VkResolveImageInfo2* pResolveImageInfo,
                                          const ErrorObject& error_obj) const override;
 
-    using QueueCallbacks = std::vector<vvl::CommandBuffer::QueueCallback>;
+    using QueueCallback = std::function<bool(const class vvl::Queue& queue_state, const vvl::CommandBuffer& cb_state)>;
+    using QueueCallbacks = std::vector<QueueCallback>;
 
     void QueueValidateImageView(QueueCallbacks& func, Func command, vvl::ImageView* view, IMAGE_SUBRESOURCE_USAGE_BP usage);
     void QueueValidateImage(QueueCallbacks& func, Func command, std::shared_ptr<vvl::Image>& state,

--- a/layers/best_practices/bp_copy_blit_resolve.cpp
+++ b/layers/best_practices/bp_copy_blit_resolve.cpp
@@ -367,7 +367,8 @@ void BestPractices::PostCallRecordCmdResolveImage(VkCommandBuffer commandBuffer,
                                                   VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
                                                   const VkImageResolve* pRegions, const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
-    auto& funcs = cb_state->queue_submit_functions;
+    auto& sub_state = bp_state::SubState(*cb_state);
+    auto& funcs = sub_state.queue_submit_functions;
     auto src = Get<vvl::Image>(srcImage);
     auto dst = Get<vvl::Image>(dstImage);
 
@@ -388,7 +389,8 @@ void BestPractices::PostCallRecordCmdResolveImage2KHR(VkCommandBuffer commandBuf
 void BestPractices::PostCallRecordCmdResolveImage2(VkCommandBuffer commandBuffer, const VkResolveImageInfo2* pResolveImageInfo,
                                                    const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
-    auto& funcs = cb_state->queue_submit_functions;
+    auto& sub_state = bp_state::SubState(*cb_state);
+    auto& funcs = sub_state.queue_submit_functions;
     auto src = Get<vvl::Image>(pResolveImageInfo->srcImage);
     auto dst = Get<vvl::Image>(pResolveImageInfo->dstImage);
     uint32_t region_count = pResolveImageInfo->regionCount;
@@ -405,7 +407,8 @@ void BestPractices::PostCallRecordCmdClearColorImage(VkCommandBuffer commandBuff
                                                      const VkClearColorValue* pColor, uint32_t rangeCount,
                                                      const VkImageSubresourceRange* pRanges, const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
-    auto& funcs = cb_state->queue_submit_functions;
+    auto& sub_state = bp_state::SubState(*cb_state);
+    auto& funcs = sub_state.queue_submit_functions;
     auto dst = Get<vvl::Image>(image);
 
     for (uint32_t i = 0; i < rangeCount; i++) {
@@ -422,14 +425,14 @@ void BestPractices::PostCallRecordCmdClearDepthStencilImage(VkCommandBuffer comm
                                                             const VkImageSubresourceRange* pRanges,
                                                             const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
-    auto& funcs = cb_state->queue_submit_functions;
+    auto& sub_state = bp_state::SubState(*cb_state);
+    auto& funcs = sub_state.queue_submit_functions;
     auto dst = Get<vvl::Image>(image);
 
     for (uint32_t i = 0; i < rangeCount; i++) {
         QueueValidateImage(funcs, record_obj.location.function, dst, IMAGE_SUBRESOURCE_USAGE_BP::CLEARED, pRanges[i]);
     }
     if (VendorCheckEnabled(kBPVendorNVIDIA)) {
-        auto& sub_state = bp_state::SubState(*cb_state);
         for (uint32_t i = 0; i < rangeCount; i++) {
             RecordResetZcullDirection(sub_state, image, pRanges[i]);
         }
@@ -440,7 +443,8 @@ void BestPractices::PostCallRecordCmdCopyImage(VkCommandBuffer commandBuffer, Vk
                                                VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
                                                const VkImageCopy* pRegions, const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
-    auto& funcs = cb_state->queue_submit_functions;
+    auto& sub_state = bp_state::SubState(*cb_state);
+    auto& funcs = sub_state.queue_submit_functions;
     auto src = Get<vvl::Image>(srcImage);
     auto dst = Get<vvl::Image>(dstImage);
 
@@ -456,7 +460,8 @@ void BestPractices::PostCallRecordCmdCopyBufferToImage(VkCommandBuffer commandBu
                                                        VkImageLayout dstImageLayout, uint32_t regionCount,
                                                        const VkBufferImageCopy* pRegions, const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
-    auto& funcs = cb_state->queue_submit_functions;
+    auto& sub_state = bp_state::SubState(*cb_state);
+    auto& funcs = sub_state.queue_submit_functions;
     auto dst = Get<vvl::Image>(dstImage);
 
     for (uint32_t i = 0; i < regionCount; i++) {
@@ -469,7 +474,8 @@ void BestPractices::PostCallRecordCmdCopyImageToBuffer(VkCommandBuffer commandBu
                                                        VkImageLayout srcImageLayout, VkBuffer dstBuffer, uint32_t regionCount,
                                                        const VkBufferImageCopy* pRegions, const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
-    auto& funcs = cb_state->queue_submit_functions;
+    auto& sub_state = bp_state::SubState(*cb_state);
+    auto& funcs = sub_state.queue_submit_functions;
     auto src = Get<vvl::Image>(srcImage);
 
     for (uint32_t i = 0; i < regionCount; i++) {
@@ -482,7 +488,8 @@ void BestPractices::PostCallRecordCmdBlitImage(VkCommandBuffer commandBuffer, Vk
                                                VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
                                                const VkImageBlit* pRegions, VkFilter filter, const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
-    auto& funcs = cb_state->queue_submit_functions;
+    auto& sub_state = bp_state::SubState(*cb_state);
+    auto& funcs = sub_state.queue_submit_functions;
     auto src = Get<vvl::Image>(srcImage);
     auto dst = Get<vvl::Image>(dstImage);
 

--- a/layers/best_practices/bp_drawdispatch.cpp
+++ b/layers/best_practices/bp_drawdispatch.cpp
@@ -630,7 +630,7 @@ void BestPractices::ValidateBoundDescriptorSets(bp_state::CommandBufferSubState&
 
                 if (image_view) {
                     auto image_view_state = Get<vvl::ImageView>(image_view);
-                    QueueValidateImageView(cb_state.base.queue_submit_functions, command, image_view_state.get(),
+                    QueueValidateImageView(cb_state.queue_submit_functions, command, image_view_state.get(),
                                            IMAGE_SUBRESOURCE_USAGE_BP::DESCRIPTOR_ACCESS);
                 }
             }

--- a/layers/best_practices/bp_render_pass.cpp
+++ b/layers/best_practices/bp_render_pass.cpp
@@ -308,32 +308,32 @@ bool BestPractices::PreCallValidateCmdBeginRenderingKHR(VkCommandBuffer commandB
 // Using PreCallRecord because LayerObjectTypeStateTracker will destroy render pass object first in PostCallRecord
 void BestPractices::PreCallRecordCmdEndRenderPass(VkCommandBuffer commandBuffer, const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
+    auto& sub_state = bp_state::SubState(*cb_state);
     if (auto rp_state = cb_state->active_render_pass.get()) {
-        auto& sub_state = bp_state::SubState(*cb_state);
         RecordCmdEndRenderingCommon(sub_state, *rp_state);
     }
 
     // Add Deferred Queue
-    cb_state->queue_submit_functions.insert(cb_state->queue_submit_functions.end(),
-                                            cb_state->queue_submit_functions_after_render_pass.begin(),
-                                            cb_state->queue_submit_functions_after_render_pass.end());
-    cb_state->queue_submit_functions_after_render_pass.clear();
+    sub_state.queue_submit_functions.insert(sub_state.queue_submit_functions.end(),
+                                            sub_state.queue_submit_functions_after_render_pass.begin(),
+                                            sub_state.queue_submit_functions_after_render_pass.end());
+    sub_state.queue_submit_functions_after_render_pass.clear();
 }
 
 // Using PreCallRecord because LayerObjectTypeStateTracker will destroy render pass object first in PostCallRecord
 void BestPractices::PreCallRecordCmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassInfo,
                                                    const RecordObject& record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
+    auto& sub_state = bp_state::SubState(*cb_state);
     if (auto rp_state = cb_state->active_render_pass.get()) {
-        auto& sub_state = bp_state::SubState(*cb_state);
         RecordCmdEndRenderingCommon(sub_state, *rp_state);
     }
 
     // Add Deferred Queue
-    cb_state->queue_submit_functions.insert(cb_state->queue_submit_functions.end(),
-                                            cb_state->queue_submit_functions_after_render_pass.begin(),
-                                            cb_state->queue_submit_functions_after_render_pass.end());
-    cb_state->queue_submit_functions_after_render_pass.clear();
+    sub_state.queue_submit_functions.insert(sub_state.queue_submit_functions.end(),
+                                            sub_state.queue_submit_functions_after_render_pass.begin(),
+                                            sub_state.queue_submit_functions_after_render_pass.end());
+    sub_state.queue_submit_functions_after_render_pass.clear();
 }
 
 void BestPractices::PreCallRecordCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfoKHR* pSubpassInfo,
@@ -441,7 +441,7 @@ void BestPractices::RecordCmdBeginRenderPass(bp_state::CommandBufferSubState& cb
             }
         }
 
-        QueueValidateImageView(cb_state.base.queue_submit_functions, Func::vkCmdBeginRenderPass, image_view.get(), usage);
+        QueueValidateImageView(cb_state.queue_submit_functions, Func::vkCmdBeginRenderPass, image_view.get(), usage);
     }
 
     // Check store ops
@@ -478,7 +478,7 @@ void BestPractices::RecordCmdBeginRenderPass(bp_state::CommandBufferSubState& cb
             }
         }
 
-        QueueValidateImageView(cb_state.base.queue_submit_functions_after_render_pass, Func::vkCmdEndRenderPass, image_view.get(),
+        QueueValidateImageView(cb_state.queue_submit_functions_after_render_pass, Func::vkCmdEndRenderPass, image_view.get(),
                                usage);
     }
 }

--- a/layers/best_practices/bp_state.h
+++ b/layers/best_practices/bp_state.h
@@ -172,6 +172,8 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
                              const void* values) final;
     void ClearPushConstants() final;
 
+    void Submit(vvl::Queue& queue_state, uint32_t perf_submit_pass, const Location& loc) final;
+
     struct SignalingInfo {
         // True, if the event's first state change within a command buffer is a signal (SetEvent)
         // rather than an unsignal (ResetEvent). It is used to do validation on the boundary
@@ -185,6 +187,12 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
         explicit SignalingInfo(bool signal) : first_state_change_is_signal(signal), signaled(signal) {}
     };
     vvl::unordered_map<VkEvent, SignalingInfo> event_signaling_state;
+
+    using QueueCallback = std::function<bool(const class vvl::Queue& queue_state, const vvl::CommandBuffer& cb_state)>;
+    std::vector<QueueCallback> queue_submit_functions;
+    // Used by some layers to defer actions until vkCmdEndRenderPass time.
+    // Layers using this are responsible for inserting the callbacks into queue_submit_functions.
+    std::vector<QueueCallback> queue_submit_functions_after_render_pass;
 
   private:
     void ResetCBState();

--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -1202,7 +1202,8 @@ bool CoreChecks::ValidateCmdExecuteCommandsRenderPassInheritance(const vvl::Comm
         }
         // Inherit primary's activeFramebuffer, or null if using dynamic rendering,
         // and while running validate functions
-        for (auto &function : secondary_cb_state.cmd_execute_commands_functions) {
+        auto &secondary_sub_state = core::SubState(secondary_cb_state);
+        for (auto &function : secondary_sub_state.cmd_execute_commands_functions) {
             skip |= function(secondary_cb_state, &cb_state, cb_state.active_framebuffer.get());
         }
     }

--- a/layers/core_checks/cc_copy_blit_resolve.cpp
+++ b/layers/core_checks/cc_copy_blit_resolve.cpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "core_validation.h"
+#include "core_checks/cc_state_tracker.h"
 #include "cc_vuid_maps.h"
 #include "error_message/error_location.h"
 #include "error_message/error_strings.h"
@@ -1923,84 +1924,83 @@ void CoreChecks::PostCallRecordCmdCopyImage2(VkCommandBuffer commandBuffer, cons
 template <typename RegionType>
 void CoreChecks::RecordCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer, uint32_t regionCount,
                                      const RegionType *pRegions, const Location &loc) {
-    const bool is_2 = loc.function == Func::vkCmdCopyBuffer2 || loc.function == Func::vkCmdCopyBuffer2KHR;
-    const char *vuid = is_2 ? "VUID-VkCopyBufferInfo2-pRegions-00117" : "VUID-vkCmdCopyBuffer-pRegions-00117";
-
+    auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
+    auto &cb_sub_state = core::SubState(*cb_state);
     auto src_buffer_state = Get<vvl::Buffer>(srcBuffer);
     auto dst_buffer_state = Get<vvl::Buffer>(dstBuffer);
     ASSERT_AND_RETURN(src_buffer_state && dst_buffer_state);
+    if (regionCount == 0 || (!src_buffer_state->sparse && !dst_buffer_state->sparse)) {
+        return;
+    }
 
-    if (regionCount > 0 && (src_buffer_state->sparse || dst_buffer_state->sparse)) {
-        auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
+    using BufferRange = vvl::BindableMemoryTracker::BufferRange;
 
-        using BufferRange = vvl::BindableMemoryTracker::BufferRange;
+    std::vector<BufferRange> src_ranges(regionCount);
+    std::vector<BufferRange> dst_ranges(regionCount);
+    BufferRange src_ranges_bounds(pRegions[0].srcOffset, pRegions[0].srcOffset + pRegions[0].size);
+    BufferRange dst_ranges_bounds(pRegions[0].dstOffset, pRegions[0].dstOffset + pRegions[0].size);
 
-        std::vector<BufferRange> src_ranges(regionCount);
-        std::vector<BufferRange> dst_ranges(regionCount);
-        BufferRange src_ranges_bounds(pRegions[0].srcOffset, pRegions[0].srcOffset + pRegions[0].size);
-        BufferRange dst_ranges_bounds(pRegions[0].dstOffset, pRegions[0].dstOffset + pRegions[0].size);
+    for (uint32_t i = 0; i < regionCount; ++i) {
+        const RegionType &region = pRegions[i];
+        src_ranges[i] = vvl::range<VkDeviceSize>{region.srcOffset, region.srcOffset + region.size};
+        dst_ranges[i] = vvl::range<VkDeviceSize>{region.dstOffset, region.dstOffset + region.size};
 
-        for (uint32_t i = 0; i < regionCount; ++i) {
-            const RegionType &region = pRegions[i];
-            src_ranges[i] = vvl::range<VkDeviceSize>{region.srcOffset, region.srcOffset + region.size};
-            dst_ranges[i] = vvl::range<VkDeviceSize>{region.dstOffset, region.dstOffset + region.size};
+        src_ranges_bounds.begin = std::min(src_ranges_bounds.begin, region.srcOffset);
+        src_ranges_bounds.end = std::max(src_ranges_bounds.end, region.srcOffset + region.size);
 
-            src_ranges_bounds.begin = std::min(src_ranges_bounds.begin, region.srcOffset);
-            src_ranges_bounds.end = std::max(src_ranges_bounds.end, region.srcOffset + region.size);
+        dst_ranges_bounds.begin = std::min(dst_ranges_bounds.begin, region.dstOffset);
+        dst_ranges_bounds.end = std::max(dst_ranges_bounds.end, region.dstOffset + region.size);
+    }
 
-            dst_ranges_bounds.begin = std::min(dst_ranges_bounds.begin, region.dstOffset);
-            dst_ranges_bounds.end = std::max(dst_ranges_bounds.end, region.dstOffset + region.size);
-        }
+    auto queue_submit_validation = [this, src_buffer_state, dst_buffer_state, src_ranges = std::move(src_ranges),
+                                    dst_ranges = std::move(dst_ranges), src_ranges_bounds, dst_ranges_bounds,
+                                    loc](const class vvl::Queue &queue_state, const vvl::CommandBuffer &cb_state) -> bool {
+        bool skip = false;
 
-        auto queue_submit_validation = [this, commandBuffer, src_buffer_state, dst_buffer_state, src_ranges = std::move(src_ranges),
-                                        dst_ranges = std::move(dst_ranges), src_ranges_bounds, dst_ranges_bounds, loc,
-                                        vuid](const class vvl::Queue &queue_state, const vvl::CommandBuffer &cb_state) -> bool {
-            bool skip = false;
+        auto src_vk_memory_to_ranges_map = src_buffer_state->GetBoundRanges(src_ranges_bounds, src_ranges);
+        auto dst_vk_memory_to_ranges_map = dst_buffer_state->GetBoundRanges(dst_ranges_bounds, dst_ranges);
 
-            auto src_vk_memory_to_ranges_map = src_buffer_state->GetBoundRanges(src_ranges_bounds, src_ranges);
-            auto dst_vk_memory_to_ranges_map = dst_buffer_state->GetBoundRanges(dst_ranges_bounds, dst_ranges);
+        for (const auto &[vk_memory, src_ranges] : src_vk_memory_to_ranges_map) {
+            const auto find_mem_it = dst_vk_memory_to_ranges_map.find(vk_memory);
+            if (find_mem_it == dst_vk_memory_to_ranges_map.end()) {
+                continue;
+            }
+            // Some source and destination ranges are bound to the same VkDeviceMemory, look for overlaps.
+            // Memory ranges are sorted, so looking for overlaps can be done in linear time
 
-            for (const auto &[vk_memory, src_ranges] : src_vk_memory_to_ranges_map) {
-                if (const auto find_mem_it = dst_vk_memory_to_ranges_map.find(vk_memory);
-                    find_mem_it != dst_vk_memory_to_ranges_map.end()) {
-                    // Some source and destination ranges are bound to the same VkDeviceMemory, look for overlaps.
-                    // Memory ranges are sorted, so looking for overlaps can be done in linear time
+            auto &dst_ranges_vec = find_mem_it->second;
+            auto src_ranges_it = src_ranges.cbegin();
+            auto dst_ranges_it = dst_ranges_vec.cbegin();
 
-                    auto &dst_ranges_vec = find_mem_it->second;
-                    auto src_ranges_it = src_ranges.cbegin();
-                    auto dst_ranges_it = dst_ranges_vec.cbegin();
+            while (src_ranges_it != src_ranges.cend() && dst_ranges_it != dst_ranges_vec.cend()) {
+                if (src_ranges_it->first.intersects(dst_ranges_it->first)) {
+                    auto memory_range_overlap = src_ranges_it->first & dst_ranges_it->first;
 
-                    while (src_ranges_it != src_ranges.cend() && dst_ranges_it != dst_ranges_vec.cend()) {
-                        if (src_ranges_it->first.intersects(dst_ranges_it->first)) {
-                            auto memory_range_overlap = src_ranges_it->first & dst_ranges_it->first;
+                    const LogObjectList objlist(cb_state.Handle(), src_buffer_state->Handle(), dst_buffer_state->Handle(),
+                                                vk_memory);
+                    const bool is_2 = loc.function == Func::vkCmdCopyBuffer2 || loc.function == Func::vkCmdCopyBuffer2KHR;
+                    const char *vuid = is_2 ? "VUID-VkCopyBufferInfo2-pRegions-00117" : "VUID-vkCmdCopyBuffer-pRegions-00117";
+                    skip |= this->LogError(
+                        vuid, objlist, loc,
+                        "Copy source buffer range %s (from buffer %s) and destination buffer range %s (from buffer %s) are "
+                        "bound to the same memory (%s), "
+                        "and end up overlapping on memory range %s.",
+                        vvl::string_range(src_ranges_it->second).c_str(), FormatHandle(src_buffer_state->VkHandle()).c_str(),
+                        vvl::string_range(dst_ranges_it->second).c_str(), FormatHandle(dst_buffer_state->VkHandle()).c_str(),
+                        FormatHandle(vk_memory).c_str(), vvl::string_range(memory_range_overlap).c_str());
+                }
 
-                            const LogObjectList objlist(commandBuffer, src_buffer_state->Handle(), dst_buffer_state->Handle(),
-                                                        vk_memory);
-                            skip |= this->LogError(
-                                vuid, objlist, loc,
-                                "Copy source buffer range %s (from buffer %s) and destination buffer range %s (from buffer %s) are "
-                                "bound to the same memory (%s), "
-                                "and end up overlapping on memory range %s.",
-                                vvl::string_range(src_ranges_it->second).c_str(),
-                                FormatHandle(src_buffer_state->VkHandle()).c_str(),
-                                vvl::string_range(dst_ranges_it->second).c_str(),
-                                FormatHandle(dst_buffer_state->VkHandle()).c_str(), FormatHandle(vk_memory).c_str(),
-                                vvl::string_range(memory_range_overlap).c_str());
-                        }
-
-                        if (src_ranges_it->first < dst_ranges_it->first) {
-                            ++src_ranges_it;
-                        } else {
-                            ++dst_ranges_it;
-                        }
-                    }
+                if (src_ranges_it->first < dst_ranges_it->first) {
+                    ++src_ranges_it;
+                } else {
+                    ++dst_ranges_it;
                 }
             }
-            return skip;
-        };
+        }
+        return skip;
+    };
 
-        cb_state->queue_submit_functions.emplace_back(queue_submit_validation);
-    }
+    cb_sub_state.queue_submit_functions.emplace_back(queue_submit_validation);
 }
 
 void CoreChecks::PostCallRecordCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer,

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -27,6 +27,7 @@
 #include "core_validation.h"
 #include "cc_sync_vuid_maps.h"
 #include "cc_vuid_maps.h"
+#include "core_checks/cc_state_tracker.h"
 #include "error_message/error_location.h"
 #include "generated/pnext_chain_extraction.h"
 #include "generated/dispatch_functions.h"
@@ -1357,6 +1358,7 @@ void CoreChecks::PostCallRecordCmdClearAttachments(VkCommandBuffer commandBuffer
     if (!rp_state || cb_state.IsPrimary()) {
         return;
     }
+    auto &cb_sub_state = core::SubState(*cb_state_ptr);
     std::shared_ptr<std::vector<VkClearRect>> clear_rect_copy;
     if (rp_state->use_dynamic_rendering_inherited) {
         for (uint32_t attachment_index = 0; attachment_index < attachmentCount; attachment_index++) {
@@ -1388,7 +1390,7 @@ void CoreChecks::PostCallRecordCmdClearAttachments(VkCommandBuffer commandBuffer
                         prim_cb->active_render_pass->dynamic_rendering_begin_rendering_info.layerCount, rectCount,
                         clear_rect_copy->data(), record_obj.location);
                 };
-                cb_state_ptr->cmd_execute_commands_functions.emplace_back(val_fn);
+                cb_sub_state.cmd_execute_commands_functions.emplace_back(val_fn);
             }
         }
     } else if (!rp_state->use_dynamic_rendering) {
@@ -1425,7 +1427,7 @@ void CoreChecks::PostCallRecordCmdClearAttachments(VkCommandBuffer commandBuffer
                     }
                     return skip;
                 };
-                cb_state_ptr->cmd_execute_commands_functions.emplace_back(val_fn);
+                cb_sub_state.cmd_execute_commands_functions.emplace_back(val_fn);
             }
         }
     }

--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -24,6 +24,7 @@
 #include "cc_sync_vuid_maps.h"
 #include "cc_synchronization.h"
 #include "core_validation.h"
+#include "core_checks/cc_state_tracker.h"
 #include "state_tracker/queue_state.h"
 #include "state_tracker/semaphore_state.h"
 #include "state_tracker/image_state.h"
@@ -73,12 +74,13 @@ struct CommandBufferSubmitState {
             return true;
         }
 
-        for (auto &function : cb_state.event_updates) {
+        auto &cb_sub_state = core::SubState(cb_state);
+        for (auto &function : cb_sub_state.event_updates) {
             skip |= function(const_cast<vvl::CommandBuffer &>(cb_state), /*do_validate*/ true, local_event_signal_info,
                              queue_state.VkHandle(), loc);
         }
         VkQueryPool first_perf_query_pool = VK_NULL_HANDLE;
-        for (auto &function : cb_state.query_updates) {
+        for (auto &function : cb_sub_state.query_updates) {
             skip |= function(const_cast<vvl::CommandBuffer &>(cb_state), /*do_validate*/ true, first_perf_query_pool, perf_pass,
                              &local_query_to_state_map);
         }

--- a/layers/core_checks/cc_state_tracker.cpp
+++ b/layers/core_checks/cc_state_tracker.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "cc_state_tracker.h"
+#include <vulkan/vulkan_core.h>
 #include "core_validation.h"
 #include "cc_sync_vuid_maps.h"
 #include "error_message/error_strings.h"
@@ -43,8 +44,33 @@ CommandBufferSubState::CommandBufferSubState(vvl::CommandBuffer& cb, CoreChecks&
     ResetCBState();
 }
 
+void CommandBufferSubState::RecordSetEvent(vvl::Func, VkEvent event, VkPipelineStageFlags2 stage_mask,
+                                           const VkDependencyInfo* dependency_info) {
+    vku::safe_VkDependencyInfo safe_dependency_info = {};
+    if (dependency_info) {
+        safe_dependency_info.initialize(dependency_info);
+    } else {
+        // Set sType to invalid, so following code can check sType to see if the struct is valid
+        safe_dependency_info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+    }
+    event_updates.emplace_back([event, stage_mask, safe_dependency_info](vvl::CommandBuffer&, bool do_validate,
+                                                                         EventMap& local_event_signal_info, VkQueue,
+                                                                         const Location& loc) {
+        local_event_signal_info[event] = EventInfo{stage_mask, true, safe_dependency_info};
+        return false;  // skip
+    });
+}
+
+void CommandBufferSubState::RecordResetEvent(vvl::Func, VkEvent event, VkPipelineStageFlags2) {
+    event_updates.emplace_back(
+        [event](vvl::CommandBuffer&, bool do_validate, EventMap& local_event_signal_info, VkQueue, const Location& loc) {
+            local_event_signal_info[event] = EventInfo{VK_PIPELINE_STAGE_2_NONE, false};
+            return false;  // skip
+        });
+}
+
 void CommandBufferSubState::RecordWaitEvents(vvl::Func command, uint32_t eventCount, const VkEvent* pEvents,
-                                             VkPipelineStageFlags2KHR srcStageMask, const VkDependencyInfo* dependency_info) {
+                                             VkPipelineStageFlags2 src_stage_mask, const VkDependencyInfo* dependency_info) {
     // vvl::CommandBuffer will add to the events vector. TODO this is now incorrect
     auto first_event_index = base.events.size();
     auto event_added_count = eventCount;
@@ -57,13 +83,83 @@ void CommandBufferSubState::RecordWaitEvents(vvl::Func command, uint32_t eventCo
         safe_dependency_info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
     }
 
-    base.event_updates.emplace_back(
-        [command, event_added_count, first_event_index, srcStageMask, safe_dependency_info](
+    event_updates.emplace_back(
+        [command, event_added_count, first_event_index, src_stage_mask, safe_dependency_info](
             vvl::CommandBuffer& cb_state, bool do_validate, EventMap& local_event_signal_info, VkQueue queue, const Location& loc) {
             if (!do_validate) return false;
-            return CoreChecks::ValidateWaitEventsAtSubmit(command, cb_state, event_added_count, first_event_index, srcStageMask,
+            return CoreChecks::ValidateWaitEventsAtSubmit(command, cb_state, event_added_count, first_event_index, src_stage_mask,
                                                           safe_dependency_info, local_event_signal_info, queue, loc);
         });
+}
+
+static bool SetQueryState(const QueryObject& object, QueryState value, QueryMap* local_query_to_state_map) {
+    (*local_query_to_state_map)[object] = value;
+    return false;
+}
+
+static bool SetQueryStateMulti(VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount, uint32_t perf_query_pass,
+                               QueryState value, QueryMap* local_query_to_state_map) {
+    for (uint32_t i = 0; i < queryCount; i++) {
+        QueryObject query_obj = {queryPool, firstQuery + i, perf_query_pass};
+        (*local_query_to_state_map)[query_obj] = value;
+    }
+    return false;
+}
+
+void CommandBufferSubState::BeginQuery(const QueryObject& query_obj) {
+    query_updates.emplace_back([query_obj](vvl::CommandBuffer& cb_state_arg, bool do_validate, VkQueryPool&,
+                                           uint32_t perf_query_pass, QueryMap* local_query_to_state_map) {
+        SetQueryState(QueryObject(query_obj, perf_query_pass), QUERYSTATE_RUNNING, local_query_to_state_map);
+        return false;
+    });
+}
+
+void CommandBufferSubState::EndQuery(const QueryObject& query_obj) {
+    query_updates.emplace_back([query_obj](vvl::CommandBuffer& cb_state_arg, bool do_validate, VkQueryPool&,
+                                           uint32_t perf_query_pass, QueryMap* local_query_to_state_map) {
+        return SetQueryState(QueryObject(query_obj, perf_query_pass), QUERYSTATE_ENDED, local_query_to_state_map);
+    });
+}
+
+void CommandBufferSubState::EndQueries(VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount) {
+    query_updates.emplace_back([queryPool, firstQuery, queryCount](vvl::CommandBuffer& cb_state_arg, bool do_validate, VkQueryPool&,
+                                                                   uint32_t perf_query_pass, QueryMap* local_query_to_state_map) {
+        return SetQueryStateMulti(queryPool, firstQuery, queryCount, perf_query_pass, QUERYSTATE_ENDED, local_query_to_state_map);
+    });
+}
+
+void CommandBufferSubState::ResetQueryPool(VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount) {
+    query_updates.emplace_back([queryPool, firstQuery, queryCount](vvl::CommandBuffer& cb_state_arg, bool do_validate, VkQueryPool&,
+                                                                   uint32_t perf_query_pass, QueryMap* local_query_to_state_map) {
+        return SetQueryStateMulti(queryPool, firstQuery, queryCount, perf_query_pass, QUERYSTATE_RESET, local_query_to_state_map);
+    });
+}
+
+void CommandBufferSubState::EnqueueUpdateVideoInlineQueries(const VkVideoInlineQueryInfoKHR& query_info) {
+    query_updates.emplace_back([query_info](vvl::CommandBuffer& cb_state_arg, bool do_validate, VkQueryPool&,
+                                            uint32_t perf_query_pass, QueryMap* local_query_to_state_map) {
+        for (uint32_t i = 0; i < query_info.queryCount; i++) {
+            SetQueryState(QueryObject(query_info.queryPool, query_info.firstQuery + i), QUERYSTATE_ENDED, local_query_to_state_map);
+        }
+        return false;
+    });
+}
+
+void CommandBufferSubState::Retire(uint32_t perf_submit_pass,
+                                   const std::function<bool(const QueryObject&)>& is_query_updated_after) {
+    QueryMap local_query_to_state_map;
+    VkQueryPool first_pool = VK_NULL_HANDLE;
+    for (auto& function : query_updates) {
+        function(base, /*do_validate*/ false, first_pool, perf_submit_pass, &local_query_to_state_map);
+    }
+
+    for (const auto& [query_object, query_state] : local_query_to_state_map) {
+        if (query_state == QUERYSTATE_ENDED && !is_query_updated_after(query_object)) {
+            auto query_pool_state = base.dev_data.Get<vvl::QueryPool>(query_object.pool);
+            if (!query_pool_state) continue;
+            query_pool_state->SetQueryState(query_object.slot, query_object.perf_pass, QUERYSTATE_AVAILABLE);
+        }
+    }
 }
 
 void CommandBufferSubState::Reset(const Location& loc) { ResetCBState(); }
@@ -79,13 +175,80 @@ void CommandBufferSubState::ResetCBState() {
     nesting_level = 0;
 
     // Submit time validation
+    queue_submit_functions.clear();
     submit_validate_dynamic_rendering_barrier_subresources.clear();
+    event_updates.clear();
+    cmd_execute_commands_functions.clear();
+    query_updates.clear();
 }
 
 void CommandBufferSubState::ExecuteCommands(vvl::CommandBuffer& secondary_command_buffer) {
+    auto& secondary_sub_state = SubState(secondary_command_buffer);
     if (secondary_command_buffer.IsSecondary()) {
-        auto& secondary_sub_state = SubState(secondary_command_buffer);
         nesting_level = std::max(nesting_level, secondary_sub_state.nesting_level + 1);
+    }
+
+    for (auto& function : secondary_sub_state.event_updates) {
+        event_updates.push_back(function);
+    }
+
+    for (auto& function : secondary_sub_state.queue_submit_functions) {
+        queue_submit_functions.push_back(function);
+    }
+
+    // Add a query update that runs all the query updates that happen in the sub command buffer.
+    // This avoids locking ambiguity because primary command buffers are locked when these
+    // callbacks run, but secondary command buffers are not.
+    const VkCommandBuffer sub_command_buffer = secondary_command_buffer.VkHandle();
+    query_updates.emplace_back([sub_command_buffer](vvl::CommandBuffer& cb_state_arg, bool do_validate,
+                                                    VkQueryPool& first_perf_query_pool, uint32_t perf_query_pass,
+                                                    QueryMap* local_query_to_state_map) {
+        bool skip = false;
+        auto secondary_cb_state_arg = cb_state_arg.dev_data.GetWrite<vvl::CommandBuffer>(sub_command_buffer);
+        auto& secondary_sub_state_arg = SubState(*secondary_cb_state_arg);
+        for (auto& function : secondary_sub_state_arg.query_updates) {
+            skip |=
+                function(*secondary_cb_state_arg, do_validate, first_perf_query_pool, perf_query_pass, local_query_to_state_map);
+        }
+        return skip;
+    });
+}
+
+void CommandBufferSubState::Submit(vvl::Queue& queue_state, uint32_t perf_submit_pass, const Location& loc) {
+    for (auto& func : queue_submit_functions) {
+        func(queue_state, base);
+    }
+
+    // Update vvl::Event with src_stage from the last recorded SetEvent.
+    // Ultimately, it tracks the last SetEvent for the entire submission.
+    {
+        EventMap local_event_signal_info;
+        for (const auto& function : event_updates) {
+            function(base, /*do_validate*/ false, local_event_signal_info,
+                     VK_NULL_HANDLE /* when do_validate is false then wait handler is inactive */, loc);
+        }
+        for (const auto& [event, info] : local_event_signal_info) {
+            auto event_state = base.dev_data.Get<vvl::Event>(event);
+            event_state->signaled = info.signal;
+            event_state->dependency_info = info.dependency_info;
+            event_state->signal_src_stage_mask = info.src_stage_mask;
+            event_state->signaling_queue = queue_state.VkHandle();
+        }
+    }
+
+    // Update vvl::QueryPool with a query state at the end of the command buffer.
+    // Ultimately, it tracks the final query state for the entire submission.
+    {
+        VkQueryPool first_pool = VK_NULL_HANDLE;
+        QueryMap local_query_to_state_map;
+        for (auto& function : query_updates) {
+            function(base, /*do_validate*/ false, first_pool, perf_submit_pass, &local_query_to_state_map);
+        }
+        for (const auto& [query_object, query_state] : local_query_to_state_map) {
+            auto query_pool_state = base.dev_data.Get<vvl::QueryPool>(query_object.pool);
+            if (!query_pool_state) continue;
+            query_pool_state->SetQueryState(query_object.slot, query_object.perf_pass, query_state);
+        }
     }
 }
 
@@ -135,6 +298,40 @@ void QueueSubState::PreSubmit(std::vector<vvl::QueueSubmission>& submissions) {
     }
 }
 
-void QueueSubState::Retire(vvl::QueueSubmission& submission) { queue_submission_validator_.Validate(submission); }
+void QueueSubState::Retire(vvl::QueueSubmission& submission) {
+    queue_submission_validator_.Validate(submission);
+
+    auto is_query_updated_after = [this](const QueryObject& query_object) {
+        auto guard = base.Lock();
+        bool first_queue_submission = true;
+        for (const vvl::QueueSubmission& queue_submission : base.Submissions()) {
+            // The current submission is still on the deque, so skip it
+            if (first_queue_submission) {
+                first_queue_submission = false;
+                continue;
+            }
+            for (const vvl::CommandBufferSubmission& cb_submission : queue_submission.cb_submissions) {
+                if (query_object.perf_pass != queue_submission.perf_submit_pass) {
+                    continue;
+                }
+                if (cb_submission.cb->UpdatesQuery(query_object)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    };
+
+    for (vvl::CommandBufferSubmission& cb_submission : submission.cb_submissions) {
+        CommandBufferSubState& cb_sub_state = SubState(*cb_submission.cb);
+        auto cb_guard = cb_sub_state.base.WriteLock();
+        for (vvl::CommandBuffer* secondary_cmd_buffer : cb_submission.cb->linked_command_buffers) {
+            CommandBufferSubState& secondary_sub_state = SubState(*secondary_cmd_buffer);
+            auto secondary_guard = secondary_sub_state.base.WriteLock();
+            secondary_sub_state.Retire(submission.perf_submit_pass, is_query_updated_after);
+        }
+        cb_sub_state.Retire(submission.perf_submit_pass, is_query_updated_after);
+    }
+}
 
 }  // namespace core

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -321,7 +321,8 @@ class CoreChecks : public vvl::DeviceProxy {
     bool ValidatePipelineCacheControlFlags(VkPipelineCreateFlags2 flags, const Location& flags_loc, const char* vuid) const;
     bool ValidatePipelineIndirectBindableFlags(VkPipelineCreateFlags2 flags, const Location& flags_loc, const char* vuid) const;
     bool ValidatePipelineProtectedAccessFlags(VkPipelineCreateFlags2 flags, const Location& flags_loc) const;
-    void EnqueueValidateImageBarrierAttachment(const Location& loc, vvl::CommandBuffer& cb_state, const ImageBarrier& barrier);
+    void EnqueueValidateImageBarrierAttachment(const Location& loc, core::CommandBufferSubState& cb_sub_state,
+                                               const ImageBarrier& barrier);
     void EnqueueValidateDynamicRenderingImageBarrierLayouts(const Location barrier_loc, vvl::CommandBuffer& cb_state,
                                                             const ImageBarrier& image_barrier);
     bool ValidateImageBarrierAttachment(const Location& barrier_loc, vvl::CommandBuffer const& cb_state,
@@ -429,9 +430,10 @@ class CoreChecks : public vvl::DeviceProxy {
     bool ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindImageMemoryInfo* pBindInfos,
                                  const ErrorObject& error_obj) const;
     static bool VerifyQueryIsReset(const vvl::CommandBuffer& cb_state, const QueryObject& query_obj, Func command,
-                                   VkQueryPool& firstPerfQueryPool, uint32_t perfPass, QueryMap* localQueryToStateMap);
+                                   uint32_t perf_query_pass, QueryMap* local_query_to_state_map);
     static bool ValidatePerformanceQuery(const vvl::CommandBuffer& cb_state, const QueryObject& query_obj, Func command,
-                                         VkQueryPool& firstPerfQueryPool, uint32_t perfPass, QueryMap* localQueryToStateMap);
+                                         VkQueryPool& first_perf_query_pool, uint32_t perf_query_pass,
+                                         QueryMap* local_query_to_state_map);
     bool ValidateBeginQuery(const vvl::CommandBuffer& cb_state, const QueryObject& query_obj, VkQueryControlFlags flags,
                             uint32_t index, const Location& loc) const;
     bool ValidateCmdEndQuery(const vvl::CommandBuffer& cb_state, VkQueryPool queryPool, uint32_t slot, uint32_t index,
@@ -1545,7 +1547,7 @@ class CoreChecks : public vvl::DeviceProxy {
     bool ValidatePerformanceQueryResults(const vvl::QueryPool& query_pool_state, uint32_t firstQuery, uint32_t queryCount,
                                          VkQueryResultFlags flags, const Location& loc) const;
     bool ValidateQueryPoolWasReset(const vvl::QueryPool& query_pool_state, uint32_t firstQuery, uint32_t queryCount,
-                                   const Location& loc, QueryMap* localQueryToStateMap, uint32_t perfPass) const;
+                                   const Location& loc, QueryMap* local_query_to_state_map, uint32_t perf_query_pass) const;
     bool PreCallValidateGetQueryPoolResults(VkDevice device, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount,
                                             size_t dataSize, void* pData, VkDeviceSize stride, VkQueryResultFlags flags,
                                             const ErrorObject& error_obj) const override;
@@ -1941,7 +1943,8 @@ class CoreChecks : public vvl::DeviceProxy {
                                               uint32_t query, const ErrorObject& error_obj) const override;
     bool PreCallValidateCmdWriteTimestamp2(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage, VkQueryPool queryPool,
                                            uint32_t query, const ErrorObject& error_obj) const override;
-    void RecordCmdWriteTimestamp2(vvl::CommandBuffer& cb_state, VkQueryPool queryPool, uint32_t query, Func command) const;
+    void RecordCmdWriteTimestamp2(core::CommandBufferSubState& cb_sub_state, VkQueryPool queryPool, uint32_t query,
+                                  Func command) const;
     void PreCallRecordCmdWriteTimestamp(VkCommandBuffer commandBuffer, VkPipelineStageFlagBits pipelineStage, VkQueryPool queryPool,
                                         uint32_t slot, const RecordObject& record_obj) override;
     void PreCallRecordCmdWriteTimestamp2KHR(VkCommandBuffer commandBuffer, VkPipelineStageFlags2KHR stage, VkQueryPool queryPool,

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -25,7 +25,6 @@
 #include "state_tracker/last_bound_state.h"
 #include "state_tracker/query_state.h"
 #include "state_tracker/vertex_index_buffer_state.h"
-#include "state_tracker/event_map.h"
 #include "utils/sync_utils.h"
 #include "generated/dynamic_state_helper.h"
 
@@ -492,23 +491,7 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     VkCommandBuffer primary_command_buffer;
     // If primary, the secondary command buffers we will call.
     vvl::unordered_set<CommandBuffer *> linked_command_buffers;
-    // Validation functions run at primary CB queue submit time
-    using QueueCallback = std::function<bool(const class vvl::Queue &queue_state, const CommandBuffer &cb_state)>;
-    std::vector<QueueCallback> queue_submit_functions;
-    // Used by some layers to defer actions until vkCmdEndRenderPass time.
-    // Layers using this are responsible for inserting the callbacks into queue_submit_functions.
-    std::vector<QueueCallback> queue_submit_functions_after_render_pass;
-    // Validation functions run when secondary CB is executed in primary
-    std::vector<std::function<bool(const CommandBuffer &secondary, const CommandBuffer *primary, const vvl::Framebuffer *)>>
-        cmd_execute_commands_functions;
 
-    using EventCallback = std::function<bool(CommandBuffer &cb_state, bool do_validate, EventMap &local_event_signal_info,
-                                             VkQueue waiting_queue, const Location &loc)>;
-    std::vector<EventCallback> event_updates;
-
-    std::vector<std::function<bool(CommandBuffer &cb_state, bool do_validate, VkQueryPool &firstPerfQueryPool,
-                                   uint32_t perfQueryPass, QueryMap *localQueryToStateMap)>>
-        query_updates;
     bool performance_lock_acquired = false;
     bool performance_lock_released = false;
 
@@ -649,8 +632,7 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     void TrackImageFirstLayout(const vvl::Image &image_state, const VkImageSubresourceRange &subresource_range,
                                VkImageLayout layout);
 
-    void Submit(Queue &queue_state, uint32_t perf_submit_pass, const Location &loc);
-    void Retire(uint32_t perf_submit_pass, const std::function<bool(const QueryObject &)> &is_query_updated_after);
+    void SubmitTimeValidate(Queue &queue_state, uint32_t perf_submit_pass, const Location &loc);
 
     // Helpers to offset into |active_attachments|
     // [all color, all color resolve, depth, depth resolve, stencil, stencil resolve, FragmentDensityMap]
@@ -726,12 +708,24 @@ class CommandBufferSubState {
     virtual void ExecuteCommands(vvl::CommandBuffer &secondary_command_buffer) {}
 
     virtual void RecordCmd(Func command) {}
-    virtual void RecordWaitEvents(Func command, uint32_t eventCount, const VkEvent *pEvents,
-                                  VkPipelineStageFlags2KHR src_stage_mask, const VkDependencyInfo *dependency_info) {}
+    virtual void RecordSetEvent(Func command, VkEvent event, VkPipelineStageFlags2 stage_mask,
+                                const VkDependencyInfo *dependency_info) {}
+    virtual void RecordResetEvent(Func command, VkEvent event, VkPipelineStageFlags2 stage_mask) {}
+    virtual void RecordWaitEvents(Func command, uint32_t eventCount, const VkEvent *pEvents, VkPipelineStageFlags2 src_stage_mask,
+                                  const VkDependencyInfo *dependency_info) {}
     virtual void RecordPushConstants(VkPipelineLayout layout, VkShaderStageFlags stage_flags, uint32_t offset, uint32_t size,
                                      const void *values) {}
+
+    virtual void BeginQuery(const QueryObject &query_obj) {}
+    virtual void EndQuery(const QueryObject &query_obj) {}
+    virtual void EndQueries(VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount) {}
+    virtual void ResetQueryPool(VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount) {}
+    virtual void EnqueueUpdateVideoInlineQueries(const VkVideoInlineQueryInfoKHR &query_info) {}
+
     virtual void ClearPushConstants() {}
     virtual void NotifyInvalidate(const StateObject::NodeList &invalid_nodes, bool unlink) {}
+
+    virtual void Submit(Queue &queue_state, uint32_t perf_submit_pass, const Location &loc) {}
 
     VulkanTypedHandle Handle() const;
     VkCommandBuffer VkHandle() const;

--- a/layers/state_tracker/event_map.h
+++ b/layers/state_tracker/event_map.h
@@ -21,6 +21,7 @@
 
 #include "vulkan/vulkan.h"
 #include "containers/custom_containers.h"
+#include <vulkan/utility/vk_safe_struct.hpp>
 
 struct EventInfo {
     VkPipelineStageFlags2 src_stage_mask = VK_PIPELINE_STAGE_2_NONE;


### PR DESCRIPTION
tl;dr move things from `state_tracker/queue_state.cpp`/`cmd_buffer_state.cpp` and move it into `core_checks/cc_state_tracker.cpp` so GPU-AV is easier to debug

----

I found there is a lot of complexity/noise around `vkQueueSubmit` because both CoreChecks and GPU-AV use it

Taking a look, we have all these callbacks for validation in CoreCheck (one for Best Practice as well) that I now it is moved from the global `vvl::CommandBuffer` state to the CoreCheck `CommandBufferSubState`
