### PR TITLE
tests: More cleanup for CoopMat tests

### DIFF
--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -435,6 +435,9 @@ class CooperativeMatrixTest : public VkLayerTest {
     bool HasValidProperty(VkScopeKHR scope, uint32_t m, uint32_t n, uint32_t k, VkComponentTypeKHR type);
     std::vector<VkCooperativeMatrixPropertiesKHR> coop_matrix_props;
     std::vector<VkCooperativeMatrixFlexibleDimensionsPropertiesNV> coop_matrix_flex_props;
+
+    bool Has8BitComponentType(const VkCooperativeMatrixPropertiesKHR &prop);
+    bool Has64BitComponentType(const VkCooperativeMatrixPropertiesKHR &prop);
 };
 
 class ParentTest : public VkLayerTest {


### PR DESCRIPTION
was failing on RADV as it was grabbing 8-bit types that just happened to be listed before any 16/32 bit types