### PR TITLE
layers: Unify the way to use limits.h

### DIFF
--- a/layers/chassis/chassis_manual.cpp
+++ b/layers/chassis/chassis_manual.cpp
@@ -1317,7 +1317,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceToolPropertiesEXT(VkPhysicalDevi
     if (original_pToolProperties != nullptr) {
         pToolProperties = original_pToolProperties;
     }
-    assert(*pToolCount != std::numeric_limits<uint32_t>::max());
+    assert(*pToolCount != vvl::kU32Max);
     (*pToolCount)++;
 
     for (auto& vo : instance_dispatch->object_dispatch) {
@@ -1366,7 +1366,7 @@ VKAPI_ATTR VkResult VKAPI_CALL GetPhysicalDeviceToolProperties(VkPhysicalDevice 
     if (original_pToolProperties != nullptr) {
         pToolProperties = original_pToolProperties;
     }
-    assert(*pToolCount != std::numeric_limits<uint32_t>::max());
+    assert(*pToolCount != vvl::kU32Max);
     (*pToolCount)++;
 
     for (auto& vo : instance_dispatch->object_dispatch) {

--- a/layers/containers/limits.h
+++ b/layers/containers/limits.h
@@ -34,14 +34,4 @@ constexpr auto kI64Max = std::numeric_limits<int64_t>::max();
 constexpr auto kNoIndex32 = kU32Max;
 constexpr auto kNoIndex64 = kU64Max;
 
-template <typename T>
-constexpr T MaxTypeValue([[maybe_unused]] T) {
-    return std::numeric_limits<T>::max();
-}
-
-template <typename T>
-constexpr T MinTypeValue([[maybe_unused]] T) {
-    return std::numeric_limits<T>::min();
-}
-
 }  // namespace vvl

--- a/layers/core_checks/cc_device.cpp
+++ b/layers/core_checks/cc_device.cpp
@@ -179,7 +179,6 @@ bool core::Instance::ValidateDeviceQueueCreateInfos(const vvl::PhysicalDevice &p
                                                     const VkDeviceQueueCreateInfo *infos, const Location &loc) const {
     bool skip = false;
 
-    const uint32_t not_used = std::numeric_limits<uint32_t>::max();
     struct create_flags {
         // uint32_t is to represent the queue family index to allow for better error messages
         uint32_t unprocted_index;
@@ -203,7 +202,7 @@ bool core::Instance::ValidateDeviceQueueCreateInfos(const vvl::PhysicalDevice &p
 
         if (api_version == VK_API_VERSION_1_0) {
             // Vulkan 1.0 didn't have protected memory so always needed unique info
-            create_flags flags = {requested_queue_family, not_used};
+            create_flags flags = {requested_queue_family, vvl::kNoIndex32};
             if (queue_family_map.emplace(requested_queue_family, flags).second == false) {
                 skip |= LogError("VUID-VkDeviceCreateInfo-queueFamilyIndex-02802", pd_state.Handle(),
                                  info_loc.dot(Field::queueFamilyIndex),
@@ -215,7 +214,7 @@ bool core::Instance::ValidateDeviceQueueCreateInfos(const vvl::PhysicalDevice &p
             auto it = queue_family_map.find(requested_queue_family);
             if (it == queue_family_map.end()) {
                 // Add first time seeing queue family index and what the create flags were
-                create_flags new_flags = {not_used, not_used};
+                create_flags new_flags = {vvl::kNoIndex32, vvl::kNoIndex32};
                 if (protected_create_bit) {
                     new_flags.protected_index = requested_queue_family;
                 } else {
@@ -225,7 +224,7 @@ bool core::Instance::ValidateDeviceQueueCreateInfos(const vvl::PhysicalDevice &p
             } else {
                 // The queue family was seen, so now need to make sure the flags were different
                 if (protected_create_bit) {
-                    if (it->second.protected_index != not_used) {
+                    if (it->second.protected_index != vvl::kNoIndex32) {
                         skip |= LogError("VUID-VkDeviceCreateInfo-queueFamilyIndex-02802", pd_state.Handle(),
                                          info_loc.dot(Field::queueFamilyIndex),
                                          "(%" PRIu32 ") is not unique and was also used in pCreateInfo->pQueueCreateInfos[%" PRIu32
@@ -236,7 +235,7 @@ bool core::Instance::ValidateDeviceQueueCreateInfos(const vvl::PhysicalDevice &p
                         it->second.protected_index = requested_queue_family;
                     }
                 } else {
-                    if (it->second.unprocted_index != not_used) {
+                    if (it->second.unprocted_index != vvl::kNoIndex32) {
                         skip |= LogError("VUID-VkDeviceCreateInfo-queueFamilyIndex-02802", pd_state.Handle(),
                                          info_loc.dot(Field::queueFamilyIndex),
                                          "(%" PRIu32 ") is not unique and was also used in pCreateInfo->pQueueCreateInfos[%" PRIu32

--- a/layers/core_checks/cc_device_generated_commands.cpp
+++ b/layers/core_checks/cc_device_generated_commands.cpp
@@ -61,11 +61,10 @@ bool CoreChecks::PreCallValidateCreateIndirectCommandsLayoutEXT(VkDevice device,
     auto pipeline_layout_state = Get<vvl::PipelineLayout>(pCreateInfo->pipelineLayout);
     auto* dynamic_layout_create = vku::FindStructInPNextChain<VkPipelineLayoutCreateInfo>(pCreateInfo->pNext);
 
-    const uint32_t kNotFound = vvl::kU32Max;
-    uint32_t execution_set_token_index = kNotFound;
-    uint32_t vertex_buffer_token_index = kNotFound;
-    uint32_t index_buffer_token_index = kNotFound;
-    uint32_t sequence_index_token_index = kNotFound;
+    uint32_t execution_set_token_index = vvl::kNoIndex32;
+    uint32_t vertex_buffer_token_index = vvl::kNoIndex32;
+    uint32_t index_buffer_token_index = vvl::kNoIndex32;
+    uint32_t sequence_index_token_index = vvl::kNoIndex32;
 
     vvl::unordered_map<uint32_t, uint32_t> vertex_binding_unit_unique;
     vvl::unordered_map<uint32_t, VkPushConstantRange> token_ranges;
@@ -126,7 +125,7 @@ bool CoreChecks::PreCallValidateCreateIndirectCommandsLayoutEXT(VkDevice device,
         // Check for duplicate tokens
         if (token.type == VK_INDIRECT_COMMANDS_TOKEN_TYPE_EXECUTION_SET_EXT) {
             // currently these 2 VUs overlap but can be helpful to catch in different times
-            if (execution_set_token_index == kNotFound) {
+            if (execution_set_token_index == vvl::kNoIndex32) {
                 execution_set_token_index = i;
                 if (i != 0) {
                     skip |= LogError(
@@ -140,7 +139,7 @@ bool CoreChecks::PreCallValidateCreateIndirectCommandsLayoutEXT(VkDevice device,
                                  execution_set_token_index);
             }
         } else if (token.type == VK_INDIRECT_COMMANDS_TOKEN_TYPE_INDEX_BUFFER_EXT) {
-            if (index_buffer_token_index == kNotFound) {
+            if (index_buffer_token_index == vvl::kNoIndex32) {
                 index_buffer_token_index = i;
             } else {
                 skip |= LogError("VUID-VkIndirectCommandsLayoutCreateInfoEXT-pTokens-11094", device, token_loc.dot(Field::type),
@@ -149,7 +148,7 @@ bool CoreChecks::PreCallValidateCreateIndirectCommandsLayoutEXT(VkDevice device,
                                  index_buffer_token_index);
             }
         } else if (token.type == VK_INDIRECT_COMMANDS_TOKEN_TYPE_SEQUENCE_INDEX_EXT) {
-            if (sequence_index_token_index == kNotFound) {
+            if (sequence_index_token_index == vvl::kNoIndex32) {
                 sequence_index_token_index = i;
             } else {
                 skip |= LogError("VUID-VkIndirectCommandsLayoutCreateInfoEXT-pTokens-11145", device, token_loc.dot(Field::type),
@@ -204,7 +203,7 @@ bool CoreChecks::PreCallValidateCreateIndirectCommandsLayoutEXT(VkDevice device,
     } else {
         if (!IsValueIn(final_token_type, {VK_INDIRECT_COMMANDS_TOKEN_TYPE_DRAW_INDEXED_EXT,
                                           VK_INDIRECT_COMMANDS_TOKEN_TYPE_DRAW_INDEXED_COUNT_EXT}) &&
-            index_buffer_token_index != kNotFound) {
+            index_buffer_token_index != vvl::kNoIndex32) {
             skip |= LogError("VUID-VkIndirectCommandsLayoutCreateInfoEXT-pTokens-11095", device,
                              create_info_loc.dot(Field::pTokens, final_token_index).dot(Field::type),
                              "is %s (not an index draw token), but pTokens[%" PRIu32
@@ -214,7 +213,7 @@ bool CoreChecks::PreCallValidateCreateIndirectCommandsLayoutEXT(VkDevice device,
         if (!IsValueIn(final_token_type,
                        {VK_INDIRECT_COMMANDS_TOKEN_TYPE_DRAW_INDEXED_EXT, VK_INDIRECT_COMMANDS_TOKEN_TYPE_DRAW_EXT,
                         VK_INDIRECT_COMMANDS_TOKEN_TYPE_DRAW_INDEXED_COUNT_EXT, VK_INDIRECT_COMMANDS_TOKEN_TYPE_DRAW_COUNT_EXT}) &&
-            vertex_buffer_token_index != kNotFound) {
+            vertex_buffer_token_index != vvl::kNoIndex32) {
             skip |= LogError("VUID-VkIndirectCommandsLayoutCreateInfoEXT-pTokens-11096", device,
                              create_info_loc.dot(Field::pTokens, final_token_index).dot(Field::type),
                              "is %s (not a non-mesh draw token), but pTokens[%" PRIu32

--- a/layers/core_checks/cc_device_memory.cpp
+++ b/layers/core_checks/cc_device_memory.cpp
@@ -1729,7 +1729,7 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
                     // since its a non-disjoint image, finding VkImage in map is a duplicate
                     auto it = resources_bound.find(image_state->VkHandle());
                     if (it == resources_bound.end()) {
-                        std::array<uint32_t, 3> bound_index = {i, vvl::kU32Max, vvl::kU32Max};
+                        std::array<uint32_t, 3> bound_index = {i, vvl::kNoIndex32, vvl::kNoIndex32};
                         resources_bound.emplace(image_state->VkHandle(), bound_index);
                     } else {
                         const LogObjectList objlist(bind_info.image, bind_info.memory);
@@ -1783,11 +1783,11 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
 
                 auto it = resources_bound.find(image_state->VkHandle());
                 if (it == resources_bound.end()) {
-                    std::array<uint32_t, 3> bound_index = {vvl::kU32Max, vvl::kU32Max, vvl::kU32Max};
+                    std::array<uint32_t, 3> bound_index = {vvl::kNoIndex32, vvl::kNoIndex32, vvl::kNoIndex32};
                     bound_index[plane] = i;
                     resources_bound.emplace(image_state->VkHandle(), bound_index);
                 } else {
-                    if (it->second[plane] == vvl::kU32Max) {
+                    if (it->second[plane] == vvl::kNoIndex32) {
                         it->second[plane] = i;
                     } else {
                         const LogObjectList objlist(bind_info.image, bind_info.memory);
@@ -2221,7 +2221,7 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
         if (image_state && image_state->disjoint == true && !is_drm) {
             uint32_t total_planes = vkuFormatPlaneCount(image_state->create_info.format);
             for (uint32_t i = 0; i < total_planes; i++) {
-                if (resource.second[i] == vvl::kU32Max) {
+                if (resource.second[i] == vvl::kNoIndex32) {
                     skip |= LogError("VUID-vkBindImageMemory2-pBindInfos-02858", resource.first, error_obj.location,
                                      "Plane %" PRIu32
                                      " of the disjoint image was not bound. All %d planes need to bound individually "

--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -1240,12 +1240,12 @@ bool CoreChecks::PreCallValidateCmdDrawMeshTasksEXT(VkCommandBuffer commandBuffe
     uint64_t invocations = static_cast<uint64_t>(groupCountX) * static_cast<uint64_t>(groupCountY);
     // Prevent overflow.
     bool fail = false;
-    if (invocations > vvl::MaxTypeValue(maxTaskWorkGroupTotalCount) || invocations > maxTaskWorkGroupTotalCount) {
+    if (invocations > vvl::kU32Max || invocations > maxTaskWorkGroupTotalCount) {
         fail = true;
     }
     if (!fail) {
         invocations *= static_cast<uint64_t>(groupCountZ);
-        if (invocations > vvl::MaxTypeValue(maxTaskWorkGroupTotalCount) || invocations > maxTaskWorkGroupTotalCount) {
+        if (invocations > vvl::kU32Max || invocations > maxTaskWorkGroupTotalCount) {
             fail = true;
         }
     }

--- a/layers/core_checks/cc_shader_interface.cpp
+++ b/layers/core_checks/cc_shader_interface.cpp
@@ -779,7 +779,7 @@ bool CoreChecks::ValidateGraphicsPipelineShaderState(const vvl::Pipeline &pipeli
     // chained together in the pipeline. Note, we could be in the PreRaster GPL path, so there may not be a Fragment Shader see
     // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8443
     if (pipeline.stage_states.size() > 1) {
-        const size_t not_found = vvl::kU32Max;
+        const size_t not_found = vvl::kNoIndex32;
         auto get_stage = [&pipeline, not_found = not_found](VkShaderStageFlagBits stage) {
             for (size_t i = 0; i < pipeline.stage_states.size(); i++) {
                 if (pipeline.stage_states[i].GetStage() == stage) {

--- a/layers/core_checks/cc_state_tracker.cpp
+++ b/layers/core_checks/cc_state_tracker.cpp
@@ -1001,9 +1001,9 @@ void CommandBufferSubState::RecordExecuteCommand(vvl::CommandBuffer& secondary_c
 
     // State is trashed after executing secondary command buffers.
     // Importantly, this function runs after CoreChecks::PreCallValidateCmdExecuteCommands.
-    viewport.trashed_mask = vvl::MaxTypeValue(viewport.trashed_mask);
+    viewport.trashed_mask = vvl::kU32Max;
     viewport.trashed_count = true;
-    scissor.trashed_mask = vvl::MaxTypeValue(scissor.trashed_mask);
+    scissor.trashed_mask = vvl::kU32Max;
     scissor.trashed_count = true;
 
     // Add a query update that runs all the query updates that happen in the sub command buffer.

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -241,7 +241,7 @@ static std::string GetSemaphoreInUseBySwapchainMessage(const vvl::Semaphore::Swa
 
             // If the last semaphore usage is within the history then print corresponding image index in brackets
             const bool show_last_semaphore_usage = (swapchain.acquire_count - swapchain_info.acquire_counter_value) < print_count;
-            uint32_t marked_history_index = vvl::kU32Max;
+            uint32_t marked_history_index = vvl::kNoIndex32;
             if (show_last_semaphore_usage) {
                 marked_history_index = (history_length - 1) - (swapchain.acquire_count - swapchain_info.acquire_counter_value);
             }

--- a/layers/error_message/error_location.cpp
+++ b/layers/error_message/error_location.cpp
@@ -22,14 +22,14 @@ void Location::AppendFields(std::ostream& out) const {
     if (prev) {
         // When apply a .dot(sub_index) we duplicate the field item
         // Instead of dealing with partial non-const Location, just do the check here
-        const Location& prev_loc = (prev->field == field && prev->index == kNoIndex && prev->prev) ? *prev->prev : *prev;
+        const Location& prev_loc = (prev->field == field && prev->index == vvl::kNoIndex32 && prev->prev) ? *prev->prev : *prev;
 
         // Work back and print for Locaiton first
         prev_loc.AppendFields(out);
 
         // check if need connector from last item
         if (prev_loc.structure != vvl::Struct::Empty || prev_loc.field != vvl::Field::Empty) {
-            out << ((prev_loc.index == kNoIndex && IsFieldPointer(prev_loc.field)) ? "->" : ".");
+            out << ((prev_loc.index == vvl::kNoIndex32 && IsFieldPointer(prev_loc.field)) ? "->" : ".");
         }
     }
     if (isPNext && structure != vvl::Struct::Empty) {
@@ -37,7 +37,7 @@ void Location::AppendFields(std::ostream& out) const {
     }
     if (field != vvl::Field::Empty) {
         out << vvl::String(field);
-        if (index != kNoIndex) {
+        if (index != vvl::kNoIndex32) {
             out << "[" << index << "]";
         }
     }

--- a/layers/error_message/error_location.h
+++ b/layers/error_message/error_location.h
@@ -30,8 +30,6 @@
 // Holds the 'Location' of where the code is inside a function/struct/etc
 // see docs/error_object.md for more details
 struct Location {
-    static const uint32_t kNoIndex = vvl::kU32Max;
-
     // name of the vulkan function we're checking
     const vvl::Func function{};
 
@@ -42,9 +40,9 @@ struct Location {
     const Location* prev{};
     mutable const std::string* debug_region{};
 
-    Location(vvl::Func func, vvl::Struct s, vvl::Field f = vvl::Field::Empty, uint32_t i = kNoIndex)
+    Location(vvl::Func func, vvl::Struct s, vvl::Field f = vvl::Field::Empty, uint32_t i = vvl::kNoIndex32)
         : function(func), structure(s), field(f), index(i), isPNext(false), prev(nullptr) {}
-    Location(vvl::Func func, vvl::Field f = vvl::Field::Empty, uint32_t i = kNoIndex)
+    Location(vvl::Func func, vvl::Field f = vvl::Field::Empty, uint32_t i = vvl::kNoIndex32)
         : function(func), structure(vvl::Struct::Empty), field(f), index(i), isPNext(false), prev(nullptr) {}
     Location(const Location& prev_loc, vvl::Struct s, vvl::Field f, uint32_t i, bool p)
         : function(prev_loc.function), structure(s), field(f), index(i), isPNext(p), prev(&prev_loc) {}
@@ -67,11 +65,11 @@ struct Location {
 
     // the dot() method is for walking down into a structure that is being validated
     // eg:  loc.dot(Field::pMemoryBarriers, 5).dot(Field::srcStagemask)
-    Location dot(vvl::Struct s, vvl::Field sub_field, uint32_t sub_index = kNoIndex) const {
+    Location dot(vvl::Struct s, vvl::Field sub_field, uint32_t sub_index = vvl::kNoIndex32) const {
         Location result(*this, s, sub_field, sub_index, false);
         return result;
     }
-    Location dot(vvl::Field sub_field, uint32_t sub_index = kNoIndex) const {
+    Location dot(vvl::Field sub_field, uint32_t sub_index = vvl::kNoIndex32) const {
         Location result(*this, this->structure, sub_field, sub_index, false);
         return result;
     }
@@ -81,7 +79,7 @@ struct Location {
     }
 
     // same as dot() but will mark these were part of a pNext struct
-    Location pNext(vvl::Struct s, vvl::Field sub_field = vvl::Field::Empty, uint32_t sub_index = kNoIndex) const {
+    Location pNext(vvl::Struct s, vvl::Field sub_field = vvl::Field::Empty, uint32_t sub_index = vvl::kNoIndex32) const {
         Location result(*this, s, sub_field, sub_index, true);
         return result;
     }

--- a/layers/gpuav/core/gpuav_validation_pipeline.h
+++ b/layers/gpuav/core/gpuav_validation_pipeline.h
@@ -38,7 +38,7 @@ class CommandBufferSubState;
 namespace valpipe {
 
 struct BoundStorageBuffer {
-    uint32_t binding = vvl::kU32Max;
+    uint32_t binding = vvl::kNoIndex32;
     VkDescriptorBufferInfo info{VK_NULL_HANDLE, vvl::kU64Max, 0};
 };
 

--- a/layers/gpuav/descriptor_validation/gpuav_descriptor_set.cpp
+++ b/layers/gpuav/descriptor_validation/gpuav_descriptor_set.cpp
@@ -71,7 +71,7 @@ static glsl::DescriptorState GetInData(const vvl::BufferDescriptor &desc) {
 
 static glsl::DescriptorState GetInData(const vvl::TexelDescriptor &desc) {
     auto *buffer_view_state = desc.GetBufferViewState();
-    uint32_t res_size = vvl::kU32Max;
+    uint32_t res_size = vvl::kNoIndex32;
     if (buffer_view_state) {
         auto view_size = buffer_view_state->Size();
         res_size = static_cast<uint32_t>(view_size / GetTexelBufferFormatSize(buffer_view_state->create_info.format));
@@ -109,11 +109,11 @@ static glsl::DescriptorState GetInData(const vvl::MutableDescriptor &desc) {
         case DescriptorClass::GeneralBuffer: {
             auto buffer_state = desc.GetSharedBufferState();
             return glsl::DescriptorState(desc_class, GetId(buffer_state.get()),
-                                         buffer_state ? static_cast<uint32_t>(buffer_state->create_info.size) : vvl::kU32Max);
+                                         buffer_state ? static_cast<uint32_t>(buffer_state->create_info.size) : vvl::kNoIndex32);
         }
         case DescriptorClass::TexelBuffer: {
             auto buffer_view_state = desc.GetSharedBufferViewState();
-            uint32_t res_size = vvl::kU32Max;
+            uint32_t res_size = vvl::kNoIndex32;
             if (buffer_view_state) {
                 auto view_size = buffer_view_state->Size();
                 res_size = static_cast<uint32_t>(view_size / GetTexelBufferFormatSize(buffer_view_state->create_info.format));
@@ -147,7 +147,7 @@ static glsl::DescriptorState GetInData(const vvl::MutableDescriptor &desc) {
             break;
     }
     // If unsupported descriptor, act as if it is null and skip
-    return glsl::DescriptorState(desc_class, glsl::kNullDescriptor, vvl::kU32Max);
+    return glsl::DescriptorState(desc_class, glsl::kNullDescriptor, vvl::kNoIndex32);
 }
 
 template <typename Binding>
@@ -165,7 +165,7 @@ void FillBindingInData(const Binding &binding, glsl::DescriptorState *data, uint
 template <>
 void FillBindingInData(const vvl::InlineUniformBinding &binding, glsl::DescriptorState *data, uint32_t &index) {
     // While not techincally a "null descriptor" we want to skip it as if it is one
-    data[index++] = glsl::DescriptorState(DescriptorClass::InlineUniform, glsl::kNullDescriptor, vvl::kU32Max);
+    data[index++] = glsl::DescriptorState(DescriptorClass::InlineUniform, glsl::kNullDescriptor, vvl::kNoIndex32);
 }
 
 VkDeviceAddress DescriptorSetSubState::GetTypeAddress(Validator &gpuav) {

--- a/layers/gpuav/descriptor_validation/gpuav_descriptor_set.h
+++ b/layers/gpuav/descriptor_validation/gpuav_descriptor_set.h
@@ -30,11 +30,11 @@ class Validator;
 
 // Information about how each descriptor was accessed
 struct DescriptorAccess {
-    uint32_t binding = vvl::kU32Max;       // binding number in the descriptor set
-    uint32_t index = vvl::kU32Max;         // index into descriptor array
-    uint32_t variable_id = vvl::kU32Max;   // OpVariableID
-    uint32_t instruction_position_offset = vvl::kU32Max;  // Instruction Position to map to source
-    uint32_t error_logger_i = vvl::kU32Max;  // Index of error logger stored in command buffer state
+    uint32_t binding = vvl::kNoIndex32;                      // binding number in the descriptor set
+    uint32_t index = vvl::kNoIndex32;                        // index into descriptor array
+    uint32_t variable_id = vvl::kNoIndex32;                  // OpVariableID
+    uint32_t instruction_position_offset = vvl::kNoIndex32;  // Instruction Position to map to source
+    uint32_t error_logger_i = vvl::kNoIndex32;               // Index of error logger stored in command buffer state
 };
 
 class DescriptorSetSubState : public vvl::DescriptorSetSubState {

--- a/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
@@ -415,7 +415,7 @@ void UpdateInstrumentationDescSet(Validator &gpuav, CommandBufferSubState &cb_st
     for (size_t func_i = 0; func_i < cb_state.on_instrumentation_desc_set_update_functions.size(); ++func_i) {
         VkWriteDescriptorSet wds = vku::InitStructHelper();
         wds.dstSet = instrumentation_desc_set;
-        wds.dstBinding = vvl::kU32Max;
+        wds.dstBinding = vvl::kNoIndex32;
         wds.descriptorCount = 1;
         wds.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
         wds.pBufferInfo = &buffer_infos[func_i];
@@ -423,7 +423,7 @@ void UpdateInstrumentationDescSet(Validator &gpuav, CommandBufferSubState &cb_st
         cb_state.on_instrumentation_desc_set_update_functions[func_i](cb_state, bind_point, buffer_infos[func_i], wds.dstBinding);
 
         assert(buffer_infos[func_i].buffer != VK_NULL_HANDLE);
-        assert(wds.dstBinding != vvl::kU32Max);
+        assert(wds.dstBinding != vvl::kNoIndex32);
 
         desc_writes.emplace_back(wds);
     }
@@ -613,7 +613,7 @@ void PreCallSetupShaderInstrumentationResources(Validator &gpuav, CommandBufferS
     // We want to grab the last (current) element in descriptor_binding_commands, but as a std::vector, the reference might be
     // garbage later, so just hold the index for later. It is possible to have no descriptor sets bound, for example if using push
     // constants.
-    instrumentation_error_blob.descriptor_binding_index = vvl::kU32Max;
+    instrumentation_error_blob.descriptor_binding_index = vvl::kNoIndex32;
     DescriptorSetBindings *desc_set_bindings = cb_state.shared_resources_cache.TryGet<DescriptorSetBindings>();
     if (desc_set_bindings && !desc_set_bindings->descriptor_set_binding_commands.empty()) {
         instrumentation_error_blob.descriptor_binding_index =
@@ -621,7 +621,7 @@ void PreCallSetupShaderInstrumentationResources(Validator &gpuav, CommandBufferS
     }
 
     instrumentation_error_blob.label_command_i =
-        !cb_state.base.GetLabelCommands().empty() ? uint32_t(cb_state.base.GetLabelCommands().size() - 1) : vvl::kU32Max;
+        !cb_state.base.GetLabelCommands().empty() ? uint32_t(cb_state.base.GetLabelCommands().size() - 1) : vvl::kNoIndex32;
 
     CommandBufferSubState::ErrorLoggerFunc error_logger = [&gpuav, &cb_state, instrumentation_error_blob](
                                                               const uint32_t *error_record, const Location &loc,
@@ -692,7 +692,7 @@ bool LogMessageInstDescriptorIndexingOOB(Validator &gpuav, const CommandBufferSu
     std::ostringstream strm;
     const GpuVuid &vuid = GetGpuVuid(loc.function);
 
-    if (instrumentation_error_blob.descriptor_binding_index == vvl::kU32Max) {
+    if (instrumentation_error_blob.descriptor_binding_index == vvl::kNoIndex32) {
         assert(false);  // This means we have hit a situtation where there are no descriptors bound
         return false;
     }
@@ -767,7 +767,7 @@ bool LogMessageInstDescriptorClass(Validator &gpuav, const CommandBufferSubState
     std::ostringstream strm;
     const GpuVuid &vuid = GetGpuVuid(loc.function);
 
-    if (instrumentation_error_blob.descriptor_binding_index == vvl::kU32Max) {
+    if (instrumentation_error_blob.descriptor_binding_index == vvl::kNoIndex32) {
         assert(false);  // This means we have hit a situtation where there are no descriptors bound
         return false;
     }
@@ -1012,7 +1012,7 @@ bool LogMessageInstIndexedDraw(Validator &gpuav, const uint32_t *error_record, s
         out += std::to_string(vertex_attribute_fetch_limit.max_vertex_attributes_count);
         out += '\n';
         if (error_sub_code == glsl::kErrorSubCode_IndexedDraw_OOBInstanceIndex) {
-            if (vertex_attribute_fetch_limit.instance_rate_divisor != vvl::kU32Max) {
+            if (vertex_attribute_fetch_limit.instance_rate_divisor != vvl::kNoIndex32) {
                 out += "- Instance rate divisor: ";
                 out += std::to_string(vertex_attribute_fetch_limit.instance_rate_divisor);
                 out += '\n';
@@ -1046,7 +1046,7 @@ bool LogMessageInstIndexedDraw(Validator &gpuav, const uint32_t *error_record, s
         out_error_msg += std::to_string(oob_instance_index);
         const uint32_t instance_rate_divisor =
             inst_error_blob.vertex_attribute_fetch_limit_instance_input_rate->instance_rate_divisor;
-        if (instance_rate_divisor > 1 && instance_rate_divisor != vvl::kU32Max) {
+        if (instance_rate_divisor > 1 && instance_rate_divisor != vvl::kNoIndex32) {
             out_error_msg += " (or ";
             out_error_msg += std::to_string(oob_instance_index / instance_rate_divisor);
             out_error_msg += " if divided by instance rate divisor of ";

--- a/layers/gpuav/instrumentation/gpuav_instrumentation.h
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation.h
@@ -57,7 +57,7 @@ struct VertexAttributeFetchLimit {
     VkDeviceSize max_vertex_attributes_count = std::numeric_limits<VkDeviceSize>::max();
     vvl::VertexBufferBinding binding_info{};
     VkVertexInputAttributeDescription attribute{};
-    uint32_t instance_rate_divisor = std::numeric_limits<uint32_t>::max();
+    uint32_t instance_rate_divisor = vvl::kNoIndex32;
 };
 
 // This is data we capture in our lambda at command buffer recording time.
@@ -68,9 +68,9 @@ struct InstrumentationErrorBlob {
     std::optional<vvl::IndexBufferBinding> index_buffer_binding{};
 
     // indexing into the VkDebugUtilsLabelEXT
-    uint32_t label_command_i = vvl::kU32Max;
+    uint32_t label_command_i = vvl::kNoIndex32;
     // used to know which action command this occured at
-    uint32_t action_command_i = vvl::kU32Max;
+    uint32_t action_command_i = vvl::kNoIndex32;
 
     // Used to know if from draw, dispatch, or traceRays
     VkPipelineBindPoint pipeline_bind_point = VK_PIPELINE_BIND_POINT_MAX_ENUM;
@@ -78,7 +78,7 @@ struct InstrumentationErrorBlob {
     bool uses_shader_object = false;
 
     // index into the last vkCmdBindDescriptors prior to a draw/dispatch
-    uint32_t descriptor_binding_index = vvl::kU32Max;
+    uint32_t descriptor_binding_index = vvl::kNoIndex32;
 };
 
 // Return true iff an error has been found

--- a/layers/gpuav/resources/gpuav_state_trackers.cpp
+++ b/layers/gpuav/resources/gpuav_state_trackers.cpp
@@ -211,10 +211,10 @@ void CommandBufferSubState::IncrementCommandCount(VkPipelineBindPoint bind_point
 std::string CommandBufferSubState::GetDebugLabelRegion(uint32_t label_command_i,
                                                        const std::vector<std::string> &initial_label_stack) const {
     std::string debug_region_name;
-    if (label_command_i != vvl::kU32Max) {
+    if (label_command_i != vvl::kNoIndex32) {
         debug_region_name = base.GetDebugRegionName(base.GetLabelCommands(), label_command_i, initial_label_stack);
     } else {
-        // label_command_i == vvl::kU32Max => when the instrumented command was recorded,
+        // label_command_i == vvl::kNoIndex32 => when the instrumented command was recorded,
         // no debug label region was yet opened in the corresponding command buffer,
         // but still a region might have been started in another previously submitted
         // command buffer. So just compute region name from initial_label_stack.

--- a/layers/gpuav/spirv/buffer_device_address_pass.h
+++ b/layers/gpuav/spirv/buffer_device_address_pass.h
@@ -54,7 +54,7 @@ class BufferDeviceAddressPass : public Pass {
     // (example https://godbolt.org/z/v6boos6Yr)
     struct Range {
         uint32_t min_instruction = 0;  // used to only instrument at the lowest offset
-        uint32_t min_struct_offsets = vvl::kU32Max;
+        uint32_t min_struct_offsets = vvl::kNoIndex32;
         uint32_t max_struct_offsets = 0;
     };
     vvl::unordered_map<uint32_t, Range> block_struct_range_map_;

--- a/layers/gpuav/spirv/module.cpp
+++ b/layers/gpuav/spirv/module.cpp
@@ -29,7 +29,7 @@
 namespace gpuav {
 namespace spirv {
 
-static constexpr uint32_t kLinkedInstruction = std::numeric_limits<uint32_t>::max();
+static constexpr uint32_t kLinkedInstruction = vvl::kNoIndex32;
 
 Module::Module(vvl::span<const uint32_t> words, DebugReport* debug_report, const Settings& settings,
                const DeviceFeatures& enabled_features,

--- a/layers/gpuav/validation_cmd/gpuav_draw.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_draw.cpp
@@ -248,7 +248,7 @@ void FirstInstance(Validator &gpuav, CommandBufferSubState &cb_state, const Loca
     // Register error logger. Happens per command GPU-AV intercepts
     // ---
     const uint32_t label_command_i =
-        !cb_state.base.GetLabelCommands().empty() ? uint32_t(cb_state.base.GetLabelCommands().size() - 1) : vvl::kU32Max;
+        !cb_state.base.GetLabelCommands().empty() ? uint32_t(cb_state.base.GetLabelCommands().size() - 1) : vvl::kNoIndex32;
     ErrorLoggerFunc error_logger = [&gpuav, &cb_state, vuid, api_struct_name, label_command_i](
                                        const uint32_t *error_record, const Location &loc, const LogObjectList &objlist,
                                        const std::vector<std::string> &initial_label_stack) {
@@ -413,7 +413,7 @@ void CountBuffer(Validator &gpuav, CommandBufferSubState &cb_state, const Locati
     // Register error logger
     // ---
     const uint32_t label_command_i =
-        !cb_state.base.GetLabelCommands().empty() ? uint32_t(cb_state.base.GetLabelCommands().size() - 1) : vvl::kU32Max;
+        !cb_state.base.GetLabelCommands().empty() ? uint32_t(cb_state.base.GetLabelCommands().size() - 1) : vvl::kNoIndex32;
     ErrorLoggerFunc error_logger = [&gpuav, &cb_state, api_buffer, draw_buffer_size = draw_buffer_state->create_info.size,
                                     api_offset, api_struct_size_byte, api_stride, api_struct_name, vuid, label_command_i](
                                        const uint32_t *error_record, const Location &loc, const LogObjectList &objlist,
@@ -629,7 +629,7 @@ void DrawMeshIndirect(Validator &gpuav, CommandBufferSubState &cb_state, const L
     // Register error logger
     // ---
     const uint32_t label_command_i =
-        !cb_state.base.GetLabelCommands().empty() ? uint32_t(cb_state.base.GetLabelCommands().size() - 1) : vvl::kU32Max;
+        !cb_state.base.GetLabelCommands().empty() ? uint32_t(cb_state.base.GetLabelCommands().size() - 1) : vvl::kNoIndex32;
     ErrorLoggerFunc error_logger = [&gpuav, &cb_state, is_task_shader, label_command_i](
                                        const uint32_t *error_record, const Location &loc, const LogObjectList &objlist,
                                        const std::vector<std::string> &initial_label_stack) {
@@ -992,7 +992,7 @@ void DrawIndexedIndirectIndexBuffer(Validator &gpuav, CommandBufferSubState &cb_
     val_cmd_cb_state.per_render_pass_validation_commands.emplace_back(std::move(validation_cmd));
 
     const uint32_t label_command_i =
-        !cb_state.base.GetLabelCommands().empty() ? uint32_t(cb_state.base.GetLabelCommands().size() - 1) : vvl::kU32Max;
+        !cb_state.base.GetLabelCommands().empty() ? uint32_t(cb_state.base.GetLabelCommands().size() - 1) : vvl::kNoIndex32;
     ErrorLoggerFunc error_logger = [&gpuav, &cb_state, vuid, api_buffer, api_offset, api_stride,
                                     index_buffer_binding = cb_state.base.index_buffer_binding, label_command_i](
                                        const uint32_t *error_record, const Location &loc, const LogObjectList &objlist,

--- a/layers/state_tracker/descriptor_sets.cpp
+++ b/layers/state_tracker/descriptor_sets.cpp
@@ -710,7 +710,7 @@ void vvl::DescriptorSet::NotifyInvalidate(const NodeList &invalid_nodes, bool un
 uint32_t vvl::DescriptorSet::GetDynamicOffsetIndexFromBinding(uint32_t dynamic_binding) const {
     const uint32_t index = layout_->GetIndexFromBinding(dynamic_binding);
     if (index == bindings_.size()) {  // binding not found
-        return vvl::kU32Max;
+        return vvl::kNoIndex32;
     }
     assert(IsDynamicDescriptor(bindings_[index]->type));
     uint32_t dynamic_offset_index = 0;
@@ -1376,7 +1376,7 @@ void vvl::MutableDescriptor::CopyUpdate(DescriptorSet &set_state, const vvl::Dev
         case DescriptorClass::TexelBuffer: {
             ReplaceStatePtr(set_state, buffer_view_state_, static_cast<const TexelDescriptor &>(src).GetSharedBufferViewState(),
                             is_bindless);
-            buffer_size = buffer_view_state_ ? buffer_view_state_->Size() : vvl::kU32Max;
+            buffer_size = buffer_view_state_ ? buffer_view_state_->Size() : vvl::kNoIndex32;
             break;
         }
         case DescriptorClass::GeneralBuffer: {

--- a/layers/state_tracker/semaphore_state.h
+++ b/layers/state_tracker/semaphore_state.h
@@ -55,7 +55,7 @@ class Semaphore : public RefcountedStateObject {
     // Swapchain information associated with QueuePresent wait semaphore
     struct SwapchainWaitInfo {
         std::shared_ptr<vvl::Swapchain> swapchain;
-        uint32_t image_index = vvl::kU32Max;  // image being presented
+        uint32_t image_index = vvl::kNoIndex32;  // image being presented
         uint32_t acquire_counter_value = 0;   // value of vvl::Swapchain::acquire_count when the image was acquired
     };
 

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -2172,7 +2172,7 @@ ResourceInterfaceVariable::ResourceInterfaceVariable(const Module& module_state,
 
 PushConstantVariable::PushConstantVariable(const Module& module_state, const Instruction& insn, VkShaderStageFlagBits stage,
                                            const VariableAccessMap& variable_access_map, const DebugNameMap& debug_name_map)
-    : VariableBase(module_state, insn, stage, variable_access_map, debug_name_map), offset(vvl::kU32Max), size(0) {
+    : VariableBase(module_state, insn, stage, variable_access_map, debug_name_map), offset(vvl::kNoIndex32), size(0) {
     assert(type_struct_info != nullptr);  // Push Constants need to be structs
 
     auto struct_size = type_struct_info->GetSize(module_state);
@@ -2208,7 +2208,7 @@ TypeStructInfo::TypeStructInfo(const Module& module_state, const Instruction& st
 }
 
 TypeStructSize TypeStructInfo::GetSize(const Module& module_state) const {
-    uint32_t offset = vvl::kU32Max;
+    uint32_t offset = vvl::kNoIndex32;
     uint32_t size = 0;
 
     // Non-Blocks don't have offset so can get packed size

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -40,10 +40,10 @@ namespace spirv {
 struct EntryPoint;
 struct Module;
 
-static constexpr uint32_t kInvalidValue = std::numeric_limits<uint32_t>::max();
+static constexpr uint32_t kInvalidValue = vvl::kNoIndex32;
 
 // Need to find a way to know if actually array length of zero, or a runtime array.
-static constexpr uint32_t kRuntimeArray = std::numeric_limits<uint32_t>::max();
+static constexpr uint32_t kRuntimeArray = vvl::kNoIndex32;
 
 struct LocalSize {
     uint32_t x = 0;

--- a/layers/state_tracker/wsi_state.cpp
+++ b/layers/state_tracker/wsi_state.cpp
@@ -99,7 +99,7 @@ Swapchain::Swapchain(vvl::DeviceState &dev_data_, const VkSwapchainCreateInfoKHR
       dev_data(dev_data_) {
     // Initialize with visible values for debugging purposes.
     // This helps to show used slots during the first few frames.
-    acquire_history.fill(vvl::kU32Max);
+    acquire_history.fill(vvl::kNoIndex32);
 }
 
 void Swapchain::PresentImage(uint32_t image_index, uint64_t present_id, const SubmissionReference &present_submission_ref,
@@ -233,7 +233,7 @@ uint32_t Swapchain::GetAcquiredImageIndexFromHistory(uint32_t acquire_history_in
     const uint32_t ring_buffer_index = global_index % acquire_history_max_length;
 
     const uint32_t acquire_image_index = acquire_history[ring_buffer_index];
-    assert(acquire_image_index != vvl::kU32Max);
+    assert(acquire_image_index != vvl::kNoIndex32);
     return acquire_image_index;
 }
 

--- a/layers/stateless/sl_cmd_buffer_dynamic.cpp
+++ b/layers/stateless/sl_cmd_buffer_dynamic.cpp
@@ -272,7 +272,7 @@ bool Device::manual_PreCallValidateCmdSetDiscardRectangleEXT(VkCommandBuffer com
         const Location loc = error_obj.location.dot(Field::pDiscardRectangles, i);
         const int64_t x_sum =
             static_cast<int64_t>(pDiscardRectangles[i].offset.x) + static_cast<int64_t>(pDiscardRectangles[i].extent.width);
-        if (x_sum > std::numeric_limits<int32_t>::max()) {
+        if (x_sum > vvl::kI32Max) {
             skip |= LogError("VUID-vkCmdSetDiscardRectangleEXT-offset-00588", commandBuffer, loc,
                              "offset.x (%" PRId32 ") + extent.width (%" PRIu32 ") is %" PRIi64 " which will overflow int32_t.",
                              pDiscardRectangles[i].offset.x, pDiscardRectangles[i].extent.width, x_sum);
@@ -280,7 +280,7 @@ bool Device::manual_PreCallValidateCmdSetDiscardRectangleEXT(VkCommandBuffer com
 
         const int64_t y_sum =
             static_cast<int64_t>(pDiscardRectangles[i].offset.y) + static_cast<int64_t>(pDiscardRectangles[i].extent.height);
-        if (y_sum > std::numeric_limits<int32_t>::max()) {
+        if (y_sum > vvl::kI32Max) {
             skip |= LogError("VUID-vkCmdSetDiscardRectangleEXT-offset-00589", commandBuffer, loc,
                              "offset.y (%" PRId32 ") + extent.height (%" PRIu32 ") is %" PRIi64 " which will overflow int32_t.",
                              pDiscardRectangles[i].offset.y, pDiscardRectangles[i].extent.height, y_sum);

--- a/layers/stateless/sl_pipeline.cpp
+++ b/layers/stateless/sl_pipeline.cpp
@@ -848,7 +848,7 @@ bool Device::manual_PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPi
                         }
 
                         const int64_t x_sum = static_cast<int64_t>(scissor.offset.x) + static_cast<int64_t>(scissor.extent.width);
-                        if (x_sum > std::numeric_limits<int32_t>::max()) {
+                        if (x_sum > vvl::kI32Max) {
                             skip |= LogError("VUID-VkPipelineViewportStateCreateInfo-offset-02822", device, scissor_loc,
                                              "offset.x (%" PRId32 ") + extent.width (%" PRId32 ") is %" PRIi64
                                              " which will overflow int32_t.",
@@ -856,7 +856,7 @@ bool Device::manual_PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPi
                         }
 
                         const int64_t y_sum = static_cast<int64_t>(scissor.offset.y) + static_cast<int64_t>(scissor.extent.height);
-                        if (y_sum > std::numeric_limits<int32_t>::max()) {
+                        if (y_sum > vvl::kI32Max) {
                             skip |= LogError("VUID-VkPipelineViewportStateCreateInfo-offset-02823", device, scissor_loc,
                                              "offset.y (%" PRId32 ") + extent.height (%" PRId32 ") is %" PRIi64
                                              " which will overflow int32_t.",

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -1229,7 +1229,7 @@ void CommandBufferAccessContext::ImportRecordedAccessLog(const CommandBufferAcce
         const uint32_t command_offset = static_cast<uint32_t>(label_commands.size() - recorded_label_commands.size());
         for (size_t i = 0; i < recorded_context.access_log_->size(); i++) {
             size_t index = (access_log_->size() - 1) - i;
-            assert((*access_log_)[index].label_command_index != vvl::kU32Max);
+            assert((*access_log_)[index].label_command_index != vvl::kNoIndex32);
             (*access_log_)[index].label_command_index += command_offset;
         }
     }

--- a/layers/sync/sync_common.h
+++ b/layers/sync/sync_common.h
@@ -29,7 +29,7 @@ using ImageRangeGen = subresource_adapter::ImageRangeGenerator;
 
 // The resource tag index is relative to the command buffer or queue in which it's found
 using QueueId = uint32_t;
-constexpr static QueueId kQueueIdInvalid = QueueId(vvl::kU32Max);
+constexpr static QueueId kQueueIdInvalid = QueueId(vvl::kNoIndex32);
 constexpr static QueueId kQueueAny = kQueueIdInvalid - 1;
 
 using ResourceUsageTag = size_t;

--- a/layers/sync/sync_reporting.cpp
+++ b/layers/sync/sync_reporting.cpp
@@ -630,7 +630,7 @@ static ResourceUsageInfo GetResourceUsageInfoFromRecord(ResourceUsageTagEx tag_e
 
 ResourceUsageInfo CommandBufferAccessContext::GetResourceUsageInfo(ResourceUsageTagEx tag_ex) const {
     const ResourceUsageRecord &record = (*access_log_)[tag_ex.tag];
-    const auto debug_name_provider = (record.label_command_index == vvl::kU32Max) ? nullptr : this;
+    const auto debug_name_provider = (record.label_command_index == vvl::kNoIndex32) ? nullptr : this;
     return GetResourceUsageInfoFromRecord(tag_ex, record, debug_name_provider);
 }
 

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -905,7 +905,7 @@ BatchAccessLog::AccessRecord BatchAccessLog::CBSubmitLog::GetAccessRecord(Resour
     assert(log_);
     assert(index < log_->size());
     const ResourceUsageRecord* record = &(*log_)[index];
-    const auto debug_name_provider = (record->label_command_index == vvl::kU32Max) ? nullptr : this;
+    const auto debug_name_provider = (record->label_command_index == vvl::kNoIndex32) ? nullptr : this;
     return AccessRecord{&batch_, record, debug_name_provider};
 }
 

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -74,7 +74,7 @@ class SyncValidator : public vvl::DeviceProxy {
     vvl::unordered_map<VkFence, FenceHostSyncPoint> waitable_fences_;
     vvl::unordered_map<VkSemaphore, std::deque<TimelineHostSyncPoint>> host_waitable_semaphores_;
 
-    uint32_t debug_command_number = vvl::kU32Max;
+    uint32_t debug_command_number = vvl::kNoIndex32;
     uint32_t debug_reset_count = 1;
     std::string debug_cmdbuf_pattern;
 

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -265,7 +265,7 @@ class Device : public internal::Handle<VkDevice> {
     std::optional<uint32_t> NonGraphicsQueueFamily() const;
     Queue *NonGraphicsQueue() const;
 
-    uint32_t graphics_queue_node_index_ = vvl::kU32Max;
+    uint32_t graphics_queue_node_index_ = vvl::kNoIndex32;
 
     const PhysicalDevice physical_device_;
 

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -462,7 +462,7 @@ void TestRenderPassBegin(ErrorMonitor *error_monitor, const VkDevice device, con
 VkResult GPDIFPHelper(VkPhysicalDevice dev, const VkImageCreateInfo *ci, VkImageFormatProperties *limits = nullptr);
 
 VkFormat FindFormatWithoutFeatures(VkPhysicalDevice gpu, VkImageTiling tiling,
-                                   VkFormatFeatureFlags undesired_features = vvl::kU32Max);
+                                   VkFormatFeatureFlags undesired_features = vvl::kNoIndex32);
 
 VkFormat FindFormatWithoutFeatures2(VkPhysicalDevice gpu, VkImageTiling tiling, VkFormatFeatureFlags2 undesired_features);
 

--- a/tests/framework/sync_helper.h
+++ b/tests/framework/sync_helper.h
@@ -50,7 +50,7 @@ class BarrierQueueFamilyBase {
         DOUBLE_COMMAND_BUFFER,
     };
 
-    static const uint32_t kInvalidQueueFamily = vvl::kU32Max;
+    static const uint32_t kInvalidQueueFamily = vvl::kNoIndex32;
     Context *context_;
     vkt::Image image_;
     vkt::Buffer buffer_;

--- a/tests/unit/copy_buffer_image.cpp
+++ b/tests/unit/copy_buffer_image.cpp
@@ -3993,7 +3993,7 @@ TEST_F(NegativeCopyBufferImage, ImageCopyWidthOverflow) {
     copy_region.srcOffset = {32, 0, 0};
     copy_region.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0u, 0u, 1u};
     copy_region.dstOffset = {32, 0, 0};
-    copy_region.extent = {std::numeric_limits<uint32_t>::max(), 32u, 1u};
+    copy_region.extent = {vvl::kU32Max, 32u, 1u};
 
     m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyImage-srcOffset-00144");
@@ -4006,7 +4006,7 @@ TEST_F(NegativeCopyBufferImage, ImageCopyWidthOverflow) {
     copy_region.extent.width = 1u;
     copy_region.srcOffset.y = 32;
     copy_region.dstOffset.y = 32;
-    copy_region.extent.height = std::numeric_limits<uint32_t>::max();
+    copy_region.extent.height = vvl::kU32Max;
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyImage-srcOffset-00145");
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyImage-dstOffset-00151");
@@ -4018,7 +4018,7 @@ TEST_F(NegativeCopyBufferImage, ImageCopyWidthOverflow) {
     copy_region.extent.height = 1u;
     copy_region.srcOffset.z = 8u;
     copy_region.dstOffset.z = 8u;
-    copy_region.extent.depth = std::numeric_limits<uint32_t>::max();
+    copy_region.extent.depth = vvl::kU32Max;
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyImage-srcOffset-00147");
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyImage-dstOffset-00153");
     vk::CmdCopyImage(m_command_buffer, src_image, VK_IMAGE_LAYOUT_GENERAL, dst_image, VK_IMAGE_LAYOUT_GENERAL, 1, &copy_region);

--- a/tests/unit/descriptors.cpp
+++ b/tests/unit/descriptors.cpp
@@ -4726,7 +4726,7 @@ TEST_F(NegativeDescriptors, DISABLED_AllocatingVariableDescriptorSets) {
 
     VkDescriptorSetLayoutBinding bindings[2] = {
         {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 10, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
-        {1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, std::numeric_limits<uint32_t>::max() / 64, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
+        {1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, vvl::kU32Max / 64, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
     VkDescriptorSetLayoutCreateInfo ds_layout_ci = vku::InitStructHelper(&flags_create_info);
     ds_layout_ci.bindingCount = 2;
     ds_layout_ci.pBindings = bindings;
@@ -5659,7 +5659,7 @@ TEST_F(NegativeDescriptors, MaxInlineUniformTotalSize) {
     GetPhysicalDeviceProperties2(properties13);
     const uint32_t limit = properties13.maxInlineUniformTotalSize;
 
-    if (limit == std::numeric_limits<uint32_t>::max()) {
+    if (limit == vvl::kU32Max) {
         GTEST_SKIP() << "maxInlineUniformTotalSize is too large";
     }
 

--- a/tests/unit/device_generated_commands.cpp
+++ b/tests/unit/device_generated_commands.cpp
@@ -439,7 +439,7 @@ TEST_F(NegativeDeviceGeneratedCommands, TokenOffsetLimit) {
     VkPhysicalDeviceDeviceGeneratedCommandsPropertiesEXT dgc_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(dgc_props);
 
-    if (dgc_props.maxIndirectCommandsTokenOffset == std::numeric_limits<uint32_t>::max()) {
+    if (dgc_props.maxIndirectCommandsTokenOffset == vvl::kU32Max) {
         GTEST_SKIP() << "maxIndirectCommandsTokenOffset is too large";
     }
 

--- a/tests/unit/dynamic_rendering.cpp
+++ b/tests/unit/dynamic_rendering.cpp
@@ -2103,14 +2103,14 @@ TEST_F(NegativeDynamicRendering, TestFragmentDensityMapRenderArea) {
     m_errorMonitor->VerifyFound();
 
     begin_rendering_info.renderArea.offset.x = 1;
-    begin_rendering_info.renderArea.extent.width = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.width) - 1;
+    begin_rendering_info.renderArea.extent.width = vvl::kU32Max - 1;
     m_errorMonitor->SetUnexpectedError("VUID-VkRenderingInfo-pNext-07815");  // if over max
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-06112");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    begin_rendering_info.renderArea.offset.x = vvl::MaxTypeValue(begin_rendering_info.renderArea.offset.x);
-    begin_rendering_info.renderArea.extent.width = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.width);
+    begin_rendering_info.renderArea.offset.x = vvl::kI32Max;
+    begin_rendering_info.renderArea.extent.width = vvl::kU32Max;
     m_errorMonitor->SetUnexpectedError("VUID-VkRenderingInfo-pNext-07815");  // if over max
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-06112");
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -2125,14 +2125,14 @@ TEST_F(NegativeDynamicRendering, TestFragmentDensityMapRenderArea) {
     m_errorMonitor->VerifyFound();
 
     begin_rendering_info.renderArea.offset.y = 1;
-    begin_rendering_info.renderArea.extent.height = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.height) - 1;
+    begin_rendering_info.renderArea.extent.height = vvl::kU32Max - 1;
     m_errorMonitor->SetUnexpectedError("VUID-VkRenderingInfo-pNext-07816");  // if over max
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-06114");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    begin_rendering_info.renderArea.offset.y = vvl::MaxTypeValue(begin_rendering_info.renderArea.offset.y);
-    begin_rendering_info.renderArea.extent.height = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.height);
+    begin_rendering_info.renderArea.offset.y = vvl::kI32Max;
+    begin_rendering_info.renderArea.extent.height = vvl::kU32Max;
     m_errorMonitor->SetUnexpectedError("VUID-VkRenderingInfo-pNext-07816");  // if over max
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-06114");
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -2572,14 +2572,14 @@ TEST_F(NegativeDynamicRendering, AreaGreaterThanAttachmentExtent) {
     m_errorMonitor->VerifyFound();
 
     begin_rendering_info.renderArea.offset.x = 1;
-    begin_rendering_info.renderArea.extent.width = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.width) - 1;
+    begin_rendering_info.renderArea.extent.width = vvl::kU32Max - 1;
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-06079");
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-07815");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    begin_rendering_info.renderArea.offset.x = vvl::MaxTypeValue(begin_rendering_info.renderArea.offset.x);
-    begin_rendering_info.renderArea.extent.width = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.width);
+    begin_rendering_info.renderArea.offset.x = vvl::kI32Max;
+    begin_rendering_info.renderArea.extent.width = vvl::kU32Max;
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-06079");
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-07815");
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -2594,14 +2594,14 @@ TEST_F(NegativeDynamicRendering, AreaGreaterThanAttachmentExtent) {
     m_errorMonitor->VerifyFound();
 
     begin_rendering_info.renderArea.offset.y = 1;
-    begin_rendering_info.renderArea.extent.height = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.height) - 1;
+    begin_rendering_info.renderArea.extent.height = vvl::kU32Max - 1;
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-06080");
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-07816");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    begin_rendering_info.renderArea.offset.y = vvl::MaxTypeValue(begin_rendering_info.renderArea.offset.y);
-    begin_rendering_info.renderArea.extent.height = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.height);
+    begin_rendering_info.renderArea.offset.y = vvl::kI32Max;
+    begin_rendering_info.renderArea.extent.height = vvl::kU32Max;
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-06080");
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-07816");
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -2655,14 +2655,14 @@ TEST_F(NegativeDynamicRendering, DeviceGroupAreaGreaterThanAttachmentExtent) {
     m_errorMonitor->VerifyFound();
 
     begin_rendering_info.renderArea.offset.x = 1;
-    begin_rendering_info.renderArea.extent.width = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.width) - 1;
+    begin_rendering_info.renderArea.extent.width = vvl::kU32Max - 1;
     m_errorMonitor->SetUnexpectedError("VUID-VkRenderingInfo-pNext-07815");  // if over max
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-06079");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    begin_rendering_info.renderArea.offset.x = vvl::MaxTypeValue(begin_rendering_info.renderArea.offset.x);
-    begin_rendering_info.renderArea.extent.width = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.width);
+    begin_rendering_info.renderArea.offset.x = vvl::kI32Max;
+    begin_rendering_info.renderArea.extent.width = vvl::kU32Max;
     m_errorMonitor->SetUnexpectedError("VUID-VkRenderingInfo-pNext-07815");  // if over max
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-06079");
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -2677,14 +2677,14 @@ TEST_F(NegativeDynamicRendering, DeviceGroupAreaGreaterThanAttachmentExtent) {
     m_errorMonitor->VerifyFound();
 
     begin_rendering_info.renderArea.offset.y = 1;
-    begin_rendering_info.renderArea.extent.height = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.height) - 1;
+    begin_rendering_info.renderArea.extent.height = vvl::kU32Max - 1;
     m_errorMonitor->SetUnexpectedError("VUID-VkRenderingInfo-pNext-07816");  // if over max
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-06080");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    begin_rendering_info.renderArea.offset.y = vvl::MaxTypeValue(begin_rendering_info.renderArea.offset.y);
-    begin_rendering_info.renderArea.extent.height = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.height);
+    begin_rendering_info.renderArea.offset.y = vvl::kI32Max;
+    begin_rendering_info.renderArea.extent.height = vvl::kU32Max;
     m_errorMonitor->SetUnexpectedError("VUID-VkRenderingInfo-pNext-07816");  // if over max
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-06080");
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -3330,13 +3330,13 @@ TEST_F(NegativeDynamicRendering, RenderArea) {
     m_errorMonitor->VerifyFound();
 
     begin_rendering_info.renderArea.offset.x = 1;
-    begin_rendering_info.renderArea.extent.width = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.width) - 1;
+    begin_rendering_info.renderArea.extent.width = vvl::kU32Max - 1;
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-07815");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    begin_rendering_info.renderArea.offset.x = vvl::MaxTypeValue(begin_rendering_info.renderArea.offset.x);
-    begin_rendering_info.renderArea.extent.width = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.width);
+    begin_rendering_info.renderArea.offset.x = vvl::kI32Max;
+    begin_rendering_info.renderArea.extent.width = vvl::kU32Max;
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-07815");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
@@ -3349,13 +3349,13 @@ TEST_F(NegativeDynamicRendering, RenderArea) {
     m_errorMonitor->VerifyFound();
 
     begin_rendering_info.renderArea.offset.y = 1;
-    begin_rendering_info.renderArea.extent.height = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.height) - 1;
+    begin_rendering_info.renderArea.extent.height = vvl::kU32Max - 1;
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-07816");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    begin_rendering_info.renderArea.offset.y = vvl::MaxTypeValue(begin_rendering_info.renderArea.offset.y);
-    begin_rendering_info.renderArea.extent.height = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.height);
+    begin_rendering_info.renderArea.offset.y = vvl::kI32Max;
+    begin_rendering_info.renderArea.extent.height = vvl::kU32Max;
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-07816");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
@@ -4436,14 +4436,14 @@ TEST_F(NegativeDynamicRendering, FragmentShadingRateAttachmentSizeWithDeviceGrou
     m_errorMonitor->VerifyFound();
 
     begin_rendering_info.renderArea.offset.x = 1;
-    begin_rendering_info.renderArea.extent.width = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.width) - 1;
+    begin_rendering_info.renderArea.extent.width = vvl::kU32Max - 1;
     m_errorMonitor->SetUnexpectedError("VUID-VkRenderingInfo-pNext-07815");  // if over max
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-06119");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    begin_rendering_info.renderArea.offset.x = vvl::MaxTypeValue(begin_rendering_info.renderArea.offset.x);
-    begin_rendering_info.renderArea.extent.width = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.width);
+    begin_rendering_info.renderArea.offset.x = vvl::kI32Max;
+    begin_rendering_info.renderArea.extent.width = vvl::kU32Max;
     m_errorMonitor->SetUnexpectedError("VUID-VkRenderingInfo-pNext-07815");  // if over max
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-06119");
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -4469,13 +4469,13 @@ TEST_F(NegativeDynamicRendering, FragmentShadingRateAttachmentSizeWithDeviceGrou
     m_errorMonitor->VerifyFound();
 
     begin_rendering_info.renderArea.offset.y = 1;
-    begin_rendering_info.renderArea.extent.height = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.height) - 1;
+    begin_rendering_info.renderArea.extent.height = vvl::kU32Max - 1;
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-06120");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    begin_rendering_info.renderArea.offset.y = vvl::MaxTypeValue(begin_rendering_info.renderArea.offset.y);
-    begin_rendering_info.renderArea.extent.height = vvl::MaxTypeValue(begin_rendering_info.renderArea.extent.height);
+    begin_rendering_info.renderArea.offset.y = vvl::kI32Max;
+    begin_rendering_info.renderArea.extent.height = vvl::kU32Max;
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-06120");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();

--- a/tests/unit/dynamic_state.cpp
+++ b/tests/unit/dynamic_state.cpp
@@ -3614,7 +3614,7 @@ TEST_F(NegativeDynamicState, CmdSetDiscardRectangleEXTRectangleCountOverflow) {
     VkRect2D discard_rectangles = {};
     discard_rectangles.offset.x = 1;
     discard_rectangles.offset.y = 0;
-    discard_rectangles.extent.width = static_cast<uint32_t>(std::numeric_limits<int32_t>::max());
+    discard_rectangles.extent.width = vvl::kU32Max;
     discard_rectangles.extent.height = 64;
 
     m_command_buffer.Begin();
@@ -3623,7 +3623,7 @@ TEST_F(NegativeDynamicState, CmdSetDiscardRectangleEXTRectangleCountOverflow) {
     m_errorMonitor->VerifyFound();
 
     discard_rectangles.offset.x = 0;
-    discard_rectangles.offset.y = std::numeric_limits<int32_t>::max();
+    discard_rectangles.offset.y = vvl::kI32Max;
     discard_rectangles.extent.width = 64;
     discard_rectangles.extent.height = 1;
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetDiscardRectangleEXT-offset-00589");

--- a/tests/unit/gpu_av_index_buffer_positive.cpp
+++ b/tests/unit/gpu_av_index_buffer_positive.cpp
@@ -39,7 +39,7 @@ TEST_F(PositiveGpuAVIndexBuffer, BadVertexIndex) {
     m_command_buffer.Begin(&begin_info);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
-    vkt::Buffer index_buffer = vkt::IndexBuffer<uint32_t>(*m_device, {0, std::numeric_limits<uint32_t>::max(), 42});
+    vkt::Buffer index_buffer = vkt::IndexBuffer<uint32_t>(*m_device, {0, vvl::kU32Max, 42});
 
     vk::CmdBindIndexBuffer(m_command_buffer, index_buffer, 0, VK_INDEX_TYPE_UINT32);
     vk::CmdDrawIndexedIndirect(m_command_buffer, draw_params_buffer, 0, 1, 0);
@@ -184,7 +184,7 @@ TEST_F(PositiveGpuAVIndexBuffer, IndexedIndirectRobustness) {
     m_command_buffer.Begin(&begin_info);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
-    vkt::Buffer index_buffer = vkt::IndexBuffer<uint32_t>(*m_device, {0, std::numeric_limits<uint32_t>::max(), 42});
+    vkt::Buffer index_buffer = vkt::IndexBuffer<uint32_t>(*m_device, {0, vvl::kU32Max, 42});
 
     vk::CmdBindIndexBuffer(m_command_buffer, index_buffer, 0, VK_INDEX_TYPE_UINT32);
     vk::CmdDrawIndexedIndirect(m_command_buffer, draw_params_buffer, 0, 1, 0);
@@ -988,7 +988,7 @@ TEST_F(PositiveGpuAVIndexBuffer, DrawIndexedIndirectWithOffset) {
     m_command_buffer.Begin(&begin_info);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
-    vkt::Buffer index_buffer = vkt::IndexBuffer<uint32_t>(*m_device, {0, std::numeric_limits<uint32_t>::max(), 42});
+    vkt::Buffer index_buffer = vkt::IndexBuffer<uint32_t>(*m_device, {0, vvl::kU32Max, 42});
 
     vk::CmdBindIndexBuffer(m_command_buffer, index_buffer, 0, VK_INDEX_TYPE_UINT32);
     vk::CmdDrawIndexedIndirect(m_command_buffer, draw_params_buffer, offset, 1u, 0u);

--- a/tests/unit/gpu_av_indirect_buffer.cpp
+++ b/tests/unit/gpu_av_indirect_buffer.cpp
@@ -410,7 +410,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, Mesh) {
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
 
-    if (mesh_shader_props.maxMeshWorkGroupCount[0] < std::numeric_limits<uint32_t>::max()) {
+    if (mesh_shader_props.maxMeshWorkGroupCount[0] < vvl::kU32Max) {
         draw_ptr[8] = mesh_shader_props.maxMeshWorkGroupCount[0] + 1;
         m_errorMonitor->SetDesiredError("VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07326");
         if (mesh_shader_props.maxMeshWorkGroupCount[0] + 1 >= mesh_shader_props.maxMeshWorkGroupTotalCount) {
@@ -422,7 +422,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, Mesh) {
     }
 
     // Set y in second draw
-    if (mesh_shader_props.maxMeshWorkGroupCount[1] < std::numeric_limits<uint32_t>::max()) {
+    if (mesh_shader_props.maxMeshWorkGroupCount[1] < vvl::kU32Max) {
         draw_ptr[5] = mesh_shader_props.maxMeshWorkGroupCount[1] + 1;
         m_errorMonitor->SetDesiredError("VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07327");
         if (mesh_shader_props.maxMeshWorkGroupCount[1] + 1 >= mesh_shader_props.maxMeshWorkGroupTotalCount) {
@@ -434,7 +434,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, Mesh) {
     }
 
     // Set z in first draw
-    if (mesh_shader_props.maxMeshWorkGroupCount[2] < std::numeric_limits<uint32_t>::max()) {
+    if (mesh_shader_props.maxMeshWorkGroupCount[2] < vvl::kU32Max) {
         draw_ptr[2] = mesh_shader_props.maxMeshWorkGroupCount[2] + 1;
         m_errorMonitor->SetDesiredError("VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07328");
         if (mesh_shader_props.maxMeshWorkGroupCount[2] + 1 >= mesh_shader_props.maxMeshWorkGroupTotalCount) {
@@ -446,7 +446,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, Mesh) {
     }
 // total count can end up being really high, draw takes too long and times out
 #if 0
-    if (mesh_shader_props.maxMeshWorkGroupTotalCount < std::numeric_limits<uint32_t>::max()) {
+    if (mesh_shader_props.maxMeshWorkGroupTotalCount < vvl::kU32Max) {
         const uint32_t half_total = (mesh_shader_props.maxMeshWorkGroupTotalCount + 2) / 2;
         if (half_total < mesh_shader_props.maxMeshWorkGroupCount[0]) {
             draw_ptr[2] = 1;
@@ -534,7 +534,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DISABLED_MeshTask) {
     m_command_buffer.End();
 
     // Set x in second draw
-    if (mesh_shader_props.maxTaskWorkGroupCount[0] < std::numeric_limits<uint32_t>::max()) {
+    if (mesh_shader_props.maxTaskWorkGroupCount[0] < vvl::kU32Max) {
         draw_ptr[4] = mesh_shader_props.maxTaskWorkGroupCount[0] + 1;
         m_errorMonitor->SetDesiredError("VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07322");
         m_default_queue->SubmitAndWait(m_command_buffer);
@@ -543,7 +543,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DISABLED_MeshTask) {
     }
 
     // Set y in first draw
-    if (mesh_shader_props.maxTaskWorkGroupCount[1] < std::numeric_limits<uint32_t>::max()) {
+    if (mesh_shader_props.maxTaskWorkGroupCount[1] < vvl::kU32Max) {
         draw_ptr[1] = mesh_shader_props.maxTaskWorkGroupCount[1] + 1;
         m_errorMonitor->SetDesiredError("VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07323");
         m_default_queue->SubmitAndWait(m_command_buffer);
@@ -552,7 +552,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DISABLED_MeshTask) {
     }
 
     // Set z in third draw
-    if (mesh_shader_props.maxTaskWorkGroupCount[2] < std::numeric_limits<uint32_t>::max()) {
+    if (mesh_shader_props.maxTaskWorkGroupCount[2] < vvl::kU32Max) {
         draw_ptr[10] = mesh_shader_props.maxTaskWorkGroupCount[2] + 1;
         m_errorMonitor->SetDesiredError("VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07324");
         m_default_queue->SubmitAndWait(m_command_buffer);
@@ -560,7 +560,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DISABLED_MeshTask) {
         draw_ptr[10] = 1;
     }
 
-    if (mesh_shader_props.maxTaskWorkGroupTotalCount < std::numeric_limits<uint32_t>::max()) {
+    if (mesh_shader_props.maxTaskWorkGroupTotalCount < vvl::kU32Max) {
         const uint32_t half_total = (mesh_shader_props.maxTaskWorkGroupTotalCount + 2) / 2;
         if (half_total < mesh_shader_props.maxTaskWorkGroupCount[0]) {
             draw_ptr[2] = 1;

--- a/tests/unit/gpu_av_positive.cpp
+++ b/tests/unit/gpu_av_positive.cpp
@@ -2203,7 +2203,7 @@ TEST_F(PositiveGpuAV, MixDynamicNormalRenderPass) {
 
     vk::CmdPushConstants(m_command_buffer, g_pipeline_layout, all_stages, 8, 4, &dummy);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
-    vkt::Buffer index_buffer = vkt::IndexBuffer<uint32_t>(*m_device, {0, std::numeric_limits<uint32_t>::max(), 42});
+    vkt::Buffer index_buffer = vkt::IndexBuffer<uint32_t>(*m_device, {0, vvl::kU32Max, 42});
     vk::CmdBindIndexBuffer(m_command_buffer, index_buffer, 0, VK_INDEX_TYPE_UINT32);
     vk::CmdPushConstants(m_command_buffer, g_pipeline_layout, all_stages, 0, 4, &dummy);
     vk::CmdDrawIndexedIndirect(m_command_buffer, draw_params_buffer, 0, 1, 0);

--- a/tests/unit/gpu_av_ray_tracing.cpp
+++ b/tests/unit/gpu_av_ray_tracing.cpp
@@ -62,7 +62,7 @@ TEST_F(NegativeGpuAVRayTracing, CmdTraceRaysIndirect) {
     VkPhysicalDeviceProperties2 props2 = vku::InitStructHelper(&rt_pipeline_props);
     vk::GetPhysicalDeviceProperties2(Gpu(), &props2);
 
-    if (rt_pipeline_props.maxRayDispatchInvocationCount == std::numeric_limits<uint32_t>::max()) {
+    if (rt_pipeline_props.maxRayDispatchInvocationCount == vvl::kU32Max) {
         GTEST_SKIP() << "maxRayDispatchInvocationCount is maxed out, cannot go past it, skipping test";
     }
 

--- a/tests/unit/memory_positive.cpp
+++ b/tests/unit/memory_positive.cpp
@@ -347,7 +347,7 @@ TEST_F(PositiveMemory, MappingWithMultiInstanceHeapFlag) {
     VkPhysicalDeviceMemoryProperties memory_info;
     vk::GetPhysicalDeviceMemoryProperties(Gpu(), &memory_info);
 
-    uint32_t memory_index = std::numeric_limits<uint32_t>::max();
+    uint32_t memory_index = vvl::kU32Max;
     for (uint32_t i = 0; i < memory_info.memoryTypeCount; ++i) {
         if ((memory_info.memoryTypes[i].propertyFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)) {
             if (memory_info.memoryHeaps[memory_info.memoryTypes[i].heapIndex].flags & VK_MEMORY_HEAP_MULTI_INSTANCE_BIT) {
@@ -357,7 +357,7 @@ TEST_F(PositiveMemory, MappingWithMultiInstanceHeapFlag) {
         }
     }
 
-    if (memory_index == std::numeric_limits<uint32_t>::max()) {
+    if (memory_index == vvl::kU32Max) {
         GTEST_SKIP() << "Did not host visible memory from memory heap with VK_MEMORY_HEAP_MULTI_INSTANCE_BIT bit";
     }
 

--- a/tests/unit/mesh.cpp
+++ b/tests/unit/mesh.cpp
@@ -213,33 +213,33 @@ TEST_F(NegativeMesh, RuntimeSpirv) {
     uint32_t max_mesh_workgroup_size_y = mesh_shader_properties.maxMeshWorkGroupSize[1];
     uint32_t max_mesh_workgroup_size_z = mesh_shader_properties.maxMeshWorkGroupSize[2];
 
-    if (max_task_workgroup_size_x < vvl::MaxTypeValue(max_task_workgroup_size_x)) {
+    if (max_task_workgroup_size_x < vvl::kU32Max) {
         error_vuids.emplace_back("VUID-RuntimeSpirv-TaskEXT-07291");
         max_task_workgroup_size_x += 1;
     }
 
-    if (max_task_workgroup_size_y < vvl::MaxTypeValue(max_task_workgroup_size_y)) {
+    if (max_task_workgroup_size_y < vvl::kU32Max) {
         error_vuids.emplace_back("VUID-RuntimeSpirv-TaskEXT-07292");
         max_task_workgroup_size_y += 1;
     }
 
-    if (max_task_workgroup_size_z < vvl::MaxTypeValue(max_task_workgroup_size_z)) {
+    if (max_task_workgroup_size_z < vvl::kU32Max) {
         error_vuids.emplace_back("VUID-RuntimeSpirv-TaskEXT-07293");
         max_task_workgroup_size_z += 1;
     }
     error_vuids.emplace_back("VUID-RuntimeSpirv-TaskEXT-07294");
 
-    if (max_mesh_workgroup_size_x < vvl::MaxTypeValue(max_mesh_workgroup_size_x)) {
+    if (max_mesh_workgroup_size_x < vvl::kU32Max) {
         error_vuids.emplace_back("VUID-RuntimeSpirv-MeshEXT-07295");
         max_mesh_workgroup_size_x += 1;
     }
 
-    if (max_mesh_workgroup_size_y < vvl::MaxTypeValue(max_mesh_workgroup_size_y)) {
+    if (max_mesh_workgroup_size_y < vvl::kU32Max) {
         error_vuids.emplace_back("VUID-RuntimeSpirv-MeshEXT-07296");
         max_mesh_workgroup_size_y += 1;
     }
 
-    if (max_mesh_workgroup_size_z < vvl::MaxTypeValue(max_mesh_workgroup_size_z)) {
+    if (max_mesh_workgroup_size_z < vvl::kU32Max) {
         error_vuids.emplace_back("VUID-RuntimeSpirv-MeshEXT-07297");
         max_mesh_workgroup_size_z += 1;
     }
@@ -327,13 +327,13 @@ TEST_F(NegativeMesh, RuntimeSpirv2) {
     uint32_t max_mesh_output_primitives = mesh_shader_properties.maxMeshOutputPrimitives;
 
     bool skip = true;
-    if (max_mesh_output_vertices < vvl::MaxTypeValue(max_mesh_output_vertices)) {
+    if (max_mesh_output_vertices < vvl::kU32Max) {
         m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-MeshEXT-07115");
         skip = false;
         max_mesh_output_vertices += 1;
     }
 
-    if (max_mesh_output_primitives < vvl::MaxTypeValue(max_mesh_output_primitives)) {
+    if (max_mesh_output_primitives < vvl::kU32Max) {
         m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-MeshEXT-07116");
         skip = false;
         max_mesh_output_primitives += 1;
@@ -749,19 +749,19 @@ TEST_F(NegativeMesh, DrawCmds) {
     uint32_t max_group_count_Y = mesh_shader_properties.maxTaskWorkGroupCount[1];
     uint32_t max_group_count_Z = mesh_shader_properties.maxTaskWorkGroupCount[2];
 
-    if (max_group_count_X < vvl::MaxTypeValue(max_group_count_X)) {
+    if (max_group_count_X < vvl::kU32Max) {
         m_errorMonitor->SetDesiredError("VUID-vkCmdDrawMeshTasksEXT-TaskEXT-07322");
-        max_group_count_X = vvl::MaxTypeValue(max_group_count_X);
+        max_group_count_X = vvl::kU32Max;
     }
 
-    if (max_group_count_Y < vvl::MaxTypeValue(max_group_count_Y)) {
+    if (max_group_count_Y < vvl::kU32Max) {
         m_errorMonitor->SetDesiredError("VUID-vkCmdDrawMeshTasksEXT-TaskEXT-07323");
-        max_group_count_Y = vvl::MaxTypeValue(max_group_count_Y);
+        max_group_count_Y = vvl::kU32Max;
     }
 
-    if (max_group_count_Z < vvl::MaxTypeValue(max_group_count_Z)) {
+    if (max_group_count_Z < vvl::kU32Max) {
         m_errorMonitor->SetDesiredError("VUID-vkCmdDrawMeshTasksEXT-TaskEXT-07324");
-        max_group_count_Z = vvl::MaxTypeValue(max_group_count_Z);
+        max_group_count_Z = vvl::kU32Max;
     }
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDrawMeshTasksEXT-TaskEXT-07325");
@@ -772,7 +772,7 @@ TEST_F(NegativeMesh, DrawCmds) {
     vk::CmdDrawMeshTasksIndirectEXT(m_command_buffer, buffer, 0, 2, sizeof(VkDrawMeshTasksIndirectCommandEXT));
     m_errorMonitor->VerifyFound();
 
-    if (m_device->Physical().limits_.maxDrawIndirectCount < vvl::MaxTypeValue(m_device->Physical().limits_.maxDrawIndirectCount)) {
+    if (m_device->Physical().limits_.maxDrawIndirectCount < vvl::kU32Max) {
         m_errorMonitor->SetUnexpectedError("VUID-vkCmdDrawMeshTasksIndirectEXT-drawCount-02718");
         m_errorMonitor->SetDesiredError("VUID-vkCmdDrawMeshTasksIndirectEXT-drawCount-07090");
         m_errorMonitor->SetDesiredError("VUID-vkCmdDrawMeshTasksIndirectEXT-drawCount-02719");
@@ -1089,13 +1089,13 @@ TEST_F(NegativeMesh, MeshTasksWorkgroupCount) {
     if (mesh_shader_properties.maxMeshWorkGroupCount[0] == mesh_shader_properties.maxMeshWorkGroupTotalCount) {
         vuids.emplace_back("VUID-RuntimeSpirv-TaskEXT-07302");
     }
-    if (mesh_shader_properties.maxMeshWorkGroupCount[0] != std::numeric_limits<uint32_t>::max()) {
+    if (mesh_shader_properties.maxMeshWorkGroupCount[0] != vvl::kU32Max) {
         CreatePipelineHelper::OneshotTest(*this, mesh_tasks_x, kErrorBit, vuids);
     }
-    if (mesh_shader_properties.maxMeshWorkGroupCount[1] != std::numeric_limits<uint32_t>::max()) {
+    if (mesh_shader_properties.maxMeshWorkGroupCount[1] != vvl::kU32Max) {
         CreatePipelineHelper::OneshotTest(*this, mesh_tasks_y, kErrorBit, "VUID-RuntimeSpirv-TaskEXT-07300");
     }
-    if (mesh_shader_properties.maxMeshWorkGroupCount[2] != std::numeric_limits<uint32_t>::max()) {
+    if (mesh_shader_properties.maxMeshWorkGroupCount[2] != vvl::kU32Max) {
         CreatePipelineHelper::OneshotTest(*this, mesh_tasks_z, kErrorBit, "VUID-RuntimeSpirv-TaskEXT-07301");
     }
 }

--- a/tests/unit/multiview.cpp
+++ b/tests/unit/multiview.cpp
@@ -31,7 +31,7 @@ TEST_F(NegativeMultiview, MaxInstanceIndex) {
 
     VkPhysicalDeviceMultiviewProperties multiview_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(multiview_props);
-    if (multiview_props.maxMultiviewInstanceIndex == std::numeric_limits<uint32_t>::max()) {
+    if (multiview_props.maxMultiviewInstanceIndex == vvl::kU32Max) {
         GTEST_SKIP() << "maxMultiviewInstanceIndex is uint32_t max";
     }
 

--- a/tests/unit/push_descriptor.cpp
+++ b/tests/unit/push_descriptor.cpp
@@ -624,7 +624,7 @@ TEST_F(NegativePushDescriptor, SetLayoutMaxPushDescriptors) {
     ds_layout_ci.bindingCount = 1;
     ds_layout_ci.pBindings = &binding;
 
-    if (push_descriptor_prop.maxPushDescriptors == std::numeric_limits<uint32_t>::max()) {
+    if (push_descriptor_prop.maxPushDescriptors == vvl::kU32Max) {
         GTEST_SKIP() << "maxPushDescriptors is set to maximum unit32_t value";
     }
 

--- a/tests/unit/query.cpp
+++ b/tests/unit/query.cpp
@@ -2133,7 +2133,7 @@ TEST_F(NegativeQuery, PerformanceQueryReset) {
     vkt::QueryPool query_pool(*m_device, query_pool_ci);
 
     auto acquire_profiling_lock_info = vku::InitStruct<VkAcquireProfilingLockInfoKHR>();
-    acquire_profiling_lock_info.timeout = std::numeric_limits<uint64_t>::max();
+    acquire_profiling_lock_info.timeout = vvl::kU64Max;
     vk::AcquireProfilingLockKHR(*m_device, &acquire_profiling_lock_info);
 
     {
@@ -2438,7 +2438,7 @@ TEST_F(NegativeQuery, PerfQueryQueueFamilyIndex) {
     vkt::CommandBuffer cb(*m_device, command_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY);
 
     auto acquire_profiling_lock_info = vku::InitStruct<VkAcquireProfilingLockInfoKHR>();
-    acquire_profiling_lock_info.timeout = std::numeric_limits<uint64_t>::max();
+    acquire_profiling_lock_info.timeout = vvl::kU64Max;
     vk::AcquireProfilingLockKHR(*m_device, &acquire_profiling_lock_info);
 
     cb.Begin();

--- a/tests/unit/query_positive.cpp
+++ b/tests/unit/query_positive.cpp
@@ -457,7 +457,7 @@ TEST_F(PositiveQuery, PerformanceQueries) {
     vkt::CommandBuffer cmd_buffer(*m_device, m_command_pool);
 
     auto acquire_profiling_lock_info = vku::InitStruct<VkAcquireProfilingLockInfoKHR>();
-    acquire_profiling_lock_info.timeout = std::numeric_limits<uint64_t>::max();
+    acquire_profiling_lock_info.timeout = vvl::kU64Max;
 
     vk::AcquireProfilingLockKHR(*m_device, &acquire_profiling_lock_info);
 
@@ -581,7 +581,7 @@ TEST_F(PositiveQuery, PerformanceCountersWithoutEnumeration) {
     vkt::CommandBuffer cmd_buffer(*m_device, m_command_pool);
 
     auto acquire_profiling_lock_info = vku::InitStruct<VkAcquireProfilingLockInfoKHR>();
-    acquire_profiling_lock_info.timeout = std::numeric_limits<uint64_t>::max();
+    acquire_profiling_lock_info.timeout = vvl::kU64Max;
 
     vk::AcquireProfilingLockKHR(*m_device, &acquire_profiling_lock_info);
 

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -3616,7 +3616,7 @@ TEST_F(NegativeRayTracing, TooManyInstances) {
     m_device->Wait();
 
     auto tlas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceTopLevel(*m_device, *blas.GetDstAS());
-    tlas.GetGeometries()[0].SetPrimitiveCount(std::numeric_limits<uint32_t>::max());
+    tlas.GetGeometries()[0].SetPrimitiveCount(vvl::kU32Max);
     m_errorMonitor->SetDesiredError("VUID-vkGetAccelerationStructureBuildSizesKHR-pBuildInfo-03785");
     tlas.GetSizeInfo();
     m_errorMonitor->VerifyFound();

--- a/tests/unit/render_pass.cpp
+++ b/tests/unit/render_pass.cpp
@@ -1170,17 +1170,17 @@ TEST_F(NegativeRenderPass, BeginRenderArea) {
     TestRenderPassBegin(m_errorMonitor, device(), m_command_buffer, &m_renderPassBeginInfo, rp2Supported, vuid, vuid);
 
     m_renderPassBeginInfo.renderArea.offset.x = 1;
-    m_renderPassBeginInfo.renderArea.extent.width = vvl::MaxTypeValue(m_renderPassBeginInfo.renderArea.extent.width) - 1;
+    m_renderPassBeginInfo.renderArea.extent.width = vvl::kU32Max - 1;
     TestRenderPassBegin(m_errorMonitor, device(), m_command_buffer, &m_renderPassBeginInfo, rp2Supported, vuid, vuid);
 
-    m_renderPassBeginInfo.renderArea.offset.x = vvl::MaxTypeValue(m_renderPassBeginInfo.renderArea.offset.x);
-    m_renderPassBeginInfo.renderArea.extent.width = vvl::MaxTypeValue(m_renderPassBeginInfo.renderArea.extent.width);
+    m_renderPassBeginInfo.renderArea.offset.x = vvl::kI32Max;
+    m_renderPassBeginInfo.renderArea.extent.width = vvl::kU32Max;
     TestRenderPassBegin(m_errorMonitor, device(), m_command_buffer, &m_renderPassBeginInfo, rp2Supported, vuid, vuid);
 
     m_renderPassBeginInfo.renderArea.offset.x = 0;
     m_renderPassBeginInfo.renderArea.extent.width = 256;
     m_renderPassBeginInfo.renderArea.offset.y = 1;
-    m_renderPassBeginInfo.renderArea.extent.height = vvl::MaxTypeValue(m_renderPassBeginInfo.renderArea.extent.height) - 1;
+    m_renderPassBeginInfo.renderArea.extent.height = vvl::kU32Max - 1;
     TestRenderPassBegin(m_errorMonitor, device(), m_command_buffer, &m_renderPassBeginInfo, rp2Supported,
                         "VUID-VkRenderPassBeginInfo-pNext-02853", "VUID-VkRenderPassBeginInfo-pNext-02853");
 }

--- a/tests/unit/shader_object.cpp
+++ b/tests/unit/shader_object.cpp
@@ -3519,19 +3519,19 @@ TEST_F(NegativeShaderObject, ComputeShaderGroupCount) {
 
     m_command_buffer.BindCompShader(comp_shader);
 
-    if (x_count_limit != std::numeric_limits<uint32_t>::max()) {
+    if (x_count_limit != vvl::kU32Max) {
         m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-groupCountX-00386");
         vk::CmdDispatch(m_command_buffer, x_count_limit + 1u, 1u, 1u);
         m_errorMonitor->VerifyFound();
     }
 
-    if (y_count_limit != std::numeric_limits<uint32_t>::max()) {
+    if (y_count_limit != vvl::kU32Max) {
         m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-groupCountY-00387");
         vk::CmdDispatch(m_command_buffer, 1u, y_count_limit + 1u, 1u);
         m_errorMonitor->VerifyFound();
     }
 
-    if (z_count_limit != std::numeric_limits<uint32_t>::max()) {
+    if (z_count_limit != vvl::kU32Max) {
         m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-groupCountZ-00388");
         vk::CmdDispatch(m_command_buffer, 1u, 1u, z_count_limit + 1u);
         m_errorMonitor->VerifyFound();

--- a/tests/unit/transform_feedback.cpp
+++ b/tests/unit/transform_feedback.cpp
@@ -149,7 +149,7 @@ TEST_F(NegativeTransformFeedback, CmdBindTransformFeedbackBuffersEXT) {
         }
 
         // Request too many bindings.
-        if (tf_properties.maxTransformFeedbackBuffers < std::numeric_limits<uint32_t>::max()) {
+        if (tf_properties.maxTransformFeedbackBuffers < vvl::kU32Max) {
             auto const bindingCount = tf_properties.maxTransformFeedbackBuffers + 1;
             std::vector<VkBuffer> buffers(bindingCount, buffer_obj);
 
@@ -283,7 +283,7 @@ TEST_F(NegativeTransformFeedback, CmdBeginTransformFeedbackEXT) {
         }
 
         // Request too many buffers.
-        if (tf_properties.maxTransformFeedbackBuffers < std::numeric_limits<uint32_t>::max()) {
+        if (tf_properties.maxTransformFeedbackBuffers < vvl::kU32Max) {
             auto const counterBufferCount = tf_properties.maxTransformFeedbackBuffers + 1;
 
             m_errorMonitor->SetDesiredError("VUID-vkCmdBeginTransformFeedbackEXT-firstCounterBuffer-02369");
@@ -373,7 +373,7 @@ TEST_F(NegativeTransformFeedback, CmdEndTransformFeedbackEXT) {
             }
 
             // Request too many buffers.
-            if (tf_properties.maxTransformFeedbackBuffers < std::numeric_limits<uint32_t>::max()) {
+            if (tf_properties.maxTransformFeedbackBuffers < vvl::kU32Max) {
                 auto const counterBufferCount = tf_properties.maxTransformFeedbackBuffers + 1;
 
                 m_errorMonitor->SetDesiredError("VUID-vkCmdEndTransformFeedbackEXT-firstCounterBuffer-02377");

--- a/tests/unit/wsi.cpp
+++ b/tests/unit/wsi.cpp
@@ -174,7 +174,7 @@ TEST_F(NegativeWsi, BindImageMemorySwapchain) {
 
     bind_info.memory = mem;
     bind_swapchain_info.swapchain = m_swapchain;
-    bind_swapchain_info.imageIndex = std::numeric_limits<uint32_t>::max();
+    bind_swapchain_info.imageIndex = vvl::kU32Max;
 
     if (mem.initialized()) {
         m_errorMonitor->SetDesiredError("VUID-VkBindImageMemoryInfo-pNext-01631");


### PR DESCRIPTION
keep finding different ways of using `limits.h`

This tries to correct and unify the places

Basically

1. When you need a limit use `vvl::kU32Max`
2. If those limit aren't there, use `std::numeric_limits<my_type>`
3. Use `vvl::kNoIndex32` when the limit is just used to mean "null, but zero is a valid value"