### PR TITLE
layers: Fix normalized_subresource_range

### DIFF
--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -544,8 +544,9 @@ ImageView::ImageView(const DeviceState &device_state, const std::shared_ptr<vvl:
       metal_imageview_export(GetMetalExport(ci)),
 #endif
       is_depth_sliced(IsDepthSliced()),
-      normalized_subresource_range(NormalizeSubresourceRange(device_state.extensions.vk_khr_maintenance9)),
-      range_generator(image_state->subresource_encoder, normalized_subresource_range),
+      normalized_subresource_range(image_state->NormalizeSubresourceRange(create_info.subresourceRange)),
+      range_generator(image_state->subresource_encoder,
+                      NormalizeImageLayoutSubresourceRange(device_state.extensions.vk_khr_maintenance9)),
       samples(image_state->create_info.samples),
       samplerConversion(GetSamplerConversion(ci)),
       filter_cubic_props(cubic_props),
@@ -578,7 +579,7 @@ bool ImageView::IsDepthSliced() {
            (create_info.viewType == VK_IMAGE_VIEW_TYPE_2D || create_info.viewType == VK_IMAGE_VIEW_TYPE_2D_ARRAY);
 }
 
-VkImageSubresourceRange ImageView::NormalizeSubresourceRange(bool is_3d_slice_transition_allowed) const {
+VkImageSubresourceRange ImageView::NormalizeImageLayoutSubresourceRange(bool is_3d_slice_transition_allowed) const {
     VkImageSubresourceRange subres_range = create_info.subresourceRange;
 
     // if we're mapping a 3D image to a 2d image view, convert the view's subresource range to be compatible with the

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -313,7 +313,7 @@ class ImageView : public StateObject, public SubStateManager<ImageViewSubState> 
     bool Invalid() const override { return Destroyed() || !image_state || image_state->Invalid(); }
 
   private:
-    VkImageSubresourceRange NormalizeSubresourceRange(bool is_3d_slice_transition_allowed) const;
+    VkImageSubresourceRange NormalizeImageLayoutSubresourceRange(bool is_3d_slice_transition_allowed) const;
     bool IsDepthSliced();
 };
 

--- a/tests/unit/dynamic_rendering_positive.cpp
+++ b/tests/unit/dynamic_rendering_positive.cpp
@@ -1352,3 +1352,39 @@ TEST_F(PositiveDynamicRendering, ColorAttachmentLayerCount) {
     m_command_buffer.EndRendering();
     m_command_buffer.End();
 }
+
+TEST_F(PositiveDynamicRendering, ColorAttachmentLayerCount2DArray) {
+    AddRequiredExtensions(VK_EXT_IMAGE_2D_VIEW_OF_3D_EXTENSION_NAME);
+    RETURN_IF_SKIP(InitBasicDynamicRendering());
+    InitRenderTarget();
+
+    VkImageCreateInfo image_ci = vku::InitStructHelper();
+    image_ci.flags = VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT | VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT;
+    image_ci.imageType = VK_IMAGE_TYPE_3D;
+    image_ci.format = VK_FORMAT_R32_SINT;
+    image_ci.extent = {8, 8, 8};
+    image_ci.mipLevels = 1;
+    image_ci.arrayLayers = 1;
+    image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
+    image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
+    image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    vkt::Image image(*m_device, image_ci, vkt::set_layout);
+
+    vkt::ImageView image_view = image.CreateView(VK_IMAGE_VIEW_TYPE_2D_ARRAY, 0, 1, 0, 8);
+
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
+    color_attachment.imageView = image_view;
+    color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkRenderingInfo begin_rendering_info = vku::InitStructHelper();
+    begin_rendering_info.layerCount = 8;
+    begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
+    begin_rendering_info.colorAttachmentCount = 1;
+    begin_rendering_info.pColorAttachments = &color_attachment;
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRendering(begin_rendering_info);
+    m_command_buffer.EndRendering();
+    m_command_buffer.End();
+}


### PR DESCRIPTION
Mike pointed out a Zink test we were throwing a false positive

The use of `normalized_subresource_range` is tricky, because it involves calling `NormalizeSubresourceRange` and the "idea" is you do it in `vvl::Image` state with a provided `VkImageSubresourceRange`... the main goal is to really just resolve `VK_REMAINING_ARRAY_LAYERS`

the issue is `maintenance9` is only applied to Image Layout, not to things like `vkCmdBeginRendering`, but we were applying the image layout