### PR TITLE
layers: Refactor semaphore LastOp usage (part 1)

### DIFF
--- a/layers/core_checks/cc_synchronization.h
+++ b/layers/core_checks/cc_synchronization.h
@@ -50,7 +50,12 @@ struct SemaphoreSubmitState {
 
     VkQueue AnotherQueueWaits(const vvl::Semaphore &semaphore_state) const;
 
-    bool ValidateBinaryWait(const Location &loc, VkQueue queue, const vvl::Semaphore &semaphore_state);
-    bool ValidateWaitSemaphore(const Location &wait_semaphore_loc, const vvl::Semaphore &semaphore_state, uint64_t value);
-    bool ValidateSignalSemaphore(const Location &signal_semaphore_loc, const vvl::Semaphore &semaphore_state, uint64_t value);
+    bool ValidateBinaryWait(const Location &semaphore_loc, const vvl::Semaphore &semaphore_state);
+    bool ValidateTimelineWait(const Location &semaphore_loc, const vvl::Semaphore &semaphore_state, uint64_t value);
+    bool ValidateWaitSemaphore(const Location &semaphore_loc, const vvl::Semaphore &semaphore_state, uint64_t value);
+
+
+    bool ValidateBinarySignal(const Location &semaphore_loc, const vvl::Semaphore &semaphore_state);
+    bool ValidateTimelineSignal(const Location &semaphore_loc, const vvl::Semaphore &semaphore_state, uint64_t value);
+    bool ValidateSignalSemaphore(const Location &semaphore_loc, const vvl::Semaphore &semaphore_state, uint64_t value);
 };


### PR DESCRIPTION
Replace some usages of `Semaphore::LastOp()` general search helper with context-aware functionality that does only what's needed.

The problem with generic helper is not only poor readability (collects logic from multiple scenarios and tries to represent as something unified). It is also the reason of poor performance in some cases. For example, without knowing the context we iterate over all timeline entries instead of accessing only the first/last entry or running a binary search.

The following refactors will replace the remainng LastOp usages.

Part of https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9264