### PR TITLE
layers: Improve BufferAddressValidation messages

### DIFF
--- a/layers/core_checks/cc_device_generated_commands.cpp
+++ b/layers/core_checks/cc_device_generated_commands.cpp
@@ -485,9 +485,7 @@ bool CoreChecks::ValidateGeneratedCommandsInfo(const vvl::CommandBuffer& cb_stat
                    return (buffer_state.usage & VK_BUFFER_USAGE_2_PREPROCESS_BUFFER_BIT_EXT) == 0;
                },
                []() { return "The following buffers are missing VK_BUFFER_USAGE_2_PREPROCESS_BUFFER_BIT_EXT"; },
-               [](const vvl::Buffer& buffer_state) {
-                   return "buffer has usage " + string_VkBufferUsageFlags2(buffer_state.usage);
-               }}}}};
+               [](const vvl::Buffer& buffer_state) { return "has usage " + string_VkBufferUsageFlags2(buffer_state.usage); }}}}};
 
         skip |= buffer_address_validator.ValidateDeviceAddress(*this, info_loc.dot(Field::preprocessAddress),
                                                                LogObjectList(cb_state.Handle()),
@@ -499,7 +497,7 @@ bool CoreChecks::ValidateGeneratedCommandsInfo(const vvl::CommandBuffer& cb_stat
             "VUID-VkGeneratedCommandsInfoEXT-sequenceCountAddress-11072",
             [](const vvl::Buffer& buffer_state) { return (buffer_state.usage & VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT) == 0; },
             []() { return "The following buffers are missing VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT"; },
-            [](const vvl::Buffer& buffer_state) { return "buffer has usage " + string_VkBufferUsageFlags2(buffer_state.usage); },
+            [](const vvl::Buffer& buffer_state) { return "has usage " + string_VkBufferUsageFlags2(buffer_state.usage); },
         }}}};
 
         skip |= buffer_address_validator.ValidateDeviceAddress(*this, info_loc.dot(Field::sequenceCountAddress),

--- a/layers/core_checks/cc_device_memory.cpp
+++ b/layers/core_checks/cc_device_memory.cpp
@@ -20,6 +20,7 @@
 
 #include <assert.h>
 #include <sstream>
+#include <string>
 
 #include <vulkan/utility/vk_format_utils.h>
 #include <vulkan/vulkan_core.h>
@@ -2862,74 +2863,50 @@ bool CoreChecks::PreCallValidateCmdDecompressMemoryEXT(VkCommandBuffer commandBu
             const VkDeviceSize size = region.compressedSize;
 
             BufferAddressValidation<2> buffer_address_validator = {
-                {{{
-                      "VUID-VkDecompressMemoryRegionEXT-srcAddress-07686",
-                      [start, size](const vvl::Buffer& buffer_state) {
-                          const VkDeviceSize end =
-                              buffer_state.create_info.size - static_cast<VkDeviceSize>(start - buffer_state.deviceAddress);
-                          return size > end;
-                      },
-                      [start, size]() {
-                          const vvl::range<VkDeviceAddress> req_range{start, start + size};
-                          return std::string("The required source range ") + string_range_hex(req_range) + " does not fit:";
-                      },
-                      [](const vvl::Buffer& buffer_state) {
-                          const vvl::range<VkDeviceAddress> buf_range{buffer_state.deviceAddress,
-                                                                      buffer_state.deviceAddress + buffer_state.create_info.size};
-                          return std::string("buffer provides ") + std::to_string(buffer_state.create_info.size) +
-                                 " bytes at range " + string_range_hex(buf_range);
-                      },
-                  },
+                {{{"VUID-VkDecompressMemoryRegionEXT-srcAddress-07686",
+                   [start, size](const vvl::Buffer &buffer_state) {
+                       const VkDeviceSize end =
+                           buffer_state.create_info.size - static_cast<VkDeviceSize>(start - buffer_state.deviceAddress);
+                       return size > end;
+                   },
+                   [size]() { return "The compressedSize (" + std::to_string(size) + ") does not fit in any buffer"; }},
                   {
                       "VUID-VkDecompressMemoryRegionEXT-srcAddress-11764",
-                      [](const vvl::Buffer& buffer_state) {
+                      [](const vvl::Buffer &buffer_state) {
                           return (buffer_state.usage & VK_BUFFER_USAGE_2_MEMORY_DECOMPRESSION_BIT_EXT) == 0;
                       },
                       []() { return "The following buffers are missing VK_BUFFER_USAGE_2_MEMORY_DECOMPRESSION_BIT_EXT"; },
-                      [](const vvl::Buffer& buffer_state) {
+                      [](const vvl::Buffer &buffer_state) {
                           return "buffer has usage " + string_VkBufferUsageFlags2(buffer_state.usage);
                       },
                   }}}};
 
             const Location src_loc = region_loc.dot(Field::srcAddress);
-            skip |= buffer_address_validator.ValidateDeviceAddress(*this, src_loc, objlist, start);
+            skip |= buffer_address_validator.ValidateDeviceAddress(*this, src_loc, objlist, start, size);
         }
 
         if (region.decompressedSize > 0) {
             const VkDeviceAddress start = region.dstAddress;
             const VkDeviceSize size = region.decompressedSize;
             BufferAddressValidation<2> dst_range_validator = {
-                {{{
-                      "VUID-VkDecompressMemoryRegionEXT-dstAddress-07688",
-                      [start, size](const vvl::Buffer& buffer_state) {
-                          const VkDeviceSize end =
-                              buffer_state.create_info.size - static_cast<VkDeviceSize>(start - buffer_state.deviceAddress);
-                          return size > end;
-                      },
-                      [start, size]() {
-                          const vvl::range<VkDeviceAddress> req_range{start, start + size};
-                          return std::string("The required destination range ") + string_range_hex(req_range) + " does not fit:";
-                      },
-                      [](const vvl::Buffer& buffer_state) {
-                          const vvl::range<VkDeviceAddress> buf_range{buffer_state.deviceAddress,
-                                                                      buffer_state.deviceAddress + buffer_state.create_info.size};
-                          return std::string("buffer provides ") + std::to_string(buffer_state.create_info.size) +
-                                 " bytes at range " + string_range_hex(buf_range);
-                      },
-                  },
+                {{{"VUID-VkDecompressMemoryRegionEXT-dstAddress-07688",
+                   [start, size](const vvl::Buffer &buffer_state) {
+                       const VkDeviceSize end =
+                           buffer_state.create_info.size - static_cast<VkDeviceSize>(start - buffer_state.deviceAddress);
+                       return size > end;
+                   },
+                   [size]() { return "The decompressedSize (" + std::to_string(size) + ") does not fit in any buffer"; }},
                   {
                       "VUID-VkDecompressMemoryRegionEXT-dstAddress-11765",
-                      [](const vvl::Buffer& buffer_state) {
+                      [](const vvl::Buffer &buffer_state) {
                           return (buffer_state.usage & VK_BUFFER_USAGE_2_MEMORY_DECOMPRESSION_BIT_EXT) == 0;
                       },
                       []() { return "The following buffers are missing VK_BUFFER_USAGE_2_MEMORY_DECOMPRESSION_BIT_EXT"; },
-                      [](const vvl::Buffer& buffer_state) {
-                          return "buffer has usage " + string_VkBufferUsageFlags2(buffer_state.usage);
-                      },
+                      [](const vvl::Buffer &buffer_state) { return "has usage " + string_VkBufferUsageFlags2(buffer_state.usage); },
                   }}}};
 
             const Location dst_loc = region_loc.dot(Field::dstAddress);
-            skip |= dst_range_validator.ValidateDeviceAddress(*this, dst_loc, objlist, start);
+            skip |= dst_range_validator.ValidateDeviceAddress(*this, dst_loc, objlist, start, size);
         }
     }
 
@@ -2947,16 +2924,15 @@ bool CoreChecks::PreCallValidateCmdDecompressMemoryIndirectCountEXT(VkCommandBuf
     const LogObjectList objlist(cb_state->Handle());
 
     {
+        const VkDeviceSize max_range_size = static_cast<VkDeviceSize>(stride) * static_cast<VkDeviceSize>(maxDecompressionCount);
         BufferAddressValidation<2> buffer_address_validator = {
             {{{"VUID-vkCmdDecompressMemoryIndirectCountEXT-indirectCommandsAddress-07694",
-               [](const vvl::Buffer& buffer_state) { return (buffer_state.usage & VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT) == 0; },
-               []() { return "The following buffers are missing VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT:"; },
-               [](const vvl::Buffer& buffer_state) {
-                   return std::string("buffer has usage ") + string_VkBufferUsageFlags2(buffer_state.usage);
-               }},
+               [](const vvl::Buffer &buffer_state) { return (buffer_state.usage & VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT) == 0; },
+               []() { return "The following buffers are missing VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT"; },
+               [](const vvl::Buffer &buffer_state) { return "has usage " + string_VkBufferUsageFlags2(buffer_state.usage); }},
 
               {"VUID-vkCmdDecompressMemoryIndirectCountEXT-indirectCommandsAddress-11794",
-               [indirectCommandsAddress, stride, maxDecompressionCount](const vvl::Buffer& buffer_state) {
+               [indirectCommandsAddress, stride, maxDecompressionCount](const vvl::Buffer &buffer_state) {
                    if (maxDecompressionCount == 0 || stride == 0) return false;
                    const vvl::range<VkDeviceSize> required_range(
                        indirectCommandsAddress, indirectCommandsAddress + static_cast<VkDeviceSize>(stride) *
@@ -2964,31 +2940,22 @@ bool CoreChecks::PreCallValidateCmdDecompressMemoryIndirectCountEXT(VkCommandBuf
                    const vvl::range<VkDeviceSize> buffer_address_range = buffer_state.DeviceAddressRange();
                    return !buffer_address_range.includes(required_range);
                },
-               [indirectCommandsAddress, stride, maxDecompressionCount]() {
-                   const vvl::range<VkDeviceSize> required_range(
-                       indirectCommandsAddress, indirectCommandsAddress + static_cast<VkDeviceSize>(stride) *
-                                                                              static_cast<VkDeviceSize>(maxDecompressionCount));
-                   return std::string(
-                              "The following buffers have an address range that does not include indirect commands address "
-                              "range ") +
-                          string_range_hex(required_range) + ":";
-               },
-               [](const vvl::Buffer& buffer_state) {
-                   return std::string("buffer address range is ") + string_range_hex(buffer_state.DeviceAddressRange());
+               [stride, maxDecompressionCount, max_range_size]() {
+                   return "The required " + std::to_string(max_range_size) + " byte (stride [" + std::to_string(stride) +
+                          "] * maxDecompressionCount [" + std::to_string(maxDecompressionCount) + "]) does not fit in any buffer";
                }}}}};
 
         const Location ic_addr_loc = error_obj.location.dot(Field::indirectCommandsAddress);
-        skip |= buffer_address_validator.ValidateDeviceAddress(*this, ic_addr_loc, objlist, indirectCommandsAddress);
+        skip |=
+            buffer_address_validator.ValidateDeviceAddress(*this, ic_addr_loc, objlist, indirectCommandsAddress, max_range_size);
     }
 
     {
         BufferAddressValidation<1> buffer_address_validator = {
             {{{"VUID-vkCmdDecompressMemoryIndirectCountEXT-indirectCommandsCountAddress-07697",
-               [](const vvl::Buffer& buffer_state) { return (buffer_state.usage & VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT) == 0; },
-               []() { return "The following buffers are missing VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT:"; },
-               [](const vvl::Buffer& buffer_state) {
-                   return std::string("buffer has usage ") + string_VkBufferUsageFlags2(buffer_state.usage);
-               }}}}};
+               [](const vvl::Buffer &buffer_state) { return (buffer_state.usage & VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT) == 0; },
+               []() { return "The following buffers are missing VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT"; },
+               [](const vvl::Buffer &buffer_state) { return "has usage " + string_VkBufferUsageFlags2(buffer_state.usage); }}}}};
 
         const Location ic_count_loc = error_obj.location.dot(Field::indirectCommandsCountAddress);
         skip |= buffer_address_validator.ValidateDeviceAddress(*this, ic_count_loc, objlist, indirectCommandsCountAddress);

--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -1038,7 +1038,7 @@ bool CoreChecks::ValidateCmdTraceRaysIndirect(const Location &loc, const LastBou
         {{{usage_vuid,
            [](const vvl::Buffer &buffer_state) { return (buffer_state.usage & VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT) == 0; },
            []() { return "The following buffers are missing VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT"; },
-           [](const vvl::Buffer &buffer_state) { return "buffer has usage " + string_VkBufferUsageFlags2(buffer_state.usage); }}}}};
+           [](const vvl::Buffer &buffer_state) { return "has usage " + string_VkBufferUsageFlags2(buffer_state.usage); }}}}};
 
     skip |= buffer_address_validator.ValidateDeviceAddress(
         *this, loc.dot(Field::indirectDeviceAddress), LogObjectList(last_bound_state.cb_state.Handle()), indirect_device_address);

--- a/layers/error_message/unimplementable_validation.h
+++ b/layers/error_message/unimplementable_validation.h
@@ -562,6 +562,10 @@ const char* unimplementable_validation[] = {
     "VUID-VkGeneratedCommandsInfoEXT-sequenceCountAddress-parameter",
     "VUID-VkMicromapCreateInfoEXT-deviceAddress-parameter",
     "VUID-VkStridedDeviceAddressRegionKHR-deviceAddress-parameter",
+
+    // See issue in VK_EXT_memory_decompression where we discussed why this is not possible
+    // without implementing the decompression algorithm
+    "VUID-VkDecompressMemoryRegionEXT-decompressedSize-07689",
 };
 
 // VUs from deprecated extensions that would require complex codegen to get working

--- a/tests/unit/memory.cpp
+++ b/tests/unit/memory.cpp
@@ -58,7 +58,6 @@ TEST_F(NegativeMemory, MemoryDecompressionEnabled) {
 }
 
 TEST_F(NegativeMemory, MemoryDecompressionIndirectAddressUnaligned) {
-    TEST_DESCRIPTION("vkCmdDecompressMemoryIndirectCountEXT: indirectCommandsAddress must be 4-byte aligned (07695)");
     AddRequiredExtensions(VK_EXT_MEMORY_DECOMPRESSION_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::memoryDecompression);
@@ -109,7 +108,6 @@ TEST_F(NegativeMemory, MemoryDecompressionIndirectAddressUnaligned) {
 }
 
 TEST_F(NegativeMemory, MemoryDecompressionIndirectCountAddressUnaligned) {
-    TEST_DESCRIPTION("vkCmdDecompressMemoryIndirectCountEXT: indirectCommandsCountAddress must be 4-byte aligned (07698)");
     AddRequiredExtensions(VK_EXT_MEMORY_DECOMPRESSION_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::memoryDecompression);
@@ -159,7 +157,6 @@ TEST_F(NegativeMemory, MemoryDecompressionIndirectCountAddressUnaligned) {
 }
 
 TEST_F(NegativeMemory, MemoryDecompressionCompressedSizeZero) {
-    TEST_DESCRIPTION("vkCmdDecompressMemoryEXT: compressedSize must not be zero (11795)");
     AddRequiredExtensions(VK_EXT_MEMORY_DECOMPRESSION_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::memoryDecompression);
@@ -196,7 +193,6 @@ TEST_F(NegativeMemory, MemoryDecompressionCompressedSizeZero) {
 }
 
 TEST_F(NegativeMemory, MemoryDecompressionDecompressedSizeZero) {
-    TEST_DESCRIPTION("vkCmdDecompressMemoryEXT: decompressedSize must not be zero (11796)");
     AddRequiredExtensions(VK_EXT_MEMORY_DECOMPRESSION_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::memoryDecompression);
@@ -233,7 +229,6 @@ TEST_F(NegativeMemory, MemoryDecompressionDecompressedSizeZero) {
 }
 
 TEST_F(NegativeMemory, MemoryDecompressionDstRangeExceedsBuffer) {
-    TEST_DESCRIPTION("vkCmdDecompressMemoryEXT: dstAddress+decompressedSize must be within the buffer (07688)");
     AddRequiredExtensions(VK_EXT_MEMORY_DECOMPRESSION_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::memoryDecompression);
@@ -273,8 +268,6 @@ TEST_F(NegativeMemory, MemoryDecompressionDstRangeExceedsBuffer) {
 }
 
 TEST_F(NegativeMemory, MemoryDecompressionIndirectStrideInvalid) {
-    TEST_DESCRIPTION(
-        "vkCmdDecompressMemoryIndirectCountEXT: stride must be multiple of 4 and >= sizeof(VkDecompressMemoryRegionEXT) (11767)");
     AddRequiredExtensions(VK_EXT_MEMORY_DECOMPRESSION_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::memoryDecompression);
@@ -388,7 +381,6 @@ TEST_F(NegativeMemory, MemoryDecompressionIndirectEnabled) {
 }
 
 TEST_F(NegativeMemory, MemoryDecompressionIndirectCount) {
-    TEST_DESCRIPTION("Validate vkCmdDecompressMemoryIndirectCountEXT");
     AddRequiredExtensions(VK_EXT_MEMORY_DECOMPRESSION_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::memoryDecompression);
@@ -444,7 +436,6 @@ TEST_F(NegativeMemory, MemoryDecompressionIndirectCount) {
 }
 
 TEST_F(NegativeMemory, MaxDecompressionCount) {
-    TEST_DESCRIPTION("Validate vkCmdDecompressMemoryIndirectCountEXT maxDecompressionCount");
     AddRequiredExtensions(VK_EXT_MEMORY_DECOMPRESSION_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::memoryDecompression);
@@ -495,7 +486,6 @@ TEST_F(NegativeMemory, MaxDecompressionCount) {
 }
 
 TEST_F(NegativeMemory, MemoryDecompressionIndirectAddressRangeSameBuffer) {
-    TEST_DESCRIPTION("Range [addr, addr + stride*count - 1] must be in the same buffer");
     AddRequiredExtensions(VK_EXT_MEMORY_DECOMPRESSION_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::memoryDecompression);
@@ -538,7 +528,6 @@ TEST_F(NegativeMemory, MemoryDecompressionIndirectAddressRangeSameBuffer) {
 }
 
 TEST_F(NegativeMemory, MemoryDecompression) {
-    TEST_DESCRIPTION("Validate incorrect usage of vkCmdDecompressMemoryEXT");
     AddRequiredExtensions(VK_EXT_MEMORY_DECOMPRESSION_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::memoryDecompression);
     RETURN_IF_SKIP(Init());
@@ -570,7 +559,6 @@ TEST_F(NegativeMemory, MemoryDecompression) {
 }
 
 TEST_F(NegativeMemory, MemoryDecompressionBufferUsage) {
-    TEST_DESCRIPTION("Validate memory decompression requires MEMORY_DECOMPRESSION usage on src/dst buffers");
     AddRequiredExtensions(VK_EXT_MEMORY_DECOMPRESSION_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::memoryDecompression);
@@ -611,7 +599,6 @@ TEST_F(NegativeMemory, MemoryDecompressionBufferUsage) {
 }
 
 TEST_F(NegativeMemory, MemoryDecompressionMethodSingleBit) {
-    TEST_DESCRIPTION("vkCmdDecompressMemoryEXT: decompressionMethod must have a single bit set");
     AddRequiredExtensions(VK_EXT_MEMORY_DECOMPRESSION_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::synchronization2);
@@ -659,7 +646,6 @@ TEST_F(NegativeMemory, MemoryDecompressionMethodSingleBit) {
 }
 
 TEST_F(NegativeMemory, MemoryDecompressionSrcAddressOutOfRange) {
-    TEST_DESCRIPTION("Trigger only VUID-VkDecompressMemoryRegionEXT-srcAddress-07686 by exceeding the source buffer range");
     AddRequiredExtensions(VK_EXT_MEMORY_DECOMPRESSION_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);

--- a/tests/unit/memory_positive.cpp
+++ b/tests/unit/memory_positive.cpp
@@ -22,7 +22,6 @@
 class PositiveMemory : public VkLayerTest {};
 
 TEST_F(PositiveMemory, MemoryDecompression) {
-    TEST_DESCRIPTION("Validate vkCmdDecompressMemoryEXT");
     AddRequiredExtensions(VK_EXT_MEMORY_DECOMPRESSION_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::synchronization2);
@@ -78,7 +77,6 @@ TEST_F(PositiveMemory, MemoryDecompression) {
 }
 
 TEST_F(PositiveMemory, MemoryDecompressionIndirectCount) {
-    TEST_DESCRIPTION("Validate vkCmdDecompressMemoryIndirectCountEXT");
     AddRequiredExtensions(VK_EXT_MEMORY_DECOMPRESSION_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::synchronization2);


### PR DESCRIPTION
This me trying to unify all the `BufferAddressValidation` messages

1. Always print the buffer size/range when listing them out
2. When the user provides a size, print that, and range
3. A future change will to make a template for all the Buffer Usage checks to use

```
vkCmdDecompressMemoryEXT(): pDecompressMemoryInfoEXT->pRegions[0].dstAddress [0x1000003c, 0x10000044) (8 bytes) has no buffer(s) associated that are valid.
The decompressedSize (8) does not fit in any buffer:
  VkBuffer 0x40000000004, size 64, range [0x10000000, 0x10000040)
```

```
vkCmdDecompressMemoryEXT(): pDecompressMemoryInfoEXT->pRegions[0].dstAddress [0x10000040, 0x10000080) (64 bytes) has no buffer(s) associated that are valid.
The following buffers are missing VK_BUFFER_USAGE_2_MEMORY_DECOMPRESSION_BIT_EXT
  VkBuffer 0x60000000006, size 64, range [0x10000040, 0x10000080) has usage VK_BUFFER_USAGE_2_SHADER_DEVICE_ADDRESS_BIT
```

```
vkCmdDecompressMemoryIndirectCountEXT(): indirectCommandsCountAddress (0x10000c40) has no buffer(s) associated that are valid.
The following buffers are missing VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT:
  VkBuffer 0xa000000000a, size 4, range [0x10000c40, 0x10000c44) has usage VK_BUFFER_USAGE_2_SHADER_DEVICE_ADDRESS_BIT
```