### PR TITLE
sync: Reduce FirstAccesses initial capacity from 3 to 2

### DIFF
--- a/layers/sync/sync_access_context.cpp
+++ b/layers/sync/sync_access_context.cpp
@@ -44,7 +44,7 @@ class HazardDetectorWithOrdering {
 
   public:
     HazardResult Detect(const ResourceAccessRangeMap::const_iterator &pos) const {
-        const OrderingBarrier &ordering = ResourceAccessState::GetOrderingRules(ordering_rule_);
+        const OrderingBarrier &ordering = GetOrderingRules(ordering_rule_);
         return pos->second.DetectHazard(access_info_, ordering, flags_, kQueueIdInvalid);
     }
     HazardResult DetectAsync(const ResourceAccessRangeMap::const_iterator &pos, ResourceUsageTag start_tag,


### PR DESCRIPTION
In cs2/doom captures it was maximum 2 first accesses registered per access state object. Use 2 as default capacity.

Cleanup OrderingBarrier definitions.