### PR TITLE
layers: Remove not-zero check for srcInfosCount in cluster API 

### DIFF
--- a/layers/vulkan/generated/stateless_validation_helper.cpp
+++ b/layers/vulkan/generated/stateless_validation_helper.cpp
@@ -26293,10 +26293,6 @@ bool Device::PreCallValidateCmdBuildClusterAccelerationStructureIndirectNV(
                                         "VUID-VkClusterAccelerationStructureCommandsInfoNV-scratchData-parameter",
                                         pCommandInfos_loc.dot(Field::scratchData));
 
-        skip |= context.ValidateNotZero(pCommandInfos->srcInfosCount == 0,
-                                        "VUID-VkClusterAccelerationStructureCommandsInfoNV-srcInfosCount-parameter",
-                                        pCommandInfos_loc.dot(Field::srcInfosCount));
-
         skip |= context.ValidateFlags(
             pCommandInfos_loc.dot(Field::addressResolutionFlags),
             vvl::FlagBitmask::VkClusterAccelerationStructureAddressResolutionFlagBitsNV,

--- a/scripts/generators/stateless_validation_helper_generator.py
+++ b/scripts/generators/stateless_validation_helper_generator.py
@@ -384,6 +384,7 @@ class StatelessValidationHelperOutputGenerator(BaseGenerator):
             'VkDescriptorDataEXT' :['pSampler'],
             # https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9887
             'VkClusterAccelerationStructureInputInfoNV' :['opInput'],
+            'VkClusterAccelerationStructureCommandsInfoNV' :['srcInfosCount'],
         }
         for struct in [x for x in self.vk.structs.values() if x.name in structMemberBlacklist]:
             for member in [x for x in struct.members if x.name in structMemberBlacklist[struct.name]]:


### PR DESCRIPTION
When `VkClusterAccelerationStructureCommandsInfoNV::srcInfosCount` is zero, the we see the following validation layer error:
```
2025-10-30T14:08:16Z | Error   | [Vulkan] [VUID-VkClusterAccelerationStructureCommandsInfoNV-srcInfosCount-parameter] Code -1523107376 : vkCmdBuildClusterAccelerationStructureIndirectNV(): pCommandInfos->srcInfosCount is zero.
2025-10-30T14:08:16Z | Error   | [Vulkan] The Vulkan spec states: srcInfosCount must be a valid VkDeviceAddress value (https://vulkan.lunarg.com/doc/view/1.4.328.1/windows/antora/spec/latest/chapters/accelstructures.html#VUID-VkClusterAccelerationStructureCommandsInfoNV-srcInfosCount-parameter)
```
The spec allows for this field to be zero:
> srcInfosCount is the device address of memory containing the count of number of build or move operations to perform. The actual value is the minimum of this value and the value specified in input::maxAccelerationStructureCount. **If this value is 0, the count is determined by input::maxAccelerationStructureCount alone.**

Note that the spec doesn't mention any such provision for `VkBuildPartitionedAccelerationStructureInfoNV::srcInfosCount`, so I've left that alone.