### PR TITLE
scripts: Update to latest mimalloc

### DIFF
--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -57,7 +57,7 @@
                 "-DMI_BUILD_SHARED=OFF",
                 "-DMI_BUILD_TESTS=OFF"
             ],
-            "commit": "v3.0.3",
+            "commit": "v3.1.5",
             "build_platforms": [
                 "windows"
             ]


### PR DESCRIPTION
We updated mimcalloc from `2.*` to `3.*` in https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/10251 to match SPIR-V tools, so picking `3.0.3` over the latest `3.1.5` was due to that

but since released in the latest SDK, we have found the `3.0.3` version had issues where when you debug with GDB you will get leaked virtual allocation (https://vulkan.lunarg.com/issue/view/6891df0a75be2560b8b4cb89 https://vulkan.lunarg.com/issue/view/68606660758e2e78d0e00387)

This updates to 3.1.5 which we found doesn't have these issues

update - seems SPIR-V Tools just grabs the [latest version anyway](https://github.com/KhronosGroup/SPIRV-Tools/commit/c2977ef0a6e2c36bcb0755d9ac17ee8f760199a4) so this is even more justified to do