### PR TITLE
layers: Cleanup ValidateCmdExecuteCommandsRenderPassInheritance

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1916,12 +1916,14 @@ class CoreChecks : public vvl::DeviceProxy {
                                            const VkCommandBuffer* pCommandBuffers, const ErrorObject& error_obj) const override;
     bool ValidateCmdExecuteCommandsRenderPass(const vvl::CommandBuffer& cb_state, const vvl::RenderPass& rp_state,
                                               const Location& loc) const;
-    bool ValidateCmdExecuteCommandsRenderPassSecondary(const vvl::CommandBuffer& cb_state, const vvl::RenderPass& rp_state,
-                                                       const vvl::CommandBuffer& secondary_cb_state, const Location& cb_loc) const;
     bool ValidateCmdExecuteCommandsRenderPassInheritance(const vvl::CommandBuffer& cb_state, const vvl::RenderPass& rp_state,
                                                          const vvl::CommandBuffer& secondary_cb_state,
                                                          const VkCommandBufferInheritanceInfo& inheritance_info,
                                                          const Location& cb_loc) const;
+    bool ValidateCmdExecuteCommandsDynamicRenderingInherited(const vvl::CommandBuffer& cb_state, const vvl::RenderPass& rp_state,
+                                                             const vvl::CommandBuffer& secondary_cb_state,
+                                                             const vvl::RenderPass& secondary_rp_state,
+                                                             const Location& cb_loc) const;
     bool ValidateCmdExecuteCommandsDynamicRenderingSecondary(const vvl::CommandBuffer& cb_state,
                                                              const vvl::CommandBuffer& secondary_cb_state,
                                                              const vvl::RenderPass& secondary_rp_state,


### PR DESCRIPTION
`ValidateCmdExecuteCommandsRenderPassInheritance` was a bit messy and cleaning up for future extension worked on that has code in here