### PR TITLE
tests: Simplify transition to present layout in wsi tests

### DIFF
--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -366,11 +366,6 @@ class SyncObjectTest : public VkLayerTest {
 };
 
 class WsiTest : public VkLayerTest {
-  public:
-    // most tests need images in VK_IMAGE_LAYOUT_PRESENT_SRC_KHR layout
-    void SetImageLayoutPresentSrc(VkImage image);
-    VkImageMemoryBarrier TransitionToPresent(VkImage swapchain_image, VkImageLayout old_layout, VkAccessFlags src_access_mask);
-
   protected:
     // Find physical device group that contains physical device selected by the test framework
     std::optional<VkPhysicalDeviceGroupProperties> FindPhysicalDeviceGroup();

--- a/tests/framework/render.cpp
+++ b/tests/framework/render.cpp
@@ -969,6 +969,23 @@ void VkRenderFramework::SupportSurfaceResize() {
     }
 }
 
+void VkRenderFramework::SetPresentImageLayout(VkImage image) {
+    VkImageMemoryBarrier layout_transition = vku::InitStructHelper();
+    layout_transition.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    layout_transition.newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+    layout_transition.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    layout_transition.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+    layout_transition.image = image;
+    layout_transition.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+
+    vkt::CommandBuffer cmdbuf(*m_device, m_command_pool);
+    cmdbuf.Begin();
+    vk::CmdPipelineBarrier(cmdbuf, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 0,
+                           nullptr, 1, &layout_transition);
+    cmdbuf.End();
+    m_default_queue->SubmitAndWait(cmdbuf);
+}
+
 void VkRenderFramework::InitRenderTarget() { InitRenderTarget(1); }
 
 void VkRenderFramework::InitRenderTarget(uint32_t targets) { InitRenderTarget(targets, NULL); }

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -115,6 +115,8 @@ class VkRenderFramework : public VkTestFramework {
     void SupportMultiSwapchain();
     void SupportSurfaceResize();
 
+    void SetPresentImageLayout(VkImage image);
+
     void InitRenderTarget();
     void InitRenderTarget(uint32_t targets);
     void InitRenderTarget(const VkImageView *dsBinding);
@@ -137,7 +139,6 @@ class VkRenderFramework : public VkTestFramework {
     // default to CommandPool Reset flag to allow recording multiple command buffers simpler
     void InitState(VkPhysicalDeviceFeatures *features = nullptr, void *create_device_pnext = nullptr,
                    const VkCommandPoolCreateFlags flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
-    void InitStateWithRequirements(vkt::FeatureRequirements &feature_requirements);
     bool DeviceExtensionSupported(const char *extension_name, uint32_t spec_version = 0) const;
     bool DeviceExtensionSupported(VkPhysicalDevice, const char *, const char *name,
                                   uint32_t spec_version = 0) const {  // deprecated


### PR DESCRIPTION
Remove `TransitionToPresent` helper and use `SetPresentImageLayout` in most places. There are some places where manual recording of present transition is still needed but those few lines of code are arguably easier to read comparing to using `TransitionToPresent`.