### PR TITLE
tests: Check sample count is supported

### DIFF
--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -107,6 +107,9 @@ bool IsImageFormatSupported(const VkPhysicalDevice gpu, const VkImageCreateInfo 
     if (ci.arrayLayers > props.maxArrayLayers) {
         return false;
     }
+    if ((ci.samples & props.sampleCounts) == 0) {
+        return false;
+    }
 
     return true;
 }


### PR DESCRIPTION
This fixes:

```
[ RUN      ] NegativeDynamicRendering.RenderingAttachmentImageUsage
C:\Projects\Vulkan-ValidationLayers\tests\framework\error_monitor.cpp(309): error: Failed
Validation Error: [ VUID-VkImageCreateInfo-samples-02258 ] | MessageID = 0x5fccc613
vkCreateImage(): pCreateInfo->samples (VK_SAMPLE_COUNT_4_BIT) is not supported by format VK_FORMAT_R8_SRGB (format sampleCounts: VK_SAMPLE_COUNT_1_BIT).
The Vulkan spec states: samples must be a valid VkSampleCountFlagBits value that is set in imageCreateSampleCounts (as defined in Image Creation Limits) (https://docs.vulkan.org/spec/latest/chapters/resources.html#VUID-VkImageCreateInfo-samples-02258)
```