### PR TITLE
layers: Simply the BufferDeviceAddress more

### DIFF
--- a/layers/core_checks/cc_copy_blit_resolve.cpp
+++ b/layers/core_checks/cc_copy_blit_resolve.cpp
@@ -3942,7 +3942,8 @@ bool CoreChecks::ValidateStridedDeviceAddressRange(VkCommandBuffer command_buffe
            [&strided_range]() {
                return "The VkStridedDeviceAddressRangeKHR::size (" + std::to_string(strided_range.size) +
                       ") bytes does not fit in any buffer";
-           }}}}};
+           },
+           kEmptyErrorMsgBuffer}}}};
 
     skip |= buffer_address_validator.ValidateDeviceAddress(
         *this, strided_range_loc.dot(Field::address), LogObjectList(command_buffer), strided_range.address, strided_range.size);

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -2699,21 +2699,19 @@ bool CoreChecks::PreCallValidateCmdBindDescriptorBuffersEXT(VkCommandBuffer comm
                  return false;
              },
              []() { return "The following buffers are missing VK_BUFFER_USAGE_2_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT"; },
-             [](const vvl::Buffer &buffer_state) { return "has usage " + string_VkBufferUsageFlags2(buffer_state.usage); }},
+             kUsageErrorMsgBuffer},
 
-            {
-                "VUID-VkDescriptorBufferBindingInfoEXT-usage-08123",
-                [buffer_usage](const vvl::Buffer &buffer_state) {
-                    if (buffer_usage & VK_BUFFER_USAGE_2_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT) {
-                        if (!(buffer_state.usage & VK_BUFFER_USAGE_2_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT)) {
-                            return true;
-                        }
-                    }
-                    return false;
-                },
-                []() { return "The following buffers are missing VK_BUFFER_USAGE_2_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT"; },
-                [](const vvl::Buffer &buffer_state) { return "has usage " + string_VkBufferUsageFlags2(buffer_state.usage); },
-            },
+            {"VUID-VkDescriptorBufferBindingInfoEXT-usage-08123",
+             [buffer_usage](const vvl::Buffer &buffer_state) {
+                 if (buffer_usage & VK_BUFFER_USAGE_2_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT) {
+                     if (!(buffer_state.usage & VK_BUFFER_USAGE_2_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT)) {
+                         return true;
+                     }
+                 }
+                 return false;
+             },
+             []() { return "The following buffers are missing VK_BUFFER_USAGE_2_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT"; },
+             kUsageErrorMsgBuffer},
 
             {"VUID-VkDescriptorBufferBindingInfoEXT-usage-08124",
              [buffer_usage](const vvl::Buffer &buffer_state) {
@@ -2725,7 +2723,7 @@ bool CoreChecks::PreCallValidateCmdBindDescriptorBuffersEXT(VkCommandBuffer comm
                  return false;
              },
              []() { return "The following buffers are missing VK_BUFFER_USAGE_2_PUSH_DESCRIPTORS_DESCRIPTOR_BUFFER_BIT_EXT"; },
-             [](const vvl::Buffer &buffer_state) { return "has usage " + string_VkBufferUsageFlags2(buffer_state.usage); }},
+             kUsageErrorMsgBuffer},
         }}};
 
         buffer_address_validator.update_callback = [buffer_usage, &push_descriptor_buffers, &resource_buffers,
@@ -3112,7 +3110,8 @@ bool CoreChecks::ValidateDescriptorAddressInfoEXT(const VkDescriptorAddressInfoE
            [&address_info]() {
                return "The VkDescriptorAddressInfoEXT::range (" + std::to_string(address_info.range) +
                       ") bytes does not fit in any buffer";
-           }}}}};
+           },
+           kEmptyErrorMsgBuffer}}}};
 
     skip |= buffer_address_validator.ValidateDeviceAddress(*this, address_loc.dot(Field::address), LogObjectList(device),
                                                            address_info.address, address_info.range);

--- a/layers/core_checks/cc_device_generated_commands.cpp
+++ b/layers/core_checks/cc_device_generated_commands.cpp
@@ -485,7 +485,7 @@ bool CoreChecks::ValidateGeneratedCommandsInfo(const vvl::CommandBuffer& cb_stat
                    return (buffer_state.usage & VK_BUFFER_USAGE_2_PREPROCESS_BUFFER_BIT_EXT) == 0;
                },
                []() { return "The following buffers are missing VK_BUFFER_USAGE_2_PREPROCESS_BUFFER_BIT_EXT"; },
-               [](const vvl::Buffer& buffer_state) { return "has usage " + string_VkBufferUsageFlags2(buffer_state.usage); }}}}};
+               kUsageErrorMsgBuffer}}}};
 
         skip |= buffer_address_validator.ValidateDeviceAddress(*this, info_loc.dot(Field::preprocessAddress),
                                                                LogObjectList(cb_state.Handle()),
@@ -493,12 +493,10 @@ bool CoreChecks::ValidateGeneratedCommandsInfo(const vvl::CommandBuffer& cb_stat
     }
 
     {
-        BufferAddressValidation<1> buffer_address_validator = {{{{
-            "VUID-VkGeneratedCommandsInfoEXT-sequenceCountAddress-11072",
-            [](const vvl::Buffer& buffer_state) { return (buffer_state.usage & VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT) == 0; },
-            []() { return "The following buffers are missing VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT"; },
-            [](const vvl::Buffer& buffer_state) { return "has usage " + string_VkBufferUsageFlags2(buffer_state.usage); },
-        }}}};
+        BufferAddressValidation<1> buffer_address_validator = {
+            {{{"VUID-VkGeneratedCommandsInfoEXT-sequenceCountAddress-11072",
+               [](const vvl::Buffer& buffer_state) { return (buffer_state.usage & VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT) == 0; },
+               []() { return "The following buffers are missing VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT"; }, kUsageErrorMsgBuffer}}}};
 
         skip |= buffer_address_validator.ValidateDeviceAddress(*this, info_loc.dot(Field::sequenceCountAddress),
                                                                LogObjectList(cb_state.Handle()),

--- a/layers/core_checks/cc_device_memory.cpp
+++ b/layers/core_checks/cc_device_memory.cpp
@@ -2869,17 +2869,14 @@ bool CoreChecks::PreCallValidateCmdDecompressMemoryEXT(VkCommandBuffer commandBu
                            buffer_state.create_info.size - static_cast<VkDeviceSize>(start - buffer_state.deviceAddress);
                        return size > end;
                    },
-                   [size]() { return "The compressedSize (" + std::to_string(size) + ") does not fit in any buffer"; }},
-                  {
-                      "VUID-VkDecompressMemoryRegionEXT-srcAddress-11764",
-                      [](const vvl::Buffer &buffer_state) {
-                          return (buffer_state.usage & VK_BUFFER_USAGE_2_MEMORY_DECOMPRESSION_BIT_EXT) == 0;
-                      },
-                      []() { return "The following buffers are missing VK_BUFFER_USAGE_2_MEMORY_DECOMPRESSION_BIT_EXT"; },
-                      [](const vvl::Buffer &buffer_state) {
-                          return "buffer has usage " + string_VkBufferUsageFlags2(buffer_state.usage);
-                      },
-                  }}}};
+                   [size]() { return "The compressedSize (" + std::to_string(size) + ") does not fit in any buffer"; },
+                   kEmptyErrorMsgBuffer},
+                  {"VUID-VkDecompressMemoryRegionEXT-srcAddress-11764",
+                   [](const vvl::Buffer &buffer_state) {
+                       return (buffer_state.usage & VK_BUFFER_USAGE_2_MEMORY_DECOMPRESSION_BIT_EXT) == 0;
+                   },
+                   []() { return "The following buffers are missing VK_BUFFER_USAGE_2_MEMORY_DECOMPRESSION_BIT_EXT"; },
+                   kUsageErrorMsgBuffer}}}};
 
             const Location src_loc = region_loc.dot(Field::srcAddress);
             skip |= buffer_address_validator.ValidateDeviceAddress(*this, src_loc, objlist, start, size);
@@ -2895,15 +2892,14 @@ bool CoreChecks::PreCallValidateCmdDecompressMemoryEXT(VkCommandBuffer commandBu
                            buffer_state.create_info.size - static_cast<VkDeviceSize>(start - buffer_state.deviceAddress);
                        return size > end;
                    },
-                   [size]() { return "The decompressedSize (" + std::to_string(size) + ") does not fit in any buffer"; }},
-                  {
-                      "VUID-VkDecompressMemoryRegionEXT-dstAddress-11765",
-                      [](const vvl::Buffer &buffer_state) {
-                          return (buffer_state.usage & VK_BUFFER_USAGE_2_MEMORY_DECOMPRESSION_BIT_EXT) == 0;
-                      },
-                      []() { return "The following buffers are missing VK_BUFFER_USAGE_2_MEMORY_DECOMPRESSION_BIT_EXT"; },
-                      [](const vvl::Buffer &buffer_state) { return "has usage " + string_VkBufferUsageFlags2(buffer_state.usage); },
-                  }}}};
+                   [size]() { return "The decompressedSize (" + std::to_string(size) + ") does not fit in any buffer"; },
+                   kEmptyErrorMsgBuffer},
+                  {"VUID-VkDecompressMemoryRegionEXT-dstAddress-11765",
+                   [](const vvl::Buffer &buffer_state) {
+                       return (buffer_state.usage & VK_BUFFER_USAGE_2_MEMORY_DECOMPRESSION_BIT_EXT) == 0;
+                   },
+                   []() { return "The following buffers are missing VK_BUFFER_USAGE_2_MEMORY_DECOMPRESSION_BIT_EXT"; },
+                   kUsageErrorMsgBuffer}}}};
 
             const Location dst_loc = region_loc.dot(Field::dstAddress);
             skip |= dst_range_validator.ValidateDeviceAddress(*this, dst_loc, objlist, start, size);
@@ -2928,8 +2924,7 @@ bool CoreChecks::PreCallValidateCmdDecompressMemoryIndirectCountEXT(VkCommandBuf
         BufferAddressValidation<2> buffer_address_validator = {
             {{{"VUID-vkCmdDecompressMemoryIndirectCountEXT-indirectCommandsAddress-07694",
                [](const vvl::Buffer &buffer_state) { return (buffer_state.usage & VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT) == 0; },
-               []() { return "The following buffers are missing VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT"; },
-               [](const vvl::Buffer &buffer_state) { return "has usage " + string_VkBufferUsageFlags2(buffer_state.usage); }},
+               []() { return "The following buffers are missing VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT"; }, kUsageErrorMsgBuffer},
 
               {"VUID-vkCmdDecompressMemoryIndirectCountEXT-indirectCommandsAddress-11794",
                [indirectCommandsAddress, stride, maxDecompressionCount](const vvl::Buffer &buffer_state) {
@@ -2943,7 +2938,8 @@ bool CoreChecks::PreCallValidateCmdDecompressMemoryIndirectCountEXT(VkCommandBuf
                [stride, maxDecompressionCount, max_range_size]() {
                    return "The required " + std::to_string(max_range_size) + " byte (stride [" + std::to_string(stride) +
                           "] * maxDecompressionCount [" + std::to_string(maxDecompressionCount) + "]) does not fit in any buffer";
-               }}}}};
+               },
+               kEmptyErrorMsgBuffer}}}};
 
         const Location ic_addr_loc = error_obj.location.dot(Field::indirectCommandsAddress);
         skip |=
@@ -2954,8 +2950,7 @@ bool CoreChecks::PreCallValidateCmdDecompressMemoryIndirectCountEXT(VkCommandBuf
         BufferAddressValidation<1> buffer_address_validator = {
             {{{"VUID-vkCmdDecompressMemoryIndirectCountEXT-indirectCommandsCountAddress-07697",
                [](const vvl::Buffer &buffer_state) { return (buffer_state.usage & VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT) == 0; },
-               []() { return "The following buffers are missing VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT"; },
-               [](const vvl::Buffer &buffer_state) { return "has usage " + string_VkBufferUsageFlags2(buffer_state.usage); }}}}};
+               []() { return "The following buffers are missing VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT"; }, kUsageErrorMsgBuffer}}}};
 
         const Location ic_count_loc = error_obj.location.dot(Field::indirectCommandsCountAddress);
         skip |= buffer_address_validator.ValidateDeviceAddress(*this, ic_count_loc, objlist, indirectCommandsCountAddress);

--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -1037,8 +1037,7 @@ bool CoreChecks::ValidateCmdTraceRaysIndirect(const Location &loc, const LastBou
     BufferAddressValidation<1> buffer_address_validator = {
         {{{usage_vuid,
            [](const vvl::Buffer &buffer_state) { return (buffer_state.usage & VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT) == 0; },
-           []() { return "The following buffers are missing VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT"; },
-           [](const vvl::Buffer &buffer_state) { return "has usage " + string_VkBufferUsageFlags2(buffer_state.usage); }}}}};
+           []() { return "The following buffers are missing VK_BUFFER_USAGE_2_INDIRECT_BUFFER_BIT"; }, kUsageErrorMsgBuffer}}}};
 
     skip |= buffer_address_validator.ValidateDeviceAddress(
         *this, loc.dot(Field::indirectDeviceAddress), LogObjectList(last_bound_state.cb_state.Handle()), indirect_device_address);


### PR DESCRIPTION
1. create a `kEmptyErrorMsgBuffer`/`kUsageErrorMsgBuffer` that currently all, but 1 special Descriptor Buffer check, uses
2. Remove the "default init" in `VuidAndValidation` as it should be explicit by the caller, but with the constants, make it simpler