### PR TITLE
docs: Update syncval limitation docs

### DIFF
--- a/docs/syncval_usage.md
+++ b/docs/syncval_usage.md
@@ -123,7 +123,7 @@ The pipelined and multi-threaded nature of Vulkan makes it particularly importan
 - Dynamic Rendering support
 
 ### Known Limitations
-- Does not support precise tracking of descriptors accessed by the shader (requires integration with GPU-AV)
+- Does not support precise tracking of descriptors accessed by the shader (requires integration with GPU-AV). This includes both classic VkDescriptorSet and VK_EXT_descriptor_buffer APIs
 - Hazards related to memory aliasing are not detected properly
 - Indirectly accessed (indirect/indexed) buffers validated at *binding* granularity. (Every valid location assumed to be accessed.)
 - Queue family ownership transfer not supported

--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -471,7 +471,7 @@
                                 {
                                     "key": "syncval_shader_accesses_heuristic",
                                     "label": "Shader accesses heuristic",
-                                    "description": "Take into account memory accesses performed by the shader based on SPIR-V static analysis. Warning: can produce false-positives, can ignore certain types of accesses.",
+                                    "description": "Take into account memory accesses performed by the shader based on SPIR-V static analysis. Warning: can produce false-positives, can ignore certain types of accesses, does not support VK_EXT_descriptor_buffer.",
                                     "type": "BOOL",
                                     "default": false,
                                     "dependence": {


### PR DESCRIPTION
Mention in the docs that VK_EXT_descriptor_buffer is not supported. Something that caused confusion https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11011
