### PR TITLE
sync: Fix access_contexts stats counter

### DIFF
--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -1366,13 +1366,11 @@ void UpdateAccessMapStats(const ResourceAccessRangeMap &access_map, syncval_stat
 void CommandBufferAccessContext::UpdateStats(syncval_stats::AccessStats &access_stats) const {
 #if VVL_ENABLE_SYNCVAL_STATS != 0
     UpdateAccessMapStats(cb_access_context_.GetAccessStateMap(), access_stats.cb_access_stats);
-    access_stats.cb_access_stats.access_contexts += 1;
 
     for (const auto &render_pass_context : render_pass_contexts_) {
         for (const AccessContext &subpass_access_context : render_pass_context->GetContexts()) {
             UpdateAccessMapStats(subpass_access_context.GetAccessStateMap(), access_stats.subpass_access_stats);
         }
-        access_stats.subpass_access_stats.access_contexts += (uint32_t)render_pass_context->GetContexts().size();
     }
 #endif
 }

--- a/layers/sync/sync_stats.cpp
+++ b/layers/sync/sync_stats.cpp
@@ -105,17 +105,8 @@ void AccessContextStats::UpdateMax(const AccessContextStats& cur_stats) {
 #undef UPDATE_MAX
 }
 
-void AccessContextStats::Report(std::ostringstream& ss) {
-    ss << "\taccess_contexts = " << access_contexts << '\n';
-    ss << "\taccess_states = " << access_states << '\n';
-    ss << "\tread_states = " << read_states << '\n';
-    ss << "\twrite_states = " << write_states << '\n';
-    ss << "\taccess_states_with_multiple_reads = " << access_states_with_multiple_reads << '\n';
-    ss << "\taccess_states_with_dynamic_allocations = " << access_states_with_dynamic_allocations << '\n';
-    ss << "\taccess_states_dynamic_allocation_size = " << access_states_dynamic_allocation_size << '\n';
-}
-
 void UpdateAccessMapStats(const ResourceAccessRangeMap& access_map, AccessContextStats& stats) {
+    stats.access_contexts += 1;
     stats.access_states += (uint32_t)access_map.size();
     for (const auto& entry : access_map) {
         const ResourceAccessState& access_state = entry.second;

--- a/layers/sync/sync_stats.h
+++ b/layers/sync/sync_stats.h
@@ -88,7 +88,6 @@ struct AccessContextStats {
     uint64_t access_states_dynamic_allocation_size = 0;
 
     void UpdateMax(const AccessContextStats& cur_stats);
-    void Report(std::ostringstream& ss);
 };
 
 struct AccessStats {


### PR DESCRIPTION
Fix stats bug that counter was always zero for queue access contexts.