### PR TITLE
scripts: Fix unwrapping of NDO arrays with pointer to count

### DIFF
--- a/scripts/generators/dispatch_object_generator.py
+++ b/scripts/generators/dispatch_object_generator.py
@@ -617,6 +617,11 @@ class DispatchObjectGenerator(BaseGenerator):
                 if (count_name is not None) and not topLevel:
                     count_name = f'{prefix}{member.length}'
 
+                # Handle the case when the member specifying the count is a pointer
+                for count_member in members:
+                    if count_member.name == member.length and count_member.pointer:
+                        count_name = f'*{count_name}'
+
                 if (not topLevel) or (not isCreate) or (not member.pointer):
                     if count_name is not None:
                         if topLevel:


### PR DESCRIPTION
@spencer-lunarg, this is not the only place that needs to be modified when the member length is coming from a pointer variable.

The code just below that handles structs that contain NDOs at some level is also not handling the case when member length is a pointer (typical `optional="false,true"` count case when both the count and the array is a pointer argument of a command), but this MR does not attempt to fix that or other cases where this is not handled correctly.

This came up when prototyping some new functionality that hit this case.