### PR TITLE
layers: Fix more depth/stencil for dynamic rendering

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -279,6 +279,7 @@ class CoreChecks : public vvl::DeviceProxy {
     bool ValidateDrawFragmentShadingRate(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateDrawAttachmentColorBlend(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateDrawAttachmentSampleLocation(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
+    bool ValidateDrawDepthStencilAttachments(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateDrawDynamicRenderingFsOutputs(const LastBound& last_bound_state, const vvl::RenderPass& rp_state,
                                                const Location& loc) const;
     bool ValidateDrawDynamicRenderpassExternalFormatResolve(const LastBound& last_bound_state, const vvl::RenderPass& rp_state,

--- a/layers/drawdispatch/descriptor_validator.cpp
+++ b/layers/drawdispatch/descriptor_validator.cpp
@@ -562,7 +562,8 @@ bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVaria
     if (!cb_state.active_attachments.empty() && !cb_state.active_subpasses.empty() &&
         (descriptor_type != VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT)) {
         for (uint32_t att_index = 0; att_index < cb_state.active_attachments.size(); ++att_index) {
-            const auto *view_state = cb_state.active_attachments[att_index].image_view;
+            const auto &attachment_info = cb_state.active_attachments[att_index];
+            const auto *view_state = attachment_info.image_view;
             if (!view_state || view_state->Destroyed()) {
                 continue;
             }
@@ -586,7 +587,7 @@ bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVaria
             }
 
             const SubpassInfo &subpass = cb_state.active_subpasses[att_index];
-            const bool layout_read_only = IsImageLayoutReadOnly(subpass.layout);
+            const bool layout_read_only = IsImageLayoutReadOnly(attachment_info.layout);
             const bool read_attachment = (subpass.usage & (VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT)) != 0;
             if (read_attachment && descriptor_written_to) {
                 if (same_view) {

--- a/layers/error_message/error_strings.h
+++ b/layers/error_message/error_strings.h
@@ -159,6 +159,18 @@
     return ss.str();
 }
 
+[[maybe_unused]] static std::string string_VkStencilOpState(VkStencilOpState state) {
+    std::stringstream ss;
+    ss << " failOp (" << string_VkStencilOp(state.failOp) << ")\n";
+    ss << " passOp (" << string_VkStencilOp(state.passOp) << ")\n";
+    ss << " depthFailOp (" << string_VkStencilOp(state.depthFailOp) << ")\n";
+    ss << " compareOp (" << string_VkCompareOp(state.compareOp) << ")\n";
+    ss << " compareMask (" << state.compareMask << ")\n";
+    ss << " writeMask (" << state.writeMask << ")\n";
+    ss << " reference (" << state.reference << ")\n";
+    return ss.str();
+}
+
 [[maybe_unused]] static std::string string_VkDependencyInfo(const Logger &logger, VkDependencyInfo set_dependency_info,
                                                             VkDependencyInfo dependency_info) {
     std::stringstream set;

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -78,16 +78,25 @@ struct AttachmentInfo {
 
     vvl::ImageView *image_view;
     Type type;
+    VkImageLayout layout;
+    // Only for VkRenderPass with VK_KHR_separate_depth_stencil_layouts
+    VkImageLayout separate_stencil_layout;
     // When dealing with color attachments, need to know the index for things such as
     // VkPipelineColorBlendStateCreateInfo::pAttachments or vkCmdSetColorBlendEnableEXT
     uint32_t color_index;
 
-    AttachmentInfo() : image_view(nullptr), type(Type::Empty), color_index(0) {}
+    AttachmentInfo()
+        : image_view(nullptr),
+          type(Type::Empty),
+          layout(VK_IMAGE_LAYOUT_UNDEFINED),
+          separate_stencil_layout(VK_IMAGE_LAYOUT_UNDEFINED),
+          color_index(0) {}
 
     bool IsResolve() const { return type == Type::ColorResolve || type == Type::DepthResolve || type == Type::StencilResolve; }
     bool IsInput() const { return type == Type::Input; }
     bool IsColor() const { return type == Type::Color; }
     bool IsDepth() const;
+    bool IsStencil() const;
     bool IsDepthOrStencil() const {
         return type == Type::DepthStencil || type == Type::Depth || type == Type::DepthResolve || type == Type::Stencil ||
                type == Type::StencilResolve;
@@ -101,11 +110,9 @@ struct AttachmentInfo {
 struct SubpassInfo {
     bool used;
     VkImageUsageFlagBits usage;
-    VkImageLayout layout;
     VkImageAspectFlags aspectMask;
 
-    SubpassInfo()
-        : used(false), usage(VkImageUsageFlagBits(0)), layout(VK_IMAGE_LAYOUT_UNDEFINED), aspectMask(VkImageAspectFlags(0)) {}
+    SubpassInfo() : used(false), usage(VkImageUsageFlagBits(0)), aspectMask(VkImageAspectFlags(0)) {}
 };
 
 namespace vvl {

--- a/layers/state_tracker/last_bound_state.cpp
+++ b/layers/state_tracker/last_bound_state.cpp
@@ -61,8 +61,8 @@ bool LastBound::IsDepthTestEnable() const {
             return cb_state.dynamic_state_value.depth_test_enable;
         }
     } else {
-        if (pipeline_state->DepthStencilState()) {
-            return pipeline_state->DepthStencilState()->depthTestEnable;
+        if (const auto ds_state = pipeline_state->DepthStencilState()) {
+            return ds_state->depthTestEnable;
         }
     }
     return false;
@@ -74,8 +74,8 @@ bool LastBound::IsDepthBoundTestEnable() const {
             return cb_state.dynamic_state_value.depth_bounds_test_enable;
         }
     } else {
-        if (pipeline_state->DepthStencilState()) {
-            return pipeline_state->DepthStencilState()->depthBoundsTestEnable;
+        if (const auto ds_state = pipeline_state->DepthStencilState()) {
+            return ds_state->depthBoundsTestEnable;
         }
     }
     return false;
@@ -91,8 +91,8 @@ bool LastBound::IsDepthWriteEnable() const {
             return cb_state.dynamic_state_value.depth_write_enable;
         }
     } else {
-        if (pipeline_state->DepthStencilState()) {
-            return pipeline_state->DepthStencilState()->depthWriteEnable;
+        if (const auto ds_state = pipeline_state->DepthStencilState()) {
+            return ds_state->depthWriteEnable;
         }
     }
     return false;
@@ -104,8 +104,8 @@ bool LastBound::IsDepthBiasEnable() const {
             return cb_state.dynamic_state_value.depth_bias_enable;
         }
     } else {
-        if (pipeline_state->RasterizationState()) {
-            return pipeline_state->RasterizationState()->depthBiasEnable;
+        if (const auto raster_state = pipeline_state->RasterizationState()) {
+            return raster_state->depthBiasEnable;
         }
     }
     return false;
@@ -117,8 +117,8 @@ bool LastBound::IsDepthClampEnable() const {
             return cb_state.dynamic_state_value.depth_clamp_enable;
         }
     } else {
-        if (pipeline_state->RasterizationState()) {
-            return pipeline_state->RasterizationState()->depthClampEnable;
+        if (const auto raster_state = pipeline_state->RasterizationState()) {
+            return raster_state->depthClampEnable;
         }
     }
     return false;
@@ -130,8 +130,8 @@ bool LastBound::IsStencilTestEnable() const {
             return cb_state.dynamic_state_value.stencil_test_enable;
         }
     } else {
-        if (pipeline_state->DepthStencilState()) {
-            return pipeline_state->DepthStencilState()->stencilTestEnable;
+        if (const auto ds_state = pipeline_state->DepthStencilState()) {
+            return ds_state->stencilTestEnable;
         }
     }
     return false;
@@ -188,7 +188,7 @@ bool LastBound::IsRasterizationDisabled() const {
             return cb_state.dynamic_state_value.rasterizer_discard_enable;
         }
     } else {
-        return (pipeline_state->RasterizationDisabled());
+        return pipeline_state->RasterizationDisabled();
     }
     return false;
 }


### PR DESCRIPTION
Fixes `VUID-vkCmdDraw-None-06886` and ` VUID-vkCmdDraw-None-06887` that were not reporting things for Dynamic Rendering

Also `06887` was reporting a false positive when you had `stencilTestEnable` set to `VK_FALSE`

also some improvements on error messages