### PR TITLE
layer: Remove VulkanTypedHandle implicit bool conversion

### DIFF
--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -2027,8 +2027,8 @@ bool CoreChecks::ValidateShaderStage(const ShaderStageState &stage_state, const 
 
                 if (map_entry.size != spec_const_size) {
                     std::stringstream name;
-                    if (module_state.handle()) {
-                        name << "shader module " << module_state.handle();
+                    if (module_state.handle() != NullVulkanTypedHandle) {
+                        name << "shader module " << FormatHandle(module_state.handle());
                     } else {
                         name << "shader object";
                     }

--- a/layers/object_tracker/object_lifetime_validation.h
+++ b/layers/object_tracker/object_lifetime_validation.h
@@ -18,7 +18,6 @@
 
 #include "chassis/validation_object.h"
 #include "containers/small_vector.h"
-#include "utils/hash_util.h"
 
 namespace object_lifetimes {
 
@@ -37,16 +36,6 @@ using ObjectMap = vvl::concurrent_unordered_map<uint64_t, std::shared_ptr<Object
 // Used for GPL and we know there are at most only 4 libraries that should be used
 using ObjectMapGPL = vvl::concurrent_unordered_map<uint64_t, small_vector<std::shared_ptr<ObjectState>, 4>, 6>;
 
-struct VulkanTypedHandleHasher {
-    size_t operator()(VulkanTypedHandle typed_handle) const {
-        return hash_util::HashCombiner().Combine(typed_handle.handle).Combine(typed_handle.type).Value();
-    }
-};
-
-struct VulkanTypedHandleComparator {
-    bool operator()(VulkanTypedHandle a, VulkanTypedHandle b) const { return a.handle == b.handle && a.type == b.type; }
-};
-
 struct ObjectState {
     uint64_t handle;
     VulkanObjectType object_type;
@@ -58,7 +47,7 @@ struct ObjectState {
 
     // The objects to poison if the current object becomes poisoned.
     // These objects reference the current object in some way.
-    vvl::unordered_set<VulkanTypedHandle, VulkanTypedHandleHasher, VulkanTypedHandleComparator> objects_to_poison;
+    vvl::unordered_set<VulkanTypedHandle> objects_to_poison;
 
     // The objects that can poison this object (they have this object in their objects_to_poison list).
     // When the current object is destroyed it has to remove itself from all registered poisoners.

--- a/layers/state_tracker/state_object.h
+++ b/layers/state_tracker/state_object.h
@@ -28,17 +28,6 @@
 #include <atomic>
 #include <map>
 
-// Intentionally ignore VulkanTypedHandle::node, it is optional
-inline bool operator==(const VulkanTypedHandle &a, const VulkanTypedHandle &b) noexcept {
-    return a.handle == b.handle && a.type == b.type;
-}
-namespace std {
-template <>
-struct hash<VulkanTypedHandle> {
-    size_t operator()(VulkanTypedHandle obj) const noexcept { return hash<uint64_t>()(obj.handle) ^ hash<uint32_t>()(obj.type); }
-};
-}  // namespace std
-
 namespace vvl {
 // inheriting from enable_shared_from_this<> adds a method, shared_from_this(), which
 // returns a shared_ptr version of the current object. It requires the object to

--- a/layers/sync/sync_error_messages.cpp
+++ b/layers/sync/sync_error_messages.cpp
@@ -471,8 +471,9 @@ std::string ErrorMessages::FirstUseError(const HazardResult& hazard, const Comma
 
     // Use generic "resource" when resource handle is not specified for some reason (likely just a missing code).
     // TODO: specify resources in EndRenderPass (NegativeSyncVal.QSOBarrierHazard).
-    const std::string resource_description =
-        recorded_usage_info.resource_handle ? validator_.FormatHandle(recorded_usage_info.resource_handle) : "resource";
+    const std::string resource_description = (recorded_usage_info.resource_handle != NullVulkanTypedHandle)
+                                                 ? validator_.FormatHandle(recorded_usage_info.resource_handle)
+                                                 : "resource";
     return Error(hazard, exec_context, recorded_usage_info.command, resource_description, "SubmitTimeError", additional_info);
 }
 

--- a/layers/sync/sync_renderpass.cpp
+++ b/layers/sync/sync_renderpass.cpp
@@ -48,7 +48,7 @@ class ValidateResolveAction {
 
             // TODO: this error message is not triggered by the tests
             std::stringstream ss;
-            ss << view_gen.GetViewState()->Handle();
+            ss << validator.FormatHandle(view_gen.GetViewState()->Handle());
             ss << " (" << aspect_name << " " << resolve_action_name;
             ss << ", attachment " << src_at;
             ss << ", resolve attachment " << dst_at;

--- a/layers/vulkan/generated/vk_object_types.h
+++ b/layers/vulkan/generated/vk_object_types.h
@@ -25,6 +25,7 @@
 
 #pragma once
 #include "utils/cast_utils.h"
+#include "utils/hash_util.h"
 
 // Object Type enum for validation layer internal object handling
 typedef enum VulkanObjectType {
@@ -1266,8 +1267,18 @@ struct VulkanTypedHandle {
 #endif  // TYPESAFE_NONDISPATCHABLE_HANDLES
         return CastFromUint64<Handle>(handle);
     }
-    VulkanTypedHandle() : handle(CastToUint64(VK_NULL_HANDLE)), type(kVulkanObjectTypeUnknown) {}
-    operator bool() const { return handle != 0; }
+    constexpr VulkanTypedHandle() : handle(0), type(kVulkanObjectTypeUnknown) {}
+    bool operator==(const VulkanTypedHandle& other) const { return handle == other.handle && type == other.type; }
+    bool operator!=(const VulkanTypedHandle& other) const { return !(*this == other); }
 };
+constexpr VulkanTypedHandle NullVulkanTypedHandle = VulkanTypedHandle{};
+namespace std {
+template <>
+struct hash<VulkanTypedHandle> {
+    size_t operator()(VulkanTypedHandle obj) const noexcept {
+        return hash_util::HashCombiner().Combine(obj.handle).Combine(obj.type).Value();
+    }
+};
+}  // namespace std
 
 // NOLINTEND


### PR DESCRIPTION
This PR removes `operator bool() const { return handle != 0; }` from `VulkanTypedHandle`. It introduced actual bugs.

Some examples:

a) `VulkanTypedHandle` did not define operator==, but you still could compare the objects because they were converted to boolean values. Comparison of different not-null handles always returned true.
```
-------------------
VulkanTypedHandle h1;
h1.handle = 10;
h1.type = kVulkanObjectTypeBuffer;

VulkanTypedHandle h2;
h2.handle = 20;
h2.type = kVulkanObjectTypeBuffer;

bool b = (h1 == h2);
// evil: b == true
```

b) Few places that tried to format `VulkanTypedHandle` printed the result of boolean conversion (so 0 or 1):
```
----------------------
VulkanTypedHandle h;
h.handle = 42;
h.type = kVulkanObjectTypeBuffer;

std::stringstream ss;   
ss << "hello " << h;
std::string s = ss.str();
// evil: s == "hello 1"
```

In our code we had 4 places with such issues, 3 for formatting and 1 as part of actual logic.

```
ValidateGeneratedCommandsInitialShaderState:
    pipeline->Handle() != indirect_execution_set.initial_pipeline->Handle() <--- buggy comparison

cc_spirv.cpp: CoreChecks::ValidateShaderStage:
    name << "shader module " << module_state.handle(); <---- wrong output

sync_renderpass.cpp: ValidateResolveAction:
    std::stringstream ss;
    ss << view_gen.GetViewState()->Handle(); <--- wrong output

sync_error_messages:
    const std::string resource_description = recorded_usage_info.resource_handle ? ... <--- wrong output
```

With updated code the above either works correctly (comparison) or does not compile (if used dirrectly with << operator).

