### PR TITLE
gpuav: Handle OpUndef on a OpSampledImage

### DIFF
--- a/layers/gpuav/spirv/module.cpp
+++ b/layers/gpuav/spirv/module.cpp
@@ -108,6 +108,10 @@ Module::Module(vvl::span<const uint32_t> words, DebugReport* debug_report, const
                 annotations_.emplace_back(std::move(new_inst));
                 break;
 
+            case spv::OpUndef:
+                type_manager_.AddUndef(std::move(new_inst));
+                break;
+
             case spv::OpSpecConstantTrue:
             case spv::OpSpecConstantFalse:
             case spv::OpConstantTrue:

--- a/layers/gpuav/spirv/type_manager.cpp
+++ b/layers/gpuav/spirv/type_manager.cpp
@@ -647,5 +647,12 @@ uint32_t Constant::GetValueUint32() const {
     return inst_.Word(3);
 }
 
+void TypeManager::AddUndef(std::unique_ptr<Instruction> new_inst) {
+    const auto& inst = module_.types_values_constants_.emplace_back(std::move(new_inst));
+    undef_ids_.insert(inst->ResultId());
+}
+
+bool TypeManager::IsUndef(uint32_t id) const { return undef_ids_.find(id) != undef_ids_.end(); }
+
 }  // namespace spirv
 }  // namespace gpuav

--- a/layers/gpuav/spirv/type_manager.h
+++ b/layers/gpuav/spirv/type_manager.h
@@ -156,6 +156,9 @@ class TypeManager {
     const Variable* FindVariableById(uint32_t id) const;
     const Variable* FindPushConstantVariable() const;
 
+    void AddUndef(std::unique_ptr<Instruction> new_inst);
+    bool IsUndef(uint32_t id) const;
+
   private:
     Module& module_;
 
@@ -202,6 +205,9 @@ class TypeManager {
     // Save the length of a struct so we don't have to look it up everytime
     // <struct_id, struct size>
     vvl::unordered_map<uint32_t, uint32_t> struct_size_map_;
+
+    // The use of OpUndef is sometime misused, we store all OpUndef here as way to check if we have it one by accident
+    vvl::unordered_set<uint32_t> undef_ids_;
 };
 
 }  // namespace spirv


### PR DESCRIPTION
hit an `OpUndef` in a fossilize trace, need to handle it, still not sure if the spir-v was legal or not (so didn't add a test)