### PR TITLE
layers: Simplify VkDeviceAddress checks

### DIFF
--- a/layers/core_checks/cc_device_memory.cpp
+++ b/layers/core_checks/cc_device_memory.cpp
@@ -131,125 +131,6 @@ bool CoreChecks::ValidateAccelStructsMemoryDoNotOverlap(const Location &function
     return skip;
 }
 
-static bool ValidateBufferAndAccelStructsMemoryDoNotOverlap(const CoreChecks &validator, const vvl::Buffer &buffer_a,
-                                                            vvl::range<VkDeviceSize> range_a,
-                                                            const vvl::AccelerationStructureKHR &accel_struct_b,
-                                                            const Location &loc_b, std::string *err_msg) {
-    const vvl::Buffer &buffer_b = *accel_struct_b.buffer_state;
-    const vvl::range<VkDeviceSize> range_b(accel_struct_b.create_info.offset, accel_struct_b.create_info.size);
-
-    if (const auto [memory, overlap_range] = buffer_a.GetResourceMemoryOverlap(range_a, &buffer_b, range_b);
-        memory != VK_NULL_HANDLE) {
-        if (err_msg) {
-            std::stringstream err_msg_strm;
-            err_msg_strm << "memory backing buffer (" << validator.FormatHandle(buffer_a) << ") overlaps memory backing buffer ("
-                         << validator.FormatHandle(buffer_b) << ") used as storage for " << loc_b.Fields() << " ("
-                         << validator.FormatHandle(accel_struct_b.Handle()) << "). Overlapped memory is ("
-                         << validator.FormatHandle(memory) << ") on range " << string_range_hex(overlap_range);
-            *err_msg = err_msg_strm.str();
-        }
-        return false;
-    }
-
-    return true;
-}
-
-bool CoreChecks::ValidateScratchMemoryNoOverlap(const Location &function_loc, LogObjectList objlist,
-                                                const vvl::span<vvl::Buffer *const> &scratches_a, VkDeviceAddress scratch_a_address,
-                                                VkDeviceSize scratch_a_size, const Location &loc_scratches_a,
-                                                const vvl::AccelerationStructureKHR *src_accel_struct,
-                                                const Location &loc_src_accel_struct,
-                                                const vvl::AccelerationStructureKHR &dst_accel_struct,
-                                                const Location &loc_dst_accel_struct,
-                                                const vvl::span<vvl::Buffer *const> &scratches_b, VkDeviceAddress scratch_b_address,
-                                                VkDeviceSize scratch_b_size, const Location *loc_scratches_b) const {
-    bool skip = false;
-
-    const char *scratch_dst_accel_struct_overlap = "VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03703";
-    const char *scratch_src_accel_struct_overlap = "VUID-vkCmdBuildAccelerationStructuresKHR-scratchData-03705";
-    const char *scratch_scratch_overlap = "VUID-vkCmdBuildAccelerationStructuresKHR-scratchData-03704";
-    const std::string scratch_b_address_str = [&]() {
-        std::stringstream ss;
-        ss << std::hex << "0x" << scratch_b_address;
-        return ss.str();
-    }();
-
-    BufferAddressValidation<3> buffer_address_validator = {{{
-        {scratch_dst_accel_struct_overlap,
-         [this, scratch_a_address, scratch_a_size, &dst_accel_struct, &loc_dst_accel_struct](vvl::Buffer *const scratch_a,
-                                                                                             std::string *out_error_msg) {
-             const VkDeviceSize scratch_a_offset = scratch_a_address - scratch_a->deviceAddress;
-             const vvl::range<VkDeviceSize> scratch_a_range(scratch_a_offset, scratch_a_offset + scratch_a_size);
-
-             const bool no_overlap_found = ValidateBufferAndAccelStructsMemoryDoNotOverlap(
-                 *this, *scratch_a, scratch_a_range, dst_accel_struct, loc_dst_accel_struct, out_error_msg);
-
-             return no_overlap_found;
-         },
-         [scratch_a_size, &loc_dst_accel_struct]() {
-             return std::string("The following scratch buffers associated to this device address (assumed scratch byte size: ") +
-                    std::to_string(scratch_a_size) + ") overlap with memory backing " + loc_dst_accel_struct.Fields();
-         }},
-
-    }}};
-
-    if (src_accel_struct) {
-        buffer_address_validator.AddVuidValidation(
-            {scratch_src_accel_struct_overlap,
-             [this, scratch_a_address, scratch_a_size, src_accel_struct, &loc_src_accel_struct](vvl::Buffer *const scratch_a,
-                                                                                                std::string *out_error_msg) {
-                 const VkDeviceSize scratch_a_offset = scratch_a_address - scratch_a->deviceAddress;
-                 const vvl::range<VkDeviceSize> scratch_a_range(scratch_a_offset, scratch_a_offset + scratch_a_size);
-
-                 const bool no_overlap_found = ValidateBufferAndAccelStructsMemoryDoNotOverlap(
-                     *this, *scratch_a, scratch_a_range, *src_accel_struct, loc_src_accel_struct, out_error_msg);
-
-                 return no_overlap_found;
-             },
-             [scratch_a_size, &loc_src_accel_struct]() {
-                 return std::string(
-                            "The following scratch buffers associated to this device address (assumed scratch byte size: ") +
-                        std::to_string(scratch_a_size) + ") overlap with memory backing " + loc_src_accel_struct.Fields();
-             }});
-    }
-
-    if (!scratches_b.empty()) {
-        assert(loc_scratches_b);
-        buffer_address_validator.AddVuidValidation(
-            {scratch_scratch_overlap,
-             [this, scratch_a_address, scratch_a_size, scratches_b, scratch_b_address, scratch_b_size](vvl::Buffer *const scratch_a,
-                                                                                                       std::string *out_error_msg) {
-                 const VkDeviceSize scratch_a_offset = scratch_a_address - scratch_a->deviceAddress;
-                 const vvl::range<VkDeviceSize> scratch_a_range(scratch_a_offset, scratch_a_offset + scratch_a_size);
-
-                 for (auto scratch_b : scratches_b) {
-                     const VkDeviceSize scratch_b_offset = scratch_b_address - scratch_b->deviceAddress;
-                     const vvl::range<VkDeviceSize> scratch_b_range(scratch_b_offset, scratch_b_offset + scratch_b_size);
-
-                     if (auto [mem, mem_range] = scratch_b->GetResourceMemoryOverlap(scratch_b_range, scratch_a, scratch_a_range);
-                         mem != VK_NULL_HANDLE) {
-                         if (out_error_msg) {
-                             *out_error_msg +=
-                                 "Memory (" + FormatHandle(mem) + ") overlap on memory range " + string_range_hex(mem_range);
-                         }
-                         return false;
-                     }
-                 }
-                 return true;
-             },
-             [loc_scratches_b, scratch_a_size, scratch_b_size, &scratch_b_address_str]() {
-                 return std::string("The following scratch buffers associated to this device address (assumed scratch byte size: " +
-                                    std::to_string(scratch_a_size) + ") overlap with at least one scratch buffer associated to ") +
-                        loc_scratches_b->Fields() + " (" + scratch_b_address_str +
-                        ") (assumed scratch byte size: " + std::to_string(scratch_b_size) + "):";
-             }});
-    }
-
-    skip |= buffer_address_validator.LogErrorsIfNoValidBuffer(*this, scratches_a, loc_scratches_a, objlist, scratch_a_address);
-
-    return skip;
-}
-
 // Check to see if host-visible memory was bound to this buffer
 bool CoreChecks::ValidateAccelStructBufferMemoryIsHostVisible(const vvl::AccelerationStructureKHR &accel_struct,
                                                               const Location &buffer_loc, const char *vuid) const {
@@ -2666,4 +2547,11 @@ bool CoreChecks::ValidateMemoryIsBoundToBuffer(LogObjectList objlist, const vvl:
         skip |= VerifyBoundMemoryIsValid(buffer_state.MemoryState(), objlist, buffer_state.Handle(), buffer_loc, vuid);
     }
     return skip;
+}
+
+// Used when only need to check a VkDeviceAddress is tied to a VkBuffer
+bool CoreChecks::ValidateDeviceAddress(const Location &device_address_loc, const LogObjectList &objlist,
+                                       VkDeviceAddress device_address) const {
+    BufferAddressValidation<0> buffer_address_validator = {};
+    return buffer_address_validator.ValidateDeviceAddress(*this, device_address_loc, objlist, device_address);
 }

--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -958,18 +958,13 @@ bool CoreChecks::ValidateCmdTraceRaysKHR(const Location &loc, const LastBound &l
             }
         }
 
-        const char *vuid_single_device_memory = is_indirect ? "VUID-vkCmdTraceRaysIndirectKHR-pHitShaderBindingTable-03687"
-                                                            : "VUID-vkCmdTraceRaysKHR-pHitShaderBindingTable-03687";
         const char *vuid_binding_table_flag = is_indirect ? "VUID-vkCmdTraceRaysIndirectKHR-pHitShaderBindingTable-03688"
                                                           : "VUID-vkCmdTraceRaysKHR-pHitShaderBindingTable-03688";
-        skip |= ValidateRaytracingShaderBindingTable(cb_state, table_loc, vuid_single_device_memory, vuid_binding_table_flag,
-                                                     *pHitShaderBindingTable);
+        skip |= ValidateRaytracingShaderBindingTable(cb_state, table_loc, vuid_binding_table_flag, *pHitShaderBindingTable);
     }
 
     if (pRaygenShaderBindingTable) {
         const Location table_loc = loc.dot(Field::pRaygenShaderBindingTable);
-        const char *vuid_single_device_memory = is_indirect ? "VUID-vkCmdTraceRaysIndirectKHR-pRayGenShaderBindingTable-03680"
-                                                            : "VUID-vkCmdTraceRaysKHR-pRayGenShaderBindingTable-03680";
         const char *vuid_binding_table_flag = is_indirect ? "VUID-vkCmdTraceRaysIndirectKHR-pRayGenShaderBindingTable-03681"
                                                           : "VUID-vkCmdTraceRaysKHR-pRayGenShaderBindingTable-03681";
         // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9368
@@ -979,18 +974,14 @@ bool CoreChecks::ValidateCmdTraceRaysKHR(const Location &loc, const LastBound &l
                              cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR), table_loc.dot(Field::deviceAddress),
                              "(0x%" PRIx64 ") does not belong to a valid VkBuffer.", pRaygenShaderBindingTable->deviceAddress);
         }
-        skip |= ValidateRaytracingShaderBindingTable(cb_state, table_loc, vuid_single_device_memory, vuid_binding_table_flag,
-                                                     *pRaygenShaderBindingTable);
+        skip |= ValidateRaytracingShaderBindingTable(cb_state, table_loc, vuid_binding_table_flag, *pRaygenShaderBindingTable);
     }
 
     if (pMissShaderBindingTable) {
         const Location table_loc = loc.dot(Field::pMissShaderBindingTable);
-        const char *vuid_single_device_memory = is_indirect ? "VUID-vkCmdTraceRaysIndirectKHR-pMissShaderBindingTable-03683"
-                                                            : "VUID-vkCmdTraceRaysKHR-pMissShaderBindingTable-03683";
         const char *vuid_binding_table_flag = is_indirect ? "VUID-vkCmdTraceRaysIndirectKHR-pMissShaderBindingTable-03684"
                                                           : "VUID-vkCmdTraceRaysKHR-pMissShaderBindingTable-03684";
-        skip |= ValidateRaytracingShaderBindingTable(cb_state, table_loc, vuid_single_device_memory, vuid_binding_table_flag,
-                                                     *pMissShaderBindingTable);
+        skip |= ValidateRaytracingShaderBindingTable(cb_state, table_loc, vuid_binding_table_flag, *pMissShaderBindingTable);
         if (pMissShaderBindingTable->deviceAddress == 0) {
             if (pipeline_state->create_flags & VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_MISS_SHADERS_BIT_KHR) {
                 const char *vuid =
@@ -1006,12 +997,9 @@ bool CoreChecks::ValidateCmdTraceRaysKHR(const Location &loc, const LastBound &l
 
     if (pCallableShaderBindingTable) {
         const Location table_loc = loc.dot(Field::pCallableShaderBindingTable);
-        const char *vuid_single_device_memory = is_indirect ? "VUID-vkCmdTraceRaysIndirectKHR-pCallableShaderBindingTable-03691"
-                                                            : "VUID-vkCmdTraceRaysKHR-pCallableShaderBindingTable-03691";
         const char *vuid_binding_table_flag = is_indirect ? "VUID-vkCmdTraceRaysIndirectKHR-pCallableShaderBindingTable-03692"
                                                           : "VUID-vkCmdTraceRaysKHR-pCallableShaderBindingTable-03692";
-        skip |= ValidateRaytracingShaderBindingTable(cb_state, table_loc, vuid_single_device_memory, vuid_binding_table_flag,
-                                                     *pCallableShaderBindingTable);
+        skip |= ValidateRaytracingShaderBindingTable(cb_state, table_loc, vuid_binding_table_flag, *pCallableShaderBindingTable);
     }
     return skip;
 }
@@ -1698,6 +1686,8 @@ bool CoreChecks::ValidateActionStateProtectedMemory(const LastBound &last_bound_
     return skip;
 }
 
+// Note, these don't include the RTX Indirect commands (vkCmdTraceRaysIndirectKHR) because
+// they use a VkDeviceAddress instead of a VkBuffer
 bool CoreChecks::ValidateIndirectCmd(const vvl::CommandBuffer &cb_state, const vvl::Buffer &buffer_state,
                                      const DrawDispatchVuid &vuid) const {
     bool skip = false;

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -477,21 +477,14 @@ class CoreChecks : public vvl::DeviceProxy {
     bool ValidateStageMasksAgainstQueueCapabilities(const LogObjectList& objlist, const Location& stage_mask_loc,
                                                     VkQueueFlags queue_flags, VkPipelineStageFlags2KHR stage_mask) const;
 
+    bool ValidateDeviceAddress(const Location& device_address_loc, const LogObjectList& objlist,
+                               VkDeviceAddress device_address) const;
     bool ValidateMemoryIsBoundToBuffer(LogObjectList objlist, const vvl::Buffer& buffer_state, const Location& buffer_loc,
                                        const char* vuid) const;
     bool ValidateAccelStructsMemoryDoNotOverlap(const Location& function_loc, LogObjectList objlist,
                                                 const vvl::AccelerationStructureKHR& accel_struct_a, const Location& loc_a,
                                                 const vvl::AccelerationStructureKHR& accel_struct_b, const Location& loc_b,
                                                 const char* vuid) const;
-    // Look for a buffer in scratches_a that does not overlap with src_accel_struct, dst_accel_struct, and at least one buffer from
-    // scratches_b
-    bool ValidateScratchMemoryNoOverlap(const Location& function_loc, LogObjectList objlist,
-                                        const vvl::span<vvl::Buffer* const>& scratches_a, VkDeviceAddress scratch_a_address,
-                                        VkDeviceSize scratch_a_size, const Location& loc_scratches_a,
-                                        const vvl::AccelerationStructureKHR* src_accel_struct, const Location& loc_src_accel_struct,
-                                        const vvl::AccelerationStructureKHR& dst_accel_struct, const Location& loc_dst_accel_struct,
-                                        const vvl::span<vvl::Buffer* const>& scratches_b, VkDeviceAddress scratch_b_address,
-                                        VkDeviceSize scratch_b_size, const Location* loc_scratches_b) const;
     bool ValidateAccelStructBufferMemoryIsHostVisible(const vvl::AccelerationStructureKHR& accel_struct, const Location& buffer_loc,
                                                       const char* vuid) const;
     bool ValidateAccelStructBufferMemoryIsNotMultiInstance(const vvl::AccelerationStructureKHR& accel_struct,
@@ -1358,7 +1351,7 @@ class CoreChecks : public vvl::DeviceProxy {
                                        uint32_t width, uint32_t height, uint32_t depth,
                                        const ErrorObject& error_obj) const override;
     bool ValidateRaytracingShaderBindingTable(const vvl::CommandBuffer& cb_state, const Location& table_loc,
-                                              const char* vuid_single_device_memory, const char* vuid_binding_table_flag,
+                                              const char* vuid_binding_table_flag,
                                               const VkStridedDeviceAddressRegionKHR& binding_table) const;
     bool ValidateCmdTraceRaysKHR(const Location& loc, const LastBound& last_bound_state,
                                  const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,

--- a/layers/drawdispatch/drawdispatch_vuids.cpp
+++ b/layers/drawdispatch/drawdispatch_vuids.cpp
@@ -2186,7 +2186,6 @@ struct DispatchVuidsCmdTraceRaysIndirectKHR: DrawDispatchVuid {
         linear_mipmap_sampler_09599              = "VUID-vkCmdTraceRaysIndirectKHR-mipmapMode-09599";
         unnormalized_coordinates_09635           = "VUID-vkCmdTraceRaysIndirectKHR-unnormalizedCoordinates-09635";
         cubic_sampler_02692                      = "VUID-vkCmdTraceRaysIndirectKHR-None-02692";
-        indirect_contiguous_memory_02708         = "VUID-vkCmdTraceRaysIndirectKHR-indirectDeviceAddress-03632";
         indirect_buffer_bit_02290                = "VUID-vkCmdTraceRaysIndirectKHR-indirectDeviceAddress-03633";
         corner_sampled_address_mode_02696        = "VUID-vkCmdTraceRaysIndirectKHR-flags-02696";
         imageview_atomic_02691                   = "VUID-vkCmdTraceRaysIndirectKHR-None-02691";
@@ -2234,7 +2233,6 @@ struct DispatchVuidsCmdTraceRaysIndirect2KHR: DrawDispatchVuid {
         linear_mipmap_sampler_09599              = "VUID-vkCmdTraceRaysIndirect2KHR-mipmapMode-09599";
         unnormalized_coordinates_09635           = "VUID-vkCmdTraceRaysIndirect2KHR-unnormalizedCoordinates-09635";
         cubic_sampler_02692                      = "VUID-vkCmdTraceRaysIndirect2KHR-None-02692";
-        indirect_contiguous_memory_02708         = "VUID-vkCmdTraceRaysIndirect2KHR-indirectDeviceAddress-03632";
         indirect_buffer_bit_02290                = "VUID-vkCmdTraceRaysIndirect2KHR-indirectDeviceAddress-03633";
         corner_sampled_address_mode_02696        = "VUID-vkCmdTraceRaysIndirect2KHR-flags-02696";
         imageview_atomic_02691                   = "VUID-vkCmdTraceRaysIndirect2KHR-None-02691";

--- a/layers/error_message/unimplementable_validation.h
+++ b/layers/error_message/unimplementable_validation.h
@@ -554,7 +554,6 @@ const char* unimplementable_validation[] = {
     "VUID-VkAccelerationStructureCreateInfoKHR-deviceAddress-09488"
     "VUID-VkAccelerationStructureCreateInfoKHR-deviceAddress-09489"
     "VUID-VkAccelerationStructureCreateInfoKHR-deviceAddress-09490"
-    "VUID-VkAccelerationStructureCreateInfoKHR-deviceAddress-10393"
 };
 
 // VUs from deprecated extensions that would require complex codegen to get working

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -673,15 +673,6 @@ class DeviceState : public vvl::base::Device {
     // more efficient to store them using raw pointers. It is safe to do so (at time of writing) because those raw pointers come
     // from shared ones created when the buffer is first recorded, and they are removed from buffer_address_map_ at BufferDestroy
     // time
-    vvl::span<vvl::Buffer*> GetBuffersByAddress(VkDeviceAddress address) {
-        ReadLockGuard guard(buffer_address_lock_);
-        auto found_it = buffer_address_map_.find(address);
-        if (found_it == buffer_address_map_.end()) {
-            return vvl::make_span<vvl::Buffer*>(nullptr, static_cast<size_t>(0));
-        }
-        return found_it->second;
-    }
-
     vvl::span<vvl::Buffer* const> GetBuffersByAddress(VkDeviceAddress address) const {
         ReadLockGuard guard(buffer_address_lock_);
         auto found_it = buffer_address_map_.find(address);
@@ -2091,8 +2082,6 @@ class DeviceProxy : public vvl::base::Device {
     bool AnyOf(std::function<bool(const State& s)> fn) const {
         return device_state->AnyOf<State>(fn);
     }
-
-    vvl::span<vvl::Buffer*> GetBuffersByAddress(VkDeviceAddress address) { return device_state->GetBuffersByAddress(address); }
 
     vvl::span<vvl::Buffer* const> GetBuffersByAddress(VkDeviceAddress address) const {
         return const_cast<const vvl::DeviceState*>(device_state)->GetBuffersByAddress(address);

--- a/layers/stateless/sl_device_generated_commands.cpp
+++ b/layers/stateless/sl_device_generated_commands.cpp
@@ -502,8 +502,8 @@ bool Device::ValidateGeneratedCommandsInfo(VkCommandBuffer command_buffer,
     }
 
     if (generated_commands_info.indirectAddress == 0) {
-        skip |= LogError("VUID-VkGeneratedCommandsInfoEXT-indirectAddress-11076", command_buffer,
-                         info_loc.dot(Field::indirectAddress), "is NULL.");
+        skip |= LogError("VUID-VkGeneratedCommandsInfoEXT-indirectAddress-parameter", command_buffer,
+                         info_loc.dot(Field::indirectAddress), "is zero.");
     } else if (SafeModulo(generated_commands_info.indirectAddress, 4) != 0) {
         skip |=
             LogError("VUID-VkGeneratedCommandsInfoEXT-indirectAddress-11074", command_buffer, info_loc.dot(Field::indirectAddress),

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -2196,7 +2196,7 @@ TEST_F(NegativeRayTracing, CmdCopyAccelerationStructureToMemoryKHR) {
 
     m_command_buffer.Begin();
 
-    m_errorMonitor->SetDesiredError("VUID-vkCmdCopyAccelerationStructureToMemoryKHR-pInfo-03739");
+    m_errorMonitor->SetDesiredError("VUID-VkDeviceAddress-size-11364");
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyAccelerationStructureToMemoryKHR-None-03559");
     m_errorMonitor->SetDesiredError("VUID-VkCopyAccelerationStructureToMemoryInfoKHR-src-04959");
     vk::CmdCopyAccelerationStructureToMemoryKHR(m_command_buffer, &copy_info);
@@ -2270,7 +2270,7 @@ TEST_F(NegativeRayTracing, CmdCopyMemoryToAccelerationStructureKHRInvalidSrcBuff
 
     m_command_buffer.Begin();
 
-    m_errorMonitor->SetDesiredError("VUID-vkCmdCopyMemoryToAccelerationStructureKHR-pInfo-03742");
+    m_errorMonitor->SetDesiredError("VUID-VkDeviceAddress-size-11364");
     vk::CmdCopyMemoryToAccelerationStructureKHR(m_command_buffer, &copy_info);
     m_errorMonitor->VerifyFound();
 
@@ -2909,8 +2909,7 @@ TEST_F(NegativeRayTracing, TrianglesMisalignedVertexBufferAddress) {
     auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
     blas.GetGeometries()[0].SetTrianglesVertexBufferDeviceAddress(1);
 
-    m_errorMonitor->SetDesiredError(
-        "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03804");  // device address does not belong to a buffer
+    m_errorMonitor->SetDesiredError("VUID-VkDeviceAddress-size-11364");  // device address does not belong to a buffer
     m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03711");  // misaligned device address
     blas.BuildCmdBuffer(m_command_buffer);
     m_errorMonitor->VerifyFound();
@@ -3034,7 +3033,7 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometryTr
     blas.GetGeometries()[0].SetTrianglesTransformatData(666 * 16);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03766");
-    m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03808");
+    m_errorMonitor->SetDesiredError("VUID-VkDeviceAddress-size-11364");
     blas.BuildCmdBuffer(m_command_buffer);
     m_errorMonitor->VerifyFound();
     m_command_buffer.End();
@@ -3096,7 +3095,7 @@ TEST_F(NegativeRayTracing, TrianglesIndexBufferInvalidAddress) {
     blas.GetGeometries()[0].SetTrianglesIndexBufferDeviceAddress(32);
 
     m_command_buffer.Begin();
-    m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03806");
+    m_errorMonitor->SetDesiredError("VUID-VkDeviceAddress-size-11364");
     blas.BuildCmdBuffer(m_command_buffer);
     m_errorMonitor->VerifyFound();
     m_command_buffer.End();
@@ -3117,7 +3116,7 @@ TEST_F(NegativeRayTracing, AabbBufferInvalidAddress) {
     blas.GetGeometries()[0].SetAABBsDeviceAddress(32);
 
     m_command_buffer.Begin();
-    m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03811");
+    m_errorMonitor->SetDesiredError("VUID-VkDeviceAddress-size-11364");
     blas.BuildCmdBuffer(m_command_buffer);
     m_errorMonitor->VerifyFound();
     m_command_buffer.End();
@@ -3202,7 +3201,7 @@ TEST_F(NegativeRayTracing, TransformBufferInvalidDeviceAddress) {
     blas.GetGeometries()[0].SetTrianglesTransformatData(16);
 
     m_command_buffer.Begin();
-    m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03808");
+    m_errorMonitor->SetDesiredError("VUID-VkDeviceAddress-size-11364");
     blas.BuildCmdBuffer(m_command_buffer);
     m_errorMonitor->VerifyFound();
     m_command_buffer.End();
@@ -3231,7 +3230,7 @@ TEST_F(NegativeRayTracing, TransformBufferInvalid) {
     m_command_buffer.Begin();
     blas.SetupBuild(*m_device, true);
     transform_buffer.Memory().Destroy();
-    m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03809");
+    m_errorMonitor->SetDesiredError("UNASSIGNED-VkDeviceAddress-no-memory");
     blas.VkCmdBuildAccelerationStructuresKHR(m_command_buffer);
     m_errorMonitor->VerifyFound();
     m_command_buffer.End();
@@ -3316,7 +3315,7 @@ TEST_F(NegativeRayTracing, InstanceBufferBadMemory) {
 
     tlas.GetGeometries()[0].GetInstance().buffer.Memory().Destroy();
 
-    m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03814");
+    m_errorMonitor->SetDesiredError("UNASSIGNED-VkDeviceAddress-no-memory");
     tlas.VkCmdBuildAccelerationStructuresKHR(m_command_buffer);
     m_errorMonitor->VerifyFound();
     m_command_buffer.End();
@@ -3510,7 +3509,7 @@ TEST_F(NegativeRayTracing, ScratchBufferBadMemory) {
 
     buffer_memory.Destroy();
 
-    m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03803");
+    m_errorMonitor->SetDesiredError("UNASSIGNED-VkDeviceAddress-no-memory");
     blas.VkCmdBuildAccelerationStructuresKHR(m_command_buffer);
     m_errorMonitor->VerifyFound();
     m_command_buffer.End();

--- a/tests/unit/shader_cooperative_vector.cpp
+++ b/tests/unit/shader_cooperative_vector.cpp
@@ -263,7 +263,7 @@ TEST_F(NegativeShaderCooperativeVector, DeviceConvertSrcAddressInvalid) {
     RETURN_IF_SKIP(SetupCmdConvertCooperativeVectorMatrixNVTest());
 
     info.srcData.deviceAddress = 64;
-    m_errorMonitor->SetDesiredError("VUID-vkCmdConvertCooperativeVectorMatrixNV-pInfo-10083");
+    m_errorMonitor->SetDesiredError("VUID-VkDeviceAddress-size-11364");
     vk::CmdConvertCooperativeVectorMatrixNV(m_command_buffer, 1, &info);
     m_errorMonitor->VerifyFound();
 }
@@ -273,7 +273,7 @@ TEST_F(NegativeShaderCooperativeVector, DeviceConvertDstAddressInvalid) {
     RETURN_IF_SKIP(SetupCmdConvertCooperativeVectorMatrixNVTest());
 
     info.dstData.deviceAddress = 64;
-    m_errorMonitor->SetDesiredError("VUID-vkCmdConvertCooperativeVectorMatrixNV-pInfo-10083");
+    m_errorMonitor->SetDesiredError("VUID-VkDeviceAddress-size-11364");
     vk::CmdConvertCooperativeVectorMatrixNV(m_command_buffer, 1, &info);
     m_errorMonitor->VerifyFound();
 }


### PR DESCRIPTION
based on https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/7517

Makes it so any time a `VkDeviceAddress` is passed in we have a single path to check if its a valid VkDeviceAddress... some checks will want additional checks (if the VkBuffer under have certain buffer usages, etc) which can still be done as normal