### PR TITLE
gpuav: Fix warning limit and preset

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -199,7 +199,7 @@
                         { "key": "gpuav_select_instrumented_shaders", "value": false },
                         { "key": "gpuav_buffers_validation", "value": true },
                         { "key": "validate_best_practices", "value": false },
-                        { "key": "report_flags", "value": [ "error" ] },
+                        { "key": "report_flags", "value": [ "error", "warn" ] },
                         { "key": "debug_action", "value": [ "VK_DBG_LAYER_ACTION_LOG_MSG", "VK_DBG_LAYER_ACTION_DEBUG_OUTPUT" ] },
                         { "key": "enable_message_limit", "value": true }
                     ]
@@ -226,7 +226,7 @@
                         { "key": "gpuav_enable", "value": false },
                         { "key": "printf_enable", "value": true },
                         { "key": "validate_best_practices", "value": false },
-                        { "key": "report_flags",  "value": [ "error", "info" ] },
+                        { "key": "report_flags",  "value": [ "error", "warn", "info" ] },
                         { "key": "debug_action",  "value": [] },
                         { "key": "enable_message_limit", "value": false }
                     ]

--- a/layers/error_message/logging.cpp
+++ b/layers/error_message/logging.cpp
@@ -118,7 +118,7 @@ bool DebugReport::LogMessage(VkFlags msg_flags, std::string_view vuid_text, cons
         // We want to print DebugPrintf message forever, otherwise user will mistake duplicate limit for things not printing
         (vuid_hash == 0x4fe1fef9) ||
         // GPU-AV gives lots of warnings on setup to inform user which settings we are adjusting under them
-        (vuid_hash == 0x24b5c69f);
+        (vuid_hash == 0x86fe6721);
 
     // This lock needs to be here, duplicate_message_count_map is not safe to update on multiple threads
     // see https://issues.angleproject.org/issues/450466850

--- a/tests/unit/others.cpp
+++ b/tests/unit/others.cpp
@@ -84,7 +84,7 @@ TEST_F(VkLayerTest, VuidHashStability) {
     ASSERT_TRUE(hash_util::VuidHash("VUID-RayTmaxKHR-RayTmaxKHR-04349") == 0x8e67514c);
     ASSERT_TRUE(hash_util::VuidHash("VUID-RuntimeSpirv-SubgroupUniformControlFlowKHR-06379") == 0x2f574188);
     ASSERT_TRUE(hash_util::VuidHash("VVL-DEBUG-PRINTF") == 0x4fe1fef9);
-    ASSERT_TRUE(hash_util::VuidHash("WARNING-GPU-Assisted-Validation") == 0x24b5c69f);
+    ASSERT_TRUE(hash_util::VuidHash("WARNING-Setting-Limit-Adjusted") == 0x86fe6721);
 }
 
 TEST_F(VkLayerTest, RequiredParameter) {


### PR DESCRIPTION
1. We recently renamed the warning to `WARNING-Setting-Limit-Adjusted`, this is the VUID we want to exclude from the limits (they all appear at device creation time)
2. Turn on `warning` for the DebugPrintf/GPU-AV presets, they are helpful