### PR TITLE
layers: Fix minImageTransferGranularity for compressed images

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1048,9 +1048,10 @@ class CoreChecks : public vvl::DeviceProxy {
                                 const VkImageSubresourceRange& normalized_subresource_range, VkImageLayout explicit_layout,
                                 const Location& image_loc, const char* mismatch_layout_vuid, bool* error) const;
 
-    bool ValidateTransferGranularityExtent(const LogObjectList& objlist, const VkExtent3D& extent, const VkOffset3D& offset,
-                                           const VkExtent3D& granularity, VkExtent3D subresource_extent,
-                                           const vvl::Image& image_state, const Location& extent_loc, const char* vuid) const;
+    bool ValidateTransferGranularityExtent(const LogObjectList& objlist, const VkExtent3D& region_extent,
+                                           const VkOffset3D& region_offset, const VkExtent3D& granularity,
+                                           const VkExtent3D& subresource_extent, const vvl::Image& image_state,
+                                           const Location& extent_loc, const char* vuid) const;
 
     bool ValidateTransferGranularityOffset(const LogObjectList& objlist, const VkOffset3D& offset, const VkExtent3D& granularity,
                                            const Location& offset_loc, const char* vuid) const;

--- a/layers/error_message/error_strings.h
+++ b/layers/error_message/error_strings.h
@@ -41,6 +41,18 @@
     return ss.str();
 }
 
+[[maybe_unused]] static std::string string_VkExtentDimensions(VkExtent2D extent) {
+    std::stringstream ss;
+    ss << extent.width << "x" << extent.height;
+    return ss.str();
+}
+
+[[maybe_unused]] static std::string string_VkExtentDimensions(VkExtent3D extent) {
+    std::stringstream ss;
+    ss << extent.width << "x" << extent.height << "x" << extent.depth;
+    return ss.str();
+}
+
 [[maybe_unused]] static std::string string_VkOffset2D(VkOffset2D offset) {
     std::stringstream ss;
     ss << "x = " << offset.x << ", y = " << offset.y;


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10620

Fixed and new error message is MUCH nicer

> Validation Error: [ VUID-vkCmdCopyBufferToImage2-imageOffset-07738 ] | MessageID = 0x8a22c271
>
> vkCmdCopyBufferToImage2(): pCopyBufferToImageInfo->pRegions[0].imageExtent (width = 320, height = 148, depth = 1) is invalid with this command buffer's queue family minImageTransferGranularity (width = 16, height = 16, depth = 8) for copying to/from VkImage 0x40000000004 (VK_FORMAT_BC1_RGBA_SRGB_BLOCK) because both:
>
> 1) The image is in texel blocks of size (4x4x1) so the texel block extent of (width = 80, height = 37, depth = 1) is not an even integer multiple of minImageTransferGranularity.
>
> 2) The extent plus the offset (x = 0, y = 16, z = 0) is (320x164x1) which is not the entire image subresource (width = 320, height = 180, depth = 1).
