### PR TITLE
tests: Add <cmath> to fix build error in aarch64

### DIFF
--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -12,6 +12,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#include <cmath>
 #include "generated/vk_function_pointers.h"
 #include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"


### PR DESCRIPTION
added header needed to build with aarch64 architecture on linux.