### PR TITLE
sync: Use PendingBarriers for events

### DIFF
--- a/layers/sync/sync_access_context.h
+++ b/layers/sync/sync_access_context.h
@@ -124,16 +124,16 @@ struct ApplyMarkupFunctor {
 // This functor populates PendingBarriers with the results of independent barrier appication (pending barriers).
 // After this functor finished its work then PendingBarriers::Apply() can be used to update the access states.
 struct CollectBarriersFunctor {
-    CollectBarriersFunctor(QueueId queue_id, const SyncBarrier &barrier, bool layout_transition,
+    CollectBarriersFunctor(const BarrierScope &barrier_scope, const SyncBarrier &barrier, bool layout_transition,
                            uint32_t layout_transition_handle_index, PendingBarriers &pending_barriers)
-        : barrier_scope(barrier, queue_id),
+        : barrier_scope(barrier_scope),
           barrier(barrier),
           layout_transition(layout_transition),
           layout_transition_handle_index(layout_transition_handle_index),
           pending_barriers(pending_barriers) {
         // Suppress layout transition during submit time application.
         // It add write access but this is necessary only during recording.
-        if (queue_id != kQueueIdInvalid) {
+        if (barrier_scope.scope_queue != kQueueIdInvalid) {
             this->layout_transition = false;
             this->layout_transition_handle_index = vvl::kNoIndex32;
         }

--- a/layers/sync/sync_renderpass.cpp
+++ b/layers/sync/sync_renderpass.cpp
@@ -910,7 +910,8 @@ void RenderPassAccessContext::RecordEndRenderPass(AccessContext *external_contex
             ImageRangeGen range_gen(*ref_range_gen);
             PendingBarriers pending_barriers;
             for (const auto &barrier : last_trackback.barriers) {
-                CollectBarriersFunctor collect_barriers(kQueueIdInvalid, barrier, true, vvl::kNoIndex32, pending_barriers);
+                const BarrierScope barrier_scope(barrier);
+                CollectBarriersFunctor collect_barriers(barrier_scope, barrier, true, vvl::kNoIndex32, pending_barriers);
                 external_context->UpdateMemoryAccessState(collect_barriers, range_gen);
             }
             pending_barriers.Apply(barrier_tag);


### PR DESCRIPTION
This uses `PendingBarriers` object to collect pending barriers for events.
This is a follow up to https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/10639 which did the same for pipeline barriers. The remaining part is to update render pass and layout transition code.