### PR TITLE
settings: Enable DebugOutput by default on Windows

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -89,7 +89,7 @@
                         { "key": "gpuav_enable", "value": false },
                         { "key": "validate_best_practices", "value": false },
                         { "key": "report_flags", "value": [ "error", "warn" ] },
-                        { "key": "debug_action", "value": [ "VK_DBG_LAYER_ACTION_LOG_MSG" ] },
+                        { "key": "debug_action", "value": [ "VK_DBG_LAYER_ACTION_LOG_MSG", "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT" ] },
                         { "key": "enable_message_limit", "value": true }
                     ]
                 },
@@ -143,7 +143,7 @@
                         { "key": "gpuav_enable", "value": false },
                         { "key": "validate_best_practices", "value": true },
                         { "key": "report_flags", "value": [ "error", "warn", "perf" ] },
-                        { "key": "debug_action", "value": [ "VK_DBG_LAYER_ACTION_LOG_MSG" ] },
+                        { "key": "debug_action", "value": [ "VK_DBG_LAYER_ACTION_LOG_MSG", "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT" ] },
                         { "key": "enable_message_limit", "value": true }
                     ]
                 },
@@ -170,7 +170,7 @@
                         { "key": "gpuav_enable", "value": false },
                         { "key": "validate_best_practices", "value": false },
                         { "key": "report_flags", "value": [ "error" ] },
-                        { "key": "debug_action", "value": [ "VK_DBG_LAYER_ACTION_LOG_MSG" ] },
+                        { "key": "debug_action", "value": [ "VK_DBG_LAYER_ACTION_LOG_MSG", "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT" ] },
                         { "key": "enable_message_limit", "value": true }
                     ]
                 },
@@ -200,7 +200,7 @@
                         { "key": "gpuav_buffers_validation", "value": true },
                         { "key": "validate_best_practices", "value": false },
                         { "key": "report_flags", "value": [ "error" ] },
-                        { "key": "debug_action", "value": [ "VK_DBG_LAYER_ACTION_LOG_MSG" ] },
+                        { "key": "debug_action", "value": [ "VK_DBG_LAYER_ACTION_LOG_MSG", "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT" ] },
                         { "key": "enable_message_limit", "value": true }
                     ]
                 },
@@ -254,7 +254,7 @@
                         { "key": "printf_enable", "value": false },
                         { "key": "validate_best_practices", "value": false },
                         { "key": "report_flags",  "value": [ "warn" ] },
-                        { "key": "debug_action",  "value": [] },
+                        { "key": "debug_action",  "value": [ "VK_DBG_LAYER_ACTION_LOG_MSG", "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT" ] },
                         { "key": "enable_message_limit", "value": false }
                     ]
                 }
@@ -1099,7 +1099,7 @@
                         }
                     ],
                     "default": [
-                        "VK_DBG_LAYER_ACTION_LOG_MSG"
+                        "VK_DBG_LAYER_ACTION_LOG_MSG", "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT"
                     ]
                 },
                 {

--- a/layers/error_message/logging.cpp
+++ b/layers/error_message/logging.cpp
@@ -807,16 +807,14 @@ VKAPI_ATTR VkBool32 VKAPI_CALL MessengerLogCallback(VkDebugUtilsMessageSeverityF
     return false;
 }
 
+#ifdef VK_USE_PLATFORM_WIN32_KHR
 VKAPI_ATTR VkBool32 VKAPI_CALL MessengerWin32DebugOutputMsg(VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,
                                                             VkDebugUtilsMessageTypeFlagsEXT message_type,
                                                             const VkDebugUtilsMessengerCallbackDataEXT *callback_data,
                                                             [[maybe_unused]] void *user_data) {
     const std::string msg_buffer_str = CreateDefaultCallbackMessage(message_severity, message_type, *callback_data);
-    [[maybe_unused]] const char *cstr = msg_buffer_str.c_str();
-
-#ifdef VK_USE_PLATFORM_WIN32_KHR
-    OutputDebugString(cstr);
-#endif
-
+    const char *cstr = msg_buffer_str.c_str();
+    OutputDebugStringA(cstr);
     return false;
 }
+#endif

--- a/layers/error_message/logging.h
+++ b/layers/error_message/logging.h
@@ -375,7 +375,9 @@ VKAPI_ATTR VkBool32 VKAPI_CALL MessengerLogCallback(VkDebugUtilsMessageSeverityF
                                                     VkDebugUtilsMessageTypeFlagsEXT message_type,
                                                     const VkDebugUtilsMessengerCallbackDataEXT *callback_data, void *user_data);
 
+#ifdef VK_USE_PLATFORM_WIN32_KHR
 VKAPI_ATTR VkBool32 VKAPI_CALL MessengerWin32DebugOutputMsg(VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,
                                                             VkDebugUtilsMessageTypeFlagsEXT message_type,
                                                             const VkDebugUtilsMessengerCallbackDataEXT *callback_data,
                                                             void *user_data);
+#endif

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -743,12 +743,14 @@ static void ProcessDebugReportSettings(ConfigAndEnvSettings *settings_data, VkuL
                                       " but VK_DBG_LAYER_ACTION_LOG_MSG was not set, so it won't be sent to the file.");
     }
 
+#ifdef VK_USE_PLATFORM_WIN32_KHR
     messenger = VK_NULL_HANDLE;
     if (debug_action & VK_DBG_LAYER_ACTION_DEBUG_OUTPUT) {
         dbg_create_info.pfnUserCallback = MessengerWin32DebugOutputMsg;
         dbg_create_info.pUserData = nullptr;
         LayerCreateMessengerCallback(debug_report, default_layer_callback, &dbg_create_info, &messenger);
     }
+#endif
 
     messenger = VK_NULL_HANDLE;
     if (debug_action & VK_DBG_LAYER_ACTION_BREAK) {


### PR DESCRIPTION
`Debug Output` is very useful on Windows (`OutputDebugStringA` win32 api). It works for the apps that do not create console. For the apps that go with console sometimes you still prefer to work with `Debug Output` because that's what Visual Studio, DebugView and other gui tools use as debug output. It's also common to see other unrelated app reports debug info here when you debug something in VS (and then it hard not to notice that information in the "Output" window).

Enabled this for the main validation presets (standard, sync, gpu-av, best) except low overhead preset.