### PR TITLE
sync: Remove copy

### DIFF
--- a/layers/sync/sync_renderpass.cpp
+++ b/layers/sync/sync_renderpass.cpp
@@ -446,7 +446,7 @@ bool RenderPassAccessContext::ValidateResolveOperations(const CommandBufferAcces
 
 void RenderPassAccessContext::UpdateAttachmentResolveAccess(const vvl::RenderPass &rp_state,
                                                             const AttachmentViewGenVector &attachment_views, uint32_t subpass,
-                                                            const ResourceUsageTag tag, AccessContext access_context) {
+                                                            const ResourceUsageTag tag, AccessContext &access_context) {
     UpdateStateResolveAction update(access_context, tag);
     ResolveOperation(update, rp_state, attachment_views, subpass);
 }

--- a/layers/sync/sync_renderpass.h
+++ b/layers/sync/sync_renderpass.h
@@ -97,7 +97,7 @@ class RenderPassAccessContext {
     bool ValidateResolveOperations(const CommandBufferAccessContext &cb_context, vvl::Func command) const;
 
     static void UpdateAttachmentResolveAccess(const vvl::RenderPass &rp_state, const AttachmentViewGenVector &attachment_views,
-                                              uint32_t subpass, const ResourceUsageTag tag, AccessContext access_context);
+                                              uint32_t subpass, const ResourceUsageTag tag, AccessContext &access_context);
 
     static void UpdateAttachmentStoreAccess(const vvl::RenderPass &rp_state, const AttachmentViewGenVector &attachment_views,
                                             uint32_t subpass, const ResourceUsageTag tag, AccessContext &access_context);


### PR DESCRIPTION
According to git history, this copy slipped in during the refactor we did two years ago