### PR TITLE
scripts: Add VVL_ENABLE_MI_STAT option

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -98,6 +98,11 @@ if (UPDATE_DEPS)
         list(APPEND cmake_var "--cmake_var" "VUL_MOCK_ANDROID=ON")
     endif()
 
+    # Enable mimalloc statistics level 1. This is useful for release builds.
+    # Default value for release builds is MI_STAT=0, for debug builds it is MI_STAT=2.
+    if (VVL_ENABLE_MI_STAT)
+         list(APPEND cmake_var "--cmake_var" "MI_EXTRA_CPPDEFS=\"MI_STAT=1\"")
+    endif()
 
     if (cmake_var)
         list(APPEND update_dep_command "${cmake_var}")


### PR DESCRIPTION
This allows to build mimalloc dependency with stats system enabled (disabled by default for release builds).

I need this for memory statistics tracking script. Can be useful in general for vvl since mimalloc provides a bunch of memory releated counters (e.g. how many times malloc was called, current, peak and total values for memory counters).
