### PR TITLE
docs: Replace legacy `VK_LAYER_*` settings env vars with `VK_VALIDATION_*`

### DIFF
--- a/docs/error_messages.md
+++ b/docs/error_messages.md
@@ -148,10 +148,10 @@ To try it out, use `vkconfig` or set with
 
 ```bash
 # Windows
-set VK_LAYER_MESSAGE_FORMAT_JSON=1
+set VK_VALIDATION_MESSAGE_FORMAT_JSON=1
 
 # Linux
-export VK_LAYER_MESSAGE_FORMAT_JSON=1
+export VK_VALIDATION_MESSAGE_FORMAT_JSON=1
 
 # Android
 adb shell setprop debug.vulkan.khronos_validation.message_format_json=1

--- a/docs/legacy_detection.md
+++ b/docs/legacy_detection.md
@@ -48,10 +48,10 @@ instance_ci.pNext = &layer_settings_create_info;
 
 ```bash
 # Windows
-set VK_LAYER_LEGACY_DETECTION=1
+set VK_VALIDATION_LEGACY_DETECTION=1
 
 # Linux
-export VK_LAYER_LEGACY_DETECTION=1
+export VK_VALIDATION_LEGACY_DETECTION=1
 
 # Android
 adb shell setprop debug.vulkan.khronos_validation.legacy_detection=1

--- a/docs/syncval_usage.md
+++ b/docs/syncval_usage.md
@@ -41,10 +41,10 @@ instance_ci.pNext = &layer_settings_create_info;
 
 ```bash
 # Windows
-set VK_LAYER_VALIDATE_SYNC=1
+set VK_VALIDATION_VALIDATE_SYNC=1
 
 # Linux
-export VK_LAYER_VALIDATE_SYNC=1
+export VK_VALIDATION_VALIDATE_SYNC=1
 
 # Android
 adb shell setprop debug.vulkan.khronos_validation.validate_sync=1


### PR DESCRIPTION
Similar to https://github.com/KhronosGroup/Vulkan-Utility-Libraries/pull/334.

According to https://github.com/KhronosGroup/Vulkan-Utility-Libraries/pull/332#issuecomment-3443995794 this `VK_LAYER_` prefix for environment variables is legacy and deprecated in favour of `VK_LayerVendor_LayerName_setting_name`, `VK_LayerName_setting_name` or even `VK_setting_name`.  Use the middle one over `VK_LAYER_` wherever it is currently mentioned in the docs rather than suggesting an older name that seemingly has the least precedence too.

Additionally I would have liked to append a `(deprecated)` or `(legacy)` suffix to the `VK_LAYER_` variables mentioned in the table at https://vulkan.lunarg.com/doc/view/latest/windows/khronos_validation_layer.html, but it seems the first part comes from https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/main/docs/khronos_validation_layer.md while everything from `Layer Properties` onwards appears to be generated somewhere based on `VkLayer_khronos_validation.json.in`; and I've yet to find where that is (or if that's even correctly tweakable to mark some of its `"env"` variables as deprecated?).