### PR TITLE
tests: Fix CopyAccelerationStructureMutableDescriptors

### DIFF
--- a/tests/unit/descriptors_positive.cpp
+++ b/tests/unit/descriptors_positive.cpp
@@ -538,9 +538,9 @@ TEST_F(PositiveDescriptors, CopyAccelerationStructureMutableDescriptors) {
 
     std::array<VkDescriptorPoolSize, 2> pool_sizes = {};
     pool_sizes[0].type = VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR;
-    pool_sizes[0].descriptorCount = 1;
+    pool_sizes[0].descriptorCount = 2;
     pool_sizes[1].type = VK_DESCRIPTOR_TYPE_MUTABLE_EXT;
-    pool_sizes[1].descriptorCount = 1;
+    pool_sizes[1].descriptorCount = 2;
 
     VkDescriptorPoolCreateInfo ds_pool_ci = vku::InitStructHelper(&mdtci);
     ds_pool_ci.maxSets = 2;


### PR DESCRIPTION
this test was hitting

```
Validation Warning: [ WARNING-VkDescriptorSetAllocateInfo-descriptorCount ] | MessageID = 0x1ed8505a
vkAllocateDescriptorSets(): Trying to allocate 2 of VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR descriptors from VkDescriptorPool 0x30000000003, but this pool only has a total of 1 descriptors for this type so you will likely get VK_ERROR_OUT_OF_POOL_MEMORY_KHR. While this might succeed on some implementations, it will fail on others.
Where VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR is found in the pool:
  pPoolSizes[0].descriptorCount = 1
Where the allocation are being requested:
  pSetLayouts[0]::pBindings[1].descriptorCount = 1
  pSetLayouts[1]::pBindings[1].descriptorCount = 1
```

and failing on me (took looking at driver code to catch)