### PR TITLE
sync: Improve layout transition hazard reporting

### DIFF
--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -1368,7 +1368,7 @@ CommandBufferSubState::CommandBufferSubState(SyncValidator &dev, vvl::CommandBuf
 }
 
 void CommandBufferSubState::End() {
-    // For threads that are dedicated to recording command buffers but do not submit themsevles,
+    // For threads that are dedicated to recording command buffers but do not submit themselves,
     // the end of recording is a logical point to update memory stats
     access_context.GetSyncState().stats.UpdateMemoryStats();
 }


### PR DESCRIPTION
This fixes questionable recommendation to add stage NONE to solve sync problem:

> The current synchronization defines the destination stage mask as VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT|VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT, but to prevent this hazard, it must include VK_PIPELINE_STAGE_2_NONE.

New version:
> The current synchronization defines the destination stage mask as VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT, but layout transition does not synchronize with these stages.
Vulkan insight: If the layout transition is done via an image barrier, consider including VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT in srcStageMask. If the transition occurs as part of the render pass begin operation, consider specifying an external subpass dependency (VK_SUBPASS_EXTERNAL) with srcStageMask that includes VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT, or perform the transition in a separate image barrier before the render pass begins.

Thanks @ziga-lunarg for the test to reproduce the issue (I modified it to reproduce the issue exactly as was reported by the client).
