### PR TITLE
layers: Remove old redundant comments

### DIFF
--- a/layers/stateless/sl_buffer.cpp
+++ b/layers/stateless/sl_buffer.cpp
@@ -33,17 +33,13 @@ bool Device::manual_PreCallValidateCreateBuffer(VkDevice device, const VkBufferC
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
     skip |= context.ValidateNotZero(pCreateInfo->size == 0, "VUID-VkBufferCreateInfo-size-00912", create_info_loc.dot(Field::size));
 
-    // Validation for parameters excluded from the generated validation code due to a 'noautovalidity' tag in vk.xml
     if (pCreateInfo->sharingMode == VK_SHARING_MODE_CONCURRENT) {
-        // If sharingMode is VK_SHARING_MODE_CONCURRENT, queueFamilyIndexCount must be greater than 1
         if (pCreateInfo->queueFamilyIndexCount <= 1) {
             skip |= LogError("VUID-VkBufferCreateInfo-sharingMode-00914", device, create_info_loc.dot(Field::sharingMode),
                              "is VK_SHARING_MODE_CONCURRENT, but queueFamilyIndexCount is %" PRIu32 ".",
                              pCreateInfo->queueFamilyIndexCount);
         }
 
-        // If sharingMode is VK_SHARING_MODE_CONCURRENT, pQueueFamilyIndices must be a pointer to an array of
-        // queueFamilyIndexCount uint32_t values
         if (pCreateInfo->pQueueFamilyIndices == nullptr) {
             skip |= LogError("VUID-VkBufferCreateInfo-sharingMode-00913", device, create_info_loc.dot(Field::sharingMode),
                              "is VK_SHARING_MODE_CONCURRENT, but pQueueFamilyIndices is NULL.");
@@ -123,7 +119,6 @@ bool Device::manual_PreCallValidateCreateBufferView(VkDevice device, const VkBuf
                          string_VkFormat(format));
     }
 
-    // Buffer view offset must be a multiple of VkPhysicalDeviceLimits::minTexelBufferOffsetAlignment
     if ((pCreateInfo->offset % phys_dev_props.limits.minTexelBufferOffsetAlignment) != 0 &&
         !enabled_features.texelBufferAlignment) {
         skip |= LogError("VUID-VkBufferViewCreateInfo-offset-02749", pCreateInfo->buffer, create_info_loc.dot(Field::offset),
@@ -137,12 +132,11 @@ bool Device::manual_PreCallValidateCreateBufferView(VkDevice device, const VkBuf
         const VkDeviceSize texels_per_block = static_cast<VkDeviceSize>(vkuFormatTexelsPerBlock(format));
         const VkDeviceSize texel_block_size = static_cast<VkDeviceSize>(GetTexelBufferFormatSize(format));
 
-        // Range must be greater than 0
         if (range <= 0) {
             skip |= LogError("VUID-VkBufferViewCreateInfo-range-00928", pCreateInfo->buffer, create_info_loc.dot(Field::range),
                              "(%" PRIuLEAST64 ") does not equal VK_WHOLE_SIZE, range must be greater than 0.", range);
         }
-        // Range must be a multiple of the texel block size of format
+
         if (SafeModulo(range, texel_block_size) != 0) {
             skip |= LogError("VUID-VkBufferViewCreateInfo-range-00929", pCreateInfo->buffer, create_info_loc.dot(Field::range),
                              "(%" PRIuLEAST64
@@ -182,8 +176,6 @@ bool Device::ValidateCreateBufferFlags(const VkBufferCreateFlags flags, const Lo
                          "includes VK_BUFFER_CREATE_SPARSE_ALIASED_BIT, but the sparseResidencyAliased feature is not enabled.");
     };
 
-    // If flags contains VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT or VK_BUFFER_CREATE_SPARSE_ALIASED_BIT, it must also contain
-    // VK_BUFFER_CREATE_SPARSE_BINDING_BIT
     if (((flags & (VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT | VK_BUFFER_CREATE_SPARSE_ALIASED_BIT)) != 0) &&
         ((flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) != VK_BUFFER_CREATE_SPARSE_BINDING_BIT)) {
         skip |=


### PR DESCRIPTION
noticed from @stefano-bucciarelli-arm in https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/10392#discussion_r2200574187

These comments date some of the **ORIGINAL** validation added 8 years ago... these are just noisy, we the code is basic to understand what it is doing (it is stateless!) and the VUID are there for a reason