### PR TITLE
sync: Allow only explicit copies of AccessContext

### DIFF
--- a/layers/sync/sync_op.h
+++ b/layers/sync/sync_op.h
@@ -344,26 +344,19 @@ struct BatchBarrierOp {
 // Allow keep track of the exec contexts replay state
 class ReplayState {
   public:
+    // A minimal subset of the functionality present in the RenderPassAccessContext. Since the accesses are recorded in the
+    // first_use information of the recorded access contexts, s.t. all we need to support is the barrier/resolve operations
     struct RenderPassReplayState {
-        // A minimal subset of the functionality present in the RenderPassAccessContext. Since the accesses are recorded in the
-        // first_use information of the recorded access contexts, s.t. all we need to support is the barrier/resolve operations
-        RenderPassReplayState() { Reset(); }
         AccessContext *Begin(VkQueueFlags queue_flags, const SyncOpBeginRenderPass &begin_op_,
                              const AccessContext &external_context);
         AccessContext *Next();
         void End(AccessContext &external_context);
+        vvl::span<AccessContext> GetSubpassContexts();
 
         const SyncOpBeginRenderPass *begin_op = nullptr;
         const AccessContext *replay_context = nullptr;
         uint32_t subpass = VK_SUBPASS_EXTERNAL;
-        std::vector<AccessContext> subpass_contexts;
-        void Reset() {
-            begin_op = nullptr;
-            replay_context = nullptr;
-            subpass = VK_SUBPASS_EXTERNAL;
-            subpass_contexts.clear();
-        }
-        operator bool() const { return begin_op != nullptr; }
+        std::unique_ptr<AccessContext[]> subpass_contexts;
     };
 
     bool ValidateFirstUse();

--- a/layers/sync/sync_renderpass.h
+++ b/layers/sync/sync_renderpass.h
@@ -74,8 +74,8 @@ struct BeginRenderingCmdState {
 };
 }  // namespace syncval_state
 
-void InitSubpassContexts(VkQueueFlags queue_flags, const vvl::RenderPass &rp_state, const AccessContext *external_context,
-                         std::vector<AccessContext> &subpass_contexts);
+std::unique_ptr<AccessContext[]> InitSubpassContexts(VkQueueFlags queue_flags, const vvl::RenderPass &rp_state,
+                                                     const AccessContext *external_context);
 
 class RenderPassAccessContext {
   public:
@@ -121,10 +121,11 @@ class RenderPassAccessContext {
     void RecordNextSubpass(ResourceUsageTag store_tag, ResourceUsageTag barrier_tag, ResourceUsageTag load_tag);
     void RecordEndRenderPass(AccessContext *external_context, ResourceUsageTag store_tag, ResourceUsageTag barrier_tag);
 
-    AccessContext &CurrentContext() { return subpass_contexts_[current_subpass_]; }
-    const AccessContext &CurrentContext() const { return subpass_contexts_[current_subpass_]; }
-    const std::vector<AccessContext> &GetContexts() const { return subpass_contexts_; }
     uint32_t GetCurrentSubpass() const { return current_subpass_; }
+    AccessContext &CurrentContext();
+    const AccessContext &CurrentContext() const;
+    vvl::span<const AccessContext> GetSubpassContexts() const;
+    vvl::span<AccessContext> GetSubpassContexts();
     const vvl::RenderPass *GetRenderPassState() const { return rp_state_; }
     AccessContext *CreateStoreResolveProxy() const;
 
@@ -132,6 +133,6 @@ class RenderPassAccessContext {
     const vvl::RenderPass *rp_state_;
     const VkRect2D render_area_;
     uint32_t current_subpass_;
-    std::vector<AccessContext> subpass_contexts_;
+    std::unique_ptr<AccessContext[]> subpass_contexts_;
     AttachmentViewGenVector attachment_views_;
 };


### PR DESCRIPTION
Because `AccessContext` is a heavy object ensure there's no possibility of an accidental copy and that all copy operations are easily searchable.

Additional code cleanup.