### PR TITLE
gpuav: Fix naming for CopyMemoryIndirect

### DIFF
--- a/layers/gpuav/shaders/gpuav_error_codes.h
+++ b/layers/gpuav/shaders/gpuav_error_codes.h
@@ -37,7 +37,7 @@ const int kErrorGroupGpuPreTraceRays = 6;
 const int kErrorGroupGpuCopyBufferToImage = 7;
 const int kErrorGroupInstDescriptorClass = 8;
 const int kErrorGroupInstIndexedDraw = 9;
-const int kErrorGroupInstCopyMemoryIndirect = 10;
+const int kErrorGroupGpuCopyMemoryIndirect = 10;
 
 // We just take ExecutionModel and normalize it so we only use 5 bits to store it
 const int kExecutionModelVertex = 0;

--- a/layers/gpuav/shaders/validation_cmd/copy_memory_indirect.comp
+++ b/layers/gpuav/shaders/validation_cmd/copy_memory_indirect.comp
@@ -110,42 +110,42 @@ void main() {
     if (api.is_image_copy != 0) {
         CopyMemoryToImageIndirectCommand command = CopyMemoryToImageIndirectCommand(command_address);
         if (!ValidDeviceAddress(command.srcAddress)) {
-            GpuavLogError4(kErrorGroupInstCopyMemoryIndirect, kErrorSubCodePreCopyMemoryToImageIndirectSrcAddressInvalid,
+            GpuavLogError4(kErrorGroupGpuCopyMemoryIndirect, kErrorSubCodePreCopyMemoryToImageIndirectSrcAddressInvalid,
                             uint(command.srcAddress), uint(command.srcAddress >> 32), tid, 0);
             MakeSafeImage(command_address);
         } else if ((command.srcAddress & 3ul) != 0) {
-            GpuavLogError4(kErrorGroupInstCopyMemoryIndirect, kErrorSubCodePreCopyMemoryToImageIndirectSrcAddressAligned,
+            GpuavLogError4(kErrorGroupGpuCopyMemoryIndirect, kErrorSubCodePreCopyMemoryToImageIndirectSrcAddressAligned,
                             uint(command.srcAddress), uint(command.srcAddress >> 32), tid, 0);
             MakeSafeImage(command_address);
         } else if (command.bufferRowLength != 0 && command.bufferRowLength < command.imageExtent_width) {
-            GpuavLogError4(kErrorGroupInstCopyMemoryIndirect, kErrorSubCodePreCopyMemoryToImageIndirectBufferRowLength,
+            GpuavLogError4(kErrorGroupGpuCopyMemoryIndirect, kErrorSubCodePreCopyMemoryToImageIndirectBufferRowLength,
                             command.bufferRowLength, command.imageExtent_width, tid, 0);
             MakeSafeImage(command_address);
         } else if (command.bufferImageHeight != 0 && command.bufferImageHeight < command.imageExtent_height) {
-            GpuavLogError4(kErrorGroupInstCopyMemoryIndirect, kErrorSubCodePreCopyMemoryToImageIndirectBufferImageHeight,
+            GpuavLogError4(kErrorGroupGpuCopyMemoryIndirect, kErrorSubCodePreCopyMemoryToImageIndirectBufferImageHeight,
                             command.bufferImageHeight, command.imageExtent_height, tid, 0);
             MakeSafeImage(command_address);
         }
     } else {
         CopyMemoryIndirectCommand command = CopyMemoryIndirectCommand(command_address);
         if (!ValidDeviceAddress(command.srcAddress)) {
-            GpuavLogError4(kErrorGroupInstCopyMemoryIndirect, kErrorSubCodePreCopyMemoryIndirectSrcAddressInvalid,
+            GpuavLogError4(kErrorGroupGpuCopyMemoryIndirect, kErrorSubCodePreCopyMemoryIndirectSrcAddressInvalid,
                             uint(command.srcAddress), uint(command.srcAddress >> 32), tid, 0);
             MakeSafeBuffer(command_address);
         } else if (!ValidDeviceAddress(command.dstAddress)) {
-            GpuavLogError4(kErrorGroupInstCopyMemoryIndirect, kErrorSubCodePreCopyMemoryIndirectDstAddressInvalid,
+            GpuavLogError4(kErrorGroupGpuCopyMemoryIndirect, kErrorSubCodePreCopyMemoryIndirectDstAddressInvalid,
                             uint(command.dstAddress), uint(command.dstAddress >> 32), tid, 0);
             MakeSafeBuffer(command_address);
         } else if ((command.srcAddress & 3ul) != 0) {
-            GpuavLogError4(kErrorGroupInstCopyMemoryIndirect, kErrorSubCodePreCopyMemoryIndirectSrcAddressAligned,
+            GpuavLogError4(kErrorGroupGpuCopyMemoryIndirect, kErrorSubCodePreCopyMemoryIndirectSrcAddressAligned,
                             uint(command.srcAddress), uint(command.srcAddress >> 32), tid, 0);
             MakeSafeBuffer(command_address);
         } else if ((command.dstAddress & 3ul) != 0) {
-            GpuavLogError4(kErrorGroupInstCopyMemoryIndirect, kErrorSubCodePreCopyMemoryIndirectDstAddressAligned,
+            GpuavLogError4(kErrorGroupGpuCopyMemoryIndirect, kErrorSubCodePreCopyMemoryIndirectDstAddressAligned,
                             uint(command.dstAddress), uint(command.dstAddress >> 32), tid, 0);
             MakeSafeBuffer(command_address);
         } else if ((command.size & 3ul) != 0) {
-            GpuavLogError4(kErrorGroupInstCopyMemoryIndirect, kErrorSubCodePreCopyMemoryIndirectSizeAligned,
+            GpuavLogError4(kErrorGroupGpuCopyMemoryIndirect, kErrorSubCodePreCopyMemoryIndirectSizeAligned,
                             uint(command.size), uint(command.size >> 32), tid, 0);
             MakeSafeBuffer(command_address);
         }

--- a/layers/gpuav/validation_cmd/gpuav_copy_memory_indirect.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_copy_memory_indirect.cpp
@@ -162,7 +162,7 @@ void CopyMemoryIndirect(Validator &gpuav, const Location &loc, CommandBufferSubS
         using namespace glsl;
 
         const uint32_t error_group = error_record[kHeaderShaderIdErrorOffset] >> kErrorGroupShift;
-        if (error_group != kErrorGroupInstCopyMemoryIndirect) {
+        if (error_group != kErrorGroupGpuCopyMemoryIndirect) {
             return skip;
         }
 


### PR DESCRIPTION
We have `kErrorGroupInst` for shader instrumentation, I gave this the wrong name