### PR TITLE
sync: Introduce BarrierScope

### DIFF
--- a/layers/sync/sync_access_context.cpp
+++ b/layers/sync/sync_access_context.cpp
@@ -536,7 +536,7 @@ HazardResult AccessContext::DetectImageBarrierHazard(const vvl::Image &image, Vk
 }
 
 ResourceAccessRangeMap::iterator AccessContext::UpdateMemoryAccessStateFunctor::Infill(ResourceAccessRangeMap *accesses,
-                                                                                       const Iterator &pos,
+                                                                                       const Iterator &pos_hint,
                                                                                        const ResourceAccessRange &range) const {
     // this is only called on gaps, and never returns a gap.
     ResourceAccessState default_state;

--- a/layers/sync/sync_op.h
+++ b/layers/sync/sync_op.h
@@ -332,12 +332,12 @@ class SyncOpEndRenderPass : public SyncOpBase {
 // Batch barrier ops don't modify in place, and thus don't need to hold pending state, and also are *never* layout transitions.
 struct BatchBarrierOp {
     SyncBarrier barrier;
-    ResourceAccessState::QueueScopeOps scope;
+    BarrierScope barrier_scope;
 
-    BatchBarrierOp(QueueId queue_id, const SyncBarrier &barrier) : barrier(barrier), scope(queue_id) {}
+    BatchBarrierOp(QueueId queue_id, const SyncBarrier &barrier) : barrier(barrier), barrier_scope(barrier, queue_id) {}
 
     void operator()(ResourceAccessState *access_state) const {
-        access_state->ApplyBarrier(scope, barrier, false);
+        access_state->ApplyBarrier(barrier_scope, barrier, false);
         access_state->ApplyPendingBarriers(kInvalidTag);  // There can't be any need for this tag
     }
 };


### PR DESCRIPTION
This unifies handling of barrier scopes - `UntaggedScopeOps`, `QueueScopeOps` and `EventScopeOps` are gone.

`ApplyBarrier()` was untemplated and is a regular function now. Templated type is replaced with `BarrierScope` parameter.

Improved naming of various `InScop`e methods, since the previous versions were not consistent in what they describe.
