### PR TITLE
layers: Cleanup subresource range functionality

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -72,7 +72,6 @@ config("vulkan_layer_config") {
 vvl_sources = [
   "$vulkan_headers_dir/include/vulkan/vk_layer.h",
   "$vulkan_headers_dir/include/vulkan/vulkan.h",
-  "layers/best_practices/best_practices_utils.cpp",
   "layers/best_practices/best_practices_validation.h",
   "layers/best_practices/bp_buffer.cpp",
   "layers/best_practices/bp_cmd_buffer.cpp",
@@ -92,6 +91,8 @@ vvl_sources = [
   "layers/best_practices/bp_state.h",
   "layers/best_practices/bp_state.cpp",
   "layers/best_practices/bp_synchronization.cpp",
+  "layers/best_practices/bp_utils.cpp",
+  "layers/best_practices/bp_utils.h",
   "layers/best_practices/bp_video.cpp",
   "layers/best_practices/bp_wsi.cpp",
   "layers/chassis/chassis.h",

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -179,7 +179,6 @@ else()
 endif()
 
 target_sources(vvl PRIVATE
-    best_practices/best_practices_utils.cpp
     best_practices/bp_buffer.cpp
     best_practices/bp_cmd_buffer.cpp
     best_practices/bp_cmd_buffer_nv.cpp
@@ -198,6 +197,8 @@ target_sources(vvl PRIVATE
     best_practices/bp_state.h
     best_practices/bp_state.cpp
     best_practices/bp_synchronization.cpp
+    best_practices/bp_utils.cpp
+    best_practices/bp_utils.h
     best_practices/bp_video.cpp
     best_practices/bp_wsi.cpp
     best_practices/best_practices_validation.h

--- a/layers/best_practices/best_practices_validation.h
+++ b/layers/best_practices/best_practices_validation.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "best_practices/bp_constants.h"
+#include "best_practices/bp_utils.h"
 #include "chassis/validation_object.h"
 #include "state_tracker/shader_module.h"
 #include "state_tracker/state_tracker.h"
@@ -75,10 +76,6 @@ void LogResult(const StateObject& state, Handle handle, const RecordObject& reco
     }
 }
 
-const char* VendorSpecificTag(BPVendorFlags vendors);
-
-bool VendorCheckEnabled(const ValidationEnabled& enabled, BPVendorFlags vendors);
-
 class Instance : public vvl::InstanceProxy {
     using BaseClass = vvl::InstanceProxy;
 
@@ -89,7 +86,7 @@ class Instance : public vvl::InstanceProxy {
 
     Instance(vvl::dispatch::Instance* dispatch) : BaseClass(dispatch, LayerObjectTypeBestPractices) {}
 
-    bool VendorCheckEnabled(BPVendorFlags vendors) const { return bp_state::VendorCheckEnabled(enabled, vendors); }
+    bool VendorCheckEnabled(BPVendorFlags vendors) const { return IsVendorCheckEnabled(enabled, vendors); }
 
     bool PreCallValidateCreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                        VkInstance* pInstance, const ErrorObject& error_obj) const override;
@@ -594,8 +591,7 @@ class BestPractices : public vvl::DeviceProxy {
     void Created(vvl::Image& image_state) override;
 
     // Check that vendor-specific checks are enabled for at least one of the vendors
-    bool VendorCheckEnabled(BPVendorFlags vendors) const { return bp_state::VendorCheckEnabled(enabled, vendors); }
-    const char* VendorSpecificTag(BPVendorFlags vendors) const { return bp_state::VendorSpecificTag(vendors); }
+    bool VendorCheckEnabled(BPVendorFlags vendors) const { return IsVendorCheckEnabled(enabled, vendors); }
 
     // TODO - Move these to CommandBufferSubState
     void RecordCmdDrawTypeArm(bp_state::CommandBufferSubState& cb_state, uint32_t draw_count);

--- a/layers/best_practices/bp_cmd_buffer_nv.cpp
+++ b/layers/best_practices/bp_cmd_buffer_nv.cpp
@@ -53,22 +53,6 @@ static bool IsClearColorZeroOrOne(VkFormat format, const std::array<uint32_t, 4>
     return is_one || is_zero;
 }
 
-template <typename Func>
-static void ForEachSubresource(const vvl::Image& image, const VkImageSubresourceRange& range, Func&& func) {
-    const uint32_t layer_count =
-        (range.layerCount == VK_REMAINING_ARRAY_LAYERS) ? (image.full_range.layerCount - range.baseArrayLayer) : range.layerCount;
-    const uint32_t level_count =
-        (range.levelCount == VK_REMAINING_MIP_LEVELS) ? (image.full_range.levelCount - range.baseMipLevel) : range.levelCount;
-
-    for (uint32_t i = 0; i < layer_count; ++i) {
-        const uint32_t layer = range.baseArrayLayer + i;
-        for (uint32_t j = 0; j < level_count; ++j) {
-            const uint32_t level = range.baseMipLevel + j;
-            func(layer, level);
-        }
-    }
-}
-
 bool BestPractices::ValidateZcullScope(const bp_state::CommandBufferSubState& cb_state, const Location& loc) const {
     assert(VendorCheckEnabled(kBPVendorNVIDIA));
 

--- a/layers/best_practices/bp_instance_device.cpp
+++ b/layers/best_practices/bp_instance_device.cpp
@@ -254,6 +254,22 @@ bool bp_state::Instance::PreCallValidateGetPhysicalDeviceQueueFamilyProperties2K
                                                                   error_obj);
 }
 
+ReadLockGuard BestPractices::ReadLock() const {
+    if (global_settings.fine_grained_locking) {
+        return ReadLockGuard(validation_object_mutex, std::defer_lock);
+    } else {
+        return ReadLockGuard(validation_object_mutex);
+    }
+}
+
+WriteLockGuard BestPractices::WriteLock() {
+    if (global_settings.fine_grained_locking) {
+        return WriteLockGuard(validation_object_mutex, std::defer_lock);
+    } else {
+        return WriteLockGuard(validation_object_mutex);
+    }
+}
+
 void BestPractices::PreCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence,
                                              const RecordObject& record_obj) {
     auto queue_state = Get<vvl::Queue>(queue);

--- a/layers/best_practices/bp_state.cpp
+++ b/layers/best_practices/bp_state.cpp
@@ -642,22 +642,6 @@ void CommandBufferSubState::RecordResetEvent(VkEvent event, VkPipelineStageFlags
     }
 }
 
-template <typename Func>
-static void ForEachSubresource(const vvl::Image& image, const VkImageSubresourceRange& range, Func&& func) {
-    const uint32_t layer_count =
-        (range.layerCount == VK_REMAINING_ARRAY_LAYERS) ? (image.full_range.layerCount - range.baseArrayLayer) : range.layerCount;
-    const uint32_t level_count =
-        (range.levelCount == VK_REMAINING_MIP_LEVELS) ? (image.full_range.levelCount - range.baseMipLevel) : range.levelCount;
-
-    for (uint32_t i = 0; i < layer_count; ++i) {
-        const uint32_t layer = range.baseArrayLayer + i;
-        for (uint32_t j = 0; j < level_count; ++j) {
-            const uint32_t level = range.baseMipLevel + j;
-            func(layer, level);
-        }
-    }
-}
-
 void CommandBufferSubState::RecordBarriers(uint32_t, const VkBufferMemoryBarrier*, uint32_t image_barrier_count,
                                            const VkImageMemoryBarrier* image_barriers, VkPipelineStageFlags, VkPipelineStageFlags,
                                            const Location& loc) {

--- a/layers/best_practices/bp_synchronization.cpp
+++ b/layers/best_practices/bp_synchronization.cpp
@@ -398,22 +398,6 @@ bool BestPractices::ValidateCmdPipelineBarrierImageBarrier(VkCommandBuffer comma
     return skip;
 }
 
-template <typename Func>
-static void ForEachSubresource(const vvl::Image& image, const VkImageSubresourceRange& range, Func&& func) {
-    const uint32_t layer_count =
-        (range.layerCount == VK_REMAINING_ARRAY_LAYERS) ? (image.full_range.layerCount - range.baseArrayLayer) : range.layerCount;
-    const uint32_t level_count =
-        (range.levelCount == VK_REMAINING_MIP_LEVELS) ? (image.full_range.levelCount - range.baseMipLevel) : range.levelCount;
-
-    for (uint32_t i = 0; i < layer_count; ++i) {
-        const uint32_t layer = range.baseArrayLayer + i;
-        for (uint32_t j = 0; j < level_count; ++j) {
-            const uint32_t level = range.baseMipLevel + j;
-            func(layer, level);
-        }
-    }
-}
-
 void BestPractices::PostCallRecordCmdPipelineBarrier(
     VkCommandBuffer commandBuffer, VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask,
     VkDependencyFlags dependencyFlags, uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,

--- a/layers/best_practices/bp_utils.h
+++ b/layers/best_practices/bp_utils.h
@@ -1,0 +1,40 @@
+/* Copyright (c) 2025 The Khronos Group Inc.
+ * Copyright (c) 2025 Valve Corporation
+ * Copyright (c) 2025 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "best_practices/bp_constants.h"
+#include "state_tracker/image_state.h"
+#include "utils/image_utils.h"
+#include "layer_options.h"
+
+bool IsVendorCheckEnabled(const ValidationEnabled& enabled, BPVendorFlags vendors);
+const char* VendorSpecificTag(BPVendorFlags vendors);
+
+template <typename Func>
+static inline void ForEachSubresource(const vvl::Image& image, const VkImageSubresourceRange& range, Func&& func) {
+    const uint32_t layer_count = GetEffectiveLayerCount(range, image.full_range.layerCount);
+    const uint32_t level_count = GetEffectiveLevelCount(range, image.full_range.levelCount);
+
+    for (uint32_t i = 0; i < layer_count; ++i) {
+        const uint32_t layer = range.baseArrayLayer + i;
+        for (uint32_t j = 0; j < level_count; ++j) {
+            const uint32_t level = range.baseMipLevel + j;
+            func(layer, level);
+        }
+    }
+}

--- a/layers/containers/subresource_adapter.cpp
+++ b/layers/containers/subresource_adapter.cpp
@@ -25,6 +25,7 @@
 #include <cmath>
 #include "state_tracker/image_state.h"
 #include "generated/dispatch_functions.h"
+#include "utils/image_utils.h"
 
 namespace subresource_adapter {
 Subresource::Subresource(const RangeEncoder& encoder, const VkImageSubresource& subres)
@@ -429,14 +430,9 @@ void ImageRangeEncoder::Decode(const VkImageSubresource& subres, const IndexType
     out_offset.x = static_cast<int32_t>(static_cast<double>(decode) / texel_sizes_[LowerBoundFromMask(subres.aspectMask)]);
 }
 
-
 inline VkImageSubresourceRange GetRemaining(const VkImageSubresourceRange& full_range, VkImageSubresourceRange subres_range) {
-    if (subres_range.levelCount == VK_REMAINING_MIP_LEVELS) {
-        subres_range.levelCount = full_range.levelCount - subres_range.baseMipLevel;
-    }
-    if (subres_range.layerCount == VK_REMAINING_ARRAY_LAYERS) {
-        subres_range.layerCount = full_range.layerCount - subres_range.baseArrayLayer;
-    }
+    subres_range.levelCount = GetEffectiveLevelCount(subres_range, full_range.levelCount);
+    subres_range.layerCount = GetEffectiveLayerCount(subres_range, full_range.layerCount);
     return subres_range;
 }
 inline bool CoversAllLayers(const VkImageSubresourceRange& full_range, VkImageSubresourceRange subres_range) {

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -238,8 +238,6 @@ class Image : public Bindable, public SubStateManager<ImageSubState> {
     void NotifyInvalidate(const StateObject::NodeList &invalid_nodes, bool unlink) override;
 
   private:
-    VkImageSubresourceRange MakeImageFullRange();
-
     // Subresource encoder need to take into account that 3d image can have a separate layout
     // per slice, if supported by the implementation. This adjusts the layout range so
     // layouts map can address each slice.
@@ -316,8 +314,8 @@ class ImageView : public StateObject, public SubStateManager<ImageViewSubState> 
                                                                       const VkImageViewCreateInfo &image_view_ci);
 
   private:
-    VkImageSubresourceRange NormalizeImageLayoutSubresourceRange(bool is_3d_slice_transition_allowed) const;
-    bool IsDepthSliced();
+    VkImageSubresourceRange GetRangeGeneratorRange(bool is_3d_slice_transition_allowed) const;
+    static bool IsDepthSliced(const Image &image_state, VkImageViewType view_type);
 };
 
 class ImageViewSubState {

--- a/layers/utils/image_utils.h
+++ b/layers/utils/image_utils.h
@@ -24,6 +24,8 @@
 
 #include <vulkan/vulkan_core.h>
 
+uint32_t GetEffectiveLevelCount(const VkImageSubresourceRange &subresource_range, uint32_t total_level_count);
+uint32_t GetEffectiveLayerCount(const VkImageSubresourceRange &subresource_range, uint32_t total_layer_count);
 VkExtent3D GetEffectiveExtent(const VkImageCreateInfo &ci, const VkImageAspectFlags aspect_mask, const uint32_t mip_level);
 
 // When dealing with a compressed format, we could have a miplevel that is less than a single texel block
@@ -68,6 +70,7 @@ bool IsValidPlaneAspect(VkFormat format, VkImageAspectFlags aspect_mask);
 bool IsOnlyOneValidPlaneAspect(VkFormat format, VkImageAspectFlags aspect_mask);
 bool IsMultiplePlaneAspect(VkImageAspectFlags aspect_mask);
 bool IsAnyPlaneAspect(VkImageAspectFlags aspect_mask);
+VkImageAspectFlags NormalizeAspectMask(VkImageAspectFlags aspect_mask, VkFormat format);
 
 bool IsImageLayoutReadOnly(VkImageLayout layout);
 bool IsImageLayoutDepthOnly(VkImageLayout layout);


### PR DESCRIPTION
This PR is a cleanup and refactor, no new fixes
* Address one cleanup TODO item
* Add `GetEffectiveLevelCount`/`GetEffectiveLayerCount` helpers to expand REMAINING constants
* This touches BP which duplicated subresource range function in three files, so move similar functionality to bp utils
