### PR TITLE
layers: Fix not checking array size in the shader

### DIFF
--- a/layers/drawdispatch/descriptor_validator.cpp
+++ b/layers/drawdispatch/descriptor_validator.cpp
@@ -128,7 +128,12 @@ template <typename T>
 bool DescriptorValidator::ValidateDescriptorsStatic(const spirv::ResourceInterfaceVariable &resource_variable,
                                                     const T &binding) const {
     bool skip = false;
-    for (uint32_t index = 0; !skip && index < binding.count; index++) {
+
+    // If there is a descriptor array, we care about the size of the array statically used in the shader, not what was declared in
+    // the pipeline layout more info https://gitlab.khronos.org/vulkan/vulkan/-/issues/4383
+    const uint32_t count = resource_variable.array_length != 0 ? resource_variable.array_length : binding.count;
+
+    for (uint32_t index = 0; !skip && index < count; index++) {
         const auto &descriptor = binding.descriptors[index];
 
         if (!binding.updated[index]) {


### PR DESCRIPTION
found if you only declare part of your descriptor array in a shader, the rest can be ignored (like when you don't use a certain binding from the pipeline layout)