### PR TITLE
layers: Use const char over static or char const

### DIFF
--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -1185,7 +1185,7 @@ enum AttachmentType {
     ATTACHMENT_RESOLVE = 16,
 };
 
-char const *StringAttachmentType(uint8_t type) {
+const char *StringAttachmentType(uint8_t type) {
     switch (type) {
         case ATTACHMENT_COLOR:
             return "color";

--- a/layers/gpuav/core/gpuav_record.cpp
+++ b/layers/gpuav/core/gpuav_record.cpp
@@ -82,7 +82,7 @@ void Validator::PreCallRecordBeginCommandBuffer(VkCommandBuffer commandBuffer, c
 }
 
 void Instance::InternalWarning(LogObjectList objlist, const Location &loc, const char *const specific_message) const {
-    char const *vuid = gpuav_settings.debug_printf_only ? "WARNING-DEBUG-PRINTF" : "WARNING-GPU-Assisted-Validation";
+    const char *vuid = gpuav_settings.debug_printf_only ? "WARNING-DEBUG-PRINTF" : "WARNING-GPU-Assisted-Validation";
     LogWarning(vuid, objlist, loc, "Internal Warning: %s", specific_message);
 }
 

--- a/layers/gpuav/core/gpuav_setup.cpp
+++ b/layers/gpuav/core/gpuav_setup.cpp
@@ -399,8 +399,8 @@ void Validator::InternalVmaError(LogObjectList objlist, VkResult result, const c
     error_message += stats_string;
     vmaFreeStatsString(vma_allocator_, stats_string);
 
-    char const *layer_name = gpuav_settings.debug_printf_only ? "DebugPrintf" : "GPU-AV";
-    char const *vuid = gpuav_settings.debug_printf_only ? "UNASSIGNED-DEBUG-PRINTF" : "UNASSIGNED-GPU-Assisted-Validation";
+    const char *layer_name = gpuav_settings.debug_printf_only ? "DebugPrintf" : "GPU-AV";
+    const char *vuid = gpuav_settings.debug_printf_only ? "UNASSIGNED-DEBUG-PRINTF" : "UNASSIGNED-GPU-Assisted-Validation";
 
     LogError(vuid, objlist, Location(vvl::Func::Empty), "Internal VMA Error (%s), %s is being disabled. Details:\n%s",
              string_VkResult(result), layer_name, error_message.c_str());

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
@@ -1460,8 +1460,8 @@ void GpuShaderInstrumentor::InternalError(LogObjectList objlist, const Location 
     aborted_ = true;
     std::string error_message = specific_message;
 
-    char const *layer_name = gpuav_settings.debug_printf_only ? "DebugPrintf" : "GPU-AV";
-    char const *vuid = gpuav_settings.debug_printf_only ? "UNASSIGNED-DEBUG-PRINTF" : "UNASSIGNED-GPU-Assisted-Validation";
+    const char *layer_name = gpuav_settings.debug_printf_only ? "DebugPrintf" : "GPU-AV";
+    const char *vuid = gpuav_settings.debug_printf_only ? "UNASSIGNED-DEBUG-PRINTF" : "UNASSIGNED-GPU-Assisted-Validation";
 
     LogError(vuid, objlist, loc, "Internal Error, %s is being disabled. Details:\n%s", layer_name, error_message.c_str());
 
@@ -1472,12 +1472,12 @@ void GpuShaderInstrumentor::InternalError(LogObjectList objlist, const Location 
 }
 
 void GpuShaderInstrumentor::InternalWarning(LogObjectList objlist, const Location &loc, const char *const specific_message) const {
-    char const *vuid = gpuav_settings.debug_printf_only ? "WARNING-DEBUG-PRINTF" : "WARNING-GPU-Assisted-Validation";
+    const char *vuid = gpuav_settings.debug_printf_only ? "WARNING-DEBUG-PRINTF" : "WARNING-GPU-Assisted-Validation";
     LogWarning(vuid, objlist, loc, "Internal Warning: %s", specific_message);
 }
 
 void GpuShaderInstrumentor::InternalInfo(LogObjectList objlist, const Location &loc, const char *const specific_message) const {
-    char const *vuid = gpuav_settings.debug_printf_only ? "INFO-DEBUG-PRINTF" : "INFO-GPU-Assisted-Validation";
+    const char *vuid = gpuav_settings.debug_printf_only ? "INFO-DEBUG-PRINTF" : "INFO-GPU-Assisted-Validation";
     LogInfo(vuid, objlist, loc, "Internal Info: %s", specific_message);
 }
 

--- a/layers/state_tracker/shader_instruction.h
+++ b/layers/state_tracker/shader_instruction.h
@@ -64,9 +64,9 @@ class Instruction {
     // Only used to get strings in SPIR-V instructions
     // SPIR-V spec (and spirv-val) ensure:
     // "A string is interpreted as a nul-terminated stream of characters"
-    char const* GetAsString(uint32_t operand) const {
+    const char* GetAsString(uint32_t operand) const {
         assert(operand < Length());
-        return (char const*)&words_[operand];
+        return (const char*)&words_[operand];
     }
 
     uint32_t GetConstantValue() const;

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -1542,7 +1542,7 @@ std::string Module::DescribeInstruction(const Instruction& error_insn) const {
     return ss.str();
 }
 
-std::shared_ptr<const EntryPoint> Module::FindEntrypoint(char const* name, VkShaderStageFlagBits stageBits) const {
+std::shared_ptr<const EntryPoint> Module::FindEntrypoint(const char* name, VkShaderStageFlagBits stageBits) const {
     if (!name) return nullptr;
     for (const auto& entry_point : static_data_.entry_points) {
         if (entry_point->name.compare(name) == 0 && entry_point->stage == stageBits) {
@@ -1787,7 +1787,7 @@ uint32_t GetFormatType(VkFormat format) {
     return NumericTypeFloat;
 }
 
-char const* string_NumericType(uint32_t type) {
+const char* string_NumericType(uint32_t type) {
     if (type == NumericTypeSint) return "SINT";
     if (type == NumericTypeUint) return "UINT";
     if (type == NumericTypeFloat) return "FLOAT";

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -328,7 +328,7 @@ enum NumericType {
     NumericTypeUint = 4,
 };
 uint32_t GetFormatType(VkFormat format);
-char const *string_NumericType(uint32_t type);
+const char *string_NumericType(uint32_t type);
 
 // Common info needed for all OpVariable
 struct VariableBase {
@@ -759,7 +759,7 @@ struct Module {
     std::string DescribeVariable(uint32_t id) const;
     std::string DescribeInstruction(const Instruction &error_insn) const;
 
-    std::shared_ptr<const EntryPoint> FindEntrypoint(char const *name, VkShaderStageFlagBits stageBits) const;
+    std::shared_ptr<const EntryPoint> FindEntrypoint(const char *name, VkShaderStageFlagBits stageBits) const;
     LocalSize FindLocalSize(const EntryPoint &entrypoint) const;
 
     uint32_t CalculateWorkgroupSharedMemory() const;

--- a/tests/framework/ray_tracing_helper_nv.cpp
+++ b/tests/framework/ray_tracing_helper_nv.cpp
@@ -78,7 +78,7 @@ void RayTracingPipelineHelper::InitPipelineLayoutInfo() {
 }
 
 void RayTracingPipelineHelper::InitShaderInfo() {  // DONE
-    static const char rayGenShaderText[] = R"glsl(
+    const char rayGenShaderText[] = R"glsl(
         #version 460 core
         #extension GL_NV_ray_tracing : require
         layout(set = 0, binding = 0, rgba8) uniform image2D image;
@@ -102,7 +102,7 @@ void RayTracingPipelineHelper::InitShaderInfo() {  // DONE
         }
     )glsl";
 
-    static char const closestHitShaderText[] = R"glsl(
+    const char closestHitShaderText[] = R"glsl(
         #version 460 core
         #extension GL_NV_ray_tracing : require
         layout(location = 0) rayPayloadInNV float hitValue;
@@ -112,7 +112,7 @@ void RayTracingPipelineHelper::InitShaderInfo() {  // DONE
         }
     )glsl";
 
-    static char const missShaderText[] = R"glsl(
+    const char missShaderText[] = R"glsl(
         #version 460 core
         #extension GL_NV_ray_tracing : require
         layout(location = 0) rayPayloadInNV float hitValue;

--- a/tests/framework/shader_helper.cpp
+++ b/tests/framework/shader_helper.cpp
@@ -457,7 +457,7 @@ bool SlangToSPV(const char *slang_shader, const char *entry_point_name, std::vec
 VkPipelineShaderStageCreateInfo const &VkShaderObj::GetStageCreateInfo() const { return m_stage_info; }
 
 VkShaderObj::VkShaderObj(vkt::Device &device, const char *source, VkShaderStageFlagBits stage, const spv_target_env env,
-                         SpvSourceType source_type, const VkSpecializationInfo *spec_info, char const *entry_point,
+                         SpvSourceType source_type, const VkSpecializationInfo *spec_info, const char *entry_point,
                          const void *pNext)
     : m_device(&device), m_source(source), m_spv_env(env) {
     m_stage_info = vku::InitStructHelper();
@@ -476,7 +476,7 @@ VkShaderObj::VkShaderObj(vkt::Device &device, const char *source, VkShaderStageF
 }
 
 VkShaderObj::VkShaderObj(VkRenderFramework *framework, const char *source, VkShaderStageFlagBits stage, const spv_target_env env,
-                         SpvSourceType source_type, const VkSpecializationInfo *spec_info, char const *entry_point,
+                         SpvSourceType source_type, const VkSpecializationInfo *spec_info, const char *entry_point,
                          const void *pNext)
     : VkShaderObj(*framework->DeviceObj(), source, stage, env, source_type, spec_info, entry_point, pNext) {}
 

--- a/tests/framework/shader_helper.h
+++ b/tests/framework/shader_helper.h
@@ -55,12 +55,12 @@ class VkShaderObj : public vkt::ShaderModule {
     // optional arguments listed order of most likely to be changed manually by a test
     VkShaderObj(vkt::Device &device, const char *source, VkShaderStageFlagBits stage, const spv_target_env env = SPV_ENV_VULKAN_1_0,
                 SpvSourceType source_type = SPV_SOURCE_GLSL, const VkSpecializationInfo *spec_info = nullptr,
-                char const *entry_point = "main", const void *pNext = nullptr);
+                const char *entry_point = "main", const void *pNext = nullptr);
 
     // DEPRECATED
     VkShaderObj(VkRenderFramework *framework, const char *source, VkShaderStageFlagBits stage,
                 const spv_target_env env = SPV_ENV_VULKAN_1_0, SpvSourceType source_type = SPV_SOURCE_GLSL,
-                const VkSpecializationInfo *spec_info = nullptr, char const *entry_point = "main", const void *pNext = nullptr);
+                const VkSpecializationInfo *spec_info = nullptr, const char *entry_point = "main", const void *pNext = nullptr);
 
     VkPipelineShaderStageCreateInfo const &GetStageCreateInfo() const;
 

--- a/tests/framework/shader_templates.h
+++ b/tests/framework/shader_templates.h
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (c) 2015-2024 Google, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2025 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ static const char kVertexPointSizeGlsl[] = R"glsl(
     }
 )glsl";
 
-static char const kGeometryMinimalGlsl[] = R"glsl(
+static const char kGeometryMinimalGlsl[] = R"glsl(
     #version 460
     layout(triangles) in;
     layout(triangle_strip, max_vertices=3) out;
@@ -60,7 +60,7 @@ static char const kGeometryMinimalGlsl[] = R"glsl(
     }
 )glsl";
 
-static char const kGeometryPointSizeGlsl[] = R"glsl(
+static const char kGeometryPointSizeGlsl[] = R"glsl(
     #version 460
     layout (points) in;
     layout (points) out;
@@ -117,7 +117,7 @@ static const char kFragmentUniformGlsl[] = R"glsl(
     }
 )glsl";
 
-static char const kFragmentSubpassLoadGlsl[] = R"glsl(
+static const char kFragmentSubpassLoadGlsl[] = R"glsl(
     #version 460
     layout(input_attachment_index=0, set=0, binding=0) uniform subpassInput x;
     void main() {
@@ -148,7 +148,7 @@ static char const kFragmentSubpassLoadGlsl[] = R"glsl(
     void main() {}
 )glsl";
 
-[[maybe_unused]] static char const kRayTracingPayloadMinimalGlsl[] = R"glsl(
+[[maybe_unused]] static const char kRayTracingPayloadMinimalGlsl[] = R"glsl(
         #version 460
         #extension GL_EXT_ray_tracing : enable
         layout(location = 0) rayPayloadInEXT float hitValue;
@@ -164,7 +164,7 @@ static char const kFragmentSubpassLoadGlsl[] = R"glsl(
     void main() {}
 )glsl";
 
-static char const kShaderTileImageDepthReadSpv[] = R"(
+static const char kShaderTileImageDepthReadSpv[] = R"(
                OpCapability Shader
                OpCapability TileImageDepthReadAccessEXT
                OpExtension "SPV_EXT_shader_tile_image"
@@ -198,7 +198,7 @@ static char const kShaderTileImageDepthReadSpv[] = R"(
                OpFunctionEnd
         )";
 
-static char const kShaderTileImageStencilReadSpv[] = R"(
+static const char kShaderTileImageStencilReadSpv[] = R"(
                OpCapability Shader
                OpCapability TileImageStencilReadAccessEXT
                OpExtension "SPV_EXT_shader_tile_image"
@@ -235,7 +235,7 @@ static char const kShaderTileImageStencilReadSpv[] = R"(
                OpFunctionEnd
         )";
 
-static char const kShaderTileImageColorReadSpv[] = R"(
+static const char kShaderTileImageColorReadSpv[] = R"(
                OpCapability Shader
                OpCapability TileImageColorReadAccessEXT
                OpExtension "SPV_EXT_shader_tile_image"
@@ -268,7 +268,7 @@ static char const kShaderTileImageColorReadSpv[] = R"(
                OpFunctionEnd
         )";
 
-static char const kShaderTileImageDepthStencilReadSpv[] = R"(
+static const char kShaderTileImageDepthStencilReadSpv[] = R"(
                OpCapability Shader
                OpCapability TileImageDepthReadAccessEXT
                OpCapability TileImageStencilReadAccessEXT
@@ -338,4 +338,4 @@ static char const kShaderTileImageDepthStencilReadSpv[] = R"(
         }
     )glsl";
 
-[[maybe_unused]] static char const *kMissGlsl = kRayTracingPayloadMinimalGlsl;
+[[maybe_unused]] static const char *kMissGlsl = kRayTracingPayloadMinimalGlsl;

--- a/tests/unit/amd_best_practices.cpp
+++ b/tests/unit/amd_best_practices.cpp
@@ -600,7 +600,7 @@ TEST_F(VkAmdBestPracticesLayerTest, ComputeWorkgroupSizeMaintenance5) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableAMDValidation));
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(local_size_x = 4, local_size_y = 1, local_size_z = 1) in;
         void main(){}

--- a/tests/unit/arm_best_practices.cpp
+++ b/tests/unit/arm_best_practices.cpp
@@ -743,7 +743,7 @@ TEST_F(VkArmBestPracticesLayerTest, ComputeShaderBadWorkGroupThreadAlignmentTest
     RETURN_IF_SKIP(InitState());
 
     {
-        char const* csSource = R"glsl(
+        const char* csSource = R"glsl(
             #version 450
             layout(local_size_x = 4, local_size_y = 1, local_size_z = 1) in;
             void main(){}
@@ -755,7 +755,7 @@ TEST_F(VkArmBestPracticesLayerTest, ComputeShaderBadWorkGroupThreadAlignmentTest
     }
 
     {
-        char const* csSource = R"glsl(
+        const char* csSource = R"glsl(
             #version 450
             layout(local_size_x = 4, local_size_y = 1, local_size_z = 3) in;
             void main(){}
@@ -771,7 +771,7 @@ TEST_F(VkArmBestPracticesLayerTest, ComputeShaderBadWorkGroupThreadAlignmentTest
     }
 
     if (m_device->Physical().limits_.maxComputeWorkGroupInvocations > 128) {
-        char const* csSource = R"glsl(
+        const char* csSource = R"glsl(
             #version 450
             layout(local_size_x = 16, local_size_y = 9, local_size_z = 1) in;
             void main(){}
@@ -793,7 +793,7 @@ TEST_F(VkArmBestPracticesLayerTest, ComputeShaderBadWorkGroupThreadCountTest) {
 
     // these two pipelines should not cause any warning
     {
-        char const* csSource = R"glsl(
+        const char* csSource = R"glsl(
             #version 450
             layout(local_size_x = 4, local_size_y = 1, local_size_z = 1) in;
             void main(){}
@@ -805,7 +805,7 @@ TEST_F(VkArmBestPracticesLayerTest, ComputeShaderBadWorkGroupThreadCountTest) {
     }
 
     {
-        char const* csSource = R"glsl(
+        const char* csSource = R"glsl(
             #version 450
             layout(local_size_x = 4, local_size_y = 1, local_size_z = 3) in;
             void main(){}
@@ -818,7 +818,7 @@ TEST_F(VkArmBestPracticesLayerTest, ComputeShaderBadWorkGroupThreadCountTest) {
 
     // this pipeline should cause a warning due to the total workgroup count
     {
-        char const* csSource = R"glsl(
+        const char* csSource = R"glsl(
             #version 450
             layout(local_size_x = 16, local_size_y = 8, local_size_z = 1) in;
             void main(){}
@@ -846,7 +846,7 @@ TEST_F(VkArmBestPracticesLayerTest, ComputeShaderBadSpatialLocality) {
                                        });
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
-    char const* compute_sampler_2d_8_8_1 = R"glsl(
+    const char* compute_sampler_2d_8_8_1 = R"glsl(
         #version 450
         layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
         layout(set = 0, binding = 0) uniform sampler2D uSampler;
@@ -855,7 +855,7 @@ TEST_F(VkArmBestPracticesLayerTest, ComputeShaderBadSpatialLocality) {
         }
     )glsl";
 
-    char const* compute_sampler_1d_64_1_1 = R"glsl(
+    const char* compute_sampler_1d_64_1_1 = R"glsl(
         #version 450
         layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
         layout(set = 0, binding = 0) uniform sampler1D uSampler;
@@ -864,7 +864,7 @@ TEST_F(VkArmBestPracticesLayerTest, ComputeShaderBadSpatialLocality) {
         }
     )glsl";
 
-    char const* compute_sampler_2d_64_1_1 = R"glsl(
+    const char* compute_sampler_2d_64_1_1 = R"glsl(
         #version 450
         layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
         layout(set = 0, binding = 0) uniform sampler2D uSampler;
@@ -904,7 +904,7 @@ TEST_F(VkArmBestPracticesLayerTest, ComputeShaderBadSpatialLocalityMultiEntrypoi
 
     // Empty 1D compute entrypoint
     // Fragment entrypoint accesses simple 2D sampler
-    char const* cs_source = R"(
+    const char* cs_source = R"(
                OpCapability Shader
           %2 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450

--- a/tests/unit/atomics.cpp
+++ b/tests/unit/atomics.cpp
@@ -29,7 +29,7 @@ TEST_F(NegativeAtomic, VertexStoresAndAtomicsFeatureDisable) {
 
     // Test StoreOp
     {
-        char const *vsSource = R"glsl(
+        const char *vsSource = R"glsl(
             #version 450
             layout(set=0, binding=0, rgba8) uniform image2D si0;
             void main() {
@@ -49,7 +49,7 @@ TEST_F(NegativeAtomic, VertexStoresAndAtomicsFeatureDisable) {
 
     // Test AtomicOp
     {
-        char const *vsSource = R"glsl(
+        const char *vsSource = R"glsl(
             #version 450
             layout(set=0, binding=0, r32f) uniform image2D si0;
             void main() {
@@ -80,7 +80,7 @@ TEST_F(NegativeAtomic, FragmentStoresAndAtomicsFeatureDisable) {
 
     // Test StoreOp
     {
-        char const *fsSource = R"glsl(
+        const char *fsSource = R"glsl(
             #version 450
             layout(set=0, binding=0, rgba8) uniform image2D si0;
             void main() {
@@ -100,7 +100,7 @@ TEST_F(NegativeAtomic, FragmentStoresAndAtomicsFeatureDisable) {
 
     // Test AtomicOp
     {
-        char const *fsSource = R"glsl(
+        const char *fsSource = R"glsl(
             #version 450
             layout(set=0, binding=0, r32f) uniform image2D si0;
             void main() {
@@ -127,7 +127,7 @@ TEST_F(NegativeAtomic, FragmentStoresAndAtomicsFeatureBuffer) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer ssbo { int y; };
         void main() {
@@ -155,7 +155,7 @@ TEST_F(NegativeAtomic, VertexStoresAndAtomicsFeatureDisableShaderObject) {
 
     RETURN_IF_SKIP(Init());
 
-    char const *vs_source = R"glsl(
+    const char *vs_source = R"glsl(
         #version 450
         layout(set=0, binding=0, rgba8) uniform image2D si0;
         void main() {
@@ -1338,7 +1338,7 @@ TEST_F(NegativeAtomic, InvalidStorageOperation) {
     vkt::Buffer buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT);
     vkt::BufferView buffer_view(*m_device, buffer, buffer_view_format);
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(set = 0, binding = 3, r32f) uniform image2D si0;
         layout(set = 0, binding = 2, r32f) uniform image2D si1[2];
@@ -1475,7 +1475,7 @@ TEST_F(NegativeAtomic, VertexPipelineStoresAndAtomics) {
     //     float a;
     //     float b;
     // } data;
-    char const *vsSource = R"(
+    const char *vsSource = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %main "main" %o

--- a/tests/unit/atomics_positive.cpp
+++ b/tests/unit/atomics_positive.cpp
@@ -946,7 +946,7 @@ TEST_F(PositiveAtomic, VertexPipelineStoresAndAtomics) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(set=0, binding=0, std430) readonly buffer SSBO {
             float a;

--- a/tests/unit/best_practices.cpp
+++ b/tests/unit/best_practices.cpp
@@ -911,7 +911,7 @@ TEST_F(VkBestPracticesLayerTest, CreatePipelineVsFsTypeMismatchArraySize) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) out float x[2];
         void main(){
@@ -919,7 +919,7 @@ TEST_F(VkBestPracticesLayerTest, CreatePipelineVsFsTypeMismatchArraySize) {
            gl_Position = vec4(1);
         }
     )glsl";
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0) in float x[1];
         layout(location=0) out vec4 color;
@@ -1837,7 +1837,7 @@ TEST_F(VkBestPracticesLayerTest, PartialPushConstantSetEnd) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *const vsSource = R"glsl(
+    const char *const vsSource = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo { uint x[2]; } constants;
         void main(){
@@ -1879,7 +1879,7 @@ TEST_F(VkBestPracticesLayerTest, PartialPushConstantSetMiddle) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *const vsSource = R"glsl(
+    const char *const vsSource = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo {
             uint a; // set
@@ -2133,7 +2133,7 @@ TEST_F(VkBestPracticesLayerTest, PartialPushConstantSetEndCompute) {
     RETURN_IF_SKIP(InitBestPracticesFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *const csSource = R"glsl(
+    const char *const csSource = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo { uint x[2]; } constants;
         layout(set = 0, binding = 0) buffer bar { vec4 r; } res;

--- a/tests/unit/best_practices_positive.cpp
+++ b/tests/unit/best_practices_positive.cpp
@@ -196,7 +196,7 @@ TEST_F(VkPositiveBestPracticesLayerTest, PushConstantSet) {
 
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit);
 
-    char const *const vsSource = R"glsl(
+    const char *const vsSource = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo { uint x[4]; } constants;
         void main(){
@@ -450,7 +450,7 @@ TEST_F(VkPositiveBestPracticesLayerTest, ShaderObjectDraw) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    static const char kVertexGlsl[] = R"glsl(
+    const char kVertexGlsl[] = R"glsl(
         #version 460
         layout(location = 0) in vec4 pos;
         void main() {

--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -297,7 +297,7 @@ TEST_F(NegativeCommand, PushConstants) {
     //
     struct PipelineLayoutTestCase {
         VkPushConstantRange const range;
-        char const *msg;
+        const char *msg;
     };
 
     const uint32_t too_big = m_device->Physical().limits_.maxPushConstantsSize + 0x4;
@@ -338,7 +338,7 @@ TEST_F(NegativeCommand, PushConstants) {
     const uint32_t ranges_per_test = 5;
     struct DuplicateStageFlagsTestCase {
         VkPushConstantRange const ranges[ranges_per_test];
-        std::vector<char const *> const msg;
+        std::vector<const char *> const msg;
     };
     // Overlapping ranges are OK, but a stage flag can appear only once.
     const std::array<DuplicateStageFlagsTestCase, 3> duplicate_stageFlags_tests = {
@@ -887,7 +887,7 @@ TEST_F(NegativeCommand, DrawTimeImageViewTypeMismatchWithPipeline) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler3D s;
         layout(location=0) out vec4 color;
@@ -935,7 +935,7 @@ TEST_F(NegativeCommand, DrawTimeImageViewTypeMismatchWithPipelineFunction) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler3D s;
         layout(location=0) out vec4 color;
@@ -991,7 +991,7 @@ TEST_F(NegativeCommand, DrawTimeImageComponentTypeMismatchWithPipeline) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform isampler2D s;
         layout(location=0) out vec4 color;
@@ -2524,7 +2524,7 @@ TEST_F(NegativeCommand, ImageFilterCubicSamplerInCmdDraw) {
     vkt::Sampler sampler(*m_device, sampler_ci);
     ASSERT_TRUE(sampler.initialized());
 
-    static const char fs_src[] = R"glsl(
+    const char fs_src[] = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler3D s;
         layout(location=0) out vec4 x;
@@ -4090,7 +4090,7 @@ TEST_F(NegativeCommand, CommandBufferRecording) {
 TEST_F(NegativeCommand, ManyInvalidatedObjects) {
     RETURN_IF_SKIP(Init());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer SSBO_0 {
             vec4 a;

--- a/tests/unit/debug_printf.cpp
+++ b/tests/unit/debug_printf.cpp
@@ -65,7 +65,7 @@ void NegativeDebugPrintf::BasicComputeTest(const char *shader, const char *messa
 }
 
 TEST_F(NegativeDebugPrintf, Float) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -77,7 +77,7 @@ TEST_F(NegativeDebugPrintf, Float) {
 }
 
 TEST_F(NegativeDebugPrintf, IntUnsigned) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -89,7 +89,7 @@ TEST_F(NegativeDebugPrintf, IntUnsigned) {
 }
 
 TEST_F(NegativeDebugPrintf, IntUnsignedUnderflow) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -101,7 +101,7 @@ TEST_F(NegativeDebugPrintf, IntUnsignedUnderflow) {
 }
 
 TEST_F(NegativeDebugPrintf, IntSignedOverflow) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -113,7 +113,7 @@ TEST_F(NegativeDebugPrintf, IntSignedOverflow) {
 }
 
 TEST_F(NegativeDebugPrintf, TwoFloats) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -125,7 +125,7 @@ TEST_F(NegativeDebugPrintf, TwoFloats) {
 }
 
 TEST_F(NegativeDebugPrintf, FloatPrecision) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -137,7 +137,7 @@ TEST_F(NegativeDebugPrintf, FloatPrecision) {
 }
 
 TEST_F(NegativeDebugPrintf, TextBeforeAndAfter) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -149,7 +149,7 @@ TEST_F(NegativeDebugPrintf, TextBeforeAndAfter) {
 }
 
 TEST_F(NegativeDebugPrintf, IntOctal) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -161,7 +161,7 @@ TEST_F(NegativeDebugPrintf, IntOctal) {
 }
 
 TEST_F(NegativeDebugPrintf, IntOctalNegative) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -173,7 +173,7 @@ TEST_F(NegativeDebugPrintf, IntOctalNegative) {
 }
 
 TEST_F(NegativeDebugPrintf, IntNegative) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -185,7 +185,7 @@ TEST_F(NegativeDebugPrintf, IntNegative) {
 }
 
 TEST_F(NegativeDebugPrintf, FloatVector2) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -197,7 +197,7 @@ TEST_F(NegativeDebugPrintf, FloatVector2) {
 }
 
 TEST_F(NegativeDebugPrintf, FloatVector3) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -209,7 +209,7 @@ TEST_F(NegativeDebugPrintf, FloatVector3) {
 }
 
 TEST_F(NegativeDebugPrintf, FloatVector4) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -221,7 +221,7 @@ TEST_F(NegativeDebugPrintf, FloatVector4) {
 }
 
 TEST_F(NegativeDebugPrintf, FloatVectorPrecision) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -233,7 +233,7 @@ TEST_F(NegativeDebugPrintf, FloatVectorPrecision) {
 }
 
 TEST_F(NegativeDebugPrintf, FloatVectorPrecisionZeroPad) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -245,7 +245,7 @@ TEST_F(NegativeDebugPrintf, FloatVectorPrecisionZeroPad) {
 }
 
 TEST_F(NegativeDebugPrintf, FloatVectorZeroPad) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -257,7 +257,7 @@ TEST_F(NegativeDebugPrintf, FloatVectorZeroPad) {
 }
 
 TEST_F(NegativeDebugPrintf, FloatVectorScientificNotation) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -269,7 +269,7 @@ TEST_F(NegativeDebugPrintf, FloatVectorScientificNotation) {
 }
 
 TEST_F(NegativeDebugPrintf, IntVector) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -281,7 +281,7 @@ TEST_F(NegativeDebugPrintf, IntVector) {
 }
 
 TEST_F(NegativeDebugPrintf, IntVectorUnsigned) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -293,7 +293,7 @@ TEST_F(NegativeDebugPrintf, IntVectorUnsigned) {
 }
 
 TEST_F(NegativeDebugPrintf, IntVectorHex) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -305,7 +305,7 @@ TEST_F(NegativeDebugPrintf, IntVectorHex) {
 }
 
 TEST_F(NegativeDebugPrintf, IntVectorZeroPad) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -317,7 +317,7 @@ TEST_F(NegativeDebugPrintf, IntVectorZeroPad) {
 }
 
 TEST_F(NegativeDebugPrintf, ScientificNotation) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -329,7 +329,7 @@ TEST_F(NegativeDebugPrintf, ScientificNotation) {
 }
 
 TEST_F(NegativeDebugPrintf, ScientificNotationPrecision) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -341,7 +341,7 @@ TEST_F(NegativeDebugPrintf, ScientificNotationPrecision) {
 }
 
 TEST_F(NegativeDebugPrintf, FloatShortest) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -354,7 +354,7 @@ TEST_F(NegativeDebugPrintf, FloatShortest) {
 
 // TODO - This prints out  0x1.921cacp+1 vs 0x1.921cac0000000p+1 depending on Windows or not
 TEST_F(NegativeDebugPrintf, DISABLED_FloatHex) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -366,7 +366,7 @@ TEST_F(NegativeDebugPrintf, DISABLED_FloatHex) {
 }
 
 TEST_F(NegativeDebugPrintf, FloatHexPrecision) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -379,7 +379,7 @@ TEST_F(NegativeDebugPrintf, FloatHexPrecision) {
 
 TEST_F(NegativeDebugPrintf, Int64) {
     AddRequiredFeature(vkt::Feature::shaderInt64);
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -393,7 +393,7 @@ TEST_F(NegativeDebugPrintf, Int64) {
 
 TEST_F(NegativeDebugPrintf, Int64Vector) {
     AddRequiredFeature(vkt::Feature::shaderInt64);
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -408,7 +408,7 @@ TEST_F(NegativeDebugPrintf, Int64Vector) {
 
 TEST_F(NegativeDebugPrintf, Int64Hex) {
     AddRequiredFeature(vkt::Feature::shaderInt64);
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -422,7 +422,7 @@ TEST_F(NegativeDebugPrintf, Int64Hex) {
 
 TEST_F(NegativeDebugPrintf, Int64VectorHex) {
     AddRequiredFeature(vkt::Feature::shaderInt64);
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -438,7 +438,7 @@ TEST_F(NegativeDebugPrintf, Int64VectorHex) {
 // TODO - Windows trims the leading values and will print 0x001 (Linux ignores the Precision)
 TEST_F(NegativeDebugPrintf, DISABLED_Int64VectorHexPrecision) {
     AddRequiredFeature(vkt::Feature::shaderInt64);
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -453,7 +453,7 @@ TEST_F(NegativeDebugPrintf, DISABLED_Int64VectorHexPrecision) {
 
 TEST_F(NegativeDebugPrintf, Int64VectorDecimal) {
     AddRequiredFeature(vkt::Feature::shaderInt64);
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -468,7 +468,7 @@ TEST_F(NegativeDebugPrintf, Int64VectorDecimal) {
 
 TEST_F(NegativeDebugPrintf, Float64) {
     AddRequiredFeature(vkt::Feature::shaderFloat64);
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_shader_explicit_arithmetic_types_float64 : enable
@@ -483,7 +483,7 @@ TEST_F(NegativeDebugPrintf, Float64) {
 
 TEST_F(NegativeDebugPrintf, Float64Vector) {
     AddRequiredFeature(vkt::Feature::shaderFloat64);
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_shader_explicit_arithmetic_types_float64 : enable
@@ -498,7 +498,7 @@ TEST_F(NegativeDebugPrintf, Float64Vector) {
 
 TEST_F(NegativeDebugPrintf, Float64VectorPrecision) {
     AddRequiredFeature(vkt::Feature::shaderFloat64);
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_shader_explicit_arithmetic_types_float64 : enable
@@ -515,7 +515,7 @@ TEST_F(NegativeDebugPrintf, FloatMix) {
     AddRequiredExtensions(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::shaderFloat16);
     AddRequiredFeature(vkt::Feature::shaderFloat64);
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_shader_explicit_arithmetic_types_float16 : enable
@@ -533,7 +533,7 @@ TEST_F(NegativeDebugPrintf, FloatMix) {
 TEST_F(NegativeDebugPrintf, Float16) {
     AddRequiredExtensions(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::shaderFloat16);
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_shader_explicit_arithmetic_types_float16 : enable
@@ -549,7 +549,7 @@ TEST_F(NegativeDebugPrintf, Float16) {
 TEST_F(NegativeDebugPrintf, Float16Vector) {
     AddRequiredExtensions(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::shaderFloat16);
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_shader_explicit_arithmetic_types_float16 : enable
@@ -565,7 +565,7 @@ TEST_F(NegativeDebugPrintf, Float16Vector) {
 TEST_F(NegativeDebugPrintf, Float16Precision) {
     AddRequiredExtensions(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::shaderFloat16);
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_shader_explicit_arithmetic_types_float16 : enable
@@ -580,7 +580,7 @@ TEST_F(NegativeDebugPrintf, Float16Precision) {
 // TODO casting is wrong
 TEST_F(NegativeDebugPrintf, Int16) {
     AddRequiredFeature(vkt::Feature::shaderInt16);
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_shader_explicit_arithmetic_types_int16: enable
@@ -595,7 +595,7 @@ TEST_F(NegativeDebugPrintf, Int16) {
 
 TEST_F(NegativeDebugPrintf, Int16Vector) {
     AddRequiredFeature(vkt::Feature::shaderInt16);
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_shader_explicit_arithmetic_types_int16: enable
@@ -612,7 +612,7 @@ TEST_F(NegativeDebugPrintf, Int16Vector) {
 
 TEST_F(NegativeDebugPrintf, Int16Hex) {
     AddRequiredFeature(vkt::Feature::shaderInt16);
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_shader_explicit_arithmetic_types_int16: enable
@@ -628,7 +628,7 @@ TEST_F(NegativeDebugPrintf, Int16Hex) {
 TEST_F(NegativeDebugPrintf, Int8) {
     AddRequiredExtensions(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::shaderInt8);
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_shader_explicit_arithmetic_types_int8: enable
@@ -644,7 +644,7 @@ TEST_F(NegativeDebugPrintf, Int8) {
 TEST_F(NegativeDebugPrintf, Int8Vector) {
     AddRequiredExtensions(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::shaderInt8);
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_shader_explicit_arithmetic_types_int8: enable
@@ -662,7 +662,7 @@ TEST_F(NegativeDebugPrintf, Int8Vector) {
 TEST_F(NegativeDebugPrintf, Int8Hex) {
     AddRequiredExtensions(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::shaderInt8);
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_shader_explicit_arithmetic_types_int8: enable
@@ -676,7 +676,7 @@ TEST_F(NegativeDebugPrintf, Int8Hex) {
 }
 
 TEST_F(NegativeDebugPrintf, BoolAsHex) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -689,7 +689,7 @@ TEST_F(NegativeDebugPrintf, BoolAsHex) {
 }
 
 TEST_F(NegativeDebugPrintf, BoolVector) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
 
@@ -708,7 +708,7 @@ TEST_F(NegativeDebugPrintf, BoolVector) {
 }
 
 TEST_F(NegativeDebugPrintf, BoolNonConstant) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
 
@@ -724,7 +724,7 @@ TEST_F(NegativeDebugPrintf, BoolNonConstant) {
 }
 
 TEST_F(NegativeDebugPrintf, Int32Before) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -739,7 +739,7 @@ TEST_F(NegativeDebugPrintf, Int32Before) {
 }
 
 TEST_F(NegativeDebugPrintf, Int32After) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -755,7 +755,7 @@ TEST_F(NegativeDebugPrintf, Int32After) {
 
 TEST_F(NegativeDebugPrintf, Int64Before) {
     AddRequiredFeature(vkt::Feature::shaderInt64);
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -773,7 +773,7 @@ TEST_F(NegativeDebugPrintf, Int64Before) {
 
 TEST_F(NegativeDebugPrintf, Int64After) {
     AddRequiredFeature(vkt::Feature::shaderInt64);
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -790,7 +790,7 @@ TEST_F(NegativeDebugPrintf, Int64After) {
 
 TEST_F(NegativeDebugPrintf, Int64Signed) {
     AddRequiredFeature(vkt::Feature::shaderInt64);
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -807,7 +807,7 @@ TEST_F(NegativeDebugPrintf, Int64Signed) {
 
 TEST_F(NegativeDebugPrintf, Int64SignedMix) {
     AddRequiredFeature(vkt::Feature::shaderInt64);
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -822,7 +822,7 @@ TEST_F(NegativeDebugPrintf, Int64SignedMix) {
 }
 
 TEST_F(NegativeDebugPrintf, FunctionParam) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         int foo(int x, int y) {
@@ -844,7 +844,7 @@ TEST_F(NegativeDebugPrintf, Pointers) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_buffer_reference : enable
@@ -902,7 +902,7 @@ TEST_F(NegativeDebugPrintf, Empty) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -931,7 +931,7 @@ TEST_F(NegativeDebugPrintf, MultipleFunctions) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         int data = 0;
@@ -979,7 +979,7 @@ TEST_F(NegativeDebugPrintf, Fragment) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(location = 0) out vec4 outColor;
@@ -1024,7 +1024,7 @@ TEST_F(NegativeDebugPrintf, HLSL) {
     //         printf("launchIndex %v2d", launchIndex);
     //    }
     // }
-    char const *shader_source = R"(
+    const char *shader_source = R"(
                OpCapability Shader
                OpExtension "SPV_KHR_non_semantic_info"
          %29 = OpExtInstImport "NonSemantic.DebugPrintf"
@@ -1105,7 +1105,7 @@ TEST_F(NegativeDebugPrintf, MultiDraw) {
     descriptor_set.WriteDescriptorBufferInfo(0, buffer_in, 0, sizeof(uint32_t));
     descriptor_set.UpdateDescriptorSets();
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) uniform ufoo {
@@ -1197,7 +1197,7 @@ TEST_F(NegativeDebugPrintf, MeshTaskShadersNV) {
     RETURN_IF_SKIP(InitState(nullptr, &mesh_shader_features));
     InitRenderTarget();
 
-    static const char taskShaderText[] = R"glsl(
+    const char taskShaderText[] = R"glsl(
         #version 460
         #extension GL_NV_mesh_shader : enable
         #extension GL_EXT_debug_printf : enable
@@ -1211,7 +1211,7 @@ TEST_F(NegativeDebugPrintf, MeshTaskShadersNV) {
         }
         )glsl";
 
-    static const char meshShaderText[] = R"glsl(
+    const char meshShaderText[] = R"glsl(
         #version 450
         #extension GL_NV_mesh_shader : require
         #extension GL_EXT_debug_printf : enable
@@ -1365,7 +1365,7 @@ TEST_F(NegativeDebugPrintf, MeshTaskIndirect) {
         }
     )glsl";
 
-    char const *mesh_source = R"glsl(
+    const char *mesh_source = R"glsl(
         #version 450
         #extension GL_EXT_mesh_shader : require
         #extension GL_EXT_debug_printf : enable
@@ -1384,7 +1384,7 @@ TEST_F(NegativeDebugPrintf, MeshTaskIndirect) {
         }
     )glsl";
 
-    char const *frag_source = R"glsl(
+    const char *frag_source = R"glsl(
         #version 460
         #extension GL_EXT_debug_printf : enable
         layout(location = 0) out vec4 uFragColor;
@@ -1448,7 +1448,7 @@ TEST_F(NegativeDebugPrintf, GPL) {
     descriptor_set.WriteDescriptorBufferInfo(0, buffer_in, 0, sizeof(uint32_t));
     descriptor_set.UpdateDescriptorSets();
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) uniform ufoo {
@@ -1512,7 +1512,7 @@ TEST_F(NegativeDebugPrintf, GPL) {
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
 
-    std::vector<char const *> messages;
+    std::vector<const char *> messages;
     messages.emplace_back("Here are two float values 1.000000, 3.141500");
     messages.emplace_back("Here's a smaller float value 3.14");
     messages.emplace_back("Here's an integer -135 with text before and after it");
@@ -1558,7 +1558,7 @@ TEST_F(NegativeDebugPrintf, GPLMultiDraw) {
     descriptor_set.WriteDescriptorBufferInfo(0, buffer_in, 0, sizeof(uint32_t));
     descriptor_set.UpdateDescriptorSets();
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) uniform ufoo {
@@ -1642,7 +1642,7 @@ TEST_F(NegativeDebugPrintf, GPLInt64) {
     descriptor_set.WriteDescriptorBufferInfo(0, buffer_in, 0, sizeof(uint32_t));
     descriptor_set.UpdateDescriptorSets();
 
-    char const *shader_source_int64 = R"glsl(
+    const char *shader_source_int64 = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -1737,7 +1737,7 @@ TEST_F(NegativeDebugPrintf, GPLFragment) {
 
     const std::array<VkDescriptorSet, 2> desc_sets = {vertex_set.set_, fragment_set.set_};
 
-    static const char vert_shader[] = R"glsl(
+    const char vert_shader[] = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) readonly buffer Input { uint u_buffer[]; } v_in; // texel_buffer[4]
@@ -1755,7 +1755,7 @@ TEST_F(NegativeDebugPrintf, GPLFragment) {
         }
     )glsl";
 
-    static const char frag_shader[] = R"glsl(
+    const char frag_shader[] = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 1, binding = 0) readonly buffer Input { uint u_buffer[]; } f_in; // texel_buffer[4]
@@ -1832,7 +1832,7 @@ TEST_F(NegativeDebugPrintf, GPLFragmentIndependentSets) {
     vertex_input_lib.InitVertexInputLibInfo();
     vertex_input_lib.CreateGraphicsPipeline(false);
 
-    static const char vertshader[] = R"glsl(
+    const char vertshader[] = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) readonly buffer Input { uint u_buffer[]; } v_in; // texel_buffer[4]
@@ -1861,7 +1861,7 @@ TEST_F(NegativeDebugPrintf, GPLFragmentIndependentSets) {
     pre_raster_lib.gp_ci_.layout = pipeline_layout_vs;
     pre_raster_lib.CreateGraphicsPipeline(false);
 
-    static const char frag_shader[] = R"glsl(
+    const char frag_shader[] = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 1, binding = 0) readonly buffer Input { uint u_buffer[]; } f_in; // texel_buffer[4]
@@ -1922,7 +1922,7 @@ TEST_F(NegativeDebugPrintf, ShaderObjectsGraphics) {
     RETURN_IF_SKIP(InitState());
     InitDynamicRenderTarget();
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -1956,7 +1956,7 @@ TEST_F(NegativeDebugPrintf, ShaderObjects) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -2006,7 +2006,7 @@ TEST_F(NegativeDebugPrintf, ShaderObjectsInt64) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -2046,7 +2046,7 @@ TEST_F(NegativeDebugPrintf, ShaderObjectsMultiDraw) {
     RETURN_IF_SKIP(InitState());
     InitDynamicRenderTarget();
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -2120,7 +2120,7 @@ TEST_F(NegativeDebugPrintf, MeshTaskShaderObjects) {
     RETURN_IF_SKIP(InitState());
     InitDynamicRenderTarget();
 
-    static const char *taskShaderText = R"glsl(
+    const char *taskShaderText = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : require // Requires SPIR-V 1.5 (Vulkan 1.2)
         #extension GL_EXT_debug_printf : enable
@@ -2131,7 +2131,7 @@ TEST_F(NegativeDebugPrintf, MeshTaskShaderObjects) {
         }
     )glsl";
 
-    static const char *meshShaderText = R"glsl(
+    const char *meshShaderText = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : require // Requires SPIR-V 1.5 (Vulkan 1.2)
         #extension GL_EXT_debug_printf : enable
@@ -2168,7 +2168,7 @@ TEST_F(NegativeDebugPrintf, VertexFragmentSeparateShader) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    static const char vert_shader[] = R"glsl(
+    const char vert_shader[] = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
 
@@ -2178,7 +2178,7 @@ TEST_F(NegativeDebugPrintf, VertexFragmentSeparateShader) {
             gl_Position = vec4(vertices[gl_VertexIndex % 3], 0.0, 1.0);
         }
     )glsl";
-    static const char frag_shader[] = R"glsl(
+    const char frag_shader[] = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
 
@@ -2335,7 +2335,7 @@ TEST_F(NegativeDebugPrintf, ShaderObjectFragment) {
     RETURN_IF_SKIP(InitState());
     InitDynamicRenderTarget();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -2372,7 +2372,7 @@ TEST_F(NegativeDebugPrintf, ShaderObjectCompute) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -2420,7 +2420,7 @@ TEST_F(NegativeDebugPrintf, SetupErrorVersion) {
 
     InitRenderTarget();
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -2447,7 +2447,7 @@ TEST_F(NegativeDebugPrintf, LocalSizeId) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"(
+    const char *shader_source = R"(
                OpCapability Shader
                OpExtension "SPV_KHR_non_semantic_info"
          %30 = OpExtInstImport "NonSemantic.DebugPrintf"
@@ -2531,7 +2531,7 @@ TEST_F(NegativeDebugPrintf, Maintenance5) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -2573,7 +2573,7 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsPipelineReserved) {
     RETURN_IF_SKIP(InitState());
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit | kInformationBit);
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -2642,7 +2642,7 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsPipelineNotReserved) {
     RETURN_IF_SKIP(InitState());
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit | kInformationBit);
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -2710,7 +2710,7 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsPipelineGraphics) {
     InitRenderTarget();
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit | kInformationBit);
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -2787,7 +2787,7 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsPipelineGPL) {
     InitRenderTarget();
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit | kInformationBit);
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -2855,7 +2855,7 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsShaderObjectReserved) {
     RETURN_IF_SKIP(InitState());
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit | kInformationBit);
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -2925,7 +2925,7 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsShaderObjectNotReserved) {
     RETURN_IF_SKIP(InitState());
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit | kInformationBit);
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -2996,7 +2996,7 @@ TEST_F(NegativeDebugPrintf, ShaderObjectMultiCreate) {
     RETURN_IF_SKIP(InitState());
     InitDynamicRenderTarget();
 
-    char const *vs_source = R"glsl(
+    const char *vs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         vec2 vertices[3];
@@ -3009,7 +3009,7 @@ TEST_F(NegativeDebugPrintf, ShaderObjectMultiCreate) {
         }
     )glsl";
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3061,7 +3061,7 @@ TEST_F(NegativeDebugPrintf, ShaderObjectBoundDescriptor) {
     RETURN_IF_SKIP(InitState());
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit | kInformationBit);
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) buffer SSBO { uint x; };
@@ -3098,7 +3098,7 @@ TEST_F(NegativeDebugPrintf, ShaderObjectUnusedBoundDescriptor) {
     RETURN_IF_SKIP(InitState());
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit | kInformationBit);
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) buffer SSBO { uint x; };
@@ -3136,7 +3136,7 @@ TEST_F(NegativeDebugPrintf, OverflowBuffer) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
@@ -3165,7 +3165,7 @@ TEST_F(NegativeDebugPrintf, OverflowBufferLoop) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
@@ -3203,7 +3203,7 @@ void NegativeDebugPrintf::BasicFormattingTest(const char *shader, bool warning) 
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedNoVectorSize) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3214,7 +3214,7 @@ TEST_F(NegativeDebugPrintf, MisformattedNoVectorSize) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedLargeVectorSize) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3226,7 +3226,7 @@ TEST_F(NegativeDebugPrintf, MisformattedLargeVectorSize) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedSmallVectorSize) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3238,7 +3238,7 @@ TEST_F(NegativeDebugPrintf, MisformattedSmallVectorSize) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedNoSpecifier1) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3249,7 +3249,7 @@ TEST_F(NegativeDebugPrintf, MisformattedNoSpecifier1) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedNoSpecifier2) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3260,7 +3260,7 @@ TEST_F(NegativeDebugPrintf, MisformattedNoSpecifier2) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedUnknown1) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3271,7 +3271,7 @@ TEST_F(NegativeDebugPrintf, MisformattedUnknown1) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedUnknown2) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3282,7 +3282,7 @@ TEST_F(NegativeDebugPrintf, MisformattedUnknown2) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedUnknown3) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3293,7 +3293,7 @@ TEST_F(NegativeDebugPrintf, MisformattedUnknown3) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedExtraArguments) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3304,7 +3304,7 @@ TEST_F(NegativeDebugPrintf, MisformattedExtraArguments) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedNoModifiers) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3315,7 +3315,7 @@ TEST_F(NegativeDebugPrintf, MisformattedNoModifiers) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedIsloatedPercent) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3326,7 +3326,7 @@ TEST_F(NegativeDebugPrintf, MisformattedIsloatedPercent) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedNotEnoughArguments) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3337,7 +3337,7 @@ TEST_F(NegativeDebugPrintf, MisformattedNotEnoughArguments) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedNoArguments) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3348,7 +3348,7 @@ TEST_F(NegativeDebugPrintf, MisformattedNoArguments) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedNotVectorArg) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3360,7 +3360,7 @@ TEST_F(NegativeDebugPrintf, MisformattedNotVectorArg) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedNotVectorParam) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3372,7 +3372,7 @@ TEST_F(NegativeDebugPrintf, MisformattedNotVectorParam) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedVectorSmall) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3383,7 +3383,7 @@ TEST_F(NegativeDebugPrintf, MisformattedVectorSmall) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedVectorLarge) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3394,7 +3394,7 @@ TEST_F(NegativeDebugPrintf, MisformattedVectorLarge) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedFloat1) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3406,7 +3406,7 @@ TEST_F(NegativeDebugPrintf, MisformattedFloat1) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedFloat2) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3418,7 +3418,7 @@ TEST_F(NegativeDebugPrintf, MisformattedFloat2) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedFloatVector1) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3430,7 +3430,7 @@ TEST_F(NegativeDebugPrintf, MisformattedFloatVector1) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedFloatVector2) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3443,7 +3443,7 @@ TEST_F(NegativeDebugPrintf, MisformattedFloatVector2) {
 
 TEST_F(NegativeDebugPrintf, Misformatted64Int1) {
     AddRequiredFeature(vkt::Feature::shaderInt64);
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -3457,7 +3457,7 @@ TEST_F(NegativeDebugPrintf, Misformatted64Int1) {
 
 TEST_F(NegativeDebugPrintf, Misformatted64Int2) {
     AddRequiredFeature(vkt::Feature::shaderInt64);
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -3471,7 +3471,7 @@ TEST_F(NegativeDebugPrintf, Misformatted64Int2) {
 
 TEST_F(NegativeDebugPrintf, Misformatted64IntVector1) {
     AddRequiredFeature(vkt::Feature::shaderInt64);
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -3486,7 +3486,7 @@ TEST_F(NegativeDebugPrintf, Misformatted64IntVector1) {
 
 TEST_F(NegativeDebugPrintf, Misformatted64IntVector2) {
     AddRequiredFeature(vkt::Feature::shaderInt64);
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -3500,7 +3500,7 @@ TEST_F(NegativeDebugPrintf, Misformatted64IntVector2) {
 
 TEST_F(NegativeDebugPrintf, Misformatted64Bool) {
     AddRequiredFeature(vkt::Feature::shaderInt64);
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -3513,7 +3513,7 @@ TEST_F(NegativeDebugPrintf, Misformatted64Bool) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedEmptyString) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3524,7 +3524,7 @@ TEST_F(NegativeDebugPrintf, MisformattedEmptyString) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedNewLine) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3536,7 +3536,7 @@ TEST_F(NegativeDebugPrintf, MisformattedNewLine) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedVectorNewLine) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3548,7 +3548,7 @@ TEST_F(NegativeDebugPrintf, MisformattedVectorNewLine) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedPointer) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_buffer_reference : enable
@@ -3568,7 +3568,7 @@ TEST_F(NegativeDebugPrintf, MisformattedPointer) {
 }
 
 TEST_F(NegativeDebugPrintf, MisformattedNotPointer) {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -3617,7 +3617,7 @@ TEST_F(NegativeDebugPrintf, DualPipelines) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3660,7 +3660,7 @@ TEST_F(NegativeDebugPrintf, DualCommandBufferHalfPrint) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3704,7 +3704,7 @@ TEST_F(NegativeDebugPrintf, DualCommandBufferBothPrint) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(push_constant) uniform PushConstants { int x; } pc;
@@ -3757,7 +3757,7 @@ TEST_F(NegativeDebugPrintf, DualCommandBufferEmpty) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3804,7 +3804,7 @@ TEST_F(NegativeDebugPrintf, DispatchIndirect) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3838,7 +3838,7 @@ TEST_F(NegativeDebugPrintf, DispatchBase) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -3867,7 +3867,7 @@ TEST_F(NegativeDebugPrintf, DrawIndexed) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *vs_source = R"glsl(
+    const char *vs_source = R"glsl(
     #version 450
         #extension GL_EXT_debug_printf : enable
         vec2 vertices[3];
@@ -3879,7 +3879,7 @@ TEST_F(NegativeDebugPrintf, DrawIndexed) {
             debugPrintfEXT("gl_VertexIndex %u\n", gl_VertexIndex);
         }
     )glsl";
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(location = 0) out vec4 outColor;
@@ -3920,7 +3920,7 @@ TEST_F(NegativeDebugPrintf, DrawIndexedIndirect) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(location = 0) out vec4 outColor;
@@ -3969,7 +3969,7 @@ TEST_F(NegativeDebugPrintf, DrawIndirectCount) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(location = 0) out vec4 outColor;
@@ -4019,7 +4019,7 @@ TEST_F(NegativeDebugPrintf, DrawIndexedIndirectCount) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(location = 0) out vec4 outColor;
@@ -4092,7 +4092,7 @@ TEST_F(NegativeDebugPrintf, DeviceGeneratedCommandsCompute) {
     command_layout_ci.pTokens = &token;
     vkt::IndirectCommandsLayout command_layout(*m_device, command_layout_ci);
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -4183,7 +4183,7 @@ TEST_F(NegativeDebugPrintf, DeviceGeneratedCommandsGraphics) {
     command_layout_ci.pTokens = &token;
     vkt::IndirectCommandsLayout command_layout(*m_device, command_layout_ci);
 
-    char const *vs_source = R"glsl(
+    const char *vs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -4287,21 +4287,21 @@ TEST_F(NegativeDebugPrintf, DISABLED_DeviceGeneratedCommandsIES) {
     command_layout_ci.pTokens = tokens;
     vkt::IndirectCommandsLayout command_layout(*m_device, command_layout_ci);
 
-    char const *shader_source_1 = R"glsl(
+    const char *shader_source_1 = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
             debugPrintfEXT("Init Pipeline\n");
         }
     )glsl";
-    char const *shader_source_2 = R"glsl(
+    const char *shader_source_2 = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
             debugPrintfEXT("IndirectExecutionSet Pipeline 1\n");
         }
     )glsl";
-    char const *shader_source_3 = R"glsl(
+    const char *shader_source_3 = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -4387,7 +4387,7 @@ TEST_F(NegativeDebugPrintf, MultipleComputePasses) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source_1 = R"glsl(
+    const char *shader_source_1 = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(binding = 0, set = 0) uniform UBO {
@@ -4397,7 +4397,7 @@ TEST_F(NegativeDebugPrintf, MultipleComputePasses) {
             debugPrintfEXT("float x == %f", x);
         }
     )glsl";
-    char const *shader_source_2 = R"glsl(
+    const char *shader_source_2 = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -4440,7 +4440,7 @@ TEST_F(NegativeDebugPrintf, SpecConstant) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(constant_id = 0) const uint value = 22; // default
@@ -4491,7 +4491,7 @@ TEST_F(NegativeDebugPrintf, InlineUniformBlock) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) uniform UBO0 { uint ubo_0; };
@@ -4559,7 +4559,7 @@ TEST_F(NegativeDebugPrintf, StorageBufferLength) {
     RETURN_IF_SKIP(InitState());
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit | kInformationBit);
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_scalar_block_layout : enable
@@ -4627,7 +4627,7 @@ TEST_F(NegativeDebugPrintf, StorageBufferLengthUpdateAfterBind) {
     RETURN_IF_SKIP(InitState());
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit | kInformationBit);
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         #extension GL_EXT_scalar_block_layout : enable
@@ -4686,7 +4686,7 @@ TEST_F(NegativeDebugPrintf, PushDescriptor) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) uniform Push {
@@ -4747,7 +4747,7 @@ TEST_F(NegativeDebugPrintf, DescriptorTemplates) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) uniform UBO {
@@ -4811,7 +4811,7 @@ TEST_F(NegativeDebugPrintf, PushDescriptorTemplates) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) uniform UBO {
@@ -4876,7 +4876,7 @@ TEST_F(NegativeDebugPrintf, DuplicateMessageLimit) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
 
@@ -4916,7 +4916,7 @@ TEST_F(NegativeDebugPrintf, DuplicateMessageLimitExplicit) {
     RETURN_IF_SKIP(InitDebugPrintfFramework(&layer_settings_create_info));
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
 
@@ -4991,7 +4991,7 @@ TEST_F(NegativeDebugPrintf, DescriptorBuffer) {
     vk::GetDescriptorEXT(device(), &buffer_descriptor_info, descriptor_buffer_properties.storageBufferDescriptorSize,
                          mapped_descriptor_data);
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout (set = 0, binding = 0) buffer SSBO_0 {
@@ -5120,7 +5120,7 @@ TEST_F(NegativeDebugPrintf, DisableShaderValidation) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *frag_shader = R"glsl(
+    const char *frag_shader = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) buffer SSBO {
@@ -5192,7 +5192,7 @@ TEST_F(NegativeDebugPrintf, DisableShaderValidationShaderObject) {
     ds.WriteDescriptorBufferInfo(0, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     ds.UpdateDescriptorSets();
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) buffer SSBO {

--- a/tests/unit/debug_printf_shader_debug_info.cpp
+++ b/tests/unit/debug_printf_shader_debug_info.cpp
@@ -27,7 +27,7 @@ TEST_F(NegativeDebugPrintfShaderDebugInfo, DISABLED_PipelineHandle) {
     RETURN_IF_SKIP(InitDebugPrintfFramework(&layer_settings_create_info));
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -65,7 +65,7 @@ TEST_F(NegativeDebugPrintfShaderDebugInfo, ShaderObjectHandle) {
     RETURN_IF_SKIP(InitDebugPrintfFramework(&layer_settings_create_info));
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -99,7 +99,7 @@ TEST_F(NegativeDebugPrintfShaderDebugInfo, OpLine) {
     RETURN_IF_SKIP(InitDebugPrintfFramework(&layer_settings_create_info));
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"(
+    const char *shader_source = R"(
                OpCapability Shader
                OpExtension "SPV_KHR_non_semantic_info"
           %2 = OpExtInstImport "GLSL.std.450"
@@ -159,7 +159,7 @@ TEST_F(NegativeDebugPrintfShaderDebugInfo, ShaderDebugInfoDebugLine) {
 
     // Manually ran:
     //   glslangValidator -V -gVS in.comp -o out.spv --target-env vulkan1.0
-    char const *shader_source = R"(
+    const char *shader_source = R"(
                OpCapability Shader
                OpExtension "SPV_KHR_non_semantic_info"
           %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
@@ -244,7 +244,7 @@ TEST_F(NegativeDebugPrintfShaderDebugInfo, CommandBufferCommandIndex) {
     RETURN_IF_SKIP(InitDebugPrintfFramework(&layer_settings_create_info));
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -279,7 +279,7 @@ TEST_F(NegativeDebugPrintfShaderDebugInfo, CommandBufferCommandIndexMulti) {
     RETURN_IF_SKIP(InitDebugPrintfFramework(&layer_settings_create_info));
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(push_constant) uniform PushConstants { int x; } pc;
@@ -343,7 +343,7 @@ TEST_F(NegativeDebugPrintfShaderDebugInfo, StageInfo) {
     RETURN_IF_SKIP(InitDebugPrintfFramework(&layer_settings_create_info));
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -375,7 +375,7 @@ TEST_F(NegativeDebugPrintfShaderDebugInfo, Fragment) {
     RETURN_IF_SKIP(InitDebugPrintfFramework(&layer_settings_create_info));
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(location = 0) out vec4 outColor;
@@ -524,7 +524,7 @@ TEST_F(NegativeDebugPrintfShaderDebugInfo, DISABLED_DebugLabelRegion1) {
     RETURN_IF_SKIP(InitDebugPrintfFramework(&layer_settings_create_info));
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {
@@ -558,7 +558,7 @@ TEST_F(NegativeDebugPrintfShaderDebugInfo, DISABLED_DebugLabelRegion2) {
     RETURN_IF_SKIP(InitDebugPrintfFramework(&layer_settings_create_info));
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         void main() {

--- a/tests/unit/descriptor_buffer.cpp
+++ b/tests/unit/descriptor_buffer.cpp
@@ -993,7 +993,7 @@ TEST_F(NegativeDescriptorBuffer, LegacyDescriptorInvalidate) {
     void *mapped_descriptor_data = descriptor_buffer.Memory().Map();
     vk::GetDescriptorEXT(device(), get_info, descriptor_buffer_properties.storageBufferDescriptorSize, mapped_descriptor_data);
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout (set = 0, binding = 0) buffer SSBO_0 { uint x; };
         void main() {
@@ -1068,7 +1068,7 @@ TEST_F(NegativeDescriptorBuffer, InconsistentBuffer) {
     dbbi.address = buffer.Address();
     dbbi.usage = VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT;
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) uniform ufoo { uint index; };
         void main() {
@@ -1107,7 +1107,7 @@ TEST_F(NegativeDescriptorBuffer, InconsistentSet) {
                                        });
     vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) uniform ufoo { uint index; };
         void main() {

--- a/tests/unit/descriptor_buffer_positive.cpp
+++ b/tests/unit/descriptor_buffer_positive.cpp
@@ -202,7 +202,7 @@ TEST_F(PositiveDescriptorBuffer, Basic) {
     void *mapped_descriptor_data = descriptor_buffer.Memory().Map();
     vk::GetDescriptorEXT(device(), get_info, descriptor_buffer_properties.storageBufferDescriptorSize, mapped_descriptor_data);
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout (set = 0, binding = 0) buffer SSBO_0 {
             uint a;
@@ -283,7 +283,7 @@ TEST_F(PositiveDescriptorBuffer, BasicSampler) {
     vk::GetDescriptorEXT(device(), get_info_buffer, descriptor_buffer_properties.storageBufferDescriptorSize,
                          mapped_descriptor_data + ds_layout.GetDescriptorBufferBindingOffset(3));
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) uniform sampler s;
         layout(set = 0, binding = 1) uniform texture2D t; // sampled image
@@ -356,7 +356,7 @@ TEST_F(PositiveDescriptorBuffer, MultipleDescriptors) {
     vkt::DescriptorGetInfo get_info_sampler(&sampler.handle());
     vk::GetDescriptorEXT(device(), get_info_sampler, descriptor_buffer_properties.samplerDescriptorSize, mapped_descriptor_data);
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 2) uniform sampler s;
         layout(set = 0, binding = 0) uniform texture2D t;
@@ -433,7 +433,7 @@ TEST_F(PositiveDescriptorBuffer, MultipleSet) {
     mapped_descriptor_data += ds_layout_size;
     vk::GetDescriptorEXT(device(), get_info, descriptor_buffer_properties.storageBufferDescriptorSize, mapped_descriptor_data);
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout (set = 0, binding = 0) buffer SSBO_0 {
             uint a;
@@ -514,7 +514,7 @@ TEST_F(PositiveDescriptorBuffer, MultipleBinding) {
     vk::GetDescriptorEXT(device(), get_info, descriptor_buffer_properties.storageBufferDescriptorSize,
                          mapped_descriptor_data + ds_layout.GetDescriptorBufferBindingOffset(2));
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout (set = 0, binding = 0) buffer SSBO_0 {
             uint a;
@@ -596,7 +596,7 @@ TEST_F(PositiveDescriptorBuffer, DescriptorIndexing) {
     mapped_descriptor_data += descriptor_size;
     vk::GetDescriptorEXT(device(), get_info, descriptor_size, mapped_descriptor_data);
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout (set = 0, binding = 0) buffer SSBO_0 {
             uint data;
@@ -714,7 +714,7 @@ TEST_F(PositiveDescriptorBuffer, TexelBuffer) {
     vk::GetDescriptorEXT(device(), get_info_u, descriptor_buffer_properties.uniformTexelBufferDescriptorSize,
                          mapped_descriptor_data + ds_layout.GetDescriptorBufferBindingOffset(1));
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0, r32ui) uniform uimageBuffer s_buffer;
         layout(set = 0, binding = 1) uniform usamplerBuffer u_buffer;
@@ -786,7 +786,7 @@ TEST_F(PositiveDescriptorBuffer, BindingOffsets) {
     mapped_descriptor_data += ds_layout_size;
     vk::GetDescriptorEXT(device(), get_info, descriptor_buffer_properties.storageBufferDescriptorSize, mapped_descriptor_data);
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout (set = 0, binding = 0) buffer SSBO_0 {
             uint data;
@@ -860,7 +860,7 @@ TEST_F(PositiveDescriptorBuffer, ShaderObject) {
     void *mapped_descriptor_data = descriptor_buffer.Memory().Map();
     vk::GetDescriptorEXT(device(), get_info, descriptor_buffer_properties.storageBufferDescriptorSize, mapped_descriptor_data);
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout (set = 0, binding = 0) buffer SSBO_0 {
             uint a;
@@ -924,7 +924,7 @@ TEST_F(PositiveDescriptorBuffer, NotInvalidatedLegacy) {
     void *mapped_descriptor_data = descriptor_buffer.Memory().Map();
     vk::GetDescriptorEXT(device(), get_info, descriptor_buffer_properties.storageBufferDescriptorSize, mapped_descriptor_data);
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout (set = 0, binding = 0) buffer SSBO_0 { uint x; };
         void main() {

--- a/tests/unit/descriptor_indexing.cpp
+++ b/tests/unit/descriptor_indexing.cpp
@@ -92,7 +92,7 @@ TEST_F(NegativeDescriptorIndexing, UpdateAfterBind) {
     vkt::PipelineLayout pipeline_layout(*m_device, pipeline_layout_ci);
 
     // Create a dummy pipeline, since VL inspects which bindings are actually used at draw time
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 color;
         layout(set=0, binding=0) uniform foo0 { float x0; } bar0;
@@ -475,7 +475,7 @@ TEST_F(NegativeDescriptorIndexing, VariableDescriptorCountBuffer) {
 
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450 core
         layout(set = 0, binding = 0) buffer SSBO { int x; } bufs[4];
         void main() {

--- a/tests/unit/descriptor_indexing_positive.cpp
+++ b/tests/unit/descriptor_indexing_positive.cpp
@@ -61,7 +61,7 @@ TEST_F(PositiveDescriptorIndexing, BindingPartiallyBound) {
     descriptor_set.WriteDescriptorBufferInfo(0, buffer, 0, sizeof(uint32_t));
     descriptor_set.UpdateDescriptorSets();
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) uniform foo_0 { int val; } doit;
         layout(set = 0, binding = 1) uniform foo_1 { int val; } readit;
@@ -235,7 +235,7 @@ TEST_F(PositiveDescriptorIndexing, PipelineShaderBasic) {
         {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
     };
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set=0, binding=0) buffer block { int x; };
@@ -256,7 +256,7 @@ TEST_F(PositiveDescriptorIndexing, PipelineShaderSampler2D) {
         {1, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
     };
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set=0, binding=0) buffer block { vec2 x; };
@@ -276,7 +276,7 @@ TEST_F(PositiveDescriptorIndexing, PipelineShaderImageBufferArray) {
         {1, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
     };
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set=0, binding=0) buffer block { int x; };
@@ -303,7 +303,7 @@ TEST_F(PositiveDescriptorIndexing, PipelineShaderMultiArrayIndexing) {
         {2, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 6, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
     };
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform A { uint value; };
@@ -373,7 +373,7 @@ TEST_F(PositiveDescriptorIndexing, StaticAccessSomeOfTheArray) {
     descriptor_set.WriteDescriptorBufferInfo(0, buffer_0, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1);
     descriptor_set.UpdateDescriptorSets();
 
-    char const *vs_source = R"glsl(
+    const char *vs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) uniform Foo { float x; } bufs[2];
         void main() {
@@ -426,7 +426,7 @@ TEST_F(PositiveDescriptorIndexing, VariableDescriptorCountBuffer) {
 
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450 core
         layout(set = 0, binding = 0) buffer SSBO { int x; } bufs[3];
         void main() {

--- a/tests/unit/descriptors.cpp
+++ b/tests/unit/descriptors.cpp
@@ -786,7 +786,7 @@ TEST_F(NegativeDescriptors, WriteDescriptorSetConsecutiveUpdates) {
         vk::UpdateDescriptorSets(device(), 1, &descriptor_write, 0, NULL);
 
         // Create PSO that uses the uniform buffers
-        char const *fsSource = R"glsl(
+        const char *fsSource = R"glsl(
             #version 450
             layout(location=0) out vec4 x;
             layout(set=0) layout(binding=0) uniform foo { int x; int y; } bar;
@@ -831,7 +831,7 @@ TEST_F(NegativeDescriptors, CmdBufferDescriptorSetBufferDestroyed) {
         vkt::Buffer buffer(*m_device, 1024, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
 
         // Create PSO to be used for draw-time errors below
-        char const *fsSource = R"glsl(
+        const char *fsSource = R"glsl(
             #version 450
             layout(location=0) out vec4 x;
             layout(set=0) layout(binding=0) uniform foo { int x; int y; } bar;
@@ -879,7 +879,7 @@ TEST_F(NegativeDescriptors, DrawDescriptorSetBufferDestroyed) {
         vkt::Buffer buffer(*m_device, 1024, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
 
         // Create PSO to be used for draw-time errors below
-        char const *fsSource = R"glsl(
+        const char *fsSource = R"glsl(
             #version 450
             layout(location=0) out vec4 x;
             layout(set=0) layout(binding=0) uniform foo { int x; int y; } bar;
@@ -971,7 +971,7 @@ TEST_F(NegativeDescriptors, CmdBufferDescriptorSetImageSamplerDestroyed) {
     vk::UpdateDescriptorSets(device(), 1, &descriptor_write, 0, NULL);
 
     // Create PSO to be used for draw-time errors below
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler2D s;
         layout(location=0) out vec4 x;
@@ -1122,7 +1122,7 @@ TEST_F(NegativeDescriptors, OpArrayLengthStaticallyUsed) {
     RETURN_IF_SKIP(Init());
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit | kInformationBit);
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
 
@@ -1201,7 +1201,7 @@ TEST_F(NegativeDescriptors, DescriptorSetSamplerDestroyed) {
     sampler1.Destroy();
 
     // Create PSO to be used for draw-time errors below
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler2D s;
         layout(set=0, binding=1) uniform sampler2D s1;
@@ -1769,7 +1769,7 @@ TEST_F(NegativeDescriptors, DynamicOffsetWithNullBuffer) {
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     // Create PSO to be used for draw-time errors below
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 x;
         layout(set=0) layout(binding=0) uniform foo1 { int x; int y; } bar1;
@@ -1902,7 +1902,7 @@ TEST_F(NegativeDescriptors, BindInvalidPipelineLayout) {
     descriptor_set.UpdateDescriptorSets();
 
     // Create PSO to be used for draw-time errors below
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 x;
         layout(set=0, binding=1) uniform foo1 { vec4 y; };
@@ -2255,7 +2255,7 @@ TEST_F(NegativeDescriptors, DescriptorSetCompatibilityCompute) {
     const vkt::PipelineLayout pipeline_layout_a(*m_device, {&descriptor_set_storage.layout_, &descriptor_set_storage.layout_});
     const vkt::PipelineLayout pipeline_layout_b(*m_device, {&descriptor_set_storage.layout_, &descriptor_set_uniform.layout_});
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 1, binding = 0) buffer StorageBuffer_1 {
             uint a;
@@ -2314,7 +2314,7 @@ TEST_F(NegativeDescriptors, DescriptorSetCompatibilityMutableDescriptors) {
     descriptor_set_1.WriteDescriptorBufferInfo(0, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set_1.UpdateDescriptorSets();
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer SSBO {
             uint a;
@@ -3691,7 +3691,7 @@ TEST_F(NegativeDescriptors, NullDescriptorsEnabled) {
     sampler_descriptor_set.WriteDescriptorImageInfo(0, VK_NULL_HANDLE, sampler, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
     sampler_descriptor_set.UpdateDescriptorSets();
     const vkt::PipelineLayout pipeline_layout(*m_device, {&sampler_descriptor_set.layout_});
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler2D tex;
         layout(location=0) out vec4 x;
@@ -3750,7 +3750,7 @@ TEST_F(NegativeDescriptors, DISABLED_ImageSubresourceOverlapBetweenAttachmentsAn
     vkt::Framebuffer fb(*m_device, rp, 2u, attachments, 64, 64);
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(input_attachment_index=0, set=0, binding=0) uniform subpassInput ia0;
         layout(set=0, binding=1) uniform sampler2D ci1;
@@ -4386,7 +4386,7 @@ TEST_F(NegativeDescriptors, ImageSubresourceOverlapBetweenRenderPassAndDescripto
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
     vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view_handle);
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
             #version 450
             layout(location = 0) out vec4 x;
             layout(set = 0, binding = 0) writeonly uniform image2D image;
@@ -4462,7 +4462,7 @@ TEST_F(NegativeDescriptors, ImageSubresourceOverlapBetweenRenderPassAndDescripto
     //     x = vec4(1.0f);
     //     foo(image_0);
     // }
-    char const *fsSource = R"(
+    const char *fsSource = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %main "main" %color_attach
@@ -4565,7 +4565,7 @@ TEST_F(NegativeDescriptors, DISABLED_DescriptorReadFromWriteAttachment) {
 
     vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view_handle, width, height);
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
             #version 450
             layout(location = 0) out vec4 color;
             layout(set = 0, binding = 0, rgba8) readonly uniform image2D image1;
@@ -4646,7 +4646,7 @@ TEST_F(NegativeDescriptors, DescriptorWriteFromReadAttachment) {
 
     vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view_handle, width, height);
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
             #version 450
             layout(set = 0, binding = 0, rgba8) writeonly uniform image2D image1;
             layout(set = 1, binding = 0, input_attachment_index = 0) uniform subpassInput inputColor;
@@ -5156,7 +5156,7 @@ TEST_F(NegativeDescriptors, DispatchWithUnboundSet) {
     TEST_DESCRIPTION("Dispatch with unbound descriptor set");
     RETURN_IF_SKIP(Init());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(local_size_x=1, local_size_y=1, local_size_z=1) in;
         layout(set = 0, binding = 0) uniform sampler2D InputTexture;
@@ -5202,7 +5202,7 @@ TEST_F(NegativeDescriptors, DispatchWithUnboundSet) {
 TEST_F(NegativeDescriptors, CompatiblePushConstantRanges) {
     RETURN_IF_SKIP(Init());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 460
 
         layout(push_constant, std430) uniform PC {
@@ -6381,7 +6381,7 @@ TEST_F(NegativeDescriptors, ImmutableSamplerIdenticallyDefined) {
     descriptor_set.WriteDescriptorBufferInfo(0, storage_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer StorageBuffer { vec4 dummy; };
         layout(set = 0, binding = 1) uniform sampler s;
@@ -6441,7 +6441,7 @@ TEST_F(NegativeDescriptors, ImmutableSamplerIdenticallyDefinedMaintenance4) {
     descriptor_set.WriteDescriptorBufferInfo(0, storage_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer StorageBuffer { vec4 dummy; };
         layout(set = 0, binding = 1) uniform sampler s;
@@ -6508,7 +6508,7 @@ TEST_F(NegativeDescriptors, ImmutableSamplerIdenticallyDefinedFilterMinmax) {
     descriptor_set.WriteDescriptorBufferInfo(0, storage_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer StorageBuffer { vec4 dummy; };
         layout(set = 0, binding = 1) uniform sampler s;

--- a/tests/unit/descriptors_positive.cpp
+++ b/tests/unit/descriptors_positive.cpp
@@ -234,7 +234,7 @@ TEST_F(PositiveDescriptors, ImmutableSamplerOnlyDescriptor) {
 
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 x;
         layout(set=0, binding=0) uniform sampler immutableSampler;
@@ -340,7 +340,7 @@ TEST_F(PositiveDescriptors, DynamicOffsetWithInactiveBinding) {
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     // Create PSO to be used for draw-time errors below
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 x;
         layout(set=0) layout(binding=0) uniform foo1 { int x; int y; } bar1;
@@ -491,7 +491,7 @@ TEST_F(PositiveDescriptors, DescriptorSetCompatibilityMutableDescriptors) {
     descriptor_set_1.WriteDescriptorBufferInfo(0, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set_1.UpdateDescriptorSets();
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer SSBO {
             uint a;
@@ -708,7 +708,7 @@ TEST_F(PositiveDescriptors, ImageViewAsDescriptorReadAndInputAttachment) {
 
     vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view_handle);
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
             #version 450
             layout(location = 0) out vec4 color;
             layout(set = 0, binding = 0, rgba8) readonly uniform image2D image1;
@@ -875,7 +875,7 @@ TEST_F(PositiveDescriptors, DrawingWithUnboundUnusedSetWithInputAttachments) {
 
     vkt::Framebuffer fb(*m_device, rp, 1, &view_input.handle(), width, height);
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(input_attachment_index=0, set=0, binding=0) uniform subpassInput x;
         void main() {
@@ -1118,7 +1118,7 @@ TEST_F(PositiveDescriptors, AttachmentFeedbackLoopLayout) {
                                             VK_IMAGE_LAYOUT_ATTACHMENT_FEEDBACK_LOOP_OPTIMAL_EXT);
     descriptor_set.UpdateDescriptorSets();
 
-    char const *frag_src = R"glsl(
+    const char *frag_src = R"glsl(
         #version 450
         layout(set=0) layout(binding=0) uniform sampler2D tex;
         layout(location=0) out vec4 color;
@@ -1259,7 +1259,7 @@ TEST_F(PositiveDescriptors, ImageSubresourceOverlapBetweenRenderPassAndDescripto
     //     x = vec4(1.0f);
     //     foo(image_1);
     // }
-    char const *fsSource = R"(
+    const char *fsSource = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %main "main" %color_attach
@@ -1844,7 +1844,7 @@ TEST_F(PositiveDescriptors, ImmutableSamplerIdenticallyDefined) {
                                             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     descriptor_set.UpdateDescriptorSets();
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer StorageBuffer { vec4 dummy; };
         layout(set = 0, binding = 1) uniform sampler s;
@@ -1902,7 +1902,7 @@ TEST_F(PositiveDescriptors, ImmutableSamplerIdenticallyDefinedMaintenance4) {
                                             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     descriptor_set.UpdateDescriptorSets();
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer StorageBuffer { vec4 dummy; };
         layout(set = 0, binding = 1) uniform sampler s;
@@ -1969,7 +1969,7 @@ TEST_F(PositiveDescriptors, ImmutableSamplerIdenticallyDefinedFilterMinmax) {
                                             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     descriptor_set.UpdateDescriptorSets();
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer StorageBuffer { vec4 dummy; };
         layout(set = 0, binding = 1) uniform sampler s;
@@ -2102,7 +2102,7 @@ TEST_F(PositiveDescriptors, ReuseSetLayoutDefWithImmutableSamplers2) {
         descriptor_write.pImageInfo = &image_info;
         vk::UpdateDescriptorSets(*m_device, 1u, &descriptor_write, 0u, nullptr);
 
-        char const *fsSource = R"glsl(
+        const char *fsSource = R"glsl(
             #version 440
 
             layout(set = 0, binding = 0) uniform sampler2DMS u_ms_image_sampler;

--- a/tests/unit/device_generated_commands.cpp
+++ b/tests/unit/device_generated_commands.cpp
@@ -779,7 +779,7 @@ TEST_F(NegativeDeviceGeneratedCommands, UpdateIESPipelineFragmentOutput) {
     CreatePipelineHelper init_pipe(*this, &pipe_flags2);
     init_pipe.CreateGraphicsPipeline();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 460
         layout(location = 1) out vec4 uFragColor;
         void main(){
@@ -813,7 +813,7 @@ TEST_F(NegativeDeviceGeneratedCommands, UpdateIESPipelineFragDepth) {
     init_pipe.CreateGraphicsPipeline();
     vkt::IndirectExecutionSet exe_set(*m_device, init_pipe, 1);
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 460
         layout(location = 0) out vec4 uFragColor;
         void main(){
@@ -846,7 +846,7 @@ TEST_F(NegativeDeviceGeneratedCommands, UpdateIESPipelineSampleMask) {
     init_pipe.CreateGraphicsPipeline();
     vkt::IndirectExecutionSet exe_set(*m_device, init_pipe, 1);
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 460
         layout(location = 0) out vec4 uFragColor;
         void main(){
@@ -880,7 +880,7 @@ TEST_F(NegativeDeviceGeneratedCommands, UpdateIESPipelineStencilExportEXT) {
     init_pipe.CreateGraphicsPipeline();
     vkt::IndirectExecutionSet exe_set(*m_device, init_pipe, 1);
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 460
         #extension GL_ARB_shader_stencil_export: enable
         layout(location = 0) out vec4 uFragColor;
@@ -955,7 +955,7 @@ TEST_F(NegativeDeviceGeneratedCommands, UpdateIESPipelineCompatible) {
     const vkt::PipelineLayout pipeline_layout_vert(*m_device, {&descriptor_set_vert.layout_});
     const vkt::PipelineLayout pipeline_layout_all(*m_device, {&descriptor_set_all.layout_});
 
-    char const *vs_source = R"glsl(
+    const char *vs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer StorageBuffer {
             uint a;
@@ -1202,7 +1202,7 @@ TEST_F(NegativeDeviceGeneratedCommands, UpdateIESShaderObjectFragmentOutput) {
     write_exe_set.index = 1;
 
     {
-        char const *fs_source_location = R"glsl(
+        const char *fs_source_location = R"glsl(
             #version 460
             layout(location = 1) out vec4 uFragColor;
             void main(){
@@ -1221,7 +1221,7 @@ TEST_F(NegativeDeviceGeneratedCommands, UpdateIESShaderObjectFragmentOutput) {
     }
 
     {
-        char const *fs_source_depth = R"glsl(
+        const char *fs_source_depth = R"glsl(
             #version 460
             layout(location = 0) out vec4 uFragColor;
             void main(){
@@ -1242,7 +1242,7 @@ TEST_F(NegativeDeviceGeneratedCommands, UpdateIESShaderObjectFragmentOutput) {
     }
 
     {
-        char const *fs_source_mask = R"glsl(
+        const char *fs_source_mask = R"glsl(
             #version 460
             layout(location = 0) out vec4 uFragColor;
             void main(){
@@ -1263,7 +1263,7 @@ TEST_F(NegativeDeviceGeneratedCommands, UpdateIESShaderObjectFragmentOutput) {
     }
 
     {
-        char const *fs_source_stencil = R"glsl(
+        const char *fs_source_stencil = R"glsl(
             #version 460
             #extension GL_ARB_shader_stencil_export: enable
             layout(location = 0) out vec4 uFragColor;

--- a/tests/unit/dynamic_rendering.cpp
+++ b/tests/unit/dynamic_rendering.cpp
@@ -5756,7 +5756,7 @@ TEST_F(NegativeDynamicRendering, CreateGraphicsPipeline) {
     TEST_DESCRIPTION("Test for a creating a pipeline with VK_KHR_dynamic_rendering enabled");
     RETURN_IF_SKIP(InitBasicDynamicRendering());
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(input_attachment_index=0, set=0, binding=0) uniform subpassInput x;
         layout(location=0) out vec4 color;
@@ -5787,7 +5787,7 @@ TEST_F(NegativeDynamicRendering, CreateGraphicsPipelineNoInfo) {
     TEST_DESCRIPTION("Test for a creating a pipeline with VK_KHR_dynamic_rendering enabled but no rendering info struct.");
     RETURN_IF_SKIP(InitBasicDynamicRendering());
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(input_attachment_index=0, set=0, binding=0) uniform subpassInput x;
         layout(location=0) out vec4 color;

--- a/tests/unit/dynamic_rendering_positive.cpp
+++ b/tests/unit/dynamic_rendering_positive.cpp
@@ -348,7 +348,7 @@ TEST_F(PositiveDynamicRendering, CreateGraphicsPipeline) {
     TEST_DESCRIPTION("Test for a creating a pipeline with VK_KHR_dynamic_rendering enabled");
     RETURN_IF_SKIP(InitBasicDynamicRendering());
 
-    char const* fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(input_attachment_index=0, set=0, binding=0) uniform subpassInput x;
         layout(location=0) out vec4 color;
@@ -384,7 +384,7 @@ TEST_F(PositiveDynamicRendering, CreateGraphicsPipeline) {
 TEST_F(PositiveDynamicRendering, CreateGraphicsPipelineNoInfo) {
     TEST_DESCRIPTION("Test for a creating a pipeline with VK_KHR_dynamic_rendering enabled but no rendering info struct.");
     RETURN_IF_SKIP(InitBasicDynamicRendering());
-    char const* fsSource = R"glsl(
+    const char* fsSource = R"glsl(
         #version 450
         layout(input_attachment_index=0, set=0, binding=0) uniform subpassInput x;
         layout(location=0) out vec4 color;

--- a/tests/unit/dynamic_state.cpp
+++ b/tests/unit/dynamic_state.cpp
@@ -2129,7 +2129,7 @@ TEST_F(NegativeDynamicState, DrawNotSetLineStippleEnableGeometry) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    static char const geom_src[] = R"glsl(
+    const char geom_src[] = R"glsl(
         #version 460
         layout(triangles) in;
         layout(line_strip, max_vertices=2) out;
@@ -4661,7 +4661,7 @@ TEST_F(NegativeDynamicState, AlphaToCoverageOutputNoAlpha) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0) out vec3 x;
         void main(){
@@ -4896,7 +4896,7 @@ TEST_F(NegativeDynamicState, VertexInputLocationMissing) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location = 0) in vec4 x;
         layout(location = 1) in vec4 y;
@@ -5677,7 +5677,7 @@ TEST_F(NegativeDynamicState, InterpolateAtSample) {
         GTEST_SKIP() << "variableSampleLocations not supported";
     }
 
-    static const char vs_src[] = R"glsl(
+    const char vs_src[] = R"glsl(
         #version 460
         layout(location = 0) out vec2 uv;
         void main() {
@@ -5685,7 +5685,7 @@ TEST_F(NegativeDynamicState, InterpolateAtSample) {
             gl_Position = vec4(uv, 0.0f, 1.0f);
         }
     )glsl";
-    static const char fs_src[] = R"glsl(
+    const char fs_src[] = R"glsl(
         #version 460
         layout(location = 0) out vec4 uFragColor;
         layout(location = 0) in vec2 v;

--- a/tests/unit/dynamic_state_positive.cpp
+++ b/tests/unit/dynamic_state_positive.cpp
@@ -576,7 +576,7 @@ TEST_F(PositiveDynamicState, AlphaToCoverageSetFalse) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location = 0) out float x;
         void main(){
@@ -1026,7 +1026,7 @@ TEST_F(PositiveDynamicState, VertexInputMultipleBindings) {
     attributes[3].format = VK_FORMAT_R32_SFLOAT;
     attributes[3].offset = offsetof(PerInstance, d);
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location = 0) in int a;
         layout(location = 1) in float b;
@@ -1575,7 +1575,7 @@ TEST_F(PositiveDynamicState, VertexInputLocationMissing) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location = 0) in vec4 x;
         layout(location = 1) in vec4 y;

--- a/tests/unit/fragment_shading_rate.cpp
+++ b/tests/unit/fragment_shading_rate.cpp
@@ -229,7 +229,7 @@ TEST_F(NegativeFragmentShadingRate, PrimitiveFragmentShadingRateWriteMultiViewpo
     }
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         #extension GL_EXT_fragment_shading_rate : enable
         void main() {
@@ -1388,7 +1388,7 @@ TEST_F(NegativeFragmentShadingRate, PrimitiveWriteMultiViewportLimit) {
 
     // Test PrimitiveShadingRate writes with multiple viewports
     {
-        char const *vsSource = R"glsl(
+        const char *vsSource = R"glsl(
             #version 450
             #extension GL_EXT_fragment_shading_rate : enable
             void main() {
@@ -1418,12 +1418,12 @@ TEST_F(NegativeFragmentShadingRate, PrimitiveWriteMultiViewportLimit) {
 
     // Test PrimitiveShadingRate writes with ViewportIndex writes in a geometry shader
     if (features2.features.geometryShader) {
-        char const *vsSource = R"glsl(
+        const char *vsSource = R"glsl(
             #version 450
             void main() {}
         )glsl";
 
-        static char const *gsSource = R"glsl(
+        const char *gsSource = R"glsl(
             #version 450
             #extension GL_EXT_fragment_shading_rate : enable
             layout (points) in;
@@ -1453,7 +1453,7 @@ TEST_F(NegativeFragmentShadingRate, PrimitiveWriteMultiViewportLimit) {
 
     // Test PrimitiveShadingRate writes with ViewportIndex writes in a vertex shader
     if (vil_extension) {
-        char const *vsSource = R"glsl(
+        const char *vsSource = R"glsl(
             #version 450
             #extension GL_EXT_fragment_shading_rate : enable
             #extension GL_ARB_shader_viewport_layer_array : enable
@@ -1477,12 +1477,12 @@ TEST_F(NegativeFragmentShadingRate, PrimitiveWriteMultiViewportLimit) {
     if (va2_extension) {
         // Test PrimitiveShadingRate writes with ViewportIndex writes in a geometry shader
         if (features2.features.geometryShader) {
-            char const *vsSource = R"glsl(
+            const char *vsSource = R"glsl(
                 #version 450
                 void main() {}
             )glsl";
 
-            static char const *gsSource = R"glsl(
+            const char *gsSource = R"glsl(
                 #version 450
                 #extension GL_EXT_fragment_shading_rate : enable
                 #extension GL_NV_viewport_array2 : enable
@@ -1513,7 +1513,7 @@ TEST_F(NegativeFragmentShadingRate, PrimitiveWriteMultiViewportLimit) {
 
         // Test PrimitiveShadingRate writes with ViewportIndex writes in a vertex shader
         if (vil_extension) {
-            char const *vsSource = R"glsl(
+            const char *vsSource = R"glsl(
                 #version 450
                 #extension GL_EXT_fragment_shading_rate : enable
                 #extension GL_NV_viewport_array2 : enable

--- a/tests/unit/geometry_tessellation.cpp
+++ b/tests/unit/geometry_tessellation.cpp
@@ -106,7 +106,7 @@ TEST_F(NegativeGeometryTessellation, TessellationShaderEnabled) {
         GTEST_SKIP() << "patchControlPoints not supported";
     }
 
-    char const *tcsSource = R"glsl(
+    const char *tcsSource = R"glsl(
         #version 450
         layout(location=0) out int x[];
         layout(vertices=3) out;
@@ -116,7 +116,7 @@ TEST_F(NegativeGeometryTessellation, TessellationShaderEnabled) {
            x[gl_InvocationID] = gl_InvocationID;
         }
     )glsl";
-    char const *tesSource = R"glsl(
+    const char *tesSource = R"glsl(
         #version 450
         layout(triangles, equal_spacing, cw) in;
         layout(location=0) patch in int x;
@@ -158,7 +158,7 @@ TEST_F(NegativeGeometryTessellation, PointSizeGeomShaderDontWrite) {
     InitRenderTarget();
 
     // Create GS declaring PointSize and writing to it
-    static char const *gsSource = R"glsl(
+    const char *gsSource = R"glsl(
         #version 450
         layout (points) in;
         layout (points) out;
@@ -349,7 +349,7 @@ TEST_F(NegativeGeometryTessellation, BuiltinBlockSizeMismatchVsGs) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    static const char *gsSource = R"glsl(
+    const char *gsSource = R"glsl(
         #version 450
         layout (points) in;
         layout (points) out;
@@ -390,7 +390,7 @@ TEST_F(NegativeGeometryTessellation, BuiltinBlockSizeMismatchVsGsShaderObject) {
     RETURN_IF_SKIP(Init());
     InitDynamicRenderTarget();
 
-    static const char *gsSource = R"glsl(
+    const char *gsSource = R"glsl(
         #version 450
         layout (points) in;
         layout (points) out;
@@ -798,7 +798,7 @@ TEST_F(NegativeGeometryTessellation, DISABLED_TessellationPatchDecorationMismatc
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *tcsSource = R"glsl(
+    const char *tcsSource = R"glsl(
         #version 450
         layout(location=0) out int x[];
         layout(vertices=3) out;
@@ -808,7 +808,7 @@ TEST_F(NegativeGeometryTessellation, DISABLED_TessellationPatchDecorationMismatc
            x[gl_InvocationID] = gl_InvocationID;
         }
     )glsl";
-    char const *tesSource = R"glsl(
+    const char *tesSource = R"glsl(
         #version 450
         layout(triangles, equal_spacing, cw) in;
         layout(location=0) patch in int x;
@@ -841,7 +841,7 @@ TEST_F(NegativeGeometryTessellation, Tessellation) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *tcsSource = R"glsl(
+    const char *tcsSource = R"glsl(
         #version 450
         layout(vertices=3) out;
         void main(){
@@ -849,7 +849,7 @@ TEST_F(NegativeGeometryTessellation, Tessellation) {
            gl_TessLevelInner[0] = 1;
         }
     )glsl";
-    char const *tesSource = R"glsl(
+    const char *tesSource = R"glsl(
         #version 450
         layout(triangles, equal_spacing, cw) in;
         void main(){
@@ -1052,7 +1052,7 @@ TEST_F(NegativeGeometryTessellation, IncompatiblePrimitiveTopology) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    static const char *gsSource = R"glsl(
+    const char *gsSource = R"glsl(
         #version 450
         layout (points) in;
         layout (triangle_strip) out;
@@ -1089,7 +1089,7 @@ TEST_F(NegativeGeometryTessellation, IncompatibleTessGeomPrimitiveTopology) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *tcsSource = R"glsl(
+    const char *tcsSource = R"glsl(
         #version 450
         layout(location=0) out int x[];
         layout(vertices=3) out;
@@ -1099,7 +1099,7 @@ TEST_F(NegativeGeometryTessellation, IncompatibleTessGeomPrimitiveTopology) {
            x[gl_InvocationID] = gl_InvocationID;
         }
     )glsl";
-    char const *tesSource = R"glsl(
+    const char *tesSource = R"glsl(
         #version 450
         layout(triangles, equal_spacing, cw) in;
         layout(location=0) patch in int x;
@@ -1108,7 +1108,7 @@ TEST_F(NegativeGeometryTessellation, IncompatibleTessGeomPrimitiveTopology) {
            gl_Position.w = x;
         }
     )glsl";
-    static const char *gsSource = R"glsl(
+    const char *gsSource = R"glsl(
         #version 450
         layout (points) in;
         layout (triangle_strip) out;
@@ -1151,7 +1151,7 @@ TEST_F(NegativeGeometryTessellation, PipelineTessellationMissingPointSize) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    static const char tess_src[] = R"glsl(
+    const char tess_src[] = R"glsl(
         #version 460
         layout(triangles, equal_spacing, cw, point_mode) in;
         void main() { gl_Position = vec4(1); }
@@ -1180,7 +1180,7 @@ TEST_F(NegativeGeometryTessellation, PipelineTessellationPointSize) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    static const char tess_src[] = R"glsl(
+    const char tess_src[] = R"glsl(
         #version 460
         layout(triangles, equal_spacing, cw, point_mode) in;
         void main() {
@@ -1224,7 +1224,7 @@ TEST_F(NegativeGeometryTessellation, GeometryStreamsCapability) {
         GTEST_SKIP() << "maxTransformFeedbackStreams lower than required";
     }
 
-    static char const geom_src[] = R"glsl(
+    const char geom_src[] = R"glsl(
                OpCapability Geometry
                OpCapability TransformFeedback
                OpCapability GeometryStreams
@@ -1528,7 +1528,7 @@ TEST_F(NegativeGeometryTessellation, DrawDynamicPrimitiveTopology) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    static const char *gsSource = R"glsl(
+    const char *gsSource = R"glsl(
         #version 450
         layout (points) in;
         layout (triangle_strip) out;

--- a/tests/unit/geometry_tessellation_positive.cpp
+++ b/tests/unit/geometry_tessellation_positive.cpp
@@ -30,7 +30,7 @@ TEST_F(PositiveGeometryTessellation, PointSizeGeomShaderDontWriteMaintenance5) {
     InitRenderTarget();
 
     // Create GS declaring PointSize and writing to it
-    static char const *gsSource = R"glsl(
+    const char *gsSource = R"glsl(
         #version 450
         layout (points) in;
         layout (points) out;
@@ -63,7 +63,7 @@ TEST_F(PositiveGeometryTessellation, IncompatibleDynamicPrimitiveTopology) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    static const char *gsSource = R"glsl(
+    const char *gsSource = R"glsl(
         #version 450
         layout (points) in;
         layout (triangle_strip) out;
@@ -102,7 +102,7 @@ TEST_F(PositiveGeometryTessellation, DrawDynamicPrimitiveTopology) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    static const char *gsSource = R"glsl(
+    const char *gsSource = R"glsl(
         #version 450
         layout (points) in;
         layout (triangle_strip) out;
@@ -147,13 +147,13 @@ TEST_F(PositiveGeometryTessellation, TessellationPointMode) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    static const char tess_src[] = R"glsl(
+    const char tess_src[] = R"glsl(
         #version 460
         layout(triangles, equal_spacing, cw, point_mode) in;
         void main() { gl_Position = vec4(1); }
     )glsl";
 
-    static char const geom_src[] = R"glsl(
+    const char geom_src[] = R"glsl(
         #version 450
         layout (points) in;
         layout (points) out;
@@ -186,7 +186,7 @@ TEST_F(PositiveGeometryTessellation, InterfaceComponents) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vs_source = R"glsl(
+    const char *vs_source = R"glsl(
         #version 450
         layout(location = 0) out ivec4 a;
         void main() {
@@ -194,7 +194,7 @@ TEST_F(PositiveGeometryTessellation, InterfaceComponents) {
         }
     )glsl";
 
-    char const *geom_source = R"glsl(
+    const char *geom_source = R"glsl(
         #version 450
         layout(triangles) in;
         layout(triangle_strip) out;
@@ -219,7 +219,7 @@ TEST_F(PositiveGeometryTessellation, InterfaceComponents) {
         }
     )glsl";
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         layout(location = 0) in vec4 b;
         layout(location = 0) out vec4 c;
@@ -245,7 +245,7 @@ TEST_F(PositiveGeometryTessellation, TessGeomPointPrimitiveTopology) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *tcsSource = R"asm(
+    const char *tcsSource = R"asm(
                OpCapability Tessellation
           %2 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
@@ -268,7 +268,7 @@ TEST_F(PositiveGeometryTessellation, TessGeomPointPrimitiveTopology) {
                OpReturn
                OpFunctionEnd
     )asm";
-    char const *tesSource = R"glsl(
+    const char *tesSource = R"glsl(
         #version 450
         layout(triangles, equal_spacing, cw) in;
         layout(location=0) patch in int x;
@@ -277,7 +277,7 @@ TEST_F(PositiveGeometryTessellation, TessGeomPointPrimitiveTopology) {
            gl_Position.w = x;
         }
     )glsl";
-    static const char *gsSource = R"glsl(
+    const char *gsSource = R"glsl(
         #version 450
         layout (points) in;
         layout (triangle_strip) out;

--- a/tests/unit/gpu_av.cpp
+++ b/tests/unit/gpu_av.cpp
@@ -79,7 +79,7 @@ TEST_F(NegativeGpuAV, SelectInstrumentedShaders) {
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
     descriptor_set.WriteDescriptorBufferInfo(0, write_buffer, 0, 4, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
-    static const char vertshader[] = R"glsl(
+    const char vertshader[] = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer StorageBuffer { uint data[]; } Data;
         void main() {
@@ -134,7 +134,7 @@ TEST_F(NegativeGpuAV, SelectInstrumentedShadersRegex) {
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
     descriptor_set.WriteDescriptorBufferInfo(0, write_buffer, 0, 4, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
-    static const char vertshader[] = R"glsl(
+    const char vertshader[] = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer StorageBuffer { uint data[]; } Data;
         void main() {
@@ -202,7 +202,7 @@ TEST_F(NegativeGpuAV, SelectInstrumentedShadersRegexDestroyedShaders) {
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
     descriptor_set.WriteDescriptorBufferInfo(0, write_buffer, 0, 4, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
-    static const char vertshader[] = R"glsl(
+    const char vertshader[] = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer StorageBuffer { uint data[]; } Data;
         void main() {
@@ -270,7 +270,7 @@ TEST_F(NegativeGpuAV, SelectInstrumentedShadersShaderObject) {
                                             });
     vkt::PipelineLayout pipeline_layout(*m_device, {&vert_descriptor_set.layout_});
 
-    static const char vert_src[] = R"glsl(
+    const char vert_src[] = R"glsl(
         #version 460
         layout(set = 0, binding = 0) buffer StorageBuffer { uint data[]; } Data;
         void main() {
@@ -366,7 +366,7 @@ TEST_F(NegativeGpuAV, UseAllDescriptorSlotsPipelineNotReserved) {
     }
     vkt::PipelineLayout pipe_layout(*m_device, layouts);
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, std430) readonly buffer IndexBuffer {
@@ -440,7 +440,7 @@ TEST_F(NegativeGpuAV, UseAllDescriptorSlotsPipelineReserved) {
     }
     vkt::PipelineLayout pipe_layout(*m_device, layouts);
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, std430) readonly buffer IndexBuffer {
@@ -542,7 +542,7 @@ TEST_F(NegativeGpuAV, UseAllDescriptorSlotsPipelineLayout) {
     m_errorMonitor->SetAllowedFailureMsg("This Pipeline Layout has too many descriptor sets");
     vkt::PipelineLayout bad_pipe_layout(*m_device, empty_layouts);
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo {
             int x;
@@ -655,7 +655,7 @@ TEST_F(NegativeGpuAV, LeakedResource) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout (set = 0, binding = 0) uniform sampler2D samplerColor[2];
         void main() {

--- a/tests/unit/gpu_av_buffer_device_address.cpp
+++ b/tests/unit/gpu_av_buffer_device_address.cpp
@@ -29,7 +29,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ReadBeforePointerPushConstant) {
     plci.pPushConstantRanges = &push_constant_ranges;
     vkt::PipelineLayout pipeline_layout(*m_device, plci);
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
             #version 450
             #extension GL_EXT_buffer_reference : enable
             layout(buffer_reference, buffer_reference_align = 16) buffer bufStruct;
@@ -91,7 +91,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ReadAfterPointerPushConstant) {
     plci.pPushConstantRanges = &push_constant_ranges;
     vkt::PipelineLayout pipeline_layout(*m_device, plci);
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
             #version 450
             #extension GL_EXT_buffer_reference : enable
             layout(buffer_reference, buffer_reference_align = 16) buffer bufStruct;
@@ -163,7 +163,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ReadBeforePointerDescriptor) {
     memcpy(uniform_buffer_ptr, &invalid_buffer_address, sizeof(VkDeviceAddress));
     memcpy(uniform_buffer_ptr + sizeof(VkDeviceAddress), &n_writes, sizeof(uint32_t));
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, buffer_reference_align = 16) buffer bufStruct;
@@ -230,7 +230,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ReadAfterPointerDescriptor) {
     memcpy(uniform_buffer_ptr, &u_info_ptr, sizeof(VkDeviceAddress));
     memcpy(uniform_buffer_ptr + sizeof(VkDeviceAddress), &n_writes, sizeof(uint32_t));
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, buffer_reference_align = 16) buffer bufStruct;
@@ -280,7 +280,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, UVec3Array) {
     AddRequiredFeature(vkt::Feature::scalarBlockLayout);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         #extension GL_EXT_scalar_block_layout : enable
@@ -340,7 +340,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, Maintenance5) {
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
     InitRenderTarget();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -421,7 +421,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ArrayOfStruct) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(std430, buffer_reference) buffer T1 {
@@ -490,7 +490,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd140) {
     const uint32_t uniform_buffer_size = 8 + 4;  // 64 bits pointer + int
     vkt::Buffer uniform_buffer(*m_device, uniform_buffer_size, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, buffer_reference_align = 16) buffer bufStruct;
@@ -555,7 +555,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd140NumerousRanges) {
     const uint32_t uniform_buffer_size = 8 + 4;  // 64 bits pointer + int
     vkt::Buffer uniform_buffer(*m_device, uniform_buffer_size, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, buffer_reference_align = 16) buffer bufStruct;
@@ -638,7 +638,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd430) {
     const uint32_t uniform_buffer_size = 8 + 4;  // 64 bits pointer + int
     vkt::Buffer uniform_buffer(*m_device, uniform_buffer_size, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, buffer_reference_align = 16) buffer bufStruct;
@@ -711,7 +711,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreRelaxedBlockLayout) {
     //     ssbo.ptr.f = 42.0;
     //     ssbo.ptr.v = uvec3(1.0, 2.0, 3.0);
     // }
-    char const *shader_source = R"(
+    const char *shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpMemoryModel PhysicalStorageBuffer64 GLSL450
@@ -821,7 +821,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreRelaxedBlockLayoutFront) {
     // void main() {
     //     ssbo.ptr.f = 42.0;
     // }
-    char const *shader_source = R"(
+    const char *shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpMemoryModel PhysicalStorageBuffer64 GLSL450
@@ -900,7 +900,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreScalarBlockLayout) {
 
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_scalar_block_layout : enable
         #extension GL_EXT_buffer_reference : enable
@@ -963,7 +963,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreScalarBlockLayoutFront) {
 
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_scalar_block_layout : enable
         #extension GL_EXT_buffer_reference : enable
@@ -1022,7 +1022,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd430LinkedList) {
     const uint32_t uniform_buffer_size = 3 * sizeof(VkDeviceAddress);
     vkt::Buffer uniform_buffer(*m_device, uniform_buffer_size, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -1098,7 +1098,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ProxyStructLoad) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8073");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 460
         #extension GL_EXT_scalar_block_layout : require
         #extension GL_EXT_buffer_reference2 : require
@@ -1159,7 +1159,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ProxyStructLoad2) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8073");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 460
         #extension GL_EXT_scalar_block_layout : require
         #extension GL_EXT_buffer_reference2 : require
@@ -1232,7 +1232,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ProxyStructLoadSlang) {
     //     Foo a = pc.node[0];
     //     result[0] = a.x;
     // }
-    char const *shader_source = R"(
+    const char *shader_source = R"(
                OpCapability PhysicalStorageBufferAddresses
                OpCapability Shader
                OpExtension "SPV_KHR_physical_storage_buffer"
@@ -1324,7 +1324,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ProxyStructLoadUint64) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8073");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 460
         #extension GL_EXT_scalar_block_layout : require
         #extension GL_EXT_buffer_reference2 : require
@@ -1384,7 +1384,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ProxyStructLoadBadAddress) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8073");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 460
         #extension GL_EXT_scalar_block_layout : require
         #extension GL_EXT_buffer_reference2 : require
@@ -1442,7 +1442,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ProxyStructLoadBadAddress) {
 TEST_F(NegativeGpuAVBufferDeviceAddress, StoreAlignment) {
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -1488,7 +1488,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreAlignment) {
 TEST_F(NegativeGpuAVBufferDeviceAddress, LoadAlignment) {
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -1632,7 +1632,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, OpCopyObject) {
     // void main() {
     //     ptr.a = ptr.b;
     // }
-    char const *shader_source = R"(
+    const char *shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpExtension "SPV_KHR_physical_storage_buffer"
@@ -1711,7 +1711,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, MemoryModelOperand) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModel);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -1764,7 +1764,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, MemoryModelOperand2) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModelDeviceScope);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 460
         #pragma use_vulkan_memory_model
         #extension GL_KHR_memory_scope_semantics : enable
@@ -1827,7 +1827,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, AtomicLoad) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModelDeviceScope);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 460
         #pragma use_vulkan_memory_model
         #extension GL_KHR_memory_scope_semantics : enable
@@ -1875,7 +1875,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, AtomicStore) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModelDeviceScope);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 460
         #pragma use_vulkan_memory_model
         #extension GL_KHR_memory_scope_semantics : enable
@@ -1921,7 +1921,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, AtomicExchange) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModel);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 460
         #pragma use_vulkan_memory_model
         #extension GL_KHR_memory_scope_semantics : enable
@@ -1971,7 +1971,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, AtomicAddValueOperand) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModelDeviceScope);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -2021,7 +2021,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, AtomicAddPointerOperand) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModelDeviceScope);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -2069,7 +2069,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, AtomicsMaxMin) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModelDeviceScope);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -2185,7 +2185,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, AtomicExchangeSlang) {
     //     InterlockedExchange(*(x->b), 0);
     // }
 
-    char const *shader_source = R"(
+    const char *shader_source = R"(
                OpCapability Int64
                OpCapability PhysicalStorageBufferAddresses
                OpCapability Shader
@@ -2337,7 +2337,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, PointerChainLastInvalid) {
     TEST_DESCRIPTION("Have BDA point to more BDA creating a chain, and the last pointer is bad");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -2391,7 +2391,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, PointerChainFirstInvalid) {
     TEST_DESCRIPTION("Have BDA point to more BDA creating a chain, and the first pointer is bad");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -2446,7 +2446,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, PointerChainFirstInvalidAtomic) {
     TEST_DESCRIPTION("Have BDA point to more BDA creating a chain, and the first pointer is bad");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 

--- a/tests/unit/gpu_av_buffer_device_address_positive.cpp
+++ b/tests/unit/gpu_av_buffer_device_address_positive.cpp
@@ -34,7 +34,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreStd140) {
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
     InitRenderTarget();
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, buffer_reference_align = 16) buffer bufStruct;
@@ -99,7 +99,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreStd140NumerousAddressRanges) {
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
     InitRenderTarget();
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, buffer_reference_align = 16) buffer bufStruct;
@@ -168,7 +168,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreStd430) {
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
     InitRenderTarget();
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, buffer_reference_align = 16) buffer bufStruct;
@@ -229,7 +229,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreExplicitOffset) {
     TEST_DESCRIPTION("Do a OpStore to a PhysicalStorageBuffer");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -282,7 +282,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StructLoad) {
     TEST_DESCRIPTION("Do a OpLoad through a struct PhysicalStorageBuffer");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -349,7 +349,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StructLoadPadded) {
     TEST_DESCRIPTION("Do a OpLoad through a padded struct PhysicalStorageBuffer");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -417,7 +417,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, UVec3Array) {
     AddRequiredFeature(vkt::Feature::scalarBlockLayout);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         #extension GL_EXT_scalar_block_layout : enable
@@ -472,7 +472,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, ArrayOfStruct) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(std430, buffer_reference) buffer T1 {
@@ -534,7 +534,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, BitCastUvec2) {
     TEST_DESCRIPTION("test loading and storing with GL_EXT_buffer_reference_uvec2");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         #extension GL_EXT_buffer_reference_uvec2 : enable
@@ -610,7 +610,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreRelaxedBlockLayout) {
     //     ssbo.ptr.f = 42.0;
     //     ssbo.ptr.v = uvec3(1.0, 2.0, 3.0);
     // }
-    char const *shader_source = R"(
+    const char *shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpMemoryModel PhysicalStorageBuffer64 GLSL450
@@ -711,7 +711,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreScalarBlockLayout) {
 
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_scalar_block_layout : enable
         #extension GL_EXT_buffer_reference : enable
@@ -772,7 +772,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreStd430LinkedList) {
     const uint32_t uniform_buffer_size = 3 * sizeof(VkDeviceAddress);
     vkt::Buffer uniform_buffer(*m_device, uniform_buffer_size, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, kHostVisibleMemProps);
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -842,7 +842,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, MultipleBufferReferenceBlocks) {
 
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -912,7 +912,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, LoadStoreStruct) {
 
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_scalar_block_layout : enable
         #extension GL_EXT_buffer_reference : enable
@@ -1019,7 +1019,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, ConcurrentAccessesToBdaBuffer) {
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
     InitRenderTarget();
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -1082,7 +1082,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, ProxyStructLoad) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8073");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 460
         #extension GL_EXT_scalar_block_layout : require
         #extension GL_EXT_buffer_reference2 : require
@@ -1135,7 +1135,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, ProxyStructLoadLinkedList) {
     TEST_DESCRIPTION("Make sure we don't get in an infinite loop searching for BDA length");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -1169,7 +1169,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, ProxyStructUnsafe) {
     TEST_DESCRIPTION("Make sure the range for a struct load is the whole struct.");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress(false));
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 460
         #extension GL_EXT_buffer_reference2 : require
 
@@ -1243,7 +1243,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, BasicRangeUnsafe) {
     TEST_DESCRIPTION("Simple test to examine how we do the range check in unsafe mode.");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress(false));
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 460
         #extension GL_EXT_buffer_reference2 : require
 
@@ -1404,7 +1404,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, AtomicExchangeSlang) {
     //     InterlockedExchange(*foo.a, 0);
     //     InterlockedExchange(*(x->b), 0);
     // }
-    char const *shader_source = R"(
+    const char *shader_source = R"(
                OpCapability Int64
                OpCapability PhysicalStorageBufferAddresses
                OpCapability Shader
@@ -1498,7 +1498,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, MemoryModelOperand) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModel);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -1552,7 +1552,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, MemoryModelOperand2) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModelDeviceScope);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 460
         #pragma use_vulkan_memory_model
         #extension GL_KHR_memory_scope_semantics : enable
@@ -1614,7 +1614,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, Atomics) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModelDeviceScope);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 460
         #pragma use_vulkan_memory_model
         #extension GL_KHR_memory_scope_semantics : enable
@@ -1668,7 +1668,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, Atomics2) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModelDeviceScope);
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -1727,7 +1727,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, AtomicsWorkgroups) {
     TEST_DESCRIPTION("Found case where a potential BDA points to a variable not in the function");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
 
         shared int x;
@@ -1893,7 +1893,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, SharedPipelineLayoutSubsetGraphicsPushC
     pipeline_layout_ci.pushConstantRangeCount = 2;
     const vkt::PipelineLayout pipeline_layout_2(*m_device, pipeline_layout_ci);
 
-    char const *vs_source = R"glsl(
+    const char *vs_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -1911,7 +1911,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, SharedPipelineLayoutSubsetGraphicsPushC
         }
     )glsl";
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo_1 { uint c; };
         void main() {}
@@ -1991,7 +1991,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, SharedPipelineLayoutSubsetGraphicsPushC
     pipeline_layout_ci.pPushConstantRanges = push_constant_ranges.data();
     const vkt::PipelineLayout pipeline_layout(*m_device, pipeline_layout_ci);
 
-    char const *vs_source = R"glsl(
+    const char *vs_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -2009,7 +2009,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, SharedPipelineLayoutSubsetGraphicsPushC
         }
     )glsl";
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo_1 { uint c; };
         void main() {}
@@ -2081,7 +2081,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, PointerChain) {
     TEST_DESCRIPTION("Have BDA point to more BDA creating a chain");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -2145,7 +2145,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, ManyAccessToSameStruct) {
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
     InitRenderTarget();
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -2258,7 +2258,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, GlobalInvocationIdIVec3) {
     // void main() {
     //     ptr.x = int(gl_GlobalInvocationID.x);
     // }
-    char const *shader_source = R"(
+    const char *shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpExtension "SPV_KHR_physical_storage_buffer"
@@ -2316,7 +2316,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, DualShaderLibrary) {
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
     InitRenderTarget();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 
@@ -2391,7 +2391,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, DualShaderLibraryDestroyModule) {
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
     InitRenderTarget();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
 

--- a/tests/unit/gpu_av_cooperative_vector_positive.cpp
+++ b/tests/unit/gpu_av_cooperative_vector_positive.cpp
@@ -38,7 +38,7 @@ TEST_F(PositiveGpuAVCooperativeVector, CooperativeVector) {
 
     vkt::Buffer buffer(*m_device, 4096, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_NV_cooperative_vector : enable
         #extension GL_KHR_shader_subgroup_basic : enable

--- a/tests/unit/gpu_av_debug_printf.cpp
+++ b/tests/unit/gpu_av_debug_printf.cpp
@@ -76,7 +76,7 @@ void NegativeGpuAVDebugPrintf::InitWithLayerSettings(bool enable_printf, bool en
 }
 
 void NegativeGpuAVDebugPrintf::BasicComputeTest() {
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) buffer foo_0 {
@@ -187,7 +187,7 @@ TEST_F(NegativeGpuAVDebugPrintf, Graphics) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) buffer foo_0 {
@@ -236,7 +236,7 @@ TEST_F(NegativeGpuAVDebugPrintf, GPL) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) buffer foo_0 {
@@ -282,7 +282,7 @@ TEST_F(NegativeGpuAVDebugPrintf, ShaderObject) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) buffer foo_0 {
@@ -329,7 +329,7 @@ TEST_F(NegativeGpuAVDebugPrintf, DynamicRendering) {
     RETURN_IF_SKIP(InitState());
     InitDynamicRenderTarget();
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) buffer foo_0 {

--- a/tests/unit/gpu_av_descriptor_buffer_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_buffer_positive.cpp
@@ -60,7 +60,7 @@ TEST_F(PositiveGpuAVDescriptorBuffer, Basic) {
     vk::GetDescriptorEXT(device(), &buffer_descriptor_info, descriptor_buffer_properties.storageBufferDescriptorSize,
                          mapped_descriptor_data);
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout (set = 0, binding = 0) buffer SSBO_0 {
             uint a;

--- a/tests/unit/gpu_av_descriptor_class_general_buffer.cpp
+++ b/tests/unit/gpu_av_descriptor_class_general_buffer.cpp
@@ -317,7 +317,7 @@ void NegativeGpuAVDescriptorClassGeneralBuffer::ShaderBufferSizeTest(VkDeviceSiz
 
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, UniformBufferTooSmall) {
     TEST_DESCRIPTION("Test that an error is produced when trying to access uniform buffer outside the bound region.");
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
 
         layout(location=0) out vec4 x;
@@ -335,7 +335,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, UniformBufferTooSmall) {
 
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, UniformBufferTooSmall2) {
     TEST_DESCRIPTION("Buffer is correct size, but only updating half of it.");
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
 
         layout(location=0) out vec4 x;
@@ -357,7 +357,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, UniformBufferTooSmall2) {
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, StorageBufferTooSmall) {
     TEST_DESCRIPTION("Test that an error is produced when trying to access storage buffer outside the bound region.");
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
 
         layout(location=0) out vec4 x;
@@ -379,7 +379,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, UniformBufferTooSmallArray) {
         "Test that an error is produced when trying to access uniform buffer outside the bound region. Uses array in block "
         "definition.");
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
 
         layout(location=0) out vec4 x;
@@ -404,7 +404,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, UniformBufferTooSmallNestedStr
         "Test that an error is produced when trying to access uniform buffer outside the bound region. Uses nested struct in block "
         "definition.");
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
 
         struct S {
@@ -427,7 +427,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, UniformBufferTooSmallNestedStr
 
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, ObjectUniformBufferTooSmall) {
     TEST_DESCRIPTION("Test that an error is produced when trying to access uniform buffer outside the bound region.");
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
 
         layout(location=0) out vec4 x;
@@ -466,7 +466,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, GPLWrite) {
     uint32_t *data = (uint32_t *)offset_buffer.Memory().Map();
     *data = 8;
 
-    static const char vertshader[] = R"glsl(
+    const char vertshader[] = R"glsl(
         #version 450
         layout(set = 0, binding = 0) uniform Foo { uint index[]; };
         layout(set = 0, binding = 1) buffer StorageBuffer { uint data[]; };
@@ -522,7 +522,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, GPLWriteSelectPipeline) {
     uint32_t *data = (uint32_t *)offset_buffer.Memory().Map();
     *data = 8;
 
-    static const char vertshader[] = R"glsl(
+    const char vertshader[] = R"glsl(
         #version 450
         layout(set = 0, binding = 0) uniform Foo { uint index[]; };
         layout(set = 0, binding = 1) buffer StorageBuffer { uint data[]; };
@@ -632,7 +632,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, GPLWriteSelectShaders) {
     uint32_t *data = (uint32_t *)offset_buffer.Memory().Map();
     *data = 8;
 
-    static const char vertshader[] = R"glsl(
+    const char vertshader[] = R"glsl(
         #version 450
         layout(set = 0, binding = 0) uniform Foo { uint index[]; };
         layout(set = 0, binding = 1) buffer StorageBuffer { uint data[]; };
@@ -736,7 +736,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, GPLRead) {
     descriptor_set.WriteDescriptorBufferInfo(1, write_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    static const char vertshader[] = R"glsl(
+    const char vertshader[] = R"glsl(
         #version 450
         layout(set = 0, binding = 0) uniform Foo { uint index[]; };
         layout(set = 0, binding = 1) buffer StorageBuffer { uint data[]; };
@@ -801,7 +801,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, GPLReadWriteIndependentSets) {
     uint32_t *data = (uint32_t *)offset_buffer.Memory().Map();
     *data = 8;
 
-    static const char vert_shader[] = R"glsl(
+    const char vert_shader[] = R"glsl(
         #version 450
         layout(set = 1, binding = 0) uniform ufoo { uint index[]; };        // index[1]
         layout(set = 0, binding = 0) buffer StorageBuffer { uint data[]; }; // data[4]
@@ -818,7 +818,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, GPLReadWriteIndependentSets) {
         }
     )glsl";
 
-    static const char frag_shader[] = R"glsl(
+    const char frag_shader[] = R"glsl(
         #version 450
         layout(set = 1, binding = 0) uniform ufoo { uint index[]; };      // index[1]
         layout(set = 2, binding = 1) uniform samplerBuffer u_buffer;      // texel_buffer[4]
@@ -906,7 +906,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, GPLNonInlined) {
     uint32_t *offset_buffer_ptr = (uint32_t *)offset_buffer.Memory().Map();
     *offset_buffer_ptr = 8;
 
-    static const char vertshader[] = R"glsl(
+    const char vertshader[] = R"glsl(
         #version 450
         layout(set = 0, binding = 0) uniform Uniform { uint offset_buffer[]; };
         layout(set = 0, binding = 1) buffer StorageBuffer { uint write_buffer[]; };
@@ -1102,7 +1102,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, StorageBuffer) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         #extension GL_ARB_gpu_shader_int64 : enable
@@ -1162,7 +1162,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, StorageBuffer) {
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, Vector) {
     TEST_DESCRIPTION("index into a vector OOB");
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
 
         // 28 bytes large
@@ -1181,7 +1181,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, Vector) {
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, Matrix) {
     TEST_DESCRIPTION("index into a matrix OOB");
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
 
         // 32 bytes large
@@ -1206,7 +1206,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, Geometry) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *gsSource = R"glsl(
+    const char *gsSource = R"glsl(
         #version 450
         layout(triangles) in;
         layout(triangle_strip, max_vertices=3) out;
@@ -1261,7 +1261,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, DISABLED_TessellationControl) 
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    static const char shader_source[] = R"glsl(
+    const char shader_source[] = R"glsl(
         #version 460
         layout(vertices=3) out;
         layout(set = 0, binding = 0, std430) buffer foo {
@@ -1319,7 +1319,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, DISABLED_TessellationEvaluatio
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    static const char shader_source[] = R"glsl(
+    const char shader_source[] = R"glsl(
         #version 460
         layout(triangles, equal_spacing, cw) in;
         layout(set = 0, binding = 0, std430) buffer foo {
@@ -1514,7 +1514,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, PartialBoundDescriptorCopy) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo {
             vec4 a;
@@ -1588,7 +1588,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, DeviceGeneratedCommandsCompute
     command_layout_ci.pTokens = &token;
     vkt::IndirectCommandsLayout command_layout(*m_device, command_layout_ci);
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer ssbo {
             uint x[];
@@ -1664,7 +1664,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, SpecConstant) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(constant_id = 0) const uint index = 2;
 
@@ -1712,7 +1712,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, PartialBoundDescriptorSSBO) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo {
             vec4 a; // offset 0
@@ -1751,7 +1751,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, PartialBoundDescriptorSSBO) {
 }
 
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, VectorArray) {
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo {
             uvec4 a[8]; // stride 16
@@ -1764,7 +1764,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, VectorArray) {
 }
 
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, ArrayCopyGLSL) {
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0, std430) buffer foo {
             uvec4 a;
@@ -1811,7 +1811,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, ArrayCopyTwoBindingsGLSL) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0, std430) buffer foo1 {
             uvec4 a;
@@ -1914,7 +1914,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, ArrayCopyTwoBindingsSlang) {
 
 // https://github.com/KhronosGroup/glslang/issues/3892
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, DISABLED_StructCopyGLSL) {
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
 
         struct Bar {
@@ -1939,7 +1939,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, DISABLED_StructCopyGLSL) {
 }
 
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, StructCopyGLSL2) {
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
 
         struct Bar {
@@ -1962,7 +1962,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, StructCopyGLSL2) {
 }
 
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, StructCopyGLSL3) {
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
 
         struct Bar2 {
@@ -2040,7 +2040,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, ChainOfAccessChains) {
 }
 
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, AtomicStore) {
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_KHR_memory_scope_semantics : enable
         layout(set = 0, binding = 0, std430) buffer foo {
@@ -2056,7 +2056,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, AtomicStore) {
 }
 
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, AtomicLoad) {
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_KHR_memory_scope_semantics : enable
         layout(set = 0, binding = 0, std430) buffer foo {
@@ -2072,7 +2072,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, AtomicLoad) {
 }
 
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, AtomicExchange) {
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_KHR_memory_scope_semantics : enable
         layout(set = 0, binding = 0, std430) buffer foo {
@@ -2092,7 +2092,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, AtomicsDescriptorIndex) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_KHR_memory_scope_semantics : enable
         layout(set = 0, binding = 0, std430) buffer SSBO {
@@ -2177,7 +2177,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, DescriptorIndexSlang) {
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, Loops) {
     TEST_DESCRIPTION("Invalid during last iteration of a loop");
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer Input {
             uint result;
@@ -2198,7 +2198,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, Loops) {
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, LoopsNested) {
     TEST_DESCRIPTION("Invalid during last iteration of a loop");
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer Input {
             uint result;
@@ -2221,7 +2221,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, LoopsNested) {
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, LoopsHoistable) {
     TEST_DESCRIPTION("Invalid during each iteration of a loop, but not dependent on the loop itself");
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer Input {
             uint result;
@@ -2242,7 +2242,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, LoopsHoistable) {
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, LoopsNestedHoistable) {
     TEST_DESCRIPTION("Invalid during each iteration of a loop, but not dependent on the loop itself");
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer Input {
             uint result;
@@ -2265,7 +2265,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, LoopsNestedHoistable) {
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, LoopsWithBranch) {
     TEST_DESCRIPTION("Invalid during last iteration of a loop, but has branch in it");
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer Input {
             uint result;
@@ -2289,7 +2289,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, LoopsWithBranch) {
 
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, ComplexCalculate) {
     TEST_DESCRIPTION("from Granite meshopt-sandbox test");
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
 
         layout(set = 0, binding = 0, std430) buffer SSBO {
@@ -2410,7 +2410,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, MeshTaskIndirect) {
         }
     )glsl";
 
-    char const *mesh_source = R"glsl(
+    const char *mesh_source = R"glsl(
         #version 450
         #extension GL_EXT_mesh_shader : require
         layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
@@ -2432,7 +2432,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, MeshTaskIndirect) {
         }
     )glsl";
 
-    char const *frag_source = R"glsl(
+    const char *frag_source = R"glsl(
         #version 460
         layout(location = 0) out vec4 uFragColor;
         layout(set = 0, binding = 2) readonly uniform UBO {
@@ -2503,7 +2503,7 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, GPLOneLibraryTwoLinkedPipeline
     uint32_t *data = (uint32_t *)offset_buffer.Memory().Map();
     *data = 8;
 
-    static const char vertshader[] = R"glsl(
+    const char vertshader[] = R"glsl(
         #version 450
         layout(set = 0, binding = 0) uniform Foo { uint index[]; };
         layout(set = 0, binding = 1) buffer StorageBuffer { uint data[]; };

--- a/tests/unit/gpu_av_descriptor_class_general_buffer_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_class_general_buffer_positive.cpp
@@ -212,7 +212,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, GPLNonInlined) {
     uint32_t *offset_buffer_ptr = (uint32_t *)offset_buffer.Memory().Map();
     *offset_buffer_ptr = 8;
 
-    static const char vertshader[] = R"glsl(
+    const char vertshader[] = R"glsl(
         #version 450
         layout(set = 0, binding = 0) uniform Uniform { uint offset_buffer[]; };
         layout(set = 0, binding = 1) buffer StorageBuffer { uint write_buffer[]; };
@@ -328,7 +328,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, GPLFragmentIndependentSets) {
     vertex_input_lib.InitVertexInputLibInfo();
     vertex_input_lib.CreateGraphicsPipeline(false);
 
-    static const char vertshader[] = R"glsl(
+    const char vertshader[] = R"glsl(
         #version 450
         layout(set = 0, binding = 0) readonly buffer Input { uint u_buffer[]; } v_in; // texel_buffer[4]
         const vec2 vertices[3] = vec2[](
@@ -355,7 +355,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, GPLFragmentIndependentSets) {
     pre_raster_lib.gp_ci_.layout = pipeline_layout_vs;
     pre_raster_lib.CreateGraphicsPipeline(false);
 
-    static const char frag_shader[] = R"glsl(
+    const char frag_shader[] = R"glsl(
         #version 450
         layout(set = 1, binding = 0) readonly buffer Input { uint u_buffer[]; } f_in; // texel_buffer[4]
         layout(location = 0) out vec4 c_out;
@@ -548,7 +548,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, PartialBoundDescriptorSSBO) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo {
             vec4 a; // offset 0
@@ -590,7 +590,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, PartialBoundDescriptorSSBOUpda
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo {
             vec4 a; // offset 0
@@ -632,7 +632,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, PartialBoundDescriptorBuffer) 
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo {
             vec4 a; // offset 0
@@ -674,7 +674,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, PartialBoundDescriptorCopy) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo {
             vec4 a; // offset 0
@@ -769,7 +769,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, RobustBuffer) {
 }
 
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, VectorArray) {
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo {
             uvec4 a[8]; // stride 16
@@ -783,7 +783,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, VectorArray) {
 }
 
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, ArrayCopyGLSL) {
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo {
             uvec4 a;
@@ -832,7 +832,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, ArrayStrideEnd) {
     // void main() {
     //     x[3] = 0;
     // }
-    char const *cs_source = R"(
+    const char *cs_source = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint GLCompute %main "main" %_
@@ -871,7 +871,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, ArrayCopyTwoBindingsGLSL) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0, std430) buffer foo1 {
             uvec4 a;
@@ -968,7 +968,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, ArrayCopyTwoBindingsSlang) {
 
 // https://github.com/KhronosGroup/glslang/issues/3892
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, DISABLED_StructCopyGLSL) {
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
 
         struct Bar {
@@ -991,7 +991,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, DISABLED_StructCopyGLSL) {
     ComputeStorageBufferTest(cs_source, SPV_SOURCE_GLSL, 32);
 }
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, StructCopyGLSL2) {
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
 
         struct Bar {
@@ -1013,7 +1013,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, StructCopyGLSL2) {
 }
 
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, StructCopyGLSL3) {
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
 
         struct Bar2 {
@@ -1091,7 +1091,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, ChainOfAccessChains) {
 }
 
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, Atomics) {
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_KHR_memory_scope_semantics : enable
         layout(set = 0, binding = 0, std430) buffer foo {
@@ -1114,7 +1114,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, AtomicsDescriptorIndex) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_KHR_memory_scope_semantics : enable
         layout(set = 0, binding = 0, std430) buffer SSBO {
@@ -1200,7 +1200,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, OpArrayLength) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
 
@@ -1246,7 +1246,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, OpArrayLength) {
 }
 
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, Loops) {
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer Input {
             uint result;
@@ -1275,7 +1275,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, Loops) {
 }
 
 TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, LoopsEarlyBranch) {
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer Input {
             uint result;
@@ -1333,7 +1333,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, MeshTaskIndirect) {
         }
     )glsl";
 
-    char const *mesh_source = R"glsl(
+    const char *mesh_source = R"glsl(
         #version 450
         #extension GL_EXT_mesh_shader : require
         layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
@@ -1355,7 +1355,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, MeshTaskIndirect) {
         }
     )glsl";
 
-    char const *frag_source = R"glsl(
+    const char *frag_source = R"glsl(
         #version 460
         layout(location = 0) out vec4 uFragColor;
         layout(set = 0, binding = 2) readonly uniform UBO {
@@ -1435,7 +1435,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, InternalPipelineLayoutSelectio
     vertex_input_lib.InitVertexInputLibInfo();
     vertex_input_lib.CreateGraphicsPipeline(false);
 
-    static const char vertshader[] = R"glsl(
+    const char vertshader[] = R"glsl(
         #version 450
         const vec2 vertices[3] = vec2[](
             vec2(-1.0, -1.0),
@@ -1458,7 +1458,7 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, InternalPipelineLayoutSelectio
     pre_raster_lib.gp_ci_.layout = pipeline_layout_vs;
     pre_raster_lib.CreateGraphicsPipeline(false);
 
-    static const char frag_shader[] = R"glsl(
+    const char frag_shader[] = R"glsl(
         #version 450
 
         layout(location = 0) out vec4 c_out;

--- a/tests/unit/gpu_av_descriptor_class_texel_buffer.cpp
+++ b/tests/unit/gpu_av_descriptor_class_texel_buffer.cpp
@@ -38,7 +38,7 @@ TEST_F(NegativeGpuAVDescriptorClassTexelBuffer, GPLTexelFetch) {
     descriptor_set.WriteDescriptorBufferInfo(1, write_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    static const char vertshader[] = R"glsl(
+    const char vertshader[] = R"glsl(
         #version 450
         layout(set = 0, binding = 0) uniform samplerBuffer u_buffer;  // texel_buffer[4]
         layout(set = 0, binding = 1) buffer StorageBuffer { vec4 data; };
@@ -82,7 +82,7 @@ TEST_F(NegativeGpuAVDescriptorClassTexelBuffer, GPLImageLoad) {
     descriptor_set.WriteDescriptorBufferInfo(1, write_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    static const char vertshader[] = R"glsl(
+    const char vertshader[] = R"glsl(
         #version 450
         layout(set = 0, binding = 0, r32f) uniform imageBuffer s_buffer; // texel_buffer[4]
         layout(set = 0, binding = 1) buffer StorageBuffer { vec4 data; };
@@ -126,7 +126,7 @@ TEST_F(NegativeGpuAVDescriptorClassTexelBuffer, GPLImageStore) {
     descriptor_set.WriteDescriptorBufferInfo(1, write_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    static const char vertshader[] = R"glsl(
+    const char vertshader[] = R"glsl(
         #version 450
         layout(set = 0, binding = 0, r32f) uniform imageBuffer s_buffer; // texel_buffer[4]
         layout(set = 0, binding = 1) buffer StorageBuffer { vec4 data; };
@@ -187,7 +187,7 @@ TEST_F(NegativeGpuAVDescriptorClassTexelBuffer, GPLTexelFetchIndependentSets) {
     uint32_t *data = (uint32_t *)offset_buffer.Memory().Map();
     *data = 8;
 
-    static const char vert_shader[] = R"glsl(
+    const char vert_shader[] = R"glsl(
         #version 450
         layout(set = 1, binding = 0) uniform ufoo { uint index[]; };        // index[1]
         layout(set = 0, binding = 0) readonly buffer StorageBuffer { uint data[]; }; // data[4]
@@ -201,7 +201,7 @@ TEST_F(NegativeGpuAVDescriptorClassTexelBuffer, GPLTexelFetchIndependentSets) {
         }
     )glsl";
 
-    static const char frag_shader[] = R"glsl(
+    const char frag_shader[] = R"glsl(
         #version 450
         layout(set = 1, binding = 0) uniform ufoo { uint index[]; };      // index[1]
         layout(set = 2, binding = 1) uniform samplerBuffer u_buffer;      // texel_buffer[4]
@@ -262,7 +262,7 @@ TEST_F(NegativeGpuAVDescriptorClassTexelBuffer, GPLImageLoadStoreIndependentSets
 
     const std::array<VkDescriptorSet, 3> desc_sets = {vertex_set.set_, common_set.set_, fragment_set.set_};
 
-    static const char vert_shader[] = R"glsl(
+    const char vert_shader[] = R"glsl(
         #version 450
         layout(set = 1, binding = 0) uniform ufoo { uint index[]; } u_index;      // index[1]
         layout(set = 0, binding = 0) buffer StorageBuffer { uint data[]; } Data;  // data[4]
@@ -276,7 +276,7 @@ TEST_F(NegativeGpuAVDescriptorClassTexelBuffer, GPLImageLoadStoreIndependentSets
         }
     )glsl";
 
-    static const char frag_shader[] = R"glsl(
+    const char frag_shader[] = R"glsl(
         #version 450
         layout(set = 1, binding = 0) uniform ufoo { uint index[]; } u_index;      // index[1]
         layout(set = 2, binding = 2, r32f) uniform imageBuffer s_buffer;          // texel_buffer[4]
@@ -310,7 +310,7 @@ TEST_F(NegativeGpuAVDescriptorClassTexelBuffer, TexelFetch) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
 
         layout(set = 0, binding = 0, std430) buffer foo {
@@ -360,7 +360,7 @@ TEST_F(NegativeGpuAVDescriptorClassTexelBuffer, TexelFetchArray) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
 
         layout(set = 0, binding = 0, std430) buffer foo {
@@ -416,7 +416,7 @@ TEST_F(NegativeGpuAVDescriptorClassTexelBuffer, ImageLoad) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0, std430) buffer foo {
             vec4 a;
@@ -464,7 +464,7 @@ TEST_F(NegativeGpuAVDescriptorClassTexelBuffer, ImageStore) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0, r32f) uniform imageBuffer s_buffer;  // texel_buffer[4]
 

--- a/tests/unit/gpu_av_descriptor_class_texel_buffer_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_class_texel_buffer_positive.cpp
@@ -24,7 +24,7 @@ TEST_F(PositiveGpuAVDescriptorClassTexelBuffer, ImageLoadStoreTexelFetch) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
 
         layout(set = 0, binding = 0) uniform samplerBuffer u_buffer; // texel_buffer[5]
@@ -77,7 +77,7 @@ TEST_F(PositiveGpuAVDescriptorClassTexelBuffer, AtomicImageLoadStore) {
         GTEST_SKIP() << "No atomic texel buffer support";
     }
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_KHR_memory_scope_semantics : enable
         #extension GL_EXT_shader_atomic_float : enable
@@ -118,7 +118,7 @@ TEST_F(PositiveGpuAVDescriptorClassTexelBuffer, TexelFetchArray) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
 
         layout(set = 0, binding = 0, std430) buffer foo {
@@ -176,7 +176,7 @@ TEST_F(PositiveGpuAVDescriptorClassTexelBuffer, Robustness) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
 
         layout(set = 0, binding = 0) uniform samplerBuffer u_buffer; // texel_buffer[5]

--- a/tests/unit/gpu_av_descriptor_indexing.cpp
+++ b/tests/unit/gpu_av_descriptor_indexing.cpp
@@ -67,7 +67,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBBuffer) {
     descriptor_writes[1].pBufferInfo = &buffer_info[1];
     vk::UpdateDescriptorSets(device(), 2, descriptor_writes, 0, nullptr);
 
-    char const *vs_source = R"glsl(
+    const char *vs_source = R"glsl(
         #version 450
 
         layout(std140, binding = 0) uniform foo { uint tex_index[1]; } uniform_index_buffer;
@@ -81,7 +81,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBBuffer) {
            index = uniform_index_buffer.tex_index[0];
         }
         )glsl";
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -175,7 +175,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBBufferEmptyUnusedDescSet) {
     descriptor_writes[1].pBufferInfo = &buffer_info[1];
     vk::UpdateDescriptorSets(device(), 2, descriptor_writes, 0, nullptr);
 
-    char const *vs_source = R"glsl(
+    const char *vs_source = R"glsl(
         #version 450
 
         layout(std140, set = 1, binding = 0) uniform foo { uint tex_index[1]; } uniform_index_buffer;
@@ -189,7 +189,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBBufferEmptyUnusedDescSet) {
            index = uniform_index_buffer.tex_index[0];
         }
         )glsl";
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -283,7 +283,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBVertex) {
     descriptor_writes[1].pImageInfo = image_info;
     vk::UpdateDescriptorSets(device(), 2, descriptor_writes, 0, nullptr);
 
-    char const *vs_source = R"glsl(
+    const char *vs_source = R"glsl(
         #version 450
 
         layout(std140, set = 0, binding = 0) uniform foo { uint tex_index[1]; } uniform_index_buffer;
@@ -297,7 +297,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBVertex) {
            gl_Position += 1e-30 * texture(tex[uniform_index_buffer.tex_index[0]], vec2(0, 0));
         }
         )glsl";
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
 
         layout(set = 0, binding = 1) uniform sampler2D tex[6];
@@ -383,7 +383,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBFragment) {
 
     // - The vertex shader fetches the invalid index from the uniform buffer and passes it to the fragment shader.
     // - The fragment shader makes the invalid array access.
-    char const *vs_source = R"glsl(
+    const char *vs_source = R"glsl(
         #version 450
 
         layout(std140, binding = 0) uniform foo { uint tex_index[1]; } uniform_index_buffer;
@@ -397,7 +397,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBFragment) {
            index = uniform_index_buffer.tex_index[0];
         }
         )glsl";
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
 
         layout(set = 0, binding = 1) uniform sampler2D tex[6];
@@ -506,7 +506,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBRuntime) {
     descriptor_writes[1].dstSet = descriptor_set_variable.set_;
     vk::UpdateDescriptorSets(device(), 2, descriptor_writes, 0, nullptr);
 
-    char const *vs_source = R"glsl(
+    const char *vs_source = R"glsl(
         #version 450
 
         layout(std140, binding = 0) uniform foo { uint tex_index[1]; } uniform_index_buffer;
@@ -520,7 +520,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBRuntime) {
            index = uniform_index_buffer.tex_index[0];
         }
         )glsl";
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -609,7 +609,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBVariableDescriptorCountAllocate)
                                             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 1);
     descriptor_set.UpdateDescriptorSets();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform foo { uint tex_index; };
@@ -689,7 +689,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBVariableDescriptorCountAllocateU
                                             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 0);
     descriptor_set.UpdateDescriptorSets();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform foo { uint tex_index; };
@@ -893,7 +893,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBGeom) {
            gl_Position = vec4(1);
         }
     )glsl";
-    char const *gs_source = R"glsl(
+    const char *gs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(triangles) in;
@@ -991,7 +991,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBCompute) {
     descriptor_writes[1].pBufferInfo = &buffer_info[1];
     vk::UpdateDescriptorSets(device(), 2, descriptor_writes, 0, nullptr);
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform ufoo { uint index; } u_index;
@@ -1094,7 +1094,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayEarlyDelete) {
 
     // - The vertex shader fetches the invalid index from the uniform buffer and passes it to the fragment shader.
     // - The fragment shader makes the invalid array access.
-    char const *vs_source = R"glsl(
+    const char *vs_source = R"glsl(
         #version 450
 
         layout(std140, binding = 0) uniform foo { uint tex_index[1]; } uniform_index_buffer;
@@ -1110,7 +1110,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayEarlyDelete) {
         )glsl";
     VkShaderObj vs(this, vs_source, VK_SHADER_STAGE_VERTEX_BIT);
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -1213,7 +1213,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayEarlySamplerDelete) {
 
     // - The vertex shader fetches the invalid index from the uniform buffer and passes it to the fragment shader.
     // - The fragment shader makes the invalid array access.
-    char const *vs_source = R"glsl(
+    const char *vs_source = R"glsl(
         #version 450
 
         layout(std140, binding = 0) uniform foo { uint tex_index[1]; } uniform_index_buffer;
@@ -1229,7 +1229,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayEarlySamplerDelete) {
          )glsl";
     VkShaderObj vs(this, vs_source, VK_SHADER_STAGE_VERTEX_BIT);
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -1350,7 +1350,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, UpdateAfterBind) {
     vkt::PipelineLayout pipeline_layout(*m_device, pipeline_layout_ci);
 
     // Create a dummy pipeline, since VL inspects which bindings are actually used at draw time
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         layout(location=0) out vec4 color;
         layout(set=0, binding=0) uniform foo0 { float x0; } bar0;
@@ -1428,7 +1428,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, VariableDescriptorCountAllocateAfterPipe
 
     vkt::PipelineLayout pipeline_layout(*m_device, pipeline_layout_ci);
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set=0, binding=0) uniform UBO { uint in_buffer; };
@@ -1550,7 +1550,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, BasicHLSL) {
     // void main(uint3 tid : SV_DispatchThreadID) {
     //     data[0].output = textures[data[0].index].SampleLevel(ss, float2(0,0), 0);
     // }
-    char const *cs_source = R"asm(
+    const char *cs_source = R"asm(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint GLCompute %main "main" %data %ss %textures
@@ -1669,7 +1669,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, BasicHLSLRuntimeArray) {
     // void main(uint3 tid : SV_DispatchThreadID) {
     //     data[0].output = textures[data[0].index].SampleLevel(ss, float2(0,0), 0);
     // }
-    char const *cs_source = R"asm(
+    const char *cs_source = R"asm(
                OpCapability Shader
                OpCapability RuntimeDescriptorArray
                OpExtension "SPV_EXT_descriptor_indexing"
@@ -1767,7 +1767,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, PushConstant) {
     descriptor_set.WriteDescriptorImageInfo(0, image_view, sampler, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
     descriptor_set.UpdateDescriptorSets();
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -1831,7 +1831,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleIndexes) {
     descriptor_set.WriteDescriptorImageInfo(1, image_view, sampler, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
     descriptor_set.UpdateDescriptorSets();
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -1925,7 +1925,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleOOBInMultipleCmdBuffers) {
 
     // - The vertex shader fetches the invalid index from the uniform buffer and passes it to the fragment shader.
     // - The fragment shader makes the invalid array access.
-    char const *vs_source = R"glsl(
+    const char *vs_source = R"glsl(
         #version 450
 
         layout(std140, binding = 0) uniform foo { uint tex_index[1]; } uniform_index_buffer;
@@ -1939,7 +1939,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleOOBInMultipleCmdBuffers) {
            index = uniform_index_buffer.tex_index[0];
         }
         )glsl";
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
 
         layout(set = 0, binding = 1) uniform sampler2D tex[6];
@@ -2021,7 +2021,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleOOBInMultipleCmdBuffers) {
         vk::UpdateDescriptorSets(device(), 2, descriptor_writes_cb_2, 0, nullptr);
     }
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform ufoo { uint index; } u_index;
@@ -2114,7 +2114,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleOOBTypesInOneCmdBuffer) {
 
     // - The vertex shader fetches the invalid index from the uniform buffer and passes it to the fragment shader.
     // - The fragment shader makes the invalid array access.
-    char const *vs_source = R"glsl(
+    const char *vs_source = R"glsl(
         #version 450
 
         layout(std140, binding = 0) uniform foo { uint tex_index[1]; } uniform_index_buffer;
@@ -2128,7 +2128,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleOOBTypesInOneCmdBuffer) {
            index = uniform_index_buffer.tex_index[0];
         }
         )glsl";
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
 
         layout(set = 0, binding = 1) uniform sampler2D tex[6];
@@ -2204,7 +2204,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleOOBTypesInOneCmdBuffer) {
         vk::UpdateDescriptorSets(device(), 2, descriptor_writes_cb_2, 0, nullptr);
     }
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform ufoo { uint index; } u_index;
@@ -2272,7 +2272,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, BindingOOB) {
                                             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 1);
     descriptor_set.UpdateDescriptorSets();
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -2314,7 +2314,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleBoundDescriptorsSameSetFirst) {
     uint32_t *input_buffer_ptr = (uint32_t *)input_buffer.Memory().Map();
     input_buffer_ptr[0] = 1;
 
-    char const *cs_source_1 = R"glsl(
+    const char *cs_source_1 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform Input { uint index; };
@@ -2341,7 +2341,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleBoundDescriptorsSameSetFirst) {
                                                      VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 0);
     pipe_1.descriptor_set_.UpdateDescriptorSets();
 
-    char const *cs_source_2 = R"glsl(
+    const char *cs_source_2 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 1) uniform Input { uint index; };
@@ -2388,7 +2388,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleBoundDescriptorsSameSetLast) {
     uint32_t *input_buffer_ptr = (uint32_t *)input_buffer.Memory().Map();
     input_buffer_ptr[0] = 1;
 
-    char const *cs_source_1 = R"glsl(
+    const char *cs_source_1 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform Input { uint index; };
@@ -2416,7 +2416,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleBoundDescriptorsSameSetLast) {
                                                      VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 1);
     pipe_1.descriptor_set_.UpdateDescriptorSets();
 
-    char const *cs_source_2 = R"glsl(
+    const char *cs_source_2 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 1) uniform Input { uint index; };
@@ -2465,7 +2465,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleBoundDescriptorsUpdateAfterBindF
     uint32_t *input_buffer_ptr = (uint32_t *)input_buffer.Memory().Map();
     input_buffer_ptr[0] = 1;  // will be valid for both shaders
 
-    char const *cs_source_1 = R"glsl(
+    const char *cs_source_1 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform Input { uint index; };
@@ -2489,7 +2489,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleBoundDescriptorsUpdateAfterBindF
     pipe_1.cp_ci_.layout = pipeline_layout_1;
     pipe_1.CreateComputePipeline();
 
-    char const *cs_source_2 = R"glsl(
+    const char *cs_source_2 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 1) uniform Input { uint index; };
@@ -2557,7 +2557,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleBoundDescriptorsUpdateAfterBindL
     uint32_t *input_buffer_ptr = (uint32_t *)input_buffer.Memory().Map();
     input_buffer_ptr[0] = 1;  // will be valid for both shaders
 
-    char const *cs_source_1 = R"glsl(
+    const char *cs_source_1 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform Input { uint index; };
@@ -2581,7 +2581,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleBoundDescriptorsUpdateAfterBindL
     pipe_1.cp_ci_.layout = pipeline_layout_1;
     pipe_1.CreateComputePipeline();
 
-    char const *cs_source_2 = R"glsl(
+    const char *cs_source_2 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 1) uniform Input { uint index; };
@@ -2665,7 +2665,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleSetSomeUninitialized) {
     ds_bad.WriteDescriptorBufferInfo(0, input_buffer, 0, VK_WHOLE_SIZE);
     ds_bad.UpdateDescriptorSets();
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -2736,7 +2736,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleSetSomeUninitializedUpdateAfterB
         });
     const vkt::PipelineLayout pipeline_layout(*m_device, {&ds_good.layout_});
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -2816,7 +2816,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ReSubmitCommandBuffer) {
     ds_bad.WriteDescriptorBufferInfo(0, input_buffer, 0, VK_WHOLE_SIZE);
     ds_bad.UpdateDescriptorSets();
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -2867,7 +2867,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, SpecConstantUpdateAfterBind) {
     AddRequiredFeature(vkt::Feature::descriptorBindingStorageBufferUpdateAfterBind);
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(constant_id = 0) const uint index = 0;
 
@@ -2926,7 +2926,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, SpecConstantPartiallyBound) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(constant_id = 0) const uint index = 0;
 
@@ -2984,7 +2984,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, SpecConstantPartiallyBound) {
 TEST_F(NegativeGpuAVDescriptorIndexing, SpecConstant) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(constant_id = 0) const uint index = 1;
 
@@ -3030,7 +3030,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, SpecConstantNullDescriptorBindless) {
     AddRequiredFeature(vkt::Feature::nullDescriptor);
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         // will update to zero which is uninitialized
         layout(constant_id = 0) const uint index = 1;
@@ -3080,7 +3080,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, SpecConstantNullDescriptorBindless) {
 TEST_F(NegativeGpuAVDescriptorIndexing, PartiallyBoundNoArray) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(constant_id = 0) const uint index = 0;
 
@@ -3120,7 +3120,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, TexelFetch) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
     InitRenderTarget();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 460
         #extension GL_EXT_nonuniform_qualifier : enable
         layout (set = 0, binding = 0) uniform sampler2D tex[];
@@ -3540,7 +3540,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, TexelFetchNested) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
     InitRenderTarget();
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 460
         #extension GL_EXT_nonuniform_qualifier : enable
         layout (set = 0, binding = 0) uniform sampler2D tex[];
@@ -3605,7 +3605,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, TexelFetchTexelBuffer) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
     InitRenderTarget();
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 460
         layout (set = 0, binding = 0) uniform samplerBuffer u_buffer;
         layout (set = 0, binding = 1) buffer SSBO { vec4 color; };
@@ -3651,7 +3651,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, TexelFetchConstantArrayOOB) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0, std430) buffer foo {
             int index;
@@ -3699,7 +3699,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, AtomicImagePartiallyBound) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
     InitRenderTarget();
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 460
         #extension GL_EXT_nonuniform_qualifier : enable
         #extension GL_KHR_memory_scope_semantics : enable
@@ -3748,7 +3748,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, AtomicImageRuntimeArray) {
     vkt::ImageView image_view = image.CreateView();
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 460
         #extension GL_EXT_nonuniform_qualifier : enable
         #extension GL_KHR_memory_scope_semantics : enable
@@ -3791,7 +3791,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, AtomicBufferPartiallyBound) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
     InitRenderTarget();
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer ssbo { uint z; };
         void main() {
@@ -3824,7 +3824,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, AtomicBufferRuntimeArray) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
     InitRenderTarget();
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer ssbo { uint x; } atomic_buffers[];
         void main() {
@@ -3861,7 +3861,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, StorageImagePartiallyBound) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
     InitRenderTarget();
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         // VK_FORMAT_R32_UINT
         layout(set = 0, binding = 0, r32ui) uniform uimage2D storageImage;
@@ -3897,7 +3897,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, StorageImageRuntimeArray) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
     InitRenderTarget();
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         // VK_FORMAT_R32_UINT
         layout(set = 0, binding = 0, r32ui) uniform uimage2D storageImageArray[];
@@ -3955,7 +3955,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleCommandBuffersSameDescriptorSet)
     descriptor_set.WriteDescriptorBufferInfo(1, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    char const *cs_source0 = R"glsl(
+    const char *cs_source0 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set=0, binding=0) uniform sampler2D sample_array[]; // only [0] is set
@@ -3973,7 +3973,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleCommandBuffersSameDescriptorSet)
     pipe0.CreateComputePipeline();
 
     // Create different shaders so pipelines are different
-    char const *cs_source1 = R"glsl(
+    const char *cs_source1 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set=0, binding=0) uniform sampler2D sample_array[2];
@@ -4045,7 +4045,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, CommandBufferRerecordSameDescriptorSet) 
     descriptor_set.WriteDescriptorBufferInfo(1, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    char const *cs_source0 = R"glsl(
+    const char *cs_source0 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set=0, binding=0) uniform sampler2D sample_array[]; // only [0] is set
@@ -4064,7 +4064,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, CommandBufferRerecordSameDescriptorSet) 
     pipe_good.CreateComputePipeline();
 
     // Create different shaders so pipelines are different
-    char const *cs_source1 = R"glsl(
+    const char *cs_source1 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set=0, binding=0) uniform sampler2D sample_array[2];
@@ -4182,7 +4182,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, OpInBoundsAccessChain) {
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
     // Use OpInBoundsAccessChain instead of normal generated OpAccessChain
-    char const *cs_source = R"(
+    const char *cs_source = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint GLCompute %main "main"
@@ -4253,7 +4253,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MiddleBindingOOB) {
     descriptor_set.WriteDescriptorBufferInfo(0, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 0);
     descriptor_set.UpdateDescriptorSets();
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -4293,7 +4293,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, DualShaderLibrary) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
     InitRenderTarget();
 
-    char const *vs_source = R"glsl(
+    const char *vs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) uniform sampler2D tex;
         void main() {
@@ -4372,7 +4372,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, PushDescriptor) {
     AddRequiredExtensions(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) buffer UBO {
@@ -4429,7 +4429,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, PushDescriptor) {
 TEST_F(NegativeGpuAVDescriptorIndexing, DescriptorTemplates) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) buffer UBO {
@@ -4503,7 +4503,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, PushDescriptorTemplates) {
     AddRequiredExtensions(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) buffer UBO {

--- a/tests/unit/gpu_av_descriptor_indexing_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_indexing_positive.cpp
@@ -67,7 +67,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, Basic) {
                                             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 1);
     descriptor_set.UpdateDescriptorSets();
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -141,7 +141,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, BasicHLSL) {
     // void main(uint3 tid : SV_DispatchThreadID) {
     //     data[0].output = textures[data[0].index].SampleLevel(ss, float2(0,0), 0);
     // }
-    char const *cs_source = R"asm(
+    const char *cs_source = R"asm(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint GLCompute %main "main" %data %ss %textures
@@ -258,7 +258,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, BasicHLSLRuntimeArray) {
     // void main(uint3 tid : SV_DispatchThreadID) {
     //     data[0].output = textures[data[0].index].SampleLevel(ss, float2(0,0), 0);
     // }
-    char const *cs_source = R"asm(
+    const char *cs_source = R"asm(
                OpCapability Shader
                OpCapability RuntimeDescriptorArray
                OpExtension "SPV_EXT_descriptor_indexing"
@@ -434,7 +434,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, UnInitImage) {
 
     // - The vertex shader fetches the invalid index from the uniform buffer and passes it to the fragment shader.
     // - The fragment shader makes the invalid array access.
-    char const *vs_source = R"glsl(
+    const char *vs_source = R"glsl(
         #version 450
 
         layout(std140, binding = 0) uniform foo { uint tex_index[1]; } uniform_index_buffer;
@@ -450,7 +450,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, UnInitImage) {
     )glsl";
     VkShaderObj vs(this, vs_source, VK_SHADER_STAGE_VERTEX_BIT);
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -515,7 +515,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, ImageMultiBinding) {
 
     // - The vertex shader fetches the invalid index from the uniform buffer and passes it to the fragment shader.
     // - The fragment shader makes the invalid array access.
-    char const *vs_source = R"glsl(
+    const char *vs_source = R"glsl(
         #version 450
 
         layout(std140, binding = 0) uniform foo { uint tex_index[1]; } uniform_index_buffer;
@@ -531,7 +531,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, ImageMultiBinding) {
     )glsl";
     VkShaderObj vs(this, vs_source, VK_SHADER_STAGE_VERTEX_BIT);
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
     #version 450
     #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -576,7 +576,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, BindingUnusedPipeline) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *fs_source_2d = R"glsl(
+    const char *fs_source_2d = R"glsl(
         #version 450
         layout(location = 0) out vec4 outColor;
         layout(set = 1, binding = 2) uniform sampler2D tex;
@@ -586,7 +586,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, BindingUnusedPipeline) {
         }
     )glsl";
 
-    char const *fs_source_3d = R"glsl(
+    const char *fs_source_3d = R"glsl(
         #version 450
         layout(location = 0) out vec4 outColor;
         layout(set = 1, binding = 2) uniform sampler3D tex;
@@ -647,7 +647,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SampledImageShareBindingArray) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
     InitRenderTarget();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 460
         #extension GL_EXT_nonuniform_qualifier : require
         layout (set = 0, binding = 0) uniform texture2D kTextures2D[];
@@ -724,7 +724,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SampledImageShareBindingBDA) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
     InitRenderTarget();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 460
         #extension GL_EXT_buffer_reference : require
         #extension GL_EXT_nonuniform_qualifier : require
@@ -847,7 +847,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, DISABLED_Stress) {
                                             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 2);
     descriptor_set.UpdateDescriptorSets();
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -1047,7 +1047,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, DISABLED_StressGpuLoop) {
     TEST_DESCRIPTION("Show the GPU overhead of doing redundant checks inside a loop");
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing(false));
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout (local_size_x = 256) in;
         layout(set = 0, binding = 0) buffer Data {
@@ -1181,14 +1181,14 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetCompute) {
     pipeline_layout_ci.setLayoutCount = 2;
     const vkt::PipelineLayout pipeline_layout_2(*m_device, pipeline_layout_ci);
 
-    char const *source_1 = R"glsl(
+    const char *source_1 = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo_0 { int a; int b;};
         void main() {
             a = b;
         }
     )glsl";
-    char const *source_2 = R"glsl(
+    const char *source_2 = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo_0 { int a; };
         layout(set = 1, binding = 0) buffer foo_1 { int b; };
@@ -1302,14 +1302,14 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetGraphics) {
     pipeline_layout_ci.setLayoutCount = 2;
     const vkt::PipelineLayout pipeline_layout_2(*m_device, pipeline_layout_ci);
 
-    char const *vs_source_1 = R"glsl(
+    const char *vs_source_1 = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo_0 { int a; int b;};
         void main() {
             a = b;
         }
     )glsl";
-    char const *vs_source_2 = R"glsl(
+    const char *vs_source_2 = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo_0 { int a; };
         layout(set = 1, binding = 0) readonly buffer foo_1 { int b; };
@@ -1434,14 +1434,14 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetGraphicsGPL) {
     pipeline_layout_ci.setLayoutCount = 2;
     const vkt::PipelineLayout pipeline_layout_2(*m_device, pipeline_layout_ci);
 
-    char const *vs_source_1 = R"glsl(
+    const char *vs_source_1 = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo_0 { int a; int b;};
         void main() {
             a = b;
         }
         )glsl";
-    char const *vs_source_2 = R"glsl(
+    const char *vs_source_2 = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo_0 { int a; };
         layout(set = 1, binding = 0) readonly buffer foo_1 { int b; };
@@ -1555,7 +1555,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetGraphicsShader
     pipeline_layout_ci.setLayoutCount = 2;
     const vkt::PipelineLayout pipeline_layout(*m_device, pipeline_layout_ci);
 
-    char const *vs_source_1 = R"glsl(
+    const char *vs_source_1 = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo_0 { int a; int b;};
         void main() {
@@ -1563,7 +1563,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetGraphicsShader
         }
     )glsl";
     const std::vector<uint32_t> vs_spv_1 = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, vs_source_1);
-    char const *vs_source_2 = R"glsl(
+    const char *vs_source_2 = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo_0 { int a; };
         layout(set = 1, binding = 0) readonly buffer foo_1 { int b; };
@@ -1679,17 +1679,17 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetGraphicsShader
 
     const vkt::PipelineLayout pipeline_layout_2(*m_device, pipeline_layout_ci);
 
-    char const *vs_source_1 = R"glsl(
+    const char *vs_source_1 = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo_0 { uint a; uint b; };
         void main() {}
     )glsl";
-    char const *vs_source_2 = R"glsl(
+    const char *vs_source_2 = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo_1 { uint a; uint b; };
         void main() {}
     )glsl";
-    char const *fs_source_2 = R"glsl(
+    const char *fs_source_2 = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo_1 { uint c; };
         void main() {}
@@ -1766,7 +1766,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, MultipleBoundDescriptorsSameSet) {
     uint32_t *input_buffer_ptr = (uint32_t *)input_buffer.Memory().Map();
     input_buffer_ptr[0] = 1;  // will be valid for both shaders
 
-    char const *cs_source_1 = R"glsl(
+    const char *cs_source_1 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform Input { uint index; };
@@ -1794,7 +1794,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, MultipleBoundDescriptorsSameSet) {
                                                      VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 1);
     pipe_1.descriptor_set_.UpdateDescriptorSets();
 
-    char const *cs_source_2 = R"glsl(
+    const char *cs_source_2 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 1) uniform Input { uint index; };
@@ -1839,7 +1839,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, MultipleBoundDescriptorsDifferentSet) {
     uint32_t *input_buffer_ptr = (uint32_t *)input_buffer.Memory().Map();
     input_buffer_ptr[0] = 1;  // will be valid for both shaders
 
-    char const *cs_source_1 = R"glsl(
+    const char *cs_source_1 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform Input { uint index; };
@@ -1867,7 +1867,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, MultipleBoundDescriptorsDifferentSet) {
                                                      VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 1);
     pipe_1.descriptor_set_.UpdateDescriptorSets();
 
-    char const *cs_source_2 = R"glsl(
+    const char *cs_source_2 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 1, binding = 1) uniform Input { uint index; };
@@ -1920,7 +1920,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, MultipleBoundDescriptorsUpdateAfterBind)
     uint32_t *input_buffer_ptr = (uint32_t *)input_buffer.Memory().Map();
     input_buffer_ptr[0] = 1;  // will be valid for both shaders
 
-    char const *cs_source_1 = R"glsl(
+    const char *cs_source_1 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform Input { uint index; };
@@ -1944,7 +1944,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, MultipleBoundDescriptorsUpdateAfterBind)
     pipe_1.cp_ci_.layout = pipeline_layout_1;
     pipe_1.CreateComputePipeline();
 
-    char const *cs_source_2 = R"glsl(
+    const char *cs_source_2 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 1) uniform Input { uint index; };
@@ -2012,7 +2012,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, MultipleUnusedBoundDescriptorsUpdateAfte
     uint32_t *input_buffer_ptr = (uint32_t *)input_buffer.Memory().Map();
     input_buffer_ptr[0] = 1;  // will be valid for both shaders
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform Input { uint index; };
@@ -2116,7 +2116,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, MultipleSetSomeUninitialized) {
     ds_bad.WriteDescriptorBufferInfo(0, input_buffer, 0, VK_WHOLE_SIZE);
     ds_bad.UpdateDescriptorSets();
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -2179,7 +2179,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, MultipleSetSomeUninitializedUpdateAfterB
         });
     const vkt::PipelineLayout pipeline_layout(*m_device, {&ds_good.layout_});
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -2251,7 +2251,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, ReSubmitCommandBuffer) {
     ds_bad.WriteDescriptorBufferInfo(0, input_buffer, 0, VK_WHOLE_SIZE);
     ds_bad.UpdateDescriptorSets();
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -2332,7 +2332,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, VariableDescriptorCountAllocateAfterPipe
 
     vkt::PipelineLayout pipeline_layout(*m_device, pipeline_layout_ci);
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set=0, binding=0) uniform UBO { uint in_buffer; };
@@ -2412,7 +2412,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SpecConstantNullDescriptor) {
     AddRequiredFeature(vkt::Feature::nullDescriptor);
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         // will update to zero which is a null descriptor
         layout(constant_id = 0) const uint index = 1;
@@ -2456,7 +2456,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SpecConstantNullDescriptorBindless) {
     AddRequiredFeature(vkt::Feature::nullDescriptor);
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         // will update to zero which is a null descriptor
         layout(constant_id = 0) const uint index = 1;
@@ -2503,7 +2503,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, TexelFetch) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
     InitRenderTarget();
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 460
         #extension GL_EXT_nonuniform_qualifier : enable
         layout (set = 0, binding = 0) uniform samplerBuffer u_buffer;
@@ -2573,7 +2573,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, AtomicImage) {
     vkt::ImageView image_view = image.CreateView();
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 460
         #extension GL_EXT_nonuniform_qualifier : enable
         #extension GL_KHR_memory_scope_semantics : enable
@@ -2615,7 +2615,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, AtomicBuffer) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
     InitRenderTarget();
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer ssbo { uint x; } atomic_buffers[];
         void main() {
@@ -2653,7 +2653,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, StorageImage) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
     InitRenderTarget();
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         // VK_FORMAT_R32_UINT
         layout(set = 0, binding = 0, r32ui) uniform uimage2D storageImageArray[];
@@ -2699,7 +2699,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, DestroyedPipelineLayout) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    static const char vertshader[] = R"glsl(
+    const char vertshader[] = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer StorageBuffer { uint x[]; };
         void main() {
@@ -2780,7 +2780,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, BindingPartiallyBound) {
     descriptor_set.WriteDescriptorBufferInfo(0, buffer, 0, sizeof(uint32_t));
     descriptor_set.UpdateDescriptorSets();
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) uniform foo_0 { int val; } doit;
         layout(set = 0, binding = 1) uniform foo_1 { int val; } readit;
@@ -2885,7 +2885,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, BranchConditonalPostDominate) {
     RETURN_IF_SKIP(InitGpuAvFramework(layer_settings, false));
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0, std430) buffer SSBO {
             uint a;
@@ -2948,7 +2948,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, ReupdateDescriptorCount) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10079");
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 460
         #extension GL_EXT_nonuniform_qualifier : enable
 

--- a/tests/unit/gpu_av_descriptor_post_process.cpp
+++ b/tests/unit/gpu_av_descriptor_post_process.cpp
@@ -31,7 +31,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, UpdateAfterBindImageViewTypeMismatch)
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler3D s;
         layout(location=0) out vec4 color;
@@ -89,7 +89,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, PostProcesingOnly) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler3D s;
         layout(location=0) out vec4 color;
@@ -155,7 +155,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, PostProcesingOnlyShaderObject) {
     RETURN_IF_SKIP(InitState());
     InitDynamicRenderTarget();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler3D s;
         layout(location=0) out vec4 color;
@@ -217,7 +217,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, PostProcesingOnlyGPL) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler3D s;
         layout(location=0) out vec4 color;
@@ -273,7 +273,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, PostProcesingOnlyPipelineInline) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler3D s;
         layout(location=0) out vec4 color;
@@ -341,7 +341,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, ImageTypeMismatch) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform sampler3D s[];
@@ -447,7 +447,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, MixingProtectedResources) {
                                             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 1);
     descriptor_set.UpdateDescriptorSets();
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -518,7 +518,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, InvalidAtomicStorageOperation) {
     vkt::Buffer buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT);
     vkt::BufferView buffer_view(*m_device, buffer, buffer_view_format);
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(set=0, binding=3, r32f) uniform image2D si0;
         layout(set=0, binding=2, r32f) uniform image2D si1[2];
@@ -978,7 +978,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, NonMultisampleMismatchWithPipelinePar
     descriptor_set.WriteDescriptorBufferInfo(1, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         // mySampler[0] is good
         // mySampler[1] is bad
@@ -1046,7 +1046,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, NonMultisampleMismatchWithInlineShade
     descriptor_set.WriteDescriptorBufferInfo(1, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         // mySampler[0] is good
         // mySampler[1] is bad
@@ -1124,7 +1124,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, NonMultisampleMismatchWithShaderObjec
     descriptor_set.WriteDescriptorBufferInfo(1, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         // mySampler[0] is good
         // mySampler[1] is bad
@@ -1162,7 +1162,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, AliasImageMultisample) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
 
@@ -1224,7 +1224,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, AliasImageMultisampleDescriptorSetsPa
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
         layout(set = 0, binding = 0) uniform texture2D BaseTexture;
@@ -1235,7 +1235,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, AliasImageMultisampleDescriptorSetsPa
         }
     )glsl";
 
-    char const *cs_source_ms = R"glsl(
+    const char *cs_source_ms = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
         layout(set = 0, binding = 0) uniform texture2DMS BaseTextureMS;
@@ -1340,7 +1340,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, MultipleCommandBuffersSameDescriptorS
     vkt::Image image_3d(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView bad_view = image_3d.CreateView(VK_IMAGE_VIEW_TYPE_3D);
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set=0, binding=0) buffer SSBO {
@@ -1397,7 +1397,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, AliasImageBindingRuntimeArray) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
         #extension GL_EXT_nonuniform_qualifier : require
@@ -1470,7 +1470,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, AliasImageBindingPartiallyBound) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
 
@@ -1614,7 +1614,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, ImageViewArrayAliasBinding) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : require
         // Using descriptor aliasing: same binding for sampler2D and sampler2DArray.
@@ -1676,7 +1676,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, SameDescriptorAcrossSets) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler2D s2;
         layout(set=1, binding=0) uniform sampler3D s3;
@@ -1737,7 +1737,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, DISABLED_SameDescriptorAcrossStagesVe
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *vs_source = R"glsl(
+    const char *vs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler3D vertexSampler; // invalid
         vec2 vertices[3];
@@ -1750,7 +1750,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, DISABLED_SameDescriptorAcrossStagesVe
             unused = texture(vertexSampler, vec3(0));
         }
     )glsl";
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler2D fragmentSampler; // valid
         layout(location=0) in vec4 unused;
@@ -1800,7 +1800,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, SameDescriptorAcrossStagesFragment) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *vs_source = R"glsl(
+    const char *vs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler2D vertexSampler; // valid
         vec2 vertices[3];
@@ -1813,7 +1813,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, SameDescriptorAcrossStagesFragment) {
             unused = texture(vertexSampler, vec2(0));
         }
     )glsl";
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler3D fragmentSampler; // invalid
         layout(location=0) in vec4 unused;
@@ -1867,7 +1867,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, DISABLED_VariableIdClash) {
     InitRenderTarget();
 
     // layout(set=0, binding=0) uniform sampler2D vertexSampler;
-    char const *vs_source = R"(
+    const char *vs_source = R"(
                 OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %main "main" %vertexSampler %vertices %_ %gl_VertexIndex %unused
@@ -1944,7 +1944,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, DISABLED_VariableIdClash) {
     )";
 
     // layout(set=0, binding=1) uniform sampler3D fragmentSampler;
-    char const *fs_source = R"(
+    const char *fs_source = R"(
                    OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %main "main" %fragmentSampler %color %unused
@@ -2023,7 +2023,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, MultiEntrypoint) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *shader_source = R"(
+    const char *shader_source = R"(
 OpCapability Shader
 OpMemoryModel Logical GLSL450
 OpEntryPoint Fragment %main_frag "main_frag" %fragmentSampler %color %unused_f
@@ -2252,7 +2252,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, DISABLED_MultipleDrawsMixPipelines) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *fs_source_2d = R"glsl(
+    const char *fs_source_2d = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler2D s;
         layout(location=0) out vec4 color;
@@ -2261,7 +2261,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, DISABLED_MultipleDrawsMixPipelines) {
         }
     )glsl";
 
-    char const *fs_source_3d = R"glsl(
+    const char *fs_source_3d = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler3D s;
         layout(location=0) out vec4 color;
@@ -2324,7 +2324,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, MultipleDrawsMixDescriptorSets) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler2D s2;
         layout(set=1, binding=0) uniform sampler3D s3;
@@ -2429,7 +2429,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, ImageTypeMismatchDebugLabels) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform sampler3D s[];
@@ -2575,7 +2575,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, ImportFence) {
         GTEST_SKIP() << "VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_FD_BIT is not exportable";
     }
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler3D s;
         void main() {
@@ -2638,7 +2638,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, DualShaderLibraryDuplicateLayoutsDyna
     RETURN_IF_SKIP(InitState());
     InitDynamicRenderTarget();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform sampler3D s[];
@@ -2743,7 +2743,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, DualShaderLibraryDuplicateLayoutsImmu
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform sampler3D s[];

--- a/tests/unit/gpu_av_descriptor_post_process_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_post_process_positive.cpp
@@ -74,7 +74,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, MixingProtectedResources) {
                                             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 1);
     descriptor_set.UpdateDescriptorSets();
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
 
@@ -113,7 +113,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, AliasImageBindingPartiallyBound) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
 
@@ -179,7 +179,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, AliasImageBindingRuntimeArray) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 460
         #extension GL_EXT_nonuniform_qualifier : enable
         #extension GL_EXT_samplerless_texture_functions : require
@@ -242,7 +242,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, AliasImageMultisample) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
 
@@ -299,7 +299,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, AliasImageMultisampleDescriptorSets) 
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
         layout(set = 0, binding = 0) uniform texture2D BaseTexture;
@@ -310,7 +310,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, AliasImageMultisampleDescriptorSets) 
         }
     )glsl";
 
-    char const *cs_source_ms = R"glsl(
+    const char *cs_source_ms = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
         layout(set = 0, binding = 0) uniform texture2DMS BaseTextureMS;
@@ -382,7 +382,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, AliasImageMultisampleDescriptorSetsPa
     AddRequiredFeature(vkt::Feature::descriptorBindingPartiallyBound);
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
         layout(set = 0, binding = 0) uniform texture2D BaseTexture;
@@ -392,7 +392,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, AliasImageMultisampleDescriptorSetsPa
             dummy = texture(sampler2D(BaseTexture, BaseTextureSampler), vec2(0));
         }
     )glsl";
-    char const *cs_source_ms = R"glsl(
+    const char *cs_source_ms = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
         layout(set = 0, binding = 0) uniform texture2DMS BaseTextureMS;
@@ -474,7 +474,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, AliasImageMultisampleDispatches) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
 
@@ -487,7 +487,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, AliasImageMultisampleDispatches) {
         }
     )glsl";
 
-    char const *cs_source_ms = R"glsl(
+    const char *cs_source_ms = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
 
@@ -594,7 +594,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, NonMultisampleMismatchWithPipeline) {
     descriptor_set.WriteDescriptorBufferInfo(1, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         // mySampler[0] is bad
         // mySampler[1] is good
@@ -653,7 +653,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, SharedDescriptorDifferentOpVariableId
     descriptor_set.WriteDescriptorBufferInfo(1, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    char const *cs_source0 = R"glsl(
+    const char *cs_source0 = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set=0, binding=0) uniform sampler2D sample_array[];
@@ -672,7 +672,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, SharedDescriptorDifferentOpVariableId
 
     // This is the same shader as above, but the goal is to make sure the OpVariable ID are different as the descriptor is being
     // aliased
-    char const *cs_source1 = R"(
+    const char *cs_source1 = R"(
                OpCapability Shader
                OpCapability RuntimeDescriptorArray
                OpMemoryModel Logical GLSL450
@@ -812,7 +812,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, ZeroBindingDescriptor) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : enable
         layout(set = 1, binding = 0) uniform texture2D textures[2];
@@ -903,7 +903,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, ImageViewArrayAliasBinding) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : require
         // Using descriptor aliasing: same binding for sampler2D and sampler2DArray.
@@ -967,7 +967,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, DISABLED_VariableIdClash) {
     InitRenderTarget();
 
     // layout(set=0, binding=0) uniform sampler2D vertexSampler;
-    char const *vs_source = R"(
+    const char *vs_source = R"(
                 OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %main "main" %vertexSampler %vertices %_ %gl_VertexIndex %unused
@@ -1044,7 +1044,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, DISABLED_VariableIdClash) {
     )";
 
     // layout(set=0, binding=1) uniform sampler3D fragmentSampler;
-    char const *fs_source = R"(
+    const char *fs_source = R"(
                    OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %main "main" %fragmentSampler %color %unused
@@ -1127,7 +1127,7 @@ TEST_F(PositiveGpuAVDescriptorPostProcess, BranchConditonalPostDominate) {
     RETURN_IF_SKIP(InitGpuAvFramework(layer_settings));
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0, std430) buffer SSBO {
             uint a;

--- a/tests/unit/gpu_av_index_buffer_positive.cpp
+++ b/tests/unit/gpu_av_index_buffer_positive.cpp
@@ -101,7 +101,7 @@ TEST_F(PositiveGpuAVIndexBuffer, DrawIndexedDynamicStates) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
 
         layout(location=0) in vec3 pos;
@@ -207,7 +207,7 @@ TEST_F(PositiveGpuAVIndexBuffer, NoShaderInputsVertexIndex16) {
         std::array<float, 3> normal;
     };
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
 
         void main() {
@@ -272,7 +272,7 @@ TEST_F(PositiveGpuAVIndexBuffer, VertexShaderUnusedLocations) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
 
         layout(location=0) in vec3 pos;
@@ -364,7 +364,7 @@ TEST_F(PositiveGpuAVIndexBuffer, InstanceIndex) {
         std::array<float, 3> normal;
     };
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
 
         layout(location=0) in vec3 pos;
@@ -452,7 +452,7 @@ TEST_F(PositiveGpuAVIndexBuffer, CmdSetVertexInputEXT) {
         std::array<float, 3> normal;
     };
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
 
         layout(location=0) in vec3 pos;
@@ -544,7 +544,7 @@ TEST_F(PositiveGpuAVIndexBuffer, CmdSetVertexInputEXT_CmdBindVertexBuffers2EXT) 
         std::array<float, 3> normal;
     };
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
 
         layout(location=0) in vec3 pos;
@@ -631,7 +631,7 @@ TEST_F(PositiveGpuAVIndexBuffer, IndirectDrawBadVertexIndex32) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
 
         layout(location=0) in vec3 pos;
@@ -692,7 +692,7 @@ TEST_F(PositiveGpuAVIndexBuffer, VertexIndex32MultiDraw) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
 
         layout(location=0) in vec3 pos;
@@ -761,7 +761,7 @@ TEST_F(PositiveGpuAVIndexBuffer, InstanceIndexVertexAttributeDivisor) {
         std::array<float, 3> normal;
     };
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
 
         layout(location=0) in vec3 pos;
@@ -862,7 +862,7 @@ TEST_F(PositiveGpuAVIndexBuffer, InstanceIndexVertexAttributeDivisorDynamic) {
         std::array<float, 3> normal;
     };
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
 
         layout(location=0) in vec3 pos;

--- a/tests/unit/gpu_av_indirect_buffer.cpp
+++ b/tests/unit/gpu_av_indirect_buffer.cpp
@@ -91,7 +91,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCountDeviceLimit) {
     }
 
     if (mesh_shader_enabled) {
-        char const *mesh_shader_source = R"glsl(
+        const char *mesh_shader_source = R"glsl(
         #version 450
         #extension GL_EXT_mesh_shader : require
         layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
@@ -292,7 +292,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
     m_default_queue->SubmitAndWait(m_command_buffer);
     m_errorMonitor->VerifyFound();
     if (mesh_shader_enabled) {
-        char const *mesh_shader_source = R"glsl(
+        const char *mesh_shader_source = R"glsl(
         #version 450
         #extension GL_EXT_mesh_shader : require
         layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
@@ -384,7 +384,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, Mesh) {
     uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
     *count_ptr = 3;
 
-    char const *mesh_shader_source = R"glsl(
+    const char *mesh_shader_source = R"glsl(
         #version 450
         #extension GL_EXT_mesh_shader : require
         layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
@@ -498,7 +498,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DISABLED_MeshTask) {
     uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
     *count_ptr = 3;
 
-    char const *mesh_shader_source = R"glsl(
+    const char *mesh_shader_source = R"glsl(
         #version 450
         #extension GL_EXT_mesh_shader : require
         layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
@@ -512,7 +512,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DISABLED_MeshTask) {
         )glsl";
     VkShaderObj mesh_shader(this, mesh_shader_source, VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_3);
 
-    char const *task_shader_source = R"glsl(
+    const char *task_shader_source = R"glsl(
         #version 450
         #extension GL_EXT_mesh_shader : require
         layout (local_size_x=1, local_size_y=1, local_size_z=1) in;

--- a/tests/unit/gpu_av_indirect_buffer_positive.cpp
+++ b/tests/unit/gpu_av_indirect_buffer_positive.cpp
@@ -146,7 +146,7 @@ TEST_F(PositiveGpuAVIndirectBuffer, Mesh) {
     uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
     *count_ptr = 3;
 
-    char const *mesh_shader_source = R"glsl(
+    const char *mesh_shader_source = R"glsl(
         #version 450
         #extension GL_EXT_mesh_shader : require
         layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
@@ -207,7 +207,7 @@ TEST_F(PositiveGpuAVIndirectBuffer, MeshSingleCommand) {
     vkt::Buffer count_buffer(*m_device, sizeof(uint32_t), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, kHostVisibleMemProps);
     uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
     *count_ptr = 3;
-    char const *mesh_shader_source = R"glsl(
+    const char *mesh_shader_source = R"glsl(
         #version 450
         #extension GL_EXT_mesh_shader : require
         layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
@@ -324,7 +324,7 @@ TEST_F(PositiveGpuAVIndirectBuffer, RestoreStress) {
     indirect_dispatch_parameters.z = 1u;
 
     // used for all stage types
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer Input {
             uint x;

--- a/tests/unit/gpu_av_positive.cpp
+++ b/tests/unit/gpu_av_positive.cpp
@@ -151,7 +151,7 @@ TEST_F(PositiveGpuAV, InlineUniformBlock) {
     descriptor_writes[1].descriptorType = VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK;
     vk::UpdateDescriptorSets(device(), 2, descriptor_writes, 0, NULL);
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) buffer StorageBuffer { uint index; } u_index;
@@ -256,7 +256,7 @@ TEST_F(PositiveGpuAV, InlineUniformBlockAndRecovery) {
     vkt::PipelineLayout pl_layout(*m_device, layouts);
     m_errorMonitor->VerifyFound();
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) buffer StorageBuffer { uint index; } u_index;
@@ -324,7 +324,7 @@ TEST_F(PositiveGpuAV, InlineUniformBlockUninitialized) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer SSBO { uint out_buffer; };
         layout(set = 0, binding = 1) uniform InlineUBO {
@@ -389,7 +389,7 @@ TEST_F(PositiveGpuAV, InlineUniformBlockUninitializedUpdateAfterBind) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer SSBO { uint out_buffer; };
         layout(set = 0, binding = 1) uniform InlineUBO {
@@ -461,7 +461,7 @@ TEST_F(PositiveGpuAV, SetSSBOBindDescriptor) {
         GTEST_SKIP() << "maxBoundDescriptorSets is too low";
     }
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         layout(constant_id=0) const uint _const_2_0 = 1;
         layout(constant_id=1) const uint _const_3_0 = 1;
@@ -522,7 +522,7 @@ TEST_F(PositiveGpuAV, SetSSBOPushDescriptor) {
         GTEST_SKIP() << "maxBoundDescriptorSets is too low";
     }
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         layout(constant_id=0) const uint _const_2_0 = 1;
         layout(constant_id=1) const uint _const_3_0 = 1;
@@ -633,7 +633,7 @@ TEST_F(PositiveGpuAV, MutableBuffer) {
         GTEST_SKIP() << "maxBoundDescriptorSets is too low";
     }
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         layout(constant_id=0) const uint _const_2_0 = 1;
         layout(constant_id=1) const uint _const_3_0 = 1;
@@ -778,7 +778,7 @@ TEST_F(PositiveGpuAV, SelectInstrumentedShaders) {
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
     descriptor_set.WriteDescriptorBufferInfo(0, write_buffer, 0, 4, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
-    static const char vertshader[] = R"glsl(
+    const char vertshader[] = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer StorageBuffer { uint data[]; } Data;
         void main() {
@@ -826,7 +826,7 @@ TEST_F(PositiveGpuAV, DrawingWithUnboundUnusedSet) {
         GTEST_SKIP() << "Tests requires Vulkan 1.1 exactly";
     }
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         layout (set = 1, binding = 0) uniform sampler2D samplerColor;
         layout(location = 0) out vec4 color;
@@ -1129,7 +1129,7 @@ TEST_F(PositiveGpuAV, RestoreUserPushConstants) {
     plci.pPushConstantRanges = push_constant_ranges.data();
     vkt::PipelineLayout pipeline_layout(*m_device, plci);
 
-    char const *vs_source = R"glsl(
+    const char *vs_source = R"glsl(
             #version 450
             #extension GL_EXT_buffer_reference : enable
 
@@ -1157,7 +1157,7 @@ TEST_F(PositiveGpuAV, RestoreUserPushConstants) {
         )glsl";
     VkShaderObj vs(this, vs_source, VK_SHADER_STAGE_VERTEX_BIT);
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
             #version 450
             #extension GL_EXT_buffer_reference : enable
 
@@ -1229,7 +1229,7 @@ TEST_F(PositiveGpuAV, RestoreUserPushConstants2) {
     // Graphics pipeline
     // ---
 
-    char const *vs_source = R"glsl(
+    const char *vs_source = R"glsl(
             #version 450
             #extension GL_EXT_buffer_reference : enable
 
@@ -1257,7 +1257,7 @@ TEST_F(PositiveGpuAV, RestoreUserPushConstants2) {
         )glsl";
     VkShaderObj vs(this, vs_source, VK_SHADER_STAGE_VERTEX_BIT);
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
             #version 450
             #extension GL_EXT_buffer_reference : enable
 
@@ -1312,7 +1312,7 @@ TEST_F(PositiveGpuAV, RestoreUserPushConstants2) {
     // Compute pipeline
     // ---
 
-    char const *compute_source = R"glsl(
+    const char *compute_source = R"glsl(
             #version 450
             #extension GL_EXT_buffer_reference : enable
 
@@ -1478,7 +1478,7 @@ TEST_F(PositiveGpuAV, SharedPipelineLayoutSubset) {
     pipeline_layout_ci.setLayoutCount = 2;
     const vkt::PipelineLayout pipeline_layout_2(*m_device, pipeline_layout_ci);
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo_0 { int a; int b;};
         void main() {
@@ -1554,7 +1554,7 @@ TEST_F(PositiveGpuAV, SharedPipelineLayoutSubsetWithUnboundDescriptorSet) {
     pipeline_layout_ci.setLayoutCount = 3;
     const vkt::PipelineLayout pipeline_layout_2(*m_device, pipeline_layout_ci);
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer foo_0 {
             int a;
@@ -1647,7 +1647,7 @@ TEST_F(PositiveGpuAV, DestroyedPipelineLayout2) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    static const char vertshader[] = R"glsl(
+    const char vertshader[] = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer StorageBuffer { uint x; };
         void main() {
@@ -1717,7 +1717,7 @@ TEST_F(PositiveGpuAV, DISABLED_DeviceGeneratedCommandsIES) {
     command_layout_ci.pTokens = tokens;
     vkt::IndirectCommandsLayout command_layout(*m_device, command_layout_ci);
 
-    char const *shader_source_1 = R"glsl(
+    const char *shader_source_1 = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer ssbo {
             uint x[];
@@ -1726,7 +1726,7 @@ TEST_F(PositiveGpuAV, DISABLED_DeviceGeneratedCommandsIES) {
             x[48] = 0; // invalid!
         }
     )glsl";
-    char const *shader_source_2 = R"glsl(
+    const char *shader_source_2 = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer ssbo {
             uint x[];
@@ -1735,7 +1735,7 @@ TEST_F(PositiveGpuAV, DISABLED_DeviceGeneratedCommandsIES) {
             x[24] = 0; // invalid!
         }
     )glsl";
-    char const *shader_source_3 = R"glsl(
+    const char *shader_source_3 = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer ssbo {
             uint x[];
@@ -2136,7 +2136,7 @@ TEST_F(PositiveGpuAV, MixDynamicNormalRenderPass) {
     const vkt::PipelineLayout g_pipeline_layout(*m_device, {&descriptor_set1.layout_}, {pc_ranges});
     const vkt::PipelineLayout c_pipeline_layout(*m_device, {&descriptor_set2.layout_}, {pc_ranges});
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         layout(push_constant) uniform PushConstants {
             uint a[4];

--- a/tests/unit/gpu_av_ray_query.cpp
+++ b/tests/unit/gpu_av_ray_query.cpp
@@ -27,7 +27,7 @@ TEST_F(NegativeGpuAVRayQuery, NegativeTmin) {
     TEST_DESCRIPTION("Ray query with a negative value for Ray TMin");
     RETURN_IF_SKIP(InitGpuAVRayQuery());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
 
@@ -79,7 +79,7 @@ TEST_F(NegativeGpuAVRayQuery, TMaxLessThenTmin) {
     TEST_DESCRIPTION("Ray query with a Ray TMax less than Ray TMin");
     RETURN_IF_SKIP(InitGpuAVRayQuery());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
 
@@ -130,7 +130,7 @@ TEST_F(NegativeGpuAVRayQuery, ComputeRayFlagsBothSkip) {
     TEST_DESCRIPTION("Ray query in a compute shader, with dynamically set ray flags");
     RETURN_IF_SKIP(InitGpuAVRayQuery());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
 
@@ -179,7 +179,7 @@ TEST_F(NegativeGpuAVRayQuery, ComputeRayFlagsOpaque) {
     TEST_DESCRIPTION("Ray query in a compute shader, with dynamically set ray flags");
     RETURN_IF_SKIP(InitGpuAVRayQuery());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
 
@@ -228,7 +228,7 @@ TEST_F(NegativeGpuAVRayQuery, ComputeRayOriginNaN) {
     TEST_DESCRIPTION("Ray query with a Ray Origin as a NaN");
     RETURN_IF_SKIP(InitGpuAVRayQuery());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
 
@@ -281,7 +281,7 @@ TEST_F(NegativeGpuAVRayQuery, ComputeRayOriginNonFinite) {
     TEST_DESCRIPTION("Ray query with a Ray Origin as a non finite value");
     RETURN_IF_SKIP(InitGpuAVRayQuery());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
 
@@ -334,7 +334,7 @@ TEST_F(NegativeGpuAVRayQuery, ComputeUseQueryUninit) {
     TEST_DESCRIPTION("rayQueryInitializeEXT is never called, make sure we don't hang with an uninit query object");
     RETURN_IF_SKIP(InitGpuAVRayQuery());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
 
@@ -528,7 +528,7 @@ TEST_F(NegativeGpuAVRayQuery, FragmentUseQueryUninit) {
     RETURN_IF_SKIP(InitGpuAVRayQuery());
     InitRenderTarget();
 
-    char const *fragment_source = R"glsl(
+    const char *fragment_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
 

--- a/tests/unit/gpu_av_ray_query_positive.cpp
+++ b/tests/unit/gpu_av_ray_query_positive.cpp
@@ -36,7 +36,7 @@ TEST_F(PositiveGpuAVRayQuery, ComputeBasic) {
     TEST_DESCRIPTION("Ray query in a compute shader");
     RETURN_IF_SKIP(InitGpuAVRayQuery());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
 
@@ -74,7 +74,7 @@ TEST_F(PositiveGpuAVRayQuery, ComputeDynamicTminTmax) {
     TEST_DESCRIPTION("Ray query in a compute shader, with dynamically set t_min and t_max");
     RETURN_IF_SKIP(InitGpuAVRayQuery());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
 
@@ -137,7 +137,7 @@ TEST_F(PositiveGpuAVRayQuery, ComputeDynamicRayFlags) {
     TEST_DESCRIPTION("Ray query in a compute shader, with dynamically set ray flags");
     RETURN_IF_SKIP(InitGpuAVRayQuery());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
 
@@ -191,7 +191,7 @@ TEST_F(PositiveGpuAVRayQuery, ComputeDynamicRayFlagsSkipTriangles) {
     AddRequiredFeature(vkt::Feature::rayTraversalPrimitiveCulling);
     RETURN_IF_SKIP(InitGpuAVRayQuery());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
 
@@ -243,7 +243,7 @@ TEST_F(PositiveGpuAVRayQuery, GraphicsBasic) {
     RETURN_IF_SKIP(InitGpuAVRayQuery());
     InitRenderTarget();
 
-    char const *vertex_source = R"glsl(
+    const char *vertex_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
 

--- a/tests/unit/gpu_av_shader_debug_info.cpp
+++ b/tests/unit/gpu_av_shader_debug_info.cpp
@@ -57,7 +57,7 @@ void NegativeGpuAVShaderDebugInfo::BasicSingleStorageBufferComputeOOB(const char
 TEST_F(NegativeGpuAVShaderDebugInfo, OpLine) {
     TEST_DESCRIPTION("Make sure basic OpLine works");
 
-    char const *shader_source = R"(
+    const char *shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
           %2 = OpExtInstImport "GLSL.std.450"
@@ -109,7 +109,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, OpLine) {
 TEST_F(NegativeGpuAVShaderDebugInfo, OpLineColumn) {
     TEST_DESCRIPTION("Make sure the column in OpLine will add value to show which part the error occured");
 
-    char const *shader_source = R"(
+    const char *shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
           %2 = OpExtInstImport "GLSL.std.450"
@@ -168,7 +168,7 @@ void main() {
 TEST_F(NegativeGpuAVShaderDebugInfo, OpSourceContinued) {
     TEST_DESCRIPTION("Make sure can find source in OpSourceContinued");
 
-    char const *shader_source = R"(
+    const char *shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
           %2 = OpExtInstImport "GLSL.std.450"
@@ -227,7 +227,7 @@ layout(buffer_reference, std430) readonly buffer IndexBuffer { int indices[]; };
 TEST_F(NegativeGpuAVShaderDebugInfo, BadLineNumber) {
     TEST_DESCRIPTION("OpLine gives a line number not in the source");
 
-    char const *shader_source = R"(
+    const char *shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
           %2 = OpExtInstImport "GLSL.std.450"
@@ -288,7 +288,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, BasicGlslang) {
 
     // Manually ran:
     //   glslangValidator -V -g in.comp -o out.spv --target-env vulkan1.2
-    char const *shader_source = R"(
+    const char *shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
           %2 = OpExtInstImport "GLSL.std.450"
@@ -366,7 +366,7 @@ void main() {
 TEST_F(NegativeGpuAVShaderDebugInfo, GlslLineDerective) {
     TEST_DESCRIPTION("Use the #line derective in GLSL");
 
-    char const *shader_source = R"(
+    const char *shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
           %2 = OpExtInstImport "GLSL.std.450"
@@ -438,7 +438,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, BasicGlslangShaderDebugInfo) {
 
     // Manually ran:
     //   glslangValidator -V -gV in.comp -o out.spv --target-env vulkan1.2
-    char const *shader_source = R"(
+    const char *shader_source = R"(
                        OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpExtension "SPV_KHR_non_semantic_info"
@@ -549,7 +549,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, BasicGlslangShaderDebugInfo) {
 
 // Manually ran:
 //   glslangValidator -V -gVS in.comp -o out.spv --target-env vulkan1.2
-static char const *kBasicGlslShaderSource = R"(
+static const char *kBasicGlslShaderSource = R"(
               OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpExtension "SPV_KHR_non_semantic_info"
@@ -722,7 +722,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, ShaderDebugInfoColumns) {
     TEST_DESCRIPTION("DebugLine has a Column Start and Column End");
     AddRequiredExtensions(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
 
-    char const *shader_source = R"(
+    const char *shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpExtension "SPV_KHR_non_semantic_info"
@@ -800,7 +800,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, ShaderDebugSourceContinued) {
     TEST_DESCRIPTION("Make sure can find source in DebugSourceContinued");
     AddRequiredExtensions(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
 
-    char const *shader_source = R"(
+    const char *shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpExtension "SPV_KHR_non_semantic_info"
@@ -880,7 +880,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, ShaderDebugLineMultiLine) {
     TEST_DESCRIPTION("DebugLine has a Line Start and Line End");
     AddRequiredExtensions(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
 
-    char const *shader_source = R"(
+    const char *shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpExtension "SPV_KHR_non_semantic_info"
@@ -957,7 +957,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, BadShaderDebugLineStart) {
     TEST_DESCRIPTION("DebugLine Line Start has bad value");
     AddRequiredExtensions(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
 
-    char const *shader_source = R"(
+    const char *shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpExtension "SPV_KHR_non_semantic_info"
@@ -1033,7 +1033,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, BadShaderDebugLineEnd) {
     TEST_DESCRIPTION("DebugLine Line End has bad value");
     AddRequiredExtensions(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
 
-    char const *shader_source = R"(
+    const char *shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpExtension "SPV_KHR_non_semantic_info"
@@ -1120,7 +1120,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, BasicDXC) {
     // Manually ran:
     //   dxc -spirv -T cs_6_0 -E main -fspv-target-env=vulkan1.2 -fspv-extension=SPV_KHR_non_semantic_info
     //   -fspv-debug=vulkan-with-source in.hlsl
-    char const *shader_source = R"(
+    const char *shader_source = R"(
                OpCapability Shader
                OpExtension "SPV_KHR_non_semantic_info"
           %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
@@ -1230,7 +1230,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, NoLineInFunctionFirst) {
     TEST_DESCRIPTION("Test if first function listed, has no debug info, we don't use the functions after it");
     AddRequiredExtensions(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
 
-    char const *shader_source = R"(
+    const char *shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpExtension "SPV_KHR_non_semantic_info"
@@ -1357,7 +1357,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, NoLineInFunctionLast) {
     TEST_DESCRIPTION("Test if last function listed, has no debug info, we don't use the functions before it");
     AddRequiredExtensions(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
 
-    char const *shader_source = R"(
+    const char *shader_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpExtension "SPV_KHR_non_semantic_info"
@@ -1490,7 +1490,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, PipelineHandles) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, std430) readonly buffer IndexBuffer {
@@ -1551,7 +1551,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, ShaderObjectHandle) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    static const char comp_src[] = R"glsl(
+    const char comp_src[] = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, std430) readonly buffer IndexBuffer {
@@ -1611,7 +1611,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, CommandBufferCommandIndex) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, std430) readonly buffer IndexBuffer {
@@ -1675,7 +1675,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, StageInfo) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, std430) readonly buffer IndexBuffer {
@@ -1729,7 +1729,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, StageInfoWithDebugLabel1) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, std430) readonly buffer IndexBuffer {
@@ -1790,7 +1790,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, StageInfoWithDebugLabel2) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, std430) readonly buffer IndexBuffer {
@@ -1853,7 +1853,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, StageInfoWithDebugLabel3) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, std430) readonly buffer IndexBuffer {
@@ -1930,7 +1930,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, StageInfoWithDebugLabel4) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, std430) readonly buffer IndexBuffer {
@@ -2017,7 +2017,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, DISABLED_StageInfoWithDebugLabel5) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, std430) readonly buffer IndexBuffer {
@@ -2111,7 +2111,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, StageInfoWithDebugLabel6) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, std430) readonly buffer IndexBuffer {
@@ -2201,7 +2201,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, StageInfoWithDebugLabel7) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, std430) readonly buffer IndexBuffer {
@@ -2322,7 +2322,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, PostProcess) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *fs_source = R"(
+    const char *fs_source = R"(
                OpCapability Shader
           %2 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
@@ -2453,7 +2453,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, PostProcessSlangGPL) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *fs_source = R"(
+    const char *fs_source = R"(
                OpCapability Shader
                OpExtension "SPV_KHR_non_semantic_info"
           %2 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"

--- a/tests/unit/gpu_av_shader_object_positive.cpp
+++ b/tests/unit/gpu_av_shader_object_positive.cpp
@@ -74,7 +74,7 @@ TEST_F(PositiveGpuAVShaderObject, RestoreUserPushConstants) {
     plci.pPushConstantRanges = push_constant_ranges.data();
     vkt::PipelineLayout pipeline_layout(*m_device, plci);
 
-    char const *vs_source = R"glsl(
+    const char *vs_source = R"glsl(
             #version 450
             #extension GL_EXT_buffer_reference : enable
 
@@ -103,7 +103,7 @@ TEST_F(PositiveGpuAVShaderObject, RestoreUserPushConstants) {
 
     const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, vs_source);
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
             #version 450
             #extension GL_EXT_buffer_reference : enable
 
@@ -180,7 +180,7 @@ TEST_F(PositiveGpuAVShaderObject, RestoreUserPushConstants2) {
     // Graphics pipeline
     // ---
 
-    char const *vs_source = R"glsl(
+    const char *vs_source = R"glsl(
             #version 450
             #extension GL_EXT_buffer_reference : enable
 
@@ -209,7 +209,7 @@ TEST_F(PositiveGpuAVShaderObject, RestoreUserPushConstants2) {
 
     const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, vs_source);
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
             #version 450
             #extension GL_EXT_buffer_reference : enable
 
@@ -268,7 +268,7 @@ TEST_F(PositiveGpuAVShaderObject, RestoreUserPushConstants2) {
     // Compute pipeline
     // ---
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
             #version 450
             #extension GL_EXT_buffer_reference : enable
 
@@ -365,7 +365,7 @@ TEST_F(PositiveGpuAVShaderObject, DispatchShaderObjectAndPipeline) {
     RETURN_IF_SKIP(InitGpuAvFramework(layer_settings));
     RETURN_IF_SKIP(InitState());
 
-    static const char comp_src[] = R"glsl(
+    const char comp_src[] = R"glsl(
         #version 450
         layout(local_size_x=16, local_size_x=1, local_size_x=1) in;
 
@@ -428,7 +428,7 @@ TEST_F(PositiveGpuAVShaderObject, GetShaderBinaryData) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    static const char frag_src[] = R"glsl(
+    const char frag_src[] = R"glsl(
         #version 450
         layout(location = 0) in highp vec4 vtxColor;
         layout(location = 0) out highp vec4 fragColor;
@@ -458,7 +458,7 @@ TEST_F(PositiveGpuAVShaderObject, BinaryShaderObjects) {
     RETURN_IF_SKIP(InitState());
     InitDynamicRenderTarget();
 
-    static const char vert_src[] = R"glsl(
+    const char vert_src[] = R"glsl(
         #version 450
         layout(location = 0) out highp vec4 vtxColor;
         layout(set = 0, binding = 0) uniform Block { vec4 color; };
@@ -468,7 +468,7 @@ TEST_F(PositiveGpuAVShaderObject, BinaryShaderObjects) {
         }
     )glsl";
 
-    static const char frag_src[] = R"glsl(
+    const char frag_src[] = R"glsl(
         #version 450
         layout(location = 0) in highp vec4 vtxColor;
         layout(location = 0) out highp vec4 fragColor;

--- a/tests/unit/gpu_av_vertex_attribute_fetch.cpp
+++ b/tests/unit/gpu_av_vertex_attribute_fetch.cpp
@@ -105,7 +105,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, IndirectDrawBadVertexIndex32) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         void main() {
@@ -160,7 +160,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, IndirectDrawBadVertexIndex16) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         void main() {
@@ -218,7 +218,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, IndirectDrawBadVertexIndex8) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         void main() {
@@ -273,7 +273,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, DrawBadVertexIndex32) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         void main() {
@@ -330,7 +330,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, DrawBadVertexIndex32ShaderObject) {
     RETURN_IF_SKIP(InitState());
     InitDynamicRenderTarget();
 
-    char const *vs_source = R"glsl(
+    const char *vs_source = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         void main() {
@@ -380,7 +380,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, DrawInSecondaryCmdBufferBadVertexIndex
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         void main() {
@@ -459,7 +459,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, DrawBadVertexIndex16) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         void main() {
@@ -514,7 +514,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, DrawBadVertexIndex16_2) {
         std::array<float, 3> normal;
     };
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         layout(location=1) in vec2 uv;
@@ -581,7 +581,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, DrawBadVertexIndex8) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         void main() {
@@ -639,7 +639,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, DrawBadVertexIndex16DebugLabel) {
         std::array<float, 3> normal;
     };
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         layout(location=1) in vec2 uv;
@@ -716,7 +716,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, IndirectDrawBadVertexIndex32DebugLabel
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         void main() {
@@ -789,7 +789,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, InstanceIndex) {
         std::array<float, 3> normal;
     };
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         layout(location=1) in vec2 uv;
@@ -873,7 +873,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, InstanceIndexVertexAttributeDivisor) {
         std::array<float, 3> normal;
     };
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         layout(location=1) in vec2 uv;
@@ -970,7 +970,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, InstanceIndexVertexAttributeDivisorDyn
         std::array<float, 3> normal;
     };
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         layout(location=1) in vec2 uv;
@@ -1085,7 +1085,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, CmdSetVertexInputEXT) {
         std::array<float, 3> normal;
     };
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         layout(location=1) in vec2 uv;
@@ -1176,7 +1176,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, CmdBindVertexBuffers2EXT) {
         std::array<float, 3> normal;
     };
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
 
         layout(location=0) in vec3 pos;
@@ -1263,7 +1263,7 @@ TEST_F(NegativeGpuAVVertexAttributeFetch, DrawBadVertexIndex32MultiDraw) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         void main() {

--- a/tests/unit/gpu_av_vertex_attribute_fetch_positive.cpp
+++ b/tests/unit/gpu_av_vertex_attribute_fetch_positive.cpp
@@ -24,7 +24,7 @@ TEST_F(PositiveGpuAVVertexAttributeFetch, IndirectDrawZeroStride) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 pos;
         void main() {

--- a/tests/unit/graphics_library.cpp
+++ b/tests/unit/graphics_library.cpp
@@ -1182,7 +1182,7 @@ TEST_F(NegativeGraphicsLibrary, Tessellation) {
     const auto fs_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
     vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    char const *tcs_src = R"glsl(
+    const char *tcs_src = R"glsl(
         #version 450
         layout(vertices=3) out;
         void main(){
@@ -1193,7 +1193,7 @@ TEST_F(NegativeGraphicsLibrary, Tessellation) {
     const auto tcs_spv = GLSLToSPV(VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT, tcs_src);
     vkt::GraphicsPipelineLibraryStage tcs_stage(tcs_spv, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT);
 
-    char const *tes_src = R"glsl(
+    const char *tes_src = R"glsl(
         #version 450
         layout(triangles, equal_spacing, cw) in;
         void main(){
@@ -3715,7 +3715,7 @@ TEST_F(NegativeGraphicsLibrary, StatelessSpirvValidation) {
     RETURN_IF_SKIP(InitBasicGraphicsLibrary());
     InitRenderTarget();
 
-    static const char shader[] = R"glsl(
+    const char shader[] = R"glsl(
         #version 450
         #extension GL_EXT_shader_atomic_float : enable
         #extension GL_KHR_memory_scope_semantics : enable

--- a/tests/unit/image_layout.cpp
+++ b/tests/unit/image_layout.cpp
@@ -352,7 +352,7 @@ TEST_F(NegativeImageLayout, PushDescriptor) {
     const vkt::DescriptorSetLayout ds_layout(*m_device, {dsl_binding}, VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT);
     auto pipeline_layout = vkt::PipelineLayout(*m_device, {&ds_layout});
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler2D tex;
         layout(location=0) out vec4 color;
@@ -772,7 +772,7 @@ TEST_F(NegativeImageLayout, DescriptorArrayStaticIndex) {
     RETURN_IF_SKIP(Init());
     RETURN_IF_SKIP(InitRenderTarget());
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         // [0] is good layout

--- a/tests/unit/image_layout_positive.cpp
+++ b/tests/unit/image_layout_positive.cpp
@@ -541,7 +541,7 @@ TEST_F(PositiveImageLayout, DescriptorArray) {
     RETURN_IF_SKIP(Init());
     RETURN_IF_SKIP(InitRenderTarget());
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set = 0, binding = 0) uniform UBO { uint index; };
@@ -849,7 +849,7 @@ TEST_F(PositiveImageLayout, DepthSliceTransitionCriteriaNotMet) {
     layout_transition.image = image;
     layout_transition.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450 core
         layout (rgba8, set = 0, binding = 0) uniform image2D verifyImage;
         void main (void) {

--- a/tests/unit/mesh.cpp
+++ b/tests/unit/mesh.cpp
@@ -39,7 +39,7 @@ TEST_F(NegativeMesh, BasicUsage) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    static const char vert_shader_text[] = R"glsl(
+    const char vert_shader_text[] = R"glsl(
         #version 460
         vec2 vertices[3];
         void main() {
@@ -51,7 +51,7 @@ TEST_F(NegativeMesh, BasicUsage) {
         }
     )glsl";
 
-    static const char mesh_shader_text[] = R"glsl(
+    const char mesh_shader_text[] = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : require
         layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
@@ -67,7 +67,7 @@ TEST_F(NegativeMesh, BasicUsage) {
         }
     )glsl";
 
-    static const char mesh_shader_xfb_text[] = R"(
+    const char mesh_shader_xfb_text[] = R"(
                OpCapability MeshShadingEXT
                OpCapability TransformFeedback
                OpExtension "SPV_EXT_mesh_shader"
@@ -445,7 +445,7 @@ TEST_F(NegativeMesh, BasicUsageNV) {
     RETURN_IF_SKIP(InitState(nullptr, &features2));
     InitRenderTarget();
 
-    static const char vertShaderText[] = R"glsl(
+    const char vertShaderText[] = R"glsl(
         #version 450
         vec2 vertices[3];
         void main() {
@@ -457,7 +457,7 @@ TEST_F(NegativeMesh, BasicUsageNV) {
         }
     )glsl";
 
-    static const char meshShaderText[] = R"glsl(
+    const char meshShaderText[] = R"glsl(
         #version 450
         #extension GL_NV_mesh_shader : require
         layout(local_size_x = 1) in;
@@ -652,7 +652,7 @@ TEST_F(NegativeMesh, ExtensionDisabledNV) {
                OpFunctionEnd
     )";
 
-    static const char mesh_src[] = R"glsl(
+    const char mesh_src[] = R"glsl(
         #version 450
 
         #extension GL_NV_mesh_shader : require
@@ -831,7 +831,7 @@ TEST_F(NegativeMesh, MultiDrawIndirect) {
     // };
     // taskPayloadSharedEXT Task IN;
     // void main() {}
-    static const char mesh_src[] = R"(
+    const char mesh_src[] = R"(
                OpCapability MeshShadingEXT
                OpExtension "SPV_EXT_mesh_shader"
           %1 = OpExtInstImport "GLSL.std.450"
@@ -939,7 +939,7 @@ TEST_F(NegativeMesh, DrawCmdsNV) {
 
     InitRenderTarget();
 
-    static const char mesh_src[] = R"glsl(
+    const char mesh_src[] = R"glsl(
         #version 450
         #extension GL_NV_mesh_shader : require
         layout(local_size_x = 1) in;
@@ -1042,7 +1042,7 @@ TEST_F(NegativeMesh, MeshTasksWorkgroupCount) {
         }
     )glsl";
 
-    static const char mesh_src[] = R"glsl(
+    const char mesh_src[] = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : require
         layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
@@ -1058,7 +1058,7 @@ TEST_F(NegativeMesh, MeshTasksWorkgroupCount) {
         }
     )glsl";
 
-    static const char frag_src[] = R"glsl(
+    const char frag_src[] = R"glsl(
         #version 460
         layout(location = 0) out vec4 uFragColor;
         void main(){
@@ -1109,7 +1109,7 @@ TEST_F(NegativeMesh, MeshShaderConservativeRasterization) {
     RETURN_IF_SKIP(InitBasicMeshAndTask());
     InitRenderTarget();
 
-    static const char meshShaderText[] = R"glsl(
+    const char meshShaderText[] = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : require
         layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;

--- a/tests/unit/mesh_positive.cpp
+++ b/tests/unit/mesh_positive.cpp
@@ -77,7 +77,7 @@ TEST_F(PositiveMesh, MeshShaderOnly) {
 
     InitRenderTarget();
 
-    static const char meshShaderText[] = R"glsl(
+    const char meshShaderText[] = R"glsl(
         #version 450
         #extension GL_NV_mesh_shader : require
         layout(local_size_x = 1) in;
@@ -124,7 +124,7 @@ TEST_F(PositiveMesh, PointSize) {
 
     InitRenderTarget();
 
-    static const char meshShaderText[] = R"glsl(
+    const char meshShaderText[] = R"glsl(
         #version 460
         #extension GL_NV_mesh_shader : enable
         layout (local_size_x=1) in;
@@ -174,7 +174,7 @@ TEST_F(PositiveMesh, TaskAndMeshShaderNV) {
                         "VK_SHADER_STAGE_TASK_BIT_NV, skipping test.";
     }
 
-    static const char taskShaderText[] = R"glsl(
+    const char taskShaderText[] = R"glsl(
         #version 450
 
         #extension GL_NV_mesh_shader : require
@@ -209,7 +209,7 @@ TEST_F(PositiveMesh, TaskAndMeshShaderNV) {
         }
     )glsl";
 
-    static const char meshShaderText[] = R"glsl(
+    const char meshShaderText[] = R"glsl(
         #version 450
 
         #extension GL_NV_mesh_shader : require
@@ -252,7 +252,7 @@ TEST_F(PositiveMesh, MeshPerTaskNV) {
     RETURN_IF_SKIP(InitState(nullptr, &mesh_shader_features));
     InitRenderTarget();
 
-    static const char taskShaderText[] = R"glsl(
+    const char taskShaderText[] = R"glsl(
         #version 450
         #extension GL_NV_mesh_shader : require
         layout(local_size_x = 32) in;
@@ -262,7 +262,7 @@ TEST_F(PositiveMesh, MeshPerTaskNV) {
         void main() {}
     )glsl";
 
-    static const char meshShaderText[] = R"glsl(
+    const char meshShaderText[] = R"glsl(
         #version 460
         #extension GL_NV_mesh_shader : enable
 

--- a/tests/unit/multiview.cpp
+++ b/tests/unit/multiview.cpp
@@ -323,7 +323,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
 
     // Push constants
     {
-        char const *const vsSource = R"glsl(
+        const char *const vsSource = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo {
            mat3 m;
@@ -462,7 +462,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         input_attribs.format = VK_FORMAT_R32G32_SFLOAT;
         input_attribs.offset = 0;
 
-        char const *const vsSource = R"glsl(
+        const char *const vsSource = R"glsl(
         #version 450
         layout(location = 0) in vec2 input0;
         void main(){
@@ -537,7 +537,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         input_attribs.format = VK_FORMAT_R32G32_SFLOAT;
         input_attribs.offset = 0;
 
-        char const *const vsSource = R"glsl(
+        const char *const vsSource = R"glsl(
         #version 450
         layout(location = 0) in vec2 input0;
         void main(){
@@ -1075,7 +1075,7 @@ TEST_F(NegativeMultiview, FeaturesDisabled) {
 
     // tessellationShader
     {
-        char const *tcsSource = R"glsl(
+        const char *tcsSource = R"glsl(
         #version 450
         layout(vertices=3) out;
         void main(){
@@ -1083,7 +1083,7 @@ TEST_F(NegativeMultiview, FeaturesDisabled) {
            gl_TessLevelInner[0] = 1;
         }
         )glsl";
-        char const *tesSource = R"glsl(
+        const char *tesSource = R"glsl(
         #version 450
         layout(triangles, equal_spacing, cw) in;
         void main(){
@@ -1115,7 +1115,7 @@ TEST_F(NegativeMultiview, FeaturesDisabled) {
     }
     // geometryShader
     {
-        static char const *gsSource = R"glsl(
+        const char *gsSource = R"glsl(
         #version 450
         layout (points) in;
         layout (triangle_strip) out;
@@ -1200,7 +1200,7 @@ TEST_F(NegativeMultiview, ShaderLayerBuiltInRenderPass) {
     AddRequiredFeature(vkt::Feature::multiviewGeometryShader);
     RETURN_IF_SKIP(Init());
 
-    static char const *gsSource = R"glsl(
+    const char *gsSource = R"glsl(
         #version 450
         layout (triangles) in;
         layout (triangle_strip) out;
@@ -1259,7 +1259,7 @@ TEST_F(NegativeMultiview, ShaderLayerBuiltInDynamicRendering) {
     AddRequiredFeature(vkt::Feature::multiviewGeometryShader);
     RETURN_IF_SKIP(Init());
 
-    static char const *gsSource = R"glsl(
+    const char *gsSource = R"glsl(
         #version 450
         layout (triangles) in;
         layout (triangle_strip) out;

--- a/tests/unit/nvidia_best_practices.cpp
+++ b/tests/unit/nvidia_best_practices.cpp
@@ -582,12 +582,12 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindPipeline_SwitchTessGeometryMesh) {
         GTEST_SKIP() << "Device doesn't support requried maxGeometryOutputVertices";
     }
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         void main() {}
     )glsl";
 
-    char const *gsSource = R"glsl(
+    const char *gsSource = R"glsl(
         #version 450
         layout(triangles) in;
         layout(triangle_strip, max_vertices = 3) out;

--- a/tests/unit/object_lifetime.cpp
+++ b/tests/unit/object_lifetime.cpp
@@ -283,7 +283,7 @@ TEST_F(NegativeObjectLifetime, CmdBufferBufferViewDestroyed) {
         descriptor_set.WriteDescriptorBufferView(0, view);
         descriptor_set.UpdateDescriptorSets();
 
-        char const *fsSource = R"glsl(
+        const char *fsSource = R"glsl(
             #version 450
             layout(set=0, binding=0, r32f) uniform readonly imageBuffer s;
             layout(location=0) out vec4 x;
@@ -1008,7 +1008,7 @@ TEST_F(NegativeObjectLifetime, BufferViewInUseDestroyedSignaled) {
     VkResult err = vk::CreateBufferView(device(), &bvci, NULL, &view);
     ASSERT_EQ(VK_SUCCESS, err);
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(set=0, binding=0, r32f) uniform readonly imageBuffer s;
         layout(location=0) out vec4 x;

--- a/tests/unit/pipeline.cpp
+++ b/tests/unit/pipeline.cpp
@@ -382,7 +382,7 @@ TEST_F(NegativePipeline, ShaderStageBit) {
     InitRenderTarget();
 
     // Make sure compute pipeline has a compute shader stage set
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         layout(local_size_x=1, local_size_y=1, local_size_z=1) in;
         void main(){
@@ -580,7 +580,7 @@ TEST_F(NegativePipeline, RenderPassShaderResolveQCOM) {
     ASSERT_TRUE(renderpass2.initialized());
 
     // shader uses gl_SamplePosition which causes the SPIR-V to include SampleRateShading capability
-    static const char *sampleRateFragShaderText = R"glsl(
+    const char *sampleRateFragShaderText = R"glsl(
         #version 450
         layout(location = 0) out vec4 uFragColor;
         void main() {
@@ -997,7 +997,7 @@ TEST_F(NegativePipeline, DuplicateStageMaintenance5Vertex) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    static const char shader[] = R"glsl(
+    const char shader[] = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer ssbo { uint x; };
         void main() {
@@ -1071,7 +1071,7 @@ TEST_F(NegativePipeline, MissingEntrypoint) {
 TEST_F(NegativePipeline, MissingEntrypoint2) {
     RETURN_IF_SKIP(Init());
 
-    char const *shader_source = R"(
+    const char *shader_source = R"(
         OpCapability Shader
         OpMemoryModel Logical GLSL450
         OpEntryPoint GLCompute %foo "foo"
@@ -1842,7 +1842,7 @@ TEST_F(NegativePipeline, NotCompatibleForSet) {
     descriptor_set.WriteDescriptorBufferInfo(1, uniform_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer StorageBuffer { uint index; } u_index;
         layout(set = 0, binding = 1) uniform UniformStruct { ivec4 dummy; int val; } ubo;
@@ -1881,7 +1881,7 @@ TEST_F(NegativePipeline, NotCompatibleForSetIndependent) {
                                                 VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT);
     const vkt::PipelineLayout pipeline_layout_2(*m_device, {&descriptor_set.layout_});
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         layout(set = 0, binding = 0) uniform UniformStruct { uint dummy; } ubo;
         void main() {
@@ -1907,7 +1907,7 @@ TEST_F(NegativePipeline, NotCompatibleForSetIndependent) {
 TEST_F(NegativePipeline, DescriptorSetNotBound) {
     RETURN_IF_SKIP(Init());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer SSBO { uint x; };
         void main() {
@@ -2084,7 +2084,7 @@ TEST_F(NegativePipeline, SampledInvalidImageViews) {
     vkt::ImageView imageView = image.CreateView();
 
     // maps to VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER
-    char const *fs_source_combined = R"glsl(
+    const char *fs_source_combined = R"glsl(
         #version 450
         layout (set=0, binding=0) uniform sampler2D samplerColor;
         layout(location=0) out vec4 color;
@@ -2096,7 +2096,7 @@ TEST_F(NegativePipeline, SampledInvalidImageViews) {
     VkShaderObj fs_combined(this, fs_source_combined, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     // maps to VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE and VK_DESCRIPTOR_TYPE_SAMPLER
-    char const *fs_source_seperate = R"glsl(
+    const char *fs_source_seperate = R"glsl(
         #version 450
         layout (set=0, binding=0) uniform texture2D textureColor;
         layout (set=0, binding=1) uniform sampler samplers;
@@ -2112,7 +2112,7 @@ TEST_F(NegativePipeline, SampledInvalidImageViews) {
     VkShaderObj fs_seperate(this, fs_source_seperate, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     // maps to an unused image sampler that should not trigger validation as it is never sampled
-    char const *fs_source_unused = R"glsl(
+    const char *fs_source_unused = R"glsl(
         #version 450
         layout (set=0, binding=0) uniform sampler2D samplerColor;
         layout(location=0) out vec4 color;
@@ -2123,7 +2123,7 @@ TEST_F(NegativePipeline, SampledInvalidImageViews) {
     VkShaderObj fs_unused(this, fs_source_unused, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     // maps to VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER but makes sure it walks function tree to find sampling
-    char const *fs_source_function = R"glsl(
+    const char *fs_source_function = R"glsl(
         #version 450
         layout (set=0, binding=0) uniform sampler2D samplerColor;
         layout(location=0) out vec4 color;
@@ -2264,7 +2264,7 @@ TEST_F(NegativePipeline, ShaderDrawParametersNotEnabled10) {
         GTEST_SKIP() << "Test requires Vulkan exactly 1.0";
     }
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 460
         void main(){
            gl_Position = vec4(float(gl_BaseVertex));
@@ -2284,7 +2284,7 @@ TEST_F(NegativePipeline, ShaderDrawParametersNotEnabled11) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 460
         void main(){
            gl_Position = vec4(float(gl_BaseVertex));
@@ -2406,7 +2406,7 @@ TEST_F(NegativePipeline, CreateComputePipelineWithBadBasePointer) {
 
     RETURN_IF_SKIP(Init());
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         layout(local_size_x=2, local_size_y=4) in;
         void main(){
@@ -2439,7 +2439,7 @@ TEST_F(NegativePipeline, CreateComputePipelineWithDerivatives) {
 
     RETURN_IF_SKIP(Init());
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         layout(local_size_x=2, local_size_y=4) in;
         void main(){
@@ -3006,7 +3006,7 @@ TEST_F(NegativePipeline, RasterizationOrderAttachmentAccessNoSubpassFlags) {
     }
 
     if (rasterization_order_features.rasterizationOrderDepthAttachmentAccess) {
-        char const *fsSource = R"glsl(
+        const char *fsSource = R"glsl(
             #version 450
             layout(early_fragment_tests) in;
             layout(location = 0) out vec4 uFragColor;
@@ -3042,14 +3042,14 @@ TEST_F(NegativePipeline, MismatchedRenderPassAndPipelineAttachments) {
 
     m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-renderPass-07609");
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
                 #version 450
 
                 void main() {
                 }
             )glsl";
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
                 #version 450
 
                 void main() {
@@ -3609,7 +3609,7 @@ TEST_F(NegativePipeline, GeometryShaderConservativeRasterization) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    static char const *gsSource = R"glsl(
+    const char *gsSource = R"glsl(
         #version 450
         layout (triangles) in;
         layout (points) out;

--- a/tests/unit/pipeline_layout.cpp
+++ b/tests/unit/pipeline_layout.cpp
@@ -775,7 +775,7 @@ TEST_F(NegativePipelineLayout, DescriptorTypeMismatch) {
                                                      {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
                                                  });
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout (std140, set = 0, binding = 0) uniform buf {
             mat4 mvp;
@@ -801,7 +801,7 @@ TEST_F(NegativePipelineLayout, DescriptorTypeMismatchCompute) {
 
     RETURN_IF_SKIP(Init());
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         layout(local_size_x=1) in;
         layout(set=0, binding=0) buffer block { vec4 x; };
@@ -824,7 +824,7 @@ TEST_F(NegativePipelineLayout, DescriptorTypeMismatchNonCombinedImageSampler) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget(0, nullptr);
 
-    char const *fsSource = R"(
+    const char *fsSource = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %main "main"
@@ -886,7 +886,7 @@ TEST_F(NegativePipelineLayout, DescriptorNotAccessible) {
                                          {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT /*!*/, nullptr},
                                      });
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout (std140, set = 0, binding = 0) uniform buf {
             mat4 mvp;
@@ -936,7 +936,7 @@ TEST_F(NegativePipelineLayout, MissingDescriptor) {
 
     RETURN_IF_SKIP(Init());
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         layout(local_size_x=1) in;
         layout(set=0, binding=0) buffer block { vec4 x; };
@@ -1038,7 +1038,7 @@ TEST_F(NegativePipelineLayout, InlineUniformBlockArray) {
                                        0, nullptr, 0, nullptr, &pool_inline_info);
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) buffer SSBO0 { uint ssbo; };
@@ -1074,7 +1074,7 @@ TEST_F(NegativePipelineLayout, InlineUniformBlockArrayOf1) {
                                        0, nullptr, 0, nullptr, &pool_inline_info);
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) buffer SSBO0 { uint ssbo; };

--- a/tests/unit/pipeline_layout_positive.cpp
+++ b/tests/unit/pipeline_layout_positive.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 Valve Corporation
- * Copyright (c) 2023-2024 LunarG, Inc.
+ * Copyright (c) 2023-2025 Valve Corporation
+ * Copyright (c) 2023-2025 LunarG, Inc.
  * Modifications Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,7 +26,7 @@ TEST_F(PositivePipelineLayout, DescriptorTypeMismatchNonCombinedImageSampler) {
                                                      {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_ALL, nullptr},
                                                  });
 
-    char const *fsSource = R"(
+    const char *fsSource = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %main "main"

--- a/tests/unit/pipeline_positive.cpp
+++ b/tests/unit/pipeline_positive.cpp
@@ -56,7 +56,7 @@ TEST_F(PositivePipeline, MissingDescriptorUnused) {
 
     RETURN_IF_SKIP(Init());
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         layout(local_size_x=1) in;
         layout(set=0, binding=0) buffer block { vec4 x; };
@@ -79,7 +79,7 @@ TEST_F(PositivePipeline, FragmentShadingRate) {
     AddRequiredFeature(vkt::Feature::primitiveFragmentShadingRate);
     RETURN_IF_SKIP(Init());
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         layout(local_size_x=1) in;
         layout(set=0, binding=0) buffer block { vec4 x; };
@@ -99,7 +99,7 @@ TEST_F(PositivePipeline, CombinedImageSamplerConsumedAsSampler) {
 
     RETURN_IF_SKIP(Init());
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         layout(local_size_x=1) in;
         layout(set=0, binding=0) uniform sampler s;
@@ -125,7 +125,7 @@ TEST_F(PositivePipeline, CombinedImageSamplerConsumedAsImage) {
 
     RETURN_IF_SKIP(Init());
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         layout(local_size_x=1) in;
         layout(set=0, binding=0) uniform texture2D t;
@@ -152,7 +152,7 @@ TEST_F(PositivePipeline, CombinedImageSamplerConsumedAsBoth) {
 
     RETURN_IF_SKIP(Init());
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         layout(local_size_x=1) in;
         layout(set=0, binding=0) uniform texture2D t;
@@ -192,7 +192,7 @@ TEST_F(PositivePipeline, CreateComputePipelineWithDerivatives) {
 
     RETURN_IF_SKIP(Init());
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         layout(local_size_x=2, local_size_y=4) in;
         void main(){
@@ -663,7 +663,7 @@ TEST_F(PositivePipeline, AttachmentUnused) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 x;
         void main(){
@@ -1014,7 +1014,7 @@ TEST_F(PositivePipeline, PervertexNVShaderAttributes) {
 
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
                 #version 450
 
                 layout(location = 0) out PerVertex {
@@ -1033,7 +1033,7 @@ TEST_F(PositivePipeline, PervertexNVShaderAttributes) {
                 }
             )glsl";
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
                 #version 450
 
                 #extension GL_NV_fragment_shader_barycentric : enable
@@ -1331,7 +1331,7 @@ TEST_F(PositivePipeline, DualBlendShader) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location = 0, index = 0) out vec4 c1;
         layout(location = 0, index = 1) out vec4 c2;
@@ -1639,7 +1639,7 @@ TEST_F(PositivePipeline, InterpolateAtSample) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    static const char vs_src[] = R"glsl(
+    const char vs_src[] = R"glsl(
         #version 460
         layout(location = 0) out vec2 uv;
         void main() {
@@ -1647,7 +1647,7 @@ TEST_F(PositivePipeline, InterpolateAtSample) {
             gl_Position = vec4(uv, 0.0f, 1.0f);
         }
     )glsl";
-    static const char fs_src[] = R"glsl(
+    const char fs_src[] = R"glsl(
         #version 460
         layout(location = 0) out vec4 uFragColor;
         layout(location = 0) in vec2 v;
@@ -2234,7 +2234,7 @@ TEST_F(PositivePipeline, DisableShaderValidation) {
     RETURN_IF_SKIP(InitFramework(&layer_setting_ci));
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer SSBO {
             uint x; // something to trigger pipeline validation
@@ -2270,7 +2270,7 @@ TEST_F(PositivePipeline, DisableShaderValidationMaintenance5) {
     RETURN_IF_SKIP(InitFramework(&layer_setting_ci));
     RETURN_IF_SKIP(InitState());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer SSBO {
             uint x; // something to trigger pipeline validation
@@ -2321,7 +2321,7 @@ TEST_F(PositivePipeline, DisableShaderValidationGPL) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *frag_shader = R"glsl(
+    const char *frag_shader = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer SSBO {
             uint x; // something to trigger pipeline validation

--- a/tests/unit/pipeline_topology_positive.cpp
+++ b/tests/unit/pipeline_topology_positive.cpp
@@ -64,7 +64,7 @@ TEST_F(PositivePipelineTopology, PointSizeGeomShaderDontEmit) {
     InitRenderTarget();
 
     // Never calls OpEmitVertex
-    static char const *gsSource = R"glsl(
+    const char *gsSource = R"glsl(
         #version 450
         layout (points) in;
         layout (points) out;
@@ -374,7 +374,7 @@ TEST_F(PositivePipelineTopology, NotPointSizeGeometry) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    static char const geom_src[] = R"glsl(
+    const char geom_src[] = R"glsl(
         #version 460
         layout(points) in;
         layout(triangle_strip, max_vertices=3) out;
@@ -402,7 +402,7 @@ TEST_F(PositivePipelineTopology, Rasterizer) {
 
     InitRenderTarget();
 
-    char const *tcsSource = R"glsl(
+    const char *tcsSource = R"glsl(
         #version 450
         layout(vertices = 3) out;
         void main(){
@@ -410,7 +410,7 @@ TEST_F(PositivePipelineTopology, Rasterizer) {
            gl_TessLevelInner[0] = 1;
         }
     )glsl";
-    char const *tesSource = R"glsl(
+    const char *tesSource = R"glsl(
         #version 450
         layout(triangles, equal_spacing, cw) in;
         void main(){
@@ -418,7 +418,7 @@ TEST_F(PositivePipelineTopology, Rasterizer) {
            gl_Position.w = 1.0f;
         }
     )glsl";
-    static char const *gsSource = R"glsl(
+    const char *gsSource = R"glsl(
         #version 450
         layout (triangles) in;
         layout (triangle_strip) out;

--- a/tests/unit/portability_subset.cpp
+++ b/tests/unit/portability_subset.cpp
@@ -504,7 +504,7 @@ TEST_F(VkPortabilitySubsetTest, ShaderValidation) {
 
     // Attempt to use isolines in the TES shader when not available
     {
-        static const char *tes_source = R"glsl(
+        const char *tes_source = R"glsl(
             #version 450
             layout(isolines, equal_spacing, cw) in;
             void main() {
@@ -520,7 +520,7 @@ TEST_F(VkPortabilitySubsetTest, ShaderValidation) {
 
     // Attempt to use point_mode in the TES shader when not available
     {
-        static const char *tes_source = R"glsl(
+        const char *tes_source = R"glsl(
             #version 450
             layout(triangles, point_mode) in;
             void main() {
@@ -541,7 +541,7 @@ TEST_F(VkPortabilitySubsetTest, ShaderValidation) {
 
     // Attempt to use interpolation functions when not supported
     {
-        static const char *vs_source = R"glsl(
+        const char *vs_source = R"glsl(
             #version 450
             layout(location = 0) out vec4 c;
             void main() {
@@ -551,7 +551,7 @@ TEST_F(VkPortabilitySubsetTest, ShaderValidation) {
         )glsl";
         VkShaderObj vs_obj(this, vs_source, VK_SHADER_STAGE_VERTEX_BIT);
 
-        static const char *fs_source = R"glsl(
+        const char *fs_source = R"glsl(
             #version 450
             layout(location = 0) in vec4 c;
             layout(location = 0) out vec4 frag_out;

--- a/tests/unit/push_descriptor_positive.cpp
+++ b/tests/unit/push_descriptor_positive.cpp
@@ -133,7 +133,7 @@ TEST_F(PositivePushDescriptor, UnboundSet) {
     const vkt::DescriptorSetLayout push_ds_layout(*m_device, {dsl_binding}, VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT);
 
     // Create PSO
-    char const fsSource[] = R"glsl(
+    const char fsSource[] = R"glsl(
         #version 450
         layout(location=0) out vec4 x;
         layout(set=0) layout(binding=2) uniform foo1 { float x; } bar1;
@@ -212,7 +212,7 @@ TEST_F(PositivePushDescriptor, SetUpdatingSetNumber) {
         const vkt::PipelineLayout pipeline_layout(*m_device, {&ds_layout, &ds_layout, &push_ds_layout, &ds_layout});
         ASSERT_TRUE(pipeline_layout.initialized());
 
-        char const *fsSource = R"glsl(
+        const char *fsSource = R"glsl(
             #version 450
             layout(location=0) out vec4 x;
             layout(set=2) layout(binding=0) uniform foo { vec4 y; } bar;
@@ -244,7 +244,7 @@ TEST_F(PositivePushDescriptor, SetUpdatingSetNumber) {
         const VkWriteDescriptorSet descriptor_write =
             vkt::Device::WriteDescriptorSet(vkt::DescriptorSet(), 0, 0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, &buffer_info);
 
-        char const *fsSource = R"glsl(
+        const char *fsSource = R"glsl(
             #version 450
             layout(location=0) out vec4 x;
             layout(set=3) layout(binding=0) uniform foo { vec4 y; } bar;

--- a/tests/unit/ray_tracing_pipeline.cpp
+++ b/tests/unit/ray_tracing_pipeline.cpp
@@ -1003,7 +1003,7 @@ TEST_F(NegativeRayTracingPipeline, DeferredOp) {
     }
     RETURN_IF_SKIP(InitState());
 
-    static const char* chit_src = R"glsl(
+    const char* chit_src = R"glsl(
         #version 460
         #extension GL_EXT_ray_tracing : require // Requires SPIR-V 1.5 (Vulkan 1.2)
         layout(location = 0) rayPayloadEXT uvec4 hitValue;

--- a/tests/unit/ray_tracing_pipeline_nv.cpp
+++ b/tests/unit/ray_tracing_pipeline_nv.cpp
@@ -683,7 +683,7 @@ TEST_F(NegativeRayTracingPipelineNV, MissingEntrypoint) {
     RETURN_IF_SKIP(NvInitFrameworkForRayTracingTest());
     RETURN_IF_SKIP(InitState());
 
-    char const missShaderText[] = R"glsl(
+    const char missShaderText[] = R"glsl(
         #version 460 core
         #extension GL_EXT_ray_tracing : enable
         layout(location = 0) rayPayloadInEXT float hitValue;

--- a/tests/unit/render_pass.cpp
+++ b/tests/unit/render_pass.cpp
@@ -2515,7 +2515,7 @@ TEST_F(NegativeRenderPass, SamplingFromReadOnlyDepthStencilAttachment) {
 
     vkt::Framebuffer framebuffer(*m_device, rp, 1, &image_view_handle, width, height);
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
             #version 450
             layout(set = 0, binding = 0) uniform sampler2D depth;
             void main(){

--- a/tests/unit/render_pass_positive.cpp
+++ b/tests/unit/render_pass_positive.cpp
@@ -473,7 +473,7 @@ TEST_F(PositiveRenderPass, SingleMipTransition) {
 
     // Create shader modules
 
-    char const fsSource[] = R"glsl(
+    const char fsSource[] = R"glsl(
         #version 450
         layout(location=0) out vec4 x;
         layout(set=0, binding=2) uniform sampler2D depth;

--- a/tests/unit/sampler.cpp
+++ b/tests/unit/sampler.cpp
@@ -455,7 +455,7 @@ TEST_F(NegativeSampler, LinearReductionModeMinMax) {
     sampler_ci.compareEnable = VK_FALSE;
     vkt::Sampler sampler(*m_device, sampler_ci);
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         layout (set=0, binding=0) uniform sampler2D bad;
         layout(location=0) out vec4 color;
@@ -823,7 +823,7 @@ TEST_F(NegativeSampler, CustomBorderColorFormatUndefined) {
     descriptor_set.WriteDescriptorImageInfo(0, view, sampler);
     descriptor_set.UpdateDescriptorSets();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler2D s;
         layout(location=0) out vec4 x;
@@ -876,7 +876,7 @@ TEST_F(NegativeSampler, CustomBorderColorFormatUndefinedNonCombined) {
     descriptor_set.WriteDescriptorImageInfo(1, image_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
     descriptor_set.UpdateDescriptorSets();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler s;
         layout(set=0, binding=1) uniform texture2D t;
@@ -935,7 +935,7 @@ TEST_F(NegativeSampler, DISABLED_CustomBorderColorFormatUndefinedNonCombinedMult
     descriptor_set1.WriteDescriptorImageInfo(3, image_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
     descriptor_set1.UpdateDescriptorSets();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(set=0, binding=2) uniform sampler s;
         layout(set=1, binding=3) uniform texture2D t;

--- a/tests/unit/secondary_command_buffer.cpp
+++ b/tests/unit/secondary_command_buffer.cpp
@@ -399,7 +399,7 @@ TEST_F(NegativeSecondaryCommandBuffer, ExecuteWithLayoutMismatchUseGenericLayout
     descriptor_set.WriteDescriptorImageInfo(0, image_view, sampler, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
                                             VK_IMAGE_LAYOUT_GENERAL);
     descriptor_set.UpdateDescriptorSets();
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler2D color_image;
         void main() {

--- a/tests/unit/secondary_command_buffer_positive.cpp
+++ b/tests/unit/secondary_command_buffer_positive.cpp
@@ -338,7 +338,7 @@ TEST_F(PositiveSecondaryCommandBuffer, Sync2ImageLayouts) {
     descriptor_set.WriteDescriptorImageInfo(0, image_view, sampler, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
                                             VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL);
     descriptor_set.UpdateDescriptorSets();
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler2D color_image;
         void main() {

--- a/tests/unit/shader_compute_positive.cpp
+++ b/tests/unit/shader_compute_positive.cpp
@@ -250,7 +250,7 @@ TEST_F(PositiveShaderCompute, SharedMemorySpecConstantOp) {
         GTEST_SKIP() << "Supported compute shader shared memory size is too small";
     }
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
@@ -275,7 +275,7 @@ TEST_F(PositiveShaderCompute, SharedMemory) {
     RETURN_IF_SKIP(Init());
 
     // Make sure compute pipeline has a compute shader stage set
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         shared uint a;
         shared float b;

--- a/tests/unit/shader_cooperative_matrix.cpp
+++ b/tests/unit/shader_cooperative_matrix.cpp
@@ -31,7 +31,7 @@ TEST_F(NegativeShaderCooperativeMatrix, SpecInfo) {
     const vkt::DescriptorSetLayout dsl(*m_device, bindings);
     const vkt::PipelineLayout pl(*m_device, {&dsl});
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         #pragma use_vulkan_memory_model
         #extension GL_KHR_cooperative_matrix : enable
@@ -92,7 +92,7 @@ TEST_F(NegativeShaderCooperativeMatrix, UnsupportedStageUint32) {
         GTEST_SKIP() << "Cannot execute test due to vertex stage expected to be unsupported";
     }
 
-    char const *vtSource = R"glsl(
+    const char *vtSource = R"glsl(
         #version 450
         #pragma use_vulkan_memory_model
         #extension GL_KHR_cooperative_matrix : enable
@@ -134,7 +134,7 @@ TEST_F(NegativeShaderCooperativeMatrix, UnsupportedStageFloat16) {
         GTEST_SKIP() << "Cannot execute test due to vertex stage expected to be unsupported";
     }
 
-    char const *vtSource = R"glsl(
+    const char *vtSource = R"glsl(
         #version 450
         #pragma use_vulkan_memory_model
         #extension GL_KHR_cooperative_matrix : enable
@@ -179,7 +179,7 @@ TEST_F(NegativeShaderCooperativeMatrix, ParametersMatchProperties) {
     }
 
     // Tests are assume that Float16 3*5 is not available
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         #pragma use_vulkan_memory_model
         #extension GL_KHR_cooperative_matrix : enable
@@ -213,7 +213,7 @@ TEST_F(NegativeShaderCooperativeMatrix, DimXMultipleSubgroupSize) {
         GTEST_SKIP() << "Valid Property not found";
     }
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         #pragma use_vulkan_memory_model
         #extension GL_KHR_cooperative_matrix : enable
@@ -271,7 +271,7 @@ TEST_F(NegativeShaderCooperativeMatrix, DimXMultipleSubgroupSizeWorkgroupScope) 
         GTEST_SKIP() << "Valid Property not found";
     }
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         #pragma use_vulkan_memory_model
         #extension GL_KHR_cooperative_matrix : enable
@@ -327,7 +327,7 @@ TEST_F(NegativeShaderCooperativeMatrix, SameScope) {
         GTEST_SKIP() << "Valid Property not found";
     }
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         #pragma use_vulkan_memory_model
         #extension GL_KHR_cooperative_matrix : enable
@@ -391,7 +391,7 @@ TEST_F(NegativeShaderCooperativeMatrix, WorkgroupScope) {
         GTEST_SKIP() << "Valid Property not found";
     }
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         #pragma use_vulkan_memory_model
         #extension GL_KHR_cooperative_matrix : enable
@@ -432,7 +432,7 @@ TEST_F(NegativeShaderCooperativeMatrix, WorkgroupScopeMaxDimensions) {
         GTEST_SKIP() << "Valid Property not found";
     }
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         #pragma use_vulkan_memory_model
         #extension GL_KHR_cooperative_matrix : enable
@@ -495,7 +495,7 @@ TEST_F(NegativeShaderCooperativeMatrix, WorkgroupScopeMaxSharedMemory) {
         GTEST_SKIP() << "Valid Property not found";
     }
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         #pragma use_vulkan_memory_model
         #extension GL_KHR_cooperative_matrix : enable
@@ -564,7 +564,7 @@ TEST_F(NegativeShaderCooperativeMatrix, MatchSizeWithProperties) {
         GTEST_SKIP() << "Valid Property found, need invalid to test";
     }
 
-    char const *source = R"glsl(
+    const char *source = R"glsl(
         #version 450
         #pragma use_vulkan_memory_model
         #extension GL_KHR_cooperative_matrix : enable

--- a/tests/unit/shader_cooperative_matrix_positive.cpp
+++ b/tests/unit/shader_cooperative_matrix_positive.cpp
@@ -139,7 +139,7 @@ TEST_F(PositiveShaderCooperativeMatrix, CooperativeMatrixNV) {
     const vkt::DescriptorSetLayout dsl(*m_device, bindings);
     const vkt::PipelineLayout pl(*m_device, {&dsl});
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         #extension GL_NV_cooperative_matrix : enable
         #extension GL_KHR_shader_subgroup_basic : enable
@@ -422,7 +422,7 @@ TEST_F(PositiveShaderCooperativeMatrix, BFloat16) {
     AddRequiredFeature(vkt::Feature::shaderBFloat16CooperativeMatrix);
     RETURN_IF_SKIP(InitCooperativeMatrixKHR());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450 core
         #extension GL_EXT_bfloat16 : require
         #extension GL_EXT_shader_explicit_arithmetic_types : enable
@@ -450,7 +450,7 @@ TEST_F(PositiveShaderCooperativeMatrix, Float8) {
     AddRequiredFeature(vkt::Feature::shaderInt8);
     RETURN_IF_SKIP(InitCooperativeMatrixKHR());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450 core
         #extension GL_EXT_float_e4m3 : require
         #extension GL_EXT_shader_explicit_arithmetic_types : enable

--- a/tests/unit/shader_cooperative_vector_positive.cpp
+++ b/tests/unit/shader_cooperative_vector_positive.cpp
@@ -98,7 +98,7 @@ TEST_F(PositiveShaderCooperativeVector, CooperativeVectorSPIRV) {
         GTEST_SKIP() << "cooperativeVectorTrainingFloat16Accumulation not supported";
     }
 
-    char const *vt_source = R"glsl(
+    const char *vt_source = R"glsl(
         #version 450
         #extension GL_NV_cooperative_vector : enable
         #extension GL_KHR_shader_subgroup_basic : enable
@@ -153,7 +153,7 @@ TEST_F(PositiveShaderCooperativeVector, CooperativeVectorTraingingSPIRV) {
     const vkt::DescriptorSetLayout dsl(*m_device, bindings);
     const vkt::PipelineLayout pl(*m_device, {&dsl});
 
-    char const *vt_source = R"glsl(
+    const char *vt_source = R"glsl(
         #version 450
         #extension GL_NV_cooperative_vector : enable
         #extension GL_KHR_shader_subgroup_basic : enable

--- a/tests/unit/shader_debug_info.cpp
+++ b/tests/unit/shader_debug_info.cpp
@@ -22,7 +22,7 @@ TEST_F(NegativeShaderDebugInfo, FileName1) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModel);
     RETURN_IF_SKIP(Init());
 
-    char const *source = R"(
+    const char *source = R"(
                OpCapability Shader
                OpExtension "SPV_KHR_non_semantic_info"
           %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
@@ -76,7 +76,7 @@ TEST_F(NegativeShaderDebugInfo, FileName2) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModel);
     RETURN_IF_SKIP(Init());
 
-    char const *source = R"(
+    const char *source = R"(
                OpCapability Shader
                OpExtension "SPV_KHR_non_semantic_info"
           %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
@@ -132,7 +132,7 @@ TEST_F(NegativeShaderDebugInfo, FileName3) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModel);
     RETURN_IF_SKIP(Init());
 
-    char const *source = R"(
+    const char *source = R"(
                OpCapability Shader
                OpExtension "SPV_KHR_non_semantic_info"
           %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
@@ -188,7 +188,7 @@ TEST_F(NegativeShaderDebugInfo, FileName4) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModel);
     RETURN_IF_SKIP(Init());
 
-    char const *source = R"(
+    const char *source = R"(
                OpCapability Shader
                OpExtension "SPV_KHR_non_semantic_info"
           %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"

--- a/tests/unit/shader_image_access.cpp
+++ b/tests/unit/shader_image_access.cpp
@@ -28,7 +28,7 @@ TEST_F(NegativeShaderImageAccess, FunctionOpImage) {
     // }
     //
     // but instead of passing the OpTypePointer, passes a OpImage to function
-    char const *fsSource = R"(
+    const char *fsSource = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %main "main" %color
@@ -109,7 +109,7 @@ TEST_F(NegativeShaderImageAccess, ComponentTypeMismatchFunctionTwoArgs) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform isampler2D s; // accessed
         layout(set=0, binding=1) uniform usampler2D u; // not accessed
@@ -215,7 +215,7 @@ TEST_F(NegativeShaderImageAccess, MultisampleMismatchWithPipeline) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler2DMS s;
         layout(location=0) out vec4 color;
@@ -262,7 +262,7 @@ TEST_F(NegativeShaderImageAccess, AliasImageMultisample) {
     TEST_DESCRIPTION("Same binding used for Multisampling and non-Multisampling");
     RETURN_IF_SKIP(Init());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
 
@@ -319,7 +319,7 @@ TEST_F(NegativeShaderImageAccess, NonMultisampleMismatchWithPipeline) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform sampler2D s;
         layout(location=0) out vec4 color;
@@ -399,7 +399,7 @@ TEST_F(NegativeShaderImageAccess, NonMultisampleMismatchWithPipelineArray) {
     descriptor_set.WriteDescriptorBufferInfo(1, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         // mySampler[0] is good
         // mySampler[1] is bad
@@ -462,7 +462,7 @@ TEST_F(NegativeShaderImageAccess, MultipleFunctionCalls) {
     sampler_ci.compareEnable = VK_FALSE;
     vkt::Sampler sampler(*m_device, sampler_ci);
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         layout (set=0, binding=0) uniform sampler2D good_a;
         layout (set=0, binding=1) uniform sampler2D bad;
@@ -512,7 +512,7 @@ TEST_F(NegativeShaderImageAccess, AliasImageBinding) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7677");
     RETURN_IF_SKIP(Init());
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
 
@@ -564,7 +564,7 @@ TEST_F(NegativeShaderImageAccess, AliasImageBindingArrayType) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9553");
     RETURN_IF_SKIP(Init());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         // This should be an GLSL error, if both of these are accessed (without PARTIALLY_BOUND), you need to satisfy both, which is impossible
         layout(set = 0, binding = 0) uniform sampler2D uPlanetTextures[2];
@@ -612,7 +612,7 @@ TEST_F(NegativeShaderImageAccess, SampledImageShareBinding) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 460
         layout (set = 0, binding = 0) uniform texture2D kTextures2D;
         layout (set = 0, binding = 1) uniform sampler kSamplers;
@@ -676,7 +676,7 @@ TEST_F(NegativeShaderImageAccess, SampledImageShareBindingArray) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 460
         layout (set = 0, binding = 0) uniform texture2D kTextures2D[2];
         layout (set = 0, binding = 1) uniform sampler kSamplers[2];
@@ -741,7 +741,7 @@ TEST_F(NegativeShaderImageAccess, SampledImageShareBindingArrayFunction) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 460
         layout (set = 0, binding = 0) uniform texture2D kTextures2D[2];
         layout (set = 0, binding = 1) uniform sampler kSamplers[2];
@@ -810,7 +810,7 @@ TEST_F(NegativeShaderImageAccess, DISABLED_FunctionDescriptorIndexing) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 460
         layout (set = 0, binding = 0) uniform sampler2D tex[3];
         layout (location=0) out vec4 color;

--- a/tests/unit/shader_image_access_positive.cpp
+++ b/tests/unit/shader_image_access_positive.cpp
@@ -20,7 +20,7 @@ TEST_F(PositiveShaderImageAccess, FunctionParameterToVariable) {
 
     RETURN_IF_SKIP(Init());
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : enable
         layout(set = 0, binding = 0) uniform texture2D texture_image;
@@ -48,7 +48,7 @@ TEST_F(PositiveShaderImageAccess, MultipleFunctionParameterToVariable) {
 
     RETURN_IF_SKIP(Init());
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : enable
         layout(set = 0, binding = 0) uniform texture2D texture_image;
@@ -81,7 +81,7 @@ TEST_F(PositiveShaderImageAccess, DifferentFunctionParameterToVariable) {
 
     RETURN_IF_SKIP(Init());
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : enable
 
@@ -115,7 +115,7 @@ TEST_F(PositiveShaderImageAccess, FunctionParameterToLoad) {
     //    int foo(texture2D func_texture) { return textureSize(func_texture, 0).x; }
     //    void main() {  int x = foo(texture_image); }
     // But replaced so the OpFunctionCall takes a OpLoad instead of OpVariable
-    char const *csSource = R"(
+    const char *csSource = R"(
                OpCapability Shader
                OpCapability ImageQuery
                OpMemoryModel Logical GLSL450
@@ -168,7 +168,7 @@ TEST_F(PositiveShaderImageAccess, FunctionParameterToVariableSampledImage) {
 
     RETURN_IF_SKIP(Init());
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : enable
 
@@ -202,7 +202,7 @@ TEST_F(PositiveShaderImageAccess, FunctionParameterToLoadSampledImage) {
     //    int foo(texture2D func_texture) { return texture(sampler2D(func_texture,  func_sampler), vec2(0.0)); }
     //    void main() {  vec4 x = foo(texture_image, sampler_descriptor); }
     // But replaced so the OpFunctionCall takes a OpLoad instead of OpVariable
-    char const *csSource = R"(
+    const char *csSource = R"(
                 OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint GLCompute %main "main"
@@ -265,7 +265,7 @@ TEST_F(PositiveShaderImageAccess, CopyObjectFromLoad) {
     // This is simple
     //    int x = textureSize(texture_image, 0).x;
     // but with inserted OpCopyObject calls
-    char const *csSource = R"(
+    const char *csSource = R"(
                OpCapability Shader
                OpCapability ImageQuery
                OpMemoryModel Logical GLSL450
@@ -311,7 +311,7 @@ TEST_F(PositiveShaderImageAccess, UndefImage) {
 
     RETURN_IF_SKIP(Init());
 
-    char const *csSource = R"(
+    const char *csSource = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint GLCompute %main "main"
@@ -362,7 +362,7 @@ TEST_F(PositiveShaderImageAccess, ComponentTypeMismatchFunctionTwoArgs) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(set=0, binding=0) uniform isampler2D s; // not accessed (so ignored)
         layout(set=0, binding=1) uniform usampler2D u; // accessed
@@ -444,7 +444,7 @@ TEST_F(PositiveShaderImageAccess, SamplerNeverAccessed) {
     sampler_ci.compareEnable = VK_FALSE;
     vkt::Sampler sampler(*m_device, sampler_ci);
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         layout (set=0, binding=0) uniform sampler2D bad; // never accessed
         layout (set=0, binding=1) uniform sampler2D good;
@@ -489,7 +489,7 @@ TEST_F(PositiveShaderImageAccess, DISABLED_ExtraUnusedInvalidDescriptor) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 460
         layout (set = 1, binding = 0) uniform textureCube kTexturesCube[2];
         layout (set = 0, binding = 1) uniform sampler kSamplers;
@@ -547,7 +547,7 @@ TEST_F(PositiveShaderImageAccess, FunctionDescriptorIndexing) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 460
         layout (set = 0, binding = 0) uniform sampler2D tex[3];
         layout (location=0) out vec4 color;
@@ -600,7 +600,7 @@ TEST_F(PositiveShaderImageAccess, AliasImageBinding) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7677");
     RETURN_IF_SKIP(Init());
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 460
         #extension GL_EXT_samplerless_texture_functions : require
 

--- a/tests/unit/shader_interface.cpp
+++ b/tests/unit/shader_interface.cpp
@@ -352,7 +352,7 @@ TEST_F(NegativeShaderInterface, FragmentInputNotProvided) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0) in float x;
         layout(location=0) out vec4 color;
@@ -376,7 +376,7 @@ TEST_F(NegativeShaderInterface, FragmentInputNotProvidedInBlock) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         in block { layout(location=0) float x; } ins;
         layout(location=0) out vec4 color;
@@ -399,7 +399,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatch) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) out int x;
         void main(){
@@ -407,7 +407,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatch) {
            gl_Position = vec4(1);
         }
     )glsl";
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0) in float x; /* VS writes int */
         layout(location=0) out vec4 color;
@@ -431,7 +431,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatch2) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) out int x;
         void main(){
@@ -439,7 +439,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatch2) {
            gl_Position = vec4(1);
         }
     )glsl";
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0) in float x; /* VS writes int */
         layout(location=0) out vec4 color;
@@ -466,7 +466,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchInBlock) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         out block { layout(location=0) int x; } outs;
         void main(){
@@ -474,7 +474,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchInBlock) {
            gl_Position = vec4(1);
         }
     )glsl";
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         in block { layout(location=0) float x; } ins; /* VS writes int */
         layout(location=0) out vec4 color;
@@ -499,14 +499,14 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchVectorSize) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 x;
         void main(){
            gl_Position = vec4(1.0);
         }
     )glsl";
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 x;
         layout(location=0) out vec4 color;
@@ -530,7 +530,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStruct) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         struct S {
             vec4 a[2];
@@ -550,7 +550,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStruct) {
         }
     )glsl";
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         struct S {
             vec4 a[2];
@@ -586,7 +586,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStruct64bit) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         #extension GL_EXT_shader_explicit_arithmetic_types_float64 : enable
 
@@ -604,7 +604,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStruct64bit) {
         void main() {}
     )glsl";
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         struct S {
             vec4 a[2];
@@ -637,7 +637,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockArrayOfStruct) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         struct S {
             vec4 a[2];
@@ -657,7 +657,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockArrayOfStruct) {
         }
     )glsl";
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         struct S {
             vec4 a[2];
@@ -695,7 +695,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStructInnerArraySize) {
         GTEST_SKIP() << "maxVertexOutputComponents is too low";
     }
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         struct S {
             vec4 a[2];
@@ -715,7 +715,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStructInnerArraySize) {
         }
     )glsl";
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         struct S {
             vec4 a[2];
@@ -755,7 +755,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStructOuterArraySize) {
         GTEST_SKIP() << "maxVertexOutputComponents is too low";
     }
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         struct S {
             vec4 a[2];
@@ -775,7 +775,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStructOuterArraySize) {
         }
     )glsl";
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         struct S {
             vec4 a[2];
@@ -814,7 +814,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStructArraySizeVertex) {
         GTEST_SKIP() << "maxVertexOutputComponents is too low";
     }
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         struct S {
             vec4 a[2];
@@ -834,7 +834,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStructArraySizeVertex) {
         }
     )glsl";
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         struct S {
             vec4 a[2];
@@ -874,7 +874,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStructOuter2DArraySize) {
         GTEST_SKIP() << "maxVertexOutputComponents is too low";
     }
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         struct S {
             vec4 a[2];
@@ -890,7 +890,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStructOuter2DArraySize) {
         void main() {}
     )glsl";
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         struct S {
             vec4 a[2];
@@ -923,7 +923,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockNestedStructType64bit) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         #extension GL_EXT_shader_explicit_arithmetic_types_float64 : enable
 
@@ -947,7 +947,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockNestedStructType64bit) {
         void main() {}
     )glsl";
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         struct A {
             float a0_;
@@ -985,7 +985,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockNestedStructArray) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         struct A {
             float a0_;
@@ -1008,7 +1008,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockNestedStructArray) {
         void main() {}
     )glsl";
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         struct A {
             float a0_;
@@ -1049,7 +1049,7 @@ TEST_F(NegativeShaderInterface, VsFsMismatchByLocation) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         out block { layout(location=1) float x; } outs;
         void main(){
@@ -1057,7 +1057,7 @@ TEST_F(NegativeShaderInterface, VsFsMismatchByLocation) {
            gl_Position = vec4(1);
         }
     )glsl";
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         in block { layout(location=0) float x; } ins;
         layout(location=0) out vec4 color;
@@ -1083,7 +1083,7 @@ TEST_F(NegativeShaderInterface, VsFsMismatchByComponent) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         out block { layout(location=0, component=0) float x; } outs;
         void main(){
@@ -1091,7 +1091,7 @@ TEST_F(NegativeShaderInterface, VsFsMismatchByComponent) {
            gl_Position = vec4(1);
         }
     )glsl";
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         in block { layout(location=0, component=1) float x; } ins;
         layout(location=0) out vec4 color;
@@ -1118,7 +1118,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchShaderObject) {
     RETURN_IF_SKIP(Init());
     InitDynamicRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) out int x;
         void main(){
@@ -1126,7 +1126,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchShaderObject) {
            gl_Position = vec4(1);
         }
     )glsl";
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0) in float x; /* VS writes int */
         layout(location=0) out vec4 color;
@@ -1158,14 +1158,14 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchVectorSizeShaderObject) {
     RETURN_IF_SKIP(Init());
     InitDynamicRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 x;
         void main(){
            gl_Position = vec4(1.0);
         }
     )glsl";
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0) in vec3 x;
         layout(location=0) out vec4 color;
@@ -1229,7 +1229,7 @@ TEST_F(NegativeShaderInterface, VertexOutputNotConsumed) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) out float x;
         void main(){
@@ -1254,7 +1254,7 @@ TEST_F(NegativeShaderInterface, DISABLED_InputAndOutputComponents) {
     InitRenderTarget();
 
     {
-        char const *vsSource = R"glsl(
+        const char *vsSource = R"glsl(
                 #version 450
 
                 layout(location = 0, component = 0) out float r;
@@ -1267,7 +1267,7 @@ TEST_F(NegativeShaderInterface, DISABLED_InputAndOutputComponents) {
             )glsl";
         VkShaderObj vs(this, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
 
-        char const *fsSource = R"glsl(
+        const char *fsSource = R"glsl(
                 #version 450
 
                 layout(location = 0) in vec3 rgb;
@@ -1287,7 +1287,7 @@ TEST_F(NegativeShaderInterface, DISABLED_InputAndOutputComponents) {
     }
 
     {
-        char const *vsSource = R"glsl(
+        const char *vsSource = R"glsl(
                 #version 450
 
                 layout(location = 0) out vec3 v;
@@ -1297,7 +1297,7 @@ TEST_F(NegativeShaderInterface, DISABLED_InputAndOutputComponents) {
             )glsl";
         VkShaderObj vs(this, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
 
-        char const *fsSource = R"glsl(
+        const char *fsSource = R"glsl(
                 #version 450
 
                 layout(location = 0, component = 0) in float a;
@@ -1318,7 +1318,7 @@ TEST_F(NegativeShaderInterface, DISABLED_InputAndOutputComponents) {
     }
 
     {
-        char const *vsSource = R"glsl(
+        const char *vsSource = R"glsl(
                 #version 450
 
                 layout(location = 0) out vec3 v;
@@ -1329,7 +1329,7 @@ TEST_F(NegativeShaderInterface, DISABLED_InputAndOutputComponents) {
             )glsl";
         VkShaderObj vs(this, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
 
-        char const *fsSource = R"glsl(
+        const char *fsSource = R"glsl(
                 #version 450
 
                 layout(location = 0) in vec4 v;
@@ -1349,7 +1349,7 @@ TEST_F(NegativeShaderInterface, DISABLED_InputAndOutputComponents) {
     }
 
     {
-        char const *vsSource = R"glsl(
+        const char *vsSource = R"glsl(
                 #version 450
 
                 layout(location = 0) out vec3 v;
@@ -1360,7 +1360,7 @@ TEST_F(NegativeShaderInterface, DISABLED_InputAndOutputComponents) {
             )glsl";
         VkShaderObj vs(this, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
 
-        char const *fsSource = R"glsl(
+        const char *fsSource = R"glsl(
                 #version 450
 
                 layout (location = 0) out vec4 color;
@@ -1378,7 +1378,7 @@ TEST_F(NegativeShaderInterface, DISABLED_InputAndOutputComponents) {
     }
 
     {
-        char const *vsSource = R"glsl(
+        const char *vsSource = R"glsl(
                 #version 450
 
                 layout(location = 0) out vec3 v1;
@@ -1393,7 +1393,7 @@ TEST_F(NegativeShaderInterface, DISABLED_InputAndOutputComponents) {
             )glsl";
         VkShaderObj vs(this, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
 
-        char const *fsSource = R"glsl(
+        const char *fsSource = R"glsl(
                 #version 450
 
                 layout (location = 0) in vec3 v1;
@@ -1466,7 +1466,7 @@ TEST_F(NegativeShaderInterface, AlphaToCoverageOutputNoAlpha) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget(0u);
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0) out vec3 x;
         void main(){
@@ -1492,7 +1492,7 @@ TEST_F(NegativeShaderInterface, AlphaToCoverageArrayIndex) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget(0u);
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=1) out vec4 fragData[3];
         void main() {
@@ -1518,7 +1518,7 @@ TEST_F(NegativeShaderInterface, AlphaToCoverageArrayVec3) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget(0u);
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0) out vec3 fragData[4];
         void main() {
@@ -1547,13 +1547,13 @@ TEST_F(NegativeShaderInterface, MultidimensionalArray) {
         GTEST_SKIP() << "maxVertexOutputComponents is too low";
     }
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) out float[4][2][2] x;
         void main() {}
     )glsl";
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0) in float[4][3][2] x; // 2 extra Locations
         layout(location=0) out float color;
@@ -1578,13 +1578,13 @@ TEST_F(NegativeShaderInterface, MultidimensionalArrayDim) {
         GTEST_SKIP() << "maxVertexOutputComponents is too low";
     }
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) out float[4][2][2] x;
         void main() {}
     )glsl";
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0) in float[17] x; // 1 extra Locations
         layout(location=0) out float color;
@@ -1611,7 +1611,7 @@ TEST_F(NegativeShaderInterface, MultidimensionalArray64bit) {
         GTEST_SKIP() << "maxFragmentOutputAttachments is too low";
     }
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         #extension GL_EXT_shader_explicit_arithmetic_types_float64 : enable
         layout(location=0) out f64vec3[2][2][2] x; // take 2 locations each (total 16)
@@ -1619,7 +1619,7 @@ TEST_F(NegativeShaderInterface, MultidimensionalArray64bit) {
         void main() {}
     )glsl";
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         #extension GL_EXT_shader_explicit_arithmetic_types_float64 : enable
         layout(location=0) flat in f64vec3[2][3][2] x;
@@ -1642,13 +1642,13 @@ TEST_F(NegativeShaderInterface, PackingInsideArray) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location = 0, component = 1) out float[2] x;
         void main() {}
     )glsl";
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location = 0, component = 1) in float x;
         layout(location = 1, component = 0) in float y;
@@ -1746,7 +1746,7 @@ TEST_F(NegativeShaderInterface, DISABLED_FragmentOutputNotWrittenArray) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 460
         layout(location = 0) out vec4 uFragColor[2];
         void main(){
@@ -1789,7 +1789,7 @@ TEST_F(NegativeShaderInterface, DISABLED_FragmentOutputNotWrittenArrayDynamicRen
     RETURN_IF_SKIP(Init());
     InitDynamicRenderTarget();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 460
         layout(location = 0) out vec4 uFragColor[2];
         void main(){
@@ -1845,7 +1845,7 @@ TEST_F(NegativeShaderInterface, CreatePipelineFragmentOutputTypeMismatch) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0) out ivec4 x; /* not UNORM */
         void main(){
@@ -1867,7 +1867,7 @@ TEST_F(NegativeShaderInterface, FragmentOutputTypeMismatchDynamicRendering) {
     RETURN_IF_SKIP(Init());
     InitDynamicRenderTarget();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         layout(location=0) out ivec4 x; /* not UNORM */
         void main(){
@@ -1906,7 +1906,7 @@ TEST_F(NegativeShaderInterface, FragmentOutputTypeMismatchDynamicRenderingLocalR
     InitDynamicRenderTarget(VK_FORMAT_R8G8B8A8_SINT);
     InitDynamicRenderTarget(VK_FORMAT_R8G8B8A8_UNORM);
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         layout(location=0) out ivec4 x; /* not UNORM */
         void main(){
@@ -2016,7 +2016,7 @@ TEST_F(NegativeShaderInterface, CreatePipelineFragmentOutputNotConsumed) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 x;
         layout(location=1) out vec4 y; /* no matching attachment for this */
@@ -2040,7 +2040,7 @@ TEST_F(NegativeShaderInterface, FragmentOutputNotConsumedDynamicRendering) {
     RETURN_IF_SKIP(Init());
     InitDynamicRenderTarget();
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         layout(location=0) out vec4 x;
         layout(location=1) out vec4 y; /* no matching attachment for this */
@@ -2201,7 +2201,7 @@ TEST_F(NegativeShaderInterface, PhysicalStorageBuffer) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vs_source = R"(
+    const char *vs_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpExtension "SPV_KHR_physical_storage_buffer"
@@ -2242,7 +2242,7 @@ TEST_F(NegativeShaderInterface, DISABLED_MultipleFragmentAttachment) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7923");
     RETURN_IF_SKIP(Init());
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 color0;
         layout(location=1) out vec4 color1;
@@ -2293,7 +2293,7 @@ TEST_F(NegativeShaderInterface, DISABLED_MultipleFragmentAttachmentDynamicRender
     RETURN_IF_SKIP(Init());
     InitDynamicRenderTarget();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 color0;
         layout(location=1) out vec4 color1;
@@ -2531,7 +2531,7 @@ TEST_F(NegativeShaderInterface, PhysicalStorageBufferArray) {
     RETURN_IF_SKIP(Init())
     InitRenderTarget();
 
-    char const *vs_source = R"(
+    const char *vs_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpExtension "SPV_KHR_physical_storage_buffer"
@@ -2580,7 +2580,7 @@ TEST_F(NegativeShaderInterface, PhysicalStorageBufferLinkedList) {
     RETURN_IF_SKIP(Init())
     InitRenderTarget();
 
-    char const *fs_source = R"(
+    const char *fs_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpExtension "SPV_KHR_physical_storage_buffer"
@@ -2630,7 +2630,7 @@ TEST_F(NegativeShaderInterface, PhysicalStorageBufferNested) {
     RETURN_IF_SKIP(Init())
     InitRenderTarget();
 
-    char const *fs_source = R"(
+    const char *fs_source = R"(
                OpCapability Shader
                OpCapability PhysicalStorageBufferAddresses
                OpExtension "SPV_KHR_physical_storage_buffer"

--- a/tests/unit/shader_interface_positive.cpp
+++ b/tests/unit/shader_interface_positive.cpp
@@ -24,7 +24,7 @@ TEST_F(PositiveShaderInterface, InputAndOutputComponents) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
                 #version 450
 
                 layout(location = 0, component = 0) out vec2 rg;
@@ -70,7 +70,7 @@ TEST_F(PositiveShaderInterface, InputAndOutputComponents) {
             )glsl";
     VkShaderObj vs(this, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
                 #version 450
 
                 layout(location = 0, component = 0) in float r;
@@ -126,7 +126,7 @@ TEST_F(PositiveShaderInterface, InputAndOutputStructComponents) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
                 #version 450
 
                 struct R {
@@ -143,7 +143,7 @@ TEST_F(PositiveShaderInterface, InputAndOutputStructComponents) {
             )glsl";
     VkShaderObj vs(this, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
                 #version 450
 
                 struct R {
@@ -298,7 +298,7 @@ TEST_F(PositiveShaderInterface, FragmentOutputNotWrittenButMasked) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         void main() {}
     )glsl";
@@ -322,7 +322,7 @@ TEST_F(PositiveShaderInterface, RelaxedTypeMatch) {
 
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) out vec3 x;
         layout(location=1) out ivec3 y;
@@ -332,7 +332,7 @@ TEST_F(PositiveShaderInterface, RelaxedTypeMatch) {
            x = vec3(0); y = ivec3(0); z = vec3(0);
         }
     )glsl";
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 color;
         layout(location=0) in float x;
@@ -358,7 +358,7 @@ TEST_F(PositiveShaderInterface, TessPerVertex) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *tcsSource = R"glsl(
+    const char *tcsSource = R"glsl(
         #version 450
         layout(location=0) out int x[];
         layout(vertices=3) out;
@@ -368,7 +368,7 @@ TEST_F(PositiveShaderInterface, TessPerVertex) {
            x[gl_InvocationID] = gl_InvocationID;
         }
     )glsl";
-    char const *tesSource = R"glsl(
+    const char *tesSource = R"glsl(
         #version 450
         layout(triangles, equal_spacing, cw) in;
         layout(location=0) in int x[];
@@ -404,7 +404,7 @@ TEST_F(PositiveShaderInterface, GeometryInputBlockPositive) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
 
         layout(location = 0) out VertexData { vec4 x; } gs_out;
@@ -414,7 +414,7 @@ TEST_F(PositiveShaderInterface, GeometryInputBlockPositive) {
         }
     )glsl";
 
-    char const *gsSource = R"glsl(
+    const char *gsSource = R"glsl(
         #version 450
         layout(triangles) in;
         layout(triangle_strip, max_vertices=3) out;
@@ -440,7 +440,7 @@ TEST_F(PositiveShaderInterface, InputAttachment) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(input_attachment_index=0, set=0, binding=0) uniform subpassInput x;
         layout(location=0) out vec4 color;
@@ -947,7 +947,7 @@ TEST_F(PositiveShaderInterface, AlphaToCoverageOffsetToAlpha) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget(0u);
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0, component = 3) out float x;
         void main(){
@@ -973,7 +973,7 @@ TEST_F(PositiveShaderInterface, AlphaToCoverageArray) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget(0u);
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         // Just need to declare variable
         layout(location=0) out vec4 fragData[4];
@@ -1002,7 +1002,7 @@ TEST_F(PositiveShaderInterface, VsFsTypeMismatchBlockStructArray) {
         GTEST_SKIP() << "maxVertexOutputComponents is too low";
     }
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         struct S {
             float b;
@@ -1018,7 +1018,7 @@ TEST_F(PositiveShaderInterface, VsFsTypeMismatchBlockStructArray) {
         void main() {}
     )glsl";
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         struct S {
             float b;
@@ -1050,7 +1050,7 @@ TEST_F(PositiveShaderInterface, VsFsTypeMismatchBlockNestedStructLastElementArra
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         struct A {
             float a0_;
@@ -1073,7 +1073,7 @@ TEST_F(PositiveShaderInterface, VsFsTypeMismatchBlockNestedStructLastElementArra
         void main() {}
     )glsl";
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         struct A {
             float a0_;
@@ -1112,7 +1112,7 @@ TEST_F(PositiveShaderInterface, VsFsTypeMismatchBlockNestedStructArray) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         struct A {
             float a0_;
@@ -1135,7 +1135,7 @@ TEST_F(PositiveShaderInterface, VsFsTypeMismatchBlockNestedStructArray) {
         void main() {}
     )glsl";
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         struct A {
             float a0_;
@@ -1174,13 +1174,13 @@ TEST_F(PositiveShaderInterface, MultidimensionalArray) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) out float[4][2][2] x;
         void main() {}
     )glsl";
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0) in float[4][2][2] x;
         layout(location=0) out float color;
@@ -1205,13 +1205,13 @@ TEST_F(PositiveShaderInterface, MultidimensionalArrayVertex) {
         GTEST_SKIP() << "maxVertexOutputComponents is too low";
     }
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) out float[4][3][2] x;
         void main() {}
     )glsl";
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0) in float[4][2][2] x;
         layout(location=0) out float color;
@@ -1236,13 +1236,13 @@ TEST_F(PositiveShaderInterface, MultidimensionalArrayDims) {
         GTEST_SKIP() << "maxVertexOutputComponents is too low";
     }
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) out float[4][3][2] x; // 24 locations
         void main() {}
     )glsl";
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0) in float[3][2][4] x; // 24 locations
         layout(location=0) out float color;
@@ -1267,13 +1267,13 @@ TEST_F(PositiveShaderInterface, MultidimensionalArrayDims2) {
         GTEST_SKIP() << "maxVertexOutputComponents is too low";
     }
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) out float[4][3][2] x; // 24 locations
         void main() {}
     )glsl";
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0) in float[24] x;
         layout(location=0) out float color;
@@ -1300,7 +1300,7 @@ TEST_F(PositiveShaderInterface, MultidimensionalArray64bit) {
         GTEST_SKIP() << "maxFragmentOutputAttachments is too low";
     }
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         #extension GL_EXT_shader_explicit_arithmetic_types_float64 : enable
         layout(location=0) out f64vec3[2][2] x; // take 2 locations each (total 8)
@@ -1308,7 +1308,7 @@ TEST_F(PositiveShaderInterface, MultidimensionalArray64bit) {
         void main() {}
     )glsl";
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         #extension GL_EXT_shader_explicit_arithmetic_types_float64 : enable
         layout(location=0) flat in f64vec3[2][2] x;
@@ -1330,7 +1330,7 @@ TEST_F(PositiveShaderInterface, MultipleFragmentAttachment) {
     RETURN_IF_SKIP(Init());
     m_errorMonitor->ExpectSuccess(kWarningBit | kErrorBit);
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 color[2];
         void main() {
@@ -1483,7 +1483,7 @@ TEST_F(PositiveShaderInterface, FragmentOutputTypeDynamicRenderingLocalReadTypeR
     InitDynamicRenderTarget(VK_FORMAT_R8G8B8A8_UNORM);
     m_errorMonitor->ExpectSuccess(kWarningBit | kErrorBit);
 
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         layout(location=0) out vec4 x;
         void main(){
@@ -1540,13 +1540,13 @@ TEST_F(PositiveShaderInterface, NonZeroComponentArray) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location = 0, component = 1) out float[2] x;
         void main() {}
     )glsl";
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location = 0, component = 1) in float[2] x;
         layout(location=0) out float color;
@@ -1574,7 +1574,7 @@ TEST_F(PositiveShaderInterface, PackingInsideArray) {
     // layout(location = 0, component = 1) out float[2] x;
     // layout(location = 1, component = 0) out int y;
     // layout(location = 1, component = 2) out int z;
-    char const *vs_source1 = R"(
+    const char *vs_source1 = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Vertex %main "main" %x %y %z
@@ -1604,7 +1604,7 @@ TEST_F(PositiveShaderInterface, PackingInsideArray) {
 
     VkShaderObj vs1(this, vs_source1, VK_SHADER_STAGE_VERTEX_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
 
-    char const *vs_source2 = R"glsl(
+    const char *vs_source2 = R"glsl(
         #version 450
         layout(location = 0, component = 0) out float x;
         layout(location = 0, component = 1) out float[2] y;

--- a/tests/unit/shader_limits.cpp
+++ b/tests/unit/shader_limits.cpp
@@ -31,7 +31,7 @@ TEST_F(NegativeShaderLimits, MaxSampleMaskWordsInput) {
     //     int x = gl_SampleMaskIn[3]; // Exceed sample mask input array size
     //     uFragColor = vec4(0,1,0,1) * x;
     // }
-    char const *source = R"(
+    const char *source = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %main "main" %gl_SampleMaskIn %uFragColor
@@ -93,7 +93,7 @@ TEST_F(NegativeShaderLimits, MaxSampleMaskWordsOutput) {
     //    gl_SampleMask[3] = 1; // Exceed sample mask output array size
     //    uFragColor = vec4(0,1,0,1);
     // }
-    char const *source = R"(
+    const char *source = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %main "main" %gl_SampleMask %uFragColor
@@ -434,7 +434,7 @@ TEST_F(NegativeShaderLimits, MaxFragmentOutputAttachments) {
         GTEST_SKIP() << "maxFragmentOutputAttachments is not 4";
     }
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 c0;
         layout(location=1) out vec4 c1;
@@ -461,7 +461,7 @@ TEST_F(NegativeShaderLimits, MaxFragmentOutputAttachmentsArray) {
         GTEST_SKIP() << "maxFragmentOutputAttachments is not 4";
     }
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 c[5];
         void main(){
@@ -480,7 +480,7 @@ TEST_F(NegativeShaderLimits, MaxFragmentOutputAttachmentsArrayAtEnd) {
         GTEST_SKIP() << "maxFragmentOutputAttachments is not 4";
     }
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=3) out vec4 c[2];
         void main(){
@@ -506,7 +506,7 @@ TEST_F(NegativeShaderLimits, MaxFragmentCombinedOutputResources) {
     fpvkSetPhysicalDeviceLimitsEXT(Gpu(), &props.limits);
     RETURN_IF_SKIP(InitState());
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(set = 0, binding=0) buffer SSBO_0 {
             uint a;

--- a/tests/unit/shader_limits_positive.cpp
+++ b/tests/unit/shader_limits_positive.cpp
@@ -23,7 +23,7 @@ TEST_F(PositiveShaderLimits, MaxSampleMaskWords) {
     InitRenderTarget();
 
     // Valid input of sample mask
-    char const *fs_source = R"glsl(
+    const char *fs_source = R"glsl(
         #version 450
         layout(location = 0) out vec4 uFragColor;
         void main(){
@@ -298,7 +298,7 @@ TEST_F(PositiveShaderLimits, MaxFragmentOutputAttachments) {
         GTEST_SKIP() << "maxFragmentOutputAttachments is not 4";
     }
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 c0;
         layout(location=1) out vec4 c1;
@@ -326,7 +326,7 @@ TEST_F(PositiveShaderLimits, MaxFragmentOutputAttachmentsArray) {
         GTEST_SKIP() << "maxFragmentOutputAttachments is not 4";
     }
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 c[4];
         void main(){

--- a/tests/unit/shader_object.cpp
+++ b/tests/unit/shader_object.cpp
@@ -1113,7 +1113,7 @@ TEST_F(NegativeShaderObject, IncompatibleDescriptorSet) {
 TEST_F(NegativeShaderObject, DescriptorSetNotBound) {
     RETURN_IF_SKIP(InitBasicShaderObject());
 
-    char const* cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer SSBO { uint x; };
         void main() {
@@ -1136,7 +1136,7 @@ TEST_F(NegativeShaderObject, DescriptorSetNotBound) {
 TEST_F(NegativeShaderObject, DescriptorSetBoundRange) {
     RETURN_IF_SKIP(InitBasicShaderObject());
 
-    char const* cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer SSBO0 { uint x; };
         layout(set = 1, binding = 0) buffer SSBO1 { uint y; };
@@ -3550,7 +3550,7 @@ TEST_F(NegativeShaderObject, ComputeShaderMissingPushConst) {
     push_const_range.offset = 0u;
     push_const_range.size = sizeof(int);
 
-    static const char kComputeShaderGlsl[] = R"glsl(
+    const char kComputeShaderGlsl[] = R"glsl(
         #version 460
         layout (push_constant) uniform constants {
             int value;
@@ -3637,7 +3637,7 @@ TEST_F(NegativeShaderObject, SpecializationMapEntryOffset) {
 
     RETURN_IF_SKIP(InitBasicShaderObject());
 
-    static const char kVertexSource[] = R"glsl(
+    const char kVertexSource[] = R"glsl(
         #version 460
         layout (constant_id = 0) const int v = 0;
         void main() {
@@ -3674,7 +3674,7 @@ TEST_F(NegativeShaderObject, SpecializationMapEntrySize) {
 
     RETURN_IF_SKIP(InitBasicShaderObject());
 
-    static const char kVertexSource[] = R"glsl(
+    const char kVertexSource[] = R"glsl(
         #version 460
         layout (constant_id = 0) const int v = 0;
         void main() {
@@ -3711,7 +3711,7 @@ TEST_F(NegativeShaderObject, SpecializationMismatch) {
 
     RETURN_IF_SKIP(InitBasicShaderObject());
 
-    static const char kVertexSource[] = R"glsl(
+    const char kVertexSource[] = R"glsl(
         #version 460
         layout (constant_id = 0) const int v = 0;
         void main() {
@@ -3748,7 +3748,7 @@ TEST_F(NegativeShaderObject, SpecializationSameConstantId) {
 
     RETURN_IF_SKIP(InitBasicShaderObject());
 
-    static const char kVertexSource[] = R"glsl(
+    const char kVertexSource[] = R"glsl(
         #version 460
         layout (constant_id = 0) const int v = 0;
         void main() {
@@ -4089,7 +4089,7 @@ TEST_F(NegativeShaderObject, MemoryModelNotEnabled) {
 
     RETURN_IF_SKIP(Init());
 
-    char const* cs_src = R"glsl(
+    const char* cs_src = R"glsl(
         #version 450
         #extension GL_KHR_memory_scope_semantics : enable
         layout(set = 0, binding = 0) buffer ssbo { uint y; };
@@ -4337,7 +4337,7 @@ TEST_F(NegativeShaderObject, ExtendedTypesDisabled) {
         GTEST_SKIP() << "Required features not supported";
     }
 
-    char const* cs_src = R"glsl(
+    const char* cs_src = R"glsl(
         #version 450
         #extension GL_KHR_shader_subgroup_arithmetic : enable
         #extension GL_EXT_shader_subgroup_extended_types_float16 : enable
@@ -4364,7 +4364,7 @@ TEST_F(NegativeShaderObject, ReadShaderClock) {
     AddRequiredExtensions(VK_KHR_SHADER_CLOCK_EXTENSION_NAME);
     RETURN_IF_SKIP(InitBasicShaderObject());
 
-    char const* vs_src = R"glsl(
+    const char* vs_src = R"glsl(
         #version 450
         #extension GL_ARB_shader_clock: enable
         void main(){
@@ -4576,7 +4576,7 @@ TEST_F(NegativeShaderObject, MaxSampleMaskWords) {
     //     int y = gl_SampleMaskIn[0];
     //     uFragColor = vec4(0,1,0,1) * x * y;
     // }
-    char const* fs_src = R"(
+    const char* fs_src = R"(
                OpCapability Shader
                OpMemoryModel Logical GLSL450
                OpEntryPoint Fragment %main "main" %gl_SampleMaskIn %uFragColor
@@ -4739,7 +4739,7 @@ TEST_F(NegativeShaderObject, MissingLineWidthSet) {
     InitDynamicRenderTarget();
     CreateMinimalShaders();
 
-    static char const geom_src[] = R"glsl(
+    const char geom_src[] = R"glsl(
         #version 460
         layout(triangles) in;
         layout(line_strip, max_vertices=2) out;
@@ -4779,7 +4779,7 @@ TEST_F(NegativeShaderObject, InvalidViewportCount) {
         GTEST_SKIP() << "required primitiveFragmentShadingRateWithMultipleViewports to be unsupported.";
     }
 
-    char const* vsSource = R"glsl(
+    const char* vsSource = R"glsl(
             #version 450
             #extension GL_EXT_fragment_shading_rate : enable
             void main() {
@@ -4821,7 +4821,7 @@ TEST_F(NegativeShaderObject, AlphaToCoverage) {
     RETURN_IF_SKIP(InitBasicShaderObject());
     InitDynamicRenderTarget();
 
-    static const char frag_src[] = R"glsl(
+    const char frag_src[] = R"glsl(
         #version 460
         layout(location = 1) out vec4 uFragColor;
         void main(){
@@ -4856,7 +4856,7 @@ TEST_F(NegativeShaderObject, MissingLineRasterizationMode) {
     InitDynamicRenderTarget();
     CreateMinimalShaders();
 
-    static char const geom_src[] = R"glsl(
+    const char geom_src[] = R"glsl(
         #version 460
         layout(triangles) in;
         layout(line_strip, max_vertices=2) out;
@@ -4892,7 +4892,7 @@ TEST_F(NegativeShaderObject, MissingLineStippleEnable) {
     InitDynamicRenderTarget();
     CreateMinimalShaders();
 
-    static char const geom_src[] = R"glsl(
+    const char geom_src[] = R"glsl(
         #version 460
         layout(triangles) in;
         layout(line_strip, max_vertices=2) out;
@@ -4972,7 +4972,7 @@ TEST_F(NegativeShaderObject, Mismatched64BitAttributeType) {
         GTEST_SKIP() << "format not supported.";
     }
 
-    static const char vert_src[] = R"glsl(
+    const char vert_src[] = R"glsl(
         #version 460
         layout(location = 0) in int pos;
         void main() {
@@ -5017,7 +5017,7 @@ TEST_F(NegativeShaderObject, Mismatched32BitAttributeType) {
     RETURN_IF_SKIP(InitBasicShaderObject());
     InitDynamicRenderTarget();
 
-    static const char vert_src[] = R"glsl(
+    const char vert_src[] = R"glsl(
         #version 460
         #extension GL_EXT_shader_explicit_arithmetic_types : enable
         layout(location = 0) in int64_t pos;
@@ -5068,7 +5068,7 @@ TEST_F(NegativeShaderObject, MismatchedFormat64Components) {
         GTEST_SKIP() << "format not supported.";
     }
 
-    static const char vert_src[] = R"glsl(
+    const char vert_src[] = R"glsl(
         #version 460
         #extension GL_EXT_shader_explicit_arithmetic_types : enable
         layout(location = 0) in i64vec4 pos;
@@ -5113,7 +5113,7 @@ TEST_F(NegativeShaderObject, MismatchedAttributeType) {
     RETURN_IF_SKIP(InitBasicShaderObject());
     InitDynamicRenderTarget();
 
-    static const char vert_src[] = R"glsl(
+    const char vert_src[] = R"glsl(
         #version 460
         layout(location=0) in int x; /* attrib provided float */
         void main(){
@@ -5166,7 +5166,7 @@ TEST_F(NegativeShaderObject, DescriptorNotUpdated) {
 
     vkt::PipelineLayout pipeline_layout(*m_device, {&vert_descriptor_set.layout_, &frag_descriptor_set.layout_});
 
-    static const char vert_src[] = R"glsl(
+    const char vert_src[] = R"glsl(
         #version 460
         layout(location = 0) out vec2 uv;
         layout(set = 0, binding = 0) buffer Buffer {
@@ -5178,7 +5178,7 @@ TEST_F(NegativeShaderObject, DescriptorNotUpdated) {
         }
     )glsl";
 
-    static const char frag_src[] = R"glsl(
+    const char frag_src[] = R"glsl(
         #version 460
         layout(set = 1, binding = 0) uniform sampler2D s;
         layout(location = 0) in vec2 uv;
@@ -5438,7 +5438,7 @@ TEST_F(NegativeShaderObject, MissingImageFilterLinearBit) {
 
     vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
-    static const char frag_src[] = R"glsl(
+    const char frag_src[] = R"glsl(
         #version 460
         layout(set=0, binding=0) uniform isampler2D s;
         layout(location=0) out vec4 x;
@@ -5651,7 +5651,7 @@ TEST_F(NegativeShaderObject, CooperativeMatrix) {
     const vkt::PipelineLayout pl(*m_device, {&dsl});
 
     // Tests are assume that Float16 3*5 is not available
-    char const* comp_src = R"glsl(
+    const char* comp_src = R"glsl(
         #version 450
         #pragma use_vulkan_memory_model
         #extension GL_KHR_cooperative_matrix : enable
@@ -6628,7 +6628,7 @@ TEST_F(NegativeShaderObject, DescriptorWrongStage) {
     // wrong stage
     OneOffDescriptorSet descriptor_set(m_device, {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr}});
 
-    static const char comp_src[] = R"glsl(
+    const char comp_src[] = R"glsl(
         #version 450
         layout(local_size_x=16, local_size_x=1, local_size_x=1) in;
         layout(binding = 0) buffer Output {
@@ -6653,7 +6653,7 @@ TEST_F(NegativeShaderObject, DescriptorWrongStageMultipleBindings) {
                                                   {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr},
                                                   {2, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}});
 
-    static const char comp_src[] = R"glsl(
+    const char comp_src[] = R"glsl(
         #version 450
         layout(local_size_x=1, local_size_x=1, local_size_x=1) in;
         layout(set = 0, binding = 0) buffer SSBO_0 { uint a; };
@@ -6678,7 +6678,7 @@ TEST_F(NegativeShaderObject, DescriptorWrongStageMultipleSets) {
     OneOffDescriptorSet descriptor_set1(m_device, {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr}});
     OneOffDescriptorSet descriptor_set2(m_device, {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}});
 
-    static const char comp_src[] = R"glsl(
+    const char comp_src[] = R"glsl(
         #version 450
         layout(local_size_x=1, local_size_x=1, local_size_x=1) in;
         layout(set = 0, binding = 0) buffer SSBO_0 { uint a; };
@@ -6700,7 +6700,7 @@ TEST_F(NegativeShaderObject, DescriptorWrongStageMultipleSets) {
 TEST_F(NegativeShaderObject, DescriptorNotProvided) {
     RETURN_IF_SKIP(InitBasicShaderObject());
 
-    static const char comp_src[] = R"glsl(
+    const char comp_src[] = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer SSBO_0 { uint a; };
         void main() {
@@ -6716,7 +6716,7 @@ TEST_F(NegativeShaderObject, DescriptorNotProvided) {
 TEST_F(NegativeShaderObject, DescriptorTypeMismatch) {
     RETURN_IF_SKIP(InitBasicShaderObject());
 
-    static const char comp_src[] = R"glsl(
+    const char comp_src[] = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer SSBO_0 { uint a; };
         void main() {
@@ -6734,7 +6734,7 @@ TEST_F(NegativeShaderObject, DescriptorTypeMismatch) {
 TEST_F(NegativeShaderObject, DescriptorCount) {
     RETURN_IF_SKIP(InitBasicShaderObject());
 
-    static const char comp_src[] = R"glsl(
+    const char comp_src[] = R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer SSBO_0 { uint a; } x[3];
         void main() {
@@ -6754,7 +6754,7 @@ TEST_F(NegativeShaderObject, InlineUniformBlockArray) {
     AddRequiredFeature(vkt::Feature::inlineUniformBlock);
     RETURN_IF_SKIP(InitBasicShaderObject());
 
-    static const char comp_src[] = R"glsl(
+    const char comp_src[] = R"glsl(
         #version 450
         #extension GL_EXT_debug_printf : enable
         layout(set = 0, binding = 0) buffer SSBO0 { uint ssbo; };
@@ -6785,7 +6785,7 @@ TEST_F(NegativeShaderObject, PushConstantNotDeclared) {
     RETURN_IF_SKIP(InitBasicShaderObject());
     InitRenderTarget();
 
-    char const* vsSource = R"glsl(
+    const char* vsSource = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo { float x; } consts;
         void main(){
@@ -6866,7 +6866,7 @@ TEST_F(NegativeShaderObject, TaskMeshShadersDrawWithoutBindingVertex) {
 
     RETURN_IF_SKIP(InitBasicMeshShaderObject(VK_API_VERSION_1_3));
 
-    static const char task_src[] = R"glsl(
+    const char task_src[] = R"glsl(
         #version 450
         #extension GL_EXT_mesh_shader : require
         layout (local_size_x=1, local_size_y=1, local_size_z=1) in;
@@ -6875,7 +6875,7 @@ TEST_F(NegativeShaderObject, TaskMeshShadersDrawWithoutBindingVertex) {
         }
     )glsl";
 
-    static const char mesh_src[] = R"glsl(
+    const char mesh_src[] = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : require
         layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
@@ -6891,7 +6891,7 @@ TEST_F(NegativeShaderObject, TaskMeshShadersDrawWithoutBindingVertex) {
         }
     )glsl";
 
-    static const char frag_src[] = R"glsl(
+    const char frag_src[] = R"glsl(
         #version 460
         layout(location = 0) out vec4 uFragColor;
         void main(){

--- a/tests/unit/shader_object_positive.cpp
+++ b/tests/unit/shader_object_positive.cpp
@@ -216,7 +216,7 @@ TEST_F(PositiveShaderObject, VertFragShaderDraw) {
 
     RETURN_IF_SKIP(InitBasicShaderObject());
 
-    static const char vert_src[] = R"glsl(
+    const char vert_src[] = R"glsl(
         #version 460
         void main() {
             vec2 pos = vec2(float(gl_VertexIndex & 1), float((gl_VertexIndex >> 1) & 1));
@@ -224,7 +224,7 @@ TEST_F(PositiveShaderObject, VertFragShaderDraw) {
         }
     )glsl";
 
-    static const char frag_src[] = R"glsl(
+    const char frag_src[] = R"glsl(
         #version 460
         layout(location = 0) out vec4 uFragColor;
         void main(){
@@ -297,7 +297,7 @@ TEST_F(PositiveShaderObject, DrawWithAllGraphicsShaderStagesUsed) {
     AddRequiredFeature(vkt::Feature::tessellationShader);
     RETURN_IF_SKIP(InitBasicShaderObject());
 
-    static const char vert_src[] = R"glsl(
+    const char vert_src[] = R"glsl(
         #version 460
         void main() {
             vec2 pos = vec2(float(gl_VertexIndex & 1), float((gl_VertexIndex >> 1) & 1));
@@ -305,7 +305,7 @@ TEST_F(PositiveShaderObject, DrawWithAllGraphicsShaderStagesUsed) {
         }
     )glsl";
 
-    static const char tesc_src[] = R"glsl(
+    const char tesc_src[] = R"glsl(
         #version 450
         layout(vertices = 4) out;
         void main (void) {
@@ -321,7 +321,7 @@ TEST_F(PositiveShaderObject, DrawWithAllGraphicsShaderStagesUsed) {
         }
     )glsl";
 
-    static const char tese_src[] = R"glsl(
+    const char tese_src[] = R"glsl(
         #version 450
         layout(quads, equal_spacing) in;
         void main (void) {
@@ -334,7 +334,7 @@ TEST_F(PositiveShaderObject, DrawWithAllGraphicsShaderStagesUsed) {
         }
     )glsl";
 
-    static const char geom_src[] = R"glsl(
+    const char geom_src[] = R"glsl(
         #version 450
         layout(triangles) in;
         layout(triangle_strip, max_vertices = 4) out;
@@ -357,7 +357,7 @@ TEST_F(PositiveShaderObject, DrawWithAllGraphicsShaderStagesUsed) {
         }
     )glsl";
 
-    static const char frag_src[] = R"glsl(
+    const char frag_src[] = R"glsl(
         #version 460
         layout(location = 0) out vec4 uFragColor;
         void main(){
@@ -407,7 +407,7 @@ TEST_F(PositiveShaderObject, ComputeShader) {
 
     RETURN_IF_SKIP(InitBasicShaderObject());
 
-    static const char comp_src[] = R"glsl(
+    const char comp_src[] = R"glsl(
         #version 450
         layout(local_size_x=16, local_size_x=1, local_size_x=1) in;
         layout(binding = 0) buffer Output {
@@ -447,7 +447,7 @@ TEST_F(PositiveShaderObject, TaskMeshShadersDraw) {
 
     RETURN_IF_SKIP(InitBasicMeshShaderObject(VK_API_VERSION_1_3));
 
-    static const char task_src[] = R"glsl(
+    const char task_src[] = R"glsl(
         #version 450
         #extension GL_EXT_mesh_shader : require
         layout (local_size_x=1, local_size_y=1, local_size_z=1) in;
@@ -456,7 +456,7 @@ TEST_F(PositiveShaderObject, TaskMeshShadersDraw) {
         }
     )glsl";
 
-    static const char mesh_src[] = R"glsl(
+    const char mesh_src[] = R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : require
         layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
@@ -472,7 +472,7 @@ TEST_F(PositiveShaderObject, TaskMeshShadersDraw) {
         }
     )glsl";
 
-    static const char frag_src[] = R"glsl(
+    const char frag_src[] = R"glsl(
         #version 460
         layout(location = 0) out vec4 uFragColor;
         void main(){
@@ -526,7 +526,7 @@ TEST_F(PositiveShaderObject, FailCreateShaders) {
         GTEST_SKIP() << "Test not supported by MockICD because shader needs to fail";
     }
 
-    static const char vert_src[] = R"glsl(
+    const char vert_src[] = R"glsl(
         #version 460
         void main() {
             vec2 pos = vec2(float(gl_VertexIndex & 1), float((gl_VertexIndex >> 1) & 1));
@@ -534,7 +534,7 @@ TEST_F(PositiveShaderObject, FailCreateShaders) {
         }
     )glsl";
 
-    static const char tesc_src[] = R"glsl(
+    const char tesc_src[] = R"glsl(
         #version 450
         layout(vertices = 4) out;
         void main (void) {
@@ -550,7 +550,7 @@ TEST_F(PositiveShaderObject, FailCreateShaders) {
         }
     )glsl";
 
-    static const char tese_src[] = R"glsl(
+    const char tese_src[] = R"glsl(
         #version 450
         layout(quads, equal_spacing) in;
         void main (void) {
@@ -563,7 +563,7 @@ TEST_F(PositiveShaderObject, FailCreateShaders) {
         }
     )glsl";
 
-    static const char geom_src[] = R"glsl(
+    const char geom_src[] = R"glsl(
         #version 450
         layout(triangles) in;
         layout(triangle_strip, max_vertices = 4) out;
@@ -586,7 +586,7 @@ TEST_F(PositiveShaderObject, FailCreateShaders) {
         }
     )glsl";
 
-    static const char frag_src[] = R"glsl(
+    const char frag_src[] = R"glsl(
         #version 460
         layout(location = 0) out vec4 uFragColor;
         void main(){
@@ -731,7 +731,7 @@ TEST_F(PositiveShaderObject, ShadersDescriptorSets) {
 
     vkt::PipelineLayout pipeline_layout(*m_device, {&vert_descriptor_set.layout_, &frag_descriptor_set.layout_});
 
-    static const char vert_src[] = R"glsl(
+    const char vert_src[] = R"glsl(
         #version 460
         layout(location = 0) out vec2 uv;
         layout(set = 0, binding = 0) buffer Buffer {
@@ -743,7 +743,7 @@ TEST_F(PositiveShaderObject, ShadersDescriptorSets) {
         }
     )glsl";
 
-    static const char frag_src[] = R"glsl(
+    const char frag_src[] = R"glsl(
         #version 460
         layout(set = 1, binding = 0) uniform sampler2D s;
         layout(location = 0) in vec2 uv;
@@ -835,7 +835,7 @@ TEST_F(PositiveShaderObject, MultiplePushConstants) {
     RETURN_IF_SKIP(InitBasicShaderObject());
     InitDynamicRenderTarget();
 
-    static const char vert_src[] = R"glsl(
+    const char vert_src[] = R"glsl(
         #version 460
         layout (push_constant) uniform constants {
             int pos;
@@ -845,7 +845,7 @@ TEST_F(PositiveShaderObject, MultiplePushConstants) {
         }
     )glsl";
 
-    static const char frag_src[] = R"glsl(
+    const char frag_src[] = R"glsl(
         #version 460
         layout (push_constant) uniform constants {
             layout(offset = 4) float c;
@@ -894,7 +894,7 @@ TEST_F(PositiveShaderObject, MultipleSpecializationConstants) {
     RETURN_IF_SKIP(InitBasicShaderObject());
     InitDynamicRenderTarget();
 
-    static const char vert_src[] = R"glsl(
+    const char vert_src[] = R"glsl(
         #version 460
         layout (constant_id = 0) const int pos = 1;
         void main() {
@@ -902,7 +902,7 @@ TEST_F(PositiveShaderObject, MultipleSpecializationConstants) {
         }
     )glsl";
 
-    static const char frag_src[] = R"glsl(
+    const char frag_src[] = R"glsl(
         #version 460
         layout (constant_id = 1) const float c = 0.0f;
         layout(location = 0) out vec4 uFragColor;
@@ -956,7 +956,7 @@ TEST_F(PositiveShaderObject, IndirectDraw) {
     RETURN_IF_SKIP(InitBasicShaderObject());
     InitDynamicRenderTarget();
 
-    static const char vert_src[] = R"glsl(
+    const char vert_src[] = R"glsl(
         #version 460
         void main() {
             vec2 pos = vec2(float(gl_VertexIndex & 1), float((gl_VertexIndex >> 1) & 1));
@@ -964,7 +964,7 @@ TEST_F(PositiveShaderObject, IndirectDraw) {
         }
     )glsl";
 
-    static const char tesc_src[] = R"glsl(
+    const char tesc_src[] = R"glsl(
         #version 450
         layout(vertices = 4) out;
         void main (void) {
@@ -980,7 +980,7 @@ TEST_F(PositiveShaderObject, IndirectDraw) {
         }
     )glsl";
 
-    static const char tese_src[] = R"glsl(
+    const char tese_src[] = R"glsl(
         #version 450
         layout(quads, equal_spacing) in;
         void main (void) {
@@ -993,7 +993,7 @@ TEST_F(PositiveShaderObject, IndirectDraw) {
         }
     )glsl";
 
-    static const char geom_src[] = R"glsl(
+    const char geom_src[] = R"glsl(
         #version 450
         layout(triangles) in;
         layout(triangle_strip, max_vertices = 4) out;
@@ -1016,7 +1016,7 @@ TEST_F(PositiveShaderObject, IndirectDraw) {
         }
     )glsl";
 
-    static const char frag_src[] = R"glsl(
+    const char frag_src[] = R"glsl(
         #version 460
         layout(location = 0) out vec4 uFragColor;
         void main(){
@@ -1073,7 +1073,7 @@ TEST_F(PositiveShaderObject, OutputToMultipleAttachments) {
 
     InitDynamicRenderTarget();
 
-    static const char frag_src[] = R"glsl(
+    const char frag_src[] = R"glsl(
         #version 460
         layout(location = 0) out vec4 uFragColor1;
         layout(location = 1) out vec4 uFragColor2;
@@ -1461,7 +1461,7 @@ TEST_F(PositiveShaderObject, DrawWithVertGeomFragShaderObjects) {
 
     InitDynamicRenderTarget();
 
-    static const char vert_src[] = R"glsl(
+    const char vert_src[] = R"glsl(
         #version 450
 
         void main(void) {
@@ -1470,7 +1470,7 @@ TEST_F(PositiveShaderObject, DrawWithVertGeomFragShaderObjects) {
         }
     )glsl";
 
-    static const char geom_src[] = R"glsl(
+    const char geom_src[] = R"glsl(
         #version 450
         layout(triangles) in;
         layout(triangle_strip, max_vertices = 4) out;
@@ -1498,7 +1498,7 @@ TEST_F(PositiveShaderObject, DrawWithVertGeomFragShaderObjects) {
         }
     )glsl";
 
-    static const char frag_src[] = R"glsl(
+    const char frag_src[] = R"glsl(
         #version 450
 
         layout(location = 0) in vec4 in_color;

--- a/tests/unit/shader_push_constants.cpp
+++ b/tests/unit/shader_push_constants.cpp
@@ -26,7 +26,7 @@ TEST_F(NegativeShaderPushConstants, NotDeclared) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo { float x; } consts;
         void main(){
@@ -194,7 +194,7 @@ TEST_F(NegativeShaderPushConstants, NotInLayout) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo { float x; } consts;
         void main(){
@@ -234,7 +234,7 @@ TEST_F(NegativeShaderPushConstants, Range) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    char const *const vsSource = R"glsl(
+    const char *const vsSource = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo { float x[4]; } constants;
         void main(){
@@ -297,7 +297,7 @@ TEST_F(NegativeShaderPushConstants, DrawWithoutUpdate) {
     InitRenderTarget();
 
     // push constant range: 0-99
-    char const *const vsSource = R"glsl(
+    const char *const vsSource = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo {
            bool b;
@@ -321,7 +321,7 @@ TEST_F(NegativeShaderPushConstants, DrawWithoutUpdate) {
     )glsl";
 
     // push constant range: 0 - 95
-    char const *const fsSource = R"glsl(
+    const char *const fsSource = R"glsl(
         #version 450
         struct foo1{
            int i[4];
@@ -410,7 +410,7 @@ TEST_F(NegativeShaderPushConstants, BufferDeviceAddress) {
     AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
     RETURN_IF_SKIP(Init());
 
-    char const *shader_source = R"glsl(
+    const char *shader_source = R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable
         layout(buffer_reference, buffer_reference_align = 16, std430) buffer BDA {

--- a/tests/unit/shader_push_constants_positive.cpp
+++ b/tests/unit/shader_push_constants_positive.cpp
@@ -22,7 +22,7 @@ TEST_F(PositiveShaderPushConstants, OverlappingPushConstantRange) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *const vsSource = R"glsl(
+    const char *const vsSource = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo { float x[8]; } constants;
         void main(){
@@ -30,7 +30,7 @@ TEST_F(PositiveShaderPushConstants, OverlappingPushConstantRange) {
         }
     )glsl";
 
-    char const *const fsSource = R"glsl(
+    const char *const fsSource = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo { float x[4]; } constants;
         layout(location=0) out vec4 o;
@@ -278,7 +278,7 @@ TEST_F(PositiveShaderPushConstants, CompatibilityGraphicsOnly) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *const vsSource = R"glsl(
+    const char *const vsSource = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo { layout(offset = 16) vec4 x; } constants;
         void main(){
@@ -418,7 +418,7 @@ TEST_F(PositiveShaderPushConstants, StaticallyUnused) {
     VkPipelineLayoutCreateInfo pipeline_layout_info = {
         VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO, nullptr, 0, 0, nullptr, 1, &push_constant_range};
 
-    char const *vsSourceUnused = R"glsl(
+    const char *vsSourceUnused = R"glsl(
         #version 450
         layout(push_constant, std430) uniform foo { float x; } consts;
         void main(){
@@ -426,7 +426,7 @@ TEST_F(PositiveShaderPushConstants, StaticallyUnused) {
         }
     )glsl";
 
-    char const *vsSourceEmpty = R"glsl(
+    const char *vsSourceEmpty = R"glsl(
         #version 450
         void main(){
            gl_Position = vec4(1.0);
@@ -475,7 +475,7 @@ TEST_F(PositiveShaderPushConstants, OffsetVector) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *const vsSource = R"glsl(
+    const char *const vsSource = R"glsl(
         #version 450
 
         layout(push_constant) uniform Material {
@@ -516,7 +516,7 @@ TEST_F(PositiveShaderPushConstants, PhysicalStorageBufferBasic) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *const vsSource = R"glsl(
+    const char *const vsSource = R"glsl(
         #version 450
 
         #extension GL_EXT_buffer_reference : enable

--- a/tests/unit/shader_spirv.cpp
+++ b/tests/unit/shader_spirv.cpp
@@ -359,7 +359,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitCapability) {
 
     // storageBuffer8BitAccess
     {
-        char const *vsSource = R"glsl(
+        const char *vsSource = R"glsl(
             #version 450
             #extension GL_EXT_shader_8bit_storage: enable
             #extension GL_EXT_shader_explicit_arithmetic_types_int8: enable
@@ -377,7 +377,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitCapability) {
     }
     // uniformAndStorageBuffer8BitAccess
     {
-        char const *vsSource = R"glsl(
+        const char *vsSource = R"glsl(
             #version 450
             #extension GL_EXT_shader_8bit_storage: enable
             #extension GL_EXT_shader_explicit_arithmetic_types_int8: enable
@@ -396,7 +396,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitCapability) {
 
     // storagePushConstant8
     {
-        char const *vsSource = R"glsl(
+        const char *vsSource = R"glsl(
             #version 450
             #extension GL_EXT_shader_8bit_storage: enable
             #extension GL_EXT_shader_explicit_arithmetic_types_int8: enable
@@ -415,7 +415,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitCapability) {
 
     // storageBuffer16BitAccess - Float
     {
-        char const *vsSource = R"glsl(
+        const char *vsSource = R"glsl(
             #version 450
             #extension GL_EXT_shader_16bit_storage: enable
             #extension GL_EXT_shader_explicit_arithmetic_types_float16: enable
@@ -433,7 +433,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitCapability) {
 
     // uniformAndStorageBuffer16BitAccess - Float
     {
-        char const *vsSource = R"glsl(
+        const char *vsSource = R"glsl(
             #version 450
             #extension GL_EXT_shader_16bit_storage: enable
             #extension GL_EXT_shader_explicit_arithmetic_types_float16: enable
@@ -452,7 +452,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitCapability) {
 
     // storagePushConstant16 - Float
     {
-        char const *vsSource = R"glsl(
+        const char *vsSource = R"glsl(
             #version 450
             #extension GL_EXT_shader_16bit_storage: enable
             #extension GL_EXT_shader_explicit_arithmetic_types_float16: enable
@@ -471,7 +471,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitCapability) {
 
     // storageInputOutput16 - Float
     {
-        char const *vsSource = R"glsl(
+        const char *vsSource = R"glsl(
             #version 450
             #extension GL_EXT_shader_16bit_storage: enable
             #extension GL_EXT_shader_explicit_arithmetic_types_float16: enable
@@ -488,7 +488,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitCapability) {
         m_errorMonitor->VerifyFound();
 
         // Need to match in/out
-        char const *fsSource = R"glsl(
+        const char *fsSource = R"glsl(
             #version 450
             #extension GL_EXT_shader_16bit_storage: enable
             #extension GL_EXT_shader_explicit_arithmetic_types_float16: enable
@@ -507,7 +507,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitCapability) {
 
     // storageBuffer16BitAccess - Int
     {
-        char const *vsSource = R"glsl(
+        const char *vsSource = R"glsl(
             #version 450
             #extension GL_EXT_shader_16bit_storage: enable
             #extension GL_EXT_shader_explicit_arithmetic_types_int16: enable
@@ -526,7 +526,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitCapability) {
 
     // uniformAndStorageBuffer16BitAccess - Int
     {
-        char const *vsSource = R"glsl(
+        const char *vsSource = R"glsl(
             #version 450
             #extension GL_EXT_shader_16bit_storage: enable
             #extension GL_EXT_shader_explicit_arithmetic_types_int16: enable
@@ -546,7 +546,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitCapability) {
 
     // storagePushConstant16 - Int
     {
-        char const *vsSource = R"glsl(
+        const char *vsSource = R"glsl(
             #version 450
             #extension GL_EXT_shader_16bit_storage: enable
             #extension GL_EXT_shader_explicit_arithmetic_types_int16: enable
@@ -565,7 +565,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitCapability) {
 
     // storageInputOutput16 - Int
     {
-        char const *vsSource = R"glsl(
+        const char *vsSource = R"glsl(
             #version 450
             #extension GL_EXT_shader_16bit_storage: enable
             #extension GL_EXT_shader_explicit_arithmetic_types_int16: enable
@@ -582,7 +582,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitCapability) {
         m_errorMonitor->VerifyFound();
 
         // Need to match in/out
-        char const *fsSource = R"glsl(
+        const char *fsSource = R"glsl(
             #version 450
             #extension GL_EXT_shader_16bit_storage: enable
             #extension GL_EXT_shader_explicit_arithmetic_types_int16: enable
@@ -612,7 +612,7 @@ TEST_F(NegativeShaderSpirv, SpirvStatelessMaintenance5) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         #extension GL_EXT_shader_8bit_storage: enable
         #extension GL_EXT_shader_explicit_arithmetic_types_int8: enable
@@ -655,7 +655,7 @@ TEST_F(NegativeShaderSpirv, SpirvStatelessMaintenance5VertAndFrag) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    static const char shader[] = R"glsl(
+    const char shader[] = R"glsl(
         #version 450
         #extension GL_EXT_shader_atomic_float : enable
         #extension GL_KHR_memory_scope_semantics : enable
@@ -1159,7 +1159,7 @@ TEST_F(NegativeShaderSpirv, ReadShaderClock) {
     InitRenderTarget();
 
     // Device scope using GL_EXT_shader_realtime_clock
-    char const *vsSourceDevice = R"glsl(
+    const char *vsSourceDevice = R"glsl(
         #version 450
         #extension GL_EXT_shader_realtime_clock: enable
         void main(){
@@ -1172,7 +1172,7 @@ TEST_F(NegativeShaderSpirv, ReadShaderClock) {
     m_errorMonitor->VerifyFound();
 
     // Subgroup scope using ARB_shader_clock
-    char const *vsSourceScope = R"glsl(
+    const char *vsSourceScope = R"glsl(
         #version 450
         #extension GL_ARB_shader_clock: enable
         void main(){
@@ -1250,7 +1250,7 @@ TEST_F(NegativeShaderSpirv, SpecializationOffsetOutOfBounds) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout (constant_id = 0) const float r = 0.0f;
         layout(location = 0) out vec4 uFragColor;
@@ -1287,7 +1287,7 @@ TEST_F(NegativeShaderSpirv, SpecializationOffsetOutOfBoundsWithIdentifier) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vs_source = R"glsl(
+    const char *vs_source = R"glsl(
         #version 450
         layout (constant_id = 0) const float x = 0.0f;
         void main(){
@@ -1334,7 +1334,7 @@ TEST_F(NegativeShaderSpirv, SpecializationSizeOutOfBounds) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout (constant_id = 0) const float r = 0.0f;
         layout(location = 0) out vec4 uFragColor;
@@ -1675,7 +1675,7 @@ TEST_F(NegativeShaderSpirv, DuplicatedSpecializationConstantID) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout (constant_id = 0) const float r = 0.0f;
         layout(location = 0) out vec4 uFragColor;
@@ -1734,7 +1734,7 @@ TEST_F(NegativeShaderSpirv, ShaderNotEnabled) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0) out vec4 color;
         void main(){
@@ -1752,7 +1752,7 @@ TEST_F(NegativeShaderSpirv, ShaderImageFootprintEnabled) {
     AddRequiredExtensions(VK_NV_SHADER_IMAGE_FOOTPRINT_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         #extension GL_NV_shader_texture_footprint  : require
         layout(set=0, binding=0) uniform sampler2D s;
@@ -1778,7 +1778,7 @@ TEST_F(NegativeShaderSpirv, FragmentShaderBarycentricEnabled) {
     AddRequiredExtensions(VK_NV_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         #extension GL_NV_fragment_shader_barycentric : require
         layout(location=0) out float value;
@@ -1798,7 +1798,7 @@ TEST_F(NegativeShaderSpirv, ComputeShaderDerivativesEnabled) {
     AddRequiredExtensions(VK_NV_COMPUTE_SHADER_DERIVATIVES_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         #extension GL_NV_compute_shader_derivatives : require
         layout(local_size_x=2, local_size_y=4) in;
@@ -1822,7 +1822,7 @@ TEST_F(NegativeShaderSpirv, FragmentShaderInterlockEnabled) {
     AddRequiredExtensions(VK_EXT_FRAGMENT_SHADER_INTERLOCK_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         #extension GL_ARB_fragment_shader_interlock : require
         layout(sample_interlock_ordered) in;
@@ -1841,7 +1841,7 @@ TEST_F(NegativeShaderSpirv, DemoteToHelperInvocation) {
     AddRequiredExtensions(VK_EXT_SHADER_DEMOTE_TO_HELPER_INVOCATION_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         #extension GL_EXT_demote_to_helper_invocation : require
         void main(){
@@ -2028,7 +2028,7 @@ TEST_F(NegativeShaderSpirv, SubgroupRotate) {
 
     RETURN_IF_SKIP(Init());
 
-    char const *source = R"glsl(
+    const char *source = R"glsl(
         #version 450
         #extension GL_KHR_shader_subgroup_rotate: enable
         layout(binding = 0) buffer Buffers { vec4  x; } data;
@@ -2050,7 +2050,7 @@ TEST_F(NegativeShaderSpirv, SubgroupRotateClustered) {
 
     RETURN_IF_SKIP(Init());
 
-    char const *source = R"glsl(
+    const char *source = R"glsl(
         #version 450
         #extension GL_KHR_shader_subgroup_rotate: enable
         layout(binding = 0) buffer Buffers { vec4  x; } data;
@@ -2072,7 +2072,7 @@ TEST_F(NegativeShaderSpirv, DeviceMemoryScope) {
 
     RETURN_IF_SKIP(Init());
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         #extension GL_KHR_memory_scope_semantics : enable
         layout(set = 0, binding = 0) buffer ssbo { uint y; };
@@ -2094,7 +2094,7 @@ TEST_F(NegativeShaderSpirv, QueueFamilyMemoryScope) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModelDeviceScope);
     RETURN_IF_SKIP(Init());
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         #extension GL_KHR_memory_scope_semantics : enable
         layout(set = 0, binding = 0) buffer ssbo { uint y; };
@@ -2114,7 +2114,7 @@ TEST_F(NegativeShaderSpirv, DeviceMemoryScopeDebugInfo) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModel);
     RETURN_IF_SKIP(Init());
 
-    char const *csSource = R"(
+    const char *csSource = R"(
                OpCapability Shader
           %2 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
@@ -2391,7 +2391,7 @@ TEST_F(NegativeShaderSpirv, DescriptorCountConstant) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout (set = 0, binding = 0) uniform sampler2D tex[3];
         layout (location = 0) out vec4 out_color;
@@ -2415,7 +2415,7 @@ TEST_F(NegativeShaderSpirv, DISABLED_DescriptorCountSpecConstant) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout (constant_id = 0) const int index = 2;
         layout (set = 0, binding = 0) uniform sampler2D tex[index];
@@ -2446,7 +2446,7 @@ TEST_F(NegativeShaderSpirv, DescriptorCountConstantRuntimeArray) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 460
         #extension GL_EXT_nonuniform_qualifier : enable
         layout (set = 0, binding = 0) uniform sampler2D tex[];
@@ -2595,7 +2595,7 @@ TEST_F(NegativeShaderSpirv, ScalarBlockLayoutShaderCache) {
     RETURN_IF_SKIP(Init());
 
     // Matches glsl from other ScalarBlockLayoutShaderCache test
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 460
         #extension GL_EXT_buffer_reference : require
         #extension GL_EXT_scalar_block_layout : require
@@ -2723,7 +2723,7 @@ TEST_F(NegativeShaderSpirv, ShaderViewportIndexLayerEXT) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vs_source = R"glsl(
+    const char *vs_source = R"glsl(
         #version 450
         #extension GL_ARB_shader_viewport_layer_array : enable
         void main() {
@@ -2814,7 +2814,7 @@ TEST_F(NegativeShaderSpirv, Bitwise32bitMaintenance9) {
     AddRequiredFeature(vkt::Feature::shaderInt64);
     RETURN_IF_SKIP(Init());  // missing maintenance9
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_EXT_shader_explicit_arithmetic_types_int64 : enable
         void main() {

--- a/tests/unit/shader_spirv_positive.cpp
+++ b/tests/unit/shader_spirv_positive.cpp
@@ -182,7 +182,7 @@ TEST_F(PositiveShaderSpirv, CapabilityExtension1of2) {
     InitRenderTarget();
 
     // Vertex shader using viewport array capability
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         #extension GL_ARB_shader_viewport_layer_array : enable
         void main() {
@@ -208,7 +208,7 @@ TEST_F(PositiveShaderSpirv, CapabilityExtension2of2) {
     InitRenderTarget();
 
     // Vertex shader using viewport array capability
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         #extension GL_ARB_shader_viewport_layer_array : enable
         void main() {
@@ -232,7 +232,7 @@ TEST_F(PositiveShaderSpirv, ShaderViewportIndexLayerEXT) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vs_source = R"glsl(
+    const char *vs_source = R"glsl(
         #version 450
         #extension GL_ARB_shader_viewport_layer_array : enable
         void main() {
@@ -255,7 +255,7 @@ TEST_F(PositiveShaderSpirv, ShaderDrawParametersWithoutFeature) {
         GTEST_SKIP() << "requires Vulkan 1.0 exactly";
     }
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 460
         void main(){
            gl_Position = vec4(float(gl_BaseVertex));
@@ -282,7 +282,7 @@ TEST_F(PositiveShaderSpirv, ShaderDrawParametersWithoutFeature11) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 460
         void main(){
            gl_Position = vec4(float(gl_BaseVertex));
@@ -316,7 +316,7 @@ TEST_F(PositiveShaderSpirv, ShaderDrawParametersWithFeature) {
     RETURN_IF_SKIP(InitState(nullptr, &features2));
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 460
         void main(){
            gl_Position = vec4(float(gl_BaseVertex));
@@ -712,7 +712,7 @@ TEST_F(PositiveShaderSpirv, OpTypeStructRuntimeArray) {
     // %float = OpTypeFloat 32
     // %ra = OpTypeRuntimeArray %float
     // %struct = OpTypeStruct %ra
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set=0, binding=0) buffer sb {
             float values[];
@@ -1297,7 +1297,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
     // 8 bit int test (not 8 bit float support in Vulkan)
     if ((support_8_bit == true) && (float_16_int_8_features.shaderInt8 == VK_TRUE)) {
         if (storage_8_bit_features.storageBuffer8BitAccess == VK_TRUE) {
-            char const *vsSource = R"glsl(
+            const char *vsSource = R"glsl(
                 #version 450
                 #extension GL_EXT_shader_8bit_storage: enable
                 #extension GL_EXT_shader_explicit_arithmetic_types_int8: enable
@@ -1317,7 +1317,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
         }
 
         if (storage_8_bit_features.uniformAndStorageBuffer8BitAccess == VK_TRUE) {
-            char const *vsSource = R"glsl(
+            const char *vsSource = R"glsl(
                 #version 450
                 #extension GL_EXT_shader_8bit_storage: enable
                 #extension GL_EXT_shader_explicit_arithmetic_types_int8: enable
@@ -1337,7 +1337,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
         }
 
         if (storage_8_bit_features.storagePushConstant8 == VK_TRUE) {
-            char const *vsSource = R"glsl(
+            const char *vsSource = R"glsl(
                 #version 450
                 #extension GL_EXT_shader_8bit_storage: enable
                 #extension GL_EXT_shader_explicit_arithmetic_types_int8: enable
@@ -1363,7 +1363,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
     // 16 bit float tests
     if ((support_16_bit == true) && (float_16_int_8_features.shaderFloat16 == VK_TRUE)) {
         if (storage_16_bit_features.storageBuffer16BitAccess == VK_TRUE) {
-            char const *vsSource = R"glsl(
+            const char *vsSource = R"glsl(
                 #version 450
                 #extension GL_EXT_shader_16bit_storage: enable
                 #extension GL_EXT_shader_explicit_arithmetic_types_float16: enable
@@ -1383,7 +1383,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
         }
 
         if (storage_16_bit_features.uniformAndStorageBuffer16BitAccess == VK_TRUE) {
-            char const *vsSource = R"glsl(
+            const char *vsSource = R"glsl(
                 #version 450
                 #extension GL_EXT_shader_16bit_storage: enable
                 #extension GL_EXT_shader_explicit_arithmetic_types_float16: enable
@@ -1403,7 +1403,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
         }
 
         if (storage_16_bit_features.storagePushConstant16 == VK_TRUE) {
-            char const *vsSource = R"glsl(
+            const char *vsSource = R"glsl(
                 #version 450
                 #extension GL_EXT_shader_16bit_storage: enable
                 #extension GL_EXT_shader_explicit_arithmetic_types_float16: enable
@@ -1426,7 +1426,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
         }
 
         if (storage_16_bit_features.storageInputOutput16 == VK_TRUE) {
-            char const *vsSource = R"glsl(
+            const char *vsSource = R"glsl(
                 #version 450
                 #extension GL_EXT_shader_16bit_storage: enable
                 #extension GL_EXT_shader_explicit_arithmetic_types_float16: enable
@@ -1439,7 +1439,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
             VkShaderObj vs(this, vsSource, VK_SHADER_STAGE_VERTEX_BIT, SPV_ENV_VULKAN_1_1);
 
             // Need to match in/out
-            char const *fsSource = R"glsl(
+            const char *fsSource = R"glsl(
                 #version 450
                 #extension GL_EXT_shader_16bit_storage: enable
                 #extension GL_EXT_shader_explicit_arithmetic_types_float16: enable
@@ -1461,7 +1461,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
     // 16 bit int tests
     if ((support_16_bit == true) && (features2.features.shaderInt16 == VK_TRUE)) {
         if (storage_16_bit_features.storageBuffer16BitAccess == VK_TRUE) {
-            char const *vsSource = R"glsl(
+            const char *vsSource = R"glsl(
                 #version 450
                 #extension GL_EXT_shader_16bit_storage: enable
                 #extension GL_EXT_shader_explicit_arithmetic_types_int16: enable
@@ -1481,7 +1481,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
         }
 
         if (storage_16_bit_features.uniformAndStorageBuffer16BitAccess == VK_TRUE) {
-            char const *vsSource = R"glsl(
+            const char *vsSource = R"glsl(
                 #version 450
                 #extension GL_EXT_shader_16bit_storage: enable
                 #extension GL_EXT_shader_explicit_arithmetic_types_int16: enable
@@ -1501,7 +1501,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
         }
 
         if (storage_16_bit_features.storagePushConstant16 == VK_TRUE) {
-            char const *vsSource = R"glsl(
+            const char *vsSource = R"glsl(
                 #version 450
                 #extension GL_EXT_shader_16bit_storage: enable
                 #extension GL_EXT_shader_explicit_arithmetic_types_int16: enable
@@ -1524,7 +1524,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
         }
 
         if (storage_16_bit_features.storageInputOutput16 == VK_TRUE) {
-            char const *vsSource = R"glsl(
+            const char *vsSource = R"glsl(
                 #version 450
                 #extension GL_EXT_shader_16bit_storage: enable
                 #extension GL_EXT_shader_explicit_arithmetic_types_int16: enable
@@ -1537,7 +1537,7 @@ TEST_F(PositiveShaderSpirv, Storage8and16bit) {
             VkShaderObj vs(this, vsSource, VK_SHADER_STAGE_VERTEX_BIT, SPV_ENV_VULKAN_1_1);
 
             // Need to match in/out
-            char const *fsSource = R"glsl(
+            const char *fsSource = R"glsl(
                 #version 450
                 #extension GL_EXT_shader_16bit_storage: enable
                 #extension GL_EXT_shader_explicit_arithmetic_types_int16: enable
@@ -1563,7 +1563,7 @@ TEST_F(PositiveShaderSpirv, SubgroupRotate) {
     AddRequiredFeature(vkt::Feature::shaderSubgroupRotate);
     RETURN_IF_SKIP(Init());
 
-    char const *source = R"glsl(
+    const char *source = R"glsl(
         #version 450
         #extension GL_KHR_shader_subgroup_rotate: enable
         layout(binding = 0) buffer Buffers { vec4  x; } data;
@@ -1582,7 +1582,7 @@ TEST_F(PositiveShaderSpirv, SubgroupRotateClustered) {
     AddRequiredFeature(vkt::Feature::shaderSubgroupRotateClustered);
     RETURN_IF_SKIP(Init());
 
-    char const *source = R"glsl(
+    const char *source = R"glsl(
         #version 450
         #extension GL_KHR_shader_subgroup_rotate: enable
         layout(binding = 0) buffer Buffers { vec4  x; } data;
@@ -1603,7 +1603,7 @@ TEST_F(PositiveShaderSpirv, ReadShaderClockDevice) {
     InitRenderTarget();
 
     // Device scope using GL_EXT_shader_realtime_clock
-    char const *vsSourceDevice = R"glsl(
+    const char *vsSourceDevice = R"glsl(
         #version 450
         #extension GL_EXT_shader_realtime_clock: enable
         void main(){
@@ -1628,7 +1628,7 @@ TEST_F(PositiveShaderSpirv, ReadShaderClockSubgroup) {
     InitRenderTarget();
 
     // Subgroup scope using ARB_shader_clock
-    char const *vsSourceScope = R"glsl(
+    const char *vsSourceScope = R"glsl(
         #version 450
         #extension GL_ARB_shader_clock: enable
         void main(){
@@ -1859,7 +1859,7 @@ TEST_F(PositiveShaderSpirv, DescriptorCountSpecConstant) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         // over VkDescriptorSetLayoutBinding::descriptorCount
         layout (constant_id = 0) const int index = 4;
@@ -1890,7 +1890,7 @@ TEST_F(PositiveShaderSpirv, PhysicalStorageBufferGlslang6) {
 
     RETURN_IF_SKIP(Init());
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450 core
         #extension GL_EXT_buffer_reference : enable
         layout (push_constant, std430) uniform Block { int identity[32]; } pc;
@@ -2002,7 +2002,7 @@ TEST_F(PositiveShaderSpirv, ScalarBlockLayoutShaderCache) {
     RETURN_IF_SKIP(Init());
 
     // Matches glsl from other ScalarBlockLayoutShaderCache test
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 460
         #extension GL_EXT_buffer_reference : require
         #extension GL_EXT_scalar_block_layout : require
@@ -2039,7 +2039,7 @@ TEST_F(PositiveShaderSpirv, BFloat16) {
     AddRequiredFeature(vkt::Feature::shaderBFloat16Type);
     RETURN_IF_SKIP(Init());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450 core
 
         #extension GL_EXT_bfloat16 : require
@@ -2100,7 +2100,7 @@ TEST_F(PositiveShaderSpirv, BFloat16DotProduct) {
     AddRequiredFeature(vkt::Feature::shaderBFloat16DotProduct);
     RETURN_IF_SKIP(Init());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450 core
         #extension GL_EXT_bfloat16 : require
         #extension GL_EXT_shader_explicit_arithmetic_types : enable
@@ -2126,7 +2126,7 @@ TEST_F(PositiveShaderSpirv, Float8) {
     AddRequiredFeature(vkt::Feature::shaderInt8);
     RETURN_IF_SKIP(Init());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450 core
 
         #extension GL_EXT_float_e4m3 : require
@@ -2201,7 +2201,7 @@ TEST_F(PositiveShaderSpirv, ExtendedTypesEnabled) {
     const vkt::DescriptorSetLayout dsl(*m_device, bindings);
     const vkt::PipelineLayout pl(*m_device, {&dsl});
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         #extension GL_KHR_shader_subgroup_arithmetic : enable
         #extension GL_EXT_shader_subgroup_extended_types_float16 : enable
@@ -2226,7 +2226,7 @@ TEST_F(PositiveShaderSpirv, RayQueryPositionFetch) {
     AddRequiredFeature(vkt::Feature::rayTracingPositionFetch);
     RETURN_IF_SKIP(Init());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : enable
         #extension GL_EXT_ray_tracing_position_fetch : enable
@@ -2404,7 +2404,7 @@ TEST_F(PositiveShaderSpirv, Bitwise32bitMaintenance9) {
     AddRequiredFeature(vkt::Feature::maintenance9);
     RETURN_IF_SKIP(Init());
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_EXT_shader_explicit_arithmetic_types_int64 : enable
 

--- a/tests/unit/shader_storage_texel.cpp
+++ b/tests/unit/shader_storage_texel.cpp
@@ -159,7 +159,7 @@ TEST_F(NegativeShaderStorageTexel, ComponentTypeMismatch) {
         GTEST_SKIP() << "Format doesn't support storage write without format";
     }
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) writeonly uniform iimageBuffer storageTexelBuffer;
         void main() {
@@ -203,7 +203,7 @@ TEST_F(NegativeShaderStorageTexel, FormatComponentTypeMismatch) {
         GTEST_SKIP() << "Format doesn't support storage texel buffer";
     }
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0, R8ui) writeonly uniform uimageBuffer storageTexelBuffer;
         void main() {
@@ -247,7 +247,7 @@ TEST_F(NegativeShaderStorageTexel, FormatComponentTypeMismatch2) {
         GTEST_SKIP() << "Format doesn't support storage texel buffer";
     }
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0, R32ui) writeonly uniform uimageBuffer storageTexelBuffer;
         void main() {

--- a/tests/unit/sparse_image_positive.cpp
+++ b/tests/unit/sparse_image_positive.cpp
@@ -293,7 +293,7 @@ TEST_F(PositiveSparseImage, OpImageSparse) {
     ds.WriteDescriptorImageInfo(0, image_view, sampler, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
     ds.UpdateDescriptorSets();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         #extension GL_ARB_sparse_texture2 : enable
 

--- a/tests/unit/subgroups.cpp
+++ b/tests/unit/subgroups.cpp
@@ -280,7 +280,7 @@ TEST_F(NegativeSubgroup, ExtendedTypesDisabled) {
     const vkt::DescriptorSetLayout dsl(*m_device, bindings);
     const vkt::PipelineLayout pl(*m_device, {&dsl});
 
-    char const *csSource = R"glsl(
+    const char *csSource = R"glsl(
         #version 450
         #extension GL_KHR_shader_subgroup_arithmetic : enable
         #extension GL_EXT_shader_subgroup_extended_types_float16 : enable

--- a/tests/unit/subpass.cpp
+++ b/tests/unit/subpass.cpp
@@ -583,7 +583,7 @@ TEST_F(NegativeSubpass, SubpassInputNotBoundDescriptorSet) {
     {
         // input index is wrong, it doesn't exist in supbass input attachments and the set and binding is undefined
         // It causes desired failures.
-        char const *fsSource_fail = R"glsl(
+        const char *fsSource_fail = R"glsl(
             #version 450
             layout(input_attachment_index=1, set=0, binding=1) uniform subpassInput x;
             void main() {
@@ -604,7 +604,7 @@ TEST_F(NegativeSubpass, SubpassInputNotBoundDescriptorSet) {
     }
 
     {  // Binds input attachment
-        char const *fsSource = R"glsl(
+        const char *fsSource = R"glsl(
             #version 450
             layout(input_attachment_index=0, set=0, binding=0) uniform subpassInput x;
             void main() {
@@ -971,7 +971,7 @@ TEST_F(NegativeSubpass, InputAttachmentMissing) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(input_attachment_index=0, set=0, binding=0) uniform subpassInput x;
         layout(location=0) out vec4 color;
@@ -997,7 +997,7 @@ TEST_F(NegativeSubpass, InputAttachmentMissingArray) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(input_attachment_index=0, set=0, binding=0) uniform subpassInput xs[1];
         layout(location=0) out vec4 color;
@@ -1021,7 +1021,7 @@ TEST_F(NegativeSubpass, DISABLED_InputAttachmentMissingSpecConstant) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout (constant_id = 0) const int index = 2;
         layout(input_attachment_index=0, set=0, binding=0) uniform subpassInput xs[index];

--- a/tests/unit/subpass_positive.cpp
+++ b/tests/unit/subpass_positive.cpp
@@ -188,7 +188,7 @@ TEST_F(PositiveSubpass, DISABLED_InputAttachmentMissingSpecConstant) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout (constant_id = 0) const int index = 4; // over VkDescriptorSetLayoutBinding::descriptorCount
         layout(input_attachment_index=0, set=0, binding=0) uniform subpassInput xs[index];

--- a/tests/unit/sync_object.cpp
+++ b/tests/unit/sync_object.cpp
@@ -1269,20 +1269,20 @@ TEST_F(NegativeSyncObject, BarrierQueueFamilyOneFamily) {
     conc_test.Init(&families);
     {
         // src
-        static const char *img_vuid = "VUID-VkImageMemoryBarrier-None-09053";
-        static const char *buf_vuid = "VUID-VkBufferMemoryBarrier-None-09050";
+        const char *img_vuid = "VUID-VkImageMemoryBarrier-None-09053";
+        const char *buf_vuid = "VUID-VkBufferMemoryBarrier-None-09050";
         conc_test(img_vuid, buf_vuid, submit_family, VK_QUEUE_FAMILY_IGNORED);
     }
     {
         // dst
-        static const char *img_vuid = "VUID-VkImageMemoryBarrier-None-09054";
-        static const char *buf_vuid = "VUID-VkBufferMemoryBarrier-None-09051";
+        const char *img_vuid = "VUID-VkImageMemoryBarrier-None-09054";
+        const char *buf_vuid = "VUID-VkBufferMemoryBarrier-None-09051";
         conc_test(img_vuid, buf_vuid, VK_QUEUE_FAMILY_IGNORED, submit_family);
     }
     {
         // neither
-        static const char *img_vuid = "VUID-VkImageMemoryBarrier-None-09053";
-        static const char *buf_vuid = "VUID-VkBufferMemoryBarrier-None-09050";
+        const char *img_vuid = "VUID-VkImageMemoryBarrier-None-09053";
+        const char *buf_vuid = "VUID-VkBufferMemoryBarrier-None-09050";
         conc_test(img_vuid, buf_vuid, submit_family, submit_family);
     }
     conc_test(VK_QUEUE_FAMILY_IGNORED, VK_QUEUE_FAMILY_IGNORED);
@@ -1663,8 +1663,8 @@ TEST_F(NegativeSyncObject, BarrierQueueFamilyWithMemExt2) {
     BarrierQueueFamilyTestHelper conc_test(&test_context);
 
     conc_test.Init(&families);
-    static const char *img_vuid = "VUID-VkImageMemoryBarrier-None-09053";
-    static const char *buf_vuid = "VUID-VkBufferMemoryBarrier-None-09050";
+    const char *img_vuid = "VUID-VkImageMemoryBarrier-None-09053";
+    const char *buf_vuid = "VUID-VkBufferMemoryBarrier-None-09050";
     conc_test(img_vuid, buf_vuid, submit_family, submit_family);
     conc_test(VK_QUEUE_FAMILY_IGNORED, VK_QUEUE_FAMILY_IGNORED);
     conc_test(VK_QUEUE_FAMILY_IGNORED, VK_QUEUE_FAMILY_EXTERNAL_KHR);

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -3910,7 +3910,7 @@ TEST_F(NegativeSyncVal, DestroyedUnusedDescriptors) {
     vk::UpdateDescriptorSets(device(), descriptor_writes.size(), descriptor_writes.data(), 0, NULL);
 
     // only descriptor 0 is used, the rest are going to get destroyed
-    char const* shader_source = R"glsl(
+    const char* shader_source = R"glsl(
         #version 450
         layout(set = 0, binding = 0) uniform foo_0 { int val; } doit;
         layout(set = 0, binding = 1) uniform foo_1 { int val; } readit;

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -1014,7 +1014,7 @@ TEST_F(PositiveSyncVal, ImageArrayDynamicIndexing) {
     gfx_pipe.CreateGraphicsPipeline();
 
     // Read from image 2 or 3
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable
         layout(set=0, binding=0, rgba8) uniform image2D image_array[];
@@ -1079,7 +1079,7 @@ TEST_F(PositiveSyncVal, ImageArrayConstantIndexing) {
     gfx_pipe.CreateGraphicsPipeline();
 
     // Read from image 1
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set=0, binding=0, rgba8) uniform image2D image_array[];
         void main() {
@@ -1144,7 +1144,7 @@ TEST_F(PositiveSyncVal, TexelBufferArrayConstantIndexing) {
     gfx_pipe.CreateGraphicsPipeline();
 
     // Read from texel buffer 1
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set=0, binding=0, rgba8ui) uniform uimageBuffer texel_buffer_array[];
         void main() {
@@ -1220,7 +1220,7 @@ TEST_F(PositiveSyncVal, QSTransitionWithSrcNoneStage) {
     descriptor_set.WriteDescriptorImageInfo(0, view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_IMAGE_LAYOUT_GENERAL);
     descriptor_set.UpdateDescriptorSets();
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set=0, binding=0, rgba8) uniform image2D image;
         void main() {
@@ -1338,7 +1338,7 @@ TEST_F(PositiveSyncVal, QSTransitionAndRead) {
     descriptor_set.WriteDescriptorImageInfo(0, view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_IMAGE_LAYOUT_GENERAL);
     descriptor_set.UpdateDescriptorSets();
 
-    char const *cs_source = R"glsl(
+    const char *cs_source = R"glsl(
         #version 450
         layout(set=0, binding=0, rgba8) uniform image2D image;
         void main() {

--- a/tests/unit/sync_val_ray_tracing_positive.cpp
+++ b/tests/unit/sync_val_ray_tracing_positive.cpp
@@ -37,7 +37,7 @@ vkt::Buffer VkSyncValTest::GetSerializationDeserializationBuffer(const vkt::as::
 }
 
 CreateComputePipelineHelper VkSyncValTest::GetRayQueryComputePipeline(VkAccelerationStructureKHR as) {
-    char const* cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
         layout(set = 0, binding = 0) uniform accelerationStructureEXT tlas;

--- a/tests/unit/vertex_input.cpp
+++ b/tests/unit/vertex_input.cpp
@@ -772,7 +772,7 @@ TEST_F(NegativeVertexInput, AttributeAlignment) {
     input_attribs[2].format = VK_FORMAT_R32G32B32A32_SFLOAT;
     input_attribs[2].offset = offsetof(VboEntry, input2);
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location = 0) in vec2 input0;
         layout(location = 1) in vec4 input1;
@@ -1114,7 +1114,7 @@ TEST_F(NegativeVertexInput, AttributeNotProvided) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) in vec4 x; /* not provided */
         void main(){
@@ -1143,7 +1143,7 @@ TEST_F(NegativeVertexInput, AttributeTypeMismatch) {
     memset(&input_attrib, 0, sizeof(input_attrib));
     input_attrib.format = VK_FORMAT_R32_SFLOAT;
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) in int x; /* attrib provided float */
         void main(){
@@ -1180,7 +1180,7 @@ TEST_F(NegativeVertexInput, AttributeStructTypeFirstLocation) {
     //         layout(location = 4) vec4 x;
     //         layout(location = 6) uvec4 y;
     //     } x_struct;
-    char const *vsSource = R"(
+    const char *vsSource = R"(
                OpCapability Shader
                OpMemoryModel Logical Simple
                OpEntryPoint Vertex %1 "main" %2
@@ -1234,7 +1234,7 @@ TEST_F(NegativeVertexInput, AttributeStructTypeSecondLocation) {
     //         layout(location = 4) ivec4 x;
     //         layout(location = 6) uvec4 y;
     //     } x_struct;
-    char const *vsSource = R"(
+    const char *vsSource = R"(
                OpCapability Shader
                OpMemoryModel Logical Simple
                OpEntryPoint Vertex %1 "main" %2
@@ -1287,7 +1287,7 @@ TEST_F(NegativeVertexInput, AttributeStructTypeBlockLocation) {
     //         vec4 x;
     //         uvec4 y;
     //     } x_struct;
-    char const *vsSource = R"(
+    const char *vsSource = R"(
                OpCapability Shader
                OpMemoryModel Logical Simple
                OpEntryPoint Vertex %1 "main" %2
@@ -1331,7 +1331,7 @@ TEST_F(NegativeVertexInput, AttributeTypeMismatchDynamic) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) in int x; /* attrib provided float */
         void main(){
@@ -1385,7 +1385,7 @@ TEST_F(NegativeVertexInput, AttributeBindingConflict) {
     memset(&input_attrib, 0, sizeof(input_attrib));
     input_attrib.format = VK_FORMAT_R32_SFLOAT;
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) in float x; /* attrib provided float */
         void main(){
@@ -1418,7 +1418,7 @@ TEST_F(NegativeVertexInput, Attribute64bitInputAttribute) {
         GTEST_SKIP() << "Format not supported for Vertex Buffer";
     }
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450 core
         layout(location = 0) in float pos; // 32-bit
         void main() {}
@@ -1452,7 +1452,7 @@ TEST_F(NegativeVertexInput, Attribute64bitShaderInput) {
         GTEST_SKIP() << "Format not supported for Vertex Buffer";
     }
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450 core
         #extension GL_EXT_shader_explicit_arithmetic_types_float64 : enable
         layout(location = 0) in float64_t pos;
@@ -1487,7 +1487,7 @@ TEST_F(NegativeVertexInput, Attribute64bitUnusedComponent) {
         GTEST_SKIP() << "Format not supported for Vertex Buffer";
     }
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450 core
         #extension GL_EXT_shader_explicit_arithmetic_types_float64 : enable
         layout(location = 0) in f64vec2 pos;
@@ -1535,7 +1535,7 @@ TEST_F(NegativeVertexInput, AttributeStructTypeBlockLocation64bit) {
     //         float64 y;
     //         ivec4 z;
     //     } x_struct;
-    char const *vsSource = R"(
+    const char *vsSource = R"(
                OpCapability Shader
                OpCapability Float64
                OpMemoryModel Logical Simple
@@ -1758,7 +1758,7 @@ TEST_F(NegativeVertexInput, ResetCmdSetVertexInput) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vs_source = R"glsl(
+    const char *vs_source = R"glsl(
         #version 450
         layout(location=0) in uvec4 x;
         void main(){}
@@ -1806,7 +1806,7 @@ TEST_F(NegativeVertexInput, VertexInputRebinding) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location = 0) in float a;
         layout(location = 1) in float b;

--- a/tests/unit/vertex_input_positive.cpp
+++ b/tests/unit/vertex_input_positive.cpp
@@ -35,7 +35,7 @@ TEST_F(PositiveVertexInput, AttributeMatrixType) {
         input_attribs[i].location = i;
     }
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) in mat2x4 x;
         void main(){
@@ -73,7 +73,7 @@ TEST_F(PositiveVertexInput, AttributeArrayType) {
         input_attribs[i].location = i;
     }
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) in vec4 x[2];
         void main(){
@@ -110,7 +110,7 @@ TEST_F(PositiveVertexInput, AttributeStructType) {
     //     in VertexIn {
     //         layout(location = 4) vec4 x;
     //     } x_struct;
-    char const *vsSource = R"(
+    const char *vsSource = R"(
                OpCapability Shader
                OpMemoryModel Logical Simple
                OpEntryPoint Vertex %1 "main" %2
@@ -165,7 +165,7 @@ TEST_F(PositiveVertexInput, AttributeStructTypeWithArray) {
     //         layout(location = 4) vec4 y[2];
     //         layout(location = 1) vec3 x;
     //     } x_struct;
-    char const *vsSource = R"(
+    const char *vsSource = R"(
                OpCapability Shader
                OpMemoryModel Logical Simple
                OpEntryPoint Vertex %1 "main" %2
@@ -219,7 +219,7 @@ TEST_F(PositiveVertexInput, AttributeStructTypeSecondLocation) {
     //         layout(location = 4) ivec4 x;
     //         layout(location = 6) uvec4 y;
     //     } x_struct;
-    char const *vsSource = R"(
+    const char *vsSource = R"(
                OpCapability Shader
                OpMemoryModel Logical Simple
                OpEntryPoint Vertex %1 "main" %2
@@ -271,7 +271,7 @@ TEST_F(PositiveVertexInput, AttributeStructTypeBlockLocation) {
     //         vec4 x;
     //         uvec4 y;
     //     } x_struct;
-    char const *vsSource = R"(
+    const char *vsSource = R"(
                OpCapability Shader
                OpMemoryModel Logical Simple
                OpEntryPoint Vertex %1 "main" %2
@@ -324,7 +324,7 @@ TEST_F(PositiveVertexInput, AttributeComponents) {
         input_attribs[i].location = i;
     }
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) in vec4 x;
         layout(location=1) in vec3 y1;
@@ -334,7 +334,7 @@ TEST_F(PositiveVertexInput, AttributeComponents) {
            gl_Position = x + vec4(y1, y2) + z;
         }
     )glsl";
-    char const *fsSource = R"glsl(
+    const char *fsSource = R"glsl(
         #version 450
         layout(location=0, component=0) out float color0;
         layout(location=0, component=1) out float color1;
@@ -409,7 +409,7 @@ TEST_F(PositiveVertexInput, CreatePipeline64BitAttributes) {
     input_attribs[3].offset = 96;
     input_attribs[3].format = VK_FORMAT_R64G64B64A64_SFLOAT;
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) in dmat4 x;
         void main(){
@@ -443,7 +443,7 @@ TEST_F(PositiveVertexInput, VertexAttribute64bit) {
 
     vkt::Buffer vtx_buf(*m_device, 1024, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450 core
         #extension GL_EXT_shader_explicit_arithmetic_types_float64 : enable
         layout(location = 0) in float64_t pos;
@@ -488,7 +488,7 @@ TEST_F(PositiveVertexInput, AttributeStructTypeBlockLocation64bit) {
     //         float64 y;
     //         ivec4 z;
     //     } x_struct;
-    char const *vsSource = R"(
+    const char *vsSource = R"(
                OpCapability Shader
                OpCapability Float64
                OpMemoryModel Logical Simple
@@ -534,7 +534,7 @@ TEST_F(PositiveVertexInput, Attribute64bitMissingComponent) {
         GTEST_SKIP() << "Format not supported for Vertex Buffer";
     }
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450 core
         #extension GL_EXT_shader_explicit_arithmetic_types_float64 : enable
         layout(location = 0) in f64vec2 pos;
@@ -864,7 +864,7 @@ TEST_F(PositiveVertexInput, LegacyVertexAttributes) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) in int x; /* attrib provided float */
         void main(){
@@ -909,14 +909,14 @@ TEST_F(PositiveVertexInput, ResetCmdSetVertexInput) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vs_source_int = R"glsl(
+    const char *vs_source_int = R"glsl(
         #version 450
         layout(location=0) in uvec4 x;
         void main(){}
     )glsl";
     VkShaderObj vs_int(this, vs_source_int, VK_SHADER_STAGE_VERTEX_BIT);
 
-    char const *vs_source_float = R"glsl(
+    const char *vs_source_float = R"glsl(
         #version 450
         layout(location=0) in vec4 x;
         void main(){}
@@ -970,7 +970,7 @@ TEST_F(PositiveVertexInput, VertexAttributeRobustness) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vs_source = R"glsl(
+    const char *vs_source = R"glsl(
         #version 450
         layout(location=0) in vec4 x; /* not provided */
         void main(){
@@ -992,7 +992,7 @@ TEST_F(PositiveVertexInput, VertexAttributeRobustnessDynamic) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location = 0) in vec4 x;
         layout(location = 1) in vec4 y;
@@ -1041,7 +1041,7 @@ TEST_F(PositiveVertexInput, VertexInputRebinding) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location = 0) in float a;
 
@@ -1102,7 +1102,7 @@ TEST_F(PositiveVertexInput, UnusedInputBinding) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) in vec4 x;
         layout(location=1) in vec4 y;
@@ -1145,7 +1145,7 @@ TEST_F(PositiveVertexInput, UnusedInputBindingDynamic) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) in vec4 x;
         layout(location=1) in vec4 y;
@@ -1326,7 +1326,7 @@ TEST_F(PositiveVertexInput, AttributeNotProvided) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    char const *vsSource = R"glsl(
+    const char *vsSource = R"glsl(
         #version 450
         layout(location=0) in vec4 x; /* not provided */
         void main(){


### PR DESCRIPTION
1. takes all cases of `char const` and makes them `const char`
2. In the tests we used  `static const char` a lot of for our GLSL strings, but we agreed to not make them static as it provides no meaning and only a potential issue when mis-copied (there are few spots I left as they made sense, like the `shader_templates.h` file

