### PR TITLE
layers: Added tensor to descriptors not allowed to be mutable

### DIFF
--- a/layers/stateless/sl_descriptor.cpp
+++ b/layers/stateless/sl_descriptor.cpp
@@ -571,6 +571,10 @@ bool Device::ValidateMutableDescriptorTypeCreateInfo(const VkDescriptorSetLayout
                     skip |= LogError("VUID-VkMutableDescriptorTypeListEXT-pDescriptorTypes-04603", device, type_loc,
                                      "is VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK.");
                     break;
+                case VK_DESCRIPTOR_TYPE_TENSOR_ARM:
+                    skip |= LogError("VUID-VkMutableDescriptorTypeListEXT-pDescriptorTypes-09696", device, type_loc,
+                                     "is VK_DESCRIPTOR_TYPE_TENSOR_ARM.");
+                    break;
                 default:
                     break;
             }

--- a/tests/unit/data_graph.cpp
+++ b/tests/unit/data_graph.cpp
@@ -164,9 +164,9 @@ TEST_F(NegativeDataGraph, CreateDataGraphPipelinesMutableDescriptor) {
     AddRequiredFeature(vkt::Feature::mutableDescriptorType);
     RETURN_IF_SKIP(Init());
 
-    VkDescriptorType types[] = {VK_DESCRIPTOR_TYPE_TENSOR_ARM, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE};
+    VkDescriptorType types[] = {VK_DESCRIPTOR_TYPE_STORAGE_IMAGE};
     VkMutableDescriptorTypeListEXT mutable_descriptor_type_list = {};
-    mutable_descriptor_type_list.descriptorTypeCount = 2;
+    mutable_descriptor_type_list.descriptorTypeCount = 1;
     mutable_descriptor_type_list.pDescriptorTypes = types;
 
     VkMutableDescriptorTypeCreateInfoEXT mutable_descriptor_info = vku::InitStructHelper();


### PR DESCRIPTION
- also changed test CreateDataGraphPipelinesMutableDescriptor, which 
was using VK_DESCRIPTOR_TYPE_TENSOR_ARM as mutable
