### PR TITLE
layers: Combined Dynamic Rendering and RenderPass

### DIFF
--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -3370,69 +3370,47 @@ bool CoreChecks::ValidateDrawPipelineRenderpass(const LastBound &last_bound_stat
     }
     const vku::safe_VkAttachmentReference2 *ds_attachment =
         rp_state.create_info.pSubpasses[cb_state.GetActiveSubpass()].pDepthStencilAttachment;
-    if (ds_attachment != nullptr) {
-        // Check if depth stencil attachment was created with sample location compatible bit
-        if (pipeline.SampleLocationEnabled() == VK_TRUE) {
-            const uint32_t attachment = ds_attachment->attachment;
-            if (attachment != VK_ATTACHMENT_UNUSED) {
-                const auto *imageview_state = cb_state.GetActiveAttachmentImageViewState(attachment);
-                if (imageview_state != nullptr) {
-                    const auto *image_state = imageview_state->image_state.get();
-                    if (image_state != nullptr) {
-                        if ((image_state->create_info.flags & VK_IMAGE_CREATE_SAMPLE_LOCATIONS_COMPATIBLE_DEPTH_BIT_EXT) == 0) {
-                            const LogObjectList objlist(cb_state.Handle(), pipeline.Handle(), rp_state.Handle());
-                            skip |= LogError(vuid.sample_location_02689, objlist, vuid.loc(),
-                                             "sampleLocationsEnable is true for the pipeline, but the subpass (%u) depth "
-                                             "stencil attachment's VkImage was not created with "
-                                             "VK_IMAGE_CREATE_SAMPLE_LOCATIONS_COMPATIBLE_DEPTH_BIT_EXT.",
-                                             cb_state.GetActiveSubpass());
-                        }
-                    }
-                }
-            }
+    const auto ds_state = pipeline.DepthStencilState();
+    if (ds_attachment && ds_state) {
+        if (IsImageLayoutDepthReadOnly(ds_attachment->layout) && last_bound_state.IsDepthWriteEnable()) {
+            const LogObjectList objlist(pipeline.Handle(), rp_state.Handle(), cb_state.Handle());
+            skip |= LogError(vuid.depth_read_only_06886, objlist, vuid.loc(),
+                             "depthWriteEnable is VK_TRUE, while the layout (%s) of "
+                             "the depth aspect of the depth/stencil attachment in the render pass is read only.",
+                             string_VkImageLayout(ds_attachment->layout));
         }
-        const auto ds_state = pipeline.DepthStencilState();
-        if (ds_state) {
-            if (IsImageLayoutDepthReadOnly(ds_attachment->layout) && last_bound_state.IsDepthWriteEnable()) {
+
+        VkStencilOpState front = last_bound_state.GetStencilOpStateFront();
+        VkStencilOpState back = last_bound_state.GetStencilOpStateBack();
+
+        const bool all_keep_op = ((front.failOp == VK_STENCIL_OP_KEEP) && (front.passOp == VK_STENCIL_OP_KEEP) &&
+                                  (front.depthFailOp == VK_STENCIL_OP_KEEP) && (back.failOp == VK_STENCIL_OP_KEEP) &&
+                                  (back.passOp == VK_STENCIL_OP_KEEP) && (back.depthFailOp == VK_STENCIL_OP_KEEP));
+
+        const bool write_mask_enabled = (front.writeMask != 0) && (back.writeMask != 0);
+
+        if (!all_keep_op && write_mask_enabled) {
+            const bool is_stencil_layout_read_only = [&]() {
+                // Look for potential dedicated stencil layout
+                if (const auto *stencil_layout =
+                        vku::FindStructInPNextChain<VkAttachmentReferenceStencilLayout>(ds_attachment->pNext);
+                    stencil_layout)
+                    return IsImageLayoutStencilReadOnly(stencil_layout->stencilLayout);
+                // Else depth and stencil share same layout
+                return IsImageLayoutStencilReadOnly(ds_attachment->layout);
+            }();
+
+            if (is_stencil_layout_read_only) {
                 const LogObjectList objlist(pipeline.Handle(), rp_state.Handle(), cb_state.Handle());
-                skip |= LogError(vuid.depth_read_only_06886, objlist, vuid.loc(),
-                                 "depthWriteEnable is VK_TRUE, while the layout (%s) of "
-                                 "the depth aspect of the depth/stencil attachment in the render pass is read only.",
-                                 string_VkImageLayout(ds_attachment->layout));
-            }
-
-            VkStencilOpState front = last_bound_state.GetStencilOpStateFront();
-            VkStencilOpState back = last_bound_state.GetStencilOpStateBack();
-
-            const bool all_keep_op = ((front.failOp == VK_STENCIL_OP_KEEP) && (front.passOp == VK_STENCIL_OP_KEEP) &&
-                                      (front.depthFailOp == VK_STENCIL_OP_KEEP) && (back.failOp == VK_STENCIL_OP_KEEP) &&
-                                      (back.passOp == VK_STENCIL_OP_KEEP) && (back.depthFailOp == VK_STENCIL_OP_KEEP));
-
-            const bool write_mask_enabled = (front.writeMask != 0) && (back.writeMask != 0);
-
-            if (!all_keep_op && write_mask_enabled) {
-                const bool is_stencil_layout_read_only = [&]() {
-                    // Look for potential dedicated stencil layout
-                    if (const auto *stencil_layout =
-                            vku::FindStructInPNextChain<VkAttachmentReferenceStencilLayout>(ds_attachment->pNext);
-                        stencil_layout)
-                        return IsImageLayoutStencilReadOnly(stencil_layout->stencilLayout);
-                    // Else depth and stencil share same layout
-                    return IsImageLayoutStencilReadOnly(ds_attachment->layout);
-                }();
-
-                if (is_stencil_layout_read_only) {
-                    const LogObjectList objlist(pipeline.Handle(), rp_state.Handle(), cb_state.Handle());
-                    skip |= LogError(vuid.stencil_read_only_06887, objlist, vuid.loc(),
-                                     "The layout (%s) of the stencil aspect of the depth/stencil attachment in the render pass "
-                                     "is read only but not all stencil ops are VK_STENCIL_OP_KEEP.\n"
-                                     "front = { .failOp = %s,  .passOp = %s , .depthFailOp = %s }\n"
-                                     "back = { .failOp = %s, .passOp = %s, .depthFailOp = %s }\n",
-                                     string_VkImageLayout(ds_attachment->layout), string_VkStencilOp(front.failOp),
-                                     string_VkStencilOp(front.passOp), string_VkStencilOp(front.depthFailOp),
-                                     string_VkStencilOp(back.failOp), string_VkStencilOp(back.passOp),
-                                     string_VkStencilOp(back.depthFailOp));
-                }
+                skip |= LogError(vuid.stencil_read_only_06887, objlist, vuid.loc(),
+                                 "The layout (%s) of the stencil aspect of the depth/stencil attachment in the render pass "
+                                 "is read only but not all stencil ops are VK_STENCIL_OP_KEEP.\n"
+                                 "front = { .failOp = %s,  .passOp = %s , .depthFailOp = %s }\n"
+                                 "back = { .failOp = %s, .passOp = %s, .depthFailOp = %s }\n",
+                                 string_VkImageLayout(ds_attachment->layout), string_VkStencilOp(front.failOp),
+                                 string_VkStencilOp(front.passOp), string_VkStencilOp(front.depthFailOp),
+                                 string_VkStencilOp(back.failOp), string_VkStencilOp(back.passOp),
+                                 string_VkStencilOp(back.depthFailOp));
             }
         }
     }

--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -725,52 +725,52 @@ bool CoreChecks::ValidateFragmentDensityMapOffsetEnd(const vvl::CommandBuffer &c
 
         if (attachment_info.IsDepthOrStencil()) {
             const LogObjectList objlist(cb_state.Handle(), attachment->Handle());
-            skip |= LogError(
-                "VUID-VkRenderPassFragmentDensityMapOffsetEndInfoEXT-pDepthStencilAttachment-06505", objlist,
-                end_info_loc.dot(Field::fragmentDensityOffsetCount),
-                "is %" PRIu32 " but %s underlying %s was not created with VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_EXT",
-                fdm_offset_end_info.fragmentDensityOffsetCount, attachment_info.Describe(cb_state.attachment_source, i).c_str(),
-                FormatHandle(*attachment->image_state).c_str());
+            skip |= LogError("VUID-VkRenderPassFragmentDensityMapOffsetEndInfoEXT-pDepthStencilAttachment-06505", objlist,
+                             end_info_loc.dot(Field::fragmentDensityOffsetCount),
+                             "is %" PRIu32
+                             " but %s underlying %s was not created with VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_EXT",
+                             fdm_offset_end_info.fragmentDensityOffsetCount, attachment_info.Describe(cb_state, i).c_str(),
+                             FormatHandle(*attachment->image_state).c_str());
         }
 
         if (attachment_info.IsInput()) {
             const LogObjectList objlist(cb_state.Handle(), attachment->Handle());
-            skip |= LogError(
-                "VUID-VkRenderPassFragmentDensityMapOffsetEndInfoEXT-pInputAttachments-06506", objlist,
-                end_info_loc.dot(Field::fragmentDensityOffsetCount),
-                "is %" PRIu32 " but %s underlying %s was not created with VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_EXT",
-                fdm_offset_end_info.fragmentDensityOffsetCount, attachment_info.Describe(cb_state.attachment_source, i).c_str(),
-                FormatHandle(*attachment->image_state).c_str());
+            skip |= LogError("VUID-VkRenderPassFragmentDensityMapOffsetEndInfoEXT-pInputAttachments-06506", objlist,
+                             end_info_loc.dot(Field::fragmentDensityOffsetCount),
+                             "is %" PRIu32
+                             " but %s underlying %s was not created with VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_EXT",
+                             fdm_offset_end_info.fragmentDensityOffsetCount, attachment_info.Describe(cb_state, i).c_str(),
+                             FormatHandle(*attachment->image_state).c_str());
         }
 
         if (attachment_info.IsColor()) {
             const LogObjectList objlist(cb_state.Handle(), attachment->Handle());
-            skip |= LogError(
-                "VUID-VkRenderPassFragmentDensityMapOffsetEndInfoEXT-pColorAttachments-06507", objlist,
-                end_info_loc.dot(Field::fragmentDensityOffsetCount),
-                "is %" PRIu32 " but %s underlying %s was not created with VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_EXT",
-                fdm_offset_end_info.fragmentDensityOffsetCount, attachment_info.Describe(cb_state.attachment_source, i).c_str(),
-                FormatHandle(*attachment->image_state).c_str());
+            skip |= LogError("VUID-VkRenderPassFragmentDensityMapOffsetEndInfoEXT-pColorAttachments-06507", objlist,
+                             end_info_loc.dot(Field::fragmentDensityOffsetCount),
+                             "is %" PRIu32
+                             " but %s underlying %s was not created with VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_EXT",
+                             fdm_offset_end_info.fragmentDensityOffsetCount, attachment_info.Describe(cb_state, i).c_str(),
+                             FormatHandle(*attachment->image_state).c_str());
         }
 
         if (attachment_info.IsResolve()) {
             const LogObjectList objlist(cb_state.Handle(), attachment->Handle());
-            skip |= LogError(
-                "VUID-VkRenderPassFragmentDensityMapOffsetEndInfoEXT-pResolveAttachments-06508", objlist,
-                end_info_loc.dot(Field::fragmentDensityOffsetCount),
-                "is %" PRIu32 " but %s underlying %s was not created with VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_EXT",
-                fdm_offset_end_info.fragmentDensityOffsetCount, attachment_info.Describe(cb_state.attachment_source, i).c_str(),
-                FormatHandle(*attachment->image_state).c_str());
+            skip |= LogError("VUID-VkRenderPassFragmentDensityMapOffsetEndInfoEXT-pResolveAttachments-06508", objlist,
+                             end_info_loc.dot(Field::fragmentDensityOffsetCount),
+                             "is %" PRIu32
+                             " but %s underlying %s was not created with VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_EXT",
+                             fdm_offset_end_info.fragmentDensityOffsetCount, attachment_info.Describe(cb_state, i).c_str(),
+                             FormatHandle(*attachment->image_state).c_str());
         }
 
         if (attachment_info.IsFragmentDensityMap()) {
             const LogObjectList objlist(cb_state.Handle(), attachment->Handle());
-            skip |= LogError(
-                "VUID-VkRenderPassFragmentDensityMapOffsetEndInfoEXT-fragmentDensityMapAttachment-06504", objlist,
-                end_info_loc.dot(Field::fragmentDensityOffsetCount),
-                "is %" PRIu32 " but %s underlying %s was not created with VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_EXT",
-                fdm_offset_end_info.fragmentDensityOffsetCount, attachment_info.Describe(cb_state.attachment_source, i).c_str(),
-                FormatHandle(*attachment->image_state).c_str());
+            skip |= LogError("VUID-VkRenderPassFragmentDensityMapOffsetEndInfoEXT-fragmentDensityMapAttachment-06504", objlist,
+                             end_info_loc.dot(Field::fragmentDensityOffsetCount),
+                             "is %" PRIu32
+                             " but %s underlying %s was not created with VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_EXT",
+                             fdm_offset_end_info.fragmentDensityOffsetCount, attachment_info.Describe(cb_state, i).c_str(),
+                             FormatHandle(*attachment->image_state).c_str());
         }
     }
 

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -277,6 +277,7 @@ class CoreChecks : public vvl::DeviceProxy {
     bool ValidateDrawProtectedMemory(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateDrawFragmentShadingRate(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateDrawAttachmentColorBlend(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
+    bool ValidateDrawAttachmentSampleLocation(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateDrawDynamicRenderingFsOutputs(const LastBound& last_bound_state, const vvl::RenderPass& rp_state,
                                                const Location& loc) const;
     bool ValidateDrawDynamicRenderpassExternalFormatResolve(const LastBound& last_bound_state, const vvl::RenderPass& rp_state,

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -86,6 +86,7 @@ struct AttachmentInfo {
     bool IsResolve() const { return type == Type::ColorResolve || type == Type::DepthResolve || type == Type::StencilResolve; }
     bool IsInput() const { return type == Type::Input; }
     bool IsColor() const { return type == Type::Color; }
+    bool IsDepth() const { return type == Type::Depth || type == Type::DepthStencil; }
     bool IsDepthOrStencil() const {
         return type == Type::DepthStencil || type == Type::Depth || type == Type::DepthResolve || type == Type::Stencil ||
                type == Type::StencilResolve;
@@ -93,7 +94,7 @@ struct AttachmentInfo {
     bool IsFragmentDensityMap() const { return type == Type::FragmentDensityMap; }
     bool IsFragmentShadingRate() const { return type == Type::FragmentShadingRate; }
 
-    std::string Describe(AttachmentSource source, uint32_t index) const;
+    std::string Describe(const vvl::CommandBuffer &cb_state, uint32_t index) const;
 };
 
 struct SubpassInfo {
@@ -679,7 +680,6 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     // used for non-color types
     uint32_t GetDynamicRenderingAttachmentIndex(AttachmentInfo::Type type) const;
 
-    bool HasValidDepthAttachment() const;
     bool HasExternalFormatResolveAttachment() const;
 
     inline void BindLastBoundPipeline(vvl::BindPoint bind_point, vvl::Pipeline *pipe_state) {

--- a/layers/state_tracker/last_bound_state.cpp
+++ b/layers/state_tracker/last_bound_state.cpp
@@ -769,10 +769,22 @@ std::vector<vvl::ShaderObject *> LastBound::GetAllBoundGraphicsShaders() {
 }
 
 bool LastBound::IsAnyGraphicsShaderBound() const {
-    return IsValidShaderBound(ShaderObjectStage::VERTEX) || IsValidShaderBound(ShaderObjectStage::TESSELLATION_CONTROL) ||
-           IsValidShaderBound(ShaderObjectStage::TESSELLATION_EVALUATION) || IsValidShaderBound(ShaderObjectStage::GEOMETRY) ||
-           IsValidShaderBound(ShaderObjectStage::FRAGMENT) || IsValidShaderBound(ShaderObjectStage::TASK) ||
-           IsValidShaderBound(ShaderObjectStage::MESH);
+    if (pipeline_state) {
+        return (pipeline_state->active_shaders & kShaderStageAllGraphics) != 0;
+    } else {
+        return IsValidShaderBound(ShaderObjectStage::VERTEX) || IsValidShaderBound(ShaderObjectStage::TESSELLATION_CONTROL) ||
+               IsValidShaderBound(ShaderObjectStage::TESSELLATION_EVALUATION) || IsValidShaderBound(ShaderObjectStage::GEOMETRY) ||
+               IsValidShaderBound(ShaderObjectStage::FRAGMENT) || IsValidShaderBound(ShaderObjectStage::TASK) ||
+               IsValidShaderBound(ShaderObjectStage::MESH);
+    }
+}
+
+bool LastBound::IsFragmentBound() const {
+    if (pipeline_state) {
+        return (pipeline_state->active_shaders & VK_SHADER_STAGE_FRAGMENT_BIT) != 0;
+    } else {
+        return IsValidShaderBound(ShaderObjectStage::FRAGMENT);
+    }
 }
 
 VkShaderStageFlags LastBound::GetAllActiveBoundStages() const {

--- a/layers/state_tracker/last_bound_state.h
+++ b/layers/state_tracker/last_bound_state.h
@@ -142,6 +142,7 @@ struct LastBound {
     bool IsValidShaderOrNullBound(ShaderObjectStage stage) const;
     std::vector<vvl::ShaderObject *> GetAllBoundGraphicsShaders();
     bool IsAnyGraphicsShaderBound() const;
+    bool IsFragmentBound() const;
     VkShaderStageFlags GetAllActiveBoundStages() const;
     bool IsBoundSetCompatible(uint32_t set, const vvl::PipelineLayout &pipeline_layout) const;
     bool IsBoundSetCompatible(uint32_t set, const vvl::ShaderObject &shader_object_state) const;

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -419,8 +419,6 @@ class Pipeline : public StateObject {
 
     const Location GetCreateFlagsLoc(const Location &create_info_loc) const;
 
-    bool SampleLocationEnabled() const { return fragment_output_state && fragment_output_state->sample_location_enabled; }
-
     static std::vector<ShaderStageState> GetStageStates(const DeviceState &state_data, const Pipeline &pipe_state,
                                                         spirv::StatelessData *stateless_data);
 

--- a/layers/state_tracker/pipeline_sub_state.h
+++ b/layers/state_tracker/pipeline_sub_state.h
@@ -182,19 +182,6 @@ struct FragmentShaderState : public PipelineSubState {
                                       spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages]);
 };
 
-template <typename CreateInfo>
-static bool IsSampleLocationEnabled(const CreateInfo &create_info) {
-    bool result = false;
-    if (create_info.pMultisampleState) {
-        const auto *sample_location_state =
-            vku::FindStructInPNextChain<VkPipelineSampleLocationsStateCreateInfoEXT>(create_info.pMultisampleState->pNext);
-        if (sample_location_state != nullptr) {
-            result = (sample_location_state->sampleLocationsEnable != 0);
-        }
-    }
-    return result;
-}
-
 struct FragmentOutputState : public PipelineSubState {
     using AttachmentStateVector = std::vector<VkPipelineColorBlendAttachmentState>;
 
@@ -217,7 +204,6 @@ struct FragmentOutputState : public PipelineSubState {
 
         if (create_info.pMultisampleState) {
             ms_state = ToSafeMultisampleState(*create_info.pMultisampleState);
-            sample_location_enabled = IsSampleLocationEnabled(create_info);
         }
 
         const auto flags2 = vku::FindStructInPNextChain<VkPipelineCreateFlags2CreateInfoKHR>(create_info.pNext);
@@ -238,5 +224,4 @@ struct FragmentOutputState : public PipelineSubState {
     AttachmentStateVector attachment_states;
 
     bool legacy_dithering_enabled = false;
-    bool sample_location_enabled = false;
 };


### PR DESCRIPTION
related to https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/7549

basically `07484` and `02689` are the same, just one is for when `sampleLocationsEnable` is dynamic, but when it was not dynamic, it was not being validated if using dynamic rendering!