### PR TITLE
layers: Fix dynamic render local read draw VUs

### DIFF
--- a/layers/error_message/error_strings.h
+++ b/layers/error_message/error_strings.h
@@ -29,6 +29,13 @@
     }
 }
 
+[[maybe_unused]] static std::string string_AttachmentPointer(const uint32_t *attachment) {
+    if (!attachment) {
+        return "NULL";
+    }
+    return string_Attachment(*attachment);
+}
+
 [[maybe_unused]] static std::string string_VkExtent2D(VkExtent2D extent) {
     std::stringstream ss;
     ss << "width = " << extent.width << ", height = " << extent.height;

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -782,6 +782,8 @@ static void InitDefaultRenderingAttachments(CommandBuffer::RenderingAttachment &
     attachments.color_indexes.resize(count);
     attachments.depth_index = nullptr;
     attachments.stencil_index = nullptr;
+    attachments.set_color_locations = false;
+    attachments.set_color_indexes = false;
     for (uint32_t i = 0; i < count; i++) {
         // Default from spec
         attachments.color_locations[i] = i;


### PR DESCRIPTION
From discussions in [KhronosGroup/Vulkan-Docs#2565](https://github.com/KhronosGroup/Vulkan-Docs/issues/2565) - spec change https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/7640

Note: CTS fails the new validations without https://github.com/KhronosGroup/VK-GL-CTS/pull/541 in case that affects how you want to order merges