### PR TITLE
layers: Remove loop in ImmutableSamplersAreEqual

### DIFF
--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -218,7 +218,11 @@ class DescriptorSetLayoutDef {
     VkDescriptorBindingFlags GetDescriptorBindingFlagsFromBinding(const uint32_t binding) const {
         return GetDescriptorBindingFlagsFromIndex(GetIndexFromBinding(binding));
     }
+
+    // Return array with a size of descriptorCount for the given binding index,
+    // or an emtpy array if the binding does not use immutable samplers
     const std::vector<vku::safe_VkSamplerCreateInfo> &GetImmutableSamplerCreateInfosFromIndex(uint32_t index) const;
+
     size_t GetImmutableSamplersCombinedHashFromIndex(uint32_t index) const;
 
     bool IsTypeMutable(const VkDescriptorType type, uint32_t binding) const;


### PR DESCRIPTION
We don't need to iterate, work with specific binding index.

Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11070


