### PR TITLE
tests: Fix PushDescriptor test

### DIFF
--- a/tests/unit/descriptor_buffer_positive.cpp
+++ b/tests/unit/descriptor_buffer_positive.cpp
@@ -1780,6 +1780,10 @@ TEST_F(PositiveDescriptorBuffer, PushDescriptor) {
     descriptor_buffer_binding_info.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
     vk::CmdBindDescriptorBuffersEXT(m_command_buffer, 1, &descriptor_buffer_binding_info);
 
+    const uint32_t index = 0;
+    const VkDeviceSize offset = 0;
+    vk::CmdSetDescriptorBufferOffsetsEXT(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout, 0, 1, &index, &offset);
+
     VkDescriptorBufferInfo buffer_info = {buffer_data1, 0, VK_WHOLE_SIZE};
     VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstSet = VK_NULL_HANDLE;


### PR DESCRIPTION
@ziga-lunarg so this one is strange, basically found out from [RADV devs](https://gitlab.freedesktop.org/mesa/mesa/-/issues/14189#note_3166608) that the issue was we never set `vkCmdSetDescriptorBufferOffsetsEXT`, but this test literally works on other drivers, showing people tend to just set things at offset zero randomly I guess 

... one day GPU-AV will be here to catch this stuff ourselves