### PR TITLE
gpuav: Always recreate pipeline layout

### DIFF
--- a/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
@@ -508,19 +508,11 @@ void PreCallSetupShaderInstrumentationResources(Validator &gpuav, CommandBufferS
 
     // App uses regular pipelines or graphics pipeline libraries
     if (last_bound.pipeline_state) {
-        // Regular pipeline, and its pipeline layout has not been destroyed: pick it
-        const auto last_bound_pipe_layout = last_bound.pipeline_state->PipelineLayoutState();
-        if (!last_bound.pipeline_state->library_create_info && last_bound_pipe_layout && !last_bound_pipe_layout->Destroyed()) {
-            inst_binding_pipe_layout = last_bound.pipeline_state->PipelineLayoutState()->VkHandle();
-        }
-        // Pipeline layout has been destroyed, or pipeline is a graphics pipeline library
-        else {
-            const PipelineSubState &pipeline_sub_state = SubState(*last_bound.pipeline_state);
-            inst_binding_pipe_layout = pipeline_sub_state.GetPipelineLayoutUnion(loc);
-            assert(inst_binding_pipe_layout != VK_NULL_HANDLE);
-            if (gpuav.aborted_) {
-                return;
-            }
+        const PipelineSubState &pipeline_sub_state = SubState(*last_bound.pipeline_state);
+        inst_binding_pipe_layout = pipeline_sub_state.GetPipelineLayoutUnion(loc);
+        assert(inst_binding_pipe_layout != VK_NULL_HANDLE);
+        if (gpuav.aborted_) {
+            return;
         }
         inst_binding_pipe_layout_src = PipelineLayoutSource::LastBoundPipeline;
     }

--- a/layers/gpuav/resources/gpuav_state_trackers.cpp
+++ b/layers/gpuav/resources/gpuav_state_trackers.cpp
@@ -635,8 +635,9 @@ VkPipelineLayout PipelineSubState::GetPipelineLayoutUnion(const Location &loc) c
         return recreated_layout;
     }
 
-    assert(base.PipelineLayoutState()->set_layouts.size() <= gpuav_.instrumentation_desc_set_bind_index_);
-    if (base.PipelineLayoutState()->set_layouts.size() > gpuav_.instrumentation_desc_set_bind_index_) {
+    const std::shared_ptr<const vvl::PipelineLayout> pipeline_layout_state = base.PipelineLayoutState();
+    assert(pipeline_layout_state->set_layouts.size() <= gpuav_.instrumentation_desc_set_bind_index_);
+    if (pipeline_layout_state->set_layouts.size() > gpuav_.instrumentation_desc_set_bind_index_) {
         gpuav_.InternalError(LogObjectList(base.VkHandle()), loc,
                              "Trying to recreate a pipeline layout with no room for the instrumenation descriptor set.");
         return VK_NULL_HANDLE;
@@ -645,11 +646,11 @@ VkPipelineLayout PipelineSubState::GetPipelineLayoutUnion(const Location &loc) c
     std::vector<VkDescriptorSetLayout> set_layout_handles;
     set_layout_handles.reserve(gpuav_.instrumentation_desc_set_bind_index_ + 1);
     std::vector<size_t> recreated_desc_set_layouts_indices;
-    for (size_t set_layout_i = 0; set_layout_i < base.PipelineLayoutState()->set_layouts.size(); ++set_layout_i) {
-        const auto &set_layout = base.PipelineLayoutState()->set_layouts[set_layout_i];
-        assert(set_layout);
-        if (!set_layout->Destroyed()) {
-            set_layout_handles.emplace_back(set_layout->VkHandle());
+
+    for (size_t set_layout_i = 0; set_layout_i < pipeline_layout_state->set_layouts.size(); ++set_layout_i) {
+        const auto &set_layout = pipeline_layout_state->set_layouts[set_layout_i];
+        if (!set_layout) {
+            set_layout_handles.emplace_back(VK_NULL_HANDLE);
         } else {
             VkDescriptorSetLayout recreated_desc_set_layout = VK_NULL_HANDLE;
 
@@ -669,12 +670,12 @@ VkPipelineLayout PipelineSubState::GetPipelineLayoutUnion(const Location &loc) c
     set_layout_handles.emplace_back(gpuav_.GetInstrumentationDescriptorSetLayout());
 
     VkPipelineLayoutCreateInfo pipeline_layout_ci = vku::InitStructHelper();
-    pipeline_layout_ci.flags = base.PipelineLayoutState()->create_flags;
+    pipeline_layout_ci.flags = pipeline_layout_state->create_flags;
     pipeline_layout_ci.setLayoutCount = uint32_t(set_layout_handles.size());
     pipeline_layout_ci.pSetLayouts = set_layout_handles.data();
-    if (base.PipelineLayoutState()->push_constant_ranges_layout) {
-        pipeline_layout_ci.pushConstantRangeCount = uint32_t(base.PipelineLayoutState()->push_constant_ranges_layout->size());
-        pipeline_layout_ci.pPushConstantRanges = base.PipelineLayoutState()->push_constant_ranges_layout->data();
+    if (pipeline_layout_state->push_constant_ranges_layout) {
+        pipeline_layout_ci.pushConstantRangeCount = uint32_t(pipeline_layout_state->push_constant_ranges_layout->size());
+        pipeline_layout_ci.pPushConstantRanges = pipeline_layout_state->push_constant_ranges_layout->data();
     }
 
     const VkResult result = DispatchCreatePipelineLayout(gpuav_.device, &pipeline_layout_ci, nullptr, &recreated_layout);


### PR DESCRIPTION
When app is not using shader objects, always recreate a pipeline layout for GPU-AV to use, else there is a risk of getting and using a pipeline layout that has already been destroyed.
Also handle null descriptor set layouts