### PR TITLE
layers: Fix range generator usage in more places

### DIFF
--- a/layers/containers/subresource_adapter.h
+++ b/layers/containers/subresource_adapter.h
@@ -90,10 +90,6 @@ class RangeEncoder {
          : RangeEncoder(full_range, AspectParameters::Get(full_range.aspectMask)) {}
     RangeEncoder(const RangeEncoder& from) = default;
 
-    inline bool InRange(const VkImageSubresource& subres) const {
-        return (subres.mipLevel < limits_.mipLevel) && (subres.arrayLayer < limits_.arrayLayer) &&
-               (subres.aspectMask & limits_.aspectMask);
-    }
     inline bool InRange(const VkImageSubresourceRange& range) const {
         return (range.baseMipLevel < limits_.mipLevel) && ((range.baseMipLevel + range.levelCount) <= limits_.mipLevel) &&
                (range.baseArrayLayer < limits_.arrayLayer) && ((range.baseArrayLayer + range.layerCount) <= limits_.arrayLayer) &&


### PR DESCRIPTION
Follow up to https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/10953

This removes `InRange` where either incompatible ranges were compared (regular create info range vs range for layout transition) or the range was generated by our code and we know it is valid. In other places where the range is based on external data (passed as API parameter) the `InRange` check is usually needed. Also fixes initialization of range encoders and adds todo for other places that need more time to fix.
