### PR TITLE
gpuav: Fix instrumentation pipe layout selection

### DIFF
--- a/layers/gpuav/core/gpuav.h
+++ b/layers/gpuav/core/gpuav.h
@@ -205,6 +205,7 @@ class Validator : public GpuShaderInstrumentor {
     void Created(vvl::Tensor&) final;
     void Created(vvl::TensorView&) final;
     void Created(vvl::ShaderObject&) final;
+    void Created(vvl::Pipeline&) final;
 
     void DebugCapture() final;
 

--- a/layers/gpuav/core/gpuav_setup.cpp
+++ b/layers/gpuav/core/gpuav_setup.cpp
@@ -84,6 +84,10 @@ void Validator::Created(vvl::TensorView &obj) {
 }
 void Validator::Created(vvl::ShaderObject &obj) { obj.SetSubState(container_type, std::make_unique<ShaderObjectSubState>(obj)); }
 
+void Validator::Created(vvl::Pipeline &obj) {
+    obj.SetSubState(container_type, std::make_unique<PipelineTrackerSubState>(*this, obj));
+}
+
 // Trampolines to make VMA call Dispatch for Vulkan calls
 static VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL gpuVkGetInstanceProcAddr(VkInstance inst, const char *name) {
     return DispatchGetInstanceProcAddr(inst, name);

--- a/layers/gpuav/resources/gpuav_state_trackers.cpp
+++ b/layers/gpuav/resources/gpuav_state_trackers.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <vulkan/vulkan_core.h>
+#include "generated/dispatch_functions.h"
 #include "gpuav/resources/gpuav_state_trackers.h"
 #include "gpuav/descriptor_validation/gpuav_descriptor_validation.h"
 #include "gpuav/instrumentation/gpuav_instrumentation.h"
@@ -626,5 +627,75 @@ void TensorViewSubState::Destroy() { id_tracker.reset(); }
 void TensorViewSubState::NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) { id_tracker.reset(); }
 
 ShaderObjectSubState::ShaderObjectSubState(vvl::ShaderObject &obj) : vvl::ShaderObjectSubState(obj) {}
+
+PipelineTrackerSubState::PipelineTrackerSubState(Validator &gpuav, vvl::Pipeline &pipeline)
+    : vvl::PipelineTrackerSubState(pipeline), gpuav_(gpuav) {}
+
+VkPipelineLayout PipelineTrackerSubState::GetPipelineLayoutUnion(const Location &loc) const {
+    if (recreated_layout != VK_NULL_HANDLE) {
+        return recreated_layout;
+    }
+
+    assert(base.PipelineLayoutState()->set_layouts.size() <= gpuav_.instrumentation_desc_set_bind_index_);
+    if (base.PipelineLayoutState()->set_layouts.size() > gpuav_.instrumentation_desc_set_bind_index_) {
+        gpuav_.InternalError(LogObjectList(base.VkHandle()), loc,
+                             "Trying to recreate a pipeline layout with no room for the instrumenation descriptor set.");
+        return VK_NULL_HANDLE;
+    }
+
+    std::vector<VkDescriptorSetLayout> set_layout_handles;
+    set_layout_handles.reserve(gpuav_.instrumentation_desc_set_bind_index_ + 1);
+    std::vector<size_t> recreated_desc_set_layouts_indices;
+    for (size_t set_layout_i = 0; set_layout_i < base.PipelineLayoutState()->set_layouts.size(); ++set_layout_i) {
+        const auto &set_layout = base.PipelineLayoutState()->set_layouts[set_layout_i];
+        assert(set_layout);
+        if (!set_layout->Destroyed()) {
+            set_layout_handles.emplace_back(set_layout->VkHandle());
+        } else {
+            VkDescriptorSetLayout recreated_desc_set_layout = VK_NULL_HANDLE;
+
+            const VkResult result = DispatchCreateDescriptorSetLayout(gpuav_.device, set_layout->GetCreateInfo().ptr(), nullptr,
+                                                                      &recreated_desc_set_layout);
+            (void)result;
+            assert(result == VK_SUCCESS);
+
+            set_layout_handles.emplace_back(recreated_desc_set_layout);
+            recreated_desc_set_layouts_indices.emplace_back(set_layout_i);
+        }
+    }
+
+    for (size_t i = set_layout_handles.size(); i < gpuav_.instrumentation_desc_set_bind_index_; ++i) {
+        set_layout_handles.emplace_back(gpuav_.dummy_desc_layout_);
+    }
+    set_layout_handles.emplace_back(gpuav_.GetInstrumentationDescriptorSetLayout());
+
+    VkPipelineLayoutCreateInfo pipeline_layout_ci = vku::InitStructHelper();
+    pipeline_layout_ci.flags = base.PipelineLayoutState()->create_flags;
+    pipeline_layout_ci.setLayoutCount = uint32_t(set_layout_handles.size());
+    pipeline_layout_ci.pSetLayouts = set_layout_handles.data();
+    if (base.PipelineLayoutState()->push_constant_ranges_layout) {
+        pipeline_layout_ci.pushConstantRangeCount = uint32_t(base.PipelineLayoutState()->push_constant_ranges_layout->size());
+        pipeline_layout_ci.pPushConstantRanges = base.PipelineLayoutState()->push_constant_ranges_layout->data();
+    }
+
+    const VkResult result = DispatchCreatePipelineLayout(gpuav_.device, &pipeline_layout_ci, nullptr, &recreated_layout);
+    (void)result;
+    assert(result == VK_SUCCESS);
+
+    for (size_t i : recreated_desc_set_layouts_indices) {
+        DispatchDestroyDescriptorSetLayout(gpuav_.device, set_layout_handles[i], nullptr);
+    }
+
+    return recreated_layout;
+}
+
+void PipelineTrackerSubState::Destroy() {
+    if (recreated_layout != VK_NULL_HANDLE) {
+        DispatchDestroyPipelineLayout(gpuav_.device, recreated_layout, nullptr);
+        recreated_layout = VK_NULL_HANDLE;
+    }
+}
+
+void PipelineTrackerSubState::NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) { Destroy(); }
 
 }  // namespace gpuav

--- a/layers/gpuav/resources/gpuav_state_trackers.h
+++ b/layers/gpuav/resources/gpuav_state_trackers.h
@@ -26,15 +26,17 @@
 
 // We pull in most the core state tracking files
 // gpuav_state_trackers.h should NOT be included by any other header file
+
 #include "state_tracker/buffer_state.h"
-#include "state_tracker/image_state.h"
-#include "state_tracker/tensor_state.h"
 #include "state_tracker/cmd_buffer_state.h"
-#include "state_tracker/queue_state.h"
-#include "state_tracker/sampler_state.h"
-#include "state_tracker/ray_tracing_state.h"
-#include "state_tracker/shader_object_state.h"
+#include "state_tracker/image_state.h"
+#include "state_tracker/pipeline_state.h"
 #include "state_tracker/push_constant_data.h"
+#include "state_tracker/queue_state.h"
+#include "state_tracker/ray_tracing_state.h"
+#include "state_tracker/sampler_state.h"
+#include "state_tracker/shader_object_state.h"
+#include "state_tracker/tensor_state.h"
 
 namespace gpuav {
 
@@ -354,6 +356,28 @@ static inline ShaderObjectSubState &SubState(vvl::ShaderObject &obj) {
 }
 static inline const ShaderObjectSubState &SubState(const vvl::ShaderObject &obj) {
     return *static_cast<const ShaderObjectSubState *>(obj.SubState(LayerObjectTypeGpuAssisted));
+}
+
+class PipelineTrackerSubState : public vvl::PipelineTrackerSubState {
+  public:
+    explicit PipelineTrackerSubState(Validator &gpuav, vvl::Pipeline &pipeline);
+
+    void Destroy() override;
+    // #ARNO_TODO do I need that?
+    void NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) override;
+
+    VkPipelineLayout GetPipelineLayoutUnion(const Location &loc) const;
+
+  private:
+    mutable VkPipelineLayout recreated_layout = VK_NULL_HANDLE;
+    Validator &gpuav_;
+};
+
+static inline PipelineTrackerSubState &SubState(vvl::Pipeline &pipeline) {
+    return *static_cast<PipelineTrackerSubState *>(pipeline.SubState(LayerObjectTypeGpuAssisted));
+}
+static inline const PipelineTrackerSubState &SubState(const vvl::Pipeline &pipeline) {
+    return *static_cast<const PipelineTrackerSubState *>(pipeline.SubState(LayerObjectTypeGpuAssisted));
 }
 
 }  // namespace gpuav

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -765,9 +765,11 @@ std::vector<std::pair<uint32_t, uint32_t>> &GetCustomStypeInfo() {
     return custom_stype_info;
 }
 
+#if !defined(BUILD_SELF_VVL)
 // Generated, put here to mimic where it would have been if manually written
 // Can't move up to top of file until we generate the VK_LAYER_* names as well
 #include "layer_options_validation.h"
+#endif
 
 // Process enables and disables set though the vk_layer_settings.txt config file or through an environment variable
 void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {

--- a/layers/state_tracker/descriptor_sets.cpp
+++ b/layers/state_tracker/descriptor_sets.cpp
@@ -496,7 +496,9 @@ bool vvl::DescriptorSetLayout::IsCompatible(DescriptorSetLayout const *rh_ds_lay
 // handle invariant portion
 vvl::DescriptorSetLayout::DescriptorSetLayout(VkDevice device, const VkDescriptorSetLayoutCreateInfo *pCreateInfo,
                                               const VkDescriptorSetLayout handle)
-    : StateObject(handle, kVulkanObjectTypeDescriptorSetLayout), layout_id_(GetCanonicalId(pCreateInfo)) {
+    : StateObject(handle, kVulkanObjectTypeDescriptorSetLayout),
+      layout_id_(GetCanonicalId(pCreateInfo)),
+      desc_set_layout_ci(pCreateInfo) {
     if (pCreateInfo->flags & VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT) {
         DispatchGetDescriptorSetLayoutSizeEXT(device, handle, &layout_size_in_bytes_);
     }

--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -326,6 +326,7 @@ class DescriptorSetLayout : public StateObject {
     bool IsCompatible(DescriptorSetLayout const *rh_ds_layout) const;
     // Straightforward Get functions
     VkDescriptorSetLayout VkHandle() const { return handle_.Cast<VkDescriptorSetLayout>(); };
+    vku::safe_VkDescriptorSetLayoutCreateInfo GetCreateInfo() const { return desc_set_layout_ci; }
     const DescriptorSetLayoutDef *GetLayoutDef() const { return layout_id_.get(); }
     DescriptorSetLayoutId GetLayoutId() const { return layout_id_; }
     uint32_t GetTotalDescriptorCount() const { return layout_id_->GetTotalDescriptorCount(); };
@@ -388,6 +389,7 @@ class DescriptorSetLayout : public StateObject {
   private:
     DescriptorSetLayoutId layout_id_{};
     VkDeviceSize layout_size_in_bytes_ = 0;
+    vku::safe_VkDescriptorSetLayoutCreateInfo desc_set_layout_ci{};
 };
 
 // Slightly broader than type, each c++ "class" will has a corresponding "DescriptorClass"

--- a/layers/state_tracker/pipeline_layout_state.cpp
+++ b/layers/state_tracker/pipeline_layout_state.cpp
@@ -89,7 +89,14 @@ std::string PipelineLayoutCompatDef::DescribeDifference(const PipelineLayoutComp
             }
         }
     } else if (is_independent_sets != other.is_independent_sets) {
-        ss << "One set is created with VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT while the other is not\n";
+        ss << "The pipeline layout used to bind set " << set;
+        if (is_independent_sets) {
+            ss << " was created with VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT when the pipeline layout of last bound "
+                  "pipeline was not.";
+        } else {
+            ss << " was created without VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT when the pipeline layout of last bound "
+                  "pipeline was.";
+        }
     } else {
         const auto &descriptor_set_layouts = *set_layouts_id.get();
         const auto &other_ds_layouts = *other.set_layouts_id.get();
@@ -209,10 +216,6 @@ static PipelineLayout::SetLayoutVector GetSetLayouts(const vvl::span<const Pipel
         if (layout && (layout->set_layouts.size() > num_layouts)) {
             num_layouts = layout->set_layouts.size();
         }
-    }
-
-    if (!num_layouts) {
-        return {};
     }
 
     set_layouts.reserve(num_layouts);

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -863,6 +863,21 @@ Pipeline::Pipeline(const DeviceState &state_data, const VkRayTracingPipelineCrea
     assert(0 == (active_shaders & ~(kShaderStageAllRayTracing)));
 }
 
+void Pipeline::Destroy() {
+    for (auto &item : sub_states_) {
+        item.second->Destroy();
+    }
+    sub_states_.clear();
+    StateObject::Destroy();
+}
+
+void Pipeline::NotifyInvalidate(const StateObject::NodeList &invalid_nodes, bool unlink) {
+    for (auto &item : sub_states_) {
+        item.second->NotifyInvalidate(invalid_nodes, unlink);
+    }
+    StateObject::NotifyInvalidate(invalid_nodes, unlink);
+}
+
 }  // namespace vvl
 
 bool IsPipelineLayoutSetCompatible(uint32_t set, const vvl::PipelineLayout *a, const vvl::PipelineLayout *b) {

--- a/layers/state_tracker/pipeline_sub_state.h
+++ b/layers/state_tracker/pipeline_sub_state.h
@@ -46,6 +46,7 @@ static inline VkGraphicsPipelineLibraryFlagsEXT GetGraphicsLibType(const CreateI
     return static_cast<VkGraphicsPipelineLibraryFlagsEXT>(0);
 }
 
+// #ARNO_TODO rename to something like "PipelineLibrarySubState"
 // Common amoung all pipeline sub state
 struct PipelineSubState {
     PipelineSubState(const vvl::Pipeline &p) : parent(p) {}

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -2127,6 +2127,7 @@ class DeviceProxy : public vvl::base::Device {
     virtual void Created(vvl::Swapchain& state) {}
     virtual void Created(vvl::DescriptorSet& state) {}
     virtual void Created(vvl::ShaderObject& state) {}
+    virtual void Created(vvl::Pipeline& state){};
 
     // callbacks for image layout validation, which is implemented in both core validation and gpu-av
     // TODO - It would be nice to have a way to not need a duplicate copy in both CoreChecks and GPU-AV code

--- a/tests/unit/graphics_library.cpp
+++ b/tests/unit/graphics_library.cpp
@@ -3645,7 +3645,8 @@ TEST_F(NegativeGraphicsLibrary, DrawWithMismatchIndependentBit) {
                                   static_cast<uint32_t>(desc_sets.size()), desc_sets.data(), 0, nullptr);
         // VUID-vkCmdDraw-None-08600
         m_errorMonitor->SetDesiredError(
-            "One set is created with VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT while the other is not");
+            "The pipeline layout used to bind set 0 was created with VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT when the "
+            "pipeline layout of last bound pipeline was not");
         vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
         m_errorMonitor->VerifyFound();
         m_command_buffer.EndRenderPass();
@@ -3666,7 +3667,8 @@ TEST_F(NegativeGraphicsLibrary, DrawWithMismatchIndependentBit) {
                                   static_cast<uint32_t>(desc_sets.size()), desc_sets.data(), 0, nullptr);
         // VUID-vkCmdDraw-None-08600
         m_errorMonitor->SetDesiredError(
-            "One set is created with VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT while the other is not");
+            "The pipeline layout used to bind set 0 was created without VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT when "
+            "the pipeline layout of last bound pipeline was");
         vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
         m_errorMonitor->VerifyFound();
         m_command_buffer.EndRenderPass();


### PR DESCRIPTION
When using GPL, recreate a pipeline layout for use in binding GPU-AV's descriptor set.
This part of GPU-AV is more and more hacky, but will hopefully go away when we switch to using push constants + BDA to manage our resources