### PR TITLE
tests: Remove global RenderPass test helpers

### DIFF
--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -191,6 +191,10 @@ class VkLayerTest : public VkLayerTestBase {
     void CreateImageTest(const VkImageCreateInfo &create_info, const char *vuid);
     void CreateBufferViewTest(const VkBufferViewCreateInfo &create_info, const char *vuid);
     void CreateImageViewTest(const VkImageViewCreateInfo &create_info, const char *vuid);
+    void CreateRenderPassTest(const VkRenderPassCreateInfo &create_info, bool rp2_supported, const char *rp1_vuid,
+                              const char *rp2_vuid);
+    void CreateRenderPassBeginTest(const VkCommandBuffer command_buffer, const VkRenderPassBeginInfo *begin_info,
+                                   bool rp2_supported, const char *rp1_vuid, const char *rp2_vuid);
 
   protected:
     void SetTargetApiVersion(APIVersion target_api_version);
@@ -454,15 +458,6 @@ bool operator==(const VkDebugUtilsLabelEXT &rhs, const VkDebugUtilsLabelEXT &lhs
 VKAPI_ATTR VkBool32 VKAPI_CALL DebugUtilsCallback(VkDebugUtilsMessageSeverityFlagBitsEXT messageSeverity,
                                                   VkDebugUtilsMessageTypeFlagsEXT messageTypes,
                                                   const VkDebugUtilsMessengerCallbackDataEXT *pCallbackData, void *pUserData);
-
-void TestRenderPassCreate(ErrorMonitor *error_monitor, const vkt::Device &device, const VkRenderPassCreateInfo &create_info,
-                          bool rp2_supported, const char *rp1_vuid, const char *rp2_vuid);
-void PositiveTestRenderPassCreate(const vkt::Device &device, const VkRenderPassCreateInfo &create_info, bool rp2_supported);
-void PositiveTestRenderPass2KHRCreate(const vkt::Device &device, const VkRenderPassCreateInfo2KHR &create_info);
-void TestRenderPass2KHRCreate(ErrorMonitor &error_monitor, const vkt::Device &device, const VkRenderPassCreateInfo2KHR &create_info,
-                              const std::vector<const char *> &vuids);
-void TestRenderPassBegin(ErrorMonitor *error_monitor, const VkDevice device, const VkCommandBuffer command_buffer,
-                         const VkRenderPassBeginInfo *begin_info, bool rp2Supported, const char *rp1_vuid, const char *rp2_vuid);
 
 VkFormat FindFormatWithoutFeatures(VkPhysicalDevice gpu, VkImageTiling tiling,
                                    VkFormatFeatureFlags undesired_features = vvl::kNoIndex32);

--- a/tests/unit/dynamic_rendering_local_read.cpp
+++ b/tests/unit/dynamic_rendering_local_read.cpp
@@ -44,18 +44,17 @@ TEST_F(NegativeDynamicRenderingLocalRead, AttachmentLayout) {
 
     refs[0].layout = VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ;
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, true, "VUID-VkAttachmentReference-dynamicRenderingLocalRead-09546",
+    CreateRenderPassTest(rpci, true, "VUID-VkAttachmentReference-dynamicRenderingLocalRead-09546",
                          "VUID-VkAttachmentReference2-dynamicRenderingLocalRead-09546");
 
     refs[0].layout = VK_IMAGE_LAYOUT_GENERAL;
     attach->initialLayout = VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, true, "VUID-VkAttachmentDescription-dynamicRenderingLocalRead-09544",
+    CreateRenderPassTest(rpci, true, "VUID-VkAttachmentDescription-dynamicRenderingLocalRead-09544",
                          "VUID-VkAttachmentDescription2-dynamicRenderingLocalRead-09544");
 
     attach->initialLayout = VK_IMAGE_LAYOUT_GENERAL;
     attach->finalLayout = VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, true,
-                         "VUID-VkAttachmentDescription-dynamicRenderingLocalRead-09545",
+    CreateRenderPassTest(rpci, true, "VUID-VkAttachmentDescription-dynamicRenderingLocalRead-09545",
                          "VUID-VkAttachmentDescription2-dynamicRenderingLocalRead-09545");
 }
 

--- a/tests/unit/fragment_shading_rate.cpp
+++ b/tests/unit/fragment_shading_rate.cpp
@@ -287,8 +287,7 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapReferences) {
 
     auto rpci = vku::InitStruct<VkRenderPassCreateInfo>(&rpfdmi, 0u, 1u, &attach, 1u, &subpass, 0u, nullptr);
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, false, "VUID-VkRenderPassCreateInfo-fragmentDensityMapAttachment-06471",
-                         nullptr);
+    CreateRenderPassTest(rpci, false, "VUID-VkRenderPassCreateInfo-fragmentDensityMapAttachment-06471", nullptr);
 
     // Set wrong VkImageLayout
     ref = {0, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL};
@@ -296,8 +295,8 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapReferences) {
     rpfdmi = vku::InitStruct<VkRenderPassFragmentDensityMapCreateInfoEXT>(nullptr, ref);
     rpci = vku::InitStruct<VkRenderPassCreateInfo>(&rpfdmi, 0u, 1u, &attach, 1u, &subpass, 0u, nullptr);
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, false,
-                         "VUID-VkRenderPassFragmentDensityMapCreateInfoEXT-fragmentDensityMapAttachment-02549", nullptr);
+    CreateRenderPassTest(rpci, false, "VUID-VkRenderPassFragmentDensityMapCreateInfoEXT-fragmentDensityMapAttachment-02549",
+                         nullptr);
 
     // Set wrong load operation
     attach = {0,
@@ -315,8 +314,8 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapReferences) {
     rpfdmi = vku::InitStruct<VkRenderPassFragmentDensityMapCreateInfoEXT>(nullptr, ref);
     rpci = vku::InitStruct<VkRenderPassCreateInfo>(&rpfdmi, 0u, 1u, &attach, 1u, &subpass, 0u, nullptr);
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, false,
-                         "VUID-VkRenderPassFragmentDensityMapCreateInfoEXT-fragmentDensityMapAttachment-02550", nullptr);
+    CreateRenderPassTest(rpci, false, "VUID-VkRenderPassFragmentDensityMapCreateInfoEXT-fragmentDensityMapAttachment-02550",
+                         nullptr);
 
     // Set wrong store operation
     attach = {0,
@@ -334,8 +333,8 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapReferences) {
     rpfdmi = vku::InitStruct<VkRenderPassFragmentDensityMapCreateInfoEXT>(nullptr, ref);
     rpci = vku::InitStruct<VkRenderPassCreateInfo>(&rpfdmi, 0u, 1u, &attach, 1u, &subpass, 0u, nullptr);
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, false,
-                         "VUID-VkRenderPassFragmentDensityMapCreateInfoEXT-fragmentDensityMapAttachment-02551", nullptr);
+    CreateRenderPassTest(rpci, false, "VUID-VkRenderPassFragmentDensityMapCreateInfoEXT-fragmentDensityMapAttachment-02551",
+                         nullptr);
 }
 
 TEST_F(NegativeFragmentShadingRate, FragmentDensityMapDuplicateReferences) {
@@ -394,8 +393,8 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapDuplicateReferences) {
         auto rpfdmi = vku::InitStruct<VkRenderPassFragmentDensityMapCreateInfoEXT>(nullptr, ref_fdm);
         auto rpci = vku::InitStruct<VkRenderPassCreateInfo>(&rpfdmi, 0u, 5u, attachments, 1u, &subpass, 0u, nullptr);
 
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, false,
-                             "VUID-VkRenderPassFragmentDensityMapCreateInfoEXT-fragmentDensityMapAttachment-02548", nullptr);
+        CreateRenderPassTest(rpci, false, "VUID-VkRenderPassFragmentDensityMapCreateInfoEXT-fragmentDensityMapAttachment-02548",
+                             nullptr);
     }
 
     {
@@ -406,8 +405,8 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapDuplicateReferences) {
         auto rpfdmi = vku::InitStruct<VkRenderPassFragmentDensityMapCreateInfoEXT>(nullptr, ref_fdm);
         auto rpci = vku::InitStruct<VkRenderPassCreateInfo>(&rpfdmi, 0u, 5u, attachments, 1u, &subpass, 0u, nullptr);
 
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, false,
-                             "VUID-VkRenderPassFragmentDensityMapCreateInfoEXT-fragmentDensityMapAttachment-02548", nullptr);
+        CreateRenderPassTest(rpci, false, "VUID-VkRenderPassFragmentDensityMapCreateInfoEXT-fragmentDensityMapAttachment-02548",
+                             nullptr);
     }
 
     {
@@ -418,8 +417,8 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapDuplicateReferences) {
         auto rpfdmi = vku::InitStruct<VkRenderPassFragmentDensityMapCreateInfoEXT>(nullptr, ref_fdm);
         auto rpci = vku::InitStruct<VkRenderPassCreateInfo>(&rpfdmi, 0u, 5u, attachments, 1u, &subpass, 0u, nullptr);
 
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, false,
-                             "VUID-VkRenderPassFragmentDensityMapCreateInfoEXT-fragmentDensityMapAttachment-02548", nullptr);
+        CreateRenderPassTest(rpci, false, "VUID-VkRenderPassFragmentDensityMapCreateInfoEXT-fragmentDensityMapAttachment-02548",
+                             nullptr);
     }
 }
 

--- a/tests/unit/imageless_framebuffer.cpp
+++ b/tests/unit/imageless_framebuffer.cpp
@@ -124,8 +124,8 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
         framebufferCreateInfo.flags = 0;
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
         renderPassBeginInfo.framebuffer = framebuffer;
-        TestRenderPassBegin(m_errorMonitor, device(), m_command_buffer, &renderPassBeginInfo, rp2Supported,
-                            "VUID-VkRenderPassBeginInfo-framebuffer-03207", "VUID-VkRenderPassBeginInfo-framebuffer-03207");
+        CreateRenderPassBeginTest(m_command_buffer, &renderPassBeginInfo, rp2Supported,
+                                  "VUID-VkRenderPassBeginInfo-framebuffer-03207", "VUID-VkRenderPassBeginInfo-framebuffer-03207");
     }
     {
         framebufferCreateInfo.pAttachments = nullptr;
@@ -133,8 +133,8 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
         renderPassAttachmentBeginInfo.attachmentCount = 2;
         renderPassBeginInfo.framebuffer = framebuffer;
-        TestRenderPassBegin(m_errorMonitor, device(), m_command_buffer, &renderPassBeginInfo, rp2Supported,
-                            "VUID-VkRenderPassBeginInfo-framebuffer-03208", "VUID-VkRenderPassBeginInfo-framebuffer-03208");
+        CreateRenderPassBeginTest(m_command_buffer, &renderPassBeginInfo, rp2Supported,
+                                  "VUID-VkRenderPassBeginInfo-framebuffer-03208", "VUID-VkRenderPassBeginInfo-framebuffer-03208");
         renderPassAttachmentBeginInfo.attachmentCount = 1;
     }
 
@@ -143,8 +143,8 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
         renderPassAttachmentBeginInfo.attachmentCount = 2;
         renderPassBeginInfo.framebuffer = framebuffer;
-        TestRenderPassBegin(m_errorMonitor, device(), m_command_buffer, &renderPassBeginInfo, rp2Supported,
-                            "VUID-VkRenderPassBeginInfo-framebuffer-03208", "VUID-VkRenderPassBeginInfo-framebuffer-03208");
+        CreateRenderPassBeginTest(m_command_buffer, &renderPassBeginInfo, rp2Supported,
+                                  "VUID-VkRenderPassBeginInfo-framebuffer-03208", "VUID-VkRenderPassBeginInfo-framebuffer-03208");
         renderPassAttachmentBeginInfo.attachmentCount = 1;
     }
 
@@ -153,8 +153,8 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
         framebufferAttachmentImageInfo.flags = 0;
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
         renderPassBeginInfo.framebuffer = framebuffer;
-        TestRenderPassBegin(m_errorMonitor, device(), m_command_buffer, &renderPassBeginInfo, rp2Supported,
-                            "VUID-VkRenderPassBeginInfo-framebuffer-03209", "VUID-VkRenderPassBeginInfo-framebuffer-03209");
+        CreateRenderPassBeginTest(m_command_buffer, &renderPassBeginInfo, rp2Supported,
+                                  "VUID-VkRenderPassBeginInfo-framebuffer-03209", "VUID-VkRenderPassBeginInfo-framebuffer-03209");
         framebufferAttachmentImageInfo.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
     }
 
@@ -163,8 +163,8 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
         framebufferAttachmentImageInfo.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
         renderPassBeginInfo.framebuffer = framebuffer;
-        TestRenderPassBegin(m_errorMonitor, device(), m_command_buffer, &renderPassBeginInfo, rp2Supported,
-                            "VUID-VkRenderPassBeginInfo-framebuffer-04627", "VUID-VkRenderPassBeginInfo-framebuffer-04627");
+        CreateRenderPassBeginTest(m_command_buffer, &renderPassBeginInfo, rp2Supported,
+                                  "VUID-VkRenderPassBeginInfo-framebuffer-04627", "VUID-VkRenderPassBeginInfo-framebuffer-04627");
         framebufferAttachmentImageInfo.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     }
 
@@ -173,8 +173,8 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
         renderPassAttachmentBeginInfo.pAttachments = &imageViewSubset.handle();
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
         renderPassBeginInfo.framebuffer = framebuffer;
-        TestRenderPassBegin(m_errorMonitor, device(), m_command_buffer, &renderPassBeginInfo, rp2Supported,
-                            "VUID-VkRenderPassBeginInfo-framebuffer-04627", "VUID-VkRenderPassBeginInfo-framebuffer-04627");
+        CreateRenderPassBeginTest(m_command_buffer, &renderPassBeginInfo, rp2Supported,
+                                  "VUID-VkRenderPassBeginInfo-framebuffer-04627", "VUID-VkRenderPassBeginInfo-framebuffer-04627");
         renderPassAttachmentBeginInfo.pAttachments = &imageView.handle();
     }
 
@@ -183,8 +183,8 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
         framebufferAttachmentImageInfo.width += 1;
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
         renderPassBeginInfo.framebuffer = framebuffer;
-        TestRenderPassBegin(m_errorMonitor, device(), m_command_buffer, &renderPassBeginInfo, rp2Supported,
-                            "VUID-VkRenderPassBeginInfo-framebuffer-03211", "VUID-VkRenderPassBeginInfo-framebuffer-03211");
+        CreateRenderPassBeginTest(m_command_buffer, &renderPassBeginInfo, rp2Supported,
+                                  "VUID-VkRenderPassBeginInfo-framebuffer-03211", "VUID-VkRenderPassBeginInfo-framebuffer-03211");
         framebufferAttachmentImageInfo.width -= 1;
     }
 
@@ -193,8 +193,8 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
         framebufferAttachmentImageInfo.height += 1;
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
         renderPassBeginInfo.framebuffer = framebuffer;
-        TestRenderPassBegin(m_errorMonitor, device(), m_command_buffer, &renderPassBeginInfo, rp2Supported,
-                            "VUID-VkRenderPassBeginInfo-framebuffer-03212", "VUID-VkRenderPassBeginInfo-framebuffer-03212");
+        CreateRenderPassBeginTest(m_command_buffer, &renderPassBeginInfo, rp2Supported,
+                                  "VUID-VkRenderPassBeginInfo-framebuffer-03212", "VUID-VkRenderPassBeginInfo-framebuffer-03212");
         framebufferAttachmentImageInfo.height -= 1;
     }
 
@@ -203,8 +203,8 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
         framebufferAttachmentImageInfo.layerCount += 1;
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
         renderPassBeginInfo.framebuffer = framebuffer;
-        TestRenderPassBegin(m_errorMonitor, device(), m_command_buffer, &renderPassBeginInfo, rp2Supported,
-                            "VUID-VkRenderPassBeginInfo-framebuffer-03213", "VUID-VkRenderPassBeginInfo-framebuffer-03213");
+        CreateRenderPassBeginTest(m_command_buffer, &renderPassBeginInfo, rp2Supported,
+                                  "VUID-VkRenderPassBeginInfo-framebuffer-03213", "VUID-VkRenderPassBeginInfo-framebuffer-03213");
         framebufferAttachmentImageInfo.layerCount -= 1;
     }
 
@@ -213,8 +213,8 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
         framebufferAttachmentImageInfo.viewFormatCount = 3;
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
         renderPassBeginInfo.framebuffer = framebuffer;
-        TestRenderPassBegin(m_errorMonitor, device(), m_command_buffer, &renderPassBeginInfo, rp2Supported,
-                            "VUID-VkRenderPassBeginInfo-framebuffer-03214", "VUID-VkRenderPassBeginInfo-framebuffer-03214");
+        CreateRenderPassBeginTest(m_command_buffer, &renderPassBeginInfo, rp2Supported,
+                                  "VUID-VkRenderPassBeginInfo-framebuffer-03214", "VUID-VkRenderPassBeginInfo-framebuffer-03214");
         framebufferAttachmentImageInfo.viewFormatCount = 2;
     }
 
@@ -223,8 +223,8 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
         framebufferAttachmentFormats[1] = VK_FORMAT_B8G8R8A8_SRGB;
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
         renderPassBeginInfo.framebuffer = framebuffer;
-        TestRenderPassBegin(m_errorMonitor, device(), m_command_buffer, &renderPassBeginInfo, rp2Supported,
-                            "VUID-VkRenderPassBeginInfo-framebuffer-03215", "VUID-VkRenderPassBeginInfo-framebuffer-03215");
+        CreateRenderPassBeginTest(m_command_buffer, &renderPassBeginInfo, rp2Supported,
+                                  "VUID-VkRenderPassBeginInfo-framebuffer-03215", "VUID-VkRenderPassBeginInfo-framebuffer-03215");
         framebufferAttachmentFormats[1] = VK_FORMAT_B8G8R8A8_UNORM;
     }
 
@@ -235,8 +235,8 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
         renderPassAttachmentBeginInfo.pAttachments = &imageView2.handle();
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
         renderPassBeginInfo.framebuffer = framebuffer;
-        TestRenderPassBegin(m_errorMonitor, device(), m_command_buffer, &renderPassBeginInfo, rp2Supported,
-                            "VUID-VkRenderPassBeginInfo-framebuffer-03216", "VUID-VkRenderPassBeginInfo-framebuffer-03216");
+        CreateRenderPassBeginTest(m_command_buffer, &renderPassBeginInfo, rp2Supported,
+                                  "VUID-VkRenderPassBeginInfo-framebuffer-03216", "VUID-VkRenderPassBeginInfo-framebuffer-03216");
         renderPassAttachmentBeginInfo.pAttachments = &imageView.handle();
         imageViewCreateInfo.format = attachmentFormats[0];
     }
@@ -251,8 +251,8 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
         renderPassAttachmentBeginInfo.pAttachments = &imageView2.handle();
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
         renderPassBeginInfo.framebuffer = framebuffer;
-        TestRenderPassBegin(m_errorMonitor, device(), m_command_buffer, &renderPassBeginInfo, rp2Supported,
-                            "VUID-VkRenderPassBeginInfo-framebuffer-09047", "VUID-VkRenderPassBeginInfo-framebuffer-09047");
+        CreateRenderPassBeginTest(m_command_buffer, &renderPassBeginInfo, rp2Supported,
+                                  "VUID-VkRenderPassBeginInfo-framebuffer-09047", "VUID-VkRenderPassBeginInfo-framebuffer-09047");
         renderPassAttachmentBeginInfo.pAttachments = &imageView.handle();
         imageViewCreateInfo.image = image;
         imageCreateInfo.samples = VK_SAMPLE_COUNT_1_BIT;
@@ -266,9 +266,9 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
         renderPassAttachmentBeginInfo.pAttachments = &imageView2.handle();
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
         renderPassBeginInfo.framebuffer = framebuffer;
-        TestRenderPassBegin(m_errorMonitor, device(), m_command_buffer, &renderPassBeginInfo, rp2Supported,
-                            "VUID-VkRenderPassAttachmentBeginInfo-pAttachments-03218",
-                            "VUID-VkRenderPassAttachmentBeginInfo-pAttachments-03218");
+        CreateRenderPassBeginTest(m_command_buffer, &renderPassBeginInfo, rp2Supported,
+                                  "VUID-VkRenderPassAttachmentBeginInfo-pAttachments-03218",
+                                  "VUID-VkRenderPassAttachmentBeginInfo-pAttachments-03218");
         renderPassAttachmentBeginInfo.pAttachments = &imageView.handle();
         imageViewCreateInfo.subresourceRange.levelCount = 1;
     }
@@ -280,9 +280,9 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
         renderPassAttachmentBeginInfo.pAttachments = &imageView2.handle();
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
         renderPassBeginInfo.framebuffer = framebuffer;
-        TestRenderPassBegin(m_errorMonitor, device(), m_command_buffer, &renderPassBeginInfo, rp2Supported,
-                            "VUID-VkRenderPassAttachmentBeginInfo-pAttachments-03219",
-                            "VUID-VkRenderPassAttachmentBeginInfo-pAttachments-03219");
+        CreateRenderPassBeginTest(m_command_buffer, &renderPassBeginInfo, rp2Supported,
+                                  "VUID-VkRenderPassAttachmentBeginInfo-pAttachments-03219",
+                                  "VUID-VkRenderPassAttachmentBeginInfo-pAttachments-03219");
         renderPassAttachmentBeginInfo.pAttachments = &imageView.handle();
         imageViewCreateInfo.components.r = VK_COMPONENT_SWIZZLE_IDENTITY;
     }
@@ -975,9 +975,9 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageView3D) {
     renderPassBeginInfo.framebuffer = framebuffer;
 
     // Try to use 3D Image View with imageless flag
-    TestRenderPassBegin(m_errorMonitor, device(), m_command_buffer, &renderPassBeginInfo, rp2Supported,
-                        "VUID-VkRenderPassAttachmentBeginInfo-pAttachments-04114",
-                        "VUID-VkRenderPassAttachmentBeginInfo-pAttachments-04114");
+    CreateRenderPassBeginTest(m_command_buffer, &renderPassBeginInfo, rp2Supported,
+                              "VUID-VkRenderPassAttachmentBeginInfo-pAttachments-04114",
+                              "VUID-VkRenderPassAttachmentBeginInfo-pAttachments-04114");
 }
 
 TEST_F(NegativeImagelessFramebuffer, AttachmentImagePNext) {

--- a/tests/unit/layer_settings.cpp
+++ b/tests/unit/layer_settings.cpp
@@ -324,7 +324,7 @@ TEST_F(NegativeLayerSettings, VuidIdFilterString) {
                                                            nullptr, 1, &iaar};
     VkRenderPassCreateInfo rpci = {VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO, &rpiaaci, 0, 1, &attach, 1, &subpass, 0, nullptr};
     m_errorMonitor->SetUnexpectedError("VUID-VkRenderPassCreateInfo2-attachment-02525");
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, false, "VUID-VkInputAttachmentAspectReference-aspectMask-01964", nullptr);
+    CreateRenderPassTest(rpci, false, "VUID-VkInputAttachmentAspectReference-aspectMask-01964", nullptr);
 }
 
 TEST_F(NegativeLayerSettings, VuidFilterHexInt) {
@@ -357,7 +357,7 @@ TEST_F(NegativeLayerSettings, VuidFilterHexInt) {
                                                            nullptr, 1, &iaar};
     VkRenderPassCreateInfo rpci = {VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO, &rpiaaci, 0, 1, &attach, 1, &subpass, 0, nullptr};
     m_errorMonitor->SetUnexpectedError("VUID-VkRenderPassCreateInfo2-attachment-02525");
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, false, "VUID-VkInputAttachmentAspectReference-aspectMask-01964", nullptr);
+    CreateRenderPassTest(rpci, false, "VUID-VkInputAttachmentAspectReference-aspectMask-01964", nullptr);
 }
 
 TEST_F(NegativeLayerSettings, VuidFilterInt) {
@@ -389,7 +389,7 @@ TEST_F(NegativeLayerSettings, VuidFilterInt) {
                                                            nullptr, 1, &iaar};
     VkRenderPassCreateInfo rpci = {VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO, &rpiaaci, 0, 1, &attach, 1, &subpass, 0, nullptr};
     m_errorMonitor->SetUnexpectedError("VUID-VkRenderPassCreateInfo2-attachment-02525");
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, false, "VUID-VkInputAttachmentAspectReference-aspectMask-01964", nullptr);
+    CreateRenderPassTest(rpci, false, "VUID-VkInputAttachmentAspectReference-aspectMask-01964", nullptr);
 }
 
 TEST_F(NegativeLayerSettings, DebugAction) {

--- a/tests/unit/multiview.cpp
+++ b/tests/unit/multiview.cpp
@@ -716,12 +716,9 @@ TEST_F(NegativeMultiview, RenderPassCreateOverlappingCorrelationMasks) {
         nullptr, 1u, viewMasks.data(), 0u, nullptr, static_cast<uint32_t>(correlationMasks.size()), correlationMasks.data());
     auto rpci = vku::InitStruct<VkRenderPassCreateInfo>(&rpmvci, 0u, 0u, nullptr, 1u, &subpass, 0u, nullptr);
 
-    PositiveTestRenderPassCreate(*m_device, rpci, false);
-
     // Correlation masks must not overlap
     correlationMasks[1] = 0x3u;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported,
-                         "VUID-VkRenderPassMultiviewCreateInfo-pCorrelationMasks-00841",
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkRenderPassMultiviewCreateInfo-pCorrelationMasks-00841",
                          "VUID-VkRenderPassCreateInfo2-pCorrelatedViewMasks-03056");
 
     // Check for more specific "don't set any correlation masks when multiview is not enabled"
@@ -731,7 +728,9 @@ TEST_F(NegativeMultiview, RenderPassCreateOverlappingCorrelationMasks) {
         correlationMasks[1] = 0;
         auto safe_rpci2 = ConvertVkRenderPassCreateInfoToV2KHR(rpci);
 
-        TestRenderPass2KHRCreate(*m_errorMonitor, *m_device, *safe_rpci2.ptr(), {"VUID-VkRenderPassCreateInfo2-viewMask-03057"});
+        m_errorMonitor->SetDesiredError("VUID-VkRenderPassCreateInfo2-viewMask-03057");
+        vkt::RenderPass rp2(*m_device, *safe_rpci2.ptr());
+        m_errorMonitor->VerifyFound();
     }
 }
 
@@ -753,7 +752,7 @@ TEST_F(NegativeMultiview, RenderPassViewMasksNotEnough) {
     auto rpci = vku::InitStruct<VkRenderPassCreateInfo>(&rpmvci, 0u, 0u, nullptr, 2u, subpasses, 0u, nullptr);
 
     // Not enough view masks
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkRenderPassCreateInfo-pNext-01928",
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkRenderPassCreateInfo-pNext-01928",
                          "VUID-VkRenderPassCreateInfo2-viewMask-03058");
 }
 
@@ -773,8 +772,7 @@ TEST_F(NegativeMultiview, RenderPassCreateSubpassMissingAttributesBitNVX) {
 
     auto rpci = vku::InitStruct<VkRenderPassCreateInfo>(nullptr, 0u, 0u, nullptr, 1u, subpasses, 0u, nullptr);
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkSubpassDescription-flags-00856",
-                         "VUID-VkSubpassDescription2-flags-03076");
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkSubpassDescription-flags-00856", "VUID-VkSubpassDescription2-flags-03076");
 }
 
 TEST_F(NegativeMultiview, DrawWithPipelineIncompatibleWithRenderPass) {
@@ -1000,7 +998,7 @@ TEST_F(NegativeMultiview, RenderPassViewMasksZero) {
 
     auto rpci = vku::InitStruct<VkRenderPassCreateInfo>(&rpmvci, 0u, 0u, nullptr, 2u, subpasses, 0u, nullptr);
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, false, "VUID-VkRenderPassCreateInfo-pNext-02513", nullptr);
+    CreateRenderPassTest(rpci, false, "VUID-VkRenderPassCreateInfo-pNext-02513", nullptr);
 }
 
 TEST_F(NegativeMultiview, RenderPassViewOffsets) {
@@ -1028,7 +1026,7 @@ TEST_F(NegativeMultiview, RenderPassViewOffsets) {
     VkSubpassDependency dependency = {};
     auto rpci = vku::InitStruct<VkRenderPassCreateInfo>(&rpmvci, 0u, 0u, nullptr, 2u, subpasses, 1u, &dependency);
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, false, "VUID-VkRenderPassCreateInfo-pNext-02512", nullptr);
+    CreateRenderPassTest(rpci, false, "VUID-VkRenderPassCreateInfo-pNext-02512", nullptr);
 }
 
 TEST_F(NegativeMultiview, RenderPassViewMasksLimit) {
@@ -1053,7 +1051,7 @@ TEST_F(NegativeMultiview, RenderPassViewMasksLimit) {
 
     auto rpci = vku::InitStruct<VkRenderPassCreateInfo>(&rpmvci, 0u, 0u, nullptr, 1u, &subpass, 0u, nullptr);
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, false, "VUID-VkRenderPassMultiviewCreateInfo-pViewMasks-06697", nullptr);
+    CreateRenderPassTest(rpci, false, "VUID-VkRenderPassMultiviewCreateInfo-pViewMasks-06697", nullptr);
 }
 
 TEST_F(NegativeMultiview, FeaturesDisabled) {

--- a/tests/unit/render_pass.cpp
+++ b/tests/unit/render_pass.cpp
@@ -20,7 +20,19 @@
 #include "../framework/descriptor_helper.h"
 #include "../framework/render_pass_helper.h"
 
-class NegativeRenderPass : public VkLayerTest {};
+class NegativeRenderPass : public VkLayerTest {
+  public:
+    void TestRenderPass2KHRCreate(const VkRenderPassCreateInfo2KHR &create_info, const std::vector<const char *> &vuids);
+};
+
+void NegativeRenderPass::TestRenderPass2KHRCreate(const VkRenderPassCreateInfo2KHR &create_info,
+                                                  const std::vector<const char *> &vuids) {
+    for (auto vuid : vuids) {
+        m_errorMonitor->SetDesiredError(vuid);
+    }
+    vkt::RenderPass rp(*m_device, create_info);
+    m_errorMonitor->VerifyFound();
+}
 
 TEST_F(NegativeRenderPass, AttachmentIndexOutOfRange) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
@@ -33,7 +45,7 @@ TEST_F(NegativeRenderPass, AttachmentIndexOutOfRange) {
     rp.AddColorAttachment(0);
 
     // "... must be less than the total number of attachments ..."
-    TestRenderPassCreate(m_errorMonitor, *m_device, rp.GetCreateInfo(), true, "VUID-VkRenderPassCreateInfo-attachment-00834",
+    CreateRenderPassTest(rp.GetCreateInfo(), true, "VUID-VkRenderPassCreateInfo-attachment-00834",
                          "VUID-VkRenderPassCreateInfo2-attachment-03051");
 }
 
@@ -70,12 +82,12 @@ TEST_F(NegativeRenderPass, AttachmentReadOnlyButCleared) {
     description.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
 
     depth_stencil_ref.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkRenderPassCreateInfo-pAttachments-00836",
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkRenderPassCreateInfo-pAttachments-00836",
                          "VUID-VkRenderPassCreateInfo2-pAttachments-02522");
 
     if (maintenance2Supported == true) {
         depth_stencil_ref.layout = VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL;
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkRenderPassCreateInfo-pAttachments-01566",
+        CreateRenderPassTest(rpci, rp2Supported, "VUID-VkRenderPassCreateInfo-pAttachments-01566",
                              "VUID-VkRenderPassCreateInfo2-pAttachments-02522");
     }
 
@@ -85,12 +97,12 @@ TEST_F(NegativeRenderPass, AttachmentReadOnlyButCleared) {
     description.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
 
     depth_stencil_ref.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkRenderPassCreateInfo-pAttachments-02511",
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkRenderPassCreateInfo-pAttachments-02511",
                          "VUID-VkRenderPassCreateInfo2-pAttachments-02523");
 
     if (maintenance2Supported == true) {
         depth_stencil_ref.layout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL;
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkRenderPassCreateInfo-pAttachments-01567",
+        CreateRenderPassTest(rpci, rp2Supported, "VUID-VkRenderPassCreateInfo-pAttachments-01567",
                              "VUID-VkRenderPassCreateInfo2-pAttachments-02523");
     }
 
@@ -110,7 +122,7 @@ TEST_F(NegativeRenderPass, AttachmentMismatchingLayoutsColor) {
     rp.AddColorAttachment(0);
     rp.AddColorAttachment(1);
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rp.GetCreateInfo(), true, "VUID-VkSubpassDescription-layout-02519",
+    CreateRenderPassTest(rp.GetCreateInfo(), true, "VUID-VkSubpassDescription-layout-02519",
                          "VUID-VkSubpassDescription2-layout-02528");
 }
 
@@ -141,11 +153,11 @@ TEST_F(NegativeRenderPass, AttachmentDescriptionFinalLayout) {
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpass;
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentDescription-finalLayout-00843",
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-finalLayout-00843",
                          "VUID-VkAttachmentDescription2-finalLayout-00843");
 
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentDescription-finalLayout-00843",
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-finalLayout-00843",
                          "VUID-VkAttachmentDescription2-finalLayout-00843");
 
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
@@ -161,23 +173,19 @@ TEST_F(NegativeRenderPass, AttachmentDescriptionFinalLayout) {
         attach_desc.format = depth_format;
 
         attach_desc.initialLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported,
-                             "VUID-VkAttachmentDescription-separateDepthStencilLayouts-03284",
+        CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-separateDepthStencilLayouts-03284",
                              "VUID-VkAttachmentDescription2-separateDepthStencilLayouts-03284");
         attach_desc.initialLayout = VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL;
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported,
-                             "VUID-VkAttachmentDescription-separateDepthStencilLayouts-03284",
+        CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-separateDepthStencilLayouts-03284",
                              "VUID-VkAttachmentDescription2-separateDepthStencilLayouts-03284");
 
         attach_desc.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
 
         attach_desc.finalLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported,
-                             "VUID-VkAttachmentDescription-separateDepthStencilLayouts-03285",
+        CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-separateDepthStencilLayouts-03285",
                              "VUID-VkAttachmentDescription2-separateDepthStencilLayouts-03285");
         attach_desc.finalLayout = VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL;
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported,
-                             "VUID-VkAttachmentDescription-separateDepthStencilLayouts-03285",
+        CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-separateDepthStencilLayouts-03285",
                              "VUID-VkAttachmentDescription2-separateDepthStencilLayouts-03285");
 
         attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
@@ -188,23 +196,19 @@ TEST_F(NegativeRenderPass, AttachmentDescriptionFinalLayout) {
         attach_desc.format = stencil_format;
 
         attach_desc.initialLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL;
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported,
-                             "VUID-VkAttachmentDescription-separateDepthStencilLayouts-03284",
+        CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-separateDepthStencilLayouts-03284",
                              "VUID-VkAttachmentDescription2-separateDepthStencilLayouts-03284");
         attach_desc.initialLayout = VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL;
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported,
-                             "VUID-VkAttachmentDescription-separateDepthStencilLayouts-03284",
+        CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-separateDepthStencilLayouts-03284",
                              "VUID-VkAttachmentDescription2-separateDepthStencilLayouts-03284");
 
         attach_desc.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
 
         attach_desc.finalLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL;
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported,
-                             "VUID-VkAttachmentDescription-separateDepthStencilLayouts-03285",
+        CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-separateDepthStencilLayouts-03285",
                              "VUID-VkAttachmentDescription2-separateDepthStencilLayouts-03285");
         attach_desc.finalLayout = VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL;
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported,
-                             "VUID-VkAttachmentDescription-separateDepthStencilLayouts-03285",
+        CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-separateDepthStencilLayouts-03285",
                              "VUID-VkAttachmentDescription2-separateDepthStencilLayouts-03285");
 
         attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
@@ -237,7 +241,7 @@ TEST_F(NegativeRenderPass, AttachmentDescriptionFinalLayoutZeroInitialized) {
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpass;
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, true, "VUID-VkAttachmentDescription-finalLayout-00843",
+    CreateRenderPassTest(rpci, true, "VUID-VkAttachmentDescription-finalLayout-00843",
                          "VUID-VkAttachmentDescription2-finalLayout-00843");
 }
 
@@ -271,11 +275,11 @@ TEST_F(NegativeRenderPass, AttachmentDescriptionFinalLayoutSeperateDS) {
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpass;
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentDescription-finalLayout-00843",
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-finalLayout-00843",
                          "VUID-VkAttachmentDescription2-finalLayout-00843");
 
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentDescription-finalLayout-00843",
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-finalLayout-00843",
                          "VUID-VkAttachmentDescription2-finalLayout-00843");
 
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
@@ -288,31 +292,31 @@ TEST_F(NegativeRenderPass, AttachmentDescriptionFinalLayoutSeperateDS) {
     }
 
     attach_desc.initialLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03286",
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03286",
                          "VUID-VkAttachmentDescription2-format-03286");
     attach_desc.initialLayout = VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03286",
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03286",
                          "VUID-VkAttachmentDescription2-format-03286");
     attach_desc.initialLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03286",
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03286",
                          "VUID-VkAttachmentDescription2-format-03286");
     attach_desc.initialLayout = VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03286",
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03286",
                          "VUID-VkAttachmentDescription2-format-03286");
 
     attach_desc.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
 
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03287",
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03287",
                          "VUID-VkAttachmentDescription2-format-03287");
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03287",
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03287",
                          "VUID-VkAttachmentDescription2-format-03287");
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03287",
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03287",
                          "VUID-VkAttachmentDescription2-format-03287");
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03287",
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03287",
                          "VUID-VkAttachmentDescription2-format-03287");
 
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
@@ -322,19 +326,19 @@ TEST_F(NegativeRenderPass, AttachmentDescriptionFinalLayoutSeperateDS) {
         attach_desc.format = depth_format;
 
         attach_desc.initialLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL;
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03290",
+        CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03290",
                              "VUID-VkAttachmentDescription2-format-03290");
         attach_desc.initialLayout = VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL;
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03290",
+        CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03290",
                              "VUID-VkAttachmentDescription2-format-03290");
 
         attach_desc.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
 
         attach_desc.finalLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL;
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03291",
+        CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03291",
                              "VUID-VkAttachmentDescription2-format-03291");
         attach_desc.finalLayout = VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL;
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03291",
+        CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03291",
                              "VUID-VkAttachmentDescription2-format-03291");
 
         attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
@@ -345,19 +349,19 @@ TEST_F(NegativeRenderPass, AttachmentDescriptionFinalLayoutSeperateDS) {
         attach_desc.format = stencil_format;
 
         attach_desc.initialLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03292",
+        CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03292",
                              "VUID-VkAttachmentDescription2-format-06247");
         attach_desc.initialLayout = VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL;
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03292",
+        CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03292",
                              "VUID-VkAttachmentDescription2-format-06247");
 
         attach_desc.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
 
         attach_desc.finalLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03293",
+        CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03293",
                              "VUID-VkAttachmentDescription2-format-06248");
         attach_desc.finalLayout = VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL;
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03293",
+        CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03293",
                              "VUID-VkAttachmentDescription2-format-06248");
 
         attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
@@ -386,21 +390,17 @@ TEST_F(NegativeRenderPass, AttachmentDescriptionFinalLayoutSeperateDS) {
 
         for (size_t i = 0; i < forbidden_layouts_array_size; ++i) {
             attachment_description_stencil_layout.stencilInitialLayout = forbidden_layouts[i];
-            TestRenderPass2KHRCreate(*m_errorMonitor, *m_device, *rpci2.ptr(),
-                                     {"VUID-VkAttachmentDescriptionStencilLayout-stencilInitialLayout-03308"});
+            TestRenderPass2KHRCreate(*rpci2.ptr(), {"VUID-VkAttachmentDescriptionStencilLayout-stencilInitialLayout-03308"});
         }
         attachment_description_stencil_layout.stencilInitialLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL;
         for (size_t i = 0; i < forbidden_layouts_array_size; ++i) {
             attachment_description_stencil_layout.stencilFinalLayout = forbidden_layouts[i];
-            TestRenderPass2KHRCreate(*m_errorMonitor, *m_device, *rpci2.ptr(),
-                                     {"VUID-VkAttachmentDescriptionStencilLayout-stencilFinalLayout-03309"});
+            TestRenderPass2KHRCreate(*rpci2.ptr(), {"VUID-VkAttachmentDescriptionStencilLayout-stencilFinalLayout-03309"});
         }
         attachment_description_stencil_layout.stencilFinalLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-        TestRenderPass2KHRCreate(*m_errorMonitor, *m_device, *rpci2.ptr(),
-                                 {"VUID-VkAttachmentDescriptionStencilLayout-stencilFinalLayout-03310"});
+        TestRenderPass2KHRCreate(*rpci2.ptr(), {"VUID-VkAttachmentDescriptionStencilLayout-stencilFinalLayout-03310"});
         attachment_description_stencil_layout.stencilFinalLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
-        TestRenderPass2KHRCreate(*m_errorMonitor, *m_device, *rpci2.ptr(),
-                                 {"VUID-VkAttachmentDescriptionStencilLayout-stencilFinalLayout-03310"});
+        TestRenderPass2KHRCreate(*rpci2.ptr(), {"VUID-VkAttachmentDescriptionStencilLayout-stencilFinalLayout-03310"});
 
         rpci2.pAttachments[0].pNext = nullptr;
     }
@@ -435,11 +435,11 @@ TEST_F(NegativeRenderPass, AttachmentDescriptionFinalLayoutSync2) {
     rpci.subpassCount = 1;
     rpci.pSubpasses = &subpass;
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentDescription-finalLayout-00843",
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-finalLayout-00843",
                          "VUID-VkAttachmentDescription2-finalLayout-00843");
 
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentDescription-finalLayout-00843",
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-finalLayout-00843",
                          "VUID-VkAttachmentDescription2-finalLayout-00843");
 
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
@@ -454,12 +454,12 @@ TEST_F(NegativeRenderPass, AttachmentDescriptionFinalLayoutSync2) {
     attach_desc.format = VK_FORMAT_R8G8B8A8_UNORM;
     attach_desc.initialLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03280",
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03280",
                          "VUID-VkAttachmentDescription2-format-03280");
 
     attach_desc.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03282",
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03282",
                          "VUID-VkAttachmentDescription2-format-03282");
 
     // invalid formats without synchronization2
@@ -467,19 +467,19 @@ TEST_F(NegativeRenderPass, AttachmentDescriptionFinalLayoutSync2) {
         attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
 
         attach_desc.initialLayout = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL;
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentDescription-synchronization2-06908",
+        CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-synchronization2-06908",
                              "VUID-VkAttachmentDescription2-synchronization2-06908");
         attach_desc.initialLayout = VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL;
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentDescription-synchronization2-06908",
+        CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-synchronization2-06908",
                              "VUID-VkAttachmentDescription2-synchronization2-06908");
 
         attach_desc.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
 
         attach_desc.finalLayout = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL;
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentDescription-synchronization2-06909",
+        CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-synchronization2-06909",
                              "VUID-VkAttachmentDescription2-synchronization2-06909");
         attach_desc.finalLayout = VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL;
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentDescription-synchronization2-06909",
+        CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-synchronization2-06909",
                              "VUID-VkAttachmentDescription2-synchronization2-06909");
 
         attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
@@ -490,12 +490,12 @@ TEST_F(NegativeRenderPass, AttachmentDescriptionFinalLayoutSync2) {
         attach_desc.format = depth_stencil_format;
         attach_desc.initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
         attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03281",
+        CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03281",
                              "VUID-VkAttachmentDescription2-format-03281");
 
         attach_desc.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
         attach_desc.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03283",
+        CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-format-03283",
                              "VUID-VkAttachmentDescription2-format-03283");
     }
 }
@@ -586,8 +586,7 @@ TEST_F(NegativeRenderPass, AttachmentsMisc) {
         VkRenderPassCreateInfo test_rpci = rpci;
         test_rpci.pSubpasses = &test_subpass;
 
-        TestRenderPassCreate(m_errorMonitor, *m_device, test_rpci, rp2Supported,
-                             "VUID-VkSubpassDescription-colorAttachmentCount-00845",
+        CreateRenderPassTest(test_rpci, rp2Supported, "VUID-VkSubpassDescription-colorAttachmentCount-00845",
                              "VUID-VkSubpassDescription2-colorAttachmentCount-03063");
     }
 
@@ -595,7 +594,7 @@ TEST_F(NegativeRenderPass, AttachmentsMisc) {
     attachments[subpass.pColorAttachments[1].attachment].samples = VK_SAMPLE_COUNT_8_BIT;
     depth.attachment = VK_ATTACHMENT_UNUSED;  // Avoids triggering 01418
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkSubpassDescription-pColorAttachments-09430",
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkSubpassDescription-pColorAttachments-09430",
                          "VUID-VkSubpassDescription2-multisampledRenderToSingleSampled-06872");
 
     depth.attachment = 3;
@@ -605,7 +604,7 @@ TEST_F(NegativeRenderPass, AttachmentsMisc) {
     attachments[subpass.pDepthStencilAttachment->attachment].samples = VK_SAMPLE_COUNT_8_BIT;
     subpass.colorAttachmentCount = 1;
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkSubpassDescription-pDepthStencilAttachment-01418",
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkSubpassDescription-pDepthStencilAttachment-01418",
                          "VUID-VkSubpassDescription2-multisampledRenderToSingleSampled-06872");
 
     attachments[subpass.pDepthStencilAttachment->attachment].samples = attachments[subpass.pColorAttachments[0].attachment].samples;
@@ -614,7 +613,7 @@ TEST_F(NegativeRenderPass, AttachmentsMisc) {
     // Test resolve attachment with UNUSED color attachment
     color[0].attachment = VK_ATTACHMENT_UNUSED;
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkSubpassDescription-pResolveAttachments-00847",
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkSubpassDescription-pResolveAttachments-00847",
                          "VUID-VkSubpassDescription2-externalFormatResolve-09335");
 
     color[0].attachment = 1;
@@ -624,7 +623,7 @@ TEST_F(NegativeRenderPass, AttachmentsMisc) {
     subpass.colorAttachmentCount = 1;           // avoid mismatch (00337), and avoid double report
     subpass.pDepthStencilAttachment = nullptr;  // avoid mismatch (01418)
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkSubpassDescription-pResolveAttachments-00848",
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkSubpassDescription-pResolveAttachments-00848",
                          "VUID-VkSubpassDescription2-externalFormatResolve-09338");
 
     attachments[subpass.pColorAttachments[0].attachment].samples = VK_SAMPLE_COUNT_4_BIT;
@@ -634,7 +633,7 @@ TEST_F(NegativeRenderPass, AttachmentsMisc) {
     // Test resolve to a multi-sampled resolve attachment
     attachments[subpass.pResolveAttachments[0].attachment].samples = VK_SAMPLE_COUNT_4_BIT;
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkSubpassDescription-pResolveAttachments-00849",
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkSubpassDescription-pResolveAttachments-00849",
                          "VUID-VkSubpassDescription2-pResolveAttachments-03067");
 
     attachments[subpass.pResolveAttachments[0].attachment].samples = VK_SAMPLE_COUNT_1_BIT;
@@ -642,7 +641,7 @@ TEST_F(NegativeRenderPass, AttachmentsMisc) {
     // Test with color/resolve format mismatch
     attachments[subpass.pColorAttachments[0].attachment].format = VK_FORMAT_R8G8B8A8_SRGB;
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkSubpassDescription-pResolveAttachments-00850",
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkSubpassDescription-pResolveAttachments-00850",
                          "VUID-VkSubpassDescription2-externalFormatResolve-09339");
 
     attachments[subpass.pColorAttachments[0].attachment].format = attachments[subpass.pResolveAttachments[0].attachment].format;
@@ -650,14 +649,14 @@ TEST_F(NegativeRenderPass, AttachmentsMisc) {
     // Test for UNUSED preserve attachments
     preserve[0] = VK_ATTACHMENT_UNUSED;
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkSubpassDescription-attachment-00853",
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkSubpassDescription-attachment-00853",
                          "VUID-VkSubpassDescription2-attachment-03073");
 
     preserve[0] = 5;
     // Test for preserve attachments used elsewhere in the subpass
     color[0].attachment = preserve[0];
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkSubpassDescription-pPreserveAttachments-00854",
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkSubpassDescription-pPreserveAttachments-00854",
                          "VUID-VkSubpassDescription2-pPreserveAttachments-03074");
 
     color[0].attachment = 1;
@@ -673,7 +672,7 @@ TEST_F(NegativeRenderPass, AttachmentsMisc) {
         auto rpci_multipass = vku::InitStruct<VkRenderPassCreateInfo>(nullptr, 0u, size32(attachments), attachments.data(),
                                                                       size32(subpasses), subpasses.data(), 0u, nullptr);
 
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci_multipass, rp2Supported, "VUID-VkSubpassDescription-loadOp-00846",
+        CreateRenderPassTest(rpci_multipass, rp2Supported, "VUID-VkSubpassDescription-loadOp-00846",
                              "VUID-VkSubpassDescription2-loadOp-03064");
 
         attachments[input[0].attachment].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
@@ -690,28 +689,24 @@ TEST_F(NegativeRenderPass, AttachmentsMisc) {
 
         // only test rp1 so can ignore the expected 2nd error
         m_errorMonitor->SetUnexpectedError("VUID-VkSubpassDescription-pColorAttachments-02648");
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci_same, false, "VUID-VkSubpassDescription-pDepthStencilAttachment-04438",
-                             nullptr);
+        CreateRenderPassTest(rpci_same, false, "VUID-VkSubpassDescription-pDepthStencilAttachment-04438", nullptr);
 
         if (rp2Supported) {
             auto create_info2 = ConvertVkRenderPassCreateInfoToV2KHR(rpci_same);
             m_errorMonitor->SetUnexpectedError("VUID-VkSubpassDescription2-pColorAttachments-02898");
-            TestRenderPass2KHRCreate(*m_errorMonitor, *m_device, *create_info2.ptr(),
-                                     {"VUID-VkSubpassDescription2-pDepthStencilAttachment-04440"});
+            TestRenderPass2KHRCreate(*create_info2.ptr(), {"VUID-VkSubpassDescription2-pDepthStencilAttachment-04440"});
         }
 
         // Same test but use 2 different VkAttachmentReference to point to same attachment
         subpass_same.pDepthStencilAttachment = &depth_1bit.data()[1];
 
         m_errorMonitor->SetUnexpectedError("VUID-VkSubpassDescription-pColorAttachments-02648");
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci_same, false, "VUID-VkSubpassDescription-pDepthStencilAttachment-04438",
-                             nullptr);
+        CreateRenderPassTest(rpci_same, false, "VUID-VkSubpassDescription-pDepthStencilAttachment-04438", nullptr);
 
         if (rp2Supported) {
             auto create_info2 = ConvertVkRenderPassCreateInfoToV2KHR(rpci_same);
             m_errorMonitor->SetUnexpectedError("VUID-VkSubpassDescription2-pColorAttachments-02898");
-            TestRenderPass2KHRCreate(*m_errorMonitor, *m_device, *create_info2.ptr(),
-                                     {"VUID-VkSubpassDescription2-pDepthStencilAttachment-04440"});
+            TestRenderPass2KHRCreate(*create_info2.ptr(), {"VUID-VkSubpassDescription2-pDepthStencilAttachment-04440"});
         }
     }
 }
@@ -779,7 +774,7 @@ TEST_F(NegativeRenderPass, ShaderResolveQCOM) {
     VkRenderPassCreateInfo test_rpci = rpci;
     test_rpci.pSubpasses = &test_subpass;
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, test_rpci, rp2Supported, "VUID-VkSubpassDescription-flags-03341",
+    CreateRenderPassTest(test_rpci, rp2Supported, "VUID-VkSubpassDescription-flags-03341",
                          "VUID-VkSubpassDescription2-flags-04907");
 
     // Create a resolve subpass which is not the last subpass in the subpass dependency chain.
@@ -793,7 +788,7 @@ TEST_F(NegativeRenderPass, ShaderResolveQCOM) {
         auto test2_rpci = vku::InitStruct<VkRenderPassCreateInfo>(nullptr, 0u, size32(attachments), attachments.data(), 2u,
                                                                   subpasses, size32(dependency), dependency.data());
 
-        TestRenderPassCreate(m_errorMonitor, *m_device, test2_rpci, rp2Supported, "VUID-VkSubpassDescription-flags-03343",
+        CreateRenderPassTest(test2_rpci, rp2Supported, "VUID-VkSubpassDescription-flags-03343",
                              "VUID-VkSubpassDescription2-flags-04909");
     }
 }
@@ -829,13 +824,11 @@ TEST_F(NegativeRenderPass, AttachmentReferenceLayout) {
 
     // Use UNDEFINED layout
     refs[0].layout = VK_IMAGE_LAYOUT_UNDEFINED;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentReference-layout-03077",
-                         "VUID-VkAttachmentReference2-layout-03077");
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentReference-layout-03077", "VUID-VkAttachmentReference2-layout-03077");
 
     // Use PREINITIALIZED layout
     refs[0].layout = VK_IMAGE_LAYOUT_PREINITIALIZED;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentReference-layout-03077",
-                         "VUID-VkAttachmentReference2-layout-03077");
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentReference-layout-03077", "VUID-VkAttachmentReference2-layout-03077");
 
     if (rp2Supported) {
         auto rpci2 = ConvertVkRenderPassCreateInfoToV2KHR(rpci);
@@ -846,31 +839,26 @@ TEST_F(NegativeRenderPass, AttachmentReferenceLayout) {
 
         rpci2.pSubpasses[0].pDepthStencilAttachment->aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
         rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
-        TestRenderPass2KHRCreate(
-            *m_errorMonitor, *m_device, *rpci2.ptr(),
-            {"VUID-VkAttachmentReference2-separateDepthStencilLayouts-03313", "VUID-VkRenderPassCreateInfo2-attachment-06244"});
+        TestRenderPass2KHRCreate(*rpci2.ptr(), {"VUID-VkAttachmentReference2-separateDepthStencilLayouts-03313",
+                                                "VUID-VkRenderPassCreateInfo2-attachment-06244"});
         rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL;
-        TestRenderPass2KHRCreate(
-            *m_errorMonitor, *m_device, *rpci2.ptr(),
-            {"VUID-VkAttachmentReference2-separateDepthStencilLayouts-03313", "VUID-VkRenderPassCreateInfo2-attachment-06244"});
+        TestRenderPass2KHRCreate(*rpci2.ptr(), {"VUID-VkAttachmentReference2-separateDepthStencilLayouts-03313",
+                                                "VUID-VkRenderPassCreateInfo2-attachment-06244"});
 
         rpci2.pSubpasses[0].pDepthStencilAttachment->aspectMask = VK_IMAGE_ASPECT_STENCIL_BIT;
         rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL;
-        TestRenderPass2KHRCreate(
-            *m_errorMonitor, *m_device, *rpci2.ptr(),
-            {"VUID-VkAttachmentReference2-separateDepthStencilLayouts-03313", "VUID-VkRenderPassCreateInfo2-attachment-06245"});
+        TestRenderPass2KHRCreate(*rpci2.ptr(), {"VUID-VkAttachmentReference2-separateDepthStencilLayouts-03313",
+                                                "VUID-VkRenderPassCreateInfo2-attachment-06245"});
         rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL;
-        TestRenderPass2KHRCreate(
-            *m_errorMonitor, *m_device, *rpci2.ptr(),
-            {"VUID-VkAttachmentReference2-separateDepthStencilLayouts-03313", "VUID-VkRenderPassCreateInfo2-attachment-06245"});
+        TestRenderPass2KHRCreate(*rpci2.ptr(), {"VUID-VkAttachmentReference2-separateDepthStencilLayouts-03313",
+                                                "VUID-VkRenderPassCreateInfo2-attachment-06245"});
     }
 
     // test RenderPass 1
     refs[0].layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     refs[1].layout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassCreateInfo2-attachment-06244");
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, false, "VUID-VkAttachmentReference-separateDepthStencilLayouts-03313",
-                         nullptr);
+    CreateRenderPassTest(rpci, false, "VUID-VkAttachmentReference-separateDepthStencilLayouts-03313", nullptr);
 }
 
 TEST_F(NegativeRenderPass, AttachmentReferenceLayoutSeparateDepthStencilLayoutsFeature) {
@@ -927,13 +915,11 @@ TEST_F(NegativeRenderPass, AttachmentReferenceLayoutSeparateDepthStencilLayoutsF
 
     // Use UNDEFINED layout
     refs[0].layout = VK_IMAGE_LAYOUT_UNDEFINED;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentReference-layout-03077",
-                         "VUID-VkAttachmentReference2-layout-03077");
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentReference-layout-03077", "VUID-VkAttachmentReference2-layout-03077");
 
     // Use PREINITIALIZED layout
     refs[0].layout = VK_IMAGE_LAYOUT_PREINITIALIZED;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentReference-layout-03077",
-                         "VUID-VkAttachmentReference2-layout-03077");
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentReference-layout-03077", "VUID-VkAttachmentReference2-layout-03077");
 
     if (rp2Supported) {
         auto rpci2 = ConvertVkRenderPassCreateInfoToV2KHR(rpci);
@@ -957,9 +943,9 @@ TEST_F(NegativeRenderPass, AttachmentReferenceLayoutSeparateDepthStencilLayoutsF
             rpci2.pSubpasses[0].pDepthStencilAttachment->aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
 
             rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
-            PositiveTestRenderPass2KHRCreate(*m_device, *rpci2.ptr());
+            vkt::RenderPass rp1(*m_device, *rpci2.ptr());
             rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL;
-            PositiveTestRenderPass2KHRCreate(*m_device, *rpci2.ptr());
+            vkt::RenderPass rp2(*m_device, *rpci2.ptr());
         }
         {
             rpci2.pSubpasses[0].pDepthStencilAttachment->aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
@@ -967,9 +953,9 @@ TEST_F(NegativeRenderPass, AttachmentReferenceLayoutSeparateDepthStencilLayoutsF
             rpci2.pSubpasses[0].pDepthStencilAttachment->attachment = 2;
 
             rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-            PositiveTestRenderPass2KHRCreate(*m_device, *rpci2.ptr());
+            vkt::RenderPass rp1(*m_device, *rpci2.ptr());
             rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
-            PositiveTestRenderPass2KHRCreate(*m_device, *rpci2.ptr());
+            vkt::RenderPass rp2(*m_device, *rpci2.ptr());
 
             rpci2.pSubpasses[0].pDepthStencilAttachment->attachment = original_attachment;
         }
@@ -977,9 +963,9 @@ TEST_F(NegativeRenderPass, AttachmentReferenceLayoutSeparateDepthStencilLayoutsF
             rpci2.pSubpasses[0].pDepthStencilAttachment->aspectMask = VK_IMAGE_ASPECT_STENCIL_BIT;
 
             rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
-            PositiveTestRenderPass2KHRCreate(*m_device, *rpci2.ptr());
+            vkt::RenderPass rp1(*m_device, *rpci2.ptr());
             rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL;
-            PositiveTestRenderPass2KHRCreate(*m_device, *rpci2.ptr());
+            vkt::RenderPass rp2(*m_device, *rpci2.ptr());
         }
 
         rpci2.pAttachments[1].format = ds_format;                                                                // reset
@@ -1000,8 +986,7 @@ TEST_F(NegativeRenderPass, AttachmentReferenceLayoutSeparateDepthStencilLayoutsF
         rpci2.pSubpasses[0].pDepthStencilAttachment->layout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
         for (size_t i = 0; i < forbidden_layouts.size(); ++i) {
             attachment_reference_stencil_layout.stencilLayout = forbidden_layouts[i];
-            TestRenderPass2KHRCreate(*m_errorMonitor, *m_device, *rpci2.ptr(),
-                                     {"VUID-VkAttachmentReferenceStencilLayout-stencilLayout-03318"});
+            TestRenderPass2KHRCreate(*rpci2.ptr(), {"VUID-VkAttachmentReferenceStencilLayout-stencilLayout-03318"});
         }
 
         attachment_reference_stencil_layout.stencilLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL;
@@ -1014,21 +999,21 @@ TEST_F(NegativeRenderPass, AttachmentReferenceLayoutSeparateDepthStencilLayoutsF
 
         rpci2.pAttachments[1].initialLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL;
         rpci2.pAttachments[1].finalLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
-        TestRenderPass2KHRCreate(*m_errorMonitor, *m_device, *rpci2.ptr(), {"VUID-VkAttachmentDescription2-format-06906"});
+        TestRenderPass2KHRCreate(*rpci2.ptr(), {"VUID-VkAttachmentDescription2-format-06906"});
 
         rpci2.pAttachments[1].initialLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
         rpci2.pAttachments[1].finalLayout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL;
-        TestRenderPass2KHRCreate(*m_errorMonitor, *m_device, *rpci2.ptr(), {"VUID-VkAttachmentDescription2-format-06907"});
+        TestRenderPass2KHRCreate(*rpci2.ptr(), {"VUID-VkAttachmentDescription2-format-06907"});
 
         rpci2.pAttachments[1].pNext = nullptr;
 
         rpci2.pAttachments[1].initialLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
         rpci2.pAttachments[1].finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-        TestRenderPass2KHRCreate(*m_errorMonitor, *m_device, *rpci2.ptr(), {"VUID-VkAttachmentDescription2-format-06249"});
+        TestRenderPass2KHRCreate(*rpci2.ptr(), {"VUID-VkAttachmentDescription2-format-06249"});
 
         rpci2.pAttachments[1].initialLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
         rpci2.pAttachments[1].finalLayout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
-        TestRenderPass2KHRCreate(*m_errorMonitor, *m_device, *rpci2.ptr(), {"VUID-VkAttachmentDescription2-format-06250"});
+        TestRenderPass2KHRCreate(*rpci2.ptr(), {"VUID-VkAttachmentDescription2-format-06250"});
 
         rpci2.pSubpasses[0].pDepthStencilAttachment->pNext = nullptr;
     }
@@ -1079,7 +1064,7 @@ TEST_F(NegativeRenderPass, AttachmentReferenceSync2Layout) {
 
     // Use ATTACHMENT_OPTIMAL_KHR layout
     refs[0].layout = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, true, "VUID-VkAttachmentReference-synchronization2-06910",
+    CreateRenderPassTest(rpci, true, "VUID-VkAttachmentReference-synchronization2-06910",
                          "VUID-VkAttachmentReference2-synchronization2-06910");
 }
 
@@ -1147,8 +1132,7 @@ TEST_F(NegativeRenderPass, MixedAttachmentSamplesAMD) {
     attachments[0].samples = VK_SAMPLE_COUNT_4_BIT;
     attachments[1].samples = VK_SAMPLE_COUNT_1_BIT;
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkSubpassDescription-None-09431",
-                         "VUID-VkSubpassDescription2-None-09456");
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkSubpassDescription-None-09431", "VUID-VkSubpassDescription2-None-09456");
 }
 
 TEST_F(NegativeRenderPass, BeginRenderArea) {
@@ -1167,22 +1151,22 @@ TEST_F(NegativeRenderPass, BeginRenderArea) {
     m_renderPassBeginInfo.renderArea.extent.height = 256;
 
     const char *vuid = "VUID-VkRenderPassBeginInfo-pNext-02852";
-    TestRenderPassBegin(m_errorMonitor, device(), m_command_buffer, &m_renderPassBeginInfo, rp2Supported, vuid, vuid);
+    CreateRenderPassBeginTest(m_command_buffer, &m_renderPassBeginInfo, rp2Supported, vuid, vuid);
 
     m_renderPassBeginInfo.renderArea.offset.x = 1;
     m_renderPassBeginInfo.renderArea.extent.width = vvl::kU32Max - 1;
-    TestRenderPassBegin(m_errorMonitor, device(), m_command_buffer, &m_renderPassBeginInfo, rp2Supported, vuid, vuid);
+    CreateRenderPassBeginTest(m_command_buffer, &m_renderPassBeginInfo, rp2Supported, vuid, vuid);
 
     m_renderPassBeginInfo.renderArea.offset.x = vvl::kI32Max;
     m_renderPassBeginInfo.renderArea.extent.width = vvl::kU32Max;
-    TestRenderPassBegin(m_errorMonitor, device(), m_command_buffer, &m_renderPassBeginInfo, rp2Supported, vuid, vuid);
+    CreateRenderPassBeginTest(m_command_buffer, &m_renderPassBeginInfo, rp2Supported, vuid, vuid);
 
     m_renderPassBeginInfo.renderArea.offset.x = 0;
     m_renderPassBeginInfo.renderArea.extent.width = 256;
     m_renderPassBeginInfo.renderArea.offset.y = 1;
     m_renderPassBeginInfo.renderArea.extent.height = vvl::kU32Max - 1;
-    TestRenderPassBegin(m_errorMonitor, device(), m_command_buffer, &m_renderPassBeginInfo, rp2Supported,
-                        "VUID-VkRenderPassBeginInfo-pNext-02853", "VUID-VkRenderPassBeginInfo-pNext-02853");
+    CreateRenderPassBeginTest(m_command_buffer, &m_renderPassBeginInfo, rp2Supported, "VUID-VkRenderPassBeginInfo-pNext-02853",
+                              "VUID-VkRenderPassBeginInfo-pNext-02853");
 }
 
 TEST_F(NegativeRenderPass, BeginWithinRenderPass) {
@@ -1246,8 +1230,7 @@ TEST_F(NegativeRenderPass, BeginIncompatibleFramebuffer) {
     auto rp_begin =
         vku::InitStruct<VkRenderPassBeginInfo>(nullptr, rp2.handle(), fb.handle(), VkRect2D{{0, 0}, {128u, 128u}}, 0u, nullptr);
 
-    TestRenderPassBegin(m_errorMonitor, device(), m_command_buffer, &rp_begin, false, "VUID-VkRenderPassBeginInfo-renderPass-00904",
-                        nullptr);
+    CreateRenderPassBeginTest(m_command_buffer, &rp_begin, false, "VUID-VkRenderPassBeginInfo-renderPass-00904", nullptr);
 }
 
 TEST_F(NegativeRenderPass, BeginLayoutsFramebufferImageUsageMismatches) {
@@ -1317,7 +1300,7 @@ TEST_F(NegativeRenderPass, BeginLayoutsFramebufferImageUsageMismatches) {
         vkt::Framebuffer fb_invalid(*m_device, fbci);
         rp_begin.renderPass = rp_invalid;
         rp_begin.framebuffer = fb_invalid;
-        TestRenderPassBegin(m_errorMonitor, device(), m_command_buffer, &rp_begin, rp2Supported, rp1_vuid, rp2_vuid);
+        CreateRenderPassBeginTest(m_command_buffer, &rp_begin, rp2Supported, rp1_vuid, rp2_vuid);
     };
 
     // Initial layout is VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL but attachment doesn't support IMAGE_USAGE_COLOR_ATTACHMENT_BIT
@@ -1395,9 +1378,8 @@ TEST_F(NegativeRenderPass, BeginLayoutsFramebufferImageUsageMismatches) {
 
 TEST_F(NegativeRenderPass, BeginLayoutsStencilBufferImageUsageMismatches) {
     TEST_DESCRIPTION("Test that separate stencil initial/final layouts match up with the usage bits in framebuffer attachment");
-
     SetTargetApiVersion(VK_API_VERSION_1_2);
-    AddRequiredExtensions(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);  // Because TestRenderPassBegin relies on it
+    AddRequiredExtensions(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);  // Because CreateRenderPassBeginTest relies on it
     AddRequiredFeature(vkt::Feature::separateDepthStencilLayouts);
     RETURN_IF_SKIP(Init());
 
@@ -1437,7 +1419,7 @@ TEST_F(NegativeRenderPass, BeginLayoutsStencilBufferImageUsageMismatches) {
         rp_begin.framebuffer = fb;
         rp_begin.renderArea.extent = {fb_width, fb_height};
 
-        TestRenderPassBegin(m_errorMonitor, device(), m_command_buffer, &rp_begin, true, rp1_vuid, rp2_vuid);
+        CreateRenderPassBeginTest(m_command_buffer, &rp_begin, true, rp1_vuid, rp2_vuid);
     };
 
     test(VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL, VK_IMAGE_LAYOUT_GENERAL, "VUID-vkCmdBeginRenderPass-initialLayout-02842",
@@ -1539,8 +1521,8 @@ TEST_F(NegativeRenderPass, BeginClearOpMismatch) {
     rp_begin.renderArea.extent = {1, 1};
     rp_begin.clearValueCount = 0;  // Should be 1
 
-    TestRenderPassBegin(m_errorMonitor, device(), m_command_buffer, &rp_begin, rp2Supported,
-                        "VUID-VkRenderPassBeginInfo-clearValueCount-00902", "VUID-VkRenderPassBeginInfo-clearValueCount-00902");
+    CreateRenderPassBeginTest(m_command_buffer, &rp_begin, rp2Supported, "VUID-VkRenderPassBeginInfo-clearValueCount-00902",
+                              "VUID-VkRenderPassBeginInfo-clearValueCount-00902");
 }
 
 TEST_F(NegativeRenderPass, BeginSampleLocationsIndicesEXT) {
@@ -1594,13 +1576,12 @@ TEST_F(NegativeRenderPass, BeginSampleLocationsIndicesEXT) {
         vku::InitStruct<VkRenderPassBeginInfo>(&rp_sl_begin, rp.handle(), fb.handle(), VkRect2D{{0, 0}, {128u, 128u}}, 0u, nullptr);
 
     attachment_sample_locations.attachmentIndex = 1;
-    TestRenderPassBegin(m_errorMonitor, device(), m_command_buffer, &rp_begin, false,
-                        "VUID-VkAttachmentSampleLocationsEXT-attachmentIndex-01531", nullptr);
+    CreateRenderPassBeginTest(m_command_buffer, &rp_begin, false, "VUID-VkAttachmentSampleLocationsEXT-attachmentIndex-01531",
+                              nullptr);
     attachment_sample_locations.attachmentIndex = 0;
 
     subpass_sample_locations.subpassIndex = 1;
-    TestRenderPassBegin(m_errorMonitor, device(), m_command_buffer, &rp_begin, false,
-                        "VUID-VkSubpassSampleLocationsEXT-subpassIndex-01532", nullptr);
+    CreateRenderPassBeginTest(m_command_buffer, &rp_begin, false, "VUID-VkSubpassSampleLocationsEXT-subpassIndex-01532", nullptr);
 }
 
 TEST_F(NegativeRenderPass, DestroyWhileInUse) {
@@ -2076,10 +2057,10 @@ void RenderPassCreatePotentialFormatFeaturesTest::Test(bool const useLinearColor
     // Color attachment
     subpass.pColorAttachments = &references[1];
     if (useLinearColorAttachment) {
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkSubpassDescription-linearColorAttachment-06497",
+        CreateRenderPassTest(rpci, rp2Supported, "VUID-VkSubpassDescription-linearColorAttachment-06497",
                              "VUID-VkSubpassDescription2-linearColorAttachment-06500");
     } else {
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkSubpassDescription-pColorAttachments-02648",
+        CreateRenderPassTest(rpci, rp2Supported, "VUID-VkSubpassDescription-pColorAttachments-02648",
                              "VUID-VkSubpassDescription2-pColorAttachments-02898");
     }
     subpass = originalSubpass;
@@ -2088,17 +2069,17 @@ void RenderPassCreatePotentialFormatFeaturesTest::Test(bool const useLinearColor
     subpass.inputAttachmentCount = 1;
     subpass.pInputAttachments = &references[1];
     if (useLinearColorAttachment) {
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkSubpassDescription-linearColorAttachment-06496",
+        CreateRenderPassTest(rpci, rp2Supported, "VUID-VkSubpassDescription-linearColorAttachment-06496",
                              "VUID-VkSubpassDescription2-linearColorAttachment-06499");
     } else {
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkSubpassDescription-pInputAttachments-02647",
+        CreateRenderPassTest(rpci, rp2Supported, "VUID-VkSubpassDescription-pInputAttachments-02647",
                              "VUID-VkSubpassDescription2-pInputAttachments-02897");
     }
     subpass = originalSubpass;
 
     // Depth Stencil attachment
     subpass.pDepthStencilAttachment = &references[3];
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkSubpassDescription-pDepthStencilAttachment-02650",
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkSubpassDescription-pDepthStencilAttachment-02650",
                          "VUID-VkSubpassDescription2-pDepthStencilAttachment-02900");
     subpass = originalSubpass;
 
@@ -2401,8 +2382,7 @@ TEST_F(NegativeRenderPass, RenderPassBeginNullValues) {
     auto rpbi = m_renderPassBeginInfo;
     rpbi.clearValueCount = 1;
     rpbi.pClearValues = nullptr;  // clearValueCount != 0, but pClearValues = null, leads to 04962
-    TestRenderPassBegin(m_errorMonitor, device(), m_command_buffer, &rpbi, false,
-                        "VUID-VkRenderPassBeginInfo-clearValueCount-04962", nullptr);
+    CreateRenderPassBeginTest(m_command_buffer, &rpbi, false, "VUID-VkRenderPassBeginInfo-clearValueCount-04962", nullptr);
 }
 
 TEST_F(NegativeRenderPass, DepthStencilResolveAttachmentFormat) {
@@ -2710,7 +2690,7 @@ TEST_F(NegativeRenderPass, AttachmentUndefinedLayout) {
     rpci.attachmentCount = 1;
     rpci.pAttachments = &attach_desc;
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkAttachmentDescription-format-06699",
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkAttachmentDescription-format-06699",
                          "VUID-VkAttachmentDescription2-format-06699");
 
     attach_desc.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
@@ -3443,11 +3423,11 @@ TEST_F(NegativeRenderPass, SubpassAttachmentImageLayout) {
     ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     subpass.inputAttachmentCount = 1;
     subpass.pInputAttachments = &ref;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06912",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06912",
                          "VUID-VkSubpassDescription2-attachment-06912");
 
     ref.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06912",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06912",
                          "VUID-VkSubpassDescription2-attachment-06912");
 
     reset_subpass();
@@ -3455,11 +3435,11 @@ TEST_F(NegativeRenderPass, SubpassAttachmentImageLayout) {
     ref.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
     subpass.colorAttachmentCount = 1;
     subpass.pColorAttachments = &ref;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06913",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06913",
                          "VUID-VkSubpassDescription2-attachment-06913");
 
     ref.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06913",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06913",
                          "VUID-VkSubpassDescription2-attachment-06913");
 
     reset_subpass();
@@ -3471,11 +3451,11 @@ TEST_F(NegativeRenderPass, SubpassAttachmentImageLayout) {
 
         ref.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
         subpass.pResolveAttachments = &ref;
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06914",
+        CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06914",
                              "VUID-VkSubpassDescription2-attachment-06914");
 
         ref.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06914",
+        CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06914",
                              "VUID-VkSubpassDescription2-attachment-06914");
     }
 
@@ -3484,11 +3464,11 @@ TEST_F(NegativeRenderPass, SubpassAttachmentImageLayout) {
     ref.attachment = 2;
     ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     subpass.pDepthStencilAttachment = &ref;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06915",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06915",
                          "VUID-VkSubpassDescription2-attachment-06915");
 
     ref.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06915",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06915",
                          "VUID-VkSubpassDescription2-attachment-06915");
 }
 
@@ -3529,11 +3509,11 @@ TEST_F(NegativeRenderPass, SubpassAttachmentImageLayoutMaintenance2) {
     ref.layout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL;
     subpass.colorAttachmentCount = 1;
     subpass.pColorAttachments = &ref;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06916",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06916",
                          "VUID-VkSubpassDescription2-attachment-06916");
 
     ref.layout = VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06916",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06916",
                          "VUID-VkSubpassDescription2-attachment-06916");
 
     reset_subpass();
@@ -3545,11 +3525,11 @@ TEST_F(NegativeRenderPass, SubpassAttachmentImageLayoutMaintenance2) {
 
         ref.layout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL;
         subpass.pResolveAttachments = &ref;
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06917",
+        CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06917",
                              "VUID-VkSubpassDescription2-attachment-06917");
 
         ref.layout = VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL;
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06917",
+        CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06917",
                              "VUID-VkSubpassDescription2-attachment-06917");
     }
 }
@@ -3592,7 +3572,7 @@ TEST_F(NegativeRenderPass, SubpassAttachmentImageLayoutSynchronization2) {
     ref.layout = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL;
     subpass.inputAttachmentCount = 1;
     subpass.pInputAttachments = &ref;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06921",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06921",
                          "VUID-VkSubpassDescription2-attachment-06921");
 
     reset_subpass();
@@ -3600,7 +3580,7 @@ TEST_F(NegativeRenderPass, SubpassAttachmentImageLayoutSynchronization2) {
     ref.layout = VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL;
     subpass.colorAttachmentCount = 1;
     subpass.pColorAttachments = &ref;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06922",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06922",
                          "VUID-VkSubpassDescription2-attachment-06922");
 
     reset_subpass();
@@ -3612,7 +3592,7 @@ TEST_F(NegativeRenderPass, SubpassAttachmentImageLayoutSynchronization2) {
 
         ref.layout = VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL;
         subpass.pResolveAttachments = &ref;
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06923",
+        CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06923",
                              "VUID-VkSubpassDescription2-attachment-06923");
     }
 }
@@ -3659,11 +3639,11 @@ TEST_F(NegativeRenderPass, SubpassAttachmentImageLayoutSeparateDepthStencil) {
     ref.layout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
     subpass.inputAttachmentCount = 1;
     subpass.pInputAttachments = &ref;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06918",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06918",
                          "VUID-VkSubpassDescription2-attachment-06918");
 
     ref.layout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06918",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06918",
                          "VUID-VkSubpassDescription2-attachment-06918");
 
     reset_subpass();
@@ -3671,19 +3651,19 @@ TEST_F(NegativeRenderPass, SubpassAttachmentImageLayoutSeparateDepthStencil) {
     ref.layout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
     subpass.colorAttachmentCount = 1;
     subpass.pColorAttachments = &ref;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06919",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06919",
                          "VUID-VkSubpassDescription2-attachment-06919");
 
     ref.layout = VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06919",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06919",
                          "VUID-VkSubpassDescription2-attachment-06919");
 
     ref.layout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06919",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06919",
                          "VUID-VkSubpassDescription2-attachment-06919");
 
     ref.layout = VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06919",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06919",
                          "VUID-VkSubpassDescription2-attachment-06919");
 
     reset_subpass();
@@ -3695,19 +3675,19 @@ TEST_F(NegativeRenderPass, SubpassAttachmentImageLayoutSeparateDepthStencil) {
 
         ref.layout = VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL;
         subpass.pResolveAttachments = &ref;
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06920",
+        CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06920",
                              "VUID-VkSubpassDescription2-attachment-06920");
 
         ref.layout = VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_OPTIMAL;
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06920",
+        CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06920",
                              "VUID-VkSubpassDescription2-attachment-06920");
 
         ref.layout = VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL;
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06920",
+        CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06920",
                              "VUID-VkSubpassDescription2-attachment-06920");
 
         ref.layout = VK_IMAGE_LAYOUT_STENCIL_READ_ONLY_OPTIMAL;
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06920",
+        CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDescription-attachment-06920",
                              "VUID-VkSubpassDescription2-attachment-06920");
     }
 

--- a/tests/unit/render_pass_positive.cpp
+++ b/tests/unit/render_pass_positive.cpp
@@ -11,10 +11,12 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#include <vulkan/vulkan_core.h>
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
 #include "../framework/render_pass_helper.h"
+#include "utils/convert_utils.h"
 
 class PositiveRenderPass : public VkLayerTest {};
 
@@ -398,19 +400,34 @@ TEST_F(PositiveRenderPass, ValidStages) {
     dependency.dstSubpass = 1;
     dependency.srcStageMask = kGraphicsStages;
     dependency.dstStageMask = kGraphicsStages;
-    PositiveTestRenderPassCreate(*m_device, rpci, rp2_supported);
+    {
+        vkt::RenderPass rp(*m_device, rpci);
+        if (rp2_supported) {
+            vkt::RenderPass rp2(*m_device, *ConvertVkRenderPassCreateInfoToV2KHR(rpci).ptr());
+        }
+    }
 
     dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
     dependency.dstSubpass = 0;
     dependency.srcStageMask = kGraphicsStages | VK_PIPELINE_STAGE_HOST_BIT;
     dependency.dstStageMask = kGraphicsStages;
-    PositiveTestRenderPassCreate(*m_device, rpci, rp2_supported);
+    {
+        vkt::RenderPass rp(*m_device, rpci);
+        if (rp2_supported) {
+            vkt::RenderPass rp2(*m_device, *ConvertVkRenderPassCreateInfoToV2KHR(rpci).ptr());
+        }
+    }
 
     dependency.srcSubpass = 0;
     dependency.dstSubpass = VK_SUBPASS_EXTERNAL;
     dependency.srcStageMask = kGraphicsStages;
     dependency.dstStageMask = VK_PIPELINE_STAGE_HOST_BIT;
-    PositiveTestRenderPassCreate(*m_device, rpci, rp2_supported);
+    {
+        vkt::RenderPass rp(*m_device, rpci);
+        if (rp2_supported) {
+            vkt::RenderPass rp2(*m_device, *ConvertVkRenderPassCreateInfoToV2KHR(rpci).ptr());
+        }
+    }
 }
 
 TEST_F(PositiveRenderPass, SingleMipTransition) {
@@ -998,11 +1015,9 @@ TEST_F(PositiveRenderPass, SeparateDepthStencilSubresourceLayout) {
 
 TEST_F(PositiveRenderPass, InputResolve) {
     TEST_DESCRIPTION("Create render pass where input attachment == resolve attachment");
-
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddOptionalExtensions(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
-    const bool rp2Supported = IsExtensionsEnabled(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
 
     RenderPassSingleSubpass rp(*this);
     // input attachments
@@ -1019,8 +1034,7 @@ TEST_F(PositiveRenderPass, InputResolve) {
     rp.AddInputAttachment(0);
     rp.AddColorAttachment(1);
     rp.AddResolveAttachment(2);
-
-    PositiveTestRenderPassCreate(*m_device, rp.GetCreateInfo(), rp2Supported);
+    rp.CreateRenderPass();
 }
 
 TEST_F(PositiveRenderPass, TestDepthStencilRenderPassTransition) {

--- a/tests/unit/subpass.cpp
+++ b/tests/unit/subpass.cpp
@@ -33,7 +33,7 @@ TEST_F(NegativeSubpass, NonGraphicsPipeline) {
 
     auto rpci = vku::InitStruct<VkRenderPassCreateInfo>(nullptr, 0u, 0u, nullptr, 1u, subpasses, 0u, nullptr);
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2Supported, "VUID-VkSubpassDescription-pipelineBindPoint-04952",
+    CreateRenderPassTest(rpci, rp2Supported, "VUID-VkSubpassDescription-pipelineBindPoint-04952",
                          "VUID-VkSubpassDescription2-pipelineBindPoint-04953");
 }
 
@@ -63,28 +63,31 @@ TEST_F(NegativeSubpass, InputAttachmentParameters) {
 
     auto rpci2 = vku::InitStruct<VkRenderPassCreateInfo2KHR>(nullptr, 0u, 1u, &attach_desc, 1u, &subpass, 0u, nullptr, 0u, nullptr);
 
-    // Valid
-    PositiveTestRenderPass2KHRCreate(*m_device, rpci2);
-
     attach_desc.format = VK_FORMAT_R8G8B8A8_UNORM;
 
     reference.aspectMask = 0;
     // Test for aspect mask of 0
     m_errorMonitor->SetUnexpectedError("VUID-VkRenderPassCreateInfo2-attachment-02525");
     m_errorMonitor->SetUnexpectedError("VUID-VkSubpassDescription2-pInputAttachments-02897");
-    TestRenderPass2KHRCreate(*m_errorMonitor, *m_device, rpci2, {"VUID-VkSubpassDescription2-attachment-02800"});
+    m_errorMonitor->SetDesiredError("VUID-VkSubpassDescription2-attachment-02800");
+    vkt::RenderPass rp1(*m_device, rpci2);
+    m_errorMonitor->VerifyFound();
 
     // Test for invalid aspect mask bits
     reference.aspectMask = 0x40000000;  // invalid VkImageAspectFlagBits value
     m_errorMonitor->SetUnexpectedError("VUID-VkRenderPassCreateInfo2-attachment-02525");
     m_errorMonitor->SetUnexpectedError("VUID-VkSubpassDescription2-pInputAttachments-02897");
-    TestRenderPass2KHRCreate(*m_errorMonitor, *m_device, rpci2, {"VUID-VkSubpassDescription2-attachment-02799"});
+    m_errorMonitor->SetDesiredError("VUID-VkSubpassDescription2-attachment-02799");
+    vkt::RenderPass rp2(*m_device, rpci2);
+    m_errorMonitor->VerifyFound();
 
     // Test for invalid use of VK_IMAGE_ASPECT_METADATA_BIT
     reference.aspectMask = VK_IMAGE_ASPECT_METADATA_BIT;
     m_errorMonitor->SetUnexpectedError("VUID-VkRenderPassCreateInfo2-attachment-02525");
     m_errorMonitor->SetUnexpectedError("VUID-VkSubpassDescription2-pInputAttachments-02897");
-    TestRenderPass2KHRCreate(*m_errorMonitor, *m_device, rpci2, {"VUID-VkSubpassDescription2-attachment-02801"});
+    m_errorMonitor->SetDesiredError("VUID-VkSubpassDescription2-attachment-02801");
+    vkt::RenderPass rp3(*m_device, rpci2);
+    m_errorMonitor->VerifyFound();
 }
 
 TEST_F(NegativeSubpass, SubpassDependencies) {
@@ -117,69 +120,69 @@ TEST_F(NegativeSubpass, SubpassDependencies) {
     // Non graphics stages in subpass dependency
     dependency = {0, 1, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT | VK_PIPELINE_STAGE_TRANSFER_BIT,
                   VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT};
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkRenderPassCreateInfo-pDependencies-00837",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkRenderPassCreateInfo-pDependencies-00837",
                          "VUID-VkRenderPassCreateInfo2-pDependencies-03054");
 
     dependency = {0, 1, VK_PIPELINE_STAGE_HOST_BIT, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0, 0, 0};
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkRenderPassCreateInfo-pDependencies-00837",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkRenderPassCreateInfo-pDependencies-00837",
                          "VUID-VkRenderPassCreateInfo2-pDependencies-03054");
 
     dependency = {0, 1, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
                   VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT | VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT};
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkRenderPassCreateInfo-pDependencies-00838",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkRenderPassCreateInfo-pDependencies-00838",
                          "VUID-VkRenderPassCreateInfo2-pDependencies-03055");
 
     dependency = {0, 1, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_HOST_BIT, 0, 0, 0};
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkRenderPassCreateInfo-pDependencies-00838",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkRenderPassCreateInfo-pDependencies-00838",
                          "VUID-VkRenderPassCreateInfo2-pDependencies-03055");
 
     dependency = {0, VK_SUBPASS_EXTERNAL, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 0, 0};
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkRenderPassCreateInfo-pDependencies-00837",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkRenderPassCreateInfo-pDependencies-00837",
                          "VUID-VkRenderPassCreateInfo2-pDependencies-03054");
 
     dependency = {VK_SUBPASS_EXTERNAL, 0, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 0, 0};
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkRenderPassCreateInfo-pDependencies-00838",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkRenderPassCreateInfo-pDependencies-00838",
                          "VUID-VkRenderPassCreateInfo2-pDependencies-03055");
 
     dependency = {0, 0, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0, 0};
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkRenderPassCreateInfo-pDependencies-00837",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkRenderPassCreateInfo-pDependencies-00837",
                          "VUID-VkRenderPassCreateInfo2-pDependencies-03054");
 
     // Geometry shaders not enabled source
     dependency = {0, 1, VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0, 0};
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDependency-srcStageMask-04090",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDependency-srcStageMask-04090",
                          "VUID-VkSubpassDependency2-srcStageMask-04090");
 
     // Geometry shaders not enabled destination
     dependency = {0, 1, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_GEOMETRY_SHADER_BIT, 0, 0, 0};
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDependency-dstStageMask-04090",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDependency-dstStageMask-04090",
                          "VUID-VkSubpassDependency2-dstStageMask-04090");
 
     // Tessellation not enabled source
     dependency = {0, 1, VK_PIPELINE_STAGE_TESSELLATION_CONTROL_SHADER_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0, 0};
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDependency-srcStageMask-04091",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDependency-srcStageMask-04091",
                          "VUID-VkSubpassDependency2-srcStageMask-04091");
 
     // Tessellation not enabled destination
     dependency = {0, 1, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_TESSELLATION_EVALUATION_SHADER_BIT, 0, 0, 0};
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDependency-dstStageMask-04091",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDependency-dstStageMask-04091",
                          "VUID-VkSubpassDependency2-dstStageMask-04091");
 
     // Potential cyclical dependency
     dependency = {1, 0, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0, 0};
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDependency-srcSubpass-00864",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDependency-srcSubpass-00864",
                          "VUID-VkSubpassDependency2-srcSubpass-03084");
 
     // EXTERNAL to EXTERNAL dependency
     dependency = {
         VK_SUBPASS_EXTERNAL, VK_SUBPASS_EXTERNAL, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0, 0};
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDependency-srcSubpass-00865",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDependency-srcSubpass-00865",
                          "VUID-VkSubpassDependency2-srcSubpass-03085");
 
     // srcStage contains framebuffer space, and dstStage contains non-framebuffer space
@@ -191,42 +194,42 @@ TEST_F(NegativeSubpass, SubpassDependencies) {
                   0,
                   0};
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDependency-srcSubpass-06809",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDependency-srcSubpass-06809",
                          "VUID-VkSubpassDependency2-srcSubpass-06810");
 
     // framebuffer space stages in self dependency with region bit
     dependency = {0, 0, VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT, VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT, 0, 0, 0};
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDependency-srcSubpass-02243",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDependency-srcSubpass-02243",
                          "VUID-VkSubpassDependency2-srcSubpass-02245");
 
     // Same test but make sure the logical invalid order does not trip other VUID since both are framebuffer space stages
     dependency = {0, 0, VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT, VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT, 0, 0, 0};
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDependency-srcSubpass-02243",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDependency-srcSubpass-02243",
                          "VUID-VkSubpassDependency2-srcSubpass-02245");
 
     // Source access mask mismatch with source stage mask
     dependency = {0, 1, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VK_ACCESS_UNIFORM_READ_BIT, 0, 0};
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDependency-srcAccessMask-00868",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDependency-srcAccessMask-00868",
                          "VUID-VkSubpassDependency2-srcAccessMask-03088");
 
     // Destination access mask mismatch with destination stage mask
     dependency = {
         0, 1, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0, VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT, 0};
 
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDependency-dstAccessMask-00869",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDependency-dstAccessMask-00869",
                          "VUID-VkSubpassDependency2-dstAccessMask-03089");
 
     // srcSubpass larger than subpassCount
     dependency = {3, 0, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0, 0, 0};
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkRenderPassCreateInfo-pDependencies-06866",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkRenderPassCreateInfo-pDependencies-06866",
                          "VUID-VkRenderPassCreateInfo2-srcSubpass-02526");
 
     // dstSubpass larger than subpassCount
     dependency = {0, 3, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0, 0, 0};
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkRenderPassCreateInfo-pDependencies-06867",
+    CreateRenderPassTest(rpci, rp2_supported, "VUID-VkRenderPassCreateInfo-pDependencies-06867",
                          "VUID-VkRenderPassCreateInfo2-dstSubpass-02527");
 
     if (multiview_supported) {
@@ -234,8 +237,7 @@ TEST_F(NegativeSubpass, SubpassDependencies) {
         dependency = {0, 1, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
                       0, 0, VK_DEPENDENCY_VIEW_LOCAL_BIT};
 
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, nullptr,
-                             "VUID-VkRenderPassCreateInfo2-viewMask-03059");
+        CreateRenderPassTest(rpci, rp2_supported, nullptr, "VUID-VkRenderPassCreateInfo2-viewMask-03059");
 
         // Enable multiview
         uint32_t pViewMasks[2] = {0x3u, 0x3u};
@@ -249,7 +251,7 @@ TEST_F(NegativeSubpass, SubpassDependencies) {
         rpmvci.pViewOffsets = pViewOffsets;
         rpmvci.dependencyCount = 2;
 
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, false, "VUID-VkRenderPassCreateInfo-pNext-01929", nullptr);
+        CreateRenderPassTest(rpci, false, "VUID-VkRenderPassCreateInfo-pNext-01929", nullptr);
 
         rpmvci.dependencyCount = 0;
 
@@ -260,8 +262,7 @@ TEST_F(NegativeSubpass, SubpassDependencies) {
         pViewOffsets[0] = 1;
         rpmvci.dependencyCount = 1;
 
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, false, "VUID-VkRenderPassCreateInfo-pNext-01930",
-                             "VUID-VkSubpassDependency2-viewOffset-02530");
+        CreateRenderPassTest(rpci, false, "VUID-VkRenderPassCreateInfo-pNext-01930", "VUID-VkSubpassDependency2-viewOffset-02530");
 
         rpmvci.dependencyCount = 0;
 
@@ -272,8 +273,7 @@ TEST_F(NegativeSubpass, SubpassDependencies) {
             pViewOffsets[0] = 1;
             rpmvci.dependencyCount = 1;
 
-            TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, nullptr,
-                                 "VUID-VkSubpassDependency2-dependencyFlags-03092");
+            CreateRenderPassTest(rpci, rp2_supported, nullptr, "VUID-VkSubpassDependency2-dependencyFlags-03092");
 
             rpmvci.dependencyCount = 0;
         }
@@ -282,20 +282,20 @@ TEST_F(NegativeSubpass, SubpassDependencies) {
         dependency = {VK_SUBPASS_EXTERNAL,         1, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0,
                       VK_DEPENDENCY_VIEW_LOCAL_BIT};
 
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDependency-dependencyFlags-02520",
+        CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDependency-dependencyFlags-02520",
                              "VUID-VkSubpassDependency2-dependencyFlags-03090");
 
         // EXTERNAL subpass with VIEW_LOCAL_BIT - destination subpass
         dependency = {0, VK_SUBPASS_EXTERNAL,         VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0,
                       0, VK_DEPENDENCY_VIEW_LOCAL_BIT};
 
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDependency-dependencyFlags-02521",
+        CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDependency-dependencyFlags-02521",
                              "VUID-VkSubpassDependency2-dependencyFlags-03091");
 
         // Multiple views but no view local bit in self-dependency
         dependency = {0, 0, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0, 0};
 
-        TestRenderPassCreate(m_errorMonitor, *m_device, rpci, rp2_supported, "VUID-VkSubpassDependency-srcSubpass-00872",
+        CreateRenderPassTest(rpci, rp2_supported, "VUID-VkSubpassDependency-srcSubpass-00872",
                              "VUID-VkRenderPassCreateInfo2-pDependencies-03060");
     }
 }
@@ -863,104 +863,26 @@ TEST_F(NegativeSubpass, InputAttachmentReferences) {
     iaar.aspectMask = VK_IMAGE_ASPECT_METADATA_BIT;
     m_errorMonitor->SetUnexpectedError("VUID-VkRenderPassCreateInfo-pNext-01963");
     m_errorMonitor->SetUnexpectedError("VUID-VkRenderPassCreateInfo2-attachment-02525");
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, false, "VUID-VkInputAttachmentAspectReference-aspectMask-01964", nullptr);
+    CreateRenderPassTest(rpci, false, "VUID-VkInputAttachmentAspectReference-aspectMask-01964", nullptr);
 
     iaar.aspectMask = VK_IMAGE_ASPECT_MEMORY_PLANE_1_BIT_EXT;
     m_errorMonitor->SetUnexpectedError("VUID-VkRenderPassCreateInfo-pNext-01963");
     m_errorMonitor->SetUnexpectedError("VUID-VkRenderPassCreateInfo2-attachment-02525");
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, false, "VUID-VkInputAttachmentAspectReference-aspectMask-02250", nullptr);
+    CreateRenderPassTest(rpci, false, "VUID-VkInputAttachmentAspectReference-aspectMask-02250", nullptr);
 
     // Aspect not present
     iaar.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, false, "VUID-VkRenderPassCreateInfo-pNext-01963",
-                         "VUID-VkRenderPassCreateInfo2-attachment-02525");
+    CreateRenderPassTest(rpci, false, "VUID-VkRenderPassCreateInfo-pNext-01963", "VUID-VkRenderPassCreateInfo2-attachment-02525");
 
     // Invalid subpass index
     iaar.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     iaar.subpass = 1;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, false, "VUID-VkRenderPassCreateInfo-pNext-01926", nullptr);
+    CreateRenderPassTest(rpci, false, "VUID-VkRenderPassCreateInfo-pNext-01926", nullptr);
     iaar.subpass = 0;
 
     // Invalid input attachment index
     iaar.inputAttachmentIndex = 1;
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, false, "VUID-VkRenderPassCreateInfo-pNext-01927", nullptr);
-}
-
-TEST_F(NegativeSubpass, InputAttachmentLayout) {
-    TEST_DESCRIPTION("Create renderpass where an input attachment is also uses as another type");
-
-    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
-    AddOptionalExtensions(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
-    RETURN_IF_SKIP(Init());
-    const bool rp2_supported = IsExtensionsEnabled(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
-
-    const VkAttachmentDescription attach0 = {0,
-                                             VK_FORMAT_R8G8B8A8_UNORM,
-                                             VK_SAMPLE_COUNT_1_BIT,
-                                             VK_ATTACHMENT_LOAD_OP_DONT_CARE,
-                                             VK_ATTACHMENT_STORE_OP_DONT_CARE,
-                                             VK_ATTACHMENT_LOAD_OP_DONT_CARE,
-                                             VK_ATTACHMENT_STORE_OP_DONT_CARE,
-                                             VK_IMAGE_LAYOUT_UNDEFINED,
-                                             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL};
-    const VkAttachmentDescription attach1 = {0,
-                                             VK_FORMAT_R8G8B8A8_UNORM,
-                                             VK_SAMPLE_COUNT_1_BIT,
-                                             VK_ATTACHMENT_LOAD_OP_DONT_CARE,
-                                             VK_ATTACHMENT_STORE_OP_DONT_CARE,
-                                             VK_ATTACHMENT_LOAD_OP_DONT_CARE,
-                                             VK_ATTACHMENT_STORE_OP_DONT_CARE,
-                                             VK_IMAGE_LAYOUT_UNDEFINED,
-                                             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL};
-
-    const VkAttachmentReference ref0 = {0, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
-    const VkAttachmentReference ref1 = {1, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL};
-    const VkAttachmentReference inRef0 = {0, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL};
-    const VkAttachmentReference inRef1 = {1, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL};
-
-    // First subpass draws to attachment 0
-    const VkSubpassDescription subpass0 = {0, VK_PIPELINE_BIND_POINT_GRAPHICS, 0, nullptr, 1, &ref0, nullptr, nullptr, 0, nullptr};
-    // Second subpass reads attachment 0 as input-attachment, writes to attachment 1
-    const VkSubpassDescription subpass1 = {0, VK_PIPELINE_BIND_POINT_GRAPHICS, 1, &inRef0, 1, &ref1, nullptr, nullptr, 0, nullptr};
-    // Seconnd subpass reads attachment 1 as input-attachment, writes to attachment 0
-    const VkSubpassDescription subpass2 = {0, VK_PIPELINE_BIND_POINT_GRAPHICS, 1, &inRef1, 1, &ref0, nullptr, nullptr, 0, nullptr};
-
-    // Subpass 0 writes attachment 0 as output, subpass 1 reads as input (RAW)
-    VkSubpassDependency dep0 = {0,
-                                1,
-                                VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-                                VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
-                                VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
-                                VK_ACCESS_INPUT_ATTACHMENT_READ_BIT,
-                                VK_DEPENDENCY_BY_REGION_BIT};
-    // Subpass 1 writes attachment 1 as output, subpass 2 reads as input while (RAW)
-    VkSubpassDependency dep1 = {1,
-                                2,
-                                VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-                                VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
-                                VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
-                                VK_ACCESS_INPUT_ATTACHMENT_READ_BIT,
-                                VK_DEPENDENCY_BY_REGION_BIT};
-    // Subpass 1 reads attachment 0 as input, subpass 2 writes output (WAR)
-    VkSubpassDependency dep2 = {1,
-                                2,
-                                VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
-                                VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
-                                VK_ACCESS_INPUT_ATTACHMENT_READ_BIT,
-                                VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
-                                VK_DEPENDENCY_BY_REGION_BIT};
-
-    std::vector<VkAttachmentDescription> attachs = {attach0, attach1};
-    std::vector<VkSubpassDescription> subpasses = {subpass0, subpass1, subpass2};
-    std::vector<VkSubpassDependency> deps = {dep0, dep1, dep2};
-
-    auto rpci = vku::InitStruct<VkRenderPassCreateInfo>(nullptr, 0u, size32(attachs), attachs.data(), size32(subpasses),
-                                                      subpasses.data(), size32(deps), deps.data());
-
-    // Current setup should be OK -- no attachment is both input and output in same subpass
-    PositiveTestRenderPassCreate(*m_device, rpci, rp2_supported);
-
-    vkt::RenderPass render_pass(*m_device, rpci);
+    CreateRenderPassTest(rpci, false, "VUID-VkRenderPassCreateInfo-pNext-01927", nullptr);
 }
 
 TEST_F(NegativeSubpass, InputAttachmentMissing) {
@@ -1233,6 +1155,6 @@ TEST_F(NegativeSubpass, FamilyOwnershipMaintenance8) {
                   0,
                   0,
                   VK_DEPENDENCY_QUEUE_FAMILY_OWNERSHIP_TRANSFER_USE_ALL_STAGES_BIT_KHR};
-    TestRenderPassCreate(m_errorMonitor, *m_device, rpci, true, "VUID-VkSubpassDependency-dependencyFlags-10203",
+    CreateRenderPassTest(rpci, true, "VUID-VkSubpassDependency-dependencyFlags-10203",
                          "VUID-VkSubpassDependency2-dependencyFlags-10204");
 }


### PR DESCRIPTION
Branch says it all, these never should have been globals in `layer_validation_tests.h`