### PR TITLE
gpuav: Explicit HOST_COHERENT cache type

### DIFF
--- a/layers/gpuav/debug_printf/debug_printf.cpp
+++ b/layers/gpuav/debug_printf/debug_printf.cpp
@@ -412,7 +412,7 @@ void RegisterDebugPrintf(Validator &gpuav, CommandBufferSubState &cb_state) {
             CommandBufferSubState &cb, VkPipelineBindPoint bind_point, VkDescriptorBufferInfo &out_buffer_info,
             uint32_t &out_dst_binding) {
             vko::BufferRange debug_printf_output_buffer =
-                cb.gpu_resources_manager.GetHostVisibleBufferRange(debug_printf_buffer_size);
+                cb.gpu_resources_manager.GetHostCoherentBufferRange(debug_printf_buffer_size);
             std::memset(debug_printf_output_buffer.offset_mapped_ptr, 0, (size_t)debug_printf_buffer_size);
 
             out_buffer_info.buffer = debug_printf_output_buffer.buffer;
@@ -431,7 +431,7 @@ void RegisterDebugPrintf(Validator &gpuav, CommandBufferSubState &cb_state) {
             CommandBufferSubState &cb, VkPipelineBindPoint bind_point, VkDescriptorAddressInfoEXT &out_address_info,
             uint32_t &out_dst_binding) {
             vko::BufferRange debug_printf_output_buffer =
-                cb.gpu_resources_manager.GetHostVisibleBufferRange(debug_printf_buffer_size);
+                cb.gpu_resources_manager.GetHostCoherentBufferRange(debug_printf_buffer_size);
             std::memset(debug_printf_output_buffer.offset_mapped_ptr, 0, (size_t)debug_printf_buffer_size);
 
             out_address_info.address = debug_printf_output_buffer.offset_address;

--- a/layers/gpuav/instrumentation/buffer_device_address.cpp
+++ b/layers/gpuav/instrumentation/buffer_device_address.cpp
@@ -66,7 +66,7 @@ void RegisterBufferDeviceAddressValidation(Validator& gpuav, CommandBufferSubSta
         cb.gpu_resources_manager.FlushAllocation(bda_table);
 
         // Fill a GPU buffer with a pointer to the BDA table
-        vko::BufferRange bda_table_ptr = cb.gpu_resources_manager.GetHostVisibleBufferRange(sizeof(VkDeviceAddress));
+        vko::BufferRange bda_table_ptr = cb.gpu_resources_manager.GetHostCoherentBufferRange(sizeof(VkDeviceAddress));
         *(VkDeviceAddress*)bda_table_ptr.offset_mapped_ptr = bda_table.offset_address;
 
         // Dispatch a copy command, copying the per CB submission BDA table pointer to the BDA table pointer created at

--- a/layers/gpuav/instrumentation/descriptor_checks.cpp
+++ b/layers/gpuav/instrumentation/descriptor_checks.cpp
@@ -119,7 +119,7 @@ void RegisterDescriptorChecksValidation(Validator& gpuav, CommandBufferSubState&
         [](Validator& gpuav, CommandBufferSubState& cb, DescriptorSetBindings::BindingCommand& desc_binding_cmd) {
             DescriptorChecksCbState& dc_cb_state = cb.shared_resources_cache.GetOrCreate<DescriptorChecksCbState>();
             dc_cb_state.last_bound_desc_sets_state_ssbo =
-                cb.gpu_resources_manager.GetHostVisibleBufferRange(sizeof(glsl::BoundDescriptorSetsStateSSBO));
+                cb.gpu_resources_manager.GetHostCoherentBufferRange(sizeof(glsl::BoundDescriptorSetsStateSSBO));
             dc_cb_state.last_bound_desc_sets_state_ssbo.Clear();
             auto desc_state_ssbo =
                 static_cast<glsl::BoundDescriptorSetsStateSSBO*>(dc_cb_state.last_bound_desc_sets_state_ssbo.offset_mapped_ptr);

--- a/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
@@ -401,7 +401,7 @@ void UpdateInstrumentationDescSet(Validator &gpuav, CommandBufferSubState &cb_st
             // This check is only for indexed draws
             if (vvl::IsCommandDrawVertexIndexed(loc.function)) {
                 vko::BufferRange vertex_attribute_fetch_limits_buffer_range =
-                    cb_state.gpu_resources_manager.GetHostVisibleBufferRange(4 * sizeof(uint32_t));
+                    cb_state.gpu_resources_manager.GetHostCoherentBufferRange(4 * sizeof(uint32_t));
                 if (vertex_attribute_fetch_limits_buffer_range.buffer == VK_NULL_HANDLE) {
                     return;
                 }

--- a/layers/gpuav/instrumentation/post_process_descriptor_indexing.cpp
+++ b/layers/gpuav/instrumentation/post_process_descriptor_indexing.cpp
@@ -81,7 +81,7 @@ void RegisterPostProcessingValidation(Validator& gpuav, CommandBufferSubState& c
         DescriptorSetBindings& desc_set_bindings = cb.shared_resources_cache.Get<DescriptorSetBindings>();
 
         for (const DescriptorSetBindings::BindingCommand& desc_binding_cmd : desc_set_bindings.descriptor_set_binding_commands) {
-            vko::BufferRange desc_set_buffer_lut_buffer_range = cb.gpu_resources_manager.GetHostVisibleBufferRange(
+            vko::BufferRange desc_set_buffer_lut_buffer_range = cb.gpu_resources_manager.GetHostCoherentBufferRange(
                 32 * sizeof(VkDeviceAddress));  // No driver offers more than 32 descriptor set bindings
 
             // For each unique bound descriptor set in this command buffer,

--- a/layers/gpuav/resources/gpuav_state_trackers.cpp
+++ b/layers/gpuav/resources/gpuav_state_trackers.cpp
@@ -59,7 +59,7 @@ void CommandBufferSubState::AllocateResources(const Location &loc) {
 
     // Error output buffer
     {
-        error_output_buffer_range_ = gpu_resources_manager.GetHostVisibleBufferRange(glsl::kErrorBufferByteSize);
+        error_output_buffer_range_ = gpu_resources_manager.GetHostCoherentBufferRange(glsl::kErrorBufferByteSize);
         if (error_output_buffer_range_.buffer == VK_NULL_HANDLE) {
             return;
         }

--- a/layers/gpuav/resources/gpuav_vulkan_objects.h
+++ b/layers/gpuav/resources/gpuav_vulkan_objects.h
@@ -100,7 +100,7 @@ class GpuResourcesManager {
 
     VkDescriptorSet GetManagedDescriptorSet(VkDescriptorSetLayout desc_set_layout);
 
-    vko::BufferRange GetHostVisibleBufferRange(VkDeviceSize size);
+    vko::BufferRange GetHostCoherentBufferRange(VkDeviceSize size);
     vko::BufferRange GetHostCachedBufferRange(VkDeviceSize size);
     void FlushAllocation(const vko::BufferRange &buffer_range);
     void InvalidateAllocation(const vko::BufferRange &buffer_range);
@@ -153,9 +153,9 @@ class GpuResourcesManager {
 
     // One cache per buffer type: having them mixed in just one would make cache lookups worse
     struct BufferCaches {
-        // Will have HOST_VISIBLE
-        BufferCache host_visible;
-        // Will have HOST_VISIBLE and HOST_CACHED
+        // Will have HOST_VISIBLE and HOST_COHERENT (may be HOST_CACHED)
+        BufferCache host_coherent;
+        // Will have HOST_VISIBLE and HOST_CACHED (may be HOST_COHERENT)
         BufferCache host_cached;
         // Will have DEVICE_LOCAL
         BufferCache device_local;
@@ -165,7 +165,7 @@ class GpuResourcesManager {
         BufferCache staging;
 
         void ReturnBuffers() {
-            host_visible.ReturnBuffers();
+            host_coherent.ReturnBuffers();
             host_cached.ReturnBuffers();
             device_local.ReturnBuffers();
             device_local_indirect.ReturnBuffers();
@@ -173,7 +173,7 @@ class GpuResourcesManager {
         }
 
         void DestroyBuffers() {
-            host_visible.DestroyBuffers();
+            host_coherent.DestroyBuffers();
             host_cached.DestroyBuffers();
             device_local.DestroyBuffers();
             device_local_indirect.DestroyBuffers();

--- a/layers/gpuav/validation_cmd/gpuav_copy_buffer_to_image.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_copy_buffer_to_image.cpp
@@ -137,7 +137,7 @@ void CopyBufferToImage(Validator &gpuav, const Location &loc, CommandBufferSubSt
 
         const VkDeviceSize buffer_size =
             uniform_buffer_constants_byte_size + sizeof(BufferImageCopy) * copy_buffer_to_img_info->regionCount;
-        vko::BufferRange copy_src_regions_mem_buffer_range = cb_state.gpu_resources_manager.GetHostVisibleBufferRange(buffer_size);
+        vko::BufferRange copy_src_regions_mem_buffer_range = cb_state.gpu_resources_manager.GetHostCoherentBufferRange(buffer_size);
         if (copy_src_regions_mem_buffer_range.buffer == VK_NULL_HANDLE) {
             return;
         }


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10024

needed for latest Intel drivers (https://vulkan.gpuinfo.org/displayreport.php?id=42914#memory)