### PR TITLE
sync: Faster search of first accesses within a range

### DIFF
--- a/layers/sync/sync_access_state.cpp
+++ b/layers/sync/sync_access_state.cpp
@@ -887,9 +887,18 @@ bool ResourceAccessState::WaitAcquirePredicate::operator()(const ResourceAccessS
     return (write_state.tag == present_tag) && write_state.access_index == SYNC_PRESENT_ENGINE_SYNCVAL_PRESENT_PRESENTED_SYNCVAL;
 }
 
+ResourceUsageRange ResourceAccessState::GetFirstAccessRange() const {
+    if (first_accesses_.empty()) {
+        return {};
+    }
+    return ResourceUsageRange(first_accesses_.front().tag, first_accesses_.back().tag + 1);
+}
+
 bool ResourceAccessState::FirstAccessInTagRange(const ResourceUsageRange &tag_range) const {
-    if (!first_accesses_.size()) return false;
-    const ResourceUsageRange first_access_range = {first_accesses_.front().tag, first_accesses_.back().tag + 1};
+    if (first_accesses_.empty()) {
+        return false;
+    }
+    const ResourceUsageRange first_access_range = GetFirstAccessRange();
     return tag_range.intersects(first_access_range);
 }
 

--- a/layers/sync/sync_access_state.h
+++ b/layers/sync/sync_access_state.h
@@ -452,6 +452,7 @@ class ResourceAccessState {
     template <typename Predicate>
     bool ClearPredicatedAccesses(Predicate &predicate);
 
+    ResourceUsageRange GetFirstAccessRange() const;
     bool FirstAccessInTagRange(const ResourceUsageRange &tag_range) const;
 
     void OffsetTag(ResourceUsageTag offset);

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -1383,6 +1383,8 @@ CommandBufferSubState::CommandBufferSubState(SyncValidator &dev, vvl::CommandBuf
 }
 
 void CommandBufferSubState::End() {
+    access_context.GetCurrentAccessContext()->Finalize();
+
     // For threads that are dedicated to recording command buffers but do not submit themselves,
     // the end of recording is a logical point to update memory stats
     access_context.GetSyncState().stats.UpdateMemoryStats();


### PR DESCRIPTION
This optimizes one places where we iterated over entire map of memory accesses to find accesses that match criteria. For apps that generate large access maps it takes some time to do this. This solution adds parallel data structure that  provides full or partial sorting and accelerates the search.

Here on the flame graph ValidateFirstUse for the problematic scenario consists of 3 segments of approx. the same duration
<img width="2248" height="166" alt="first_use" src="https://github.com/user-attachments/assets/ee81b18f-c469-434b-a54d-1c13e299a47c" />

With faster search the first two blocks takes very little time - shown with arrows on the right
<img width="3820" height="188" alt="first_use_after2" src="https://github.com/user-attachments/assets/e16504fd-c389-4c87-8638-3caf583b9ad0" />

`StressSyncVal.CopyPagesInSmallChunks` stress test takes ~40% less time (so close to 2x faster).
Captures:  
doom - does not react much to this solution
cs2 capture ~ takes 35% less time (from 108 ms to 68 ms per frame) 
dota2 capture ~ takes 13% less time time (from 55 ms to 47 ms per frame)

