### PR TITLE
sync: Track synchronized present accesses

### DIFF
--- a/layers/sync/sync_access_state.cpp
+++ b/layers/sync/sync_access_state.cpp
@@ -835,6 +835,11 @@ void ResourceAccessState::GatherReferencedTags(ResourceUsageTagSet &used) const 
     }
 }
 
+const WriteState &ResourceAccessState::LastWrite() const {
+    assert(last_write.has_value());
+    return *last_write;
+}
+
 void ResourceAccessState::UpdateStats(syncval_stats::AccessContextStats &stats) const {
 #if VVL_ENABLE_SYNCVAL_STATS != 0
     stats.read_states += (uint32_t)last_reads.size();

--- a/layers/sync/sync_commandbuffer.h
+++ b/layers/sync/sync_commandbuffer.h
@@ -39,10 +39,12 @@ class AlternateResourceUsage {
         using Record = std::unique_ptr<RecordBase>;
         virtual Record MakeRecord() const = 0;
         virtual vvl::Func GetCommand() const = 0;
+        virtual VkSwapchainKHR GetSwapchainHandle() const = 0;
         virtual ~RecordBase() {}
     };
 
     vvl::Func GetCommand() const { return record_->GetCommand(); }
+    VkSwapchainKHR GetSwapchainHandle() const { return record_->GetSwapchainHandle(); }
     AlternateResourceUsage() = default;
     AlternateResourceUsage(const RecordBase &record) : record_(record.MakeRecord()) {}
     AlternateResourceUsage(const AlternateResourceUsage &other) : record_() {

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -103,7 +103,7 @@ class SyncValidator : public vvl::DeviceProxy {
     bool ProcessUnresolvedBatch(UnresolvedBatch &unresolved_batch, SignalsUpdate &signals_update, BatchContextPtr &last_batch,
                                 bool &skip, const ErrorObject &error_obj) const;
 
-    void ApplyTaggedWait(QueueId queue_id, ResourceUsageTag tag);
+    void ApplyTaggedWait(QueueId queue_id, ResourceUsageTag tag, const LastSynchronizedPresent &last_synchronized_present);
     void ApplyAcquireWait(const AcquiredImage &acquired);
 
     std::vector<QueueBatchContext::Ptr> GetAllQueueBatchContexts();
@@ -116,6 +116,7 @@ class SyncValidator : public vvl::DeviceProxy {
     void UpdateSyncImageMemoryBindState(uint32_t count, const VkBindImageMemoryInfo *infos);
 
     std::shared_ptr<const QueueSyncState> GetQueueSyncStateShared(VkQueue queue) const;
+    std::shared_ptr<const QueueSyncState> GetQueueSyncStateShared(QueueId queue_id) const;
     QueueId GetQueueIdLimit() const { return queue_id_limit_; }
 
     std::vector<QueueBatchContext::ConstPtr> GetLastBatches(std::function<bool(const QueueBatchContext::ConstPtr &)> filter) const;
@@ -133,7 +134,8 @@ class SyncValidator : public vvl::DeviceProxy {
                                     const RecordObject &record_obj) override;
     void PreCallRecordDestroyImage(VkDevice device, VkImage image, const VkAllocationCallbacks *pAllocator,
                                    const RecordObject &record_obj) override;
-
+    void PreCallRecordDestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain, const VkAllocationCallbacks *pAllocator,
+                                          const RecordObject &record_obj) override;
     bool SuppressedBoundDescriptorWAW(const HazardResult &hazard) const;
 
     void FinishDeviceSetup(const VkDeviceCreateInfo *pCreateInfo, const Location &loc) override;

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -102,14 +102,16 @@ class VkRenderFramework : public VkTestFramework {
     // Functions to modify the VkRenderFramework surface & swapchain variables
     void InitSurface();
     void InitSwapchainInfo();
-    void InitSwapchain(VkImageUsageFlags imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
-                       VkSurfaceTransformFlagBitsKHR preTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR);
+    void InitSwapchain(VkImageUsageFlags image_usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     void DestroySwapchain();
+
     // Functions to create surfaces and swapchains that *aren't* member variables of VkRenderFramework
     VkResult CreateSurface(SurfaceContext &surface_context, vkt::Surface &surface, VkInstance custom_instance = VK_NULL_HANDLE);
     SurfaceInformation GetSwapchainInfo(const VkSurfaceKHR surface);
-    vkt::Swapchain CreateSwapchain(VkSurfaceKHR surface, VkImageUsageFlags imageUsage, VkSurfaceTransformFlagBitsKHR preTransform,
-                                   VkSwapchainKHR oldSwapchain = VK_NULL_HANDLE);
+    static VkSwapchainCreateInfoKHR GetDefaultSwapchainCreateInfo(VkSurfaceKHR surface, const SurfaceInformation &surface_info,
+                                                                  VkImageUsageFlags image_usage);
+    vkt::Swapchain CreateSwapchain(VkSurfaceKHR surface, VkImageUsageFlags image_usage, VkSurfaceTransformFlagBitsKHR pre_transform,
+                                   VkSwapchainKHR old_swapchain = VK_NULL_HANDLE);
 
     // Swapchain capabilities declaration to be used with RETURN_IF_SKIP
     void SupportMultiSwapchain();

--- a/tests/unit/sync_val_wsi_positive.cpp
+++ b/tests/unit/sync_val_wsi_positive.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "../framework/sync_val_tests.h"
+#include <vulkan/utility/vk_format_utils.h>
 #include <thread>
 
 struct PositiveSyncValWsi : public VkSyncValTest {};
@@ -423,5 +424,420 @@ TEST_F(PositiveSyncValWsi, RecreateImage) {
         m_default_queue->Present(m_swapchain, image_index, submit_semaphore);
         std::swap(acquire_fences[image_index], current_fence);
     }
+    m_default_queue->Wait();
+}
+
+TEST_F(PositiveSyncValWsi, ResyncWithSwapchain) {
+    // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10586
+    // Semaphore wait should not introduce unsynchronized swapchain accesses from internal
+    // queue access contexts if those acceses were properly synchronized.
+    TEST_DESCRIPTION("Try to introduce unsynchronized swapchain accesses after proper swapchain synchronization");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddSurfaceExtension();
+    AddRequiredFeature(vkt::Feature::synchronization2);
+
+    RETURN_IF_SKIP(InitSyncVal());
+    RETURN_IF_SKIP(InitSwapchain(VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT));
+
+    const auto swapchain_images = m_swapchain.GetImages();
+    if (swapchain_images.size() != 2) {
+        GTEST_SKIP() << "The test requires swapchain with 2 images";
+    }
+    for (auto image : swapchain_images) {
+        SetPresentImageLayout(image);
+    }
+    const VkImage swapchain_image0 = swapchain_images[0];
+
+    vkt::Semaphore acquire_semaphore0(*m_device);
+    vkt::Semaphore acquire_semaphore1(*m_device);
+    vkt::Semaphore acquire_semaphore2(*m_device);
+    vkt::Semaphore submit_semaphore0(*m_device);
+    vkt::Semaphore submit_semaphore1(*m_device);
+
+    // This semaphore is signaled when swapchain still uses image0
+    vkt::Semaphore semaphore(*m_device);
+
+    VkImageMemoryBarrier2 transition_swapchain_image0 = vku::InitStructHelper();
+    transition_swapchain_image0.dstStageMask = VK_PIPELINE_STAGE_2_COPY_BIT;
+    transition_swapchain_image0.dstAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
+    transition_swapchain_image0.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    transition_swapchain_image0.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+    transition_swapchain_image0.image = swapchain_image0;
+    transition_swapchain_image0.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+
+    const SurfaceInformation info = GetSwapchainInfo(m_surface.Handle());
+    const uint32_t width = info.surface_capabilities.minImageExtent.width;
+    const uint32_t height = info.surface_capabilities.minImageExtent.height;
+    const uint32_t format_size = vkuFormatTexelBlockSize(info.surface_formats[0].format);
+    vkt::Buffer buffer(*m_device, width * height * format_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
+
+    VkBufferImageCopy copy_region{};
+    copy_region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    copy_region.imageExtent = {width, height, 1};
+
+    // Frame 0
+    uint32_t image_index = m_swapchain.AcquireNextImage(acquire_semaphore0, kWaitTimeout);
+    if (image_index != 0) {
+        GTEST_SKIP() << "This test requires the first acquired image index is 0";
+    }
+    m_default_queue->Submit2(vkt::no_cmd, vkt::Wait(acquire_semaphore0), vkt::Signal(submit_semaphore0));
+    m_default_queue->Present(m_swapchain, image_index, submit_semaphore0);
+
+    // Signal semaphore when swapchain image0 can still be in use by the swapchain.
+    // If we immediately synchronize with this semaphore image0 can still be in use.
+    // If at first we synchronize with swapchain image0 and only then wait on this
+    // semaphore (maybe redundantly), then it changes nothing, image0 remains synchronized
+    // and it is safe to access it. This test recreates a regression scenario when binary
+    // semaphore wait imported unsynchronized swapchain accesses even though swapchain
+    // accesses were already synchronized.
+    m_default_queue->Submit2(vkt::no_cmd, vkt::Signal(semaphore));
+
+    // Frame 1
+    image_index = m_swapchain.AcquireNextImage(acquire_semaphore1, kWaitTimeout);
+    if (image_index != 1) {
+        m_default_queue->Wait();
+        GTEST_SKIP() << "This test requires the second acquired image index is 1";
+    }
+    m_default_queue->Submit2(vkt::no_cmd, vkt::Wait(acquire_semaphore1), vkt::Signal(submit_semaphore1));
+    m_default_queue->Present(m_swapchain, image_index, submit_semaphore1);
+
+    // Frame 2. Re-acquire image0 that was presented in Frame0
+    image_index = m_swapchain.AcquireNextImage(acquire_semaphore2, kWaitTimeout);
+    if (image_index != 0) {
+        m_default_queue->Wait();
+        GTEST_SKIP() << "This test requires the third acquired image index is 0";
+    }
+
+    // Explanation of what the following sequence does.
+    // Waiting on acquire_semaphore2 imports synchronized swapchain image0 accesses into queue context.
+    // The important point is that imported accesses are synchronized due to acquire semaphore wait
+    // In the next step we import image0 layout transition accesses from command buffer and this replaces
+    // synchronized swapchain accesses with image layout write accesses. Then Wait() synchronized all
+    // accesses on default queue. In our case this removes layout transition accesses from queue context
+    // (queue context gets empty).
+    m_command_buffer.Begin();
+    m_command_buffer.Barrier(transition_swapchain_image0);
+    m_command_buffer.End();
+    m_default_queue->Submit2(m_command_buffer, vkt::Wait(acquire_semaphore2));
+    // QueueWaitIdle filters synchronized swapchain accesses across queue contexts (including context associated with 'semaphore')
+    m_default_queue->Wait();
+
+    // The second sequence starts by importing accesses associated with semaphore wait (from queue context
+    // where this semaphore was signaled). Because this semaphore was signaled when swapchain image0
+    // accesses were not synchronized yet, there is a danger (with buggy implementation) that those
+    // unsynchronized accesses can be imported into queue context and they will hazard with subsequent copy
+    // operation. The goal of this test is to check that implementation correctly handles this.
+    // Please note, it is important the previous sequence clears queue context by doing Wait(). If queue context
+    // is not cleared and, for example, still contains layout transition accesses, then even in the case of
+    // regression the buggy unsynchronized accesses won't overwrite layout transition accesses (the latter have
+    // newer tags), so without Wait() the test won't be able to detect regression.
+    m_command_buffer.Begin();
+    vk::CmdCopyBufferToImage(m_command_buffer, buffer, swapchain_image0, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy_region);
+    m_command_buffer.End();
+    // Test semaphore wait does not import unsynchronized swapchain accesses
+    m_default_queue->Submit2(m_command_buffer, vkt::Wait(semaphore));
+
+    m_default_queue->Wait();
+}
+
+TEST_F(PositiveSyncValWsi, ResyncWithSwapchain2) {
+    // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10586
+    // This test is a variation of PositiveSyncValWsi.ResyncWithSwapchain that uses DeviceWaitIdle instead of QueueWaitIdle.
+    // Check comments in ResyncWithSwapchain for additional details.
+    TEST_DESCRIPTION("Try to introduce unsynchronized swapchain accesses after proper swapchain synchronization");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddSurfaceExtension();
+    AddRequiredFeature(vkt::Feature::synchronization2);
+
+    RETURN_IF_SKIP(InitSyncVal());
+    RETURN_IF_SKIP(InitSwapchain(VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT));
+
+    const auto swapchain_images = m_swapchain.GetImages();
+    if (swapchain_images.size() != 2) {
+        GTEST_SKIP() << "The test requires swapchain with 2 images";
+    }
+    for (auto image : swapchain_images) {
+        SetPresentImageLayout(image);
+    }
+    const VkImage swapchain_image0 = swapchain_images[0];
+
+    vkt::Semaphore acquire_semaphore0(*m_device);
+    vkt::Semaphore acquire_semaphore1(*m_device);
+    vkt::Semaphore acquire_semaphore2(*m_device);
+    vkt::Semaphore submit_semaphore0(*m_device);
+    vkt::Semaphore submit_semaphore1(*m_device);
+
+    // This semaphore is signaled when swapchain still uses image0
+    vkt::Semaphore semaphore(*m_device);
+
+    VkImageMemoryBarrier2 transition_swapchain_image0 = vku::InitStructHelper();
+    transition_swapchain_image0.dstStageMask = VK_PIPELINE_STAGE_2_COPY_BIT;
+    transition_swapchain_image0.dstAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
+    transition_swapchain_image0.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    transition_swapchain_image0.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+    transition_swapchain_image0.image = swapchain_image0;
+    transition_swapchain_image0.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+
+    const SurfaceInformation info = GetSwapchainInfo(m_surface.Handle());
+    const uint32_t width = info.surface_capabilities.minImageExtent.width;
+    const uint32_t height = info.surface_capabilities.minImageExtent.height;
+    const uint32_t format_size = vkuFormatTexelBlockSize(info.surface_formats[0].format);
+    vkt::Buffer buffer(*m_device, width * height * format_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
+
+    VkBufferImageCopy copy_region{};
+    copy_region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    copy_region.imageExtent = {width, height, 1};
+
+    // Frame 0
+    uint32_t image_index = m_swapchain.AcquireNextImage(acquire_semaphore0, kWaitTimeout);
+    if (image_index != 0) {
+        GTEST_SKIP() << "This test requires the first acquired image index is 0";
+    }
+    m_default_queue->Submit2(vkt::no_cmd, vkt::Wait(acquire_semaphore0), vkt::Signal(submit_semaphore0));
+    m_default_queue->Present(m_swapchain, image_index, submit_semaphore0);
+    m_default_queue->Submit2(vkt::no_cmd, vkt::Signal(semaphore));
+    // Frame 1
+    image_index = m_swapchain.AcquireNextImage(acquire_semaphore1, kWaitTimeout);
+    if (image_index != 1) {
+        m_default_queue->Wait();
+        GTEST_SKIP() << "This test requires the second acquired image index is 1";
+    }
+    m_default_queue->Submit2(vkt::no_cmd, vkt::Wait(acquire_semaphore1), vkt::Signal(submit_semaphore1));
+    m_default_queue->Present(m_swapchain, image_index, submit_semaphore1);
+    // Frame 2. Re-acquire image0 that was presented in Frame0
+    image_index = m_swapchain.AcquireNextImage(acquire_semaphore2, kWaitTimeout);
+    if (image_index != 0) {
+        m_default_queue->Wait();
+        GTEST_SKIP() << "This test requires the third acquired image index is 0";
+    }
+
+    m_command_buffer.Begin();
+    m_command_buffer.Barrier(transition_swapchain_image0);
+    m_command_buffer.End();
+    m_default_queue->Submit2(m_command_buffer, vkt::Wait(acquire_semaphore2));
+    // DeviceWaitIdle filters synchronized swapchain accesses across queue contexts
+    m_device->Wait();
+
+    m_command_buffer.Begin();
+    vk::CmdCopyBufferToImage(m_command_buffer, buffer, swapchain_image0, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy_region);
+    m_command_buffer.End();
+    // Test semaphore wait does not import unsynchronized swapchain accesses
+    m_default_queue->Submit2(m_command_buffer, vkt::Wait(semaphore));
+
+    m_default_queue->Wait();
+}
+
+TEST_F(PositiveSyncValWsi, ResyncWithSwapchain3) {
+    // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10586
+    // This test is a variation of PositiveSyncValWsi.ResyncWithSwapchain that uses timeline semaphore to sync queue.
+    // Check comments in ResyncWithSwapchain for additional details.
+    TEST_DESCRIPTION("Try to introduce unsynchronized swapchain accesses after proper swapchain synchronization");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddSurfaceExtension();
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    AddRequiredFeature(vkt::Feature::timelineSemaphore);
+
+    RETURN_IF_SKIP(InitSyncVal());
+    RETURN_IF_SKIP(InitSwapchain(VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT));
+
+    const auto swapchain_images = m_swapchain.GetImages();
+    if (swapchain_images.size() != 2) {
+        GTEST_SKIP() << "The test requires swapchain with 2 images";
+    }
+    for (auto image : swapchain_images) {
+        SetPresentImageLayout(image);
+    }
+    const VkImage swapchain_image0 = swapchain_images[0];
+
+    vkt::Semaphore acquire_semaphore0(*m_device);
+    vkt::Semaphore acquire_semaphore1(*m_device);
+    vkt::Semaphore acquire_semaphore2(*m_device);
+    vkt::Semaphore submit_semaphore0(*m_device);
+    vkt::Semaphore submit_semaphore1(*m_device);
+
+    vkt::Semaphore semaphore(*m_device);
+    vkt::Semaphore timeline(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
+
+    VkImageMemoryBarrier2 transition_swapchain_image0 = vku::InitStructHelper();
+    transition_swapchain_image0.dstStageMask = VK_PIPELINE_STAGE_2_COPY_BIT;
+    transition_swapchain_image0.dstAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
+    transition_swapchain_image0.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    transition_swapchain_image0.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+    transition_swapchain_image0.image = swapchain_image0;
+    transition_swapchain_image0.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+
+    const SurfaceInformation info = GetSwapchainInfo(m_surface.Handle());
+    const uint32_t width = info.surface_capabilities.minImageExtent.width;
+    const uint32_t height = info.surface_capabilities.minImageExtent.height;
+    const uint32_t format_size = vkuFormatTexelBlockSize(info.surface_formats[0].format);
+    vkt::Buffer buffer(*m_device, width * height * format_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
+
+    VkBufferImageCopy copy_region{};
+    copy_region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    copy_region.imageExtent = {width, height, 1};
+
+    // Frame 0
+    uint32_t image_index = m_swapchain.AcquireNextImage(acquire_semaphore0, kWaitTimeout);
+    if (image_index != 0) {
+        GTEST_SKIP() << "This test requires the first acquired image index is 0";
+    }
+    m_default_queue->Submit2(vkt::no_cmd, vkt::Wait(acquire_semaphore0), vkt::Signal(submit_semaphore0));
+    m_default_queue->Present(m_swapchain, image_index, submit_semaphore0);
+    m_default_queue->Submit2(vkt::no_cmd, vkt::Signal(semaphore));
+    // Frame 1
+    image_index = m_swapchain.AcquireNextImage(acquire_semaphore1, kWaitTimeout);
+    if (image_index != 1) {
+        m_default_queue->Wait();
+        GTEST_SKIP() << "This test requires the second acquired image index is 1";
+    }
+    m_default_queue->Submit2(vkt::no_cmd, vkt::Wait(acquire_semaphore1), vkt::Signal(submit_semaphore1));
+    m_default_queue->Present(m_swapchain, image_index, submit_semaphore1);
+    // Frame 2. Re-acquire image0 that was presented in Frame0
+    image_index = m_swapchain.AcquireNextImage(acquire_semaphore2, kWaitTimeout);
+    if (image_index != 0) {
+        m_default_queue->Wait();
+        GTEST_SKIP() << "This test requires the third acquired image index is 0";
+    }
+
+    m_command_buffer.Begin();
+    m_command_buffer.Barrier(transition_swapchain_image0);
+    m_command_buffer.End();
+    m_default_queue->Submit2(m_command_buffer, vkt::Wait(acquire_semaphore2), vkt::TimelineSignal(timeline, 1));
+    // WaitSemaphores filters synchronized swapchain accesses across queue contexts
+    timeline.Wait(1, kWaitTimeout);
+
+    m_command_buffer.Begin();
+    vk::CmdCopyBufferToImage(m_command_buffer, buffer, swapchain_image0, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy_region);
+    m_command_buffer.End();
+    // Test semaphore wait does not import unsynchronized swapchain accesses
+    m_default_queue->Submit2(m_command_buffer, vkt::Wait(semaphore));
+
+    m_default_queue->Wait();
+}
+
+TEST_F(PositiveSyncValWsi, ResyncWithSwapchain4) {
+    // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10586
+    // This test is a variation of PositiveSyncValWsi.ResyncWithSwapchain.
+    // This scenario synchronizes with 2 swapchain images.
+    // We need a swapchain with 3 images in order to acquire 2 images without blocking.
+    TEST_DESCRIPTION("Try to introduce unsynchronized swapchain accesses after proper swapchain synchronization");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddSurfaceExtension();
+    AddRequiredFeature(vkt::Feature::synchronization2);
+
+    RETURN_IF_SKIP(InitSyncVal());
+    RETURN_IF_SKIP(InitSurface());
+
+    const SurfaceInformation surface_info = GetSwapchainInfo(m_surface.Handle());
+    if (surface_info.surface_capabilities.minImageCount > 3 || surface_info.surface_capabilities.maxImageCount < 3) {
+        GTEST_SKIP() << "Surface must support swapchains with 3 images";
+    }
+
+    VkSwapchainCreateInfoKHR swapchain_ci = GetDefaultSwapchainCreateInfo(
+        m_surface.Handle(), surface_info, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    swapchain_ci.minImageCount = 3;
+    vkt::Swapchain swapchain(*m_device, swapchain_ci);
+
+    const auto swapchain_images = swapchain.GetImages();
+    if (swapchain_images.size() != 3) {
+        GTEST_SKIP() << "The test requires swapchain with 3 images";
+    }
+    for (auto image : swapchain_images) {
+        SetPresentImageLayout(image);
+    }
+    const VkImage swapchain_image0 = swapchain_images[0];
+
+    vkt::Semaphore acquire_semaphore0(*m_device);
+    vkt::Semaphore acquire_semaphore1(*m_device);
+    vkt::Semaphore acquire_semaphore2(*m_device);
+    vkt::Semaphore acquire_semaphore3(*m_device);
+    vkt::Semaphore acquire_semaphore4(*m_device);
+    vkt::Semaphore submit_semaphore0(*m_device);
+    vkt::Semaphore submit_semaphore1(*m_device);
+    vkt::Semaphore submit_semaphore2(*m_device);
+
+    // This semaphore is signaled when swapchain still uses image0
+    vkt::Semaphore semaphore(*m_device);
+
+    VkImageMemoryBarrier2 transition_swapchain_image = vku::InitStructHelper();
+    transition_swapchain_image.dstStageMask = VK_PIPELINE_STAGE_2_COPY_BIT;
+    transition_swapchain_image.dstAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
+    transition_swapchain_image.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    transition_swapchain_image.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+    transition_swapchain_image.image = swapchain_image0;
+    transition_swapchain_image.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+
+    const uint32_t width = surface_info.surface_capabilities.minImageExtent.width;
+    const uint32_t height = surface_info.surface_capabilities.minImageExtent.height;
+    const uint32_t format_size = vkuFormatTexelBlockSize(surface_info.surface_formats[0].format);
+    vkt::Buffer buffer(*m_device, width * height * format_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
+
+    VkBufferImageCopy copy_region{};
+    copy_region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    copy_region.imageExtent = {width, height, 1};
+
+    // Frame 0
+    uint32_t image_index = swapchain.AcquireNextImage(acquire_semaphore0, kWaitTimeout);
+    if (image_index != 0) {
+        GTEST_SKIP() << "This test requires the first acquired image index is 0";
+    }
+    m_default_queue->Submit2(vkt::no_cmd, vkt::Wait(acquire_semaphore0), vkt::Signal(submit_semaphore0));
+    m_default_queue->Present(swapchain, image_index, submit_semaphore0);
+    m_default_queue->Submit2(vkt::no_cmd, vkt::Signal(semaphore));
+
+    // Frame 1
+    image_index = swapchain.AcquireNextImage(acquire_semaphore1, kWaitTimeout);
+    if (image_index != 1) {
+        m_default_queue->Wait();
+        GTEST_SKIP() << "This test requires the second acquired image index is 1";
+    }
+    m_default_queue->Submit2(vkt::no_cmd, vkt::Wait(acquire_semaphore1), vkt::Signal(submit_semaphore1));
+    m_default_queue->Present(swapchain, image_index, submit_semaphore1);
+
+    // Frame 2
+    image_index = swapchain.AcquireNextImage(acquire_semaphore2, kWaitTimeout);
+    if (image_index != 2) {
+        m_default_queue->Wait();
+        GTEST_SKIP() << "This test requires the third acquired image index is 2";
+    }
+    m_default_queue->Submit2(vkt::no_cmd, vkt::Wait(acquire_semaphore2), vkt::Signal(submit_semaphore2));
+    m_default_queue->Present(swapchain, image_index, submit_semaphore2);
+
+    // Frame 3. Re-acquire image0 that was presented in Frame0.
+    // Also re-acquire image1 that was presented in Frame1.
+    image_index = swapchain.AcquireNextImage(acquire_semaphore3, kWaitTimeout);
+    if (image_index != 0) {
+        m_default_queue->Wait();
+        GTEST_SKIP() << "This test requires the fourth acquired image index is 0";
+    }
+
+    uint32_t image_index2 = swapchain.AcquireNextImage(acquire_semaphore4, kWaitTimeout);
+    if (image_index2 != 1) {
+        m_default_queue->Wait();
+        GTEST_SKIP() << "This test requires the fifth acquired image index is 1";
+    }
+
+    m_command_buffer.Begin();
+    m_command_buffer.Barrier(transition_swapchain_image);
+    m_command_buffer.End();
+    // Import accesses from two swapchain images before applying command buffer accesses
+    // (layout transition of the first image). Test that implementation properly tracks
+    // multiple synchronized swapchain accesses (image0 and image1) accross all queue contexts
+    // where these accesses are registered.
+    m_default_queue->Submit2(vkt::no_cmd, vkt::Wait(acquire_semaphore3));
+    m_default_queue->Submit2(m_command_buffer, vkt::Wait(acquire_semaphore4));
+    // QueueWaitIdle filters synchronized swapchain accesses across queue contexts
+    m_default_queue->Wait();
+
+    m_command_buffer.Begin();
+    vk::CmdCopyBufferToImage(m_command_buffer, buffer, swapchain_image0, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy_region);
+    m_command_buffer.End();
+    // Without proper tracking of multiple synchronized accesses the buggy implementation might remember only
+    // the last one (image1 accesses synced by acquire_semaphore4) and can forget about image0 accesses synced
+    // by acquire_semaphore3. By waiting on 'semaphore' that was signaled after image0 presentation we test
+    // that imlementation remembers that image0 accesses were already synced and does not import them as
+    // unsynchronized accesses (in that case they will hazard with command buffer copy operation).
+    m_default_queue->Submit2(m_command_buffer, vkt::Wait(semaphore));
+
     m_default_queue->Wait();
 }


### PR DESCRIPTION
This fixes the problem that import of accesses from another batch context can introduce unsynchronized present accesses, even  though such accesses were arlready properly synchronized. This resuls in false positives.

The origin of this issue is that waiting on the queue does not synchronize presentation operations submitted on this queue, because presentation accesses are related to the presentation engine, so in general such accesses are not removed by various Wait() apis - that's correct behavior.

Still, if the swapchain access is synchronized via other means (e.g. waiting on acquire semaphore) then all contexts where this access is still marked as unsynchronized should take this into account, otherwise such unsynchronized accesses can leak out and introduce false positives. That what was happening in the scenario from the issue. The tests recreate a variety of such scenarios.

Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10586

We have few other older issues that might or might not be related to this one. I'll check later if this fix helps there.