### PR TITLE
layers: Add earlier check for invalid YCbCr

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -952,16 +952,9 @@ class CoreChecks : public vvl::DeviceProxy {
     bool ValidateShaderInterfaceVariable(const spirv::Module& module_state, const spirv::ResourceInterfaceVariable& variable,
                                          vvl::unordered_set<uint32_t>& descriptor_type_set, const Location& loc) const;
     bool ValidateShaderYcbcrSampler(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
-                                    const vvl::DescriptorSetLayoutList& all_dsl,
                                     const vvl::DescriptorSetLayout& descriptor_set_layout,
                                     const VkDescriptorSetLayoutBinding& binding, const spirv::ResourceInterfaceVariable& variable,
                                     const LogObjectList& objlist, const Location& loc) const;
-    bool ValidateShaderYcbcrSamplerAccess(const vvl::DescriptorSetLayout& descriptor_set_layout,
-                                          const VkDescriptorSetLayoutBinding& binding,
-                                          const spirv::ResourceInterfaceVariable& image_variable,
-                                          const spirv::ResourceInterfaceVariable* sampler_variable,
-                                          const YcbcrSamplerUsedByImage* sampler_info, const LogObjectList& objlist,
-                                          const Location& loc) const;
     bool ValidateShader64BitIndexing(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
                                      const ShaderStageState& stage_state, const vvl::Pipeline* pipeline, const Location& loc) const;
     bool ValidateTransformFeedbackPipeline(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,

--- a/layers/error_message/unimplementable_validation.h
+++ b/layers/error_message/unimplementable_validation.h
@@ -123,6 +123,14 @@ const char* unimplementable_validation[] = {
     "VUID-VkDescriptorAddressInfoEXT-address-parameter",
     "VUID-VkStridedDeviceAddressRangeKHR-address-parameter",
 
+    // These were added as a fix for https://gitlab.khronos.org/vulkan/vulkan/-/issues/4544
+    // But really the "real" fix is banning it earlier https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/7858
+    // These should be removed from the spec, as they are not needed/possible anymore,
+    // ... but that is an annoying challenge for the WG, so leaving them here
+    "VUID-RuntimeSpirv-OpTypeSampler-12203",
+    "VUID-RuntimeSpirv-OpTypeImage-12204",
+    "VUID-RuntimeSpirv-OpTypeImage-12207",
+
     // VUID-vkUpdateDescriptorSets-pDescriptorWrites-06238
     // VUID-vkUpdateDescriptorSets-pDescriptorWrites-06239
     // already covers these explicitly, this is just a left over generated VUID

--- a/layers/state_tracker/descriptor_set_layouts.cpp
+++ b/layers/state_tracker/descriptor_set_layouts.cpp
@@ -33,13 +33,4 @@ const vvl::DescriptorSetLayout *DescriptorSetLayoutList::FindFromVariable(const 
     return nullptr;
 }
 
-bool DescriptorSetLayoutList::HasYcbcrSamplers() const {
-    for (const auto &layout : list) {
-        if (layout && layout->HasYcbcrSamplers()) {
-            return true;
-        }
-    }
-    return false;
-}
-
 }  // namespace vvl

--- a/layers/state_tracker/descriptor_set_layouts.h
+++ b/layers/state_tracker/descriptor_set_layouts.h
@@ -35,8 +35,7 @@ struct DescriptorSetLayoutList {
 
   std::vector<std::shared_ptr<vvl::DescriptorSetLayout const>> list;
 
-  const vvl::DescriptorSetLayout* FindFromVariable(const spirv::ResourceInterfaceVariable &variable) const;
-  bool HasYcbcrSamplers() const;
+  const vvl::DescriptorSetLayout* FindFromVariable(const spirv::ResourceInterfaceVariable& variable) const;
 };
 
 }  // namespace vvl

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -2235,9 +2235,6 @@ ResourceInterfaceVariable::ResourceInterfaceVariable(const Module& module_state,
                     for (const Instruction* sampler_insn : image_access.variable_sampler_insn) {
                         const uint32_t sampler_variable_id = sampler_insn->ResultId();
 
-                        ycbcr_samplers_used_by_image.emplace(YcbcrSamplerUsedByImage{
-                            sampler_variable_id, image_access.image_access_chain_index, image_access.sampler_access_chain_index});
-
                         const auto& decoration_set = module_state.GetDecorationSet(sampler_variable_id);
                         samplers_used_by_image[image_index].emplace(
                             SamplerUsedByImage{DescriptorSlot{decoration_set.set, decoration_set.binding}, sampler_index});

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -424,8 +424,6 @@ struct ResourceInterfaceVariable : public VariableBase {
 
     // The index of vector is index of image. (TODO - this doesn't work for GPU-AV)
     std::vector<vvl::unordered_set<SamplerUsedByImage>> samplers_used_by_image;
-    // workaround for YCbCr to track sampler variables until |samplers_used_by_image| is fixed
-    vvl::unordered_set<YcbcrSamplerUsedByImage> ycbcr_samplers_used_by_image;
 
     // For storage images - list of Texel component length the OpImageWrite
     std::vector<uint32_t> write_without_formats_component_count_list;


### PR DESCRIPTION
follow up of https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/10958

Basically I wasted a bunch of effort and time because no one added a simple VU like https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/7858 to just ban SAMPLER from having YCbCr before we got the pipeline time

This removes a lot of tests I added that were not valid, and now are banned earlier at `vkCreateDescriptorSetLayout`... like they should have been for years

<img width="488" height="326" alt="image" src="https://github.com/user-attachments/assets/685d72fd-0292-40b7-b97b-50b0f828b249" />
