### PR TITLE
sync: Update how ResourceAccessState stores ReadState

### DIFF
--- a/layers/sync/sync_renderpass.cpp
+++ b/layers/sync/sync_renderpass.cpp
@@ -503,7 +503,7 @@ void RenderPassAccessContext::RecordLayoutTransitions(const vvl::RenderPass &rp_
                                                       const AttachmentViewGenVector &attachment_views, const ResourceUsageTag tag,
                                                       AccessContext &access_context) {
     const auto &transitions = rp_state.subpass_transitions[subpass];
-    const ResourceAccessState empty_infill;
+    const ResourceAccessState empty_infill{};
     for (const auto &transition : transitions) {
         const auto prev_pass = transition.prev_pass;
         const auto &view_gen = attachment_views[transition.attachment];


### PR DESCRIPTION
This moves in direction not to use full-fledged containers inside `ResourceAccessState` and make the latter close to POD type. Still we need support the case of multiple read states.

Instead of using `small_vector` for last_reads this stores single `ReadState` object directly for a common case of a single read. For multiple reads memory allocated dynamically.

`ResourceAccessState` size reduction: 344 bytes -> 280 bytes.

doom 2016 capture ~3% speed up, doom dark ages game ~6% speed up, no performance changes for other captures.