### PR TITLE
gpuav: Allow a bypass for Descriptor Buffer in short term

### DIFF
--- a/layers/gpuav/core/gpuav_settings.h
+++ b/layers/gpuav/core/gpuav_settings.h
@@ -44,6 +44,8 @@ struct GpuAVSettings {
     uint32_t debug_max_instrumentations_count = 0;  // zero is same as "unlimited"
     bool debug_print_instrumentation_info = false;
 
+    bool descriptor_buffer_override = false;
+
     // Note - even though DebugPrintf basically fits in here, from the user point of view they are different and that is reflected
     // in the settings (which are reflected in VkConfig). To make our lives easier, we just make these settings with the hierarchy
     // of the settings exposed

--- a/layers/gpuav/core/gpuav_setup.cpp
+++ b/layers/gpuav/core/gpuav_setup.cpp
@@ -364,11 +364,13 @@ void Validator::InitSettings(const Location &loc) {
         }
     }
 
-    if (IsExtEnabled(extensions.vk_ext_descriptor_buffer)) {
+    if (IsExtEnabled(extensions.vk_ext_descriptor_buffer) && !gpuav_settings.descriptor_buffer_override) {
         InternalWarning(
             device, loc,
             "VK_EXT_descriptor_buffer is enabled, but GPU-AV does not currently support validation of descriptor buffers. "
-            "[Disabling all shader instrumentation checks]");
+            "[Disabling all shader instrumentation checks]"
+            "\nThere is a VK_LAYER_GPUAV_DESCRIPTOR_BUFFER_OVERRIDE that can be set to bypass this if you know you are not going "
+            "to use descriptor buffers.");
         // Because of VUs like VUID-VkPipelineLayoutCreateInfo-pSetLayouts-08008 we currently would need to rework the entire shader
         // instrumentation logic
         gpuav_settings.DisableShaderInstrumentationAndOptions();
@@ -376,7 +378,9 @@ void Validator::InitSettings(const Location &loc) {
         if (gpuav_settings.debug_printf_enabled) {
             InternalWarning(device, loc,
                             "VK_EXT_descriptor_buffer is enabled, but DebugPrintf uses a normal descriptor and currently can't "
-                            "exist with descriptor buffers. [Disabling debug_printf]");
+                            "exist with descriptor buffers. [Disabling debug_printf]"
+                            "\nThere is a VK_LAYER_GPUAV_DESCRIPTOR_BUFFER_OVERRIDE that can be set to bypass this if you know you "
+                            "are not going to use descriptor buffers.");
             gpuav_settings.debug_printf_enabled = false;
         }
     }

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -204,6 +204,9 @@ const char *VK_LAYER_GPUAV_INDIRECT_TRACE_RAYS_BUFFERS = "gpuav_indirect_trace_r
 const char *VK_LAYER_GPUAV_BUFFER_COPIES = "gpuav_buffer_copies";
 const char *VK_LAYER_GPUAV_INDEX_BUFFERS = "gpuav_index_buffers";
 
+// A temporary workaround until we get proper Descriptor Buffer support
+const char *VK_LAYER_GPUAV_DESCRIPTOR_BUFFER_OVERRIDE = "gpuav_descriptor_buffer_override";
+
 // Keep removed warning until October 2025 SDK is released
 const char *REMOVED_GPUAV_IMAGE_LAYOUT = "gpuav_image_layout";
 
@@ -936,6 +939,11 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
         if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_INDEX_BUFFERS)) {
             vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_INDEX_BUFFERS, gpuav_settings.validate_index_buffers);
         }
+    }
+
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_DESCRIPTOR_BUFFER_OVERRIDE)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_DESCRIPTOR_BUFFER_OVERRIDE,
+                                gpuav_settings.descriptor_buffer_override);
     }
 
     if (vkuHasLayerSetting(layer_setting_set, REMOVED_GPUAV_IMAGE_LAYOUT)) {


### PR DESCRIPTION
allows those who have `VK_EXT_descriptor_buffer` turned on always (like CTS) but want to still use DebugPrintf