### PR TITLE
cmake: Only organize VS solution when UPDATE_DEPS=ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,7 +209,7 @@ endif()
 
 add_subdirectory(layers)
 
-if(MSVC)
+if(MSVC AND UPDATE_DEPS)
     set(SCRIPTS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/scripts")
     file(GLOB_RECURSE SCRIPTS
         "${SCRIPTS_DIR}/*.py"


### PR DESCRIPTION
The SDK build process does not use UPDATE_DEPS, which upsets the logic to organize the external dependencies into convenient folders in the Visual Studio solution. Since the SDK build does not care about such niceties, make this logic dependent on UPDATE_DEPS being true.