### PR TITLE
sync: Assert syncval does not produce invalid ranges

### DIFF
--- a/layers/sync/sync_access_map.cpp
+++ b/layers/sync/sync_access_map.cpp
@@ -33,6 +33,7 @@ void AccessMap::Erase(iterator first, iterator last) {
 }
 
 AccessMap::iterator AccessMap::LowerBound(const AccessRange &range) {
+    assert(range.valid());
     if (range.valid()) {
         // ImplMap doesn't give us what want with a direct query, it will give us the first entry contained (if any) in key,
         // not the first entry intersecting key, so, first look for the the first entry that starts at or after key.begin
@@ -56,6 +57,7 @@ AccessMap::iterator AccessMap::LowerBound(const AccessRange &range) {
 }
 
 AccessMap::const_iterator AccessMap::LowerBound(const AccessRange &range) const {
+    assert(range.valid());
     if (range.valid()) {
         // ImplMap doesn't give us what want with a direct query, it will give us the first entry contained (if any) in key,
         // not the first entry intersecting key, so, first look for the the first entry that starts at or after key.begin

--- a/layers/sync/sync_access_map.h
+++ b/layers/sync/sync_access_map.h
@@ -87,7 +87,10 @@ class TAccessMapLocator {
     index_type DistanceToEdge() const;
 
   private:
-    iterator LowerBoundForIndex(index_type index) const { return map_->LowerBound(AccessRange(index, index + 1)); }
+    iterator LowerBoundForIndex(index_type index) const {
+        return index == std::numeric_limits<AccessRange::index_type>::max() ? map_->end()
+                                                                            : map_->LowerBound(AccessRange(index, index + 1));
+    }
     bool InsideLowerBoundRange() const { return lower_bound != map_->end() && lower_bound->first.includes(index); }
     bool TrySeekLocal(index_type seek_to);
 

--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -132,6 +132,7 @@ class FilteredGeneratorGenerator {
     AccessRange AdvanceFilter() {
         ++filter_pos_;
         auto filter_range = FilterRange();
+        assert(filter_range.valid());
         if (filter_range.valid()) {
             FastForwardGen(filter_range);
         }


### PR DESCRIPTION
No valid reason to have invalid  ranges in syncval. Starting by adding asserts.
This will allow to simplify `AccessMap::LowerBound` API - we only search the beginning of the range (single point), the whole range is passed only to check for validity.