### PR TITLE
layers: Report 10168 only once

### DIFF
--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -1442,6 +1442,7 @@ bool CoreChecks::ValidateWorkgroupSharedMemory(const spirv::Module &module_state
                             "cooperativeMatrixWorkgroupScopeReservedSharedMemory (%" PRIu32 ").",
                             total_workgroup_shared_memory, phys_dev_props.limits.maxComputeSharedMemorySize,
                             phys_dev_ext_props.cooperative_matrix_props2_nv.cooperativeMatrixWorkgroupScopeReservedSharedMemory);
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
This fixes `NegativeShaderCooperativeMatrix.WorkgroupScopeMaxSharedMemory` where the VUID would be reported 3 times