### PR TITLE
sync: Report VkRenderPasss in render pass messages

### DIFF
--- a/layers/sync/sync_error_messages.cpp
+++ b/layers/sync/sync_error_messages.cpp
@@ -21,6 +21,7 @@
 #include "error_message/error_strings.h"
 #include "state_tracker/descriptor_sets.h"
 #include "state_tracker/pipeline_state.h"
+#include "state_tracker/render_pass_state.h"
 
 #include <cassert>
 #include <sstream>
@@ -359,7 +360,9 @@ std::string ErrorMessages::RenderPassLayoutTransitionVsStoreOrResolveError(const
     AdditionalMessageInfo additional_info;
     additional_info.properties.Add(kPropertyOldLayout, old_layout_str);
     additional_info.properties.Add(kPropertyNewLayout, new_layout_str);
-    additional_info.access_action = "performs image layout transition";
+    additional_info.access_action =
+        "performs image layout transition during " +
+        validator_.FormatHandle(cb_context.GetCurrentRenderPassContext()->GetRenderPassState()->Handle());
     additional_info.brief_description_end_text = "during store/resolve operation in subpass ";
     additional_info.brief_description_end_text += std::to_string(store_resolve_subpass);
 
@@ -377,7 +380,9 @@ std::string ErrorMessages::RenderPassFinalLayoutTransitionError(const HazardResu
     AdditionalMessageInfo additional_info;
     additional_info.properties.Add(kPropertyOldLayout, old_layout_str);
     additional_info.properties.Add(kPropertyNewLayout, new_layout_str);
-    additional_info.access_action = "performs final image layout transition";
+    additional_info.access_action =
+        "performs final image layout transition during " +
+        validator_.FormatHandle(cb_context.GetCurrentRenderPassContext()->GetRenderPassState()->Handle());
     return Error(hazard, cb_context, command, resource_description, "RenderPassFinalLayoutTransitionError", additional_info);
 }
 
@@ -393,7 +398,9 @@ std::string ErrorMessages::RenderPassFinalLayoutTransitionVsStoreOrResolveError(
     AdditionalMessageInfo additional_info;
     additional_info.properties.Add(kPropertyOldLayout, old_layout_str);
     additional_info.properties.Add(kPropertyNewLayout, new_layout_str);
-    additional_info.access_action = "performs final image layout transition";
+    additional_info.access_action =
+        "performs final image layout transition during " +
+        validator_.FormatHandle(cb_context.GetCurrentRenderPassContext()->GetRenderPassState()->Handle());
     additional_info.brief_description_end_text = "during store/resolve operation in subpass ";
     additional_info.brief_description_end_text += std::to_string(store_resolve_subpass);
 


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10654

Message example:

> vkCmdBeginRenderPass(): WRITE_AFTER_WRITE hazard detected: attachment loadOp access is not synchronized with the attachment layout transition. vkCmdBeginRenderPass clears the color aspect of attachment 0 (VkImageView 0xe000000000e) in subpass 0 of **VkRenderPass 0x100000000010** (loadOp VK_ATTACHMENT_LOAD_OP_CLEAR), which was previously written during an image layout transition initiated by the same command. 
The current synchronization allows VK_ACCESS_2_INPUT_ATTACHMENT_READ_BIT|VK_ACCESS_2_SHADER_READ_BIT accesses at VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT, but to prevent this hazard, it must allow VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT accesses at VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT.

