### PR TITLE
sync: Remove pending state from access objects

### DIFF
--- a/layers/sync/sync_access_context.h
+++ b/layers/sync/sync_access_context.h
@@ -174,7 +174,6 @@ struct ApplyTrackbackStackAction {
         : barriers(barriers_), previous_barrier(previous_barrier_) {}
     void operator()(ResourceAccessState *access) const {
         assert(access);
-        assert(!access->HasPendingState());
         ApplyBarriers(*access, barriers);
         if (previous_barrier) {
             assert(bool(*previous_barrier));
@@ -379,7 +378,8 @@ class AccessContext {
     };
 
     // Follow the context previous to access the access state, supporting "lazy" import into the context. Not intended for
-    // subpass layout transition, as the pending state handling is more complex
+    // subpass layout transition, as the pending state handling is more complex (TODO: check if previous statement is
+    // still true after pending barriers rework).
     // TODO: See if returning the lower_bound would be useful from a performance POV -- look at the lower_bound overhead
     // Would need to add a "hint" overload to parallel_iterator::invalidate_[AB] call, if so.
     void ResolvePreviousAccess(const ResourceAccessRange &range, ResourceAccessRangeMap *descent_map,


### PR DESCRIPTION
Pending state that lives inside access objects is not used anymore after the previous PRs. The pending barriers logic was rewritten to use local PendingBarriers objects instead.

Reduced size of access objects:
ReadState: 56 bytes - > 48 bytes (this will be 32 bytes soon)
WriteState: 128 bytes -> 64 bytes (nice, 2x smaller)
ResourceAccessState: 520 bytes -> 432 bytes (minus 88 bytes, still large)

In summary ~10-15% less memory used by syncval as reported by mimalloc. The reworked barrier code is much simpler to start with and to modify.