### PR TITLE
layers: Fix incomplete test for sliceable image

### DIFF
--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -1543,9 +1543,7 @@ bool CoreChecks::ValidateCreateImageViewSubresourceRange(const vvl::Image &image
                                                          const VkImageSubresourceRange &subresourceRange,
                                                          const Location &loc) const {
     const bool is_khr_maintenance1 = IsExtEnabled(extensions.vk_khr_maintenance1);
-    const bool is_2d_compatible =
-        image_state.create_info.flags & (VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT | VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT);
-    const bool is_image_slicable = (image_state.create_info.imageType == VK_IMAGE_TYPE_3D) && is_2d_compatible;
+    const bool is_image_slicable = image_state.IsDepthSliceable();
     const bool is_3d_to_2d_map = is_khr_maintenance1 && is_image_slicable && is_imageview_2d_type;
 
     uint32_t image_layer_count;

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -132,8 +132,8 @@ class Image : public Bindable, public SubStateManager<ImageSubState> {
 
     bool IsCreateInfoEqual(const VkImageCreateInfo &other_create_info) const;
     bool IsCreateInfoDedicatedAllocationImageAliasingCompatible(const VkImageCreateInfo &other_create_info) const;
-
     bool IsSwapchainImage() const { return create_from_swapchain != VK_NULL_HANDLE; }
+    bool IsDepthSliceable() const;
 
     // TODO - need to understand if VkBindImageMemorySwapchainInfoKHR counts as "bound"
     bool HasBeenBound() const { return (MemoryState() != nullptr) || (bind_swapchain); }

--- a/tests/unit/image_positive.cpp
+++ b/tests/unit/image_positive.cpp
@@ -932,3 +932,25 @@ TEST_F(PositiveImage, Image3DWith2DArrayCompatIssue) {
                            nullptr, 1, &image_memory_barrier);
     m_command_buffer.End();
 }
+
+TEST_F(PositiveImage, ImageView2dOf3dBaseLayer) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10416");
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_EXT_IMAGE_2D_VIEW_OF_3D_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_9_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+
+    VkImageCreateInfo image_ci = vku::InitStructHelper();
+    image_ci.flags = VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT;
+    image_ci.imageType = VK_IMAGE_TYPE_3D;
+    image_ci.format = VK_FORMAT_R8G8B8A8_UNORM;
+    image_ci.extent = {32u, 32u, 2u};
+    image_ci.mipLevels = 1u;
+    image_ci.arrayLayers = 1u;
+    image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
+    image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
+    image_ci.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
+    image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    vkt::Image image(*m_device, image_ci);
+    vkt::ImageView image_view = image.CreateView(VK_IMAGE_VIEW_TYPE_2D, 0u, 1u, 1u, 1u);
+}


### PR DESCRIPTION
In `Image::GetSubresourceEncoderRange` I forgot to check for `VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT` in addition to `VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT`. Introduce ` Image::IsDepthSliceable` to have this check in one place.

p.s. To be honest I briefly checked VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT when wrote that code but it was all new and confusing. Now with the help of reasoning software I know that these are similar flags but VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT supports more features.