### PR TITLE
tests: Set colorWriteMask

### DIFF
--- a/tests/framework/pipeline_helper.cpp
+++ b/tests/framework/pipeline_helper.cpp
@@ -71,6 +71,10 @@ CreatePipelineHelper::CreatePipelineHelper(VkLayerTest &test, void *pNext) : lay
         rs_state_ci_.pNext = &line_state_ci_;
     }
 
+    // Init VkPipelineColorBlendAttachmentState
+    cb_attachments_.colorWriteMask =
+        VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+
     // InitBlendStateInfo
     cb_ci_ = vku::InitStructHelper();
     cb_ci_.logicOpEnable = VK_FALSE;

--- a/tests/unit/amd_best_practices.cpp
+++ b/tests/unit/amd_best_practices.cpp
@@ -494,7 +494,6 @@ TEST_F(VkAmdBestPracticesLayerTest, SecondaryCmdBuffer) {
 
     m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-DrawState-ClearCmdBeforeDraw");
     m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-AMD-VkCommandBuffer-AvoidSecondaryCmdBuffers");
 
     vk::CmdExecuteCommands(m_command_buffer, 1, &secondary_cmd_buf.handle());


### PR DESCRIPTION
Some drivers will skip fragment shading if it is set to 0, even though fragment shader may write to storage buffers