### PR TITLE
sync: Reduce ReadStates initial capacity from 3 to 2

### DIFF
--- a/layers/sync/sync_access_state.h
+++ b/layers/sync/sync_access_state.h
@@ -521,7 +521,15 @@ class ResourceAccessState {
 
     VkPipelineStageFlags2 last_read_stages;
     VkPipelineStageFlags2 read_execution_barriers;
-    using ReadStates = small_vector<ReadState, 3, uint32_t>;
+
+    // NOTE: default capacity is set to 2. A single read is the most common case.
+    // Two reads occur sometimes and more than two is rare in practice.
+    // Syncval performance is sensitive to memory usage (there are many access objects).
+    // The early tests show that capacity of 1 can further improve performance and in some
+    // apps reduced memory bandwidth outweight the cost of additional allocations.
+    // More testing is needed.
+    using ReadStates = small_vector<ReadState, 2, uint32_t>;
+
     ReadStates last_reads;
 
     // TODO Input Attachment cleanup for multiple reads in a given stage


### PR DESCRIPTION
Reduces default capacity of `ResourceAccessState::ReadStates` small_vector from 3 to 2.

In most cases apps use 1 read access per access object.
Sometimes 2 read accesses are allocated (happens in doom capture in around 5-10% of cases). 
More than 2 is posible but in practice less common (I did not see in the captures/games that I test).

Also tested with capacity 1. Memory wise it's obviously better than 2 (most apps need 1 element). But even for the apps that need 2 read accesses and need to allocate (doom capture), this still adds 2-3% speed up due ot reduced memory traffic. Still decided to go with 2 for now and test it for some time.

`ResourceAccessState` size reduction: 432 bytes -> 384 bytres.
Small performance increase ~2%. Yesterdays removal of pending barrier state also gave around 3% speedup.
