### PR TITLE
layers: Use disabled and enabled

### DIFF
--- a/layers/layer_options.h
+++ b/layers/layer_options.h
@@ -112,8 +112,8 @@ struct ConfigAndEnvSettings {
     const VkInstanceCreateInfo *create_info;
 
     // Find grain way to turn off/on parts of validation
-    ValidationEnabled &enables;
-    ValidationDisabled &disables;
+    ValidationEnabled &enabled;
+    ValidationDisabled &disabled;
 
     // Settings for DebugReport
     DebugReport *debug_report;


### PR DESCRIPTION
nit fix, but we use `enabled`/`disabled` everywhere else and was harder then should be to search for things because we had these variable names as `enables`/`disables`