### PR TITLE
Fix 01273 false positives

### DIFF
--- a/layers/core_checks/cc_wsi.cpp
+++ b/layers/core_checks/cc_wsi.cpp
@@ -517,7 +517,7 @@ bool CoreChecks::ValidateCreateSwapchain(const VkSwapchainCreateInfoKHR &create_
                 }
             }
         }
-        if (!found_match) {
+        if (!found_match && !formats.empty()) {
             if (!found_format) {
                 if (LogError("VUID-VkSwapchainCreateInfoKHR-imageFormat-01273", device, create_info_loc.dot(Field::imageFormat),
                              "is %s.", string_VkFormat(create_info.imageFormat))) {


### PR DESCRIPTION
If `vkGetPhysicalDeviceSurfaceSupportKHR` fails for example with `VK_ERROR_OUT_OF_HOST_MEMORY` then `formats` here will be empty and validation layers will start reporting `VUID-VkSwapchainCreateInfoKHR-imageFormat-01273` for valid formats