### PR TITLE
layers: Improve error messages for Subpasses

### DIFF
--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -1167,14 +1167,15 @@ bool CoreChecks::ValidateDrawDynamicStateValue(const LastBound& last_bound_state
             const auto& attachment_info = cb_state.active_attachments[i];
             const auto* attachment = attachment_info.image_view;
             if (attachment && attachment->create_info.format == VK_FORMAT_E5B9G9R9_UFLOAT_PACK32) {
-                const auto color_write_mask = cb_state.dynamic_state_value.color_write_masks[attachment_info.color_index];
+                const uint32_t color_index = attachment_info.type_index;
+                const auto color_write_mask = cb_state.dynamic_state_value.color_write_masks[color_index];
                 VkColorComponentFlags rgb = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT;
                 if ((color_write_mask & rgb) != rgb && (color_write_mask & rgb) != 0) {
                     skip |= LogError(
                         vuid.color_write_mask_09116, cb_state.Handle(), vuid.loc(),
                         "%s has format VK_FORMAT_E5B9G9R9_UFLOAT_PACK32, but vkCmdSetColorWriteMaskEXT::pColorWriteMasks[%" PRIu32
                         "] is %s.",
-                        attachment_info.Describe(cb_state, i).c_str(), attachment_info.color_index,
+                        attachment_info.Describe(cb_state, i).c_str(), color_index,
                         string_VkColorComponentFlags(color_write_mask).c_str());
                 }
             }

--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -1918,7 +1918,7 @@ bool CoreChecks::ValidateDrawAttachmentColorBlend(const LastBound &last_bound_st
         if (!attachment || !attachment_info.IsColor()) {
             continue;
         }
-        const uint32_t color_index = attachment_info.color_index;
+        const uint32_t color_index = attachment_info.type_index;
 
         if (dynamic_write_mask && cb_state.IsDynamicStateSet(CB_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT) &&
             !cb_state.dynamic_state_value.color_write_mask_attachments[color_index]) {

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -87,14 +87,20 @@ struct AttachmentInfo {
     VkImageLayout separate_stencil_layout;
     // When dealing with color attachments, need to know the index for things such as
     // VkPipelineColorBlendStateCreateInfo::pAttachments or vkCmdSetColorBlendEnableEXT
-    uint32_t color_index;
+    //
+    // This index is tied to a Attachment::Type and will line up to the index in either:
+    //   VkRenderingInfo::pColorAttachments
+    //   VkSubpassDescription::pColorAttachments
+    //   VkSubpassDescription::pInputAttachments
+    //   VkSubpassDescription::pResolveAttachments
+    uint32_t type_index;
 
     AttachmentInfo()
         : image_view(nullptr),
           type(Type::Empty),
           layout(VK_IMAGE_LAYOUT_UNDEFINED),
           separate_stencil_layout(VK_IMAGE_LAYOUT_UNDEFINED),
-          color_index(0) {}
+          type_index(0) {}
 
     bool IsResolve() const { return type == Type::ColorResolve || type == Type::DepthResolve || type == Type::StencilResolve; }
     bool IsInput() const { return type == Type::Input; }
@@ -108,7 +114,7 @@ struct AttachmentInfo {
     bool IsFragmentDensityMap() const { return type == Type::FragmentDensityMap; }
     bool IsFragmentShadingRate() const { return type == Type::FragmentShadingRate; }
 
-    std::string Describe(const vvl::CommandBuffer &cb_state, uint32_t index) const;
+    std::string Describe(const vvl::CommandBuffer &cb_state, uint32_t rp_index) const;
 };
 
 struct SubpassInfo {


### PR DESCRIPTION
For https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10535 

will now print things like

```
VkRenderPassCreateInfo::pAttachments[0] (Subpass 0, VkSubpassDescription::pColorAttachments[0])
VkRenderPassCreateInfo::pAttachments[1] (Subpass 0, VkSubpassDescription::pDepthStencilAttachment)
VkRenderPassCreateInfo::pAttachments[2] (Subpass 0, VkSubpassDescription::pColorAttachments[1])
VkRenderPassCreateInfo::pAttachments[0] (Subpass 1, VkSubpassDescription::pColorAttachments[0])
VkRenderPassCreateInfo::pAttachments[1] (Subpass 1, VkSubpassDescription::pDepthStencilAttachment)
```

for subpasses to help aid developers which attachment is actually the issue