### PR TITLE
tests: More Descriptor Buffer examples

### DIFF
--- a/tests/framework/descriptor_helper.h
+++ b/tests/framework/descriptor_helper.h
@@ -12,6 +12,8 @@
 
 #pragma once
 
+#include <vulkan/vulkan_core.h>
+#include <vulkan/utility/vk_struct_helper.hpp>
 #include "layer_validation_tests.h"
 
 class OneOffDescriptorSet {
@@ -79,3 +81,24 @@ class OneOffDescriptorIndexingSet : public OneOffDescriptorSet {
     OneOffDescriptorIndexingSet(vkt::Device *device, const Bindings &bindings, void *allocate_pnext = nullptr,
                                 void *create_pool_pnext = nullptr);
 };
+
+namespace vkt {
+class Buffer;
+
+// VK_EXT_descriptor_buffer
+struct DescriptorGetInfo {
+    explicit DescriptorGetInfo(VkSampler *sampler);       // VK_DESCRIPTOR_TYPE_SAMPLER
+    explicit DescriptorGetInfo(VkDeviceAddress address);  // VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR
+    DescriptorGetInfo(VkDescriptorType type, VkSampler sampler, VkImageView image_view, VkImageLayout image_layout);
+    DescriptorGetInfo(VkDescriptorType type, VkDeviceAddress address, VkDeviceSize range, VkFormat format = VK_FORMAT_UNDEFINED);
+    DescriptorGetInfo(VkDescriptorType type, const vkt::Buffer &buffer, VkDeviceSize range, VkFormat format = VK_FORMAT_UNDEFINED);
+
+    VkDescriptorGetInfoEXT get_info = vku::InitStructHelper();
+    VkSampler sampler_handle;
+    VkDescriptorImageInfo image_info;
+    VkDescriptorAddressInfoEXT address_info;
+
+    operator VkDescriptorGetInfoEXT *() { return &get_info; }
+};
+
+}  // namespace vkt


### PR DESCRIPTION
1. Adds more examples for Descriptor Buffer
2. Adds easier way to set `VkDescriptorGetInfoEXT`
3. Fixes some VU error messages found along the way