### PR TITLE
layers: Use Pipeline Library State better

### DIFF
--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -1281,12 +1281,18 @@ bool CoreChecks::ValidateDrawRenderingAttachmentLocation(const vvl::CommandBuffe
     // Default from spec
     uint32_t pipeline_color_count = pipeline_state.ColorBlendState() ? pipeline_state.ColorBlendState()->attachmentCount : 0;
     const uint32_t* pipeline_color_locations = nullptr;
+
+    // if no fragment output, Locations are useless
+    if (!pipeline_state.fragment_output_state) {
+        return skip;
+    }
+
     bool explicit_pipeline = false;
-    if (pipeline_state.fragment_output_state && pipeline_state.fragment_output_state->attachement_locations) {
+    if (auto info = vku::FindStructInPNextChain<VkRenderingAttachmentLocationInfo>(
+            pipeline_state.fragment_output_state->parent.GetCreateInfoPNext())) {
         explicit_pipeline = true;
-        const VkRenderingAttachmentLocationInfo info = *pipeline_state.fragment_output_state->attachement_locations->ptr();
-        pipeline_color_count = info.colorAttachmentCount;
-        pipeline_color_locations = info.pColorAttachmentLocations;
+        pipeline_color_count = info->colorAttachmentCount;
+        pipeline_color_locations = info->pColorAttachmentLocations;
     }
 
     // If the count mismatches, that will either be caught by VUID-06179 or allowed,
@@ -1326,14 +1332,19 @@ bool CoreChecks::ValidateDrawRenderingInputAttachmentIndex(const vvl::CommandBuf
     const uint32_t* pipeline_depth_index = nullptr;
     const uint32_t* pipeline_stencil_index = nullptr;
 
+    // if no fragment shader, Index are useless
+    if (!pipeline_state.fragment_shader_state) {
+        return skip;
+    }
+
     bool explicit_pipeline = false;
-    if (pipeline_state.fragment_shader_state && pipeline_state.fragment_shader_state->attachement_index) {
+    if (auto info = vku::FindStructInPNextChain<VkRenderingInputAttachmentIndexInfo>(
+            pipeline_state.fragment_shader_state->parent.GetCreateInfoPNext())) {
         explicit_pipeline = true;
-        const VkRenderingInputAttachmentIndexInfo info = *pipeline_state.fragment_shader_state->attachement_index->ptr();
-        pipeline_color_count = info.colorAttachmentCount;
-        pipeline_color_indexes = info.pColorAttachmentInputIndices;
-        pipeline_depth_index = info.pDepthInputAttachmentIndex;
-        pipeline_stencil_index = info.pStencilInputAttachmentIndex;
+        pipeline_color_count = info->colorAttachmentCount;
+        pipeline_color_indexes = info->pColorAttachmentInputIndices;
+        pipeline_depth_index = info->pDepthInputAttachmentIndex;
+        pipeline_stencil_index = info->pStencilInputAttachmentIndex;
     }
 
     // If the count mismatches, that will either be caught by VUID-06179 or allowed,

--- a/layers/state_tracker/pipeline_library_state.cpp
+++ b/layers/state_tracker/pipeline_library_state.cpp
@@ -188,24 +188,6 @@ std::unique_ptr<const vku::safe_VkPipelineDepthStencilStateCreateInfo> ToSafeDep
     const VkPipelineDepthStencilStateCreateInfo &cbs) {
     return std::make_unique<const vku::safe_VkPipelineDepthStencilStateCreateInfo>(&cbs);
 }
-std::unique_ptr<const vku::safe_VkRenderingAttachmentLocationInfo> ToSafeAttachmentLocationState(
-    const vku::safe_VkRenderingAttachmentLocationInfo &cbs) {
-    // This is needlessly copied here. Might better to make this a plain pointer, with an optional "backing unique_ptr"
-    return std::make_unique<const vku::safe_VkRenderingAttachmentLocationInfo>(cbs);
-}
-std::unique_ptr<const vku::safe_VkRenderingAttachmentLocationInfo> ToSafeAttachmentLocationState(
-    const VkRenderingAttachmentLocationInfo &cbs) {
-    return std::make_unique<const vku::safe_VkRenderingAttachmentLocationInfo>(&cbs);
-}
-std::unique_ptr<const vku::safe_VkRenderingInputAttachmentIndexInfo> ToSafeAttachmentIndexState(
-    const vku::safe_VkRenderingInputAttachmentIndexInfo &cbs) {
-    // This is needlessly copied here. Might better to make this a plain pointer, with an optional "backing unique_ptr"
-    return std::make_unique<const vku::safe_VkRenderingInputAttachmentIndexInfo>(cbs);
-}
-std::unique_ptr<const vku::safe_VkRenderingInputAttachmentIndexInfo> ToSafeAttachmentIndexState(
-    const VkRenderingInputAttachmentIndexInfo &cbs) {
-    return std::make_unique<const vku::safe_VkRenderingInputAttachmentIndexInfo>(&cbs);
-}
 std::unique_ptr<const vku::safe_VkPipelineShaderStageCreateInfo> ToShaderStageCI(
     const vku::safe_VkPipelineShaderStageCreateInfo &cbs) {
     // This is needlessly copied here. Might better to make this a plain pointer, with an optional "backing unique_ptr"

--- a/layers/state_tracker/pipeline_library_state.h
+++ b/layers/state_tracker/pipeline_library_state.h
@@ -142,14 +142,6 @@ std::unique_ptr<const vku::safe_VkPipelineDepthStencilStateCreateInfo> ToSafeDep
     const vku::safe_VkPipelineDepthStencilStateCreateInfo &cbs);
 std::unique_ptr<const vku::safe_VkPipelineDepthStencilStateCreateInfo> ToSafeDepthStencilState(
     const VkPipelineDepthStencilStateCreateInfo &cbs);
-std::unique_ptr<const vku::safe_VkRenderingAttachmentLocationInfo> ToSafeAttachmentLocationState(
-    const vku::safe_VkRenderingAttachmentLocationInfo &cbs);
-std::unique_ptr<const vku::safe_VkRenderingAttachmentLocationInfo> ToSafeAttachmentLocationState(
-    const VkRenderingAttachmentLocationInfo &cbs);
-std::unique_ptr<const vku::safe_VkRenderingInputAttachmentIndexInfo> ToSafeAttachmentIndexState(
-    const vku::safe_VkRenderingInputAttachmentIndexInfo &cbs);
-std::unique_ptr<const vku::safe_VkRenderingInputAttachmentIndexInfo> ToSafeAttachmentIndexState(
-    const VkRenderingInputAttachmentIndexInfo &cbs);
 std::unique_ptr<const vku::safe_VkPipelineShaderStageCreateInfo> ToShaderStageCI(
     const vku::safe_VkPipelineShaderStageCreateInfo &cbs);
 std::unique_ptr<const vku::safe_VkPipelineShaderStageCreateInfo> ToShaderStageCI(const VkPipelineShaderStageCreateInfo &cbs);
@@ -168,9 +160,6 @@ struct FragmentShaderState : public PipelineLibraryState {
         if (create_info.pDepthStencilState) {
             ds_state = ToSafeDepthStencilState(*create_info.pDepthStencilState);
         }
-        if (const auto attachment_info = vku::FindStructInPNextChain<VkRenderingInputAttachmentIndexInfo>(create_info.pNext)) {
-            attachement_index = ToSafeAttachmentIndexState(*attachment_info);
-        }
         FragmentShaderState::SetFragmentShaderInfo(pipeline_state, *this, dev_data, create_info, stateless_data);
     }
 
@@ -182,8 +171,6 @@ struct FragmentShaderState : public PipelineLibraryState {
     std::shared_ptr<const vvl::PipelineLayout> pipeline_layout;
     std::unique_ptr<const vku::safe_VkPipelineMultisampleStateCreateInfo> ms_state;
     std::unique_ptr<const vku::safe_VkPipelineDepthStencilStateCreateInfo> ds_state;
-    // VK_KHR_dynamic_rendering_local_read
-    std::unique_ptr<const vku::safe_VkRenderingInputAttachmentIndexInfo> attachement_index;
 
     std::shared_ptr<const vvl::ShaderModule> fragment_shader;
     std::unique_ptr<const vku::safe_VkPipelineShaderStageCreateInfo> fragment_shader_ci;
@@ -228,9 +215,6 @@ struct FragmentOutputState : public PipelineLibraryState {
             legacy_dithering_enabled = (flags2->flags & VK_PIPELINE_CREATE_2_ENABLE_LEGACY_DITHERING_BIT_EXT) != 0;
         }
 
-        if (const auto attachment_info = vku::FindStructInPNextChain<VkRenderingAttachmentLocationInfo>(create_info.pNext)) {
-            attachement_locations = ToSafeAttachmentLocationState(*attachment_info);
-        }
         // TODO
         // auto format_ci = vku::FindStructInPNextChain<VkPipelineRenderingFormatCreateInfoKHR>(gpci->pNext);
     }
@@ -240,8 +224,6 @@ struct FragmentOutputState : public PipelineLibraryState {
 
     std::unique_ptr<const vku::safe_VkPipelineColorBlendStateCreateInfo> color_blend_state;
     std::unique_ptr<const vku::safe_VkPipelineMultisampleStateCreateInfo> ms_state;
-    // VK_KHR_dynamic_rendering_local_read
-    std::unique_ptr<const vku::safe_VkRenderingAttachmentLocationInfo> attachement_locations;
 
     AttachmentStateVector attachment_states;
 


### PR DESCRIPTION
Recently added this, found didn't need to as there is a `parent` helper in the pipeline library we can grab the saved pNext struct from