### PR TITLE
scripts: Cleanup how update_deps gets binaries

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -32,9 +32,6 @@ if (UPDATE_DEPS)
         list(APPEND update_dep_command "${CMAKE_GENERATOR_PLATFORM}")
     endif()
 
-    list(APPEND update_dep_command "--pointer_size")
-    list(APPEND update_dep_command "${CMAKE_SIZEOF_VOID_P}")
-
     if (NOT CMAKE_BUILD_TYPE)
         message(WARNING "CMAKE_BUILD_TYPE not set. Using Debug for dependency build type")
         set(_build_type Debug)
@@ -73,6 +70,7 @@ if (UPDATE_DEPS)
         list(APPEND update_dep_command "--skip-existing-install")
     endif()
 
+    # Need to propagate current CMake variables into the builds that update_deps.py executes - so collect all the variable names and use a function to set them all
     list(APPEND cmake_vars "CMAKE_TOOLCHAIN_FILE")
 
     # Avoids manually setting CMAKE_SYSTEM_NAME unless it's needed:

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -120,9 +120,32 @@
         },
         {
             "name": "slang",
-            "repo_binaries_url": "https://github.com/shader-slang/slang/releases/tag/v2025.12.1",
+            "url": "https://github.com/shader-slang/slang/releases/download/v{release}/slang-{release}-{system}-{arch}.zip",
+            "sub_dir": "slang",
             "build_dir": "slang/download",
-            "install_dir": "slang/install"
+            "install_dir": "slang/install",
+            "release": "2025.12.1",
+            "url_format_map": {
+                "64": "x86_64",
+                "x64": "x86_64",
+                "win64": "x86_64",
+                "arm64": "aarch64",
+                "Darwin": "macos"
+            },
+            "optional": [
+                "tests"
+            ],
+            "build_platforms": [
+                "linux",
+                "macos",
+                "windows"
+            ],
+            "build_architectures": [
+                "64",
+                "x64",
+                "win64",
+                "arm64"
+            ]
         }
     ],
     "install_names": {


### PR DESCRIPTION
When slang was added as a dependency, the logic needed to select the correct binary artifact to download was hardcoded in update_deps. Now, the url is parameterized on the name of the release, the operating system, and the architecture being used.

Doing so required refactoring update_deps to include the new fields in the repo objects:
 - release: The name of the release to download. This is added as an exclusive option group with commit, so repos can be either source git repos or binary artifact repos.
 - url_format_map: Map of names that are used to turn python's platform.system() and `arch`` command line argument into strings that correspond to the correct binary artifact for the current system.
 - build_architectures: If present, will allow this dependency to be ignored on architectures that aren't supported.

Removed the --pointer_size command line argument as that is redundant with the --arch command line argument.