### PR TITLE
sync: Fix execution dependencies for sync2 barriers

### DIFF
--- a/layers/containers/small_vector.h
+++ b/layers/containers/small_vector.h
@@ -237,6 +237,8 @@ class small_vector {
         size_ = new_size;
     }
 
+    bool Contains(const T &value) const { return std::find(cbegin(), cend(), value) != cend(); }
+
     void reserve(size_type new_cap) {
         // Since this can't shrink, if we're growing we're newing
         if (new_cap > capacity_) {

--- a/layers/sync/sync_op.h
+++ b/layers/sync/sync_op.h
@@ -153,7 +153,7 @@ struct BarrierSet {
                                   uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier *pBufferMemoryBarriers);
     void MakeImageMemoryBarriers(const SyncValidator &sync_state, const SyncExecScope &src, const SyncExecScope &dst,
                                  uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier *pImageMemoryBarriers);
-    void MakeMemoryBarriers(VkQueueFlags queue_flags, uint32_t barrier_count, const VkMemoryBarrier2 *barriers);
+    void MakeMemoryBarriers(VkQueueFlags queue_flags, const VkDependencyInfo &dep_info);
     void MakeBufferMemoryBarriers(const SyncValidator &sync_state, VkQueueFlags queue_flags, uint32_t barrier_count,
                                   const VkBufferMemoryBarrier2 *barriers);
     void MakeImageMemoryBarriers(const SyncValidator &sync_state, VkQueueFlags queue_flags, uint32_t barrier_count,

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -367,7 +367,7 @@ bool SyncValidator::PreCallValidateCmdCopyBuffer(VkCommandBuffer commandBuffer, 
                 skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
             }
         }
-        if (dst_buffer && !skip) {
+        if (dst_buffer) {
             const ResourceAccessRange dst_range = MakeRange(*dst_buffer, copy_region.dstOffset, copy_region.size);
             auto hazard = context->DetectHazard(*dst_buffer, SYNC_COPY_TRANSFER_WRITE, dst_range);
             if (hazard.IsHazard()) {
@@ -377,7 +377,9 @@ bool SyncValidator::PreCallValidateCmdCopyBuffer(VkCommandBuffer commandBuffer, 
                 skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
             }
         }
-        if (skip) break;
+        if (skip) {
+            break;
+        }
     }
     return skip;
 }
@@ -469,7 +471,9 @@ bool SyncValidator::PreCallValidateCmdCopyImage(VkCommandBuffer commandBuffer, V
                     copy_region.dstOffset, copy_region.extent, copy_region.dstSubresource);
                 skip |= SyncError(hazard.Hazard(), objlist, error_obj.location, error);
             }
-            if (skip) break;
+        }
+        if (skip) {
+            break;
         }
     }
 

--- a/tests/unit/sync_val_video.cpp
+++ b/tests/unit/sync_val_video.cpp
@@ -86,14 +86,6 @@ TEST_F(NegativeSyncValVideo, DecodeReconstructedPicture) {
     cb.DecodeVideo(context.DecodeFrame(1).AddReferenceFrame(0));
     vk::CmdPipelineBarrier2KHR(cb, context.DecodeOutput()->MemoryBarrier());
 
-    m_errorMonitor->SetDesiredError("SYNC-HAZARD-WRITE-AFTER-READ");
-    cb.DecodeVideo(context.DecodeReferenceFrame(0));
-    m_errorMonitor->VerifyFound();
-
-    m_errorMonitor->SetDesiredError("SYNC-HAZARD-WRITE-AFTER-READ");
-    cb.DecodeVideo(context.DecodeFrame(0));
-    m_errorMonitor->VerifyFound();
-
     cb.EndVideoCoding(context.End());
     cb.End();
 }
@@ -219,14 +211,6 @@ TEST_F(NegativeSyncValVideo, EncodeReconstructedPicture) {
 
     cb.EncodeVideo(context.EncodeFrame(1).AddReferenceFrame(0));
     vk::CmdPipelineBarrier2KHR(cb, context.Bitstream().MemoryBarrier());
-
-    m_errorMonitor->SetDesiredError("SYNC-HAZARD-WRITE-AFTER-READ");
-    cb.EncodeVideo(context.EncodeReferenceFrame(0));
-    m_errorMonitor->VerifyFound();
-
-    m_errorMonitor->SetDesiredError("SYNC-HAZARD-WRITE-AFTER-READ");
-    cb.EncodeVideo(context.EncodeFrame(0));
-    m_errorMonitor->VerifyFound();
 
     cb.EndVideoCoding(context.End());
     cb.End();


### PR DESCRIPTION
While studying syncval barrier code found missing sync2 functionality. Documented some non-trivial parts.
