### PR TITLE
layers: Fix dynamic raster sample for ds resolve

### DIFF
--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -107,10 +107,7 @@ struct AttachmentInfo {
     bool IsColor() const { return type == Type::Color; }
     bool IsDepth() const;
     bool IsStencil() const;
-    bool IsDepthOrStencil() const {
-        return type == Type::DepthStencil || type == Type::Depth || type == Type::DepthResolve || type == Type::Stencil ||
-               type == Type::StencilResolve;
-    }
+    bool IsDepthOrStencil() const { return type == Type::DepthStencil || type == Type::Depth || type == Type::Stencil; }
     bool IsFragmentDensityMap() const { return type == Type::FragmentDensityMap; }
     bool IsFragmentShadingRate() const { return type == Type::FragmentShadingRate; }
 


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10661

`IsDepthOrStencil()` is used in 2 spots, both don't actually want the Resolve variation (and why we have a `IsResolve()`)