### PR TITLE
gpuav: Fix logged pipeline in post processing

### DIFF
--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -854,7 +854,7 @@ bool CoreChecks::PreCallValidateGetDescriptorSetLayoutSupportKHR(VkDevice device
 // Return true if state is acceptable, or false and write an error message into error string
 bool CoreChecks::ValidateDrawState(const vvl::DescriptorSet &descriptor_set, uint32_t set_index,
                                    const BindingVariableMap &binding_req_map, const vvl::CommandBuffer &cb_state,
-                                   const vvl::DrawDispatchVuid &vuids, const VulkanTypedHandle &shader_handle) const {
+                                   const vvl::DrawDispatchVuid &vuids, const LogObjectList &objlist) const {
     bool result = false;
     const Location &loc = vuids.loc();
     const VkFramebuffer framebuffer = cb_state.active_framebuffer ? cb_state.active_framebuffer->VkHandle() : VK_NULL_HANDLE;
@@ -862,8 +862,8 @@ bool CoreChecks::ValidateDrawState(const vvl::DescriptorSet &descriptor_set, uin
     // descriptors, via the non-const version of ValidateBindingDynamic(), this code uses the const path only even it gives up
     // non-const versions of its state objects here.
     const vvl::DescriptorValidator desc_val(const_cast<CoreChecks &>(*this), const_cast<vvl::CommandBuffer &>(cb_state),
-                                            const_cast<vvl::DescriptorSet &>(descriptor_set), set_index, framebuffer,
-                                            &shader_handle, loc);
+                                            const_cast<vvl::DescriptorSet &>(descriptor_set), set_index, framebuffer, &objlist,
+                                            loc);
 
     for (const auto &[binding_index, desc_set_reqs] : binding_req_map) {
         ASSERT_AND_CONTINUE(desc_set_reqs.variable);
@@ -871,8 +871,8 @@ bool CoreChecks::ValidateDrawState(const vvl::DescriptorSet &descriptor_set, uin
 
         const vvl::DescriptorBinding *binding = descriptor_set.GetBinding(binding_index);
         if (!binding) {  //  End at construction is the condition for an invalid binding.
-            const LogObjectList objlist(cb_state.Handle(), shader_handle, descriptor_set.Handle());
-            result |= LogError(vuids.descriptor_buffer_bit_set_08114, objlist, loc, "%s %s is invalid.",
+            const LogObjectList updated_objlist(cb_state.Handle(), objlist, descriptor_set.Handle());
+            result |= LogError(vuids.descriptor_buffer_bit_set_08114, updated_objlist, loc, "%s %s is invalid.",
                                FormatHandle(descriptor_set).c_str(), resource_variable.DescribeDescriptor().c_str());
             return result;
         }

--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -1547,7 +1547,8 @@ bool CoreChecks::ValidateActionStateDescriptorsPipeline(const LastBound &last_bo
                 const bool need_validate =
                     NeedDrawStateValidated(cb_state, descriptor_set, ds_slot, disabled[image_layout_validation]);
                 if (need_validate) {
-                    skip |= ValidateDrawState(*descriptor_set, set_index, binding_req_map, cb_state, vuid, pipeline.Handle());
+                    skip |= ValidateDrawState(*descriptor_set, set_index, binding_req_map, cb_state, vuid,
+                                              LogObjectList(pipeline.Handle()));
                 }
             }
         }
@@ -1621,8 +1622,8 @@ bool CoreChecks::ValidateActionStateDescriptorsShaderObject(const LastBound &las
                     const bool need_validate =
                         NeedDrawStateValidated(cb_state, descriptor_set, ds_slot, disabled[image_layout_validation]);
                     if (need_validate) {
-                        skip |=
-                            ValidateDrawState(*descriptor_set, set_index, binding_req_map, cb_state, vuid, shader_state->Handle());
+                        skip |= ValidateDrawState(*descriptor_set, set_index, binding_req_map, cb_state, vuid,
+                                                  LogObjectList(shader_state->Handle()));
                     }
                 }
             }

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -739,7 +739,7 @@ class CoreChecks : public vvl::DeviceProxy {
     // For given bindings validate state at time of draw is correct, returning false on error and writing error details into string*
     bool ValidateDrawState(const vvl::DescriptorSet& descriptor_set, uint32_t set_index, const BindingVariableMap& binding_req_map,
                            const vvl::CommandBuffer& cb_state, const vvl::DrawDispatchVuid& vuid,
-                           const VulkanTypedHandle& shader_handle) const;
+                           const LogObjectList& objlist) const;
 
     bool ImmutableSamplersAreEqual(const VkDescriptorSetLayoutBinding& b1, const VkDescriptorSetLayoutBinding& b2,
                                    bool& out_exception) const;

--- a/layers/drawdispatch/descriptor_validator.h
+++ b/layers/drawdispatch/descriptor_validator.h
@@ -42,7 +42,7 @@ class TensorDescriptor;
 class DescriptorValidator : public Logger {
   public:
     DescriptorValidator(DeviceProxy& dev, vvl::CommandBuffer& cb_state, vvl::DescriptorSet& descriptor_set, uint32_t set_index,
-                        VkFramebuffer framebuffer, const VulkanTypedHandle* shader_handle, const Location& loc);
+                        VkFramebuffer framebuffer, const LogObjectList* objlist, const Location& loc);
 
     // Used with normal validation where we know which descriptors are accessed.
     bool ValidateBindingStatic(const spirv::ResourceInterfaceVariable& binding_info, const vvl::DescriptorBinding& binding) const;
@@ -51,7 +51,7 @@ class DescriptorValidator : public Logger {
     bool ValidateBindingDynamic(const spirv::ResourceInterfaceVariable& binding_info, DescriptorBinding& binding,
                                 const uint32_t index);
     void SetSetIndexForGpuAv(uint32_t set_index) { this->set_index = set_index; }
-    void SetShaderHandleForGpuAv(const VulkanTypedHandle* shader_handle) { this->shader_handle = shader_handle; }
+    void SetObjlistForGpuAv(const LogObjectList* objlist) { this->objlist = objlist; }
     void SetLocationForGpuAv(const Location& gpuav_loc);
 
   private:
@@ -91,8 +91,9 @@ class DescriptorValidator : public Logger {
     const DrawDispatchVuid* vuids;
 
     // For GPU-AV, these can become aliased and need to be mutable between descriptor accesses
-    uint32_t set_index;
     // A descriptor set might be used between multiple shaders and need to adjust which one was found
-    const VulkanTypedHandle* shader_handle;  // VkPipeline or VkShaderObject
+    uint32_t set_index;
+
+    const LogObjectList* objlist;  // VkPipeline or VkShaderObject
 };
 }  // namespace vvl

--- a/layers/error_message/logging.h
+++ b/layers/error_message/logging.h
@@ -55,6 +55,21 @@ struct LogObjectList {
         object_list.emplace_back(object, ConvertCoreObjectToVulkanObject(VkHandleInfo<HANDLE_T>::kVkObjectType));
     }
 
+    void add(const LogObjectList &rhs) {
+        for (const auto &obj : rhs) {
+            object_list.emplace_back(obj);
+        }
+    }
+
+    void add(const LogObjectList *rhs) {
+        if (!rhs) {
+            return;
+        }
+        for (const auto &obj : *rhs) {
+            object_list.emplace_back(obj);
+        }
+    }
+
     template <typename... HANDLE_T>
     void add(HANDLE_T... objects) {
         (..., add(objects));
@@ -72,10 +87,10 @@ struct LogObjectList {
         (..., add(objects));
     }
 
-    [[nodiscard]] auto size() const { return object_list.size(); }
-    [[nodiscard]] auto empty() const { return object_list.empty(); }
-    [[nodiscard]] auto begin() const { return object_list.begin(); }
-    [[nodiscard]] auto end() const { return object_list.end(); }
+    [[nodiscard]] auto size() const -> decltype(object_list.size()) { return object_list.size(); }
+    [[nodiscard]] auto empty() const -> decltype(object_list.empty()) { return object_list.empty(); }
+    [[nodiscard]] auto begin() const -> decltype(object_list.begin()) { return object_list.begin(); }
+    [[nodiscard]] auto end() const -> decltype(object_list.end()) { return object_list.end(); }
 
     LogObjectList(){};
 };

--- a/layers/gpuav/instrumentation/gpuav_instrumentation.h
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation.h
@@ -72,7 +72,6 @@ struct InstrumentationErrorBlob {
     // used to know which action command this occured at
     uint32_t action_command_i = vvl::kU32Max;
 
-    VkPipeline pipeline = VK_NULL_HANDLE;
     // Used to know if from draw, dispatch, or traceRays
     VkPipelineBindPoint pipeline_bind_point = VK_PIPELINE_BIND_POINT_MAX_ENUM;
     // Used pick which VUID to report

--- a/layers/gpuav/instrumentation/post_process_descriptor_indexing.cpp
+++ b/layers/gpuav/instrumentation/post_process_descriptor_indexing.cpp
@@ -215,11 +215,9 @@ void RegisterPostProcessingValidation(Validator& gpuav, CommandBufferSubState& c
                 if (it->second.pipeline != VK_NULL_HANDLE) {
                     // We use pipeline over vkShaderModule as likely they will have been destroyed by now
                     pipeline_state = gpuav.Get<vvl::Pipeline>(it->second.pipeline).get();
-                    context.SetShaderHandleForGpuAv(&pipeline_state->Handle());
                 } else if (it->second.shader_object != VK_NULL_HANDLE) {
                     shader_object_state = gpuav.Get<vvl::ShaderObject>(it->second.shader_object).get();
                     ASSERT_AND_CONTINUE(shader_object_state->entrypoint);
-                    context.SetShaderHandleForGpuAv(&shader_object_state->Handle());
                 } else {
                     assert(false);
                     continue;
@@ -262,12 +260,13 @@ void RegisterPostProcessingValidation(Validator& gpuav, CommandBufferSubState& c
 
                     const CommandBufferSubState::CommandErrorLogger& cmd_error_logger =
                         cb.command_error_loggers[descriptor_access.error_logger_i];
+                    context.SetObjlistForGpuAv(&cmd_error_logger.objlist);
                     std::string debug_region_name;
                     if (cmd_error_logger.label_cmd_i >= 0) {
                         debug_region_name = cb.GetDebugLabelRegion(cmd_error_logger.label_cmd_i, label_logging.initial_label_stack);
                     }
 
-                    Location access_loc(cmd_error_logger.loc, debug_region_name);
+                    Location access_loc(cmd_error_logger.loc.Get(), debug_region_name);
                     context.SetLocationForGpuAv(access_loc);
                     context.ValidateBindingDynamic(*resource_variable, *descriptor_binding, descriptor_access.index);
                 }

--- a/layers/gpuav/resources/gpuav_state_trackers.cpp
+++ b/layers/gpuav/resources/gpuav_state_trackers.cpp
@@ -334,8 +334,8 @@ void CommandBufferSubState::OnCompletion(VkQueue queue, const std::vector<std::s
                     error_record_ptr[glsl::kHeaderActionIdErrorLoggerIdOffset] & glsl::kErrorLoggerIdMask;
                 assert(error_logger_i < command_error_loggers.size());
                 CommandErrorLogger &error_logger = command_error_loggers[error_logger_i];
-                const LogObjectList objlist(queue, VkHandle());
-                error_logger.error_logger_func(error_record_ptr, error_logger.loc, objlist, initial_label_stack);
+                const LogObjectList objlist(queue, VkHandle(), error_logger.objlist);
+                error_logger.error_logger_func(error_record_ptr, error_logger.loc.Get(), objlist, initial_label_stack);
 
                 // Next record
                 error_record_ptr += record_size;

--- a/layers/gpuav/resources/gpuav_state_trackers.h
+++ b/layers/gpuav/resources/gpuav_state_trackers.h
@@ -129,7 +129,8 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
                                       const std::vector<std::string> &initial_label_stack),
                                  288 /*lambda storage size (bytes), large enough to store biggest error lambda*/>;
     struct CommandErrorLogger {
-        Location loc;
+        vvl::LocationCapture loc;
+        LogObjectList objlist;
         ErrorLoggerFunc error_logger_func;
         int32_t label_cmd_i = -1;
     };

--- a/layers/gpuav/validation_cmd/gpuav_copy_buffer_to_image.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_copy_buffer_to_image.cpp
@@ -257,7 +257,8 @@ void CopyBufferToImage(Validator &gpuav, const Location &loc, CommandBufferSubSt
         return skip;
     };
 
-    cb_state.command_error_loggers.emplace_back(CommandBufferSubState::CommandErrorLogger{loc, std::move(error_logger)});
+    cb_state.command_error_loggers.emplace_back(
+        CommandBufferSubState::CommandErrorLogger{loc, LogObjectList{}, std::move(error_logger)});
 }
 }  // namespace valcmd
 }  // namespace gpuav

--- a/layers/gpuav/validation_cmd/gpuav_dispatch.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_dispatch.cpp
@@ -148,7 +148,8 @@ void DispatchIndirect(Validator &gpuav, const Location &loc, CommandBufferSubSta
         return skip;
     };
 
-    cb_state.command_error_loggers.emplace_back(CommandBufferSubState::CommandErrorLogger{loc, std::move(error_logger)});
+    cb_state.command_error_loggers.emplace_back(
+        CommandBufferSubState::CommandErrorLogger{loc, LogObjectList{}, std::move(error_logger)});
 }
 }  // namespace valcmd
 }  // namespace gpuav

--- a/layers/gpuav/validation_cmd/gpuav_draw.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_draw.cpp
@@ -275,7 +275,8 @@ void FirstInstance(Validator &gpuav, CommandBufferSubState &cb_state, const Loca
         return skip;
     };
 
-    cb_state.command_error_loggers.emplace_back(CommandBufferSubState::CommandErrorLogger{loc, std::move(error_logger)});
+    cb_state.command_error_loggers.emplace_back(
+        CommandBufferSubState::CommandErrorLogger{loc, LogObjectList{}, std::move(error_logger)});
 }
 
 template <>
@@ -454,7 +455,8 @@ void CountBuffer(Validator &gpuav, CommandBufferSubState &cb_state, const Locati
         return skip;
     };
 
-    cb_state.command_error_loggers.emplace_back(CommandBufferSubState::CommandErrorLogger{loc, std::move(error_logger)});
+    cb_state.command_error_loggers.emplace_back(
+        CommandBufferSubState::CommandErrorLogger{loc, LogObjectList{}, std::move(error_logger)});
 }
 
 struct MeshValidationShader {
@@ -713,7 +715,8 @@ void DrawMeshIndirect(Validator &gpuav, CommandBufferSubState &cb_state, const L
         return skip;
     };
 
-    cb_state.command_error_loggers.emplace_back(CommandBufferSubState::CommandErrorLogger{loc, std::move(error_logger)});
+    cb_state.command_error_loggers.emplace_back(
+        CommandBufferSubState::CommandErrorLogger{loc, LogObjectList{}, std::move(error_logger)});
 }
 
 struct DrawIndexedIndirectIndexBufferShader {
@@ -1050,7 +1053,8 @@ void DrawIndexedIndirectIndexBuffer(Validator &gpuav, CommandBufferSubState &cb_
         return skip;
     };
 
-    cb_state.command_error_loggers.emplace_back(CommandBufferSubState::CommandErrorLogger{loc, std::move(error_logger)});
+    cb_state.command_error_loggers.emplace_back(
+        CommandBufferSubState::CommandErrorLogger{loc, LogObjectList{}, std::move(error_logger)});
 }
 
 }  // namespace valcmd

--- a/layers/gpuav/validation_cmd/gpuav_trace_rays.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_trace_rays.cpp
@@ -173,7 +173,8 @@ void TraceRaysIndirect(Validator& gpuav, const Location& loc, CommandBufferSubSt
         return skip;
     };
 
-    cb_state.command_error_loggers.emplace_back(CommandBufferSubState::CommandErrorLogger{loc, std::move(error_logger)});
+    cb_state.command_error_loggers.emplace_back(
+        CommandBufferSubState::CommandErrorLogger{loc, LogObjectList{}, std::move(error_logger)});
 }
 }  // namespace valcmd
 }  // namespace gpuav


### PR DESCRIPTION
In GPU-AV post processing validation, a random pipeline was logged, not the one that caused the error.

Change seems big because instead of passing down validation functions an handle to be logged,
I now pass down what we ultimately want: an object list