### PR TITLE
tests: Fix Mutable CombinedImageSampler

### DIFF
--- a/tests/unit/descriptors.cpp
+++ b/tests/unit/descriptors.cpp
@@ -4830,7 +4830,7 @@ TEST_F(NegativeDescriptors, CopyMutableDescriptors) {
         m_errorMonitor->VerifyFound();
     }
     {
-        VkDescriptorType descriptor_types[] = {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER};
+        VkDescriptorType descriptor_types[] = {VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE};
 
         VkMutableDescriptorTypeListEXT mutable_descriptor_type_lists[2] = {{1, &descriptor_types[0]}, {1, &descriptor_types[1]}};
         VkMutableDescriptorTypeCreateInfoEXT mdtci = vku::InitStructHelper();


### PR DESCRIPTION
`VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER` is not a required type to support for mutable descriptors (RADV doesn't support)

So fix tests using it and added a test that still uses it, but does the proper `vkGetDescriptorSetLayoutSupport` check first