### PR TITLE
gpuav: Handle hitting Action Command Limit

### DIFF
--- a/layers/error_message/error_location.h
+++ b/layers/error_message/error_location.h
@@ -46,7 +46,7 @@ struct Location {
         : function(func), structure(vvl::Struct::Empty), field(f), index(i), isPNext(false), prev(nullptr) {}
     Location(const Location& prev_loc, vvl::Struct s, vvl::Field f, uint32_t i, bool p)
         : function(prev_loc.function), structure(s), field(f), index(i), isPNext(p), prev(&prev_loc) {}
-    Location(const Location& loc, std::string& debug_region)
+    Location(const Location& loc, const std::string& debug_region)
         : function(loc.function),
           structure(loc.structure),
           field(loc.field),

--- a/layers/gpuav/core/gpuav.h
+++ b/layers/gpuav/core/gpuav.h
@@ -67,7 +67,7 @@ class Validator : public GpuShaderInstrumentor {
 
   public:
     Validator(vvl::dispatch::Device* dev, Instance* instance_vo)
-        : BaseClass(dev, instance_vo, LayerObjectTypeGpuAssisted), indices_buffer_(*this) {}
+        : BaseClass(dev, instance_vo, LayerObjectTypeGpuAssisted), global_indices_buffer_(*this) {}
 
     // gpuav_setup.cpp
     // -------------
@@ -222,7 +222,9 @@ class Validator : public GpuShaderInstrumentor {
     std::unique_ptr<vko::DescriptorSetManager> desc_set_manager_;
 
     // This is so universally used, that we decided currently to not be in vko::SharedResourcesCache
-    vko::Buffer indices_buffer_;
+    // This is just a buffer with a uint32_t value from [0, cts::indices_count - 1] so we can update prior to an action command
+    // (draw/dispatch) to know where it came from
+    vko::Buffer global_indices_buffer_;
     uint32_t indices_buffer_alignment_ = 0;
 
   private:

--- a/layers/gpuav/core/gpuav_constants.h
+++ b/layers/gpuav/core/gpuav_constants.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2018-2024 The Khronos Group Inc.
- * Copyright (c) 2018-2024 Valve Corporation
- * Copyright (c) 2018-2024 LunarG, Inc.
+/* Copyright (c) 2018-2025 The Khronos Group Inc.
+ * Copyright (c) 2018-2025 Valve Corporation
+ * Copyright (c) 2018-2025 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,10 +20,14 @@
 #include <cstdint>
 
 namespace gpuav {
+// constant
 namespace cst {
 
 // Number of indices held in the buffer used to index commands and validation resources
-inline constexpr uint32_t indices_count = 16384;
+inline constexpr uint32_t indices_count = 1u << 13;  // 8192
+// If we hit our limit, we will use this to signal to the app what they are seeing is likely garbage.
+// This is required because we still need to bind our descriptors regardless.
+inline constexpr uint32_t invalid_index_command = indices_count - 1;
 
 // Stream Output Buffer Offsets
 //

--- a/layers/gpuav/core/gpuav_record.cpp
+++ b/layers/gpuav/core/gpuav_record.cpp
@@ -152,7 +152,7 @@ void Validator::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCa
 
     shared_resources_manager.Clear();
 
-    indices_buffer_.Destroy();
+    global_indices_buffer_.Destroy();
 
     BaseClass::PreCallRecordDestroyDevice(device, pAllocator, record_obj);
 
@@ -167,9 +167,6 @@ void Validator::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCa
 // Common logic before any draw/dispatch/traceRays
 void Validator::PreCallActionCommand(Validator &gpuav, CommandBufferSubState &cb_state, VkPipelineBindPoint bind_point,
                                      const Location &loc) {
-    if (cb_state.max_actions_cmd_validation_reached_) {
-        return;
-    }
     PreCallSetupShaderInstrumentationResources(gpuav, cb_state, bind_point, loc);
 }
 

--- a/layers/gpuav/debug_printf/debug_printf.cpp
+++ b/layers/gpuav/debug_printf/debug_printf.cpp
@@ -417,7 +417,8 @@ void RegisterDebugPrintf(Validator &gpuav, CommandBufferSubState &cb_state) {
             out_dst_binding = glsl::kBindingInstDebugPrintf;
 
             DebugPrintfCbState &debug_printf_cb_state = cb.shared_resources_cache.GetOrCreate<DebugPrintfCbState>();
-            debug_printf_cb_state.buffer_infos.emplace_back(debug_printf_output_buffer, bind_point, cb.action_command_count);
+            debug_printf_cb_state.buffer_infos.emplace_back(debug_printf_output_buffer, bind_point,
+                                                            cb.GetActionCommandIndex(bind_point));
         });
 
     cb_state.on_cb_completion_functions.emplace_back([](Validator &gpuav, CommandBufferSubState &cb,

--- a/layers/gpuav/instrumentation/gpuav_instrumentation.h
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation.h
@@ -67,10 +67,8 @@ struct InstrumentationErrorBlob {
     std::optional<VertexAttributeFetchLimit> vertex_attribute_fetch_limit_instance_input_rate{};
     std::optional<vvl::IndexBufferBinding> index_buffer_binding{};
 
-    // indexing into the VkDebugUtilsLabelEXT
-    uint32_t label_command_i = vvl::kNoIndex32;
     // used to know which action command this occured at
-    uint32_t action_command_i = vvl::kNoIndex32;
+    uint32_t action_command_index = vvl::kNoIndex32;
 
     // Used to know if from draw, dispatch, or traceRays
     VkPipelineBindPoint pipeline_bind_point = VK_PIPELINE_BIND_POINT_MAX_ENUM;
@@ -83,9 +81,8 @@ struct InstrumentationErrorBlob {
 
 // Return true iff an error has been found
 bool LogInstrumentationError(Validator& gpuav, const CommandBufferSubState& cb_state, const LogObjectList& objlist,
-                             const InstrumentationErrorBlob& instrumentation_error_blob,
-                             const std::vector<std::string>& initial_label_stack, const uint32_t* error_record,
-                             const Location& loc);
+                             const InstrumentationErrorBlob& instrumentation_error_blob, const uint32_t* error_record,
+                             const Location& loc_with_debug_region);
 
 // Return true iff an error has been found in error_record, among the list of errors this function manages
 bool LogMessageInstDescriptorIndexingOOB(Validator& gpuav, const CommandBufferSubState& cb_state, const uint32_t* error_record,

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
@@ -23,6 +23,7 @@
 #include "generated/vk_extension_helper.h"
 #include "generated/dispatch_functions.h"
 #include "chassis/chassis_modification_state.h"
+#include "gpuav/core/gpuav_constants.h"
 #include "utils/shader_utils.h"
 
 #include "gpuav/shaders/gpuav_shaders_constants.h"
@@ -1603,7 +1604,7 @@ static void GenerateStageMessage(std::ostringstream &ss, const GpuShaderInstrume
 std::string GpuShaderInstrumentor::GenerateDebugInfoMessage(VkCommandBuffer commandBuffer, const ShaderMessageInfo &shader_info,
                                                             const InstrumentedShader *instrumented_shader,
                                                             VkPipelineBindPoint pipeline_bind_point,
-                                                            uint32_t operation_index) const {
+                                                            uint32_t action_command_index) const {
     std::ostringstream ss;
     if (!instrumented_shader || instrumented_shader->original_spirv.empty()) {
         ss << "[Internal Error] - Can't get instructions from shader_map\n";
@@ -1635,7 +1636,12 @@ std::string GpuShaderInstrumentor::GenerateDebugInfoMessage(VkCommandBuffer comm
             assert(false);
             ss << "Unknown Pipeline Operation ";
         }
-        ss << "Index " << operation_index << '\n';
+
+        if (action_command_index == cst::invalid_index_command) {
+            ss << "Index Unknown (After " << cst::invalid_index_command << " commands, we stop tracking) \n";
+        } else {
+            ss << "Index " << action_command_index << '\n';
+        }
         ss << std::hex << std::noshowbase;
 
         if (instrumented_shader->shader_module == VK_NULL_HANDLE) {

--- a/layers/gpuav/instrumentation/post_process_descriptor_indexing.cpp
+++ b/layers/gpuav/instrumentation/post_process_descriptor_indexing.cpp
@@ -263,12 +263,10 @@ void RegisterPostProcessingValidation(Validator& gpuav, CommandBufferSubState& c
                     context.SetSetIndexForGpuAv(resource_variable->decorations.set);
 
                     const CommandBufferSubState::CommandErrorLogger& cmd_error_logger =
-                        cb.command_error_loggers[descriptor_access.error_logger_i];
+                        cb.GetErrorLogger(descriptor_access.error_logger_i);
                     context.SetObjlistForGpuAv(&cmd_error_logger.objlist);
-                    std::string debug_region_name;
-                    if (cmd_error_logger.label_cmd_i >= 0) {
-                        debug_region_name = cb.GetDebugLabelRegion(cmd_error_logger.label_cmd_i, label_logging.initial_label_stack);
-                    }
+                    std::string debug_region_name =
+                        cb.GetDebugLabelRegion(cmd_error_logger.label_cmd_i, label_logging.initial_label_stack);
 
                     Location access_loc(cmd_error_logger.loc.Get(), debug_region_name);
                     context.SetLocationForGpuAv(access_loc);

--- a/layers/gpuav/shaders/gpuav_error_header.h
+++ b/layers/gpuav/shaders/gpuav_error_header.h
@@ -110,7 +110,7 @@ const int kInstructionIdMask = 0x7FFFFFF;
 // This dword is split up as
 // | 31 ..... 16 | 15 ................. 0 |
 // | Error Group | Instrumented Shader Id |
-// Note we have a limit (kMaxActionsPerCommandBuffer) but for simplicity, divide in half until find need to adjust.
+// Note we have a limit (cst::indices_count) but for simplicity, divide in half until find need to adjust.
 const int kActionIdShift = 16;
 const int kActionIdMask = 0xFFFF << kActionIdShift;  // 64k slot
 const int kErrorLoggerIdMask = 0xFFFF;

--- a/layers/gpuav/shaders/gpuav_shaders_constants.h
+++ b/layers/gpuav/shaders/gpuav_shaders_constants.h
@@ -140,8 +140,10 @@ const uint kShaderIdMask = 0x3FFFF;
 //
 // We make some assumptions from profiling that we can maintain these limits and squeeze all this information in a single dword
 // these values are asserted for and can be adjusted if we edge cases that matter
-const uint kMaxActionsPerCommandBuffer = 1u << 13;  // 8,192
-// We use a single bit mark if this descriptor was accessed or not
+//
+// cst::indices_count is set at 1u << 13 (8192) used to set the action cmd index
+//
+// // We use a single bit mark if this descriptor was accessed or not
 const uint kPostProcessMetaMaskAccessed = 1u << 31;
 const uint kPostProcessMetaShiftErrorLoggerIndex = 18;
 const uint kPostProcessMetaMaskErrorLoggerIndex = 0x1FFF << kPostProcessMetaShiftErrorLoggerIndex;

--- a/layers/gpuav/validation_cmd/gpuav_trace_rays.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_trace_rays.cpp
@@ -50,10 +50,6 @@ void TraceRaysIndirect(Validator& gpuav, const Location& loc, CommandBufferSubSt
         return;
     }
 
-    if (cb_state.max_actions_cmd_validation_reached_) {
-        return;
-    }
-
     valpipe::RestorablePipelineState restorable_state(cb_state, VK_PIPELINE_BIND_POINT_COMPUTE);
 
     ValidationCommandsCommon& val_cmd_common =
@@ -89,8 +85,8 @@ void TraceRaysIndirect(Validator& gpuav, const Location& loc, CommandBufferSubSt
         shader_resources.push_constants.max_ray_dispatch_invocation_count =
             gpuav.phys_dev_ext_props.ray_tracing_props_khr.maxRayDispatchInvocationCount;
 
-        if (!BindShaderResources(validation_pipeline, gpuav, cb_state, cb_state.compute_index,
-                                 uint32_t(cb_state.command_error_loggers.size()), shader_resources)) {
+        if (!BindShaderResources(validation_pipeline, gpuav, cb_state, cb_state.compute_index, cb_state.GetErrorLoggerIndex(),
+                                 shader_resources)) {
             return;
         }
     }
@@ -103,8 +99,9 @@ void TraceRaysIndirect(Validator& gpuav, const Location& loc, CommandBufferSubSt
         DispatchCmdDispatch(cb_state.VkHandle(), 1, 1, 1);
     }
 
-    CommandBufferSubState::ErrorLoggerFunc error_logger = [&gpuav](const uint32_t* error_record, const Location& loc,
-                                                                   const LogObjectList& objlist, const std::vector<std::string>&) {
+    CommandBufferSubState::ErrorLoggerFunc error_logger = [&gpuav](const uint32_t* error_record,
+                                                                   const Location& loc_with_debug_region,
+                                                                   const LogObjectList& objlist) {
         bool skip = false;
         using namespace glsl;
 
@@ -117,7 +114,7 @@ void TraceRaysIndirect(Validator& gpuav, const Location& loc, CommandBufferSubSt
         switch (error_sub_code) {
             case kErrorSubCodePreTraceRaysLimitWidth: {
                 const uint32_t width = error_record[kPreActionParamOffset_0];
-                skip |= gpuav.LogError("VUID-VkTraceRaysIndirectCommandKHR-width-03638", objlist, loc,
+                skip |= gpuav.LogError("VUID-VkTraceRaysIndirectCommandKHR-width-03638", objlist, loc_with_debug_region,
                                        "Indirect trace rays of VkTraceRaysIndirectCommandKHR::width of %" PRIu32
                                        " would exceed VkPhysicalDeviceLimits::maxComputeWorkGroupCount[0] * "
                                        "VkPhysicalDeviceLimits::maxComputeWorkGroupSize[0] limit of %" PRIu64 ".",
@@ -128,7 +125,7 @@ void TraceRaysIndirect(Validator& gpuav, const Location& loc, CommandBufferSubSt
             }
             case kErrorSubCodePreTraceRaysLimitHeight: {
                 const uint32_t height = error_record[kPreActionParamOffset_0];
-                skip |= gpuav.LogError("VUID-VkTraceRaysIndirectCommandKHR-height-03639", objlist, loc,
+                skip |= gpuav.LogError("VUID-VkTraceRaysIndirectCommandKHR-height-03639", objlist, loc_with_debug_region,
                                        "Indirect trace rays of VkTraceRaysIndirectCommandKHR::height of %" PRIu32
                                        " would exceed VkPhysicalDeviceLimits::maxComputeWorkGroupCount[1] * "
                                        "VkPhysicalDeviceLimits::maxComputeWorkGroupSize[1] limit of %" PRIu64 ".",
@@ -139,7 +136,7 @@ void TraceRaysIndirect(Validator& gpuav, const Location& loc, CommandBufferSubSt
             }
             case kErrorSubCodePreTraceRaysLimitDepth: {
                 const uint32_t depth = error_record[kPreActionParamOffset_0];
-                skip |= gpuav.LogError("VUID-VkTraceRaysIndirectCommandKHR-depth-03640", objlist, loc,
+                skip |= gpuav.LogError("VUID-VkTraceRaysIndirectCommandKHR-depth-03640", objlist, loc_with_debug_region,
                                        "Indirect trace rays of VkTraceRaysIndirectCommandKHR::height of %" PRIu32
                                        " would exceed VkPhysicalDeviceLimits::maxComputeWorkGroupCount[2] * "
                                        "VkPhysicalDeviceLimits::maxComputeWorkGroupSize[2] limit of %" PRIu64 ".",
@@ -153,7 +150,7 @@ void TraceRaysIndirect(Validator& gpuav, const Location& loc, CommandBufferSubSt
                                                       error_record[kPreActionParamOffset_2]};
                 const uint64_t rays_volume = trace_rays_extent.width * trace_rays_extent.height * trace_rays_extent.depth;
                 skip |= gpuav.LogError(
-                    "VUID-VkTraceRaysIndirectCommandKHR-width-03641", objlist, loc,
+                    "VUID-VkTraceRaysIndirectCommandKHR-width-03641", objlist, loc_with_debug_region,
                     "Indirect trace rays of volume %" PRIu64
                     " (%s) would exceed VkPhysicalDeviceRayTracingPipelinePropertiesKHR::maxRayDispatchInvocationCount "
                     "limit of %" PRIu32 ".",
@@ -168,8 +165,7 @@ void TraceRaysIndirect(Validator& gpuav, const Location& loc, CommandBufferSubSt
         return skip;
     };
 
-    cb_state.command_error_loggers.emplace_back(
-        CommandBufferSubState::CommandErrorLogger{loc, LogObjectList{}, std::move(error_logger)});
+    cb_state.AddCommandErrorLogger(loc, LogObjectList{}, std::move(error_logger));
 }
 }  // namespace valcmd
 }  // namespace gpuav

--- a/layers/gpuav/validation_cmd/gpuav_validation_cmd_common.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_validation_cmd_common.cpp
@@ -118,8 +118,8 @@ ValidationCommandsCommon::ValidationCommandsCommon(Validator &gpuav, CommandBuff
 
     VkDescriptorBufferInfo cmd_indices_buffer_desc_info = {};
 
-    assert(!gpuav_.indices_buffer_.IsDestroyed());
-    cmd_indices_buffer_desc_info.buffer = gpuav_.indices_buffer_.VkHandle();
+    assert(!gpuav_.global_indices_buffer_.IsDestroyed());
+    cmd_indices_buffer_desc_info.buffer = gpuav_.global_indices_buffer_.VkHandle();
     cmd_indices_buffer_desc_info.offset = 0;
     cmd_indices_buffer_desc_info.range = sizeof(uint32_t);
 


### PR DESCRIPTION
There are two GPU-AV bindings we use the Dynamic Offset trick for

1. Action Commands
2. Index into the Error Logger

This removes the old "we hit the validation limit" and now just handles it by

1. Saying we don't know which draw/dispatch index it is
2. Reporting a new `GPUAV-Overflow-Unknown` error message