### PR TITLE
sync: Untemplate and cleanup SubpassBarrierTrackback

### DIFF
--- a/layers/sync/sync_access_context.cpp
+++ b/layers/sync/sync_access_context.cpp
@@ -109,7 +109,7 @@ AccessContext::AccessContext(uint32_t subpass, VkQueueFlags queue_flags,
         src_external_ = &prev_.back();
     }
     if (subpass_dep.barrier_to_external.size()) {
-        dst_external_ = TrackBack(this, queue_flags, subpass_dep.barrier_to_external);
+        dst_external_ = SubpassBarrierTrackback(this, queue_flags, subpass_dep.barrier_to_external);
     }
 }
 
@@ -281,7 +281,8 @@ void AccessContext::ImportAsyncContexts(const AccessContext &from) {
 }
 
 // Suitable only for *subpass* access contexts
-HazardResult AccessContext::DetectSubpassTransitionHazard(const TrackBack &track_back, const AttachmentViewGen &attach_view) const {
+HazardResult AccessContext::DetectSubpassTransitionHazard(const SubpassBarrierTrackback &track_back,
+                                                          const AttachmentViewGen &attach_view) const {
     if (!attach_view.IsValid()) return HazardResult();
 
     // We should never ask for a transition from a context we don't have

--- a/layers/sync/sync_renderpass.cpp
+++ b/layers/sync/sync_renderpass.cpp
@@ -150,7 +150,7 @@ bool RenderPassAccessContext::ValidateLayoutTransitions(const CommandBufferAcces
     // Note: we could be more efficient by tracking whether or not we actually *have* any changes (e.g. attachment resolve)
     // to apply and only copy then, if this proves a hot spot.
     std::unique_ptr<AccessContext> proxy_for_prev;
-    AccessContext::TrackBack proxy_track_back;
+    SubpassBarrierTrackback proxy_track_back;
 
     const auto &transitions = rp_state.subpass_transitions[subpass];
     for (const auto &transition : transitions) {


### PR DESCRIPTION
Also use `SubpassBarrierTrackback` name directly instead of `TrackBack` alias which sounds a bit cryptic