### PR TITLE
layers: Add IsRasterizationDisabled check to FS Output

### DIFF
--- a/layers/core_checks/cc_shader_interface.cpp
+++ b/layers/core_checks/cc_shader_interface.cpp
@@ -570,7 +570,9 @@ bool CoreChecks::ValidateDrawDynamicRenderingFsOutputs(const LastBound &last_bou
     if (global_settings.only_report_errors) {
         return skip;
     }
-
+    if (last_bound_state.IsRasterizationDisabled()) {
+        return skip;
+    }
     const spirv::EntryPoint *entrypoint = last_bound_state.GetFragmentEntryPoint();
     if (!entrypoint) {
         return skip;


### PR DESCRIPTION
Was noticed that the RenderPass version checks, but we didn't for dynamic rendering