### PR TITLE
layers: Add message around active color attachments

### DIFF
--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -1125,10 +1125,12 @@ bool CoreChecks::ValidateDrawDynamicStateValue(const LastBound& last_bound_state
                                             VK_FORMAT_R32_UINT, VK_FORMAT_R32_SINT})) {
                         const char* vuid_string =
                             has_pipeline ? vuid.set_coverage_to_color_location_07490 : vuid.set_coverage_to_color_location_09420;
-                        skip |= LogError(vuid_string, cb_state.Handle(), vuid.loc(),
-                                         "coverageToColorLocation (%" PRIu32
-                                         ") set by vkCmdSetCoverageToColorLocationNV points to a color attachment with format %s.",
-                                         cb_state.dynamic_state_value.coverage_to_color_location, string_VkFormat(format));
+                        skip |=
+                            LogError(vuid_string, cb_state.Handle(), vuid.loc(),
+                                     "coverageToColorLocation (%" PRIu32
+                                     ") set by vkCmdSetCoverageToColorLocationNV points to a color attachment with format %s.\n%s",
+                                     cb_state.dynamic_state_value.coverage_to_color_location, string_VkFormat(format),
+                                     cb_state.DescribeActiveColorAttachment());
                     }
                 }
             }

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -189,6 +189,17 @@ void CommandBuffer::SetActiveSubpass(uint32_t subpass) {
     active_subpass_sample_count_ = std::nullopt;
 }
 
+// Put here, instead of vvl::RenderPass for ease of access
+const char *CommandBuffer::DescribeActiveColorAttachment() const {
+    if (!active_render_pass) {
+        return "";
+    } else if (active_render_pass->UsesDynamicRendering()) {
+        return "Active color attachments are those where VkRenderingInfo::pColorAttachments[i].imageView != VK_NULL_HANDLE";
+    } else {
+        return "Active color attachments are those where pSubpasses[i].pColorAttachments[i].attachment != VK_ATTACHMENT_UNUSED";
+    }
+}
+
 CommandBuffer::CommandBuffer(DeviceState &dev, VkCommandBuffer handle, const VkCommandBufferAllocateInfo *allocate_info,
                              const vvl::CommandPool *pool)
     : RefcountedStateObject(handle, kVulkanObjectTypeCommandBuffer),

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -465,6 +465,7 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     // only when not using dynamic rendering
     vku::safe_VkRenderPassSampleLocationsBeginInfoEXT sample_locations_begin_info;
     std::vector<SubpassInfo> active_subpasses;
+    const char *DescribeActiveColorAttachment() const;
 
     VkSubpassContents active_subpass_contents;
     uint32_t GetActiveSubpass() const { return active_subpass_; }


### PR DESCRIPTION
The spec has the term "active color attachments" which gets annoying when dealing with `VK_EXT_dynamic_rendering_unused_attachments`

This adds the information to the various draw time VUs explaining where these "active" attachments are coming from