### PR TITLE
layers: Remove old deprecated settings

### DIFF
--- a/docs/debug_printf.md
+++ b/docs/debug_printf.md
@@ -221,7 +221,6 @@ and see the Debug Printf output.
 ### Limitations
 * Debug Printf consumes a descriptor set. If your application uses every last
 descriptor set on the GPU, Debug Printf will not work.
-  * Suggest using `VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT`
 * Debug Printf consumes device memory on the GPU. Large or numerous Debug Printf
 messages can exhaust device memory. See settings above to control
 buffer size.

--- a/docs/gpu_validation.md
+++ b/docs/gpu_validation.md
@@ -29,7 +29,7 @@ There are several limitations that may impede the operation of GPU Assisted Vali
 - Vulkan 1.1+ required
 - A Descriptor Slot
     - GPU-AV requires one descriptor set, which means if an application is using all sets in `VkPhysicalDeviceLimits::maxBoundDescriptorSets`, GPU-AV will not work.
-    - There is a `VK_LAYER_GPUAV_RESERVE_BINDING_SLOT` that will reduce `maxBoundDescriptorSets` by one if the app uses that value to determine its logic.
+    - GPU-AV will reduce the returned value of `maxBoundDescriptorSets` by one.
 - `fragmentStoresAndAtomics` and `vertexPipelineStoresAndAtomics` so we can write out information from those stages.
 - `timelineSemaphore` so we don't have a big `vkQueueWaitIdle` after each submission.
 

--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -193,7 +193,6 @@
                         { "key": "gpuav_shader_instrumentation", "value": true },
                         { "key": "gpuav_select_instrumented_shaders", "value": false },
                         { "key": "gpuav_buffers_validation", "value": true },
-                        { "key": "gpuav_reserve_binding_slot", "value": true },
                         { "key": "validate_best_practices", "value": false },
                         { "key": "report_flags", "value": [ "error" ] },
                         { "key": "debug_action", "value": [ "VK_DBG_LAYER_ACTION_LOG_MSG" ] },
@@ -738,29 +737,7 @@
                                                     { "key": "gpuav_enable", "value": true },
                                                     { "key": "gpuav_shader_instrumentation", "value": true }
                                                 ]
-                                            },
-                                            "settings": [
-                                                {
-                                                    "key": "gpuav_max_buffer_device_addresses",
-                                                    "label": "Deprecated and disabled setting",
-                                                    "description": "",
-                                                    "type": "INT",
-                                                    "status": "DEPRECATED",
-                                                    "default": 10000,
-                                                    "range": {
-                                                        "min": 100,
-                                                        "max": 10000000
-                                                    },
-                                                    "dependence": {
-                                                        "mode": "ALL",
-                                                        "settings": [
-                                                            { "key": "gpuav_enable", "value": true },
-                                                            { "key": "gpuav_shader_instrumentation", "value": true },
-                                                            { "key": "gpuav_buffer_address_oob", "value": true }
-                                                        ]
-                                                    }
-                                                }
-                                            ]
+                                            }
                                         },
                                         {
                                             "key": "gpuav_validate_ray_query",
@@ -875,48 +852,6 @@
                                                 "settings": [
                                                     { "key": "gpuav_enable", "value": true },
                                                     { "key": "gpuav_buffers_validation", "value": true }
-                                                ]
-                                            }
-                                        }
-                                    ]
-                                },
-                                {
-                                    "key": "gpuav_advanced_settings",
-                                    "label": "Advanced Settings",
-                                    "description": "GPU-AV advanced settings",
-                                    "type": "GROUP",
-                                    "status": "DEPRECATED",
-                                    "view": "ADVANCED",
-                                    "dependence": {
-                                        "mode": "ALL",
-                                        "settings": [
-                                            { "key": "gpuav_enable", "value": true }
-                                        ]
-                                    },
-                                    "settings": [
-                                        {
-                                            "key": "gpuav_reserve_binding_slot",
-                                            "label": "Reserve Descriptor Set Binding Slot",
-                                            "type": "BOOL",
-                                            "default": true,
-                                            "description": "Specifies that the validation layers reserve a descriptor set binding slot for their own use. The layer reports a value for VkPhysicalDeviceLimits::maxBoundDescriptorSets that is one less than the value reported by the device. If the device supports the binding of only one descriptor set, the validation layer does not perform GPU-assisted validation.",
-                                            "dependence": {
-                                                "mode": "ALL",
-                                                "settings": [
-                                                    { "key": "gpuav_enable", "value": true }
-                                                ]
-                                            }
-                                        },
-                                        {
-                                            "key": "gpuav_vma_linear_output",
-                                            "label": "Linear Memory Allocation Mode",
-                                            "description": "Use VMA linear memory allocations for GPU-AV output buffers instead of finding best place for new allocations among free regions to optimize memory usage. Enabling this setting reduces performance cost but disabling this method minimizes memory usage.",
-                                            "type": "BOOL",
-                                            "default": true,
-                                            "dependence": {
-                                                "mode": "ALL",
-                                                "settings": [
-                                                    { "key": "gpuav_enable", "value": true }
                                                 ]
                                             }
                                         }
@@ -1397,7 +1332,7 @@
                             "label": "Reserve Descriptor Set Binding Slot",
                             "description": "Specifies that the validation layers reserve a descriptor set binding slot for their own use. The layer reports a value for VkPhysicalDeviceLimits::maxBoundDescriptorSets that is one less than the value reported by the device. If the device supports the binding of only one descriptor set, the validation layer does not perform GPU-assisted validation.",
                             "platforms": [ "WINDOWS", "LINUX" ],
-                            "deprecated_by_key": "gpuav_reserve_binding_slot"
+                            "deprecated_by_key": "gpuav_enable"
                         },
                         {
                             "key": "VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT",

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -209,11 +209,6 @@ const char *REMOVED_GPUAV_IMAGE_LAYOUT = "gpuav_image_layout";
 
 const char *VK_LAYER_GPUAV_FORCE_ON_ROBUSTNESS = "gpuav_force_on_robustness";
 
-// Plan to remove after deprecated for July 2025 SDK
-const char *DEPRECATED_VK_LAYER_GPUAV_RESERVE_BINDING_SLOT = "gpuav_reserve_binding_slot";
-const char *DEPRECATED_VK_LAYER_GPUAV_VMA_LINEAR_OUTPUT = "gpuav_vma_linear_output";
-const char *DEPRECATED_VK_LAYER_GPUAV_MAX_BUFFER_DEVICE_ADDRESSES = "gpuav_max_buffer_device_addresses";
-
 const char *VK_LAYER_GPUAV_DEBUG_DISABLE_ALL = "gpuav_debug_disable_all";
 const char *VK_LAYER_GPUAV_DEBUG_VALIDATE_INSTRUMENTED_SHADERS = "gpuav_debug_validate_instrumented_shaders";
 const char *VK_LAYER_GPUAV_DEBUG_DUMP_INSTRUMENTED_SHADERS = "gpuav_debug_dump_instrumented_shaders";
@@ -234,16 +229,6 @@ const char *VK_LAYER_MESSAGE_FORMAT_DISPLAY_APPLICATION_NAME = "message_format_d
 const char *VK_LAYER_LOG_FILENAME = "log_filename";
 const char *VK_LAYER_DEBUG_ACTION = "debug_action";
 const char *VK_LAYER_REPORT_FLAGS = "report_flags";
-
-// These were deprecated after the 1.3.280 SDK release
-const char *DEPRECATED_VK_LAYER_GPUAV_VALIDATE_COPIES = "gpuav_validate_copies";
-const char *DEPRECATED_VK_LAYER_GPUAV_VALIDATE_INDIRECT_BUFFER = "gpuav_validate_indirect_buffer";
-const char *DEPRECATED_VK_LAYER_RESERVE_BINDING_SLOT = "reserve_binding_slot";
-const char *DEPRECATED_GPUAV_VMA_LINEAR_OUTPUT = "vma_linear_output";
-const char *DEPRECATED_GPUAV_SELECT_INSTRUMENTED_SHADERS = "select_instrumented_shaders";
-
-// These were deprecated after the 1.3.283 SDK release
-const char *DEPRECATED_VK_LAYER_VALIDATE_SYNC_QUEUE_SUBMIT = "sync_queue_submit";
 
 // Don't need any setting helper when using self vvl and don't want unused function warnings
 #if !defined(BUILD_SELF_VVL)
@@ -599,8 +584,6 @@ static void ValidateLayerSettingsProvided(const VkLayerSettingsCreateInfoEXT *la
             required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
         } else if (strcmp(VK_LAYER_GPUAV_BUFFER_ADDRESS_OOB, setting.pSettingName) == 0) {
             required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
-        } else if (strcmp(DEPRECATED_VK_LAYER_GPUAV_MAX_BUFFER_DEVICE_ADDRESSES, setting.pSettingName) == 0) {
-            required_type = VK_LAYER_SETTING_TYPE_UINT32_EXT;
         } else if (strcmp(VK_LAYER_GPUAV_VALIDATE_RAY_QUERY, setting.pSettingName) == 0) {
             required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
         } else if (strcmp(VK_LAYER_GPUAV_POST_PROCESS_DESCRIPTOR_INDEXING, setting.pSettingName) == 0) {
@@ -620,10 +603,6 @@ static void ValidateLayerSettingsProvided(const VkLayerSettingsCreateInfoEXT *la
         } else if (strcmp(VK_LAYER_GPUAV_BUFFER_COPIES, setting.pSettingName) == 0) {
             required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
         } else if (strcmp(VK_LAYER_GPUAV_INDEX_BUFFERS, setting.pSettingName) == 0) {
-            required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
-        } else if (strcmp(DEPRECATED_VK_LAYER_GPUAV_RESERVE_BINDING_SLOT, setting.pSettingName) == 0) {
-            required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
-        } else if (strcmp(DEPRECATED_VK_LAYER_GPUAV_VMA_LINEAR_OUTPUT, setting.pSettingName) == 0) {
             required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
         } else if (strcmp(VK_LAYER_SYNCVAL_SUBMIT_TIME_VALIDATION, setting.pSettingName) == 0) {
             required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
@@ -645,18 +624,6 @@ static void ValidateLayerSettingsProvided(const VkLayerSettingsCreateInfoEXT *la
             required_type = VK_LAYER_SETTING_TYPE_STRING_EXT;
         } else if (strcmp(VK_LAYER_DISABLES, setting.pSettingName) == 0) {
             required_type = VK_LAYER_SETTING_TYPE_STRING_EXT;
-        } else if (strcmp(DEPRECATED_VK_LAYER_GPUAV_VALIDATE_COPIES, setting.pSettingName) == 0) {
-            required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
-        } else if (strcmp(DEPRECATED_VK_LAYER_GPUAV_VALIDATE_INDIRECT_BUFFER, setting.pSettingName) == 0) {
-            required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
-        } else if (strcmp(DEPRECATED_VK_LAYER_RESERVE_BINDING_SLOT, setting.pSettingName) == 0) {
-            required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
-        } else if (strcmp(DEPRECATED_GPUAV_VMA_LINEAR_OUTPUT, setting.pSettingName) == 0) {
-            required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
-        } else if (strcmp(DEPRECATED_GPUAV_SELECT_INSTRUMENTED_SHADERS, setting.pSettingName) == 0) {
-            required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
-        } else if (strcmp(DEPRECATED_VK_LAYER_VALIDATE_SYNC_QUEUE_SUBMIT, setting.pSettingName) == 0) {
-            required_type = VK_LAYER_SETTING_TYPE_BOOL32_EXT;
         } else {
             setting_warnings.emplace_back("The setting " + std::string(setting.pSettingName) +
                                           " in VkLayerSettingsCreateInfoEXT was not recognize by the Validation Layers. Please "
@@ -1061,12 +1028,6 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
         if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_SELECT_INSTRUMENTED_SHADERS)) {
             vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_SELECT_INSTRUMENTED_SHADERS,
                                     gpuav_settings.select_instrumented_shaders);
-        } else if (vkuHasLayerSetting(layer_setting_set, DEPRECATED_GPUAV_SELECT_INSTRUMENTED_SHADERS)) {
-            vkuGetLayerSettingValue(layer_setting_set, DEPRECATED_GPUAV_SELECT_INSTRUMENTED_SHADERS,
-                                    gpuav_settings.select_instrumented_shaders);
-            setting_warnings.emplace_back("Deprecated " + std::string(DEPRECATED_GPUAV_SELECT_INSTRUMENTED_SHADERS) +
-                                          " setting was set, use " + std::string(VK_LAYER_GPUAV_SELECT_INSTRUMENTED_SHADERS) +
-                                          " instead.");
         }
         if (gpuav_settings.select_instrumented_shaders) {
             std::vector<std::string> shaders_to_instrument;
@@ -1103,11 +1064,6 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
         }
         if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_BUFFER_COPIES)) {
             vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_BUFFER_COPIES, gpuav_settings.validate_buffer_copies);
-        } else if (vkuHasLayerSetting(layer_setting_set, DEPRECATED_VK_LAYER_GPUAV_VALIDATE_COPIES)) {
-            vkuGetLayerSettingValue(layer_setting_set, DEPRECATED_VK_LAYER_GPUAV_VALIDATE_COPIES,
-                                    gpuav_settings.validate_buffer_copies);
-            setting_warnings.emplace_back("Deprecated " + std::string(DEPRECATED_VK_LAYER_GPUAV_VALIDATE_COPIES) +
-                                          " setting was set, use " + std::string(VK_LAYER_GPUAV_BUFFER_COPIES) + " instead.");
         }
         if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_INDEX_BUFFERS)) {
             vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_INDEX_BUFFERS, gpuav_settings.validate_index_buffers);
@@ -1120,34 +1076,6 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
 
     if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_FORCE_ON_ROBUSTNESS)) {
         vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_FORCE_ON_ROBUSTNESS, gpuav_settings.force_on_robustness);
-    }
-
-    if (vkuHasLayerSetting(layer_setting_set, DEPRECATED_VK_LAYER_GPUAV_RESERVE_BINDING_SLOT)) {
-        SetValidationSetting(layer_setting_set, settings_data->enables, gpu_validation_reserve_binding_slot,
-                             DEPRECATED_VK_LAYER_GPUAV_RESERVE_BINDING_SLOT);
-        setting_warnings.emplace_back("Deprecated " + std::string(DEPRECATED_VK_LAYER_GPUAV_RESERVE_BINDING_SLOT) +
-                                      " setting was set, this setting will be remove after the July 2025 SDK is published.");
-    } else if (vkuHasLayerSetting(layer_setting_set, DEPRECATED_VK_LAYER_RESERVE_BINDING_SLOT)) {
-        SetValidationSetting(layer_setting_set, settings_data->enables, gpu_validation_reserve_binding_slot,
-                             DEPRECATED_VK_LAYER_RESERVE_BINDING_SLOT);
-        setting_warnings.emplace_back("Deprecated " + std::string(DEPRECATED_VK_LAYER_RESERVE_BINDING_SLOT) +
-                                      " setting was set, this setting will be remove after the July 2025 SDK is published.");
-    }
-
-    if (vkuHasLayerSetting(layer_setting_set, DEPRECATED_VK_LAYER_GPUAV_VMA_LINEAR_OUTPUT)) {
-        vkuGetLayerSettingValue(layer_setting_set, DEPRECATED_VK_LAYER_GPUAV_VMA_LINEAR_OUTPUT, gpuav_settings.vma_linear_output);
-        setting_warnings.emplace_back("Deprecated " + std::string(DEPRECATED_VK_LAYER_GPUAV_VMA_LINEAR_OUTPUT) +
-                                      " setting was set, this setting will be remove after the July 2025 SDK is published.");
-    }
-    if (vkuHasLayerSetting(layer_setting_set, DEPRECATED_GPUAV_VMA_LINEAR_OUTPUT)) {
-        vkuGetLayerSettingValue(layer_setting_set, DEPRECATED_GPUAV_VMA_LINEAR_OUTPUT, gpuav_settings.vma_linear_output);
-        setting_warnings.emplace_back("Deprecated " + std::string(DEPRECATED_GPUAV_VMA_LINEAR_OUTPUT) +
-                                      " setting was set, this setting will be remove after the July 2025 SDK is published.");
-    }
-    if (vkuHasLayerSetting(layer_setting_set, DEPRECATED_VK_LAYER_GPUAV_MAX_BUFFER_DEVICE_ADDRESSES)) {
-        setting_warnings.emplace_back("Deprecated " + std::string(DEPRECATED_VK_LAYER_GPUAV_MAX_BUFFER_DEVICE_ADDRESSES) +
-                                      " setting was set, but is has been deprecated and has no effect. It will be removed after "
-                                      "the July 2025 SDK is published.");
     }
 
     if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_DEBUG_VALIDATE_INSTRUMENTED_SHADERS)) {
@@ -1205,12 +1133,6 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
     if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_SYNCVAL_SUBMIT_TIME_VALIDATION)) {
         vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_SYNCVAL_SUBMIT_TIME_VALIDATION,
                                 syncval_settings.submit_time_validation);
-    } else if (vkuHasLayerSetting(layer_setting_set, DEPRECATED_VK_LAYER_VALIDATE_SYNC_QUEUE_SUBMIT)) {
-        vkuGetLayerSettingValue(layer_setting_set, DEPRECATED_VK_LAYER_VALIDATE_SYNC_QUEUE_SUBMIT,
-                                syncval_settings.submit_time_validation);
-        setting_warnings.emplace_back("Deprecated " + std::string(DEPRECATED_VK_LAYER_VALIDATE_SYNC_QUEUE_SUBMIT) +
-                                      " setting was set, use " + std::string(VK_LAYER_SYNCVAL_SUBMIT_TIME_VALIDATION) +
-                                      " instead.");
     }
 
     if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_SYNCVAL_SHADER_ACCESSES_HEURISTIC)) {

--- a/layers/vk_layer_settings.txt
+++ b/layers/vk_layer_settings.txt
@@ -90,11 +90,6 @@ khronos_validation.enables =
 # Check for invalid access using buffer device address
 #khronos_validation.gpuav_buffer_address_oob = true
 
-# Specify the maximum number of buffer device addresses in simultaneous use
-# =====================
-# Specify the maximum number of buffer device addresses to allow GPU-AV allocate resources
-#khronos_validation.gpuav_max_buffer_device_addresses = 10000
-
 # Validate RayQuery SPIR-V Instructions
 # =====================
 # Enable shader instrumentation on SPV_KHR_ray_query
@@ -141,11 +136,6 @@ khronos_validation.enables =
 # Validate that indexed draws do not fetch indices outside of the bounds of the index buffer
 # Also validates that those indices are not out of the bounds of the fetched vertex buffers
 #khronos_validation.gpuav_index_buffers = true
-
-# Use linear vma allocator for GPU-AV output buffers
-# =====================
-# Use VMA linear memory allocations for GPU-AV output buffers
-#khronos_validation.gpuav_vma_linear_output = true
 
 # Fine Grained Locking
 # =====================

--- a/tests/unit/gpu_av_positive.cpp
+++ b/tests/unit/gpu_av_positive.cpp
@@ -1053,9 +1053,9 @@ static std::string GetGpuAvSettingsCombinationTestName(const testing::TestParamI
 INSTANTIATE_TEST_SUITE_P(GpuAvShaderInstrumentationMainSettings, PositiveGpuAVParameterized,
 
                          ::testing::Combine(::testing::Values(std::vector<const char *>(
-                                                {"gpuav_descriptor_checks", "gpuav_buffer_address_oob", "gpuav_vma_linear_output",
-                                                 "gpuav_validate_ray_query", "gpuav_select_instrumented_shaders"})),
-                                            ::testing::Range(uint32_t(0), uint32_t(1) << 5)),
+                                                {"gpuav_descriptor_checks", "gpuav_buffer_address_oob", "gpuav_validate_ray_query",
+                                                 "gpuav_select_instrumented_shaders"})),
+                                            ::testing::Range(uint32_t(0), uint32_t(1) << 4)),
 
                          [](const testing::TestParamInfo<PositiveGpuAVParameterized::ParamType> &info) {
                              return GetGpuAvSettingsCombinationTestName(info);
@@ -1064,9 +1064,8 @@ INSTANTIATE_TEST_SUITE_P(GpuAvShaderInstrumentationMainSettings, PositiveGpuAVPa
 INSTANTIATE_TEST_SUITE_P(GpuAvMainSettings, PositiveGpuAVParameterized,
 
                          ::testing::Combine(::testing::Values(std::vector<const char *>({"gpuav_shader_instrumentation",
-                                                                                         "gpuav_buffers_validation",
-                                                                                         "gpuav_vma_linear_output"})),
-                                            ::testing::Range(uint32_t(0), uint32_t(1) << 3)),
+                                                                                         "gpuav_buffers_validation"})),
+                                            ::testing::Range(uint32_t(0), uint32_t(1) << 2)),
 
                          [](const testing::TestParamInfo<PositiveGpuAVParameterized::ParamType> &info) {
                              return GetGpuAvSettingsCombinationTestName(info);


### PR DESCRIPTION
I want to start generating more things from the JSON when it comes to settings, things like

- Validating the type (replace `ValidateLayerSettingsProvided`)
- Adding a way to dump all the setting values
- Generate the vk_layer_settings.txt file

so that adding a new setting is easier... but first, want to get rid of some very old settings I feel are fair game to remove now