### PR TITLE
layers: Add check for *OpTypeTensorARM_09906 VUIDs

### DIFF
--- a/layers/drawdispatch/drawdispatch_vuids.cpp
+++ b/layers/drawdispatch/drawdispatch_vuids.cpp
@@ -269,6 +269,7 @@ struct DispatchVuidsCmdDraw : DrawDispatchVuid {
         image_layout_09600                       = "VUID-vkCmdDraw-None-09600";
         rendering_contents_10582                 = "VUID-vkCmdDraw-flags-10582";
         line_rasterization_10608                 = "VUID-vkCmdDraw-None-10608";
+        spirv_OpTypeTensorARM_09906              = "VUID-vkCmdDraw-OpTypeTensorARM-09906";
     }
 };
 
@@ -519,6 +520,7 @@ struct DispatchVuidsCmdDrawMultiEXT : DrawDispatchVuid {
         image_layout_09600                       = "VUID-vkCmdDrawMultiEXT-None-09600";
         rendering_contents_10582                 = "VUID-vkCmdDrawMultiEXT-flags-10582";
         line_rasterization_10608                 = "VUID-vkCmdDrawMultiEXT-None-10608";
+        spirv_OpTypeTensorARM_09906              = "VUID-vkCmdDrawMultiEXT-OpTypeTensorARM-09906";
     }
 };
 
@@ -770,6 +772,7 @@ struct DispatchVuidsCmdDrawIndexed : DrawDispatchVuid {
         image_layout_09600                       = "VUID-vkCmdDrawIndexed-None-09600";
         rendering_contents_10582                 = "VUID-vkCmdDrawIndexed-flags-10582";
         line_rasterization_10608                 = "VUID-vkCmdDrawIndexed-None-10608";
+        spirv_OpTypeTensorARM_09906              = "VUID-vkCmdDrawIndexed-OpTypeTensorARM-09906";
     }
 };
 
@@ -1021,6 +1024,7 @@ struct DispatchVuidsCmdDrawMultiIndexedEXT : DrawDispatchVuid {
         image_layout_09600                       = "VUID-vkCmdDrawMultiIndexedEXT-None-09600";
         rendering_contents_10582                 = "VUID-vkCmdDrawMultiIndexedEXT-flags-10582";
         line_rasterization_10608                 = "VUID-vkCmdDrawMultiIndexedEXT-None-10608";
+        spirv_OpTypeTensorARM_09906              = "VUID-vkCmdDrawMultiIndexedEXT-OpTypeTensorARM-09906";
     }
 };
 
@@ -1270,6 +1274,7 @@ struct DispatchVuidsCmdDrawIndirect : DrawDispatchVuid {
         image_layout_09600                       = "VUID-vkCmdDrawIndirect-None-09600";
         rendering_contents_10582                 = "VUID-vkCmdDrawIndirect-flags-10582";
         line_rasterization_10608                 = "VUID-vkCmdDrawIndirect-None-10608";
+        spirv_OpTypeTensorARM_09906              = "VUID-vkCmdDrawIndirect-OpTypeTensorARM-09906";
     }
 };
 
@@ -1520,6 +1525,7 @@ struct DispatchVuidsCmdDrawIndexedIndirect : DrawDispatchVuid {
         image_layout_09600                       = "VUID-vkCmdDrawIndexedIndirect-None-09600";
         rendering_contents_10582                 = "VUID-vkCmdDrawIndexedIndirect-flags-10582";
         line_rasterization_10608                 = "VUID-vkCmdDrawIndexedIndirect-None-10608";
+        spirv_OpTypeTensorARM_09906              = "VUID-vkCmdDrawIndexedIndirect-OpTypeTensorARM-09906";
     }
 };
 
@@ -1569,6 +1575,7 @@ struct DispatchVuidsCmdDispatch : DrawDispatchVuid {
         image_view_numeric_format_07753          = "VUID-vkCmdDispatch-format-07753";
         image_layout_00344                       = "VUID-vkCmdDispatch-imageLayout-00344";
         image_layout_09600                       = "VUID-vkCmdDispatch-None-09600";
+        spirv_OpTypeTensorARM_09906              = "VUID-vkCmdDispatch-OpTypeTensorARM-09906";
     }
 };
 
@@ -1619,6 +1626,7 @@ struct DispatchVuidsCmdDispatchIndirect : DrawDispatchVuid {
         image_view_numeric_format_07753          = "VUID-vkCmdDispatchIndirect-format-07753";
         image_layout_00344                       = "VUID-vkCmdDispatchIndirect-imageLayout-00344";
         image_layout_09600                       = "VUID-vkCmdDispatchIndirect-None-09600";
+        spirv_OpTypeTensorARM_09906              = "VUID-vkCmdDispatchIndirect-OpTypeTensorARM-09906";
     }
 };
 
@@ -1871,6 +1879,7 @@ struct DispatchVuidsCmdDrawIndirectCount : DrawDispatchVuid {
         image_layout_09600                       = "VUID-vkCmdDrawIndirectCount-None-09600";
         rendering_contents_10582                 = "VUID-vkCmdDrawIndirectCount-flags-10582";
         line_rasterization_10608                 = "VUID-vkCmdDrawIndirectCount-None-10608";
+        spirv_OpTypeTensorARM_09906              = "VUID-vkCmdDrawIndirectCount-OpTypeTensorARM-09906";
     }
 };
 
@@ -2124,6 +2133,7 @@ struct DispatchVuidsCmdDrawIndexedIndirectCount : DrawDispatchVuid {
         image_layout_09600                       = "VUID-vkCmdDrawIndexedIndirectCount-None-09600";
         rendering_contents_10582                 = "VUID-vkCmdDrawIndexedIndirectCount-flags-10582";
         line_rasterization_10608                 = "VUID-vkCmdDrawIndexedIndirectCount-None-10608";
+        spirv_OpTypeTensorARM_09906              = "VUID-vkCmdDrawIndexedIndirectCount-OpTypeTensorARM-09906";
     }
 };
 
@@ -2171,6 +2181,7 @@ struct DispatchVuidsCmdTraceRaysNV: DrawDispatchVuid {
         ray_tracing_pipeline_stack_size_09458    = "VUID-vkCmdTraceRaysNV-None-09458";
         image_layout_00344                       = "VUID-vkCmdTraceRaysNV-imageLayout-00344";
         image_layout_09600                       = "VUID-vkCmdTraceRaysNV-None-09600";
+        spirv_OpTypeTensorARM_09906              = "VUID-vkCmdTraceRaysNV-OpTypeTensorARM-09906";
     }
 };
 
@@ -2218,6 +2229,7 @@ struct DispatchVuidsCmdTraceRaysKHR: DrawDispatchVuid {
         ray_tracing_pipeline_stack_size_09458    = "VUID-vkCmdTraceRaysKHR-None-09458";
         image_layout_00344                       = "VUID-vkCmdTraceRaysKHR-imageLayout-00344";
         image_layout_09600                       = "VUID-vkCmdTraceRaysKHR-None-09600";
+        spirv_OpTypeTensorARM_09906              = "VUID-vkCmdTraceRaysKHR-OpTypeTensorARM-09906";
     }
 };
 
@@ -2265,6 +2277,7 @@ struct DispatchVuidsCmdTraceRaysIndirectKHR: DrawDispatchVuid {
         ray_tracing_pipeline_stack_size_09458    = "VUID-vkCmdTraceRaysIndirectKHR-None-09458";
         image_layout_00344                       = "VUID-vkCmdTraceRaysIndirectKHR-imageLayout-00344";
         image_layout_09600                       = "VUID-vkCmdTraceRaysIndirectKHR-None-09600";
+        spirv_OpTypeTensorARM_09906              = "VUID-vkCmdTraceRaysIndirectKHR-OpTypeTensorARM-09906";
     }
 };
 
@@ -2312,6 +2325,7 @@ struct DispatchVuidsCmdTraceRaysIndirect2KHR: DrawDispatchVuid {
         ray_tracing_pipeline_stack_size_09458    = "VUID-vkCmdTraceRaysIndirect2KHR-None-09458";
         image_layout_00344                       = "VUID-vkCmdTraceRaysIndirect2KHR-imageLayout-00344";
         image_layout_09600                       = "VUID-vkCmdTraceRaysIndirect2KHR-None-09600";
+        spirv_OpTypeTensorARM_09906              = "VUID-vkCmdTraceRaysIndirect2KHR-OpTypeTensorARM-09906";
     }
 };
 
@@ -2543,6 +2557,7 @@ struct DispatchVuidsCmdDrawMeshTasksNV: DrawDispatchVuid {
         image_layout_09600                       = "VUID-vkCmdDrawMeshTasksNV-None-09600";
         rendering_contents_10582                 = "VUID-vkCmdDrawMeshTasksNV-flags-10582";
         line_rasterization_10608                 = "VUID-vkCmdDrawMeshTasksNV-None-10608";
+        spirv_OpTypeTensorARM_09906              = "VUID-vkCmdDrawMeshTasksNV-OpTypeTensorARM-09906";
     }
 };
 
@@ -2777,6 +2792,7 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectNV: DrawDispatchVuid {
         image_layout_09600                       = "VUID-vkCmdDrawMeshTasksIndirectNV-None-09600";
         rendering_contents_10582                 = "VUID-vkCmdDrawMeshTasksIndirectNV-flags-10582";
         line_rasterization_10608                 = "VUID-vkCmdDrawMeshTasksIndirectNV-None-10608";
+        spirv_OpTypeTensorARM_09906              = "VUID-vkCmdDrawMeshTasksIndirectNV-OpTypeTensorARM-09906";
     }
 };
 
@@ -3014,6 +3030,7 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectCountNV : DrawDispatchVuid {
         image_layout_09600                       = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-09600";
         rendering_contents_10582                 = "VUID-vkCmdDrawMeshTasksIndirectCountNV-flags-10582";
         line_rasterization_10608                 = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-10608";
+        spirv_OpTypeTensorARM_09906              = "VUID-vkCmdDrawMeshTasksIndirectCountNV-OpTypeTensorARM-09906";
     }
 };
 
@@ -3245,6 +3262,7 @@ struct DispatchVuidsCmdDrawMeshTasksEXT: DrawDispatchVuid {
         image_layout_09600                       = "VUID-vkCmdDrawMeshTasksEXT-None-09600";
         rendering_contents_10582                 = "VUID-vkCmdDrawMeshTasksEXT-flags-10582";
         line_rasterization_10608                 = "VUID-vkCmdDrawMeshTasksEXT-None-10608";
+        spirv_OpTypeTensorARM_09906              = "VUID-vkCmdDrawMeshTasksEXT-OpTypeTensorARM-09906";
     }
 };
 
@@ -3479,6 +3497,7 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectEXT: DrawDispatchVuid {
         image_layout_09600                       = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-09600";
         rendering_contents_10582                 = "VUID-vkCmdDrawMeshTasksIndirectEXT-flags-10582";
         line_rasterization_10608                 = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-10608";
+        spirv_OpTypeTensorARM_09906              = "VUID-vkCmdDrawMeshTasksIndirectEXT-OpTypeTensorARM-09906";
     }
 };
 
@@ -3716,6 +3735,7 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectCountEXT : DrawDispatchVuid {
         image_layout_09600                       = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-09600";
         rendering_contents_10582                 = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-flags-10582";
         line_rasterization_10608                 = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-10608";
+        spirv_OpTypeTensorARM_09906              = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-OpTypeTensorARM-09906";
     }
 };
 
@@ -3965,6 +3985,7 @@ struct DispatchVuidsCmdDrawIndirectByteCountEXT: DrawDispatchVuid {
         image_layout_09600                       = "VUID-vkCmdDrawIndirectByteCountEXT-None-09600";
         rendering_contents_10582                 = "VUID-vkCmdDrawIndirectByteCountEXT-flags-10582";
         line_rasterization_10608                 = "VUID-vkCmdDrawIndirectByteCountEXT-None-10608";
+        spirv_OpTypeTensorARM_09906              = "VUID-vkCmdDrawIndirectByteCountEXT-OpTypeTensorARM-09906";
     }
 };
 
@@ -4012,6 +4033,7 @@ struct DispatchVuidsCmdDispatchBase: DrawDispatchVuid {
         descriptor_buffer_set_offset_missing_08117 = "VUID-vkCmdDispatchBase-None-08117";
         image_view_dim_07752                     = "VUID-vkCmdDispatchBase-viewType-07752";
         image_view_numeric_format_07753          = "VUID-vkCmdDispatchBase-format-07753";
+        spirv_OpTypeTensorARM_09906              = "VUID-vkCmdDispatchBase-OpTypeTensorARM-09906";
     }
 };
 

--- a/layers/drawdispatch/drawdispatch_vuids.h
+++ b/layers/drawdispatch/drawdispatch_vuids.h
@@ -296,6 +296,8 @@ struct DrawDispatchVuid {
     const char* line_rasterization_10608 = kVUIDUndefined;
     // Ray tracing
     const char* ray_tracing_pipeline_stack_size_09458 = kVUIDUndefined;
+    // SPIR-V
+    const char* spirv_OpTypeTensorARM_09906 = kVUIDUndefined;
 };
 
 const DrawDispatchVuid& GetDrawDispatchVuid(vvl::Func function);

--- a/layers/state_tracker/shader_instruction.cpp
+++ b/layers/state_tracker/shader_instruction.cpp
@@ -203,6 +203,8 @@ bool Instruction::IsImageMultisampled() const {
     return (Opcode() == spv::OpTypeImage) && (Word(6) != 0);
 }
 
+bool Instruction::IsTensor() const { return (Opcode() == spv::OpTypeTensorARM); }
+
 spv::StorageClass Instruction::StorageClass() const {
     spv::StorageClass storage_class = spv::StorageClassMax;
     switch (Opcode()) {

--- a/layers/state_tracker/shader_instruction.h
+++ b/layers/state_tracker/shader_instruction.h
@@ -81,6 +81,7 @@ class Instruction {
     spv::Dim FindImageDim() const;
     bool IsImageArray() const;
     bool IsImageMultisampled() const;
+    bool IsTensor() const;
 
     // Auto-generated helper functions
     spv::StorageClass StorageClass() const;

--- a/tests/framework/data_graph_objects.cpp
+++ b/tests/framework/data_graph_objects.cpp
@@ -195,7 +195,7 @@ std::string DataGraphPipelineHelper::GetSpirvMultiEntryTwoDataGraph() {
 // Spirv source. For testing purposes it includes:
 // - unused OpGraphConstantARM
 // - `inserted_line` to cause different errors
-std::string DataGraphPipelineHelper::GetSpirvSourceGraph(const char* inserted_line) {
+std::string DataGraphPipelineHelper::GetSpirvBasicDataGraph(const char* inserted_line) {
     std::stringstream ss;
     ss << R"(
                                   OpCapability GraphARM
@@ -257,6 +257,51 @@ std::string DataGraphPipelineHelper::GetSpirvSourceGraph(const char* inserted_li
 )";
 
     return ss.str();
+}
+
+std::string DataGraphPipelineHelper::GetSpirvBasicShader() {
+    return R"(
+; SPIRV
+; Version: 1.6
+; Generator: Khronos Glslang Reference Front End; 11
+; Bound: 19
+; Schema: 0
+               OpCapability Shader
+               OpCapability TensorsARM
+               OpExtension "SPV_ARM_tensors"
+          %1 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %tens
+               OpExecutionMode %main LocalSize 1 1 1
+               OpSource GLSL 450
+               OpSourceExtension "GL_ARM_tensors"
+               OpSourceExtension "GL_EXT_shader_explicit_arithmetic_types"
+               OpName %main "main"
+               OpName %size_x "size_x"
+               OpName %tens "tens"
+               OpDecorate %tens Binding 0
+               OpDecorate %tens DescriptorSet 0
+       %void = OpTypeVoid
+          %3 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+%_ptr_Function_uint = OpTypePointer Function %uint
+        %int = OpTypeInt 32 1
+     %uint_1 = OpConstant %uint 1
+         %11 = OpTypeTensorARM %int %uint_1
+%_ptr_UniformConstant_11 = OpTypePointer UniformConstant %11
+       %tens = OpVariable %_ptr_UniformConstant_11 UniformConstant
+     %uint_0 = OpConstant %uint 0
+     %v3uint = OpTypeVector %uint 3
+         %18 = OpConstantComposite %v3uint %uint_1 %uint_1 %uint_1
+       %main = OpFunction %void None %3
+          %5 = OpLabel
+     %size_x = OpVariable %_ptr_Function_uint Function
+         %14 = OpLoad %11 %tens
+         %16 = OpTensorQuerySizeARM %uint %14 %uint_0
+               OpStore %size_x %16
+               OpReturn
+               OpFunctionEnd
+)";
 }
 
 void DataGraphPipelineHelper::InitPipelineResources(const std::vector<vkt::Tensor*>& tensors, VkDescriptorType desc_type,
@@ -336,7 +381,7 @@ DataGraphPipelineHelper::DataGraphPipelineHelper(VkLayerTest& test, const Helper
     device_ = layer_test_.DeviceObj();
     pipeline_ci_ = vku::InitStructHelper();
 
-    std::string spirv_string(params.spirv_source ? params.spirv_source : GetSpirvSourceGraph());
+    std::string spirv_string(params.spirv_source ? params.spirv_source : GetSpirvBasicDataGraph());
 
     InitTensor(in_tensor_, in_tensor_view_, in_tensor_dims, params.protected_tensors);
     InitTensor(out_tensor_, out_tensor_view_, out_tensor_dims, params.protected_tensors);

--- a/tests/framework/data_graph_objects.h
+++ b/tests/framework/data_graph_objects.h
@@ -60,9 +60,11 @@ class DataGraphPipelineHelper {
     virtual ~DataGraphPipelineHelper();
     void Destroy();
 
-    static std::string GetSpirvSourceGraph(const char *inserted_line = "");
+    static std::string GetSpirvBasicDataGraph(const char *inserted_line = "");
     static std::string GetSpirvMultiEntryComputeAndDataGraph();
     static std::string GetSpirvMultiEntryTwoDataGraph();
+    static std::string GetSpirvBasicShader();
+
     void InitPipelineResources(const std::vector<vkt::Tensor *> &tensors = {},
                                VkDescriptorType desc_type = VK_DESCRIPTOR_TYPE_TENSOR_ARM,
                                VkDescriptorSetLayoutCreateFlags layout_flags = 0);

--- a/tests/unit/data_graph.cpp
+++ b/tests/unit/data_graph.cpp
@@ -1211,7 +1211,7 @@ TEST_F(NegativeDataGraph, ShaderSpirvUsesOpSpecFeatureNotEnabled) {
 
     // inject a dummy line in the spirv to trigger the error
     const std::string &spirv_string =
-        vkt::dg::DataGraphPipelineHelper::GetSpirvSourceGraph("%dummy_spec_constant = OpSpecConstant %uint 3");
+        vkt::dg::DataGraphPipelineHelper::GetSpirvBasicDataGraph("%dummy_spec_constant = OpSpecConstant %uint 3");
     vkt::dg::HelperParameters params;
     params.spirv_source = spirv_string.c_str();
     vkt::dg::DataGraphPipelineHelper pipeline(*this, params);
@@ -1245,7 +1245,7 @@ TEST_F(NegativeDataGraph, DataGraphShaderModuleCreateInfoHasModuleAndShaderModul
 
     // also add the same ShaderModule in the pNext chain
     spvtools::SpirvTools tools{SPV_ENV_UNIVERSAL_1_6};
-    const std::string &spirv_source = vkt::dg::DataGraphPipelineHelper::GetSpirvSourceGraph();
+    const std::string &spirv_source = vkt::dg::DataGraphPipelineHelper::GetSpirvBasicDataGraph();
     std::vector<uint32_t> spirv_binary;
     if (!tools.Assemble(spirv_source, &spirv_binary)) {
         Monitor().SetError("Failed to compile SPIRV shader module");

--- a/tests/unit/data_graph_positive.cpp
+++ b/tests/unit/data_graph_positive.cpp
@@ -149,7 +149,7 @@ TEST_F(PositiveDataGraph, ShaderModuleInPNext) {
 
     // create a ShaderModule to add in the pNext chain
     spvtools::SpirvTools tools{SPV_ENV_UNIVERSAL_1_6};
-    const std::string& spirv_source = vkt::dg::DataGraphPipelineHelper::GetSpirvSourceGraph();
+    const std::string& spirv_source = vkt::dg::DataGraphPipelineHelper::GetSpirvBasicDataGraph();
     std::vector<uint32_t> spirv_binary;
     if (!tools.Assemble(spirv_source, &spirv_binary)) {
         Monitor().SetError("Failed to compile SPIRV shader module");


### PR DESCRIPTION
open issues:
- I couldn't find the place to add all the rules in layers/drawdispatch/drawdispatch_vuids.cpp. Currently missing:
           VUID-vkCmdDispatchGraphAMDX-OpTypeTensorARM-09906
           VUID-vkCmdDispatchGraphIndirectAMDX-OpTypeTensorARM-09906
           VUID-vkCmdDispatchGraphIndirectCountAMDX-OpTypeTensorARM-09906
           VUID-vkCmdDispatchTileQCOM-OpTypeTensorARM-09906
           VUID-vkCmdDrawClusterHUAWEI-OpTypeTensorARM-09906
           VUID-vkCmdDrawClusterIndirectHUAWEI-OpTypeTensorARM-09906
           VUID-vkCmdExecuteGeneratedCommandsEXT-OpTypeTensorARM-09906
           VUID-vkCmdExecuteGeneratedCommandsNV-OpTypeTensorARM-09906
           VUID-vkCmdSubpassShadingHUAWEI-OpTypeTensorARM-09906
Basically it's the vendor-specific rules and one EXT. Are vendors expected to implement their rules?
- the rule can be triggered also by `vkCmdDispatchDataGraphARM`, which is NOT one of the VUIDs. Unsurprisingly the error is `VUID_Undefined`. Do I need to actively prevent the rule from being checked for `vkCmdDispatchDataGraphARM`? How? 
```
Validation Error: [ VUID_Undefined ] | MessageID = 0x79de34d4
vkCmdDispatchDataGraphARM(): type, bit_width (UINT, 8) in the OpTypeTensorARM format is incompatible with the TensorView format (VK_FORMAT_R8_SINT)
```
Issues related to Vulkan specs:
- is the compatibility table 112 correct? For many TOSA operator (CONV2D, MAX_POOL2D, AVG_POOL2D...), the tensor `VkFormat` has to be _signed_, but the spirv type definition has to be `OpTypeInt N 0`. This clearly contradicts the compatibility table.