### PR TITLE
layers: Fix 07891 message

### DIFF
--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -2509,7 +2509,7 @@ bool CoreChecks::ValidateDynamicRenderingPipelineStage(const LogObjectList &objl
     if (HasFramebufferStagePipelineStageFlags(stage_mask) && loc.field == Field::srcStageMask &&
         (dependency_flags & VK_DEPENDENCY_BY_REGION_BIT) != VK_DEPENDENCY_BY_REGION_BIT) {
         const auto &vuid = GetDynamicRenderingBarrierVUID(loc, vvl::DynamicRenderingBarrierError::kDependencyFlags);
-        skip |= LogError(vuid, objlist, loc, "must contain VK_DEPENDENCY_BY_REGION_BIT.");
+        skip |= LogError(vuid, objlist, loc.prev->dot(Field::dependencyFlags), "must contain VK_DEPENDENCY_BY_REGION_BIT.");
     }
     return skip;
 }


### PR DESCRIPTION
Before the message was:

```
Test case 'dEQP-VK.renderpasses.dynamic_rendering.primary_cmd_buff.basic.single_cmdbuffer_end_rendering_2'..
Validation Error: [ VUID-vkCmdPipelineBarrier-dependencyFlags-07891 ] | MessageID = 0xaa119072
vkCmdPipelineBarrier(): srcStageMask must contain VK_DEPENDENCY_BY_REGION_BIT.
The Vulkan spec states: If vkCmdPipelineBarrier is called within a render pass instance, and the source stage masks of any memory barriers include framebuffer-space stages, then dependencyFlags must include VK_DEPENDENCY_BY_REGION_BIT (https://docs.vulkan.org/spec/latest/chapters/synchronization.html#VUID-vkCmdPipelineBarrier-dependencyFlags-07891)
Objects: 1
    [0] VkCommandBuffer 0x248d67d6390
```