### PR TITLE
layers: Provide some help if atexit is used

### DIFF
--- a/docs/khronos_validation_layer.md
+++ b/docs/khronos_validation_layer.md
@@ -14,6 +14,8 @@ Any errors in Vulkan usage can result in unexpected behavior or even a crash.  T
 can be used to to assist developers in isolating incorrect usage, and in verifying that applications
 correctly use the API.
 
+It is important to acknowledge there are a few [limitations](./limitations.md) for what the Validation Layers can do.
+
 ## Configuring the Validation Layer
 
 There are 4 ways to configure the settings: *Vulkan Configurator*, `application defined`, `vk_layer_settings.txt`, `environment variables` as described in the [layers configuration](https://vulkan.lunarg.com/doc/view/latest/windows/layer_configuration.html) documentation and described in the [Configuring Vulkan Layers](https://www.lunarg.com/wp-content/uploads/2024/04/Configuring-Vulkan-Layers-LunarG-Christophe-Riccio-04-11-2024.pdf) whitepaper.


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10398

So I originally wanted to find a better way to have VVL running, but on `atexit()` we call `vvl::dispatch::FreeAllData()` and now everything is destroyed and there is nothing left.

The 2 times this has been reported are on Linux environments, so hoping adding a `printf` and more documentation helps, but at some level, without completely redoing all the lifetime for chassis (which is a very non-trivial task) and the fact we have no way to even test `atexit` in CI currently, I feel this is best I can do with the limited time I have to look into this issue