### PR TITLE
Version check vulkan headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,9 @@
 # ~~~
 cmake_minimum_required(VERSION 3.22.1)
 
+# The VERSION field is generated with the "--generated-version" flag in the generate_source.py script
+#
+# If working with unreleased extensions, make sure the header and validation version are all on the same header version
 project(VVL VERSION 1.4.326 LANGUAGES CXX)
 
 # This variable enables downstream users to customize the target API
@@ -107,7 +110,6 @@ if (VVL_ENABLE_TRACY)
         )
     endif()
 endif()
-
 
 find_package(VulkanHeaders ${CMAKE_PROJECT_VERSION} CONFIG QUIET)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@
 # ~~~
 cmake_minimum_required(VERSION 3.22.1)
 
-project(VVL LANGUAGES CXX)
+project(VVL VERSION 1.4.326 LANGUAGES CXX)
 
 # This variable enables downstream users to customize the target API
 # variant (e.g. Vulkan SC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ if (VVL_ENABLE_TRACY)
 endif()
 
 
-find_package(VulkanHeaders CONFIG QUIET)
+find_package(VulkanHeaders ${CMAKE_PROJECT_VERSION} CONFIG QUIET)
 
 find_package(VulkanUtilityLibraries CONFIG QUIET)
 

--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -548,6 +548,15 @@ def main(argv):
                 print('update', repo_filename)
                 shutil.copyfile(temp_filename, repo_filename)
 
+    # write out the header version used to generate the code to a checked in CMake file
+    if args.generated_version:
+        # Update the CMake project version
+        with open(repo_relative('CMakeLists.txt'), "r+") as f:
+            data = f.read()
+            f.seek(0)
+            f.write(re.sub("project.*VERSION.*", f"project(VVL VERSION {args.generated_version} LANGUAGES CXX)", data))
+            f.truncate()
+
     return 0
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR does two things: Codegen the 'current generated version' into CMake's `project()` field, and use that version to specify the 'minimum VulkanHeader's version required' in `find_package`. This turns the cryptic compile errors from compiling with too-old Vulkan-Headers into a clear build failure with a specific error message.

Example error message
```
CMake Error at CMakeLists.txt:55 (find_package):
  Could not find a configuration file for package "VulkanHeaders" that is
  compatible with requested version "1.4.326".
  
  The following configuration files were considered but not accepted:
  /home/cdgiessen/lunarg/Vulkan-Loader/external/Debug/64/Vulkan-Headers/build/install/share/cmake/VulkanHeaders/VulkanHeadersConfig.cmake, version: 1.4.325
```