### PR TITLE
layers: Only parse SPIR-V once for ShaderObject

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1610,6 +1610,8 @@ class CoreChecks : public vvl::DeviceProxy {
                                                       const vvl::RenderPass& rp_state, const Location& loc) const;
     bool PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint, VkPipeline pipeline,
                                         const ErrorObject& error_obj) const override;
+    bool ValidateCreateShadersSpirv(uint32_t createInfoCount, const VkShaderCreateInfoEXT* pCreateInfos, const Location& loc,
+                                    chassis::ShaderObject& chassis_state) const;
     bool PreCallValidateCreateShadersEXT(VkDevice device, uint32_t createInfoCount, const VkShaderCreateInfoEXT* pCreateInfos,
                                          const VkAllocationCallbacks* pAllocator, VkShaderEXT* pShaders,
                                          const ErrorObject& error_obj) const override;


### PR DESCRIPTION
I realized ShaderObject falls inbetween `vkCreateShaderModule` and `vkCreateGraphicsPipeline`

- Like `vkCreateShaderModule` we need to parse/store the SPIR-V
- Like `vkCreateGraphicsPipeline` we have descriptor set layout information to validate

This moves the "Validate" to the `PreCallRecord` time (we do this with `vkCreateShaderModule` as well) so we only spend the cost of parsing the SPIR-V once!!