### PR TITLE
layers: Incorrect present mode used in 10160 error message

### DIFF
--- a/layers/core_checks/cc_wsi.cpp
+++ b/layers/core_checks/cc_wsi.cpp
@@ -132,7 +132,7 @@ bool CoreChecks::ValidateSwapchainPresentModesCreateInfo(VkPresentModeKHR presen
             skip |= LogError("VUID-VkSwapchainPresentModesCreateInfoKHR-presentModeFifoLatestReady-10160", device,
                              create_info_loc.pNext(Struct::VkSwapchainPresentModesCreateInfoKHR, Field::pPresentModes, i),
                              "is %s, but feature presentModeFifoLatestReady is not enabled",
-                             string_VkPresentModeKHR(create_info.presentMode));
+                             string_VkPresentModeKHR(swapchain_present_mode));
         }
 
         if (std::find(present_modes.begin(), present_modes.end(), swapchain_present_mode) == present_modes.end()) {


### PR DESCRIPTION
vkCreateSwapchainKHR validation uses a incorrect variable for 10160 error message. API call:
```
vkCreateSwapchainKHR(device, pCreateInfo, pAllocator, pSwapchain) returns VkResult VK_SUCCESS (0):
    device:                         VkDevice = 0x55a30f9aefd0
    pCreateInfo:                    const VkSwapchainCreateInfoKHR* = 0x7ffff2bd6c20:
        sType:                          VkStructureType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR (1000001000)
        pNext:                          const void* = VkSwapchainPresentModesCreateInfoEXT
        flags:                          VkSwapchainCreateFlagsKHR = 0
        surface:                        VkSurfaceKHR = 0x55a30f646880
        minImageCount:                  uint32_t = 4
        imageFormat:                    VkFormat = VK_FORMAT_B8G8R8A8_UNORM (44)
        imageColorSpace:                VkColorSpaceKHR = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR (0)
        imageExtent:                    VkExtent2D = 0x7ffff2bd6c4c:
            width:                          uint32_t = 512
            height:                         uint32_t = 512
        imageArrayLayers:               uint32_t = 1
        imageUsage:                     VkImageUsageFlags = 31 (VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)
        imageSharingMode:               VkSharingMode = VK_SHARING_MODE_EXCLUSIVE (0)
        queueFamilyIndexCount:          uint32_t = 0
        pQueueFamilyIndices:            const uint32_t* = UNUSED
        preTransform:                   VkSurfaceTransformFlagBitsKHR = 1 (VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR)
        compositeAlpha:                 VkCompositeAlphaFlagBitsKHR = 1 (VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR)
        presentMode:                    VkPresentModeKHR = VK_PRESENT_MODE_FIFO_KHR (2)
        clipped:                        VkBool32 = 1
        oldSwapchain:                   VkSwapchainKHR = 0
        pNext:                          VkSwapchainPresentModesCreateInfoEXT = 0x7ffff2bd6df0:
            sType:                          VkStructureType = VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_MODES_CREATE_INFO_EXT (1000275002)
            pNext:                          const void* = NULL
            presentModeCount:               uint32_t = 4
            pPresentModes:                  const VkPresentModeKHR* = 0x55a30f913de0
                pPresentModes[0]:               const VkPresentModeKHR = VK_PRESENT_MODE_FIFO_KHR (2)
                pPresentModes[1]:               const VkPresentModeKHR = VK_PRESENT_MODE_IMMEDIATE_KHR (0)
                pPresentModes[2]:               const VkPresentModeKHR = VK_PRESENT_MODE_FIFO_RELAXED_KHR (3)
                pPresentModes[3]:               const VkPresentModeKHR = VK_PRESENT_MODE_FIFO_LATEST_READY_EXT (1000361000)
    pAllocator:                     const VkAllocationCallbacks* = NULL
    pSwapchain:                     VkSwapchainKHR* = 0x55a30f913e90
```

Note that `pPresentModes[3]:               const VkPresentModeKHR = VK_PRESENT_MODE_FIFO_LATEST_READY_EXT`, and this is correctly reflected in `VUID-VkSwapchainPresentModesCreateInfoEXT-pPresentModes-parameter`

```
Validation Error: [ VUID-VkSwapchainPresentModesCreateInfoEXT-pPresentModes-parameter ] | MessageID = 0x8acce24f
vkCreateSwapchainKHR(): pCreateInfo->pNext<VkSwapchainPresentModesCreateInfoEXT>.pPresentModes[3] (VK_PRESENT_MODE_FIFO_LATEST_READY_EXT) requires the extensions VK_EXT_present_mode_fifo_latest_ready.
The Vulkan spec states: pPresentModes must be a valid pointer to an array of presentModeCount valid VkPresentModeKHR values (https://vulkan.lunarg.com/doc/view/1.4.313.0/linux/antora/spec/latest/chapters/VK_KHR_surface/wsi.html#VUID-VkSwapchainPresentModesCreateInfoEXT-pPresentModes-parameter)
```

But `VUID-VkSwapchainPresentModesCreateInfoEXT-presentModeFifoLatestReady-10160` prints the value from the `VkSwapchainCreateInfoKHR` struct:
```
Validation Error: [ VUID-VkSwapchainPresentModesCreateInfoEXT-presentModeFifoLatestReady-10160 ] | MessageID = 0x1c6dd9eb
vkCreateSwapchainKHR(): pCreateInfo->pNext<VkSwapchainPresentModesCreateInfoEXT>.pPresentModes[3] is VK_PRESENT_MODE_FIFO_KHR, but feature presentModeFifoLatestReady is not enabled.
The Vulkan spec states: If the presentModeFifoLatestReady feature is not enabled, pPresentModes must not contain VK_PRESENT_MODE_FIFO_LATEST_READY_EXT (https://vulkan.lunarg.com/doc/view/1.4.313.0/linux/antora/spec/latest/chapters/VK_KHR_surface/wsi.html#VUID-VkSwapchainPresentModesCreateInfoEXT-presentModeFifoLatestReady-10160)
```