### PR TITLE
layers: Add maintenance4 suggestion

### DIFF
--- a/layers/object_tracker/object_lifetime_validation.cpp
+++ b/layers/object_tracker/object_lifetime_validation.cpp
@@ -134,6 +134,16 @@ std::string Tracker::DescribePoisonChain(const std::vector<VulkanTypedHandle> &p
         ss << "references " << FormatHandle(poison_chain[i]) << " which became invalid because it ";
     }
     ss << "references deleted object " << FormatHandle(poison_chain[0]);
+
+    // If enablindg maintenance4 makes this setup valid, let the users know
+    if (!is_device_maintenance4_enabled_) {
+        auto pipeline_layout_it = std::find_if(poison_chain.begin(), poison_chain.end(),
+                                               [](const auto handle) { return handle.type == kVulkanObjectTypePipelineLayout; });
+        if (pipeline_layout_it != poison_chain.end()) {
+            ss << ". Note that enabling the maintenance4 allows you to destroy the VkPipelineLayout and child objects after being "
+                  "used.";
+        }
+    }
     return ss.str();
 }
 


### PR DESCRIPTION
`NegativeObjectLifetime.ImmutableSamplerInUseDestroyed` prints the same. Pipeline layout got invalidated before pipeline creation:

> vkCreateComputePipelines(): pCreateInfos[0].layout (VkPipelineLayout 0x60000000006) references VkDescriptorSetLayout 0x50000000005 which became invalid because it references deleted object VkSampler 0x40000000004.

`NegativeObjectLifetime.ImmutableSamplerInUseDestroyed2` would be valid with maintenance4. Pipeline layout got invalidated after pipeline creation:

> vkCmdBindPipeline(): pipeline (VkPipeline 0xb000000000b) references VkPipelineLayout 0x90000000009 which became invalid because it references VkDescriptorSetLayout 0x50000000005 which became invalid because it references deleted object VkSampler 0x40000000004. Note that enabling the maintenance4 feature would make this configuration valid.

Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11061
