### PR TITLE
gpuav: Lock instrumentation to single thread

### DIFF
--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
@@ -990,6 +990,8 @@ bool GpuShaderInstrumentor::PreCallRecordPipelineCreationShaderInstrumentation(
         const auto &stage_state = pipeline_state.stage_states[stage_state_i];
         auto modified_module_state = std::const_pointer_cast<vvl::ShaderModule>(stage_state.module_state);
         ASSERT_AND_CONTINUE(modified_module_state);
+        std::unique_lock<std::mutex> module_lock(modified_module_state->module_mutex_);
+
         auto &instrumentation_metadata = shader_instrumentation_metadata[stage_state_i];
 
         // Check pNext for inlined SPIR-V
@@ -1137,6 +1139,8 @@ bool GpuShaderInstrumentor::PreCallRecordPipelineCreationShaderInstrumentationGP
             const ShaderStageState &modified_stage_state = modified_lib->stage_states[stage_state_i];
             auto modified_module_state = std::const_pointer_cast<vvl::ShaderModule>(modified_stage_state.module_state);
             ASSERT_AND_CONTINUE(modified_module_state);
+            std::unique_lock<std::mutex> module_lock(modified_module_state->module_mutex_);
+
             chassis::ShaderInstrumentationMetadata &instrumentation_metadata = shader_instrumentation_metadata[shader_i++];
 
             // Check pNext for inlined SPIR-V

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -818,5 +818,9 @@ struct ShaderModule : public StateObject {
     // TODO - This (and vvl::ShaderObject) could be unique, but need handle multiple ValidationObjects
     // https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/6265/files
     std::shared_ptr<spirv::Module> spirv;
+
+    // Used by GPU-AV to make sure instrumentation only occurs in a single thread at a time
+    // (Currently we don't need seem to need this for ShaderObjects)
+    std::mutex module_mutex_;
 };
 }  // namespace vvl


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10675 - if two shader modules were referenced by two PSOs at the same time and being instrumented it could cause a crash with fine-grained locking enabled. Fix by carrying a mutex in the shader module and locking it when modifying.

Just @danginsburg fix (https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/10684) but with added comment and fixed commit message to make CI happy