### PR TITLE
tests: Fix submit wait stage

### DIFF
--- a/tests/unit/sync_object_positive.cpp
+++ b/tests/unit/sync_object_positive.cpp
@@ -810,7 +810,7 @@ TEST_F(PositiveSyncObject, ExternalSemaphore) {
     import_semaphore.ImportHandle(ext_handle, handle_type);
 
     // Signal the exported semaphore and wait on the imported semaphore
-    VkPipelineStageFlags flags = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+    const VkPipelineStageFlags flags = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
     std::vector<VkSubmitInfo> si(4, vku::InitStruct<VkSubmitInfo>());
     si[0].signalSemaphoreCount = 1;
     si[0].pSignalSemaphores = &export_semaphore.handle();


### PR DESCRIPTION
https://gitlab.khronos.org/vulkan/vulkan/-/issues/4427#note_555891

BOTTOM_OF_PIPE on wait side means wait for nothing, so should be ALL_COMMANDS (in the old style it's TOP_OF_PIPE).
