### PR TITLE
sync: Remove range_map SplitOp parameterization

### DIFF
--- a/layers/containers/range.h
+++ b/layers/containers/range.h
@@ -76,9 +76,7 @@ struct range {
 
     // use as "strictly less/greater than" to check for non-overlapping ranges
     bool strictly_less(const range &rhs) const { return end <= rhs.begin; }
-    bool strictly_less(const index_type &index) const { return end <= index; }
     bool strictly_greater(const range &rhs) const { return rhs.end <= begin; }
-    bool strictly_greater(const index_type &index) const { return index < begin; }
 
     range &operator=(const range &rhs) {
         begin = rhs.begin;
@@ -98,7 +96,7 @@ struct range {
 
     index_type size() const { return end - begin; }
     range() : begin(), end() {}
-    range(const index_type &begin_, const index_type &end_) : begin(begin_), end(end_) {}
+    range(const index_type &begin, const index_type &end) : begin(begin), end(end) {}
     range(const range &other) : begin(other.begin), end(other.end) {}
 };
 

--- a/layers/containers/subresource_adapter.h
+++ b/layers/containers/subresource_adapter.h
@@ -37,7 +37,6 @@ namespace subresource_adapter {
 class RangeEncoder;
 using IndexType = uint64_t;  // TODO: just update to 32 bit, but before collect memory usage stats, perf stats
 using IndexRange = vvl::range<IndexType>;
-using split_op_keep_both = sparse_container::split_op_keep_both;
 
 // Interface for aspect specific traits objects (now isolated in the cpp file)
 class AspectParameters {


### PR DESCRIPTION
The client code used only `keep_both` option. `keep_lower` was used only internally in one place, `keep_upper` was unused. By expanding `split_impl` with specific parameters it gets much simpler and it is straighforward to understand.

This also generates fewer instructions including minus one conditional jump (at least on MSVC) but that's a small bonus and not the goal of this change.