### PR TITLE
gpuav: Make getting the TypeManager easier

### DIFF
--- a/layers/gpuav/spirv/descriptor_class_texel_buffer_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_class_texel_buffer_pass.cpp
@@ -39,7 +39,7 @@ uint32_t DescriptorClassTexelBufferPass::GetLinkFunctionId() { return GetLinkFun
 
 void DescriptorClassTexelBufferPass::CreateFunctionCall(BasicBlock& block, InstructionIt* inst_it, const InstructionMeta& meta) {
     assert(meta.access_chain_inst && meta.var_inst);
-    const Constant& set_constant = module_.type_manager_.GetConstantUInt32(meta.descriptor_set);
+    const Constant& set_constant = type_manager_.GetConstantUInt32(meta.descriptor_set);
     const uint32_t descriptor_index_id = CastToUint32(meta.descriptor_index_id, block, inst_it);  // might be int32
 
     const uint32_t opcode = meta.target_instruction->Opcode();
@@ -56,14 +56,14 @@ void DescriptorClassTexelBufferPass::CreateFunctionCall(BasicBlock& block, Instr
     const uint32_t descriptor_offset_id = CastToUint32(meta.target_instruction->Operand(1), block, inst_it);
 
     BindingLayout binding_layout = module_.set_index_to_bindings_layout_lut_[meta.descriptor_set][meta.descriptor_binding];
-    const Constant& binding_layout_offset = module_.type_manager_.GetConstantUInt32(binding_layout.start);
+    const Constant& binding_layout_offset = type_manager_.GetConstantUInt32(binding_layout.start);
 
     const uint32_t inst_position = meta.target_instruction->GetPositionOffset();
-    const uint32_t inst_position_id = module_.type_manager_.CreateConstantUInt32(inst_position).Id();
+    const uint32_t inst_position_id = type_manager_.CreateConstantUInt32(inst_position).Id();
 
     const uint32_t function_result = module_.TakeNextId();
     const uint32_t function_def = GetLinkFunctionId();
-    const uint32_t void_type = module_.type_manager_.GetTypeVoid().Id();
+    const uint32_t void_type = type_manager_.GetTypeVoid().Id();
 
     block.CreateInstruction(spv::OpFunctionCall,
                             {void_type, function_result, function_def, inst_position_id, set_constant.Id(), descriptor_index_id,
@@ -84,7 +84,7 @@ bool DescriptorClassTexelBufferPass::RequiresInstrumentation(const Function& fun
 
     meta.image_inst = function.FindInstruction(inst.Word(image_word));
     if (!meta.image_inst) return false;
-    const Type* image_type = module_.type_manager_.FindTypeById(meta.image_inst->TypeId());
+    const Type* image_type = type_manager_.FindTypeById(meta.image_inst->TypeId());
     if (!image_type) return false;
 
     const uint32_t dim = image_type->inst_.Operand(1);
@@ -112,7 +112,7 @@ bool DescriptorClassTexelBufferPass::RequiresInstrumentation(const Function& fun
     meta.var_inst = function.FindInstruction(load_inst->Operand(0));
     if (!meta.var_inst) {
         // can be a global variable
-        const Variable* global_var = module_.type_manager_.FindVariableById(load_inst->Operand(0));
+        const Variable* global_var = type_manager_.FindVariableById(load_inst->Operand(0));
         meta.var_inst = global_var ? &global_var->inst_ : nullptr;
     }
     if (!meta.var_inst || (!meta.var_inst->IsNonPtrAccessChain() && meta.var_inst->Opcode() != spv::OpVariable)) {
@@ -130,7 +130,7 @@ bool DescriptorClassTexelBufferPass::RequiresInstrumentation(const Function& fun
             return false;
         }
 
-        const Variable* variable = module_.type_manager_.FindVariableById(meta.var_inst->Operand(0));
+        const Variable* variable = type_manager_.FindVariableById(meta.var_inst->Operand(0));
         if (!variable) {
             module_.InternalError(Name(), "OpAccessChain base is not a variable");
             return false;
@@ -138,7 +138,7 @@ bool DescriptorClassTexelBufferPass::RequiresInstrumentation(const Function& fun
         meta.var_inst = &variable->inst_;
     } else {
         // There is no array of this descriptor, so we essentially have an array of 1
-        meta.descriptor_index_id = module_.type_manager_.GetConstantZeroUint32().Id();
+        meta.descriptor_index_id = type_manager_.GetConstantZeroUint32().Id();
     }
 
     uint32_t variable_id = meta.var_inst->ResultId();

--- a/layers/gpuav/spirv/log_error_pass.cpp
+++ b/layers/gpuav/spirv/log_error_pass.cpp
@@ -38,7 +38,7 @@ void LogErrorPass::ClearErrorPayloadVariable(Function& function) {
     // First time we clear, we add the private variable to the global scope
     if (module_.error_payload_variable_id_ == 0) {
         module_.error_payload_variable_id_ = module_.TakeNextId();
-        const Type& uint32_type = module_.type_manager_.GetTypeInt(32, false);
+        const Type& uint32_type = type_manager_.GetTypeInt(32, false);
 
         const uint32_t struct_type_id = module_.TakeNextId();
         auto new_struct_inst = std::make_unique<Instruction>(7, spv::OpTypeStruct);
@@ -50,21 +50,21 @@ void LogErrorPass::ClearErrorPayloadVariable(Function& function) {
             uint32_type.Id(),  // uint parameter_1;
             uint32_type.Id(),  // uint parameter_2;
         });
-        const Type& struct_type = module_.type_manager_.AddType(std::move(new_struct_inst), SpvType::kStruct);
-        module_.type_manager_.AddStructTypeForLinking(&struct_type);
-        const Type& pointer_type = module_.type_manager_.GetTypePointer(spv::StorageClassPrivate, struct_type);
+        const Type& struct_type = type_manager_.AddType(std::move(new_struct_inst), SpvType::kStruct);
+        type_manager_.AddStructTypeForLinking(&struct_type);
+        const Type& pointer_type = type_manager_.GetTypePointer(spv::StorageClassPrivate, struct_type);
         {
             auto new_inst = std::make_unique<Instruction>(4, spv::OpVariable);
             new_inst->Fill({pointer_type.Id(), module_.error_payload_variable_id_, spv::StorageClassPrivate});
-            module_.type_manager_.AddVariable(std::move(new_inst), pointer_type);
+            type_manager_.AddVariable(std::move(new_inst), pointer_type);
         }
 
-        const uint32_t uint32_0_id = module_.type_manager_.GetConstantZeroUint32().Id();
+        const uint32_t uint32_0_id = type_manager_.GetConstantZeroUint32().Id();
         const uint32_t constant_id = module_.TakeNextId();
         {
             auto new_inst = std::make_unique<Instruction>(8, spv::OpConstantComposite);
             new_inst->Fill({struct_type.Id(), constant_id, uint32_0_id, uint32_0_id, uint32_0_id, uint32_0_id, uint32_0_id});
-            const Constant& clear_constant = module_.type_manager_.AddConstant(std::move(new_inst), struct_type);
+            const Constant& clear_constant = type_manager_.AddConstant(std::move(new_inst), struct_type);
             error_payload_variable_clear_ = clear_constant.Id();
         }
     }
@@ -81,7 +81,7 @@ void LogErrorPass::CreateFunctionCallLogError(Function& function, BasicBlock& bl
     const uint32_t stage_info_id = GetStageInfo(function, block, *inst_it);
 
     const uint32_t function_result = module_.TakeNextId();
-    const uint32_t void_type = module_.type_manager_.GetTypeVoid().Id();
+    const uint32_t void_type = type_manager_.GetTypeVoid().Id();
     block.CreateInstruction(spv::OpFunctionCall, {void_type, function_result, link_function_id_, stage_info_id}, inst_it);
 }
 

--- a/layers/gpuav/spirv/pass.h
+++ b/layers/gpuav/spirv/pass.h
@@ -26,6 +26,7 @@ namespace gpuav {
 namespace spirv {
 
 class Module;
+class TypeManager;
 struct Variable;
 struct BasicBlock;
 struct Type;
@@ -82,8 +83,9 @@ class Pass {
     void InjectFunctionPost(BasicBlock& original_block, const InjectConditionalData& ic_data);
 
   protected:
-    Pass(Module& module, const OfflineModule& offline) : module_(module), link_info_(offline) {}
+    Pass(Module& module, const OfflineModule& offline);
     Module& module_;
+    TypeManager& type_manager_;  // reference here since passes use this a lot
 
     // As various things are modifiying the instruction streams, we need to get back to where we were.
     // (normally set in the RequiresInstrumentation call)

--- a/layers/gpuav/spirv/ray_query_pass.cpp
+++ b/layers/gpuav/spirv/ray_query_pass.cpp
@@ -36,7 +36,7 @@ uint32_t RayQueryPass::GetLinkFunctionId() { return GetLinkFunction(link_functio
 uint32_t RayQueryPass::CreateFunctionCall(BasicBlock& block, InstructionIt* inst_it, const InstructionMeta& meta) {
     const uint32_t function_result = module_.TakeNextId();
     const uint32_t function_def = GetLinkFunctionId();
-    const uint32_t bool_type = module_.type_manager_.GetTypeBool().Id();
+    const uint32_t bool_type = type_manager_.GetTypeBool().Id();
 
     const uint32_t ray_flags_id = meta.target_instruction->Operand(2);
     const uint32_t ray_origin_id = meta.target_instruction->Operand(4);
@@ -45,7 +45,7 @@ uint32_t RayQueryPass::CreateFunctionCall(BasicBlock& block, InstructionIt* inst
     const uint32_t ray_tmax_id = meta.target_instruction->Operand(7);
 
     const uint32_t inst_position = meta.target_instruction->GetPositionOffset();
-    const uint32_t inst_position_id = module_.type_manager_.CreateConstantUInt32(inst_position).Id();
+    const uint32_t inst_position_id = type_manager_.CreateConstantUInt32(inst_position).Id();
 
     block.CreateInstruction(spv::OpFunctionCall,
                             {bool_type, function_result, function_def, inst_position_id, ray_flags_id, ray_origin_id, ray_tmin_id,

--- a/layers/gpuav/spirv/type_manager.cpp
+++ b/layers/gpuav/spirv/type_manager.cpp
@@ -529,10 +529,10 @@ const Constant& TypeManager::GetConstantUInt32(uint32_t value) {
         return GetConstantZeroUint32();
     }
 
-    const Type& uint32_type = module_.type_manager_.GetTypeInt(32, 0);
-    const Constant* constant = module_.type_manager_.FindConstantInt32(uint32_type.Id(), value);
+    const Type& uint32_type = GetTypeInt(32, 0);
+    const Constant* constant = FindConstantInt32(uint32_type.Id(), value);
     if (!constant) {
-        constant = &module_.type_manager_.CreateConstantUInt32(value);
+        constant = &CreateConstantUInt32(value);
     }
     return *constant;
 }
@@ -581,7 +581,7 @@ const Constant& TypeManager::GetConstantZeroVec3() {
     if (!vec3_zero_constants_) {
         const Type& float_32_type = GetTypeFloat(32);
         const Type& vec3_type = GetTypeVector(float_32_type, 3);
-        const uint32_t float32_0_id = module_.type_manager_.GetConstantZeroFloat32().Id();
+        const uint32_t float32_0_id = GetConstantZeroFloat32().Id();
 
         const uint32_t constant_id = module_.TakeNextId();
         auto new_inst = std::make_unique<Instruction>(6, spv::OpConstantComposite);
@@ -594,9 +594,9 @@ const Constant& TypeManager::GetConstantZeroVec3() {
 // It is common to use uvec4(0) as a default, so having it cached is helpful
 const Constant& TypeManager::GetConstantZeroUvec4() {
     if (!uvec4_zero_constants_) {
-        const Type& uint32_type = module_.type_manager_.GetTypeInt(32, false);
-        const Type& uvec4_type = module_.type_manager_.GetTypeVector(uint32_type, 4);
-        const uint32_t uint32_0_id = module_.type_manager_.GetConstantZeroUint32().Id();
+        const Type& uint32_type = GetTypeInt(32, false);
+        const Type& uvec4_type = GetTypeVector(uint32_type, 4);
+        const uint32_t uint32_0_id = GetConstantZeroUint32().Id();
 
         const uint32_t constant_id = module_.TakeNextId();
         auto new_inst = std::make_unique<Instruction>(7, spv::OpConstantComposite);

--- a/layers/gpuav/spirv/vertex_attribute_fetch_oob_pass.cpp
+++ b/layers/gpuav/spirv/vertex_attribute_fetch_oob_pass.cpp
@@ -62,7 +62,7 @@ bool VertexAttributeFetchOobPass::Instrument() {
             ++stage_info_inst_it;
 
             std::vector<uint32_t> index_validation_inst_words;
-            const uint32_t void_type = module_.type_manager_.GetTypeVoid().Id();
+            const uint32_t void_type = type_manager_.GetTypeVoid().Id();
             const uint32_t function_result = module_.TakeNextId();
             const uint32_t function_def = GetLinkFunctionId();
 


### PR DESCRIPTION
Going `module_.type_manager_.` is dumb and from original design... just going `type_manager_.` is easier and cleaner