### PR TITLE
sync: Update remaining places to use PendingBarriers

### DIFF
--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -412,8 +412,7 @@ struct ApplyGlobalBarrierFunctor {
 
     void operator()(const Iterator &pos) const {
         ResourceAccessState &access_state = pos->second;
-        access_state.ApplyBarrier(barrier_scope, barrier, false);
-        access_state.ApplyPendingBarriers(kInvalidTag);
+        access_state.ApplyBarrier(barrier_scope, barrier);
     }
 
     const BarrierScope barrier_scope;

--- a/layers/sync/sync_op.h
+++ b/layers/sync/sync_op.h
@@ -337,8 +337,7 @@ struct BatchBarrierOp {
     BatchBarrierOp(QueueId queue_id, const SyncBarrier &barrier) : barrier(barrier), barrier_scope(barrier, queue_id) {}
 
     void operator()(ResourceAccessState *access_state) const {
-        access_state->ApplyBarrier(barrier_scope, barrier, false);
-        access_state->ApplyPendingBarriers(kInvalidTag);  // There can't be any need for this tag
+        access_state->ApplyBarrier(barrier_scope, barrier);
     }
 };
 

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -206,7 +206,7 @@ class ApplyAcquireNextSemaphoreAction {
         // Note that the present operations may or may not be present, given that the fence wait may have cleared them out.
         // Also, if a subsequent present has happened, we *don't* want to protect that...
         if (access->LastWriteTag() <= acq_tag_) {
-            access->ApplyBarriersImmediate(barrier_);
+            access->ApplyBarrier(BarrierScope(barrier_), barrier_);
         }
     }
 


### PR DESCRIPTION
Additionally `ApplyBarrier()` name changed its meaning. Now it does what the name suggets - applies the barrier to access state. Previously `ApplyBarrier` was about pending barriers, but now when dealing with pending barriers there is always `Pending` in the name.

This PR finishes (I guess) updating functionality to use new `PendingBarriers` object instead of `pending` variables that live inside access state objects. These variable increase size of access objects even though they are used during short period of barrier function call. Also becase access state objects are very central any additional member adds conginitve load. These `pending` variables is not used anymore but there are not removed yet. They will be removed in a separate PR.
