### PR TITLE
layers: Stateless check null VkDeviceAddress

### DIFF
--- a/layers/core_checks/cc_buffer_address.h
+++ b/layers/core_checks/cc_buffer_address.h
@@ -81,10 +81,12 @@ class BufferAddressValidation {
     [[nodiscard]] bool ValidateDeviceAddress(const CoreChecks& validator, const Location& device_address_loc,
                                              const LogObjectList& objlist, VkDeviceAddress device_address) noexcept {
         bool skip = false;
-        // Assumes the caller checks if the device_address can be null or not
+        // There will be an implicit VU like "must be a valid VkDeviceAddress value" and if can't be zero, stateless validation
+        // should have caught this already
         if (device_address == 0) {
             return skip;
         }
+
         vvl::span<vvl::Buffer* const> buffer_list = validator.GetBuffersByAddress(device_address);
         if (buffer_list.empty()) {
             skip |= validator.LogError(

--- a/layers/error_message/unimplementable_validation.h
+++ b/layers/error_message/unimplementable_validation.h
@@ -557,6 +557,13 @@ const char* unimplementable_validation[] = {
     "VUID-VkAccelerationStructureCreateInfoKHR-deviceAddress-09488"
     "VUID-VkAccelerationStructureCreateInfoKHR-deviceAddress-09489"
     "VUID-VkAccelerationStructureCreateInfoKHR-deviceAddress-09490"
+
+    // If VkDeviceAddress can be zero, we will validate it in cc_buffer_address.h
+    "VUID-VkAccelerationStructureCreateInfoKHR-deviceAddress-parameter",
+    "VUID-VkGeneratedCommandsInfoEXT-preprocessAddress-parameter",
+    "VUID-VkGeneratedCommandsInfoEXT-sequenceCountAddress-parameter",
+    "VUID-VkMicromapCreateInfoEXT-deviceAddress-parameter",
+    "VUID-VkStridedDeviceAddressRegionKHR-deviceAddress-parameter",
 };
 
 // VUs from deprecated extensions that would require complex codegen to get working

--- a/layers/stateless/sl_ray_tracing.cpp
+++ b/layers/stateless/sl_ray_tracing.cpp
@@ -2207,21 +2207,6 @@ bool Device::manual_PreCallValidateCmdBuildClusterAccelerationStructureIndirectN
     const Location op_input_loc = input_loc.dot(Field::opInput);
     const auto &input = pInfo->input;
 
-    if (pInfo->dstImplicitData == 0) {
-        skip |= LogError("VUID-VkClusterAccelerationStructureCommandsInfoNV-dstImplicitData-parameter",
-                         LogObjectList(commandBuffer), input_loc.dot(Field::dstImplicitData),
-                         "(%" PRIu64 ") must be a valid VkDeviceAddress value", pInfo->dstImplicitData);
-    }
-    if (pInfo->scratchData == 0) {
-        skip |=
-            LogError("VUID-VkClusterAccelerationStructureCommandsInfoNV-scratchData-parameter", LogObjectList(commandBuffer),
-                     input_loc.dot(Field::scratchData), "(%" PRIu64 ") must be a valid VkDeviceAddress value", pInfo->scratchData);
-    }
-    if (pInfo->srcInfosCount == 0) {
-        skip |= LogError("VUID-VkClusterAccelerationStructureCommandsInfoNV-srcInfosCount-parameter", LogObjectList(commandBuffer),
-                         input_loc.dot(Field::srcInfosCount), "(%" PRIu64 ") must be a valid VkDeviceAddress value",
-                         pInfo->srcInfosCount);
-    }
     skip |= context.ValidateStructType(input_loc, &pInfo->input, VK_STRUCTURE_TYPE_CLUSTER_ACCELERATION_STRUCTURE_INPUT_INFO_NV,
                                        true, "VUID-VkClusterAccelerationStructureCommandsInfoNV-input-parameter",
                                        "VUID-VkClusterAccelerationStructureInputInfoNV-sType-sType");

--- a/scripts/generators/stateless_validation_helper_generator.py
+++ b/scripts/generators/stateless_validation_helper_generator.py
@@ -1049,6 +1049,9 @@ class StatelessValidationHelperOutputGenerator(BaseGenerator):
                         usedLines.append(f'skip |= {context}ValidateFlags({errorLoc}.dot(Field::{member.name}), vvl::FlagBitmask::{flagBitsName}, {allFlagsName}, {valuePrefix}{member.name}, {flagsType}, {invalidVuid}{zeroVuidArg});\n')
                     elif member.type == 'VkBool32':
                         usedLines.append(f'skip |= {context}ValidateBool32({errorLoc}.dot(Field::{member.name}), {valuePrefix}{member.name});\n')
+                    elif member.type == 'VkDeviceAddress' and not member.optional:
+                        vuid = self.GetVuid(callerName, f"{member.name}-parameter")
+                        usedLines.append(f'skip |= {context}ValidateNotZero({valuePrefix}{member.name} == 0, {vuid}, {errorLoc}.dot(Field::{member.name}));\n')
                     elif member.type in self.vk.enums and member.type != 'VkStructureType':
                         vuid = self.GetVuid(callerName, f"{member.name}-parameter")
                         usedLines.append(f'skip |= {context}ValidateRangedEnum({errorLoc}.dot(Field::{member.name}), vvl::Enum::{member.type}, {valuePrefix}{member.name}, {vuid});\n')

--- a/tests/unit/device_generated_commands.cpp
+++ b/tests/unit/device_generated_commands.cpp
@@ -2001,10 +2001,7 @@ TEST_F(NegativeDeviceGeneratedCommands, GeneratedCommandsInfoAddresses) {
 
     m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
-    m_errorMonitor->SetDesiredError("VUID-VkGeneratedCommandsInfoEXT-sequenceCountAddress-11073");
-    m_errorMonitor->SetDesiredError("VUID-VkGeneratedCommandsInfoEXT-maxSequenceCount-10246");
     m_errorMonitor->SetDesiredError("VUID-VkGeneratedCommandsInfoEXT-indirectAddress-parameter");
-    m_errorMonitor->SetDesiredError("VUID-VkGeneratedCommandsInfoEXT-indirectAddressSize-11077");
     vk::CmdExecuteGeneratedCommandsEXT(m_command_buffer, false, &generated_commands_info);
     m_errorMonitor->VerifyFound();
     m_command_buffer.End();

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -1422,10 +1422,8 @@ TEST_F(NegativeRayTracing, CmdTraceRaysIndirect2KHRFeatureDisabled) {
 
 TEST_F(NegativeRayTracing, CmdTraceRaysIndirect2KHRAddress) {
     TEST_DESCRIPTION("Validate vkCmdTraceRaysIndirect2KHR.");
-
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_RAY_TRACING_MAINTENANCE_1_EXTENSION_NAME);
-
     AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
     AddRequiredFeature(vkt::Feature::rayTracingPipelineTraceRaysIndirect2);
     RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
@@ -4546,11 +4544,8 @@ TEST_F(NegativeRayTracing, CmdBuildPartitionedAccelerationStructures) {
     command_info.srcInfos = 0;
     command_info.srcInfosCount = count_buffer_address;
     m_command_buffer.Begin();
-    m_errorMonitor->SetDesiredError("VUID-vkCmdBuildPartitionedAccelerationStructuresNV-partitionedAccelerationStructure-10536");
-    m_errorMonitor->SetDesiredError("VUID-VkBuildPartitionedAccelerationStructureInfoNV-dstAccelerationStructureData-10562");
-    m_errorMonitor->SetDesiredError("VUID-VkBuildPartitionedAccelerationStructureInfoNV-scratchData-10559");
-    m_errorMonitor->SetDesiredError("VUID-vkCmdBuildPartitionedAccelerationStructuresNV-pBuildInfo-10541");
-    m_errorMonitor->SetDesiredError("VUID-vkCmdBuildPartitionedAccelerationStructuresNV-pBuildInfo-10543");
+    m_errorMonitor->SetDesiredError("VUID-VkBuildPartitionedAccelerationStructureInfoNV-srcAccelerationStructureData-parameter");
+    m_errorMonitor->SetDesiredError("VUID-VkBuildPartitionedAccelerationStructureInfoNV-srcInfos-parameter");
     vk::CmdBuildPartitionedAccelerationStructuresNV(m_command_buffer.handle(), &command_info);
     m_errorMonitor->VerifyFound();
     m_command_buffer.End();

--- a/tests/unit/ray_tracing_positive.cpp
+++ b/tests/unit/ray_tracing_positive.cpp
@@ -1978,7 +1978,8 @@ TEST_F(PositiveRayTracing, ZeroPrimitiveCountWithIndexTypeNone) {
     m_device->Wait();
 }
 
-TEST_F(PositiveRayTracing, CmdBuildPartitionedAccelerationStructuresNV) {
+// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10621
+TEST_F(PositiveRayTracing, DISABLED_CmdBuildPartitionedAccelerationStructuresNV) {
     TEST_DESCRIPTION("Test vkCmdBuildPartitionedAccelerationStructuresNV can build a partitioned TLAS");
 
     SetTargetApiVersion(VK_API_VERSION_1_3);


### PR DESCRIPTION
(Will wait until https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/7601 is merged otherwise this change will have 3 spots with false positives due to a vk.xml bug)

This will now validate the newly added `"... must be a valid VkDeviceAddress value"` implicit VUs added to the spec