### PR TITLE
gpuav: Dedicated adjustment warning

### DIFF
--- a/layers/gpuav/core/gpuav.h
+++ b/layers/gpuav/core/gpuav.h
@@ -54,6 +54,7 @@ class Instance : public vvl::InstanceProxy {
                                                     const RecordObject& record_obj) final;
 
     void InternalWarning(LogObjectList objlist, const Location& loc, const char* const specific_message) const;
+    void AdjustmentWarning(LogObjectList objlist, const Location& loc, const char* const specific_message) const;
     void AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceCreateInfo* modified_create_info, const Location& loc);
     bool timeline_khr_{false};
 };

--- a/layers/gpuav/core/gpuav_features.cpp
+++ b/layers/gpuav/core/gpuav_features.cpp
@@ -86,20 +86,20 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
 
         if (modified_features) {
             if (supported_features.fragmentStoresAndAtomics && !modified_features->fragmentStoresAndAtomics) {
-                InternalWarning(kNoObjects, loc, "Forcing fragmentStoresAndAtomics to VK_TRUE");
+                AdjustmentWarning(kNoObjects, loc, "Forcing fragmentStoresAndAtomics to VK_TRUE");
                 modified_features->fragmentStoresAndAtomics = VK_TRUE;
             }
             if (supported_features.vertexPipelineStoresAndAtomics && !modified_features->vertexPipelineStoresAndAtomics) {
-                InternalWarning(kNoObjects, loc, "Forcing vertexPipelineStoresAndAtomics to VK_TRUE");
+                AdjustmentWarning(kNoObjects, loc, "Forcing vertexPipelineStoresAndAtomics to VK_TRUE");
                 modified_features->vertexPipelineStoresAndAtomics = VK_TRUE;
             }
             if (supported_features.shaderInt64 && !modified_features->shaderInt64) {
-                InternalWarning(kNoObjects, loc, "Forcing shaderInt64 to VK_TRUE");
+                AdjustmentWarning(kNoObjects, loc, "Forcing shaderInt64 to VK_TRUE");
                 modified_features->shaderInt64 = VK_TRUE;
             }
             if (gpuav_settings.force_on_robustness && supported_features.robustBufferAccess &&
                 !modified_features->robustBufferAccess) {
-                InternalWarning(kNoObjects, loc, "Forcing robustBufferAccess to VK_TRUE");
+                AdjustmentWarning(kNoObjects, loc, "Forcing robustBufferAccess to VK_TRUE");
                 modified_features->robustBufferAccess = VK_TRUE;
             }
         }
@@ -113,12 +113,12 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
             if (auto *ts_features = const_cast<VkPhysicalDeviceTimelineSemaphoreFeatures *>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceTimelineSemaphoreFeatures>(modified_create_info))) {
                 if (ts_features->timelineSemaphore == VK_FALSE) {
-                    InternalWarning(kNoObjects, loc,
-                                    "Forcing VkPhysicalDeviceTimelineSemaphoreFeatures::timelineSemaphore to VK_TRUE");
+                    AdjustmentWarning(kNoObjects, loc,
+                                      "Forcing VkPhysicalDeviceTimelineSemaphoreFeatures::timelineSemaphore to VK_TRUE");
                     ts_features->timelineSemaphore = VK_TRUE;
                 }
             } else {
-                InternalWarning(
+                AdjustmentWarning(
                     kNoObjects, loc,
                     "Adding a VkPhysicalDeviceTimelineSemaphoreFeatures to pNext with timelineSemaphore set to VK_TRUE");
                 VkPhysicalDeviceTimelineSemaphoreFeatures new_ts_features = vku::InitStructHelper();
@@ -131,7 +131,7 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
             if (auto *features12 = const_cast<VkPhysicalDeviceVulkan12Features *>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(modified_create_info->pNext))) {
                 if (features12->timelineSemaphore == VK_FALSE) {
-                    InternalWarning(kNoObjects, loc, "Forcing VkPhysicalDeviceVulkan12Features::timelineSemaphore to VK_TRUE");
+                    AdjustmentWarning(kNoObjects, loc, "Forcing VkPhysicalDeviceVulkan12Features::timelineSemaphore to VK_TRUE");
                     features12->timelineSemaphore = VK_TRUE;
                 }
             } else {
@@ -150,19 +150,19 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
             if (auto *mm_features = const_cast<VkPhysicalDeviceVulkanMemoryModelFeatures *>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkanMemoryModelFeatures>(modified_create_info))) {
                 if (mm_features->vulkanMemoryModel == VK_FALSE) {
-                    InternalWarning(kNoObjects, loc,
-                                    "Forcing VkPhysicalDeviceVulkanMemoryModelFeatures::vulkanMemoryModel to VK_TRUE");
+                    AdjustmentWarning(kNoObjects, loc,
+                                      "Forcing VkPhysicalDeviceVulkanMemoryModelFeatures::vulkanMemoryModel to VK_TRUE");
                     mm_features->vulkanMemoryModel = VK_TRUE;
                 }
                 if (mm_features->vulkanMemoryModelDeviceScope == VK_FALSE) {
-                    InternalWarning(kNoObjects, loc,
-                                    "Forcing VkPhysicalDeviceVulkanMemoryModelFeatures::vulkanMemoryModelDeviceScope to VK_TRUE");
+                    AdjustmentWarning(kNoObjects, loc,
+                                      "Forcing VkPhysicalDeviceVulkanMemoryModelFeatures::vulkanMemoryModelDeviceScope to VK_TRUE");
                     mm_features->vulkanMemoryModelDeviceScope = VK_TRUE;
                 }
             } else {
-                InternalWarning(kNoObjects, loc,
-                                "Adding a VkPhysicalDeviceVulkanMemoryModelFeatures to pNext with vulkanMemoryModel and "
-                                "vulkanMemoryModelDeviceScope set to VK_TRUE");
+                AdjustmentWarning(kNoObjects, loc,
+                                  "Adding a VkPhysicalDeviceVulkanMemoryModelFeatures to pNext with vulkanMemoryModel and "
+                                  "vulkanMemoryModelDeviceScope set to VK_TRUE");
                 VkPhysicalDeviceVulkanMemoryModelFeatures new_mm_features = vku::InitStructHelper();
                 new_mm_features.vulkanMemoryModel = VK_TRUE;
                 new_mm_features.vulkanMemoryModelDeviceScope = VK_TRUE;
@@ -174,12 +174,12 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
             if (auto *features12 = const_cast<VkPhysicalDeviceVulkan12Features *>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(modified_create_info->pNext))) {
                 if (features12->vulkanMemoryModel == VK_FALSE) {
-                    InternalWarning(kNoObjects, loc, "Forcing VkPhysicalDeviceVulkan12Features::vulkanMemoryModel to VK_TRUE");
+                    AdjustmentWarning(kNoObjects, loc, "Forcing VkPhysicalDeviceVulkan12Features::vulkanMemoryModel to VK_TRUE");
                     features12->vulkanMemoryModel = VK_TRUE;
                 }
                 if (features12->vulkanMemoryModelDeviceScope == VK_FALSE) {
-                    InternalWarning(kNoObjects, loc,
-                                    "Forcing VkPhysicalDeviceVulkan12Features::vulkanMemoryModelDeviceScope to VK_TRUE");
+                    AdjustmentWarning(kNoObjects, loc,
+                                      "Forcing VkPhysicalDeviceVulkan12Features::vulkanMemoryModelDeviceScope to VK_TRUE");
                     features12->vulkanMemoryModelDeviceScope = VK_TRUE;
                 }
             } else {
@@ -198,12 +198,12 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
             if (auto *bda_features = const_cast<VkPhysicalDeviceBufferDeviceAddressFeatures *>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceBufferDeviceAddressFeatures>(modified_create_info))) {
                 if (!bda_features->bufferDeviceAddress) {
-                    InternalWarning(kNoObjects, loc,
-                                    "Forcing VkPhysicalDeviceBufferDeviceAddressFeatures::bufferDeviceAddress to VK_TRUE");
+                    AdjustmentWarning(kNoObjects, loc,
+                                      "Forcing VkPhysicalDeviceBufferDeviceAddressFeatures::bufferDeviceAddress to VK_TRUE");
                     bda_features->bufferDeviceAddress = VK_TRUE;
                 }
             } else {
-                InternalWarning(
+                AdjustmentWarning(
                     kNoObjects, loc,
                     "Adding a VkPhysicalDeviceBufferDeviceAddressFeatures to pNext with bufferDeviceAddress set to VK_TRUE");
                 VkPhysicalDeviceBufferDeviceAddressFeatures new_bda_features = vku::InitStructHelper();
@@ -216,7 +216,7 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
             if (auto *features12 = const_cast<VkPhysicalDeviceVulkan12Features *>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(modified_create_info->pNext))) {
                 if (!features12->bufferDeviceAddress) {
-                    InternalWarning(kNoObjects, loc, "Forcing VkPhysicalDeviceVulkan12Features::bufferDeviceAddress to VK_TRUE");
+                    AdjustmentWarning(kNoObjects, loc, "Forcing VkPhysicalDeviceVulkan12Features::bufferDeviceAddress to VK_TRUE");
                     features12->bufferDeviceAddress = VK_TRUE;
                 }
             } else {
@@ -234,12 +234,12 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
             if (auto *bda_features = const_cast<VkPhysicalDeviceScalarBlockLayoutFeatures *>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceScalarBlockLayoutFeatures>(modified_create_info))) {
                 if (!bda_features->scalarBlockLayout) {
-                    InternalWarning(kNoObjects, loc,
-                                    "Forcing VkPhysicalDeviceScalarBlockLayoutFeatures::scalarBlockLayout to VK_TRUE");
+                    AdjustmentWarning(kNoObjects, loc,
+                                      "Forcing VkPhysicalDeviceScalarBlockLayoutFeatures::scalarBlockLayout to VK_TRUE");
                     bda_features->scalarBlockLayout = VK_TRUE;
                 }
             } else {
-                InternalWarning(
+                AdjustmentWarning(
                     kNoObjects, loc,
                     "Adding a VkPhysicalDeviceScalarBlockLayoutFeatures to pNext with scalarBlockLayout set to VK_TRUE");
                 VkPhysicalDeviceScalarBlockLayoutFeatures new_bda_features = vku::InitStructHelper();
@@ -252,7 +252,7 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
             if (auto *features12 = const_cast<VkPhysicalDeviceVulkan12Features *>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(modified_create_info->pNext))) {
                 if (!features12->scalarBlockLayout) {
-                    InternalWarning(kNoObjects, loc, "Forcing VkPhysicalDeviceVulkan12Features::scalarBlockLayout to VK_TRUE");
+                    AdjustmentWarning(kNoObjects, loc, "Forcing VkPhysicalDeviceVulkan12Features::scalarBlockLayout to VK_TRUE");
                     features12->scalarBlockLayout = VK_TRUE;
                 }
             } else {
@@ -271,14 +271,14 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
             if (auto *eight_bit_access_feature = const_cast<VkPhysicalDevice8BitStorageFeatures *>(
                     vku::FindStructInPNextChain<VkPhysicalDevice8BitStorageFeatures>(modified_create_info))) {
                 if (!eight_bit_access_feature->storageBuffer8BitAccess) {
-                    InternalWarning(kNoObjects, loc,
-                                    "Forcing VkPhysicalDevice8BitStorageFeatures::storageBuffer8BitAccess to VK_TRUE");
+                    AdjustmentWarning(kNoObjects, loc,
+                                      "Forcing VkPhysicalDevice8BitStorageFeatures::storageBuffer8BitAccess to VK_TRUE");
                     eight_bit_access_feature->storageBuffer8BitAccess = VK_TRUE;
                 }
             } else {
-                InternalWarning(kNoObjects, loc,
-                                "Adding a VkPhysicalDevice8BitStorageFeatures to pNext with storageBuffer8BitAccess "
-                                "set to VK_TRUE");
+                AdjustmentWarning(kNoObjects, loc,
+                                  "Adding a VkPhysicalDevice8BitStorageFeatures to pNext with storageBuffer8BitAccess "
+                                  "set to VK_TRUE");
                 VkPhysicalDevice8BitStorageFeatures new_8bit_features = vku::InitStructHelper();
                 new_8bit_features.storageBuffer8BitAccess = VK_TRUE;
                 vku::AddToPnext(*modified_create_info, new_8bit_features);
@@ -289,8 +289,8 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
             if (auto *features12 = const_cast<VkPhysicalDeviceVulkan12Features *>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(modified_create_info->pNext))) {
                 if (!features12->storageBuffer8BitAccess) {
-                    InternalWarning(kNoObjects, loc,
-                                    "Forcing VkPhysicalDeviceVulkan12Features::storageBuffer8BitAccess to VK_TRUE");
+                    AdjustmentWarning(kNoObjects, loc,
+                                      "Forcing VkPhysicalDeviceVulkan12Features::storageBuffer8BitAccess to VK_TRUE");
                     features12->storageBuffer8BitAccess = VK_TRUE;
                 }
             } else {
@@ -328,25 +328,25 @@ void Instance::AddFeatures(VkPhysicalDevice physical_device, vku::safe_VkDeviceC
             if (auto *robust_buffer_2_feature = const_cast<VkPhysicalDeviceRobustness2FeaturesKHR *>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceRobustness2FeaturesKHR>(modified_create_info))) {
                 if (!robust_buffer_2_feature->robustBufferAccess2 && supported_robustness2_feature.robustBufferAccess2) {
-                    InternalWarning(kNoObjects, loc,
-                                    "Forcing VkPhysicalDeviceRobustness2FeaturesKHR::robustBufferAccess2 to VK_TRUE");
+                    AdjustmentWarning(kNoObjects, loc,
+                                      "Forcing VkPhysicalDeviceRobustness2FeaturesKHR::robustBufferAccess2 to VK_TRUE");
                     robust_buffer_2_feature->robustBufferAccess2 = VK_TRUE;
                 }
                 if (!robust_buffer_2_feature->robustImageAccess2 && supported_robustness2_feature.robustImageAccess2) {
-                    InternalWarning(kNoObjects, loc,
-                                    "Forcing VkPhysicalDeviceRobustness2FeaturesKHR::robustImageAccess2 to VK_TRUE");
+                    AdjustmentWarning(kNoObjects, loc,
+                                      "Forcing VkPhysicalDeviceRobustness2FeaturesKHR::robustImageAccess2 to VK_TRUE");
                     robust_buffer_2_feature->robustImageAccess2 = VK_TRUE;
                 }
             } else {
                 VkPhysicalDeviceRobustness2FeaturesKHR new_robust_buffer_2_feature = vku::InitStructHelper();
                 if (supported_robustness2_feature.robustBufferAccess2) {
-                    InternalWarning(
+                    AdjustmentWarning(
                         kNoObjects, loc,
                         "Adding a VkPhysicalDeviceRobustness2FeaturesKHR to pNext with robustBufferAccess2 set to VK_TRUE");
                     new_robust_buffer_2_feature.robustBufferAccess2 = VK_TRUE;
                 }
                 if (supported_robustness2_feature.robustImageAccess2) {
-                    InternalWarning(
+                    AdjustmentWarning(
                         kNoObjects, loc,
                         "Adding a VkPhysicalDeviceRobustness2FeaturesKHR to pNext with robustImageAccess2 set to VK_TRUE");
                     new_robust_buffer_2_feature.robustImageAccess2 = VK_TRUE;

--- a/layers/gpuav/core/gpuav_record.cpp
+++ b/layers/gpuav/core/gpuav_record.cpp
@@ -81,6 +81,12 @@ void Validator::PreCallRecordBeginCommandBuffer(VkCommandBuffer commandBuffer, c
     debug_printf::RegisterDebugPrintf(*this, gpuav_cb_state);
 }
 
+// Dedicated warning VUID that likely can be ignored. We want to always warn the user when adjusting settings/limits/features/etc on
+// them
+void Instance::AdjustmentWarning(LogObjectList objlist, const Location &loc, const char *const specific_message) const {
+    LogWarning("WARNING-Setting-Limit-Adjusted", objlist, loc, "Internal Warning: %s", specific_message);
+}
+
 void Instance::InternalWarning(LogObjectList objlist, const Location &loc, const char *const specific_message) const {
     const char *vuid = gpuav_settings.debug_printf_only ? "WARNING-DEBUG-PRINTF" : "WARNING-GPU-Assisted-Validation";
     LogWarning(vuid, objlist, loc, "Internal Warning: %s", specific_message);
@@ -122,7 +128,7 @@ void Instance::PostCallRecordGetPhysicalDeviceProperties2(VkPhysicalDevice physi
         std::stringstream ss;
         ss << "Setting VkPhysicalDeviceDescriptorIndexingProperties::maxUpdateAfterBindDescriptorsInAllPools to "
            << glsl::kDebugInputBindlessMaxDescriptors;
-        InternalWarning(physicalDevice, record_obj.location, ss.str().c_str());
+        AdjustmentWarning(physicalDevice, record_obj.location, ss.str().c_str());
         desc_indexing_props->maxUpdateAfterBindDescriptorsInAllPools = glsl::kDebugInputBindlessMaxDescriptors;
     }
 
@@ -131,7 +137,7 @@ void Instance::PostCallRecordGetPhysicalDeviceProperties2(VkPhysicalDevice physi
         std::stringstream ss;
         ss << "Setting VkPhysicalDeviceVulkan12Properties::maxUpdateAfterBindDescriptorsInAllPools to "
            << glsl::kDebugInputBindlessMaxDescriptors;
-        InternalWarning(physicalDevice, record_obj.location, ss.str().c_str());
+        AdjustmentWarning(physicalDevice, record_obj.location, ss.str().c_str());
         vk12_props->maxUpdateAfterBindDescriptorsInAllPools = glsl::kDebugInputBindlessMaxDescriptors;
     }
 

--- a/layers/gpuav/core/gpuav_setup.cpp
+++ b/layers/gpuav/core/gpuav_setup.cpp
@@ -360,12 +360,12 @@ void Validator::InitSettings(const Location &loc) {
     for (auto &setting_object : all_settings) {
         if (setting_object->IsEnabled(gpuav_settings) && !setting_object->HasRequiredFeatures(modified_features)) {
             setting_object->Disable(gpuav_settings);
-            InternalWarning(device, loc, setting_object->DisableMessage().c_str());
+            AdjustmentWarning(device, loc, setting_object->DisableMessage().c_str());
         }
     }
 
     if (IsExtEnabled(extensions.vk_ext_descriptor_buffer) && !gpuav_settings.descriptor_buffer_override) {
-        InternalWarning(
+        AdjustmentWarning(
             device, loc,
             "VK_EXT_descriptor_buffer is enabled, but GPU-AV does not currently support validation of descriptor buffers. "
             "[Disabling all shader instrumentation checks]"
@@ -376,11 +376,12 @@ void Validator::InitSettings(const Location &loc) {
         gpuav_settings.DisableShaderInstrumentationAndOptions();
 
         if (gpuav_settings.debug_printf_enabled) {
-            InternalWarning(device, loc,
-                            "VK_EXT_descriptor_buffer is enabled, but DebugPrintf uses a normal descriptor and currently can't "
-                            "exist with descriptor buffers. [Disabling debug_printf]"
-                            "\nThere is a VK_LAYER_GPUAV_DESCRIPTOR_BUFFER_OVERRIDE that can be set to bypass this if you know you "
-                            "are not going to use descriptor buffers.");
+            AdjustmentWarning(
+                device, loc,
+                "VK_EXT_descriptor_buffer is enabled, but DebugPrintf uses a normal descriptor and currently can't "
+                "exist with descriptor buffers. [Disabling debug_printf]"
+                "\nThere is a VK_LAYER_GPUAV_DESCRIPTOR_BUFFER_OVERRIDE that can be set to bypass this if you know you "
+                "are not going to use descriptor buffers.");
             gpuav_settings.debug_printf_enabled = false;
         }
     }

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
@@ -304,10 +304,11 @@ void GpuShaderInstrumentor::PreCallRecordGetShaderBinaryDataEXT(VkDevice device,
 
     // Only warn on the first call to query the size
     if (pData == nullptr) {
-        LogWarning("WARNING-vkGetShaderBinaryDataEXT-GPU-AV", shader, record_obj.location,
-                   "GPU-AV instruments all shaders at vkCreateShadersEXT time, this means there are embedded descriptors bound "
-                   "that we can't detect if needed or not later.\nWe will be calling vkCreateShadersEXT again now to create the "
-                   "original shader to pass down to the drivere.");
+        InternalWarning(
+            shader, record_obj.location,
+            "GPU-AV instruments all shaders at vkCreateShadersEXT time, this means there are embedded descriptors bound "
+            "that we can't detect if needed or not later.\nWe will be calling vkCreateShadersEXT again now to create the "
+            "original shader to pass down to the drivere.");
     }
 
     // vkGetShaderBinaryDataEXT will be called twice, only need to re-created once
@@ -1480,6 +1481,13 @@ void GpuShaderInstrumentor::InternalError(LogObjectList objlist, const Location 
     // This prevents need to check "if (aborted)" (which is awful when we easily forget to check somewhere and the user gets spammed
     // with errors making it hard to see the first error with the real source of the problem).
     dispatch_device_->ReleaseValidationObject(LayerObjectTypeGpuAssisted);
+}
+
+// Dedicated warning VUID that likely can be ignored. We want to always warn the user when adjusting settings/limits/features/etc on
+// them
+void GpuShaderInstrumentor::AdjustmentWarning(LogObjectList objlist, const Location &loc,
+                                              const char *const specific_message) const {
+    LogWarning("WARNING-Setting-Limit-Adjusted", objlist, loc, "Internal Warning: %s", specific_message);
 }
 
 void GpuShaderInstrumentor::InternalWarning(LogObjectList objlist, const Location &loc, const char *const specific_message) const {

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.h
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.h
@@ -149,6 +149,7 @@ class GpuShaderInstrumentor : public vvl::DeviceProxy {
 
     void InternalError(LogObjectList objlist, const Location &loc, const char *const specific_message) const;
     void InternalWarning(LogObjectList objlist, const Location &loc, const char *const specific_message) const;
+    void AdjustmentWarning(LogObjectList objlist, const Location &loc, const char *const specific_message) const;
     void InternalInfo(LogObjectList objlist, const Location &loc, const char *const specific_message) const;
 
     bool IsSelectiveInstrumentationEnabled(const void *pNext);


### PR DESCRIPTION
for our CI runs (and future tests) I would like to easily disable the "we turned on this feature" warnings as they can hide "real" warnings using the same VUID tag