### PR TITLE
layers: Add warning for maxCombinedImageSamplerDescriptorCount

### DIFF
--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -1545,7 +1545,7 @@ bool CoreChecks::ValidateShaderYcbcrSamplerAccess(const VkDescriptorSetLayoutBin
         ASSERT_AND_CONTINUE(sampler_state);
 
         // It is possible to use pImmutableSamplers for embedded sampler that don't use YCbCr as well.
-        if (!sampler_state->samplerConversion) {
+        if (!sampler_state->sampler_conversion) {
             continue;
         }
 

--- a/layers/drawdispatch/descriptor_validator.cpp
+++ b/layers/drawdispatch/descriptor_validator.cpp
@@ -1214,13 +1214,13 @@ bool DescriptorValidator::ValidateSamplerDescriptor(const spirv::ResourceInterfa
                          "the %s is using sampler %s that is invalid or has been destroyed.%s",
                          DescribeDescriptor(resource_variable, index, VK_DESCRIPTOR_TYPE_SAMPLER).c_str(),
                          FormatHandle(sampler).c_str(), DescribeInstruction().c_str());
-    } else if (sampler_state->samplerConversion && !is_immutable) {
+    } else if (sampler_state->sampler_conversion && !is_immutable) {
         const LogObjectList objlist(this->objlist, descriptor_set.Handle());
         skip |= LogError(vuids->descriptor_buffer_bit_set_08114, objlist, loc.Get(),
                          "the %s sampler (%s) contains a YCBCR conversion (%s), but the sampler is not an "
                          "immutable sampler.%s",
                          DescribeDescriptor(resource_variable, index, VK_DESCRIPTOR_TYPE_SAMPLER).c_str(),
-                         FormatHandle(sampler).c_str(), FormatHandle(sampler_state->samplerConversion).c_str(),
+                         FormatHandle(sampler).c_str(), FormatHandle(sampler_state->sampler_conversion).c_str(),
                          DescribeInstruction().c_str());
     }
     return skip;

--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -542,7 +542,7 @@ ImageView::ImageView(const DeviceState &device_state, const std::shared_ptr<vvl:
       normalized_subresource_range(ImageView::NormalizeImageViewSubresourceRange(*image_state, create_info)),
       range_generator(image_state->subresource_encoder, GetRangeGeneratorRange(device_state.extensions)),
       samples(image_state->create_info.samples),
-      samplerConversion(GetSamplerConversion(ci)),
+      sampler_conversion(GetSamplerConversion(ci)),
       filter_cubic_props(cubic_props),
       min_lod(GetImageViewMinLod(ci)),
       format_features(ff),

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -282,7 +282,8 @@ class ImageView : public StateObject, public SubStateManager<ImageViewSubState> 
     const VkImageSubresourceRange normalized_subresource_range;
     const subresource_adapter::RangeGenerator range_generator;
     const VkSampleCountFlagBits samples;
-    const VkSamplerYcbcrConversion samplerConversion;  // Handle of the ycbcr sampler conversion the image was created with, if any
+    // VK_NULL_HANDLE if it doesn't have one chained in the pNext at creation time
+    const VkSamplerYcbcrConversion sampler_conversion;
     const VkFilterCubicImageViewImageFormatPropertiesEXT filter_cubic_props;
     const float min_lod;
     const VkFormatFeatureFlags2 format_features;

--- a/layers/state_tracker/sampler_state.cpp
+++ b/layers/state_tracker/sampler_state.cpp
@@ -24,7 +24,7 @@ Sampler::Sampler(const VkSampler handle, const VkSamplerCreateInfo *pCreateInfo)
     : StateObject(handle, kVulkanObjectTypeSampler),
       safe_create_info(pCreateInfo),
       create_info(*safe_create_info.ptr()),
-      samplerConversion(GetConversion(pCreateInfo)),
+      sampler_conversion(GetConversion(pCreateInfo)),
       customCreateInfo(GetCustomCreateInfo(pCreateInfo)) {}
 
 SamplerYcbcrConversion::SamplerYcbcrConversion(VkSamplerYcbcrConversion handle,

--- a/layers/state_tracker/sampler_state.h
+++ b/layers/state_tracker/sampler_state.h
@@ -64,7 +64,8 @@ class Sampler : public StateObject, public SubStateManager<SamplerSubState> {
     const vku::safe_VkSamplerCreateInfo safe_create_info;
     const VkSamplerCreateInfo &create_info;
 
-    const VkSamplerYcbcrConversion samplerConversion;
+    // VK_NULL_HANDLE if it doesn't have one chained in the pNext at creation time
+    const VkSamplerYcbcrConversion sampler_conversion;
     const VkSamplerCustomBorderColorCreateInfoEXT customCreateInfo;
 
     Sampler(const VkSampler handle, const VkSamplerCreateInfo *pCreateInfo);


### PR DESCRIPTION
I was trying to debug why 2 tests were failing on AMD, seems we never accounted for `maxCombinedImageSamplerDescriptorCount` and you get a confusing `VK_ERROR_OUT_OF_POOL_MEMORY` but now we will print a nice warning!