### PR TITLE
layers: Input Topology cleanup

### DIFF
--- a/layers/state_tracker/last_bound_state.cpp
+++ b/layers/state_tracker/last_bound_state.cpp
@@ -272,6 +272,27 @@ VkPrimitiveTopology LastBound::GetPrimitiveTopology() const {
     }
 }
 
+// vkspec.html#drawing-vertex-input-assembler-topology
+// When calling, we don't have to worry about Mesh shading because either VUs like 07065/07066 prevent these dynamic state being set
+// and the VkPipelineInputAssemblyStateCreateInfo is ignored
+VkPrimitiveTopology LastBound::GetVertexInputAssemblerTopology() const {
+    if (IsDynamic(CB_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY)) {
+        return cb_state.dynamic_state_value.primitive_topology;
+    } else {
+        if (auto ia_state = pipeline_state->InputAssemblyState()) {
+            return ia_state->topology;
+        }
+    }
+    return VK_PRIMITIVE_TOPOLOGY_MAX_ENUM;
+}
+
+std::string LastBound::DescribeVertexInputAssemblerTopology() const {
+    if (IsDynamic(CB_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY)) {
+        return "the last call to vkCmdSetPrimitiveTopology";
+    }
+    return "VkPipelineInputAssemblyStateCreateInfo::topology";
+}
+
 VkCullModeFlags LastBound::GetCullMode() const {
     if (IsDynamic(CB_DYNAMIC_STATE_CULL_MODE)) {
         if (cb_state.IsDynamicStateSet(CB_DYNAMIC_STATE_CULL_MODE)) {

--- a/layers/state_tracker/last_bound_state.h
+++ b/layers/state_tracker/last_bound_state.h
@@ -108,6 +108,8 @@ struct LastBound {
     bool IsColorBlendEnabled(uint32_t i) const;
     bool IsBlendConstantsEnabled(uint32_t i) const;
     VkPrimitiveTopology GetPrimitiveTopology() const;
+    VkPrimitiveTopology GetVertexInputAssemblerTopology() const;
+    std::string DescribeVertexInputAssemblerTopology() const;
     VkCullModeFlags GetCullMode() const;
     VkConservativeRasterizationModeEXT GetConservativeRasterizationMode() const;
     bool IsSampleLocationsEnable() const;

--- a/tests/unit/shader_object.cpp
+++ b/tests/unit/shader_object.cpp
@@ -3102,6 +3102,25 @@ TEST_F(NegativeShaderObject, MissingCmdSetPrimitiveRestartEnableEXT) {
     m_command_buffer.End();
 }
 
+TEST_F(NegativeShaderObject, PrimitiveRestartEnable) {
+    RETURN_IF_SKIP(InitBasicShaderObject());
+    InitDynamicRenderTarget();
+    CreateMinimalShaders();
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
+    SetDefaultDynamicStatesExclude();
+    m_command_buffer.BindShaders(m_vert_shader, m_frag_shader);
+    vk::CmdSetPrimitiveRestartEnableEXT(m_command_buffer, VK_TRUE);
+    vk::CmdSetPrimitiveTopologyEXT(m_command_buffer, VK_PRIMITIVE_TOPOLOGY_LINE_LIST);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-09637");
+    vk::CmdDraw(m_command_buffer, 4, 1, 0, 0);
+    m_errorMonitor->VerifyFound();
+
+    m_command_buffer.EndRendering();
+    m_command_buffer.End();
+}
+
 TEST_F(NegativeShaderObject, MissingCmdSetVertexInput) {
     AddRequiredExtensions(VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);


### PR DESCRIPTION
There are a number of VUs that will need to be updated with the new [Effective Primitive Topology](https://docs.vulkan.org/spec/latest/chapters/drawing.html#drawing-effective-primitive-topology)

These are VUs related the to Vertex Input Assembler Topology and wanted to do them first as they are the simplest