### PR TITLE
tests: Add an Undefined test suite

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -301,5 +301,6 @@ if(NOT VVL_SKIP_GTEST_DISCOVERY)
 endif()
 
 add_subdirectory(stress)
+add_subdirectory(undefined)
 add_subdirectory(layers)
 add_subdirectory(icd)

--- a/tests/undefined/CMakeLists.txt
+++ b/tests/undefined/CMakeLists.txt
@@ -1,0 +1,61 @@
+# ~~~
+# Copyright (c) 2025 Valve Corporation
+# Copyright (c) 2025 LunarG, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+if (ANDROID)
+    # currenlty only load vk_layer_validation_tests in for APK
+    return()
+else()
+    add_executable(vk_layer_validation_undefined)
+endif()
+target_sources(vk_layer_validation_undefined PRIVATE
+    core_undefined.cpp
+)
+
+get_target_property(TEST_SOURCES vk_layer_validation_undefined SOURCES)
+source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}" FILES ${TEST_SOURCES})
+
+add_dependencies(vk_layer_validation_undefined vvl)
+
+target_link_libraries(vk_layer_validation_undefined PRIVATE
+    vk_test_framework
+)
+
+# Want next to other executable in build folder
+set_target_properties(vk_layer_validation_undefined
+    PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "$<TARGET_FILE_DIR:vk_layer_validation_tests>"
+)
+
+if(SLANG_INSTALL_DIR)
+    configure_slang_for_target(vk_layer_validation_undefined)
+endif()
+
+install(TARGETS vk_layer_validation_undefined)
+if (WIN32)
+    install(FILES $<TARGET_RUNTIME_DLLS:vk_layer_validation_undefined> DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()
+if(SLANG_INSTALL_DIR)
+    install_slang_with_target(vk_layer_validation_undefined ${CMAKE_INSTALL_LIBDIR})
+endif()
+
+include(GoogleTest)
+# If cross-compiling, discovery will use an executable with the wrong architecture and stop execution here.
+# Set env. variable VVL_SKIP_GTEST_DISCOVERY to skip discovery.
+if(NOT VVL_SKIP_GTEST_DISCOVERY)
+    gtest_discover_tests(vk_layer_validation_undefined DISCOVERY_TIMEOUT 100)
+endif()
+

--- a/tests/undefined/core_undefined.cpp
+++ b/tests/undefined/core_undefined.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025 The Khronos Group Inc.
+ * Copyright (c) 2025 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include <vulkan/vulkan_core.h>
+#include "../framework/layer_validation_tests.h"
+#include "descriptor_helper.h"
+#include "pipeline_helper.h"
+#include "shader_helper.h"
+
+class UndefinedCore : public VkLayerTest {};
+
+TEST_F(UndefinedCore, BindInvalidPipelineLayout) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6621");
+    RETURN_IF_SKIP(Init());
+    InitRenderTarget();
+
+    vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
+    OneOffDescriptorSet descriptor_set(m_device,
+                                       {{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}});
+    descriptor_set.WriteDescriptorBufferInfo(0, buffer, 0, VK_WHOLE_SIZE);
+    descriptor_set.UpdateDescriptorSets();
+
+    // Create PSO to be used for draw-time errors below
+    const char *fsSource = R"glsl(
+        #version 450
+        layout(location=0) out vec4 x;
+        layout(set=0, binding=1) uniform foo1 { vec4 y; };
+        void main(){
+           x = y;
+        }
+    )glsl";
+    VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
+    VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
+
+    CreatePipelineHelper pipe(*this);
+    pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
+    pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&descriptor_set.layout_});
+    // consume VU so we create a pipeline handle
+    // Will crash various drivers
+    m_errorMonitor->SetAllowedFailureMsg("VUID-VkGraphicsPipelineCreateInfo-layout-07988");
+    pipe.CreateGraphicsPipeline();
+    if (pipe == VK_NULL_HANDLE) {
+        GTEST_SKIP() << "Driver failed to create a invalid pipeline handle";
+    }
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_, 0, 1, &descriptor_set.set_,
+                              0, nullptr);
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-08114");
+    vk::CmdDraw(m_command_buffer, 1, 0, 0, 0);
+    m_errorMonitor->VerifyFound();
+
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}


### PR DESCRIPTION
We have `NegativeDescriptors.BindInvalidPipelineLayout` on many driver's blacklist as it tries to create an invalid VkPipeline (in order to ensure we don't crash later)

This will now create a `vk_layer_validation_undefined.exe` (similar to `vk_layer_validation_stress`) 

The goal is we can add other tests here and in future have a way to identify which are "safe" to run... likely good test suite for something like lavapipe