### PR TITLE
layers: Fix incorrect destruction of TensorView

### DIFF
--- a/layers/state_tracker/tensor_state.cpp
+++ b/layers/state_tracker/tensor_state.cpp
@@ -38,4 +38,22 @@ TensorView::TensorView(const std::shared_ptr<Tensor> &tensor, VkTensorViewARM ha
       create_info(*safe_create_info.ptr()),
       tensor_state(tensor) {}
 
+void TensorView::Destroy() {
+    for (auto &item : sub_states_) {
+        item.second->Destroy();
+    }
+    if (tensor_state) {
+        tensor_state->RemoveParent(this);
+        tensor_state = nullptr;
+    }
+    StateObject::Destroy();
+}
+
+void TensorView::NotifyInvalidate(const StateObject::NodeList &invalid_nodes, bool unlink) {
+    for (auto &item : sub_states_) {
+        item.second->NotifyInvalidate(invalid_nodes, unlink);
+    }
+    StateObject::NotifyInvalidate(invalid_nodes, unlink);
+}
+
 }  // namespace vvl

--- a/layers/state_tracker/tensor_state.h
+++ b/layers/state_tracker/tensor_state.h
@@ -78,6 +78,11 @@ class TensorView : public StateObject, public SubStateManager<TensorViewSubState
         }
     }
     TensorView(const TensorView &rh_obj) = delete;
+
+    void Destroy() override;
+    void NotifyInvalidate(const StateObject::NodeList &invalid_nodes, bool unlink) override;
+    bool Invalid() const override { return Destroyed() || !tensor_state || tensor_state->Invalid(); }
+
 };
 
 class TensorViewSubState {


### PR DESCRIPTION
- the link between `Tensor` and `TensorView` requires special handling: override `Destroy`, `NotifyInvalidate` and `Invalid`, the same way it's done in `BufferView`
- this fixes some instances of "bad weak_ptr" in the destructor of `Tensor` seen using the VVL on real applications