### PR TITLE
gpuav: Apply DeviceLocalMappable to Indirect

### DIFF
--- a/layers/gpuav/core/gpuav.h
+++ b/layers/gpuav/core/gpuav.h
@@ -83,6 +83,7 @@ class Validator : public GpuShaderInstrumentor {
     void FinishDeviceSetup(const VkDeviceCreateInfo* pCreateInfo, const Location& loc) final;
 
     void InternalVmaError(LogObjectList objlist, VkResult result, const char* const specific_message) const;
+    bool IsAllDeviceLocalMappable() const;
 
   private:
     void InitSettings(const Location& loc);

--- a/layers/gpuav/validation_cmd/gpuav_draw.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_draw.cpp
@@ -46,7 +46,7 @@ struct SharedDrawValidationResources {
         dummy_buffer_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
         VmaAllocationCreateInfo alloc_info = {};
         alloc_info.usage = VMA_MEMORY_USAGE_AUTO;
-        if (gpuav.phys_dev_props.deviceType == VK_PHYSICAL_DEVICE_TYPE_CPU) {
+        if (gpuav.IsAllDeviceLocalMappable()) {
             alloc_info.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT;
         }
         const bool success = dummy_buffer.Create(&dummy_buffer_info, &alloc_info);


### PR DESCRIPTION
Hit the 

> vk_mem_alloc.h:11057: void VmaAllocation_T::BlockAllocMap(): Assertion `IsMappingAllowed() && "Mapping is not allowed on this allocation! Please use one of the new VMA_ALLOCATION_CREATE_HOST_ACCESS_* flags when creating it."' failed.

again... so need to move `IsAllDeviceLocalMappable` higher up