### PR TITLE
sync: Move more things to CommandBufferSubState

### DIFF
--- a/layers/best_practices/bp_state.cpp
+++ b/layers/best_practices/bp_state.cpp
@@ -418,7 +418,7 @@ void CommandBufferSubState::RecordCopyImage2(vvl::Image& src_image_state, vvl::I
     }
 }
 
-void CommandBufferSubState::RecordCopyBufferToImage(vvl::Image& dst_image_state, VkImageLayout, uint32_t region_count,
+void CommandBufferSubState::RecordCopyBufferToImage(vvl::Buffer&, vvl::Image& dst_image_state, VkImageLayout, uint32_t region_count,
                                                     const VkBufferImageCopy* regions, const Location& loc) {
     for (uint32_t i = 0; i < region_count; i++) {
         validator.QueueValidateImage(queue_submit_functions, loc, dst_image_state, IMAGE_SUBRESOURCE_USAGE_BP::COPY_WRITE,
@@ -426,15 +426,16 @@ void CommandBufferSubState::RecordCopyBufferToImage(vvl::Image& dst_image_state,
     }
 }
 
-void CommandBufferSubState::RecordCopyBufferToImage2(vvl::Image& dst_image_state, VkImageLayout, uint32_t region_count,
-                                                     const VkBufferImageCopy2* regions, const Location& loc) {
+void CommandBufferSubState::RecordCopyBufferToImage2(vvl::Buffer&, vvl::Image& dst_image_state, VkImageLayout,
+                                                     uint32_t region_count, const VkBufferImageCopy2* regions,
+                                                     const Location& loc) {
     for (uint32_t i = 0; i < region_count; i++) {
         validator.QueueValidateImage(queue_submit_functions, loc, dst_image_state, IMAGE_SUBRESOURCE_USAGE_BP::COPY_WRITE,
                                      regions[i].imageSubresource);
     }
 }
 
-void CommandBufferSubState::RecordCopyImageToBuffer(vvl::Image& src_image_state, VkImageLayout, uint32_t region_count,
+void CommandBufferSubState::RecordCopyImageToBuffer(vvl::Image& src_image_state, vvl::Buffer&, VkImageLayout, uint32_t region_count,
                                                     const VkBufferImageCopy* regions, const Location& loc) {
     for (uint32_t i = 0; i < region_count; i++) {
         validator.QueueValidateImage(queue_submit_functions, loc, src_image_state, IMAGE_SUBRESOURCE_USAGE_BP::COPY_READ,
@@ -442,8 +443,9 @@ void CommandBufferSubState::RecordCopyImageToBuffer(vvl::Image& src_image_state,
     }
 }
 
-void CommandBufferSubState::RecordCopyImageToBuffer2(vvl::Image& src_image_state, VkImageLayout, uint32_t region_count,
-                                                     const VkBufferImageCopy2* regions, const Location& loc) {
+void CommandBufferSubState::RecordCopyImageToBuffer2(vvl::Image& src_image_state, vvl::Buffer&, VkImageLayout,
+                                                     uint32_t region_count, const VkBufferImageCopy2* regions,
+                                                     const Location& loc) {
     for (uint32_t i = 0; i < region_count; i++) {
         validator.QueueValidateImage(queue_submit_functions, loc, src_image_state, IMAGE_SUBRESOURCE_USAGE_BP::COPY_READ,
                                      regions[i].imageSubresource);

--- a/layers/best_practices/bp_state.h
+++ b/layers/best_practices/bp_state.h
@@ -185,14 +185,14 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     void RecordCopyImage2(vvl::Image& src_image_state, vvl::Image& dst_image_state, VkImageLayout src_image_layout,
                           VkImageLayout dst_image_layout, uint32_t region_count, const VkImageCopy2* regions,
                           const Location& loc) final;
-    void RecordCopyBufferToImage(vvl::Image& dst_image_state, VkImageLayout dst_image_layout, uint32_t region_count,
-                                 const VkBufferImageCopy* regions, const Location& loc) final;
-    void RecordCopyBufferToImage2(vvl::Image& dst_image_state, VkImageLayout dst_image_layout, uint32_t region_count,
-                                  const VkBufferImageCopy2* regions, const Location& loc) final;
-    void RecordCopyImageToBuffer(vvl::Image& src_image_state, VkImageLayout src_image_layout, uint32_t region_count,
-                                 const VkBufferImageCopy* regions, const Location& loc) final;
-    void RecordCopyImageToBuffer2(vvl::Image& src_image_state, VkImageLayout src_image_layout, uint32_t region_count,
-                                  const VkBufferImageCopy2* regions, const Location& loc) final;
+    void RecordCopyBufferToImage(vvl::Buffer& src_buffer_state, vvl::Image& dst_image_state, VkImageLayout dst_image_layout,
+                                 uint32_t region_count, const VkBufferImageCopy* regions, const Location& loc) final;
+    void RecordCopyBufferToImage2(vvl::Buffer& src_buffer_state, vvl::Image& dst_image_state, VkImageLayout dst_image_layout,
+                                  uint32_t region_count, const VkBufferImageCopy2* regions, const Location& loc) final;
+    void RecordCopyImageToBuffer(vvl::Image& src_image_state, vvl::Buffer& dst_buffer_state, VkImageLayout src_image_layout,
+                                 uint32_t region_count, const VkBufferImageCopy* regions, const Location& loc) final;
+    void RecordCopyImageToBuffer2(vvl::Image& src_image_state, vvl::Buffer& dst_buffer_state, VkImageLayout src_image_layout,
+                                  uint32_t region_count, const VkBufferImageCopy2* regions, const Location& loc) final;
     void RecordBlitImage(vvl::Image& src_image_state, vvl::Image& dst_image_state, VkImageLayout src_image_layout,
                          VkImageLayout dst_image_layout, uint32_t region_count, const VkImageBlit* regions,
                          const Location& loc) final;

--- a/layers/core_checks/cc_state_tracker.cpp
+++ b/layers/core_checks/cc_state_tracker.cpp
@@ -328,7 +328,7 @@ void CommandBufferSubState::RecordCopyImage2(vvl::Image& src_image_state, vvl::I
     }
 }
 
-void CommandBufferSubState::RecordCopyBufferToImage(vvl::Image& dst_image_state, VkImageLayout dst_image_layout,
+void CommandBufferSubState::RecordCopyBufferToImage(vvl::Buffer&, vvl::Image& dst_image_state, VkImageLayout dst_image_layout,
                                                     uint32_t region_count, const VkBufferImageCopy* regions, const Location& loc) {
     for (const VkBufferImageCopy& region : vvl::make_span(regions, region_count)) {
         base.TrackImageFirstLayout(dst_image_state, RangeFromLayers(region.imageSubresource), region.imageOffset.z,
@@ -336,7 +336,7 @@ void CommandBufferSubState::RecordCopyBufferToImage(vvl::Image& dst_image_state,
     }
 }
 
-void CommandBufferSubState::RecordCopyBufferToImage2(vvl::Image& dst_image_state, VkImageLayout dst_image_layout,
+void CommandBufferSubState::RecordCopyBufferToImage2(vvl::Buffer&, vvl::Image& dst_image_state, VkImageLayout dst_image_layout,
                                                      uint32_t region_count, const VkBufferImageCopy2* regions,
                                                      const Location& loc) {
     for (const VkBufferImageCopy2& region : vvl::make_span(regions, region_count)) {
@@ -345,7 +345,7 @@ void CommandBufferSubState::RecordCopyBufferToImage2(vvl::Image& dst_image_state
     }
 }
 
-void CommandBufferSubState::RecordCopyImageToBuffer(vvl::Image& src_image_state, VkImageLayout src_image_layout,
+void CommandBufferSubState::RecordCopyImageToBuffer(vvl::Image& src_image_state, vvl::Buffer&, VkImageLayout src_image_layout,
                                                     uint32_t region_count, const VkBufferImageCopy* regions, const Location& loc) {
     for (const VkBufferImageCopy& region : vvl::make_span(regions, region_count)) {
         base.TrackImageFirstLayout(src_image_state, RangeFromLayers(region.imageSubresource), region.imageOffset.z,
@@ -353,7 +353,7 @@ void CommandBufferSubState::RecordCopyImageToBuffer(vvl::Image& src_image_state,
     }
 }
 
-void CommandBufferSubState::RecordCopyImageToBuffer2(vvl::Image& src_image_state, VkImageLayout src_image_layout,
+void CommandBufferSubState::RecordCopyImageToBuffer2(vvl::Image& src_image_state, vvl::Buffer&, VkImageLayout src_image_layout,
                                                      uint32_t region_count, const VkBufferImageCopy2* regions,
                                                      const Location& loc) {
     for (const VkBufferImageCopy2& region : vvl::make_span(regions, region_count)) {

--- a/layers/core_checks/cc_state_tracker.h
+++ b/layers/core_checks/cc_state_tracker.h
@@ -60,14 +60,14 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     void RecordCopyImage2(vvl::Image &src_image_state, vvl::Image &dst_image_state, VkImageLayout src_image_layout,
                           VkImageLayout dst_image_layout, uint32_t region_count, const VkImageCopy2 *regions,
                           const Location &loc) final;
-    void RecordCopyBufferToImage(vvl::Image &dst_image_state, VkImageLayout dst_image_layout, uint32_t region_count,
-                                 const VkBufferImageCopy *regions, const Location &loc) final;
-    void RecordCopyBufferToImage2(vvl::Image &dst_image_state, VkImageLayout dst_image_layout, uint32_t region_count,
-                                  const VkBufferImageCopy2 *regions, const Location &loc) final;
-    void RecordCopyImageToBuffer(vvl::Image &src_image_state, VkImageLayout src_image_layout, uint32_t region_count,
-                                 const VkBufferImageCopy *regions, const Location &loc) final;
-    void RecordCopyImageToBuffer2(vvl::Image &src_image_state, VkImageLayout src_image_layout, uint32_t region_count,
-                                  const VkBufferImageCopy2 *regions, const Location &loc) final;
+    void RecordCopyBufferToImage(vvl::Buffer &src_buffer_state, vvl::Image &dst_image_state, VkImageLayout dst_image_layout,
+                                 uint32_t region_count, const VkBufferImageCopy *regions, const Location &loc) final;
+    void RecordCopyBufferToImage2(vvl::Buffer &src_buffer_state, vvl::Image &dst_image_state, VkImageLayout dst_image_layout,
+                                  uint32_t region_count, const VkBufferImageCopy2 *regions, const Location &loc) final;
+    void RecordCopyImageToBuffer(vvl::Image &src_image_state, vvl::Buffer &dst_buffer_state, VkImageLayout src_image_layout,
+                                 uint32_t region_count, const VkBufferImageCopy *regions, const Location &loc) final;
+    void RecordCopyImageToBuffer2(vvl::Image &src_image_state, vvl::Buffer &dst_buffer_state, VkImageLayout src_image_layout,
+                                  uint32_t region_count, const VkBufferImageCopy2 *regions, const Location &loc) final;
     void RecordBlitImage(vvl::Image &src_image_state, vvl::Image &dst_image_state, VkImageLayout src_image_layout,
                          VkImageLayout dst_image_layout, uint32_t region_count, const VkImageBlit *regions,
                          const Location &loc) final;

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1680,35 +1680,39 @@ void CommandBuffer::RecordCopyImage2(vvl::Image &src_image_state, vvl::Image &ds
     }
 }
 
-void CommandBuffer::RecordCopyBufferToImage(vvl::Image &dst_image_state, VkImageLayout dst_image_layout, uint32_t region_count,
-                                            const VkBufferImageCopy *regions, const Location &loc) {
+void CommandBuffer::RecordCopyBufferToImage(vvl::Buffer &src_buffer_state, vvl::Image &dst_image_state,
+                                            VkImageLayout dst_image_layout, uint32_t region_count, const VkBufferImageCopy *regions,
+                                            const Location &loc) {
     command_count++;
     for (auto &item : sub_states_) {
-        item.second->RecordCopyBufferToImage(dst_image_state, dst_image_layout, region_count, regions, loc);
+        item.second->RecordCopyBufferToImage(src_buffer_state, dst_image_state, dst_image_layout, region_count, regions, loc);
     }
 }
 
-void CommandBuffer::RecordCopyBufferToImage2(vvl::Image &dst_image_state, VkImageLayout dst_image_layout, uint32_t region_count,
+void CommandBuffer::RecordCopyBufferToImage2(vvl::Buffer &src_buffer_state, vvl::Image &dst_image_state,
+                                             VkImageLayout dst_image_layout, uint32_t region_count,
                                              const VkBufferImageCopy2 *regions, const Location &loc) {
     command_count++;
     for (auto &item : sub_states_) {
-        item.second->RecordCopyBufferToImage2(dst_image_state, dst_image_layout, region_count, regions, loc);
+        item.second->RecordCopyBufferToImage2(src_buffer_state, dst_image_state, dst_image_layout, region_count, regions, loc);
     }
 }
 
-void CommandBuffer::RecordCopyImageToBuffer(vvl::Image &src_image_state, VkImageLayout src_image_layout, uint32_t region_count,
-                                            const VkBufferImageCopy *regions, const Location &loc) {
+void CommandBuffer::RecordCopyImageToBuffer(vvl::Image &src_image_state, vvl::Buffer &dst_buffer_state,
+                                            VkImageLayout src_image_layout, uint32_t region_count, const VkBufferImageCopy *regions,
+                                            const Location &loc) {
     command_count++;
     for (auto &item : sub_states_) {
-        item.second->RecordCopyImageToBuffer(src_image_state, src_image_layout, region_count, regions, loc);
+        item.second->RecordCopyImageToBuffer(src_image_state, dst_buffer_state, src_image_layout, region_count, regions, loc);
     }
 }
 
-void CommandBuffer::RecordCopyImageToBuffer2(vvl::Image &src_image_state, VkImageLayout src_image_layout, uint32_t region_count,
+void CommandBuffer::RecordCopyImageToBuffer2(vvl::Image &src_image_state, vvl::Buffer &dst_buffer_state,
+                                             VkImageLayout src_image_layout, uint32_t region_count,
                                              const VkBufferImageCopy2 *regions, const Location &loc) {
     command_count++;
     for (auto &item : sub_states_) {
-        item.second->RecordCopyImageToBuffer2(src_image_state, src_image_layout, region_count, regions, loc);
+        item.second->RecordCopyImageToBuffer2(src_image_state, dst_buffer_state, src_image_layout, region_count, regions, loc);
     }
 }
 

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1774,6 +1774,20 @@ void CommandBuffer::RecordClearAttachments(uint32_t attachment_count, const VkCl
     }
 }
 
+void CommandBuffer::RecordFillBuffer(vvl::Buffer &buffer_state, VkDeviceSize offset, VkDeviceSize size, const Location &loc) {
+    command_count++;
+    for (auto &item : sub_states_) {
+        item.second->RecordFillBuffer(buffer_state, offset, size, loc);
+    }
+}
+
+void CommandBuffer::RecordUpdateBuffer(vvl::Buffer &buffer_state, VkDeviceSize offset, VkDeviceSize size, const Location &loc) {
+    command_count++;
+    for (auto &item : sub_states_) {
+        item.second->RecordUpdateBuffer(buffer_state, offset, size, loc);
+    }
+}
+
 void CommandBuffer::RecordSetEvent(VkEvent event, VkPipelineStageFlags2 stage_mask, const VkDependencyInfo *dependency_info) {
     command_count++;
     for (auto &item : sub_states_) {

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -630,6 +630,8 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
                                       const VkImageSubresourceRange *ranges, const Location &loc);
     void RecordClearAttachments(uint32_t attachment_count, const VkClearAttachment *pAttachments, uint32_t rect_count,
                                 const VkClearRect *pRects, const Location &loc);
+    void RecordFillBuffer(vvl::Buffer &buffer_state, VkDeviceSize offset, VkDeviceSize size, const Location &loc);
+    void RecordUpdateBuffer(vvl::Buffer &buffer_state, VkDeviceSize offset, VkDeviceSize size, const Location &loc);
 
     void RecordSetEvent(VkEvent event, VkPipelineStageFlags2KHR stageMask, const VkDependencyInfo *dependency_info);
     void RecordResetEvent(VkEvent event, VkPipelineStageFlags2KHR stageMask);
@@ -778,6 +780,8 @@ class CommandBufferSubState {
                                               const VkImageSubresourceRange *ranges, const Location &loc) {}
     virtual void RecordClearAttachments(uint32_t attachment_count, const VkClearAttachment *pAttachments, uint32_t rect_count,
                                         const VkClearRect *pRects, const Location &loc) {}
+    virtual void RecordFillBuffer(vvl::Buffer &buffer_state, VkDeviceSize offset, VkDeviceSize size, const Location &loc) {}
+    virtual void RecordUpdateBuffer(vvl::Buffer &buffer_state, VkDeviceSize offset, VkDeviceSize size, const Location &loc) {}
 
     virtual void RecordSetEvent(VkEvent event, VkPipelineStageFlags2 stage_mask, const VkDependencyInfo *dependency_info) {}
     virtual void RecordResetEvent(VkEvent event, VkPipelineStageFlags2 stage_mask) {}

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -607,14 +607,14 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
                          VkImageLayout dst_image_layout, uint32_t region_count, const VkImageCopy *regions, const Location &loc);
     void RecordCopyImage2(vvl::Image &src_image_state, vvl::Image &dst_image_state, VkImageLayout src_image_layout,
                           VkImageLayout dst_image_layout, uint32_t region_count, const VkImageCopy2 *regions, const Location &loc);
-    void RecordCopyBufferToImage(vvl::Image &dst_image_state, VkImageLayout dst_image_layout, uint32_t region_count,
-                                 const VkBufferImageCopy *regions, const Location &loc);
-    void RecordCopyBufferToImage2(vvl::Image &dst_image_state, VkImageLayout dst_image_layout, uint32_t region_count,
-                                  const VkBufferImageCopy2 *regions, const Location &loc);
-    void RecordCopyImageToBuffer(vvl::Image &src_image_state, VkImageLayout src_image_layout, uint32_t region_count,
-                                 const VkBufferImageCopy *regions, const Location &loc);
-    void RecordCopyImageToBuffer2(vvl::Image &src_image_state, VkImageLayout src_image_layout, uint32_t region_count,
-                                  const VkBufferImageCopy2 *regions, const Location &loc);
+    void RecordCopyBufferToImage(vvl::Buffer &src_buffer_state, vvl::Image &dst_image_state, VkImageLayout dst_image_layout,
+                                 uint32_t region_count, const VkBufferImageCopy *regions, const Location &loc);
+    void RecordCopyBufferToImage2(vvl::Buffer &src_buffer_state, vvl::Image &dst_image_state, VkImageLayout dst_image_layout,
+                                  uint32_t region_count, const VkBufferImageCopy2 *regions, const Location &loc);
+    void RecordCopyImageToBuffer(vvl::Image &src_image_state, vvl::Buffer &dst_buffer_state, VkImageLayout src_image_layout,
+                                 uint32_t region_count, const VkBufferImageCopy *regions, const Location &loc);
+    void RecordCopyImageToBuffer2(vvl::Image &src_image_state, vvl::Buffer &dst_buffer_state, VkImageLayout src_image_layout,
+                                  uint32_t region_count, const VkBufferImageCopy2 *regions, const Location &loc);
     void RecordBlitImage(vvl::Image &src_image_state, vvl::Image &dst_image_state, VkImageLayout src_image_layout,
                          VkImageLayout dst_image_layout, uint32_t region_count, const VkImageBlit *regions, const Location &loc);
     void RecordBlitImage2(vvl::Image &src_image_state, vvl::Image &dst_image_state, VkImageLayout src_image_layout,
@@ -755,14 +755,16 @@ class CommandBufferSubState {
     virtual void RecordCopyImage2(vvl::Image &src_image_state, vvl::Image &dst_image_state, VkImageLayout src_image_layout,
                                   VkImageLayout dst_image_layout, uint32_t region_count, const VkImageCopy2 *regions,
                                   const Location &loc) {}
-    virtual void RecordCopyBufferToImage(vvl::Image &dst_image_state, VkImageLayout dst_image_layout, uint32_t region_count,
-                                         const VkBufferImageCopy *regions, const Location &loc) {}
-    virtual void RecordCopyBufferToImage2(vvl::Image &dst_image_state, VkImageLayout dst_image_layout, uint32_t region_count,
-                                          const VkBufferImageCopy2 *regions, const Location &loc) {}
-    virtual void RecordCopyImageToBuffer(vvl::Image &src_image_state, VkImageLayout src_image_layout, uint32_t region_count,
-                                         const VkBufferImageCopy *regions, const Location &loc) {}
-    virtual void RecordCopyImageToBuffer2(vvl::Image &src_image_state, VkImageLayout src_image_layout, uint32_t region_count,
-                                          const VkBufferImageCopy2 *regions, const Location &loc) {}
+    virtual void RecordCopyBufferToImage(vvl::Buffer &src_buffer_state, vvl::Image &dst_image_state, VkImageLayout dst_image_layout,
+                                         uint32_t region_count, const VkBufferImageCopy *regions, const Location &loc) {}
+    virtual void RecordCopyBufferToImage2(vvl::Buffer &src_buffer_state, vvl::Image &dst_image_state,
+                                          VkImageLayout dst_image_layout, uint32_t region_count, const VkBufferImageCopy2 *regions,
+                                          const Location &loc) {}
+    virtual void RecordCopyImageToBuffer(vvl::Image &src_image_state, vvl::Buffer &dst_buffer_state, VkImageLayout src_image_layout,
+                                         uint32_t region_count, const VkBufferImageCopy *regions, const Location &loc) {}
+    virtual void RecordCopyImageToBuffer2(vvl::Image &src_image_state, vvl::Buffer &dst_buffer_state,
+                                          VkImageLayout src_image_layout, uint32_t region_count, const VkBufferImageCopy2 *regions,
+                                          const Location &loc) {}
     virtual void RecordBlitImage(vvl::Image &src_image_state, vvl::Image &dst_image_state, VkImageLayout src_image_layout,
                                  VkImageLayout dst_image_layout, uint32_t region_count, const VkImageBlit *regions,
                                  const Location &loc) {}

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -701,8 +701,7 @@ void DeviceState::PostCallRecordCmdFillBuffer(VkCommandBuffer commandBuffer, VkB
     auto buffer_state = Get<Buffer>(dstBuffer);
     ASSERT_AND_RETURN(buffer_state);
     cb_state->AddChild(buffer_state);
-
-    cb_state->command_count++;
+    cb_state->RecordFillBuffer(*buffer_state, dstOffset, size, record_obj.location);
 }
 
 void DeviceState::PostCallRecordCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
@@ -2944,8 +2943,7 @@ void DeviceState::PostCallRecordCmdUpdateBuffer(VkCommandBuffer commandBuffer, V
     auto buffer_state = Get<Buffer>(dstBuffer);
     ASSERT_AND_RETURN(buffer_state);
     cb_state->AddChild(buffer_state);
-
-    cb_state->command_count++;
+    cb_state->RecordUpdateBuffer(*buffer_state, dstOffset, dataSize, record_obj.location);
 }
 
 void DeviceState::PostCallRecordCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -716,8 +716,8 @@ void DeviceState::PostCallRecordCmdCopyImageToBuffer(VkCommandBuffer commandBuff
     cb_state->AddChild(src_image_state);
     cb_state->AddChild(dst_buffer_state);
 
-    cb_state->RecordCopyImageToBuffer(*src_image_state, srcImageLayout, regionCount, pRegions, record_obj.location);
-    ;
+    cb_state->RecordCopyImageToBuffer(*src_image_state, *dst_buffer_state, srcImageLayout, regionCount, pRegions,
+                                      record_obj.location);
 }
 
 void DeviceState::PostCallRecordCmdCopyImageToBuffer2KHR(VkCommandBuffer commandBuffer,
@@ -738,9 +738,8 @@ void DeviceState::PostCallRecordCmdCopyImageToBuffer2(VkCommandBuffer commandBuf
     cb_state->AddChild(src_image_state);
     cb_state->AddChild(dst_buffer_state);
 
-    cb_state->RecordCopyImageToBuffer2(*src_image_state, pCopyImageToBufferInfo->srcImageLayout,
+    cb_state->RecordCopyImageToBuffer2(*src_image_state, *dst_buffer_state, pCopyImageToBufferInfo->srcImageLayout,
                                        pCopyImageToBufferInfo->regionCount, pCopyImageToBufferInfo->pRegions, record_obj.location);
-    ;
 }
 
 void DeviceState::PostCallRecordCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkImage dstImage,
@@ -755,7 +754,8 @@ void DeviceState::PostCallRecordCmdCopyBufferToImage(VkCommandBuffer commandBuff
     cb_state->AddChild(src_buffer_state);
     cb_state->AddChild(dst_image_state);
 
-    cb_state->RecordCopyBufferToImage(*dst_image_state, dstImageLayout, regionCount, pRegions, record_obj.location);
+    cb_state->RecordCopyBufferToImage(*src_buffer_state, *dst_image_state, dstImageLayout, regionCount, pRegions,
+                                      record_obj.location);
 }
 
 void DeviceState::PostCallRecordCmdCopyBufferToImage2KHR(VkCommandBuffer commandBuffer,
@@ -776,7 +776,7 @@ void DeviceState::PostCallRecordCmdCopyBufferToImage2(VkCommandBuffer commandBuf
     cb_state->AddChild(src_buffer_state);
     cb_state->AddChild(dst_image_state);
 
-    cb_state->RecordCopyBufferToImage2(*dst_image_state, pCopyBufferToImageInfo->dstImageLayout,
+    cb_state->RecordCopyBufferToImage2(*src_buffer_state, *dst_image_state, pCopyBufferToImageInfo->dstImageLayout,
                                        pCopyBufferToImageInfo->regionCount, pCopyBufferToImageInfo->pRegions, record_obj.location);
 }
 

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -1432,4 +1432,27 @@ void CommandBufferSubState::RecordClearAttachments(uint32_t attachment_count, co
     }
 }
 
+void CommandBufferSubState::RecordFillBuffer(vvl::Buffer &buffer_state, VkDeviceSize offset, VkDeviceSize size,
+                                             const Location &loc) {
+    const auto tag = access_context.NextCommandTag(loc.function);
+    auto *context = access_context.GetCurrentAccessContext();
+    assert(context);
+
+    const ResourceAccessRange range = MakeRange(buffer_state, offset, size);
+    const ResourceUsageTagEx tag_ex = access_context.AddCommandHandle(tag, buffer_state.Handle());
+    context->UpdateAccessState(buffer_state, SYNC_CLEAR_TRANSFER_WRITE, SyncOrdering::kNonAttachment, range, tag_ex);
+}
+
+void CommandBufferSubState::RecordUpdateBuffer(vvl::Buffer &buffer_state, VkDeviceSize offset, VkDeviceSize size,
+                                               const Location &loc) {
+    const auto tag = access_context.NextCommandTag(loc.function);
+    auto *context = access_context.GetCurrentAccessContext();
+    assert(context);
+
+    // VK_WHOLE_SIZE not allowed
+    const ResourceAccessRange range = MakeRange(offset, size);
+    const ResourceUsageTagEx tag_ex = access_context.AddCommandHandle(tag, buffer_state.Handle());
+    context->UpdateAccessState(buffer_state, SYNC_CLEAR_TRANSFER_WRITE, SyncOrdering::kNonAttachment, range, tag_ex);
+}
+
 }  // namespace syncval_state

--- a/layers/sync/sync_commandbuffer.h
+++ b/layers/sync/sync_commandbuffer.h
@@ -351,6 +351,24 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
     void Destroy() override;
     void Reset(const Location &loc) override;
 
+    void RecordCopyBuffer(vvl::Buffer &src_buffer_state, vvl::Buffer &dst_buffer_state, uint32_t region_count,
+                          const VkBufferCopy *regions, const Location &loc) override;
+    void RecordCopyBuffer2(vvl::Buffer &src_buffer_state, vvl::Buffer &dst_buffer_state, uint32_t region_count,
+                           const VkBufferCopy2 *regions, const Location &loc) override;
+    void RecordCopyImage(vvl::Image &src_image_state, vvl::Image &dst_image_state, VkImageLayout src_image_layout,
+                         VkImageLayout dst_image_layout, uint32_t region_count, const VkImageCopy *regions,
+                         const Location &loc) override;
+    void RecordCopyImage2(vvl::Image &src_image_state, vvl::Image &dst_image_state, VkImageLayout src_image_layout,
+                          VkImageLayout dst_image_layout, uint32_t region_count, const VkImageCopy2 *regions,
+                          const Location &loc) override;
+    void RecordCopyBufferToImage(vvl::Buffer &src_buffer_state, vvl::Image &dst_image_state, VkImageLayout dst_image_layout,
+                                 uint32_t region_count, const VkBufferImageCopy *regions, const Location &loc) override;
+    void RecordCopyBufferToImage2(vvl::Buffer &src_buffer_state, vvl::Image &dst_image_state, VkImageLayout dst_image_layout,
+                                  uint32_t region_count, const VkBufferImageCopy2 *regions, const Location &loc) override;
+    void RecordCopyImageToBuffer(vvl::Image &src_image_state, vvl::Buffer &dst_buffer_state, VkImageLayout src_image_layout,
+                                 uint32_t region_count, const VkBufferImageCopy *regions, const Location &loc) override;
+    void RecordCopyImageToBuffer2(vvl::Image &src_image_state, vvl::Buffer &dst_buffer_state, VkImageLayout src_image_layout,
+                                  uint32_t region_count, const VkBufferImageCopy2 *regions, const Location &loc) override;
     void RecordClearColorImage(vvl::Image &image_state, VkImageLayout image_layout, const VkClearColorValue *color_values,
                                uint32_t range_count, const VkImageSubresourceRange *ranges, const Location &loc) override;
     void RecordClearDepthStencilImage(vvl::Image &image_state, VkImageLayout image_layout,

--- a/layers/sync/sync_commandbuffer.h
+++ b/layers/sync/sync_commandbuffer.h
@@ -369,6 +369,16 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
                                  uint32_t region_count, const VkBufferImageCopy *regions, const Location &loc) override;
     void RecordCopyImageToBuffer2(vvl::Image &src_image_state, vvl::Buffer &dst_buffer_state, VkImageLayout src_image_layout,
                                   uint32_t region_count, const VkBufferImageCopy2 *regions, const Location &loc) override;
+    void RecordBlitImage(vvl::Image &src_image_state, vvl::Image &dst_image_state, VkImageLayout src_image_layout,
+                         VkImageLayout dst_image_layout, uint32_t region_count, const VkImageBlit *regions,
+                         const Location &loc) override;
+    void RecordBlitImage2(vvl::Image &src_image_state, vvl::Image &dst_image_state, VkImageLayout src_image_layout,
+                          VkImageLayout dst_image_layout, uint32_t region_count, const VkImageBlit2 *regions,
+                          const Location &loc) override;
+    void RecordResolveImage(vvl::Image &src_image_state, vvl::Image &dst_image_state, uint32_t region_count,
+                            const VkImageResolve *regions, const Location &loc) override;
+    void RecordResolveImage2(vvl::Image &src_image_state, vvl::Image &dst_image_state, uint32_t region_count,
+                             const VkImageResolve2 *regions, const Location &loc) override;
     void RecordClearColorImage(vvl::Image &image_state, VkImageLayout image_layout, const VkClearColorValue *color_values,
                                uint32_t range_count, const VkImageSubresourceRange *ranges, const Location &loc) override;
     void RecordClearDepthStencilImage(vvl::Image &image_state, VkImageLayout image_layout,

--- a/layers/sync/sync_commandbuffer.h
+++ b/layers/sync/sync_commandbuffer.h
@@ -358,6 +358,8 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
                                       const VkImageSubresourceRange *ranges, const Location &loc) override;
     void RecordClearAttachments(uint32_t attachment_count, const VkClearAttachment *pAttachments, uint32_t rect_count,
                                 const VkClearRect *pRects, const Location &loc) override;
+    void RecordFillBuffer(vvl::Buffer &buffer_state, VkDeviceSize offset, VkDeviceSize size, const Location &loc) override;
+    void RecordUpdateBuffer(vvl::Buffer &buffer_state, VkDeviceSize offset, VkDeviceSize size, const Location &loc) override;
 };
 
 static inline CommandBufferSubState &SubState(vvl::CommandBuffer &cb) {

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -2034,25 +2034,6 @@ bool SyncValidator::PreCallValidateCmdFillBuffer(VkCommandBuffer commandBuffer, 
     return skip;
 }
 
-void SyncValidator::PostCallRecordCmdFillBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
-                                                VkDeviceSize size, uint32_t data, const RecordObject &record_obj) {
-    auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    assert(cb_state);
-    if (!cb_state) return;
-    auto *cb_access_context = syncval_state::AccessContext(*cb_state);
-    const auto tag = cb_access_context->NextCommandTag(record_obj.location.function);
-    auto *context = cb_access_context->GetCurrentAccessContext();
-    assert(context);
-
-    auto dst_buffer = Get<vvl::Buffer>(dstBuffer);
-
-    if (dst_buffer) {
-        const ResourceAccessRange range = MakeRange(*dst_buffer, dstOffset, size);
-        const ResourceUsageTagEx tag_ex = cb_access_context->AddCommandHandle(tag, dst_buffer->Handle());
-        context->UpdateAccessState(*dst_buffer, SYNC_CLEAR_TRANSFER_WRITE, SyncOrdering::kNonAttachment, range, tag_ex);
-    }
-}
-
 bool SyncValidator::PreCallValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                                    VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
                                                    const VkImageResolve *pRegions, const ErrorObject &error_obj) const {
@@ -2252,26 +2233,6 @@ bool SyncValidator::PreCallValidateCmdUpdateBuffer(VkCommandBuffer commandBuffer
         }
     }
     return skip;
-}
-
-void SyncValidator::PostCallRecordCmdUpdateBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
-                                                  VkDeviceSize dataSize, const void *pData, const RecordObject &record_obj) {
-    auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
-    assert(cb_state);
-    if (!cb_state) return;
-    auto *cb_access_context = syncval_state::AccessContext(*cb_state);
-    const auto tag = cb_access_context->NextCommandTag(record_obj.location.function);
-    auto *context = cb_access_context->GetCurrentAccessContext();
-    assert(context);
-
-    auto dst_buffer = Get<vvl::Buffer>(dstBuffer);
-
-    if (dst_buffer) {
-        // VK_WHOLE_SIZE not allowed
-        const ResourceAccessRange range = MakeRange(dstOffset, dataSize);
-        const ResourceUsageTagEx tag_ex = cb_access_context->AddCommandHandle(tag, dst_buffer->Handle());
-        context->UpdateAccessState(*dst_buffer, SYNC_CLEAR_TRANSFER_WRITE, SyncOrdering::kNonAttachment, range, tag_ex);
-    }
 }
 
 bool SyncValidator::PreCallValidateCmdWriteBufferMarkerAMD(VkCommandBuffer commandBuffer, VkPipelineStageFlagBits pipelineStage,

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -171,37 +171,19 @@ class SyncValidator : public vvl::DeviceProxy {
     bool PreCallValidateCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer, uint32_t regionCount,
                                       const VkBufferCopy *pRegions, const ErrorObject &error_obj) const override;
 
-    void PostCallRecordCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer, uint32_t regionCount,
-                                     const VkBufferCopy *pRegions, const RecordObject &record_obj) override;
-
     bool PreCallValidateCmdCopyBuffer2KHR(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2KHR *pCopyBufferInfo,
                                           const ErrorObject &error_obj) const override;
     bool PreCallValidateCmdCopyBuffer2(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2 *pCopyBufferInfo,
                                        const ErrorObject &error_obj) const override;
-    void RecordCmdCopyBuffer2(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2KHR *pCopyBufferInfo, Func command);
-    void PostCallRecordCmdCopyBuffer2KHR(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2KHR *pCopyBufferInfo,
-                                         const RecordObject &record_obj) override;
-    void PostCallRecordCmdCopyBuffer2(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2 *pCopyBufferInfo,
-                                      const RecordObject &record_obj) override;
 
     bool PreCallValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                      VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
                                      const VkImageCopy *pRegions, const ErrorObject &error_obj) const override;
 
-    void PostCallRecordCmdCopyImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout, VkImage dstImage,
-                                    VkImageLayout dstImageLayout, uint32_t regionCount, const VkImageCopy *pRegions,
-                                    const RecordObject &record_obj) override;
-
     bool PreCallValidateCmdCopyImage2KHR(VkCommandBuffer commandBuffer, const VkCopyImageInfo2KHR *pCopyImageInfo,
                                          const ErrorObject &error_obj) const override;
     bool PreCallValidateCmdCopyImage2(VkCommandBuffer commandBuffer, const VkCopyImageInfo2 *pCopyImageInfo,
                                       const ErrorObject &error_obj) const override;
-
-    void RecordCmdCopyImage2(VkCommandBuffer commandBuffer, const VkCopyImageInfo2 *pCopyImageInfo, Func command);
-    void PostCallRecordCmdCopyImage2KHR(VkCommandBuffer commandBuffer, const VkCopyImageInfo2KHR *pCopyImageInfo,
-                                        const RecordObject &record_obj) override;
-    void PostCallRecordCmdCopyImage2(VkCommandBuffer commandBuffer, const VkCopyImageInfo2 *pCopyImageInfo,
-                                     const RecordObject &record_obj) override;
 
     bool PreCallValidateCmdPipelineBarrier(VkCommandBuffer commandBuffer, VkPipelineStageFlags srcStageMask,
                                            VkPipelineStageFlags dstStageMask, VkDependencyFlags dependencyFlags,
@@ -291,18 +273,6 @@ class SyncValidator : public vvl::DeviceProxy {
                                               const ErrorObject &error_obj) const override;
 
     template <typename RegionType>
-    void RecordCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkImage dstImage,
-                                    VkImageLayout dstImageLayout, uint32_t regionCount, const RegionType *pRegions, Func command);
-    void PostCallRecordCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkImage dstImage,
-                                            VkImageLayout dstImageLayout, uint32_t regionCount, const VkBufferImageCopy *pRegions,
-                                            const RecordObject &record_obj) override;
-    void PostCallRecordCmdCopyBufferToImage2KHR(VkCommandBuffer commandBuffer,
-                                                const VkCopyBufferToImageInfo2KHR *pCopyBufferToImageInfo,
-                                                const RecordObject &record_obj) override;
-    void PostCallRecordCmdCopyBufferToImage2(VkCommandBuffer commandBuffer, const VkCopyBufferToImageInfo2 *pCopyBufferToImageInfo,
-                                             const RecordObject &record_obj) override;
-
-    template <typename RegionType>
     bool ValidateCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                       VkBuffer dstBuffer, uint32_t regionCount, const RegionType *pRegions,
                                       const Location &loc) const;
@@ -314,18 +284,6 @@ class SyncValidator : public vvl::DeviceProxy {
                                                  const ErrorObject &error_obj) const override;
     bool PreCallValidateCmdCopyImageToBuffer2(VkCommandBuffer commandBuffer, const VkCopyImageToBufferInfo2 *pCopyImageToBufferInfo,
                                               const ErrorObject &error_obj) const override;
-
-    template <typename RegionType>
-    void RecordCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
-                                    VkBuffer dstBuffer, uint32_t regionCount, const RegionType *pRegions, Func command);
-    void PostCallRecordCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
-                                            VkBuffer dstBuffer, uint32_t regionCount, const VkBufferImageCopy *pRegions,
-                                            const RecordObject &record_obj) override;
-    void PostCallRecordCmdCopyImageToBuffer2KHR(VkCommandBuffer commandBuffer,
-                                                const VkCopyImageToBufferInfo2KHR *pCopyImageToBufferInfo,
-                                                const RecordObject &record_obj) override;
-    void PostCallRecordCmdCopyImageToBuffer2(VkCommandBuffer commandBuffer, const VkCopyImageToBufferInfo2 *pCopyImageToBufferInfo,
-                                             const RecordObject &record_obj) override;
 
     template <typename RegionType>
     bool ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout, VkImage dstImage,

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -298,18 +298,6 @@ class SyncValidator : public vvl::DeviceProxy {
     bool PreCallValidateCmdBlitImage2(VkCommandBuffer commandBuffer, const VkBlitImageInfo2 *pBlitImageInfo,
                                       const ErrorObject &error_obj) const override;
 
-    template <typename RegionType>
-    void RecordCmdBlitImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout, VkImage dstImage,
-                            VkImageLayout dstImageLayout, uint32_t regionCount, const RegionType *pRegions, VkFilter filter,
-                            Func command);
-    void PostCallRecordCmdBlitImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout, VkImage dstImage,
-                                    VkImageLayout dstImageLayout, uint32_t regionCount, const VkImageBlit *pRegions,
-                                    VkFilter filter, const RecordObject &record_obj) override;
-    void PostCallRecordCmdBlitImage2KHR(VkCommandBuffer commandBuffer, const VkBlitImageInfo2KHR *pBlitImageInfo,
-                                        const RecordObject &record_obj) override;
-    void PostCallRecordCmdBlitImage2(VkCommandBuffer commandBuffer, const VkBlitImageInfo2 *pBlitImageInfo,
-                                     const RecordObject &record_obj) override;
-
     bool ValidateIndirectBuffer(const CommandBufferAccessContext &cb_context, const AccessContext &context,
                                 const VkDeviceSize struct_size, const VkBuffer buffer, const VkDeviceSize offset,
                                 const uint32_t drawCount, const uint32_t stride, const Location &loc) const;
@@ -435,18 +423,10 @@ class SyncValidator : public vvl::DeviceProxy {
                                         VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
                                         const VkImageResolve *pRegions, const ErrorObject &error_obj) const override;
 
-    void PostCallRecordCmdResolveImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
-                                       VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
-                                       const VkImageResolve *pRegions, const RecordObject &record_obj) override;
-
     bool PreCallValidateCmdResolveImage2KHR(VkCommandBuffer commandBuffer, const VkResolveImageInfo2KHR *pResolveImageInfo,
                                             const ErrorObject &error_obj) const override;
     bool PreCallValidateCmdResolveImage2(VkCommandBuffer commandBuffer, const VkResolveImageInfo2 *pResolveImageInfo,
                                          const ErrorObject &error_obj) const override;
-    void PostCallRecordCmdResolveImage2KHR(VkCommandBuffer commandBuffer, const VkResolveImageInfo2KHR *pResolveImageInfo,
-                                           const RecordObject &record_obj) override;
-    void PostCallRecordCmdResolveImage2(VkCommandBuffer commandBuffer, const VkResolveImageInfo2 *pResolveImageInfo,
-                                        const RecordObject &record_obj) override;
 
     bool PreCallValidateCmdUpdateBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
                                         VkDeviceSize dataSize, const void *pData, const ErrorObject &error_obj) const override;

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -472,8 +472,6 @@ class SyncValidator : public vvl::DeviceProxy {
 
     bool PreCallValidateCmdFillBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset, VkDeviceSize size,
                                       uint32_t data, const ErrorObject &error_obj) const override;
-    void PostCallRecordCmdFillBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset, VkDeviceSize size,
-                                     uint32_t data, const RecordObject &record_obj) override;
 
     bool PreCallValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout,
                                         VkImage dstImage, VkImageLayout dstImageLayout, uint32_t regionCount,
@@ -494,8 +492,6 @@ class SyncValidator : public vvl::DeviceProxy {
 
     bool PreCallValidateCmdUpdateBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
                                         VkDeviceSize dataSize, const void *pData, const ErrorObject &error_obj) const override;
-    void PostCallRecordCmdUpdateBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
-                                       VkDeviceSize dataSize, const void *pData, const RecordObject &record_obj) override;
 
     bool PreCallValidateCmdWriteBufferMarkerAMD(VkCommandBuffer commandBuffer, VkPipelineStageFlagBits pipelineStage,
                                                 VkBuffer dstBuffer, VkDeviceSize dstOffset, uint32_t marker,


### PR DESCRIPTION
broken up to 3 commits, just moving the "boring" logic from `sync_validation.cpp` to `sync_commandbuffer.cpp`