### PR TITLE
Fix VUID 10775 when primitive count is 0

### DIFF
--- a/layers/stateless/sl_ray_tracing.cpp
+++ b/layers/stateless/sl_ray_tracing.cpp
@@ -1233,16 +1233,18 @@ bool Device::manual_PreCallValidateCmdBuildAccelerationStructuresKHR(
                     if (geom_i < infoCount && as_geometry.geometry.triangles.indexType == VK_INDEX_TYPE_NONE_KHR) {
                         for (const auto [build_range_i, build_range] :
                              vvl::enumerate(ppBuildRangeInfos[geom_i], info.geometryCount)) {
-                            const uint64_t build_range_max_vertex =
-                                uint64_t(build_range.firstVertex) + 3 * uint64_t(build_range.primitiveCount) - 1;
-                            if (uint64_t(as_geometry.geometry.triangles.maxVertex) < build_range_max_vertex) {
-                                const Location p_build_range_loc = error_obj.location.dot(Field::ppBuildRangeInfos, info_i);
-                                skip |= LogError("VUID-VkAccelerationStructureBuildRangeInfoKHR-None-10775", commandBuffer,
-                                                 p_geom_geom_loc.dot(Field::triangles).dot(Field::maxVertex),
-                                                 "is %" PRIu32 " but for %s, firstVertex ( %" PRIu32
-                                                 " ) + primitiveCount ( %" PRIu32 " ) x 3 - 1 = %" PRIu64 ".",
-                                                 as_geometry.geometry.triangles.maxVertex, p_build_range_loc.Fields().c_str(),
-                                                 build_range.firstVertex, build_range.primitiveCount, build_range_max_vertex);
+                            if (build_range.primitiveCount > 0) {
+                                const uint64_t build_range_max_vertex =
+                                    uint64_t(build_range.firstVertex) + 3 * uint64_t(build_range.primitiveCount) - 1;
+                                if (uint64_t(as_geometry.geometry.triangles.maxVertex) < build_range_max_vertex) {
+                                    const Location p_build_range_loc = error_obj.location.dot(Field::ppBuildRangeInfos, info_i);
+                                    skip |= LogError("VUID-VkAccelerationStructureBuildRangeInfoKHR-None-10775", commandBuffer,
+                                                     p_geom_geom_loc.dot(Field::triangles).dot(Field::maxVertex),
+                                                     "is %" PRIu32 " but for %s, firstVertex ( %" PRIu32
+                                                     " ) + primitiveCount ( %" PRIu32 " ) x 3 - 1 = %" PRIu64 ".",
+                                                     as_geometry.geometry.triangles.maxVertex, p_build_range_loc.Fields().c_str(),
+                                                     build_range.firstVertex, build_range.primitiveCount, build_range_max_vertex);
+                                }
                             }
                         }
                     }

--- a/tests/unit/ray_tracing_positive.cpp
+++ b/tests/unit/ray_tracing_positive.cpp
@@ -1936,3 +1936,38 @@ TEST_F(PositiveRayTracing, MultipleGeometries) {
     vk::CmdBuildAccelerationStructuresKHR(m_command_buffer, 1u, pInfos, ppBuildRangeInfos);
     m_command_buffer.End();
 }
+
+TEST_F(PositiveRayTracing, ZeroPrimitiveCountWithIndexTypeNone) {
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    RETURN_IF_SKIP(InitState());
+
+    auto blas =
+        std::make_shared<vkt::as::BuildGeometryInfoKHR>(vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device));
+
+    m_command_buffer.Begin();
+    blas->SetupBuild(true);
+    blas->GetGeometries()[0].SetTrianglesIndexType(VK_INDEX_TYPE_NONE_KHR);
+    const VkAccelerationStructureGeometryKHR* pGeometries = &blas->GetGeometries()[0].GetVkObj();
+
+    VkAccelerationStructureBuildGeometryInfoKHR build_geometry_info = vku::InitStructHelper();
+    build_geometry_info.type = VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR;
+    build_geometry_info.dstAccelerationStructure = *blas->GetDstAS();
+    build_geometry_info.geometryCount = 1u;
+    build_geometry_info.ppGeometries = &pGeometries;
+    build_geometry_info.scratchData = blas->GetInfo().scratchData;
+
+    VkAccelerationStructureBuildRangeInfoKHR build_range_info;
+    build_range_info.primitiveCount = 0u;
+    build_range_info.primitiveOffset = 0u;
+    build_range_info.firstVertex = 0u;
+    build_range_info.transformOffset = 0u;
+    const VkAccelerationStructureBuildRangeInfoKHR* p_build_range_info = &build_range_info;
+    vk::CmdBuildAccelerationStructuresKHR(m_command_buffer, 1u, &build_geometry_info, &p_build_range_info);
+    m_command_buffer.End();
+
+    m_default_queue->Submit(m_command_buffer);
+    m_device->Wait();
+}


### PR DESCRIPTION
When primitive count is 0 this would report

> Validation Error: [ VUID-VkAccelerationStructureBuildRangeInfoKHR-None-10775 ] | MessageID = 0xabfdda4
> vkCmdBuildAccelerationStructuresKHR(): pInfos[0].ppGeometries[0].geometry.triangles.maxVertex is 2 but for ppBuildRangeInfos[0], firstVertex ( 0 ) + primitiveCount ( 0 ) x 3 - 1 = 18446744073709551615.
> The Vulkan spec states: For geometries of type VK_GEOMETRY_TYPE_TRIANGLES_KHR, if the geometry does not use indices, then VkAccelerationStructureGeometryTrianglesDataKHR::maxVertex must be greater than or equal to firstVertex + primitiveCount x 3 - 1 (https://docs.vulkan.org/spec/latest/chapters/accelstructures.html#VUID-VkAccelerationStructureBuildRangeInfoKHR-None-10775)
> Objects: 1
>     [0] VkCommandBuffer 0x1cb8f4e0b40