### PR TITLE
tests: Build framework as library

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,54 +15,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ~~~
+
+add_subdirectory(framework)
+
 if (ANDROID)
     add_library(vk_layer_validation_tests MODULE)
 else()
     add_executable(vk_layer_validation_tests)
 endif()
 target_sources(vk_layer_validation_tests PRIVATE
-    framework/android_hardware_buffer.h
-    framework/layer_validation_tests.h
-    framework/layer_validation_tests.cpp
-    framework/pipeline_helper.h
-    framework/pipeline_helper.cpp
-    framework/shader_helper.h
-    framework/shader_helper.cpp
-    framework/shader_object_helper.h
-    framework/shader_object_helper.cpp
-    framework/test_common.h
-    framework/shader_templates.h
-    framework/error_monitor.cpp
-    framework/error_monitor.h
-    framework/video_objects.h
-    framework/render.cpp
-    framework/render.h
-    framework/binding.h
-    framework/binding.cpp
-    framework/buffer_helper.h
-    framework/test_framework.cpp
-    framework/ray_tracing_objects.h
-    framework/ray_tracing_objects.cpp
-    framework/data_graph_objects.h
-    framework/data_graph_objects.cpp
-    framework/ray_tracing_helper_nv.h
-    framework/ray_tracing_helper_nv.cpp
-    framework/external_memory_sync.h
-    framework/external_memory_sync.cpp
-    framework/sync_helper.h
-    framework/sync_helper.cpp
-    framework/sync_val_tests.h
-    framework/descriptor_helper.h
-    framework/descriptor_helper.cpp
-    framework/thread_helper.h
-    framework/thread_helper.cpp
-    framework/gpu_av_helper.h
-    framework/render_pass_helper.h
-    framework/render_pass_helper.cpp
-    framework/feature_requirements.h
-    framework/feature_requirements.cpp
-    framework/queue_submit_context.h
-    framework/queue_submit_context.cpp
     unit/amd_best_practices.cpp
     unit/android_hardware_buffer.cpp
     unit/android_hardware_buffer_positive.cpp
@@ -295,49 +256,8 @@ target_sources(vk_layer_validation_tests PRIVATE
     vvl_utils/small_vector.cpp
     vvl_utils/pnext_chain_extraction.cpp
 )
-if (APPLE)
-    target_sources(vk_layer_validation_tests PRIVATE
-        framework/apple_wsi.h
-        framework/apple_wsi.mm
-    )
-    # QuartzCore framework is needed for minimal Metal interaction
-    target_link_libraries(vk_layer_validation_tests PRIVATE "-framework QuartzCore")
-endif()
 
-get_target_property(TEST_SOURCES vk_layer_validation_tests SOURCES)
-source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}" FILES ${TEST_SOURCES})
-
-add_dependencies(vk_layer_validation_tests vvl)
-
-target_compile_options(vk_layer_validation_tests PRIVATE "$<IF:$<CXX_COMPILER_ID:MSVC>,/wd4100,-Wno-unused-parameter>")
-
-if(${CMAKE_CXX_COMPILER_ID} MATCHES "(GNU|Clang)")
-    target_compile_options(vk_layer_validation_tests PRIVATE
-        -Wno-sign-compare
-        -Wno-shorten-64-to-32
-        -Wno-missing-field-initializers
-    )
-    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        target_compile_options(vk_layer_validation_tests PRIVATE
-            -Wno-sign-conversion
-            -Wno-implicit-int-conversion
-        )
-    endif()
-elseif(MSVC)
-    target_compile_options(vk_layer_validation_tests PRIVATE
-        /wd4389 # signed/unsigned mismatch
-        /wd4267 # Disable some signed/unsigned mismatch warnings.
-    )
-
-    if (CMAKE_SIZEOF_VOID_P EQUAL 4)
-        # Due to IHV driver issues, we need the extra 2GB of virtual address space for 32 bit testing
-        target_link_options(vk_layer_validation_tests PRIVATE /LARGEADDRESSAWARE)
-    endif()
-endif()
-
-find_package(GTest CONFIG)
-find_package(glslang CONFIG)
-find_package(SPIRV-Tools CONFIG)
+# TODO - This slang stuff is a mess and currently need in both spots
 
 # Slang
 # ---
@@ -426,9 +346,6 @@ if(DEFINED SLANG_INSTALL_DIR)
             endif()
         endforeach()
     endif()
-
-    # Create an imported target for easier usage
-    add_library(slang SHARED IMPORTED GLOBAL)
 
     set_target_properties(slang PROPERTIES
         INTERFACE_INCLUDE_DIRECTORIES ${SLANG_INCLUDE_DIR}
@@ -529,29 +446,13 @@ else()
     set(USE_SLANG FALSE)
 endif()
 
+get_target_property(TEST_SOURCES vk_layer_validation_tests SOURCES)
+source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}" FILES ${TEST_SOURCES})
+
+add_dependencies(vk_layer_validation_tests vvl)
+
 target_link_libraries(vk_layer_validation_tests PRIVATE
-    VkLayer_utils
-    $<$<BOOL:${USE_SLANG}>:slang>
-    glslang::SPIRV
-    SPIRV-Tools-static
-    SPIRV-Headers::SPIRV-Headers
-    GTest::gtest
-    GTest::gtest_main
-    $<TARGET_NAME_IF_EXISTS:PkgConfig::XCB>
-    $<TARGET_NAME_IF_EXISTS:PkgConfig::X11>
-    $<TARGET_NAME_IF_EXISTS:PkgConfig::WAYlAND_CLIENT>
-)
-
-# setup framework/config.h using framework/config.h.in as a source
-file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/config_$<CONFIG>.h" INPUT "${CMAKE_CURRENT_SOURCE_DIR}/framework/config.h.in")
-
-# Since config_$<CONFIG>.h differs per build, set a compiler definition that files can use to include it
-target_compile_definitions(vk_layer_validation_tests PRIVATE CONFIG_HEADER_FILE="config_$<CONFIG>.h")
-
-target_sources(vk_layer_validation_tests PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/config_$<CONFIG>.h)
-target_include_directories(vk_layer_validation_tests PRIVATE
-    ${CMAKE_CURRENT_BINARY_DIR}
-    ${VVL_SOURCE_DIR}/layers/external
+    vk_test_framework
 )
 
 # More details in tests/android/mock/README.md
@@ -567,8 +468,8 @@ elseif (ANDROID)
 endif()
 
 install(TARGETS vk_layer_validation_tests)
+
 if(USE_SLANG)
-    target_compile_definitions(vk_layer_validation_tests PRIVATE VVL_USE_SLANG)
     install_slang_with_target(vk_layer_validation_tests lib)
 endif()
 

--- a/tests/android/CMakeLists.txt
+++ b/tests/android/CMakeLists.txt
@@ -1,6 +1,6 @@
 # ~~~
-# Copyright (c) 2023 Valve Corporation
-# Copyright (c) 2023 LunarG, Inc.
+# Copyright (c) 2023-2025 Valve Corporation
+# Copyright (c) 2023-2025 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 #
 # To run our tests without issue we can inform the linker to not unload VVL at runtime.
 # This will prevent VVL from being unloaded by dlclose which will avoid the issue.
-# 
+#
 # https://github.com/android/ndk/issues/360
 # https://github.com/android/ndk/issues/360#issuecomment-339107521
 # https://github.com/android/ndk/releases/tag/r26-beta1
@@ -45,10 +45,18 @@ target_sources(android_glue PRIVATE
     ${native_app_glue_dir}/android_native_app_glue.h
 )
 
-target_link_libraries(vk_layer_validation_tests PRIVATE android_glue)
+# vk_test_framework needs this because that is where we have #include <android_native_app_glue.h>
+#
+# Because vk_test_framework is a static library, we still need vk_layer_validation_tests to have it order to resolve the symbols
+#
+# Likely a better way to do this
+target_link_libraries(vk_test_framework PUBLIC android_glue)
+target_link_libraries(vk_layer_validation_tests PUBLIC android_glue)
 
 target_link_options(vk_layer_validation_tests PUBLIC LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/android.map)
 
+# Change libvk_layer_validation_tests.so to libVulkanLayerValidationTests.so
+# (honestly not sure for convention or required by something)
 set_target_properties(vk_layer_validation_tests PROPERTIES OUTPUT_NAME "VulkanLayerValidationTests")
 
 install(TARGETS vk_layer_validation_tests DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/tests/framework/CMakeLists.txt
+++ b/tests/framework/CMakeLists.txt
@@ -1,0 +1,322 @@
+# ~~~
+# Copyright (c) 2025 Valve Corporation
+# Copyright (c) 2025 LunarG, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+add_library(vk_test_framework STATIC
+    android_hardware_buffer.h
+    layer_validation_tests.h
+    layer_validation_tests.cpp
+    pipeline_helper.h
+    pipeline_helper.cpp
+    shader_helper.h
+    shader_helper.cpp
+    shader_object_helper.h
+    shader_object_helper.cpp
+    test_common.h
+    shader_templates.h
+    error_monitor.cpp
+    error_monitor.h
+    video_objects.h
+    render.cpp
+    render.h
+    binding.h
+    binding.cpp
+    buffer_helper.h
+    test_framework.cpp
+    ray_tracing_objects.h
+    ray_tracing_objects.cpp
+    data_graph_objects.h
+    data_graph_objects.cpp
+    ray_tracing_helper_nv.h
+    ray_tracing_helper_nv.cpp
+    external_memory_sync.h
+    external_memory_sync.cpp
+    sync_helper.h
+    sync_helper.cpp
+    sync_val_tests.h
+    descriptor_helper.h
+    descriptor_helper.cpp
+    thread_helper.h
+    thread_helper.cpp
+    gpu_av_helper.h
+    render_pass_helper.h
+    render_pass_helper.cpp
+    feature_requirements.h
+    feature_requirements.cpp
+    queue_submit_context.h
+    queue_submit_context.cpp
+)
+if (APPLE)
+    target_sources(vk_test_framework PRIVATE
+        apple_wsi.h
+        apple_wsi.mm
+    )
+    # QuartzCore framework is needed for minimal Metal interaction
+    target_link_libraries(vk_test_framework PRIVATE "-framework QuartzCore")
+endif()
+
+target_include_directories(vk_test_framework PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+find_package(GTest CONFIG)
+find_package(glslang CONFIG)
+find_package(SPIRV-Tools CONFIG)
+
+# Slang
+# ---
+if(DEFINED SLANG_INSTALL_DIR)
+    # Define paths based on actual structure
+    if(WIN32)
+        if(EXISTS "${SLANG_INSTALL_DIR}/bin")
+            set(SLANG_BIN_DIR "${SLANG_INSTALL_DIR}/bin")
+        endif()
+
+        if(EXISTS "${SLANG_INSTALL_DIR}/lib")
+            set(SLANG_LIB_DIR "${SLANG_INSTALL_DIR}/lib")
+        else()
+            set(SLANG_LIB_DIR "${SLANG_INSTALL_DIR}/bin")
+        endif()
+
+        set(SLANG_INCLUDE_DIR "${SLANG_INSTALL_DIR}/include")
+
+        # Find slang.lib
+        if(EXISTS "${SLANG_LIB_DIR}/slang.lib")
+            set(SLANG_LIBRARY "${SLANG_LIB_DIR}/slang.lib")
+        else()
+            file(GLOB SLANG_LIB_FILES "${SLANG_INSTALL_DIR}/**/slang.lib")
+            if(SLANG_LIB_FILES)
+                list(GET SLANG_LIB_FILES 0 SLANG_LIBRARY)
+            else()
+                message(FATAL_ERROR "Could not locate slang.lib in extracted directory")
+            endif()
+        endif()
+
+        # Find slang.dll
+        file(GLOB SLANG_DLL_FILES "${SLANG_INSTALL_DIR}/**/slang.dll")
+        if(SLANG_DLL_FILES)
+            list(GET SLANG_DLL_FILES 0 SLANG_DLL)
+        elseif(EXISTS "${SLANG_BIN_DIR}/slang.dll")
+            set(SLANG_DLL "${SLANG_BIN_DIR}/slang.dll")
+        else()
+            message(FATAL_ERROR "Could not locate slang.dll in extracted directory")
+        endif()
+
+        # On Windows, also check for any other DLLs in the same directory
+        # as slang.dll and add them to a list for copying
+        get_filename_component(SLANG_DLL_DIR "${SLANG_DLL}" DIRECTORY)
+        file(GLOB ADDITIONAL_DLLS "${SLANG_DLL_DIR}/*.dll")
+        foreach(DLL ${ADDITIONAL_DLLS})
+            if(NOT DLL STREQUAL SLANG_DLL)
+                list(APPEND SLANG_DEPENDENCY_DLLS ${DLL})
+            endif()
+        endforeach()
+
+    else()
+        set(SLANG_INCLUDE_DIR "${SLANG_INSTALL_DIR}/include")
+
+        if(EXISTS "${SLANG_INSTALL_DIR}/lib")
+            set(SLANG_LIB_DIR "${SLANG_INSTALL_DIR}/lib")
+        else()
+            # Some releases might put libraries in a different location
+            file(GLOB LIB_DIRS "${SLANG_INSTALL_DIR}/**/lib")
+            if(LIB_DIRS)
+                list(GET LIB_DIRS 0 SLANG_LIB_DIR)
+            else()
+                set(SLANG_LIB_DIR "${SLANG_INSTALL_DIR}")
+            endif()
+        endif()
+
+        # Find libslang.so
+        if(EXISTS "${SLANG_LIB_DIR}/libslang.so")
+            set(SLANG_LIBRARY "${SLANG_LIB_DIR}/libslang.so")
+            message(STATUS "Found libslang.so at: ${SLANG_LIBRARY}")
+        else()
+            file(GLOB SLANG_LIB_FILES "${SLANG_INSTALL_DIR}/**/libslang.so")
+            if(SLANG_LIB_FILES)
+                list(GET SLANG_LIB_FILES 0 SLANG_LIBRARY)
+                message(STATUS "Found libslang.so via glob at: ${SLANG_LIBRARY}")
+            else()
+                message(FATAL_ERROR "Could not locate libslang.so in extracted directory")
+            endif()
+        endif()
+
+        # Check if we have other shared libraries that might be dependencies
+        get_filename_component(SLANG_LIB_DIR_REAL "${SLANG_LIBRARY}" DIRECTORY)
+        file(GLOB ADDITIONAL_LIBS "${SLANG_LIB_DIR_REAL}/*.so*")
+        foreach(LIB ${ADDITIONAL_LIBS})
+            if(NOT LIB STREQUAL SLANG_LIBRARY)
+                list(APPEND SLANG_DEPENDENCY_LIBS ${LIB})
+            endif()
+        endforeach()
+    endif()
+
+    # Create an imported target for easier usage
+    add_library(slang SHARED IMPORTED GLOBAL)
+
+    set_target_properties(slang PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES ${SLANG_INCLUDE_DIR}
+    )
+
+    if(WIN32)
+        set_target_properties(slang PROPERTIES
+            IMPORTED_IMPLIB ${SLANG_LIBRARY}
+            IMPORTED_LOCATION ${SLANG_DLL}
+        )
+    else()
+        set_target_properties(slang PROPERTIES
+            IMPORTED_LOCATION ${SLANG_LIBRARY}
+        )
+    endif()
+
+    # For specific target directories (adds to the common destinations above)
+    function(configure_slang_for_target TARGET_NAME)
+        if(WIN32)
+            add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    ${SLANG_DLL}
+                    $<TARGET_FILE_DIR:${TARGET_NAME}>
+                COMMENT "Copying Slang DLL to output directory for ${TARGET_NAME}"
+            )
+
+            get_target_property(TARGET_OUTPUT_DIR ${TARGET_NAME} RUNTIME_OUTPUT_DIRECTORY)
+            if(NOT TARGET_OUTPUT_DIR)
+                set(TARGET_OUTPUT_DIR "$<TARGET_FILE_DIR:${TARGET_NAME}>")
+            endif()
+
+            foreach(DEP_DLL ${SLANG_DEPENDENCY_DLLS})
+                get_filename_component(DEP_DLL_NAME ${DEP_DLL} NAME)
+                add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
+                    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                        ${DEP_DLL}
+                        $<TARGET_FILE_DIR:${TARGET_NAME}>
+                    COMMENT "Copying dependency DLL ${DEP_DLL_NAME} to output directory for ${TARGET_NAME}"
+                )
+            endforeach()
+        else()
+            get_filename_component(SLANG_SONAME ${SLANG_LIBRARY} NAME)
+            add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    ${SLANG_LIBRARY}
+                    $<TARGET_FILE_DIR:${TARGET_NAME}>/${SLANG_SONAME}
+                COMMENT "Copying Slang shared library to output directory for ${TARGET_NAME}"
+            )
+
+            get_target_property(TARGET_OUTPUT_DIR ${TARGET_NAME} RUNTIME_OUTPUT_DIRECTORY)
+            if(NOT TARGET_OUTPUT_DIR)
+                set(TARGET_OUTPUT_DIR "$<TARGET_FILE_DIR:${TARGET_NAME}>")
+            endif()
+
+            # Copy any dependency libraries
+            foreach(DEP_LIB ${SLANG_DEPENDENCY_LIBS})
+                get_filename_component(DEP_LIB_NAME ${DEP_LIB} NAME)
+                add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
+                    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                        ${DEP_LIB}
+                        $<TARGET_FILE_DIR:${TARGET_NAME}>/${DEP_LIB_NAME}
+                    COMMENT "Copying dependency library ${DEP_LIB_NAME} to output directory for ${TARGET_NAME}"
+                )
+            endforeach()
+
+            # Set RPATH to look in the same directory as the executable
+            set_target_properties(${TARGET_NAME} PROPERTIES
+                INSTALL_RPATH "$ORIGIN"
+                BUILD_WITH_INSTALL_RPATH TRUE
+            )
+
+            # Add post-build step to verify the library was copied and is executable
+            add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
+                COMMAND ${CMAKE_COMMAND} -E echo "Verifying slang library path: $<TARGET_FILE_DIR:${TARGET_NAME}>/${SLANG_SONAME}"
+                COMMAND test -f "$<TARGET_FILE_DIR:${TARGET_NAME}>/${SLANG_SONAME}" || echo "Library not copied correctly"
+            )
+        endif()
+    endfunction()
+
+    function(install_slang_with_target TARGET_NAME DESTINATION)
+        if(NOT WIN32)
+            get_filename_component(SLANG_SONAME ${SLANG_LIBRARY} NAME)
+            install(FILES ${SLANG_LIBRARY} DESTINATION ${DESTINATION})
+
+            foreach(DEP_LIB ${SLANG_DEPENDENCY_LIBS})
+                get_filename_component(DEP_LIB_NAME ${DEP_LIB} NAME)
+                install(FILES ${DEP_LIB} DESTINATION ${DESTINATION})
+            endforeach()
+
+            set_target_properties(${TARGET_NAME} PROPERTIES INSTALL_RPATH "$ORIGIN")
+         endif()
+    endfunction()
+
+    set(USE_SLANG TRUE)
+    configure_slang_for_target(vk_test_framework)
+else()
+    message(STATUS "Skipping Slang setup for 32-bit architecture")
+    set(USE_SLANG FALSE)
+endif()
+
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "(GNU|Clang)")
+    target_compile_options(vk_test_framework PUBLIC
+        -Wno-sign-compare
+        -Wno-shorten-64-to-32
+        -Wno-missing-field-initializers
+    )
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        target_compile_options(vk_test_framework PUBLIC
+            -Wno-sign-conversion
+            -Wno-implicit-int-conversion
+        )
+    endif()
+elseif(MSVC)
+    target_compile_options(vk_test_framework PUBLIC
+        /wd4389 # signed/unsigned mismatch
+        /wd4267 # Disable some signed/unsigned mismatch warnings.
+    )
+
+    if (CMAKE_SIZEOF_VOID_P EQUAL 4)
+        # Due to IHV driver issues, we need the extra 2GB of virtual address space for 32 bit testing
+        target_link_options(vk_test_framework PUBLIC /LARGEADDRESSAWARE)
+    endif()
+endif()
+
+target_link_libraries(vk_test_framework PUBLIC
+    VkLayer_utils
+    $<$<BOOL:${USE_SLANG}>:slang>
+    glslang::SPIRV
+    SPIRV-Tools-static
+    SPIRV-Headers::SPIRV-Headers
+    GTest::gtest
+    GTest::gtest_main
+    $<TARGET_NAME_IF_EXISTS:PkgConfig::XCB>
+    $<TARGET_NAME_IF_EXISTS:PkgConfig::X11>
+    $<TARGET_NAME_IF_EXISTS:PkgConfig::WAYlAND_CLIENT>
+)
+
+# setup framework/config.h using framework/config.h.in as a source
+file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/config_$<CONFIG>.h" INPUT "config.h.in")
+
+# Since config_$<CONFIG>.h differs per build, set a compiler definition that files can use to include it
+target_compile_definitions(vk_test_framework PRIVATE CONFIG_HEADER_FILE="config_$<CONFIG>.h")
+
+target_sources(vk_test_framework PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/config_$<CONFIG>.h)
+
+target_include_directories(vk_test_framework PUBLIC
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${VVL_SOURCE_DIR}/layers/external
+)
+
+if(USE_SLANG)
+    target_compile_definitions(vk_test_framework PUBLIC VVL_USE_SLANG)
+    install_slang_with_target(vk_test_framework lib)
+endif()

--- a/tests/framework/data_graph_objects.cpp
+++ b/tests/framework/data_graph_objects.cpp
@@ -21,12 +21,13 @@ void CreateDataGraphPipelineHelper::CreateShaderModule(const char* spirv_source)
     spvtools::SpirvTools tools{SPV_ENV_UNIVERSAL_1_6};
 
     std::string error_msg;
-    tools.SetMessageConsumer([&](spv_message_level_t level, const char*, const spv_position_t& position, const char* message) {
+    tools.SetMessageConsumer([&](spv_message_level_t, const char*, const spv_position_t& position, const char* message) {
         std::stringstream ss;
         ss << "on line " << position.line << ", column " << position.column << ": " << message;
         error_msg = ss.str();
     });
 
+    // TODO - Replace with ASMtoSPV
     std::vector<uint32_t> spirv_binary;
     if (!tools.Assemble(spirv_source, &spirv_binary)) {
         GTEST_FAIL() << "Failed to compile SPIRV shader module. Error:\n" << error_msg << std::endl

--- a/tests/framework/data_graph_objects.h
+++ b/tests/framework/data_graph_objects.h
@@ -71,8 +71,7 @@ class CreateDataGraphPipelineHelper {
     // info_override can be any callable that takes a CreatePipelineHelper &
     // flags, error can be any args accepted by "SetDesiredFailure".
     template <typename Test, typename OverrideFunc, typename Error>
-    static void OneshotTest(Test &test, const OverrideFunc &info_override, const VkFlags flags, const std::vector<Error> &errors,
-                            bool positive_test = false) {
+    static void OneshotTest(Test &test, const OverrideFunc &info_override, const VkFlags flags, const std::vector<Error> &errors) {
         CreateDataGraphPipelineHelper helper(test);
         info_override(helper);
         // Allow lambda to decide if to skip trying to compile pipeline to prevent crashing

--- a/tests/framework/external_memory_sync.cpp
+++ b/tests/framework/external_memory_sync.cpp
@@ -223,7 +223,7 @@ bool SemaphoreExportImportSupported(VkPhysicalDevice gpu, VkSemaphoreType semaph
         VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT | VK_EXTERNAL_SEMAPHORE_FEATURE_IMPORTABLE_BIT;
 
     VkSemaphoreTypeCreateInfo type_info = vku::InitStructHelper();
-    type_info.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
+    type_info.semaphoreType = semaphore_type;
 
     VkPhysicalDeviceExternalSemaphoreInfo external_info = vku::InitStructHelper(&type_info);
     external_info.handleType = handle_type;

--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -79,8 +79,7 @@ bool FormatFeaturesAreSupported(VkPhysicalDevice phy, VkFormat format, VkImageTi
     return (features == (phy_features & features));
 }
 
-bool ImageFormatIsSupported(const VkInstance inst, const VkPhysicalDevice phy, const VkImageCreateInfo info,
-                            const VkFormatFeatureFlags features) {
+bool ImageFormatIsSupported(const VkPhysicalDevice phy, const VkImageCreateInfo info, const VkFormatFeatureFlags features) {
     // Verify physical device support of format features
     if (!FormatFeaturesAreSupported(phy, info.format, info.tiling, features)) {
         return false;
@@ -120,8 +119,7 @@ bool operator==(const VkDebugUtilsLabelEXT &rhs, const VkDebugUtilsLabelEXT &lhs
     return is_equal;
 }
 
-VKAPI_ATTR VkBool32 VKAPI_CALL DebugUtilsCallback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
-                                                  VkDebugUtilsMessageTypeFlagsEXT messageTypes,
+VKAPI_ATTR VkBool32 VKAPI_CALL DebugUtilsCallback(VkDebugUtilsMessageSeverityFlagBitsEXT, VkDebugUtilsMessageTypeFlagsEXT,
                                                   const VkDebugUtilsMessengerCallbackDataEXT *pCallbackData, void *pUserData) {
     auto *data = reinterpret_cast<DebugUtilsLabelCheckData *>(pUserData);
     data->callback(pCallbackData, data);
@@ -151,8 +149,7 @@ void TestRenderPassCreate(ErrorMonitor *error_monitor, const vkt::Device &device
     }
 }
 
-void PositiveTestRenderPassCreate(ErrorMonitor *error_monitor, const vkt::Device &device, const VkRenderPassCreateInfo &create_info,
-                                  bool rp2_supported) {
+void PositiveTestRenderPassCreate(const vkt::Device &device, const VkRenderPassCreateInfo &create_info, bool rp2_supported) {
     vkt::RenderPass rp(device, create_info);
     if (rp2_supported) {
         vkt::RenderPass rp2(device, *ConvertVkRenderPassCreateInfoToV2KHR(create_info).ptr());
@@ -537,6 +534,7 @@ bool VkLayerTest::LoadDeviceProfileLayer(PFN_VkSetPhysicalDeviceProperties2EXT &
 }
 
 void PrintAndroid(const char *c) {
+    (void)c;
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
     __android_log_print(ANDROID_LOG_INFO, "VulkanLayerValidationTests", "%s", c);
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
@@ -641,7 +639,7 @@ class LogcatPrinter : public ::testing::EmptyTestEventListener {
     };
 };
 
-static int32_t processInput(struct android_app *app, AInputEvent *event) { return 0; }
+static int32_t processInput(struct android_app *, AInputEvent *) { return 0; }
 
 static void processCommand(struct android_app *app, int32_t cmd) {
     switch (cmd) {

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -105,8 +105,7 @@ bool FormatIsSupported(VkPhysicalDevice phy, VkFormat format, VkImageTiling tili
 bool FormatFeaturesAreSupported(VkPhysicalDevice phy, VkFormat format, VkImageTiling tiling, VkFormatFeatureFlags features);
 
 // Returns true if format and *all* requested features are available.
-bool ImageFormatIsSupported(const VkInstance inst, const VkPhysicalDevice phy, const VkImageCreateInfo info,
-                            const VkFormatFeatureFlags features);
+bool ImageFormatIsSupported(const VkPhysicalDevice phy, const VkImageCreateInfo info, const VkFormatFeatureFlags features);
 
 // Returns true if format and *all* requested features are available.
 bool BufferFormatAndFeaturesSupported(VkPhysicalDevice phy, VkFormat format, VkFormatFeatureFlags features);
@@ -406,7 +405,7 @@ class TensorTest : public VkLayerTest {
 
 class DataGraphTest : public VkLayerTest {
   public:
-    void InitBasicDataGraph(bool init_types = false);
+    void InitBasicDataGraph();
     static void CheckSessionMemory(const vkt::DataGraphPipelineSession& session);
     static std::vector<VkBindDataGraphPipelineSessionMemoryInfoARM> InitSessionBindInfo(const vkt::DataGraphPipelineSession& session, const std::vector<vkt::DeviceMemory>& device_mem);
 
@@ -451,8 +450,7 @@ VKAPI_ATTR VkBool32 VKAPI_CALL DebugUtilsCallback(VkDebugUtilsMessageSeverityFla
 
 void TestRenderPassCreate(ErrorMonitor *error_monitor, const vkt::Device &device, const VkRenderPassCreateInfo &create_info,
                           bool rp2_supported, const char *rp1_vuid, const char *rp2_vuid);
-void PositiveTestRenderPassCreate(ErrorMonitor *error_monitor, const vkt::Device &device, const VkRenderPassCreateInfo &create_info,
-                                  bool rp2_supported);
+void PositiveTestRenderPassCreate(const vkt::Device &device, const VkRenderPassCreateInfo &create_info, bool rp2_supported);
 void PositiveTestRenderPass2KHRCreate(const vkt::Device &device, const VkRenderPassCreateInfo2KHR &create_info);
 void TestRenderPass2KHRCreate(ErrorMonitor &error_monitor, const vkt::Device &device, const VkRenderPassCreateInfo2KHR &create_info,
                               const std::vector<const char *> &vuids);

--- a/tests/framework/pipeline_helper.h
+++ b/tests/framework/pipeline_helper.h
@@ -165,8 +165,7 @@ class CreateComputePipelineHelper {
     // info_override can be any callable that takes a CreatePipelineHeper &
     // flags, error can be any args accepted by "SetDesiredFailure".
     template <typename Test, typename OverrideFunc, typename Error>
-    static void OneshotTest(Test &test, const OverrideFunc &info_override, const VkFlags flags, const std::vector<Error> &errors,
-                            bool positive_test = false) {
+    static void OneshotTest(Test &test, const OverrideFunc &info_override, const VkFlags flags, const std::vector<Error> &errors) {
         CreateComputePipelineHelper helper(test);
         info_override(helper);
         // Allow lambda to decide if to skip trying to compile pipeline to prevent crashing

--- a/tests/framework/queue_submit_context.h
+++ b/tests/framework/queue_submit_context.h
@@ -99,7 +99,7 @@ struct QSTestContext {
         Submit(q1, cb, wait, wait_mask, signal, fence);
     }
     void Submit1Wait(vkt::CommandBuffer& cb, VkPipelineStageFlags wait_mask) { Submit1(cb, semaphore, wait_mask); }
-    void Submit1Signal(vkt::CommandBuffer& cb, VkPipelineStageFlags signal_mask) { Submit1(cb, VK_NULL_HANDLE, 0U, semaphore); }
+    void Submit1Signal(vkt::CommandBuffer& cb) { Submit1(cb, VK_NULL_HANDLE, 0U, semaphore); }
     void SetEvent(VkPipelineStageFlags src_mask) { event.CmdSet(*current_cb, src_mask); }
     void WaitEventBufferTransfer(vkt::Buffer& buffer, VkPipelineStageFlags src_mask, VkPipelineStageFlags dst_mask);
 

--- a/tests/framework/ray_tracing_helper_nv.h
+++ b/tests/framework/ray_tracing_helper_nv.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2024 Valve Corporation
- * Copyright (c) 2023-2024 LunarG, Inc.
+ * Copyright (c) 2023-2025 Valve Corporation
+ * Copyright (c) 2023-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ class RayTracingPipelineHelper {
     }
 
     template <typename Test, typename OverrideFunc>
-    static void OneshotPositiveTest(Test& test, const OverrideFunc& info_override, const VkFlags message_flag_mask = kErrorBit) {
+    static void OneshotPositiveTest(Test& test, const OverrideFunc& info_override) {
         RayTracingPipelineHelper helper(test);
         info_override(helper);
 

--- a/tests/framework/ray_tracing_objects.cpp
+++ b/tests/framework/ray_tracing_objects.cpp
@@ -492,9 +492,9 @@ BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetIndirectDeviceAddress(std::option
     return *this;
 }
 
-void BuildGeometryInfoKHR::BuildCmdBuffer(VkCommandBuffer cmd_buffer, bool use_ppGeometries /*= true*/) {
+void BuildGeometryInfoKHR::BuildCmdBuffer(VkCommandBuffer cmd_buffer) {
     SetupBuild(true);
-    VkCmdBuildAccelerationStructuresKHR(cmd_buffer, use_ppGeometries);
+    VkCmdBuildAccelerationStructuresKHR(cmd_buffer);
 }
 
 void BuildGeometryInfoKHR::BuildCmdBufferIndirect(VkCommandBuffer cmd_buffer) {

--- a/tests/framework/ray_tracing_objects.h
+++ b/tests/framework/ray_tracing_objects.h
@@ -189,7 +189,7 @@ class BuildGeometryInfoKHR {
 
     // Those functions call Build() on internal resources (geometries, src and dst acceleration structures, scratch buffer),
     // then will build/update an acceleration structure.
-    void BuildCmdBuffer(VkCommandBuffer cmd_buffer, bool use_ppGeometries = true);
+    void BuildCmdBuffer(VkCommandBuffer cmd_buffer);
     void BuildCmdBufferIndirect(VkCommandBuffer cmd_buffer);
     void BuildHost();
 

--- a/tests/framework/render.cpp
+++ b/tests/framework/render.cpp
@@ -736,6 +736,7 @@ void SurfaceContext::Resize(uint32_t width, uint32_t height) {
 VkResult VkRenderFramework::CreateSurface(SurfaceContext &surface_context, vkt::Surface &surface, VkInstance custom_instance) {
     const VkInstance surface_instance = (custom_instance != VK_NULL_HANDLE) ? custom_instance : instance();
     (void)surface_instance;
+    (void)surface_context;
 #if defined(VK_USE_PLATFORM_WIN32_KHR)
     if (IsExtensionsEnabled(VK_KHR_WIN32_SURFACE_EXTENSION_NAME)) {
         HINSTANCE window_instance = GetModuleHandle(nullptr);

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -63,7 +63,7 @@ struct SurfaceContext {
     void Resize(uint32_t width, uint32_t height);
 #else
     static bool CanResize() { return false; }
-    void Resize(uint32_t width, uint32_t height) {}
+    void Resize(uint32_t, uint32_t) {}
 #endif
     void Destroy();
     ~SurfaceContext() { Destroy(); }

--- a/tests/framework/sync_helper.cpp
+++ b/tests/framework/sync_helper.cpp
@@ -248,7 +248,7 @@ void Barrier2QueueFamilyTestHelper::operator()(const std::string &img_err, const
     context_->Reset();
 }
 
-void ValidOwnershipTransferOp(ErrorMonitor *monitor, vkt::Queue *queue, vkt::CommandBuffer &cb, VkPipelineStageFlags src_stages,
+void ValidOwnershipTransferOp(vkt::Queue *queue, vkt::CommandBuffer &cb, VkPipelineStageFlags src_stages,
                               VkPipelineStageFlags dst_stages, const VkBufferMemoryBarrier *buf_barrier,
                               const VkImageMemoryBarrier *img_barrier) {
     cb.Begin();
@@ -260,16 +260,15 @@ void ValidOwnershipTransferOp(ErrorMonitor *monitor, vkt::Queue *queue, vkt::Com
     queue->Wait();
 }
 
-void ValidOwnershipTransfer(ErrorMonitor *monitor, vkt::Queue *queue_from, vkt::CommandBuffer &cb_from, vkt::Queue *queue_to,
-                            vkt::CommandBuffer &cb_to, VkPipelineStageFlags src_stages, VkPipelineStageFlags dst_stages,
+void ValidOwnershipTransfer(vkt::Queue *queue_from, vkt::CommandBuffer &cb_from, vkt::Queue *queue_to, vkt::CommandBuffer &cb_to,
+                            VkPipelineStageFlags src_stages, VkPipelineStageFlags dst_stages,
                             const VkBufferMemoryBarrier *buf_barrier, const VkImageMemoryBarrier *img_barrier) {
-    ValidOwnershipTransferOp(monitor, queue_from, cb_from, src_stages, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, buf_barrier,
-                             img_barrier);
-    ValidOwnershipTransferOp(monitor, queue_to, cb_to, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, dst_stages, buf_barrier, img_barrier);
+    ValidOwnershipTransferOp(queue_from, cb_from, src_stages, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, buf_barrier, img_barrier);
+    ValidOwnershipTransferOp(queue_to, cb_to, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, dst_stages, buf_barrier, img_barrier);
 }
 
-void ValidOwnershipTransferOp(ErrorMonitor *monitor, vkt::Queue *queue, vkt::CommandBuffer &cb,
-                              const VkBufferMemoryBarrier2 *buf_barrier, const VkImageMemoryBarrier2 *img_barrier) {
+void ValidOwnershipTransferOp(vkt::Queue *queue, vkt::CommandBuffer &cb, const VkBufferMemoryBarrier2 *buf_barrier,
+                              const VkImageMemoryBarrier2 *img_barrier) {
     cb.Begin();
     VkDependencyInfo dep_info = vku::InitStructHelper();
     dep_info.bufferMemoryBarrierCount = (buf_barrier) ? 1 : 0;
@@ -282,9 +281,8 @@ void ValidOwnershipTransferOp(ErrorMonitor *monitor, vkt::Queue *queue, vkt::Com
     queue->Wait();
 }
 
-void ValidOwnershipTransfer(ErrorMonitor *monitor, vkt::Queue *queue_from, vkt::CommandBuffer &cb_from, vkt::Queue *queue_to,
-                            vkt::CommandBuffer &cb_to, const VkBufferMemoryBarrier2 *buf_barrier,
-                            const VkImageMemoryBarrier2 *img_barrier) {
+void ValidOwnershipTransfer(vkt::Queue *queue_from, vkt::CommandBuffer &cb_from, vkt::Queue *queue_to, vkt::CommandBuffer &cb_to,
+                            const VkBufferMemoryBarrier2 *buf_barrier, const VkImageMemoryBarrier2 *img_barrier) {
     VkBufferMemoryBarrier2 fixup_buf_barrier;
     VkImageMemoryBarrier2 fixup_img_barrier;
     if (buf_barrier) {
@@ -298,7 +296,7 @@ void ValidOwnershipTransfer(ErrorMonitor *monitor, vkt::Queue *queue_from, vkt::
         fixup_img_barrier.dstAccessMask = 0;
     }
 
-    ValidOwnershipTransferOp(monitor, queue_from, cb_from, buf_barrier ? &fixup_buf_barrier : nullptr,
+    ValidOwnershipTransferOp(queue_from, cb_from, buf_barrier ? &fixup_buf_barrier : nullptr,
                              img_barrier ? &fixup_img_barrier : nullptr);
 
     if (buf_barrier) {
@@ -311,6 +309,6 @@ void ValidOwnershipTransfer(ErrorMonitor *monitor, vkt::Queue *queue_from, vkt::
         fixup_img_barrier.srcStageMask = VK_PIPELINE_STAGE_2_NONE;
         fixup_img_barrier.srcAccessMask = 0;
     }
-    ValidOwnershipTransferOp(monitor, queue_to, cb_to, buf_barrier ? &fixup_buf_barrier : nullptr,
+    ValidOwnershipTransferOp(queue_to, cb_to, buf_barrier ? &fixup_buf_barrier : nullptr,
                              img_barrier ? &fixup_img_barrier : nullptr);
 }

--- a/tests/framework/sync_helper.h
+++ b/tests/framework/sync_helper.h
@@ -95,17 +95,16 @@ class Barrier2QueueFamilyTestHelper : public BarrierQueueFamilyBase {
     VkBufferMemoryBarrier2 buffer_barrier_;
 };
 
-void ValidOwnershipTransferOp(ErrorMonitor *monitor, vkt::Queue *queue, vkt::CommandBuffer &cb, VkPipelineStageFlags src_stages,
+void ValidOwnershipTransferOp(vkt::Queue *queue, vkt::CommandBuffer &cb, VkPipelineStageFlags src_stages,
                               VkPipelineStageFlags dst_stages, const VkBufferMemoryBarrier *buf_barrier,
                               const VkImageMemoryBarrier *img_barrier);
 
-void ValidOwnershipTransferOp(ErrorMonitor *monitor, vkt::Queue *queue, vkt::CommandBuffer &cb,
-                              const VkBufferMemoryBarrier2 *buf_barrier, const VkImageMemoryBarrier2 *img_barrier);
+void ValidOwnershipTransferOp(vkt::Queue *queue, vkt::CommandBuffer &cb, const VkBufferMemoryBarrier2 *buf_barrier,
+                              const VkImageMemoryBarrier2 *img_barrier);
 
-void ValidOwnershipTransfer(ErrorMonitor *monitor, vkt::Queue *queue_from, vkt::CommandBuffer &cb_from, vkt::Queue *queue_to,
-                            vkt::CommandBuffer &cb_to, VkPipelineStageFlags src_stages, VkPipelineStageFlags dst_stages,
+void ValidOwnershipTransfer(vkt::Queue *queue_from, vkt::CommandBuffer &cb_from, vkt::Queue *queue_to, vkt::CommandBuffer &cb_to,
+                            VkPipelineStageFlags src_stages, VkPipelineStageFlags dst_stages,
                             const VkBufferMemoryBarrier *buf_barrier, const VkImageMemoryBarrier *img_barrier);
 
-void ValidOwnershipTransfer(ErrorMonitor *monitor, vkt::Queue *queue_from, vkt::CommandBuffer &cb_from, vkt::Queue *queue_to,
-                            vkt::CommandBuffer &cb_to, const VkBufferMemoryBarrier2 *buf_barrier,
-                            const VkImageMemoryBarrier2 *img_barrier);
+void ValidOwnershipTransfer(vkt::Queue *queue_from, vkt::CommandBuffer &cb_from, vkt::Queue *queue_to, vkt::CommandBuffer &cb_to,
+                            const VkBufferMemoryBarrier2 *buf_barrier, const VkImageMemoryBarrier2 *img_barrier);

--- a/tests/framework/video_objects.h
+++ b/tests/framework/video_objects.h
@@ -3361,11 +3361,8 @@ class VkVideoLayerTest : public VkLayerTest {
 
   private:
     // InitFramework and InitState is explicitly hidden because there is a custom Init that should be used instead
-    void InitFramework(void* instance_pnext = NULL) { assert(false); }
-    void InitState(VkPhysicalDeviceFeatures* features = nullptr, void* create_device_pnext = nullptr,
-                   const VkCommandPoolCreateFlags flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT) {
-        assert(false);
-    }
+    void InitFramework(void*) { assert(false); }
+    void InitState(VkPhysicalDeviceFeatures*, void*, const VkCommandPoolCreateFlags) { assert(false); }
 
     uint32_t FindQueueFamilySupportingCodecOp(VkVideoCodecOperationFlagBitsKHR codec_op) {
         uint32_t qfi = VK_QUEUE_FAMILY_IGNORED;

--- a/tests/unit/atomics.cpp
+++ b/tests/unit/atomics.cpp
@@ -476,7 +476,7 @@ TEST_F(NegativeAtomic, ImageInt64DrawtimeSparse) {
 
     auto image_ci = vkt::Image::ImageCreateInfo2D(32, 32, 1, 1, VK_FORMAT_R64_UINT, VK_IMAGE_USAGE_STORAGE_BIT);
     image_ci.flags = VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT | VK_IMAGE_CREATE_SPARSE_BINDING_BIT;
-    if (ImageFormatIsSupported(instance(), Gpu(), image_ci, VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT)) {
+    if (ImageFormatIsSupported(Gpu(), image_ci, VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT)) {
         GTEST_SKIP() << "Cannot make VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT not supported.";
     }
 
@@ -1316,7 +1316,7 @@ TEST_F(NegativeAtomic, InvalidStorageOperation) {
                                                        // cause DesiredFailure. VK_FORMAT_R32_UINT is right format.
     auto image_ci = vkt::Image::ImageCreateInfo2D(64, 64, 1, 1, image_format, usage);
 
-    if (ImageFormatIsSupported(instance(), Gpu(), image_ci, VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT)) {
+    if (ImageFormatIsSupported(Gpu(), image_ci, VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT)) {
         GTEST_SKIP() << "Cannot make VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT not supported.";
     }
 

--- a/tests/unit/buffer_positive.cpp
+++ b/tests/unit/buffer_positive.cpp
@@ -35,19 +35,19 @@ TEST_F(PositiveBuffer, OwnershipTranfers) {
     // Let gfx own it.
     buffer_barrier.srcQueueFamilyIndex = m_device->graphics_queue_node_index_;
     buffer_barrier.dstQueueFamilyIndex = m_device->graphics_queue_node_index_;
-    ValidOwnershipTransferOp(m_errorMonitor, m_default_queue, m_command_buffer, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT,
-                             VK_PIPELINE_STAGE_TRANSFER_BIT, &buffer_barrier, nullptr);
+    ValidOwnershipTransferOp(m_default_queue, m_command_buffer, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                             &buffer_barrier, nullptr);
 
     // Transfer it to non-gfx
     buffer_barrier.dstQueueFamilyIndex = no_gfx_queue->family_index;
-    ValidOwnershipTransfer(m_errorMonitor, m_default_queue, m_command_buffer, no_gfx_queue, no_gfx_cb,
-                           VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, &buffer_barrier, nullptr);
+    ValidOwnershipTransfer(m_default_queue, m_command_buffer, no_gfx_queue, no_gfx_cb, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT,
+                           VK_PIPELINE_STAGE_TRANSFER_BIT, &buffer_barrier, nullptr);
 
     // Transfer it to gfx
     buffer_barrier.srcQueueFamilyIndex = no_gfx_queue->family_index;
     buffer_barrier.dstQueueFamilyIndex = m_device->graphics_queue_node_index_;
-    ValidOwnershipTransfer(m_errorMonitor, no_gfx_queue, no_gfx_cb, m_default_queue, m_command_buffer,
-                           VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, &buffer_barrier, nullptr);
+    ValidOwnershipTransfer(no_gfx_queue, no_gfx_cb, m_default_queue, m_command_buffer, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                           VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, &buffer_barrier, nullptr);
 }
 
 TEST_F(PositiveBuffer, TexelBufferAlignmentIn13) {

--- a/tests/unit/command_positive.cpp
+++ b/tests/unit/command_positive.cpp
@@ -289,7 +289,7 @@ TEST_F(PositiveCommand, ThreadedCommandBuffersWithLabels) {
     constexpr int worker_count = 8;
     ThreadTimeoutHelper timeout_helper(worker_count);
 
-    auto worker_thread = [&](int worker_index) {
+    auto worker_thread = [&]() {
         auto timeout_guard = timeout_helper.ThreadGuard();
         // Command pool per worker thread
         vkt::CommandPool pool(*m_device, m_device->graphics_queue_node_index_, VK_COMMAND_POOL_CREATE_TRANSIENT_BIT);
@@ -318,7 +318,7 @@ TEST_F(PositiveCommand, ThreadedCommandBuffersWithLabels) {
         }
     };
     std::vector<std::thread> workers;
-    for (int i = 0; i < worker_count; i++) workers.emplace_back(worker_thread, i);
+    for (int i = 0; i < worker_count; i++) workers.emplace_back(worker_thread);
     constexpr int wait_time = 60;
     if (!timeout_helper.WaitForThreads(wait_time))
         ADD_FAILURE() << "The waiting time for the worker threads exceeded the maximum limit: " << wait_time << " seconds.";

--- a/tests/unit/copy_buffer_image.cpp
+++ b/tests/unit/copy_buffer_image.cpp
@@ -808,7 +808,7 @@ TEST_F(NegativeCopyBufferImage, CopyBufferCompressedMipLevels) {
     image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    if (!ImageFormatIsSupported(instance(), Gpu(), image_ci, VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
+    if (!ImageFormatIsSupported(Gpu(), image_ci, VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
         GTEST_SKIP() << "image format not supported";
     }
     vkt::Image dst_image(*m_device, image_ci);
@@ -972,7 +972,7 @@ TEST_F(NegativeCopyBufferImage, CopyBufferSizePlanar) {
     image_ci.arrayLayers = 1;
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
 
-    if (!ImageFormatIsSupported(instance(), Gpu(), image_ci, kSrcDstFeature)) {
+    if (!ImageFormatIsSupported(Gpu(), image_ci, kSrcDstFeature)) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Multiplane image format not supported";
     }
@@ -4236,7 +4236,7 @@ TEST_F(NegativeCopyBufferImage, CopyBufferToCompressedNonFullTexelBlock) {
     image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    if (!ImageFormatIsSupported(instance(), Gpu(), image_ci, VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
+    if (!ImageFormatIsSupported(Gpu(), image_ci, VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
         GTEST_SKIP() << "image format not supported";
     }
     vkt::Image dst_image(*m_device, image_ci);
@@ -4319,7 +4319,7 @@ TEST_F(NegativeCopyBufferImage, CopyCompress2DTo1D) {
     RETURN_IF_SKIP(Init());
 
     auto image_ci = vkt::Image::ImageCreateInfo2D(64, 64, 1, 1, VK_FORMAT_BC1_RGBA_UNORM_BLOCK, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
-    if (!ImageFormatIsSupported(instance(), Gpu(), image_ci, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT)) {
+    if (!ImageFormatIsSupported(Gpu(), image_ci, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT)) {
         GTEST_SKIP() << "image format not supported";
     }
     vkt::Image src_image(*m_device, image_ci);
@@ -4327,7 +4327,7 @@ TEST_F(NegativeCopyBufferImage, CopyCompress2DTo1D) {
     image_ci.imageType = VK_IMAGE_TYPE_1D;
     image_ci.extent = {1024u, 1u, 1u};
     image_ci.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-    if (!ImageFormatIsSupported(instance(), Gpu(), image_ci, VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
+    if (!ImageFormatIsSupported(Gpu(), image_ci, VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
         GTEST_SKIP() << "image format not supported";
     }
     vkt::Image dst_image(*m_device, image_ci);
@@ -4364,7 +4364,7 @@ TEST_F(NegativeCopyBufferImage, CopyCompressToCompress) {
     image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     image_ci.extent = {30, 30, 1};
     image_ci.usage = kSrcDstUsage;
-    if (!ImageFormatIsSupported(instance(), Gpu(), image_ci, kSrcDstFeature)) {
+    if (!ImageFormatIsSupported(Gpu(), image_ci, kSrcDstFeature)) {
         GTEST_SKIP() << "image format not supported";
     }
     vkt::Image src_image(*m_device, image_ci);

--- a/tests/unit/copy_buffer_image_positive.cpp
+++ b/tests/unit/copy_buffer_image_positive.cpp
@@ -798,14 +798,14 @@ TEST_F(PositiveCopyBufferImage, CopyCompressed1DImage) {
     image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     image_ci.usage = kSrcDstUsage;
-    if (!ImageFormatIsSupported(instance(), Gpu(), image_ci, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT)) {
+    if (!ImageFormatIsSupported(Gpu(), image_ci, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT)) {
         GTEST_SKIP() << "image format not supported";
     }
     vkt::Image uncomp_image(*m_device, image_ci);
 
     image_ci.format = VK_FORMAT_BC1_RGBA_UNORM_BLOCK;
     image_ci.usage = kSrcDstUsage;
-    if (!ImageFormatIsSupported(instance(), Gpu(), image_ci, VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
+    if (!ImageFormatIsSupported(Gpu(), image_ci, VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
         GTEST_SKIP() << "image format not supported";
     }
     vkt::Image comp_image(*m_device, image_ci);
@@ -881,7 +881,7 @@ TEST_F(PositiveCopyBufferImage, CopyCompress1DTo2D) {
     image_ci.imageType = VK_IMAGE_TYPE_1D;
     image_ci.extent = {256u, 1u, 1u};
     image_ci.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-    if (!ImageFormatIsSupported(instance(), Gpu(), image_ci, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT)) {
+    if (!ImageFormatIsSupported(Gpu(), image_ci, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT)) {
         GTEST_SKIP() << "image format not supported";
     }
     vkt::Image src_image(*m_device, image_ci);
@@ -889,7 +889,7 @@ TEST_F(PositiveCopyBufferImage, CopyCompress1DTo2D) {
     image_ci.imageType = VK_IMAGE_TYPE_2D;
     image_ci.extent = {32u, 32u, 1u};
     image_ci.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-    if (!ImageFormatIsSupported(instance(), Gpu(), image_ci, VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
+    if (!ImageFormatIsSupported(Gpu(), image_ci, VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
         GTEST_SKIP() << "image format not supported";
     }
     vkt::Image dst_image(*m_device, image_ci);
@@ -926,7 +926,7 @@ TEST_F(PositiveCopyBufferImage, CopyBufferTo1DCompressedImage) {
     image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    if (!ImageFormatIsSupported(instance(), Gpu(), image_ci, VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
+    if (!ImageFormatIsSupported(Gpu(), image_ci, VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
         GTEST_SKIP() << "image format not supported";
     }
     vkt::Image dst_image(*m_device, image_ci);
@@ -957,7 +957,7 @@ TEST_F(PositiveCopyBufferImage, CopyCompress2DTo1D) {
     RETURN_IF_SKIP(Init());
 
     auto image_ci = vkt::Image::ImageCreateInfo2D(64, 64, 1, 1, VK_FORMAT_BC1_RGBA_UNORM_BLOCK, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
-    if (!ImageFormatIsSupported(instance(), Gpu(), image_ci, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT)) {
+    if (!ImageFormatIsSupported(Gpu(), image_ci, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT)) {
         GTEST_SKIP() << "image format not supported";
     }
     vkt::Image src_image(*m_device, image_ci);
@@ -965,7 +965,7 @@ TEST_F(PositiveCopyBufferImage, CopyCompress2DTo1D) {
     image_ci.imageType = VK_IMAGE_TYPE_1D;
     image_ci.extent = {1024u, 1u, 1u};
     image_ci.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-    if (!ImageFormatIsSupported(instance(), Gpu(), image_ci, VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
+    if (!ImageFormatIsSupported(Gpu(), image_ci, VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
         GTEST_SKIP() << "image format not supported";
     }
     vkt::Image dst_image(*m_device, image_ci);
@@ -1001,7 +1001,7 @@ TEST_F(PositiveCopyBufferImage, CopyCompressLowestMip) {
     image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     image_ci.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-    if (!ImageFormatIsSupported(instance(), Gpu(), image_ci, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT)) {
+    if (!ImageFormatIsSupported(Gpu(), image_ci, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT)) {
         GTEST_SKIP() << "image format not supported";
     }
     vkt::Image src_image(*m_device, image_ci);
@@ -1009,7 +1009,7 @@ TEST_F(PositiveCopyBufferImage, CopyCompressLowestMip) {
     image_ci.format = VK_FORMAT_BC1_RGBA_UNORM_BLOCK;
     image_ci.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     image_ci.mipLevels = 4u;
-    if (!ImageFormatIsSupported(instance(), Gpu(), image_ci, VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
+    if (!ImageFormatIsSupported(Gpu(), image_ci, VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
         GTEST_SKIP() << "image format not supported";
     }
     vkt::Image dst_image(*m_device, image_ci);
@@ -1120,7 +1120,7 @@ TEST_F(PositiveCopyBufferImage, CopyCompressToCompress) {
     image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     image_ci.extent = {30, 30, 1};
     image_ci.usage = kSrcDstUsage;
-    if (!ImageFormatIsSupported(instance(), Gpu(), image_ci, kSrcDstFeature)) {
+    if (!ImageFormatIsSupported(Gpu(), image_ci, kSrcDstFeature)) {
         GTEST_SKIP() << "image format not supported";
     }
     vkt::Image src_image(*m_device, image_ci);
@@ -1168,7 +1168,7 @@ TEST_F(PositiveCopyBufferImage, CopyBufferToCompressedNonFullTexelBlock) {
     image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    if (!ImageFormatIsSupported(instance(), Gpu(), image_ci, VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
+    if (!ImageFormatIsSupported(Gpu(), image_ci, VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
         GTEST_SKIP() << "image format not supported";
     }
     vkt::Image dst_image(*m_device, image_ci);
@@ -1203,7 +1203,7 @@ TEST_F(PositiveCopyBufferImage, CopyBufferToCompressedMipLevels) {
     image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    if (!ImageFormatIsSupported(instance(), Gpu(), image_ci, VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
+    if (!ImageFormatIsSupported(Gpu(), image_ci, VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
         GTEST_SKIP() << "image format not supported";
     }
     vkt::Image dst_image(*m_device, image_ci);
@@ -1238,7 +1238,7 @@ TEST_F(PositiveCopyBufferImage, CopyBufferSizePlanar) {
     image_ci.arrayLayers = 1;
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
 
-    if (!ImageFormatIsSupported(instance(), Gpu(), image_ci, kSrcDstFeature)) {
+    if (!ImageFormatIsSupported(Gpu(), image_ci, kSrcDstFeature)) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Multiplane image format not supported";
     }
@@ -1277,7 +1277,7 @@ TEST_F(PositiveCopyBufferImage, CopyImagePlanar) {
     image_ci.mipLevels = 1;
     image_ci.arrayLayers = 1;
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
-    if (!ImageFormatIsSupported(instance(), Gpu(), image_ci, kSrcDstFeature)) {
+    if (!ImageFormatIsSupported(Gpu(), image_ci, kSrcDstFeature)) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Multiplane image format not supported";
     }

--- a/tests/unit/data_graph.cpp
+++ b/tests/unit/data_graph.cpp
@@ -27,8 +27,10 @@ TEST_F(NegativeDataGraph, CreateDataGraphPipelinesFeatureNotEnabled) {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModel);
     RETURN_IF_SKIP(Init());
 
-    auto set_info = [](vkt::dg::CreateDataGraphPipelineHelper &helper) {};
-    vkt::dg::CreateDataGraphPipelineHelper::OneshotTest(*this, set_info, 0, "VUID-vkCreateDataGraphPipelinesARM-dataGraph-09760");
+    vkt::dg::CreateDataGraphPipelineHelper pipe(*this);
+    m_errorMonitor->SetDesiredError("VUID-vkCreateDataGraphPipelinesARM-dataGraph-09760");
+    pipe.CreateDataGraphPipeline();
+    m_errorMonitor->VerifyFound();
 }
 
 TEST_F(NegativeDataGraph, CreateDataGraphPipelinesDeferredOperationNotNull) {

--- a/tests/unit/data_graph_positive.cpp
+++ b/tests/unit/data_graph_positive.cpp
@@ -14,7 +14,7 @@
 
 class PositiveDataGraph : public DataGraphTest {};
 
-void DataGraphTest::InitBasicDataGraph(bool init_types) {
+void DataGraphTest::InitBasicDataGraph() {
     SetTargetApiVersion(VK_API_VERSION_1_4);
     AddRequiredExtensions(VK_ARM_TENSORS_EXTENSION_NAME);
     AddRequiredExtensions(VK_ARM_DATA_GRAPH_EXTENSION_NAME);

--- a/tests/unit/debug_extensions.cpp
+++ b/tests/unit/debug_extensions.cpp
@@ -139,9 +139,7 @@ TEST_F(NegativeDebugExtensions, DebugUtilsName) {
     }
 
     DebugUtilsLabelCheckData callback_data;
-    auto empty_callback = [](const VkDebugUtilsMessengerCallbackDataEXT *pCallbackData, DebugUtilsLabelCheckData *data) {
-        data->count++;
-    };
+    auto empty_callback = [](const VkDebugUtilsMessengerCallbackDataEXT *, DebugUtilsLabelCheckData *data) { data->count++; };
     callback_data.count = 0;
     callback_data.callback = empty_callback;
 
@@ -308,9 +306,7 @@ TEST_F(NegativeDebugExtensions, DebugUtilsParameterFlags) {
     RETURN_IF_SKIP(Init());
 
     DebugUtilsLabelCheckData callback_data;
-    auto empty_callback = [](const VkDebugUtilsMessengerCallbackDataEXT *pCallbackData, DebugUtilsLabelCheckData *data) {
-        data->count++;
-    };
+    auto empty_callback = [](const VkDebugUtilsMessengerCallbackDataEXT *, DebugUtilsLabelCheckData *data) { data->count++; };
     callback_data.count = 0;
     callback_data.callback = empty_callback;
 
@@ -383,9 +379,7 @@ TEST_F(NegativeDebugExtensions, SetDebugUtilsObjectSecondDevice) {
     vkt::Device second_device(gpu_, m_device_extension_names, &features);
 
     DebugUtilsLabelCheckData callback_data;
-    auto empty_callback = [](const VkDebugUtilsMessengerCallbackDataEXT *pCallbackData, DebugUtilsLabelCheckData *data) {
-        data->count++;
-    };
+    auto empty_callback = [](const VkDebugUtilsMessengerCallbackDataEXT *, DebugUtilsLabelCheckData *data) { data->count++; };
     callback_data.count = 0;
     callback_data.callback = empty_callback;
 
@@ -421,9 +415,7 @@ TEST_F(NegativeDebugExtensions, SetDebugUtilsObjectDestroyedHandle) {
     }
 
     DebugUtilsLabelCheckData callback_data;
-    auto empty_callback = [](const VkDebugUtilsMessengerCallbackDataEXT *pCallbackData, DebugUtilsLabelCheckData *data) {
-        data->count++;
-    };
+    auto empty_callback = [](const VkDebugUtilsMessengerCallbackDataEXT *, DebugUtilsLabelCheckData *data) { data->count++; };
     callback_data.count = 0;
     callback_data.callback = empty_callback;
 

--- a/tests/unit/debug_extensions_positive.cpp
+++ b/tests/unit/debug_extensions_positive.cpp
@@ -23,9 +23,7 @@ TEST_F(PositiveDebugExtensions, SetDebugUtilsObjectBuffer) {
     }
 
     DebugUtilsLabelCheckData callback_data;
-    auto empty_callback = [](const VkDebugUtilsMessengerCallbackDataEXT *pCallbackData, DebugUtilsLabelCheckData *data) {
-        data->count++;
-    };
+    auto empty_callback = [](const VkDebugUtilsMessengerCallbackDataEXT *, DebugUtilsLabelCheckData *data) { data->count++; };
     callback_data.count = 0;
     callback_data.callback = empty_callback;
 
@@ -60,9 +58,7 @@ TEST_F(PositiveDebugExtensions, SetDebugUtilsObjectDevice) {
     }
 
     DebugUtilsLabelCheckData callback_data;
-    auto empty_callback = [](const VkDebugUtilsMessengerCallbackDataEXT *pCallbackData, DebugUtilsLabelCheckData *data) {
-        data->count++;
-    };
+    auto empty_callback = [](const VkDebugUtilsMessengerCallbackDataEXT *, DebugUtilsLabelCheckData *data) { data->count++; };
     callback_data.count = 0;
     callback_data.callback = empty_callback;
 

--- a/tests/unit/dynamic_rendering.cpp
+++ b/tests/unit/dynamic_rendering.cpp
@@ -3147,7 +3147,7 @@ TEST_F(NegativeDynamicRendering, RenderingFragmentDensityMapAttachment) {
     auto image_ci = vkt::Image::ImageCreateInfo2D(
         32, 32, 1, 2, VK_FORMAT_R8G8B8A8_UNORM,
         VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT | VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR);
-    if (!ImageFormatIsSupported(instance(), Gpu(), image_ci, VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR)) {
+    if (!ImageFormatIsSupported(Gpu(), image_ci, VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR)) {
         GTEST_SKIP() << "format doesn't support FRAGMENT_SHADING_RATE_ATTACHMENT_BIT";
     }
 

--- a/tests/unit/gpu_av_descriptor_indexing.cpp
+++ b/tests/unit/gpu_av_descriptor_indexing.cpp
@@ -3741,7 +3741,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, AtomicImageRuntimeArray) {
     InitRenderTarget();
 
     auto image_ci = vkt::Image::ImageCreateInfo2D(64, 64, 1, 1, VK_FORMAT_R32_UINT, VK_IMAGE_USAGE_STORAGE_BIT);
-    if (!ImageFormatIsSupported(instance(), Gpu(), image_ci, VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT)) {
+    if (!ImageFormatIsSupported(Gpu(), image_ci, VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT)) {
         GTEST_SKIP() << "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT is not supported.";
     }
     vkt::Image image(*m_device, image_ci, vkt::set_layout);

--- a/tests/unit/gpu_av_descriptor_indexing_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_indexing_positive.cpp
@@ -2566,7 +2566,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, AtomicImage) {
     InitRenderTarget();
 
     auto image_ci = vkt::Image::ImageCreateInfo2D(64, 64, 1, 1, VK_FORMAT_R32_UINT, VK_IMAGE_USAGE_STORAGE_BIT);
-    if (!ImageFormatIsSupported(instance(), Gpu(), image_ci, VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT)) {
+    if (!ImageFormatIsSupported(Gpu(), image_ci, VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT)) {
         GTEST_SKIP() << "VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT is not supported.";
     }
     vkt::Image image(*m_device, image_ci, vkt::set_layout);

--- a/tests/unit/gpu_av_descriptor_post_process.cpp
+++ b/tests/unit/gpu_av_descriptor_post_process.cpp
@@ -497,7 +497,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, InvalidAtomicStorageOperation) {
                                                        // cause DesiredFailure. VK_FORMAT_R32_UINT is right format.
     auto image_ci = vkt::Image::ImageCreateInfo2D(64, 64, 1, 1, image_format, usage);
 
-    if (ImageFormatIsSupported(instance(), Gpu(), image_ci, VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT)) {
+    if (ImageFormatIsSupported(Gpu(), image_ci, VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT)) {
         GTEST_SKIP() << "Cannot make VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT not supported.";
     }
 

--- a/tests/unit/image.cpp
+++ b/tests/unit/image.cpp
@@ -3802,7 +3802,7 @@ TEST_F(NegativeImage, ImageCompressionControl) {
             vkt::Image::ImageCreateInfo2D(128, 128, 1, 1, format, VK_IMAGE_USAGE_TRANSFER_SRC_BIT, imageTiling);
         image_create_info.pNext = &compression_control;
 
-        bool supported = ImageFormatIsSupported(instance(), Gpu(), image_create_info, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT);
+        bool supported = ImageFormatIsSupported(Gpu(), image_create_info, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT);
 
         if (supported) {
             image.Init(*m_device, image_create_info);
@@ -3944,7 +3944,7 @@ TEST_F(NegativeImage, ImageCompressionControlMultiPlane) {
             vkt::Image::ImageCreateInfo2D(128, 128, 1, 1, format, VK_IMAGE_USAGE_TRANSFER_SRC_BIT, imageTiling);
         image_create_info.pNext = &compression_control;
 
-        bool supported = ImageFormatIsSupported(instance(), Gpu(), image_create_info, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT);
+        bool supported = ImageFormatIsSupported(Gpu(), image_create_info, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT);
 
         if (supported) {
             image.Init(*m_device, image_create_info);

--- a/tests/unit/image_positive.cpp
+++ b/tests/unit/image_positive.cpp
@@ -57,8 +57,8 @@ TEST_F(PositiveImage, OwnershipTranfersImage) {
 
     image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
 
-    ValidOwnershipTransfer(m_errorMonitor, m_default_queue, m_command_buffer, no_gfx_queue, no_gfx_cb,
-                           VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, nullptr, &image_barrier);
+    ValidOwnershipTransfer(m_default_queue, m_command_buffer, no_gfx_queue, no_gfx_cb, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT,
+                           VK_PIPELINE_STAGE_TRANSFER_BIT, nullptr, &image_barrier);
 
     // Change layouts while changing ownership
     image_barrier.srcQueueFamilyIndex = no_gfx_queue->family_index;
@@ -71,8 +71,8 @@ TEST_F(PositiveImage, OwnershipTranfersImage) {
         image_barrier.newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     }
 
-    ValidOwnershipTransfer(m_errorMonitor, no_gfx_queue, no_gfx_cb, m_default_queue, m_command_buffer,
-                           VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, nullptr, &image_barrier);
+    ValidOwnershipTransfer(no_gfx_queue, no_gfx_cb, m_default_queue, m_command_buffer, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                           VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, nullptr, &image_barrier);
 }
 
 TEST_F(PositiveImage, AliasedMemoryTracking) {

--- a/tests/unit/instance_positive.cpp
+++ b/tests/unit/instance_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2025 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ TEST_F(PositiveInstance, ValidEnumBeforeLogicalDevice) {
 
     // Verify formats
     VkFormatFeatureFlags features = VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT;
-    ImageFormatIsSupported(instance(), Gpu(), ci, features);
+    ImageFormatIsSupported(Gpu(), ci, features);
 }
 
 TEST_F(PositiveInstance, EmptyVkLayerSettingEXT) {

--- a/tests/unit/instanceless.cpp
+++ b/tests/unit/instanceless.cpp
@@ -218,6 +218,7 @@ void* VKAPI_PTR DummyAlloc(void*, size_t size, size_t alignment, VkSystemAllocat
     return std::align(alignment, size, mem_ptr, space);
 }
 void VKAPI_PTR DummyFree(void*, void* pMemory) {
+    (void)pMemory;
 // The test which uses DummyFree plays foul of the nature of memory allocation on Windows. Because it doesn't use
 // a VkAllocationCallback during vkCreateInstance then passes one in during vkDestroyInstance, the memory that is
 // allocated during vkCreateInstance lives in a different 'heap'. Trying to free it from the application with the

--- a/tests/unit/multiview.cpp
+++ b/tests/unit/multiview.cpp
@@ -716,7 +716,7 @@ TEST_F(NegativeMultiview, RenderPassCreateOverlappingCorrelationMasks) {
         nullptr, 1u, viewMasks.data(), 0u, nullptr, static_cast<uint32_t>(correlationMasks.size()), correlationMasks.data());
     auto rpci = vku::InitStruct<VkRenderPassCreateInfo>(&rpmvci, 0u, 0u, nullptr, 1u, &subpass, 0u, nullptr);
 
-    PositiveTestRenderPassCreate(m_errorMonitor, *m_device, rpci, false);
+    PositiveTestRenderPassCreate(*m_device, rpci, false);
 
     // Correlation masks must not overlap
     correlationMasks[1] = 0x3u;

--- a/tests/unit/parent.cpp
+++ b/tests/unit/parent.cpp
@@ -15,8 +15,8 @@
 #include "../framework/data_graph_objects.h"
 
 namespace {
-VKAPI_ATTR VkBool32 VKAPI_CALL EmptyDebugReportCallback(VkDebugReportFlagsEXT message_flags, VkDebugReportObjectTypeEXT, uint64_t,
-                                                        size_t, int32_t, const char *, const char *message, void *user_data) {
+VKAPI_ATTR VkBool32 VKAPI_CALL EmptyDebugReportCallback(VkDebugReportFlagsEXT, VkDebugReportObjectTypeEXT, uint64_t, size_t,
+                                                        int32_t, const char *, const char *, void *) {
     return VK_FALSE;
 }
 }  // namespace
@@ -431,7 +431,7 @@ TEST_F(NegativeParent, Instance_DebugUtilsMessenger) {
     RETURN_IF_SKIP(Init());
     vkt::Instance instance2(GetInstanceCreateInfo());
 
-    auto empty_callback = [](const VkDebugUtilsMessengerCallbackDataEXT *pCallbackData, DebugUtilsLabelCheckData *data) {};
+    auto empty_callback = [](const VkDebugUtilsMessengerCallbackDataEXT *, DebugUtilsLabelCheckData *) {};
     DebugUtilsLabelCheckData callback_data{};
     callback_data.callback = empty_callback;
 

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -1631,14 +1631,15 @@ TEST_F(NegativeRayTracing, CmdBuildAccelerationStructuresKHR) {
     {
         m_command_buffer.Begin();
         auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
-        blas.BuildCmdBuffer(m_command_buffer, true);
+        blas.BuildCmdBuffer(m_command_buffer);
         m_command_buffer.End();
     }
 
     {
         m_command_buffer.Begin();
         auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
-        blas.BuildCmdBuffer(m_command_buffer, false);
+        blas.SetupBuild(true);
+        blas.VkCmdBuildAccelerationStructuresKHR(m_command_buffer, false);
         m_command_buffer.End();
     }
 

--- a/tests/unit/ray_tracing_pipeline_positive_nv.cpp
+++ b/tests/unit/ray_tracing_pipeline_positive_nv.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2024 The Khronos Group Inc.
- * Copyright (c) 2015-2024 Valve Corporation
- * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (c) 2015-2024 Google, Inc.
+ * Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2025 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,6 @@ TEST_F(PositiveRayTracingPipelineNV, BasicUsage) {
 
     RETURN_IF_SKIP(InitState());
 
-    auto ignore_update = [](nv::rt::RayTracingPipelineHelper &helper) {};
+    auto ignore_update = [](nv::rt::RayTracingPipelineHelper &) {};
     nv::rt::RayTracingPipelineHelper::OneshotPositiveTest(*this, ignore_update);
 }

--- a/tests/unit/render_pass_positive.cpp
+++ b/tests/unit/render_pass_positive.cpp
@@ -398,19 +398,19 @@ TEST_F(PositiveRenderPass, ValidStages) {
     dependency.dstSubpass = 1;
     dependency.srcStageMask = kGraphicsStages;
     dependency.dstStageMask = kGraphicsStages;
-    PositiveTestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported);
+    PositiveTestRenderPassCreate(*m_device, rpci, rp2_supported);
 
     dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
     dependency.dstSubpass = 0;
     dependency.srcStageMask = kGraphicsStages | VK_PIPELINE_STAGE_HOST_BIT;
     dependency.dstStageMask = kGraphicsStages;
-    PositiveTestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported);
+    PositiveTestRenderPassCreate(*m_device, rpci, rp2_supported);
 
     dependency.srcSubpass = 0;
     dependency.dstSubpass = VK_SUBPASS_EXTERNAL;
     dependency.srcStageMask = kGraphicsStages;
     dependency.dstStageMask = VK_PIPELINE_STAGE_HOST_BIT;
-    PositiveTestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported);
+    PositiveTestRenderPassCreate(*m_device, rpci, rp2_supported);
 }
 
 TEST_F(PositiveRenderPass, SingleMipTransition) {
@@ -1020,7 +1020,7 @@ TEST_F(PositiveRenderPass, InputResolve) {
     rp.AddColorAttachment(1);
     rp.AddResolveAttachment(2);
 
-    PositiveTestRenderPassCreate(m_errorMonitor, *m_device, rp.GetCreateInfo(), rp2Supported);
+    PositiveTestRenderPassCreate(*m_device, rp.GetCreateInfo(), rp2Supported);
 }
 
 TEST_F(PositiveRenderPass, TestDepthStencilRenderPassTransition) {

--- a/tests/unit/sampler.cpp
+++ b/tests/unit/sampler.cpp
@@ -557,7 +557,7 @@ TEST_F(NegativeSampler, MultiplaneImageSamplerConversionMismatch) {
     image_ci.tiling = VK_IMAGE_TILING_LINEAR;
 
     // Verify formats
-    bool supported = ImageFormatIsSupported(instance(), Gpu(), image_ci, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT);
+    bool supported = ImageFormatIsSupported(Gpu(), image_ci, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT);
     if (!supported) {
         GTEST_SKIP() << "Multiplane image format not supported";
     }
@@ -670,7 +670,7 @@ TEST_F(NegativeSampler, ImageSamplerConversionNullImageView) {
     auto image_ci = vkt::Image::ImageCreateInfo2D(128, 128, 1, 1, VK_FORMAT_G8_B8R8_2PLANE_420_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
     image_ci.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;  // need for multi-planar
     image_ci.tiling = VK_IMAGE_TILING_LINEAR;
-    if (!ImageFormatIsSupported(instance(), Gpu(), image_ci, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
+    if (!ImageFormatIsSupported(Gpu(), image_ci, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
         GTEST_SKIP() << "Multiplane image format not supported";
     }
     if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_G8_B8R8_2PLANE_420_UNORM, VK_IMAGE_TILING_OPTIMAL,

--- a/tests/unit/subpass.cpp
+++ b/tests/unit/subpass.cpp
@@ -958,7 +958,7 @@ TEST_F(NegativeSubpass, InputAttachmentLayout) {
                                                       subpasses.data(), size32(deps), deps.data());
 
     // Current setup should be OK -- no attachment is both input and output in same subpass
-    PositiveTestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported);
+    PositiveTestRenderPassCreate(*m_device, rpci, rp2_supported);
 
     vkt::RenderPass render_pass(*m_device, rpci);
 }

--- a/tests/unit/sync_object_positive.cpp
+++ b/tests/unit/sync_object_positive.cpp
@@ -56,7 +56,7 @@ TEST_F(PositiveSyncObject, Sync2OwnershipTranfersImage) {
     image_barrier.image = image;
     image_barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
 
-    ValidOwnershipTransfer(m_errorMonitor, m_default_queue, m_command_buffer, no_gfx_queue, no_gfx_cb, nullptr, &image_barrier);
+    ValidOwnershipTransfer(m_default_queue, m_command_buffer, no_gfx_queue, no_gfx_cb, nullptr, &image_barrier);
 
     // Change layouts while changing ownership
     image_barrier.srcQueueFamilyIndex = no_gfx_queue->family_index;
@@ -71,7 +71,7 @@ TEST_F(PositiveSyncObject, Sync2OwnershipTranfersImage) {
         image_barrier.newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     }
 
-    ValidOwnershipTransfer(m_errorMonitor, no_gfx_queue, no_gfx_cb, m_default_queue, m_command_buffer, nullptr, &image_barrier);
+    ValidOwnershipTransfer(no_gfx_queue, no_gfx_cb, m_default_queue, m_command_buffer, nullptr, &image_barrier);
 }
 
 TEST_F(PositiveSyncObject, Sync2OwnershipTranfersBuffer) {
@@ -96,11 +96,11 @@ TEST_F(PositiveSyncObject, Sync2OwnershipTranfersBuffer) {
     // Let gfx own it.
     buffer_barrier.srcQueueFamilyIndex = m_device->graphics_queue_node_index_;
     buffer_barrier.dstQueueFamilyIndex = m_device->graphics_queue_node_index_;
-    ValidOwnershipTransferOp(m_errorMonitor, m_default_queue, m_command_buffer, &buffer_barrier, nullptr);
+    ValidOwnershipTransferOp(m_default_queue, m_command_buffer, &buffer_barrier, nullptr);
 
     // Transfer it to non-gfx
     buffer_barrier.dstQueueFamilyIndex = no_gfx_queue->family_index;
-    ValidOwnershipTransfer(m_errorMonitor, m_default_queue, m_command_buffer, no_gfx_queue, no_gfx_cb, &buffer_barrier, nullptr);
+    ValidOwnershipTransfer(m_default_queue, m_command_buffer, no_gfx_queue, no_gfx_cb, &buffer_barrier, nullptr);
 
     // Transfer it to gfx
     buffer_barrier.srcQueueFamilyIndex = no_gfx_queue->family_index;
@@ -108,7 +108,7 @@ TEST_F(PositiveSyncObject, Sync2OwnershipTranfersBuffer) {
     buffer_barrier.srcStageMask = VK_PIPELINE_STAGE_2_TRANSFER_BIT;
     buffer_barrier.dstStageMask = VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT;
 
-    ValidOwnershipTransfer(m_errorMonitor, no_gfx_queue, no_gfx_cb, m_default_queue, m_command_buffer, &buffer_barrier, nullptr);
+    ValidOwnershipTransfer(no_gfx_queue, no_gfx_cb, m_default_queue, m_command_buffer, &buffer_barrier, nullptr);
 }
 
 TEST_F(PositiveSyncObject, BarrierQueueFamily2) {

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -857,8 +857,8 @@ TEST_F(NegativeSyncVal, CopyOptimalMultiPlanarHazards) {
     VkFormat format = VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM;
     const auto image_ci = vkt::Image::ImageCreateInfo2D(128, 128, 1, 2, format, usage);
     // Verify format
-    bool supported = ImageFormatIsSupported(instance(), Gpu(), image_ci,
-                                            VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT);
+    bool supported =
+        ImageFormatIsSupported(Gpu(), image_ci, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT);
     if (!supported) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Multiplane image format not supported";
@@ -1036,8 +1036,8 @@ TEST_F(NegativeSyncVal, CopyLinearMultiPlanarHazards) {
     VkFormat format = VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM;
     const auto image_ci = vkt::Image::ImageCreateInfo2D(128, 128, 1, 1, format, usage, VK_IMAGE_TILING_LINEAR);
     // Verify format
-    bool supported = ImageFormatIsSupported(instance(), Gpu(), image_ci,
-                                            VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT);
+    bool supported =
+        ImageFormatIsSupported(Gpu(), image_ci, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT);
     if (!supported) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Multiplane image format not supported";

--- a/tests/unit/ycbcr.cpp
+++ b/tests/unit/ycbcr.cpp
@@ -467,7 +467,7 @@ TEST_F(NegativeYcbcr, CopyImageSinglePlane422Alignment) {
 
     // Verify formats
     VkFormatFeatureFlags features = VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT;
-    bool supported = ImageFormatIsSupported(instance(), Gpu(), ci, features);
+    bool supported = ImageFormatIsSupported(Gpu(), ci, features);
     if (!supported) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Single-plane _422 image format not supported";
@@ -535,7 +535,7 @@ TEST_F(NegativeYcbcr, MultiplaneImageCopyBufferToImage) {
     ci.samples = VK_SAMPLE_COUNT_1_BIT;
 
     VkFormatFeatureFlags features = VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT;
-    if (!ImageFormatIsSupported(instance(), Gpu(), ci, features)) {
+    if (!ImageFormatIsSupported(Gpu(), ci, features)) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Multiplane image format not supported";
     }
@@ -588,11 +588,11 @@ TEST_F(NegativeYcbcr, CopyImageMultiplaneAspectBits) {
 
     // Verify formats
     VkFormatFeatureFlags features = VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT;
-    bool supported = ImageFormatIsSupported(instance(), Gpu(), ci, features);
+    bool supported = ImageFormatIsSupported(Gpu(), ci, features);
     ci.format = VK_FORMAT_D24_UNORM_S8_UINT;
-    supported = supported && ImageFormatIsSupported(instance(), Gpu(), ci, features);
+    supported = supported && ImageFormatIsSupported(Gpu(), ci, features);
     ci.format = mp3_format;
-    supported = supported && ImageFormatIsSupported(instance(), Gpu(), ci, features);
+    supported = supported && ImageFormatIsSupported(Gpu(), ci, features);
     if (!supported) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Multiplane image formats or optimally tiled depth-stencil buffers not supported";
@@ -697,7 +697,7 @@ TEST_F(NegativeYcbcr, ClearColorImageFormat) {
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     image_create_info.arrayLayers = 1;
 
-    bool supported = ImageFormatIsSupported(instance(), Gpu(), image_create_info, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT);
+    bool supported = ImageFormatIsSupported(Gpu(), image_create_info, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT);
     if (supported == false) {
         GTEST_SKIP() << "Multiplane image format not supported";
     }
@@ -776,9 +776,9 @@ TEST_F(NegativeYcbcr, MultiplaneImageLayoutAspectFlags) {
     ci.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
 
     // Verify formats
-    bool supported = ImageFormatIsSupported(instance(), Gpu(), ci, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT);
+    bool supported = ImageFormatIsSupported(Gpu(), ci, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT);
     ci.format = VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM;
-    supported = supported && ImageFormatIsSupported(instance(), Gpu(), ci, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT);
+    supported = supported && ImageFormatIsSupported(Gpu(), ci, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT);
     if (!supported) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Multiplane image format not supported";
@@ -1373,7 +1373,7 @@ TEST_F(NegativeYcbcr, MultiplaneIncompatibleViewFormat3Plane) {
     ci.samples = VK_SAMPLE_COUNT_1_BIT;
 
     const VkFormatFeatureFlags features = VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT;
-    bool supported = ImageFormatIsSupported(instance(), Gpu(), ci, features);
+    bool supported = ImageFormatIsSupported(Gpu(), ci, features);
     // Verify format 3 Plane format
     if (!supported) {
         GTEST_SKIP() << "Multiplane image format not supported";
@@ -1429,7 +1429,7 @@ TEST_F(NegativeYcbcr, MultiplaneIncompatibleViewFormat2Plane) {
     ci.samples = VK_SAMPLE_COUNT_1_BIT;
 
     const VkFormatFeatureFlags features = VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT;
-    bool supported = ImageFormatIsSupported(instance(), Gpu(), ci, features);
+    bool supported = ImageFormatIsSupported(Gpu(), ci, features);
 
     // Verify format 2 Plane format
     if (!supported) {
@@ -1935,7 +1935,7 @@ TEST_F(NegativeYcbcr, FormatCompatibilitySamePlane) {
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    if (!ImageFormatIsSupported(instance(), Gpu(), image_create_info, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
+    if (!ImageFormatIsSupported(Gpu(), image_create_info, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
         GTEST_SKIP() << "Multiplane image format not supported";
     }
     m_errorMonitor->SetDesiredError("VUID-VkImageCreateInfo-pNext-10062");
@@ -1965,7 +1965,7 @@ TEST_F(NegativeYcbcr, FormatCompatibilityDifferentPlane) {
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    if (!ImageFormatIsSupported(instance(), Gpu(), image_create_info, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
+    if (!ImageFormatIsSupported(Gpu(), image_create_info, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
         GTEST_SKIP() << "Multiplane image format not supported";
     }
     m_errorMonitor->SetDesiredError("VUID-VkImageCreateInfo-pNext-10062");
@@ -1996,7 +1996,7 @@ TEST_F(NegativeYcbcr, DISABLED_FormatCompatibilityNonMutable) {
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    if (!ImageFormatIsSupported(instance(), Gpu(), image_create_info, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
+    if (!ImageFormatIsSupported(Gpu(), image_create_info, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
         GTEST_SKIP() << "Multiplane image format not supported";
     }
     m_errorMonitor->SetDesiredError("VUID-VkImageCreateInfo-pNext-10062");
@@ -2020,7 +2020,7 @@ TEST_F(NegativeYcbcr, MultiplaneImageCopyAspectMask) {
     ci.arrayLayers = 1;
     ci.samples = VK_SAMPLE_COUNT_1_BIT;
 
-    if (!ImageFormatIsSupported(instance(), Gpu(), ci, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
+    if (!ImageFormatIsSupported(Gpu(), ci, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
         GTEST_SKIP() << "Multiplane image format not supported";
     }
 

--- a/tests/unit/ycbcr_positive.cpp
+++ b/tests/unit/ycbcr_positive.cpp
@@ -56,7 +56,7 @@ TEST_F(PositiveYcbcr, MultiplaneGetImageSubresourceLayout) {
     ci.tiling = VK_IMAGE_TILING_LINEAR;
     ci.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     // Verify format
-    if (!ImageFormatIsSupported(instance(), Gpu(), ci, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT)) {
+    if (!ImageFormatIsSupported(Gpu(), ci, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT)) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Multiplane image format not supported";
     }
@@ -91,7 +91,7 @@ TEST_F(PositiveYcbcr, MultiplaneImageCopyBufferToImage) {
     ci.samples = VK_SAMPLE_COUNT_1_BIT;
 
     VkFormatFeatureFlags features = VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT;
-    if (!ImageFormatIsSupported(instance(), Gpu(), ci, features)) {
+    if (!ImageFormatIsSupported(Gpu(), ci, features)) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Multiplane image format not supported";
     }
@@ -143,7 +143,7 @@ TEST_F(PositiveYcbcr, MultiplaneImageCopy) {
 
     // Verify format
     VkFormatFeatureFlags features = VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT;
-    if (!ImageFormatIsSupported(instance(), Gpu(), ci, features)) {
+    if (!ImageFormatIsSupported(Gpu(), ci, features)) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Multiplane image format not supported";
     }
@@ -195,7 +195,7 @@ TEST_F(PositiveYcbcr, MultiplaneImageBindDisjoint) {
     // Verify format
     VkFormatFeatureFlags features =
         VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT | VK_FORMAT_FEATURE_DISJOINT_BIT;
-    if (!ImageFormatIsSupported(instance(), Gpu(), ci, features)) {
+    if (!ImageFormatIsSupported(Gpu(), ci, features)) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Multiplane image format not supported";
     }
@@ -282,7 +282,7 @@ TEST_F(PositiveYcbcr, ImageLayout) {
 
     // Verify format
     VkFormatFeatureFlags features = VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT;
-    if (!ImageFormatIsSupported(instance(), Gpu(), ci, features)) {
+    if (!ImageFormatIsSupported(Gpu(), ci, features)) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Multiplane image format not supported";
     }
@@ -374,7 +374,7 @@ TEST_F(PositiveYcbcr, DrawCombinedImageSampler) {
     ci.mipLevels = 1;
     ci.arrayLayers = 1;
     ci.samples = VK_SAMPLE_COUNT_1_BIT;
-    if (!ImageFormatIsSupported(instance(), Gpu(), ci, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
+    if (!ImageFormatIsSupported(Gpu(), ci, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Multiplane image format not supported";
     }
@@ -435,7 +435,7 @@ TEST_F(PositiveYcbcr, ImageQuerySizeLod) {
     ci.mipLevels = 1;
     ci.arrayLayers = 1;
     ci.samples = VK_SAMPLE_COUNT_1_BIT;
-    if (!ImageFormatIsSupported(instance(), Gpu(), ci, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
+    if (!ImageFormatIsSupported(Gpu(), ci, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Multiplane image format not supported";
     }
@@ -537,7 +537,7 @@ TEST_F(PositiveYcbcr, FormatCompatibilitySamePlane) {
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    if (!ImageFormatIsSupported(instance(), Gpu(), image_create_info, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
+    if (!ImageFormatIsSupported(Gpu(), image_create_info, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
         GTEST_SKIP() << "Multiplane image format not supported";
     }
     vkt::Image image(*m_device, image_create_info);
@@ -565,7 +565,7 @@ TEST_F(PositiveYcbcr, FormatCompatibilityDifferentPlane) {
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    if (!ImageFormatIsSupported(instance(), Gpu(), image_create_info, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
+    if (!ImageFormatIsSupported(Gpu(), image_create_info, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
         GTEST_SKIP() << "Multiplane image format not supported";
     }
     vkt::Image image(*m_device, image_create_info);
@@ -581,7 +581,7 @@ TEST_F(PositiveYcbcr, DISABLED_CopyImageSinglePlane422Alignment) {
                                                                VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
 
     VkFormatFeatureFlags features = VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT;
-    bool supported = ImageFormatIsSupported(instance(), Gpu(), image_ci, features);
+    bool supported = ImageFormatIsSupported(Gpu(), image_ci, features);
     if (!supported) {
         GTEST_SKIP() << "Single-plane _422 image format not supported";
     }


### PR DESCRIPTION
1. This moves the `tests/framework` code to be its own library, which will help with rebuilds 
2. While here, I removed a lot of `-Wunused-parameter` errors
3. This is prep for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10643 which will make it easy to share all the code that framework has