### PR TITLE
layers: Skip all SPIR-V processing when shader validation is disabled

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -313,7 +313,7 @@
                                 {
                                     "key": "check_shaders",
                                     "label": "Shader",
-                                    "description": "This will validate the contents of the SPIR-V which can be CPU intensive during application start up. This does internal checks as well as calling spirv-val.",
+                                    "description": "This will validate the contents of the SPIR-V which can be CPU intensive during application start up. This does internal checks as well as calling spirv-val. (Same effect using VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT)",
                                     "type": "BOOL",
                                     "default": true,
                                     "expanded": true,

--- a/layers/core_checks/cc_shader_object.cpp
+++ b/layers/core_checks/cc_shader_object.cpp
@@ -287,9 +287,9 @@ bool CoreChecks::PreCallValidateCreateShadersEXT(VkDevice device, uint32_t creat
                                                  VkShaderEXT* pShaders, const ErrorObject& error_obj) const {
     bool skip = false;
 
-    // the spec clarifies that VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT works on VK_EXT_shader_object as well
+    // If user has VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT, just skip all things related to creating the shader object
     if (disabled[shader_validation]) {
-        return skip; // VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT
+        return skip;
     }
 
     if (enabled_features.shaderObject == VK_FALSE) {
@@ -323,7 +323,8 @@ bool CoreChecks::PreCallValidateCreateShadersEXT(VkDevice device, uint32_t creat
         spv_const_binary_t binary{static_cast<const uint32_t*>(create_info.pCode), create_info.codeSize / sizeof(uint32_t)};
         skip |= RunSpirvValidation(binary, create_info_loc, cache);
 
-        const auto spirv = std::make_shared<spirv::Module>(create_info.codeSize, static_cast<const uint32_t*>(create_info.pCode));
+        const auto spirv =
+            vvl::CreateSpirvModuleState(create_info.codeSize, static_cast<const uint32_t*>(create_info.pCode), global_settings);
         vku::safe_VkShaderCreateInfoEXT safe_create_info = vku::safe_VkShaderCreateInfoEXT(&pCreateInfos[i]);
         const ShaderStageState stage_state(nullptr, &safe_create_info, nullptr, spirv);
         skip |= ValidateShaderStage(stage_state, nullptr, create_info_loc);

--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -141,7 +141,7 @@ bool CoreChecks::ValidatePushConstantUsage(const spirv::Module &module_state, co
         }
     } else {
         shader_object_push_constant_ranges_id = GetCanonicalId(stage_state.shader_object_create_info->pushConstantRangeCount,
-                                                          stage_state.shader_object_create_info->pPushConstantRanges);
+                                                               stage_state.shader_object_create_info->pPushConstantRanges);
         push_constant_ranges = shader_object_push_constant_ranges_id.get();
         stage_vuid = "VUID-VkShaderCreateInfoEXT-codeType-10064";
         range_vuid = "VUID-VkShaderCreateInfoEXT-codeType-10065";
@@ -2224,7 +2224,7 @@ bool CoreChecks::ValidateShaderModuleCreateInfo(const VkShaderModuleCreateInfo &
     bool skip = false;
 
     if (disabled[shader_validation]) {
-        return skip; // VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT
+        return skip;  // VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT
     } else if (!create_info.pCode) {
         return skip;  // will be caught elsewhere
     }

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -222,7 +222,7 @@ class CoreChecks : public vvl::DeviceProxy {
 
     CoreChecks(vvl::dispatch::Device* dev, core::Instance* instance_vo)
         : BaseClass(dev, instance_vo, LayerObjectTypeCoreValidation),
-          stateless_spirv_validator(dev->debug_report, dev->stateless_device_data) {}
+          stateless_spirv_validator(dev->debug_report, dev->stateless_device_data, dev->settings.disabled[shader_validation]) {}
 
     ReadLockGuard ReadLock() const override;
     WriteLockGuard WriteLock() override;

--- a/layers/layer_options.h
+++ b/layers/layer_options.h
@@ -84,6 +84,20 @@ struct GlobalSettings {
     bool fine_grained_locking = true;
 
     bool debug_disable_spirv_val = false;
+
+    // We have the spirv::Module state object designed to hold the SPIR-V and parse it so we can do validation on it, the
+    // issue/tricky part is gpuav/debugPrint use this to get the original SPIR-V (which we need to provide any useful error
+    // messages). These settings are here to make it more obvious what we want at runtime
+    //
+    // Stores a copy, needed to provide error messages and how DebugPrintf works
+    // (performance is fast, but memory overhead is higher)
+    bool spirv_store = true;
+    // Parsing of the SPIR-V to provide information for validation (core check, sync val, etc)
+    // (small performance hit for large shader)
+    bool spirv_parse = true;
+    // If we want to have spirv-opt potentially do constant folding on the spec constants
+    // (by far the largest performance bottle neck for large shaders using spec cosntants)
+    bool spirv_const_fold = true;
 };
 
 class DebugReport;

--- a/layers/state_tracker/pipeline_library_state.cpp
+++ b/layers/state_tracker/pipeline_library_state.cpp
@@ -99,7 +99,8 @@ PreRasterState::PreRasterState(const vvl::Pipeline &p, const vvl::DeviceState &s
                 // don't need to worry about GroupDecoration in GPL
                 spirv::StatelessData *stateless_data_stage =
                     (stateless_data && i < kCommonMaxGraphicsShaderStages) ? &stateless_data[i] : nullptr;
-                auto spirv_module = std::make_shared<spirv::Module>(shader_ci->codeSize, shader_ci->pCode, stateless_data_stage);
+                auto spirv_module = vvl::CreateSpirvModuleState(shader_ci->codeSize, shader_ci->pCode, state_data.global_settings,
+                                                                stateless_data_stage);
                 module_state = std::make_shared<vvl::ShaderModule>(VK_NULL_HANDLE, spirv_module);
                 if (stateless_data_stage) {
                     stateless_data_stage->pipeline_pnext_module = spirv_module;
@@ -219,8 +220,8 @@ void SetFragmentShaderInfoPrivate(const vvl::Pipeline &pipeline_state, FragmentS
                     // don't need to worry about GroupDecoration in GPL
                     spirv::StatelessData *stateless_data_stage =
                         (stateless_data && i < kCommonMaxGraphicsShaderStages) ? &stateless_data[i] : nullptr;
-                    auto spirv_module =
-                        std::make_shared<spirv::Module>(shader_ci->codeSize, shader_ci->pCode, stateless_data_stage);
+                    auto spirv_module = vvl::CreateSpirvModuleState(shader_ci->codeSize, shader_ci->pCode,
+                                                                    state_data.global_settings, stateless_data_stage);
                     module_state = std::make_shared<vvl::ShaderModule>(VK_NULL_HANDLE, spirv_module);
                     if (stateless_data_stage) {
                         stateless_data_stage->pipeline_pnext_module = spirv_module;

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -91,7 +91,8 @@ std::vector<ShaderStageState> Pipeline::GetStageStates(const DeviceState &state_
             // This support was also added in VK_KHR_maintenance5
             if (const auto shader_ci = vku::FindStructInPNextChain<VkShaderModuleCreateInfo>(stage_ci.pNext)) {
                 // don't need to worry about GroupDecoration in GPL
-                auto spirv_module = std::make_shared<spirv::Module>(shader_ci->codeSize, shader_ci->pCode, stateless_data);
+                auto spirv_module =
+                    CreateSpirvModuleState(shader_ci->codeSize, shader_ci->pCode, state_data.global_settings, stateless_data);
                 module_state = std::make_shared<vvl::ShaderModule>(VK_NULL_HANDLE, spirv_module);
                 if (stateless_data) {
                     stateless_data->pipeline_pnext_module = spirv_module;

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -794,7 +794,9 @@ namespace vvl {
 struct ShaderModule : public StateObject {
     ShaderModule(VkShaderModule handle, std::shared_ptr<spirv::Module> &spirv_module)
         : StateObject(handle, kVulkanObjectTypeShaderModule), spirv(spirv_module) {
-        spirv->handle_ = handle_;
+        if (spirv) {
+            spirv->handle_ = handle_;
+        }
     }
 
     // For when we need to create a module with no SPIR-V backing it

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -191,7 +191,7 @@ struct ExecutionModeSet {
 struct AtomicInstructionInfo {
     uint32_t storage_class;
     uint32_t bit_width;
-    uint32_t type;  // ex. OpTypeInt
+    uint32_t type;             // ex. OpTypeInt
     uint32_t vector_size = 0;  // 0 for scalar, otherwise number of components
 };
 

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -4980,11 +4980,13 @@ void DeviceState::PostCallRecordCmdExecuteGeneratedCommandsEXT(VkCommandBuffer c
 void DeviceState::PreCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo *pCreateInfo,
                                                   const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule,
                                                   const RecordObject &record_obj, chassis::CreateShaderModule &chassis_state) {
-    if (pCreateInfo->codeSize == 0 || !pCreateInfo->pCode) {
+    if (disabled[shader_validation]) {
+        return;  // VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT
+    } else if (pCreateInfo->codeSize == 0 || !pCreateInfo->pCode) {
         return;
     } else if (chassis_state.module_state) {
         // We store the shader module at a chassis stack level (because we need it for PostCallRecord in things like GPU-AV)
-        // Only one validaiton object needs to create it
+        // Only one validation object needs to create it
         return;
     }
 
@@ -5013,6 +5015,9 @@ void DeviceState::PreCallRecordCreateShadersEXT(VkDevice device, uint32_t create
                                                 const VkShaderCreateInfoEXT *pCreateInfos, const VkAllocationCallbacks *pAllocator,
                                                 VkShaderEXT *pShaders, const RecordObject &record_obj,
                                                 chassis::ShaderObject &chassis_state) {
+    if (disabled[shader_validation]) {
+        return;  // VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT
+    }
     for (uint32_t i = 0; i < createInfoCount; ++i) {
         const VkShaderCreateInfoEXT &create_info = pCreateInfos[i];
         if (create_info.codeSize == 0 || !create_info.pCode || create_info.codeType != VK_SHADER_CODE_TYPE_SPIRV_EXT) {

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -510,7 +510,7 @@ void DeviceState::PostCallRecordBindTensorMemoryARM(VkDevice device, uint32_t bi
         auto mem_info = Get<vvl::DeviceMemory>(pBindInfos[i].memory);
         ASSERT_AND_RETURN(tensor_state && mem_info);
         tensor_state->BindMemory(tensor_state.get(), mem_info, pBindInfos[i].memoryOffset, 0u,
-                                    tensor_state->MemReqs()->memoryRequirements.size);
+                                 tensor_state->MemReqs()->memoryRequirements.size);
     }
 }
 
@@ -918,8 +918,7 @@ void DeviceState::FinishDeviceSetup(const VkDeviceCreateInfo *pCreateInfo, const
         uint32_t num_queue_families = 0;
         DispatchGetPhysicalDeviceQueueFamilyProperties(physical_device, &num_queue_families, nullptr);
         std::vector<VkQueueFamilyProperties> queue_family_properties_list(num_queue_families);
-        DispatchGetPhysicalDeviceQueueFamilyProperties(physical_device, &num_queue_families,
-                                                                       queue_family_properties_list.data());
+        DispatchGetPhysicalDeviceQueueFamilyProperties(physical_device, &num_queue_families, queue_family_properties_list.data());
 
         for (uint32_t i = 0; i < pCreateInfo->queueCreateInfoCount; ++i) {
             const VkDeviceQueueCreateInfo &queue_create_info = pCreateInfo->pQueueCreateInfos[i];
@@ -1411,7 +1410,7 @@ void DeviceState::PreCallRecordQueueBindSparse(VkQueue queue, uint32_t bindInfoC
                 }
             }
         }
-        auto* timeline_info = vku::FindStructInPNextChain<VkTimelineSemaphoreSubmitInfo>(bind_info.pNext);
+        auto *timeline_info = vku::FindStructInPNextChain<VkTimelineSemaphoreSubmitInfo>(bind_info.pNext);
         Location submit_loc = record_obj.location.dot(Struct::VkBindSparseInfo, Field::pBindInfo, bind_idx);
         QueueSubmission submission(submit_loc);
         for (uint32_t i = 0; i < bind_info.waitSemaphoreCount; ++i) {
@@ -1578,8 +1577,7 @@ void DeviceState::RecordGetDeviceQueueState(uint32_t queue_family_index, uint32_
         uint32_t num_queue_families = 0;
         DispatchGetPhysicalDeviceQueueFamilyProperties(physical_device, &num_queue_families, nullptr);
         std::vector<VkQueueFamilyProperties> queue_family_properties_list(num_queue_families);
-        DispatchGetPhysicalDeviceQueueFamilyProperties(physical_device, &num_queue_families,
-                                                                       queue_family_properties_list.data());
+        DispatchGetPhysicalDeviceQueueFamilyProperties(physical_device, &num_queue_families, queue_family_properties_list.data());
 
         Add(CreateQueue(queue, queue_family_index, queue_index, flags, queue_family_properties_list[queue_family_index]));
     }

--- a/layers/stateless/sl_spirv.cpp
+++ b/layers/stateless/sl_spirv.cpp
@@ -57,8 +57,9 @@ static void GetVariableInfo(const spirv::Module &module_state, const spirv::Inst
     }
 }
 
-SpirvValidator::SpirvValidator(DebugReport *debug_report, const vvl::StatelessDeviceData &stateless_device_data)
+SpirvValidator::SpirvValidator(DebugReport *debug_report, const vvl::StatelessDeviceData &stateless_device_data, bool disabled)
     : Logger(debug_report),
+      disabled(disabled),
       api_version(stateless_device_data.api_version),
       extensions(stateless_device_data.extensions),
       phys_dev_props(stateless_device_data.phys_dev_props),
@@ -77,7 +78,9 @@ SpirvValidator::SpirvValidator(DebugReport *debug_report, const vvl::StatelessDe
 bool SpirvValidator::Validate(const spirv::Module &module_state, const spirv::StatelessData &stateless_data,
                               const Location &loc) const {
     bool skip = false;
-    if (!module_state.valid_spirv) return skip;
+    if (!module_state.valid_spirv || disabled) {
+        return skip;
+    }
 
     skip |= ValidateShaderClock(module_state, stateless_data, loc);
     skip |= ValidateAtomicsTypes(module_state, stateless_data, loc);

--- a/layers/stateless/sl_spirv.h
+++ b/layers/stateless/sl_spirv.h
@@ -42,9 +42,12 @@ namespace stateless {
 
 class SpirvValidator : public Logger {
   public:
-    SpirvValidator(DebugReport* debug_report, const vvl::StatelessDeviceData& stateless_device_data);
+    SpirvValidator(DebugReport* debug_report, const vvl::StatelessDeviceData& stateless_device_data, bool disabled);
 
     bool Validate(const spirv::Module& module_state, const spirv::StatelessData& stateless_data, const Location& loc) const;
+
+    // When we create the SpirvValidator, we will see if the runtime setting to disable it was set or not
+    const bool disabled;
 
     const APIVersion& api_version;
     const DeviceExtensions& extensions;

--- a/tests/unit/debug_printf_ray_tracing.cpp
+++ b/tests/unit/debug_printf_ray_tracing.cpp
@@ -39,9 +39,6 @@ class NegativeDebugPrintfRayTracing : public DebugPrintfTests {
         if (!CanEnableGpuAV(*this)) {
             GTEST_SKIP() << "Requirements for GPU-AV/Printf are not met";
         }
-        if (IsExtensionsEnabled(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME)) {
-            GTEST_SKIP() << "Currently disabled for Portability";
-        }
     }
 };
 

--- a/tests/unit/shader_object_positive.cpp
+++ b/tests/unit/shader_object_positive.cpp
@@ -1673,3 +1673,25 @@ TEST_F(PositiveShaderObject, MultiCreateGraphicsCompute) {
         vk::DestroyShaderEXT(*m_device, shaders[i], nullptr);
     }
 }
+
+TEST_F(PositiveShaderObject, DisableShaderValidation) {
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_EXT_SHADER_OBJECT_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    AddRequiredFeature(vkt::Feature::shaderObject);
+    const VkLayerSettingEXT setting = {OBJECT_LAYER_NAME, "check_shaders", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &kVkFalse};
+    VkLayerSettingsCreateInfoEXT layer_setting_ci = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1, &setting};
+    RETURN_IF_SKIP(InitFramework(&layer_setting_ci));
+    RETURN_IF_SKIP(InitState());
+    InitDynamicRenderTarget();
+    CreateMinimalShaders();
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
+    SetDefaultDynamicStatesExclude();
+    m_command_buffer.BindShaders(m_vert_shader, m_frag_shader);
+    vk::CmdDraw(m_command_buffer, 4, 1, 0, 0);
+    m_command_buffer.EndRendering();
+    m_command_buffer.End();
+}


### PR DESCRIPTION
https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/10566 but with fixes to handle GPU-AV/DebugPrintf and also passing shader via GPL or inlined with Maintenance5 