### PR TITLE
cmake: Bugfix Windows build

### DIFF
--- a/tests/framework/CMakeLists.txt
+++ b/tests/framework/CMakeLists.txt
@@ -131,7 +131,7 @@ endif()
 function(configure_slang_for_target TARGET_NAME)
     if(WIN32)
         add_custom_command(TARGET ${TARGET_NAME} PRE_LINK
-            COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:${TARGET_NAME}> $<TARGET_RUNTIME_DLLS:${TARGET_NAME}>
+            COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_RUNTIME_DLLS:${TARGET_NAME}> $<TARGET_FILE_DIR:${TARGET_NAME}>
             COMMAND_EXPAND_LISTS
         )
     endif()


### PR DESCRIPTION
Windows fails to build VVL due to copy command does not have parameter -t.

The change https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/10896 introduces bug that makes build under Windows to fail.

The build under Windows 11 fails with:
```
1>EXEC : error : Target (for copy command) "D:/develop/vvl/external/slang/install/bin/slang.dll" is not a directory.
1>Microsoft.CppCommon.targets(161,5): error MSB3073: The command "setlocal
1>Microsoft.CppCommon.targets(161,5): error MSB3073: "C:\Program Files\CMake\bin\cmake.exe" -E copy -t D:/develop/vvl/build/tests/Debug D:/develop/vvl/external/slang/install/bin/slang.dll
```

This happens due to there is no `-t` switch in `copy` command under Windows:

```
C:\Users>copy /?
Copies one or more files to another location.

COPY [/D] [/V] [/N] [/Y | /-Y] [/Z] [/L] [/A | /B ] source [/A | /B]
     [+ source [/A | /B] [+ ...]] [destination [/A | /B]]
...

```

Also destination is a last command argument.
