### PR TITLE
tests: Add synval performance tests

### DIFF
--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -2866,3 +2866,97 @@ TEST_F(PositiveSyncVal, SingleQueryCopyIgnoresStride) {
     vk::CmdFillBuffer(m_command_buffer, buffer16, 8, 8, 0x42);
     m_command_buffer.End();
 }
+
+TEST_F(PositiveSyncVal, CopyPagesInSmallChunks) {
+    // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10376
+    TEST_DESCRIPTION("Performance stress testing test");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(InitSyncVal());
+
+    const uint32_t page_count = 2;
+    const uint32_t page_size = 65536;
+    const uint32_t copies_per_page = page_size / 16;  // 4K
+
+    // Double buffer resources. Wait on the fence to ensure it's safe to use resource.
+    // This matches the scenario from the issue. By waiting on the fence syncval resets
+    // previous queue state, so adding new pages does not increase time it takes to
+    // process a single page. Total time increases linearly to the number of pages.
+    vkt::CommandBuffer command_buffers[2] = {vkt::CommandBuffer(*m_device, m_command_pool),
+                                             vkt::CommandBuffer(*m_device, m_command_pool)};
+    vkt::Fence fences[2] = {vkt::Fence(*m_device, VK_FENCE_CREATE_SIGNALED_BIT),
+                            vkt::Fence(*m_device, VK_FENCE_CREATE_SIGNALED_BIT)};
+
+    VkMemoryBarrier2 barrier = vku::InitStructHelper();
+    barrier.srcStageMask = VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT;
+    barrier.srcAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
+    barrier.dstStageMask = VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT;
+    barrier.dstAccessMask = VK_ACCESS_2_TRANSFER_READ_BIT;
+
+    vkt::Buffer buffer(*m_device, page_count * page_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+    VkBufferCopy region = {0 /*src offset*/, 16 /*dst offset*/, 16 /*size*/};
+
+    for (uint32_t page = 0; page < page_count; page++) {
+        vkt::CommandBuffer &command_buffer = command_buffers[page % 2];
+        vkt::Fence &fence = fences[page % 2];
+        fence.Wait(kWaitTimeout);
+        fence.Reset();
+        command_buffer.Begin();
+        for (uint32_t copy = (page == 0) ? 1 : 0; copy < copies_per_page; copy++) {
+            command_buffer.Barrier(barrier);
+            vk::CmdCopyBuffer(command_buffer, buffer, buffer, 1, &region);
+            region.srcOffset += 16;
+            region.dstOffset += 16;
+        }
+        command_buffer.End();
+        m_default_queue->Submit(command_buffer, fence);
+    }
+    m_default_queue->Wait();
+}
+
+TEST_F(PositiveSyncVal, CopyPagesInSmallChunksNoQueueSync) {
+    // Similar to CopyPagesInSmallChunks test but do not reset queue state.
+    TEST_DESCRIPTION("Performance stress testing test");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(InitSyncVal());
+
+    const uint32_t page_count = 2;
+    const uint32_t page_size = 65536;
+    const uint32_t copies_per_page = page_size / 16;  // 4K
+
+    // Create command buffer for each page. With this setup we can submit
+    // command buffers and do not wait for previous submissions. Without
+    // synchonization syncval does not have opportunity to trim queue
+    // state and adding more pages increases time to process each page.
+    // Total time increases non-linearly with the number of pages.
+    // NOTE: ideally we need to come up with solution that is has linear
+    // complexity in this case.
+    std::vector<vkt::CommandBuffer> command_buffers;
+    for (uint32_t i = 0; i < page_count; i++) {
+        command_buffers.emplace_back(*m_device, m_command_pool);
+    }
+
+    VkMemoryBarrier2 barrier = vku::InitStructHelper();
+    barrier.srcStageMask = VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT;
+    barrier.srcAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
+    barrier.dstStageMask = VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT;
+    barrier.dstAccessMask = VK_ACCESS_2_TRANSFER_READ_BIT;
+
+    vkt::Buffer buffer(*m_device, page_count * page_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+    VkBufferCopy region = {0 /*src offset*/, 16 /*dst offset*/, 16 /*size*/};
+
+    for (uint32_t page = 0; page < page_count; page++) {
+        vkt::CommandBuffer &command_buffer = command_buffers[page];
+        command_buffer.Begin();
+        for (uint32_t copy = (page == 0) ? 1 : 0; copy < copies_per_page; copy++) {
+            command_buffer.Barrier(barrier);
+            vk::CmdCopyBuffer(command_buffer, buffer, buffer, 1, &region);
+            region.srcOffset += 16;
+            region.dstOffset += 16;
+        }
+        command_buffer.End();
+        m_default_queue->Submit(command_buffer);
+    }
+    m_default_queue->Wait();
+}


### PR DESCRIPTION
Add test that behaves similarly to the scenario from https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10376.
The sparse resources are not related to the issue and it looks like we do not hit some separate slow path. That's the current performance of general path. Syncval works well when resources are accessed as large ranges of bytes but when access if fine-graned (close to separate bytes) this creates a lot of access ranges and current data structures are not fast enough in this case.

General optimization of syncval will make this faster, but even 3-4x faster syncval (which will bring syncval perf to core checks level in some cases) means that current scenario will be only 3-4x faster. A lot of small memory accesses probably will remain a not good performance case, but will see (one option is to have configuration that trades memory for performance but using large but fast data structures).

