### PR TITLE
layers: Provide spirv-val command to reproduce

### DIFF
--- a/layers/core_checks/cc_device.cpp
+++ b/layers/core_checks/cc_device.cpp
@@ -346,7 +346,9 @@ bool core::Instance::PreCallValidateCreateDevice(VkPhysicalDevice gpu, const VkD
 void CoreChecks::FinishDeviceSetup(const VkDeviceCreateInfo *pCreateInfo, const Location &loc) {
     BaseClass::FinishDeviceSetup(pCreateInfo, loc);
 
-    AdjustValidatorOptions(extensions, enabled_features, spirv_val_options, &spirv_val_option_hash);
+    spirv_environment = PickSpirvEnv(api_version, IsExtEnabled(extensions.vk_khr_spirv_1_4));
+    AdjustValidatorOptions(extensions, enabled_features, spirv_environment, spirv_val_options, &spirv_val_option_hash,
+                           spirv_val_command);
 
     // Allocate shader validation cache
     if (!disabled[shader_validation_caching] && !disabled[shader_validation] && !core_validation_cache) {

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -218,6 +218,8 @@ class CoreChecks : public vvl::DeviceProxy {
     // the second time).
     spvtools::ValidatorOptions spirv_val_options;
     uint32_t spirv_val_option_hash;
+    std::string spirv_val_command;
+    spv_target_env spirv_environment;
     stateless::SpirvValidator stateless_spirv_validator;
 
     CoreChecks(vvl::dispatch::Device* dev, core::Instance* instance_vo)

--- a/layers/utils/shader_utils.h
+++ b/layers/utils/shader_utils.h
@@ -113,6 +113,7 @@ class ValidationCache {
 spv_target_env PickSpirvEnv(const APIVersion &api_version, bool spirv_1_4);
 
 void AdjustValidatorOptions(const DeviceExtensions &device_extensions, const DeviceFeatures &enabled_features,
-                            spvtools::ValidatorOptions &out_options, uint32_t *out_hash);
+                            spv_target_env spirv_environment, spvtools::ValidatorOptions &out_options, uint32_t *out_hash,
+                            std::string &out_command);
 
 void DumpSpirvToFile(const std::string &file_name, const uint32_t *spirv, size_t spirv_dwords_count);


### PR DESCRIPTION
The interaction between VVL and spirv-val can be a mystery for many. We pass in various arguments into `spirv-val` that can be reproduced with command line options, but are not obvious. This change adds at the bottom of `spirv-val` errors the command that can be rerun to reproduce without VVL involved (also helps when the vulkan version doesn't match up with the spirv version)

<img width="985" height="129" alt="image" src="https://github.com/user-attachments/assets/6337f08c-7a0a-4635-9e74-020bb53f1c11" />
