### PR TITLE
layers: Fix ImageView layerCount normalization

### DIFF
--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -1911,7 +1911,12 @@ bool CoreChecks::ValidateImageViewCreateInfo(const VkImageViewCreateInfo &create
         image_state, create_info.viewType == VK_IMAGE_VIEW_TYPE_2D || create_info.viewType == VK_IMAGE_VIEW_TYPE_2D_ARRAY,
         create_info.subresourceRange, create_info_loc);
 
-    const auto normalized_subresource_range = image_state.NormalizeSubresourceRange(create_info.subresourceRange);
+    // TODO: this is incorrectly normalizes layerCount when image view selects slices of 3d image
+    // (it is enough to run PositiveImage.FramebufferRemainingArrayLayers to show this).
+    // Still currently it does not affect any of the following validations. Fix this when we have a repro case.
+    // The fix should be similar to how ImageView normalizes its ImageView::normalized_subresource_range.
+    auto normalized_subresource_range = image_state.NormalizeSubresourceRange(create_info.subresourceRange);
+
     const VkImageCreateFlags image_flags = image_state.create_info.flags;
     const VkFormat image_format = image_state.create_info.format;
     const VkFormat view_format = create_info.format;
@@ -2889,7 +2894,7 @@ bool CoreChecks::ValidateImageViewSampleWeightQCOM(const VkImageViewCreateInfo &
         skip |=
             LogError("VUID-VkImageViewCreateInfo-pNext-06951", create_info.image, create_info_loc.dot(Field::pNext),
                      "chain includes VkImageViewSampleWeightCreateInfoQCOM "
-                     "and the view type is VK_IMAGE_VIEW_TYPE_1D_ARRAY so teh subresourceRange.layerCount must be 2, but it is %s.",
+                     "and the view type is VK_IMAGE_VIEW_TYPE_1D_ARRAY so the subresourceRange.layerCount must be 2, but it is %s.",
                      string_LayerCount(image_state.create_info, create_info.subresourceRange).c_str());
     }
 

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -313,6 +313,8 @@ class ImageView : public StateObject, public SubStateManager<ImageViewSubState> 
     bool Invalid() const override { return Destroyed() || !image_state || image_state->Invalid(); }
 
   private:
+    static VkImageSubresourceRange NormalizeImageViewSubresourceRange(const Image &image_state,
+                                                                      const VkImageViewCreateInfo &image_view_ci);
     VkImageSubresourceRange NormalizeImageLayoutSubresourceRange(bool is_3d_slice_transition_allowed) const;
     bool IsDepthSliced();
 };

--- a/tests/unit/dynamic_rendering.cpp
+++ b/tests/unit/dynamic_rendering.cpp
@@ -1911,43 +1911,6 @@ TEST_F(NegativeDynamicRendering, ColorAttachmentLayerCount) {
     m_command_buffer.End();
 }
 
-TEST_F(NegativeDynamicRendering, ColorAttachmentLayerCount2DArray) {
-    AddRequiredExtensions(VK_EXT_IMAGE_2D_VIEW_OF_3D_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitBasicDynamicRendering());
-    InitRenderTarget();
-
-    VkImageCreateInfo image_ci = vku::InitStructHelper();
-    image_ci.flags = VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT | VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT;
-    image_ci.imageType = VK_IMAGE_TYPE_3D;
-    image_ci.format = VK_FORMAT_R32_SINT;
-    image_ci.extent = {8, 8, 8};
-    image_ci.mipLevels = 1;
-    image_ci.arrayLayers = 1;
-    image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
-    image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
-    image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-    image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    vkt::Image image(*m_device, image_ci, vkt::set_layout);
-    // Only 1 layer
-    vkt::ImageView image_view = image.CreateView(VK_IMAGE_VIEW_TYPE_2D_ARRAY, 0, 1, 0, VK_REMAINING_ARRAY_LAYERS);
-
-    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
-    color_attachment.imageView = image_view;
-    color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-
-    VkRenderingInfo begin_rendering_info = vku::InitStructHelper();
-    begin_rendering_info.layerCount = 8;
-    begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
-    begin_rendering_info.colorAttachmentCount = 1;
-    begin_rendering_info.pColorAttachments = &color_attachment;
-
-    m_command_buffer.Begin();
-    m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-viewMask-10859");
-    m_command_buffer.BeginRendering(begin_rendering_info);
-    m_errorMonitor->VerifyFound();
-    m_command_buffer.End();
-}
-
 TEST_F(NegativeDynamicRendering, DeviceGroupRenderPassBeginInfo) {
     TEST_DESCRIPTION("Test render area of DeviceGroupRenderPassBeginInfo.");
     RETURN_IF_SKIP(InitBasicDynamicRendering());

--- a/tests/unit/dynamic_rendering_positive.cpp
+++ b/tests/unit/dynamic_rendering_positive.cpp
@@ -1357,7 +1357,6 @@ TEST_F(PositiveDynamicRendering, ColorAttachmentLayerCount) {
 TEST_F(PositiveDynamicRendering, ColorAttachmentLayerCount2DArray) {
     AddRequiredExtensions(VK_EXT_IMAGE_2D_VIEW_OF_3D_EXTENSION_NAME);
     RETURN_IF_SKIP(InitBasicDynamicRendering());
-    InitRenderTarget();
 
     VkImageCreateInfo image_ci = vku::InitStructHelper();
     image_ci.flags = VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT | VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT;
@@ -1373,6 +1372,40 @@ TEST_F(PositiveDynamicRendering, ColorAttachmentLayerCount2DArray) {
     vkt::Image image(*m_device, image_ci, vkt::set_layout);
 
     vkt::ImageView image_view = image.CreateView(VK_IMAGE_VIEW_TYPE_2D_ARRAY, 0, 1, 0, 8);
+
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
+    color_attachment.imageView = image_view;
+    color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkRenderingInfo begin_rendering_info = vku::InitStructHelper();
+    begin_rendering_info.layerCount = 8;
+    begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
+    begin_rendering_info.colorAttachmentCount = 1;
+    begin_rendering_info.pColorAttachments = &color_attachment;
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRendering(begin_rendering_info);
+    m_command_buffer.EndRendering();
+    m_command_buffer.End();
+}
+
+TEST_F(PositiveDynamicRendering, ColorAttachmentLayerCount2DArray2) {
+    AddRequiredExtensions(VK_EXT_IMAGE_2D_VIEW_OF_3D_EXTENSION_NAME);
+    RETURN_IF_SKIP(InitBasicDynamicRendering());
+
+    VkImageCreateInfo image_ci = vku::InitStructHelper();
+    image_ci.flags = VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT | VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT;
+    image_ci.imageType = VK_IMAGE_TYPE_3D;
+    image_ci.format = VK_FORMAT_R32_SINT;
+    image_ci.extent = {8, 8, 8};
+    image_ci.mipLevels = 1;
+    image_ci.arrayLayers = 1;
+    image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
+    image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
+    image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    vkt::Image image(*m_device, image_ci, vkt::set_layout);
+    vkt::ImageView image_view = image.CreateView(VK_IMAGE_VIEW_TYPE_2D_ARRAY, 0, 1, 0, VK_REMAINING_ARRAY_LAYERS);
 
     VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
     color_attachment.imageView = image_view;


### PR DESCRIPTION
This fixes that after normalization we had uint32_max for image view layer count. Also this found issue in one test.

The idea is to preserve the original meaning of layerCount when resource is created. For vvl::Image layerCount is always in array layer units since VkImage can only specify layers when created and depth slices are specified via additional contexts. 

Similarly vvl::ImageView preserves the original meaning of layerCount. If it's in depth slices units then VUIDs works with depth slices units for such views (e.g. VUID-VkImageViewCreateInfo-subresourceRange-02725), so REMAINING_LAYERS constant should be resolved against depth slices, and non-REMAINING_LAYERS remain unchanged (still in depth slices units).
