### PR TITLE
layers: Extra dynamicRenderingUnusedAttachments check

### DIFF
--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -3532,8 +3532,9 @@ bool CoreChecks::ValidateDrawPipelineDynamicRenderpassUnusedAttachments(const La
         if (color_attachment_count && (color_attachment_count != rendering_color_attachment_count)) {
             const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
             skip |= LogError(vuid.dynamic_rendering_color_count_06179, objlist, vuid.loc(),
-                             "Currently bound pipeline %s VkPipelineRenderingCreateInfo::colorAttachmentCount (%" PRIu32
-                             ") must be equal to VkRenderingInfo::colorAttachmentCount (%" PRIu32 ")",
+                             "Currently bound %s was created with VkPipelineRenderingCreateInfo::colorAttachmentCount (%" PRIu32
+                             ") which must be equal to VkRenderingInfo::colorAttachmentCount (%" PRIu32
+                             ").\nThe dynamicRenderingUnusedAttachments feature allows a way to remove this restriction.",
                              FormatHandle(pipeline).c_str(), pipeline_rendering_ci.colorAttachmentCount,
                              rendering_color_attachment_count);
         }
@@ -3547,6 +3548,8 @@ bool CoreChecks::ValidateDrawPipelineDynamicRenderpassUnusedAttachments(const La
                 if ((pipeline_rendering_ci.colorAttachmentCount > i) && (view_state->create_info.format != VK_FORMAT_UNDEFINED) &&
                     (pipeline_rendering_ci.pColorAttachmentFormats[i] != VK_FORMAT_UNDEFINED) &&
                     (view_state->create_info.format != pipeline_rendering_ci.pColorAttachmentFormats[i])) {
+                    // This VU is hard to word, some extra context for future help
+                    // https://gitlab.khronos.org/vulkan/vulkan/-/issues/4379
                     const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
                     skip |= LogError(vuid.dynamic_rendering_unused_attachments_08911, objlist, vuid.loc(),
                                      "VkRenderingInfo::pColorAttachments[%" PRIu32
@@ -3566,7 +3569,8 @@ bool CoreChecks::ValidateDrawPipelineDynamicRenderpassUnusedAttachments(const La
                     skip |= LogError(vuid.dynamic_rendering_undefined_color_formats_08912, objlist, vuid.loc(),
                                      "VkRenderingInfo::pColorAttachments[%" PRIu32
                                      "].imageView is VK_NULL_HANDLE, but the corresponding format in "
-                                     "VkPipelineRenderingCreateInfo::pColorAttachmentFormats[%" PRIu32 "] is %s.",
+                                     "VkPipelineRenderingCreateInfo::pColorAttachmentFormats[%" PRIu32
+                                     "] is %s (but must be VK_FORMAT_UNDEFINED).",
                                      i, i, string_VkFormat(pipeline_rendering_ci.pColorAttachmentFormats[i]));
                 }
             } else {


### PR DESCRIPTION
Follow up of https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/10441 with @ziga-lunarg  test 

I raised https://gitlab.khronos.org/vulkan/vulkan/-/issues/4379 as I am still not sure it is actually allowed to do what we are doing here, but good to have the OOB check regardless