### PR TITLE
printf: Improve user experience

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -590,7 +590,7 @@
                                 {
                                     "key": "printf_buffer_size",
                                     "label": "Printf buffer size",
-                                    "description": "Set the size in bytes of the buffer per draw/dispatch/traceRays to hold the messages",
+                                    "description": "Set the size in bytes of the buffer per VkCommandBuffer to hold the messages (Each message is about 50 bytes)",
                                     "type": "INT",
                                     "default": 1024,
                                     "range": {

--- a/layers/vk_layer_settings.txt
+++ b/layers/vk_layer_settings.txt
@@ -182,7 +182,7 @@ khronos_validation.object_lifetime = true
 
 # Printf buffer size
 # =====================
-# Set the size in bytes of the buffer per draw/dispatch/traceRays to hold the messages
+# Set the size in bytes of the buffer per VkCommandBuffer to hold the messages (Each message is about 50 bytes)
 khronos_validation.printf_buffer_size = 1024
 
 # Debug Printf

--- a/tests/unit/debug_printf.cpp
+++ b/tests/unit/debug_printf.cpp
@@ -3132,8 +3132,12 @@ TEST_F(NegativeDebugPrintf, ShaderObjectUnusedBoundDescriptor) {
 }
 
 TEST_F(NegativeDebugPrintf, OverflowBuffer) {
-    TEST_DESCRIPTION("go over the default VK_LAYER_PRINTF_BUFFER_SIZE limit");
-    RETURN_IF_SKIP(InitDebugPrintfFramework());
+    TEST_DESCRIPTION("go over the VK_LAYER_PRINTF_BUFFER_SIZE limit");
+    uint32_t value = 128;
+    const VkLayerSettingEXT settings = {OBJECT_LAYER_NAME, "printf_buffer_size", VK_LAYER_SETTING_TYPE_UINT32_EXT, 1, &value};
+    VkLayerSettingsCreateInfoEXT layer_settings_create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1,
+                                                               &settings};
+    RETURN_IF_SKIP(InitDebugPrintfFramework(&layer_settings_create_info));
     RETURN_IF_SKIP(InitState());
 
     const char *shader_source = R"glsl(
@@ -3154,15 +3158,19 @@ TEST_F(NegativeDebugPrintf, OverflowBuffer) {
     vk::CmdDispatch(m_command_buffer, 4, 4, 1);
     m_command_buffer.End();
 
-    m_errorMonitor->SetDesiredWarning(
-        "Debug Printf message was truncated due to a buffer size (1024) being too small for the messages");
+    m_errorMonitor->SetDesiredInfo("WorkGroup");  // actual message
+    m_errorMonitor->SetDesiredInfo("Debug Printf message was truncated");
     m_default_queue->SubmitAndWait(m_command_buffer);
     m_errorMonitor->VerifyFound();
 }
 
 TEST_F(NegativeDebugPrintf, OverflowBufferLoop) {
-    TEST_DESCRIPTION("go over the default VK_LAYER_PRINTF_BUFFER_SIZE limit... by a LOT");
-    RETURN_IF_SKIP(InitDebugPrintfFramework());
+    TEST_DESCRIPTION("go over the VK_LAYER_PRINTF_BUFFER_SIZE limit... by a LOT");
+    uint32_t value = 128;
+    const VkLayerSettingEXT settings = {OBJECT_LAYER_NAME, "printf_buffer_size", VK_LAYER_SETTING_TYPE_UINT32_EXT, 1, &value};
+    VkLayerSettingsCreateInfoEXT layer_settings_create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1,
+                                                               &settings};
+    RETURN_IF_SKIP(InitDebugPrintfFramework(&layer_settings_create_info));
     RETURN_IF_SKIP(InitState());
 
     const char *shader_source = R"glsl(
@@ -3185,8 +3193,8 @@ TEST_F(NegativeDebugPrintf, OverflowBufferLoop) {
     vk::CmdDispatch(m_command_buffer, 4, 4, 1);
     m_command_buffer.End();
 
-    m_errorMonitor->SetDesiredWarning(
-        "Debug Printf message was truncated due to a buffer size (1024) being too small for the messages");
+    m_errorMonitor->SetDesiredInfo("WorkGroup");  // actual message
+    m_errorMonitor->SetDesiredInfo("Debug Printf message was truncated");
     m_default_queue->SubmitAndWait(m_command_buffer);
     m_errorMonitor->VerifyFound();
 }


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11119

- The warning message was not being displayed, so now print to the Log/stdout 
- It provides what the new suggested buffer size should be