### PR TITLE
scripts: Remove debug command workaround

### DIFF
--- a/layers/vulkan/generated/command_validation.cpp
+++ b/layers/vulkan/generated/command_validation.cpp
@@ -1216,7 +1216,7 @@ static const vvl::unordered_map<Func, CommandValidationInfo> kCommandValidationT
     CommandScope::Both, kVUIDUndefined,
     CommandScope::Both, kVUIDUndefined,
     kVUIDUndefined,
-    false, false, false,
+    true, false, false,
 }},
 {Func::vkCmdDebugMarkerEndEXT, {
     "VUID-vkCmdDebugMarkerEndEXT-commandBuffer-recording",
@@ -1225,7 +1225,7 @@ static const vvl::unordered_map<Func, CommandValidationInfo> kCommandValidationT
     CommandScope::Both, kVUIDUndefined,
     CommandScope::Both, kVUIDUndefined,
     kVUIDUndefined,
-    false, false, false,
+    true, false, false,
 }},
 {Func::vkCmdDebugMarkerInsertEXT, {
     "VUID-vkCmdDebugMarkerInsertEXT-commandBuffer-recording",
@@ -1234,7 +1234,7 @@ static const vvl::unordered_map<Func, CommandValidationInfo> kCommandValidationT
     CommandScope::Both, kVUIDUndefined,
     CommandScope::Both, kVUIDUndefined,
     kVUIDUndefined,
-    false, false, false,
+    true, false, false,
 }},
 {Func::vkCmdBindTransformFeedbackBuffersEXT, {
     "VUID-vkCmdBindTransformFeedbackBuffersEXT-commandBuffer-recording",
@@ -1378,7 +1378,7 @@ static const vvl::unordered_map<Func, CommandValidationInfo> kCommandValidationT
     CommandScope::Both, kVUIDUndefined,
     CommandScope::Both, kVUIDUndefined,
     kVUIDUndefined,
-    false, false, false,
+    true, false, false,
 }},
 {Func::vkCmdEndDebugUtilsLabelEXT, {
     "VUID-vkCmdEndDebugUtilsLabelEXT-commandBuffer-recording",
@@ -1387,7 +1387,7 @@ static const vvl::unordered_map<Func, CommandValidationInfo> kCommandValidationT
     CommandScope::Both, kVUIDUndefined,
     CommandScope::Both, kVUIDUndefined,
     kVUIDUndefined,
-    false, false, false,
+    true, false, false,
 }},
 {Func::vkCmdInsertDebugUtilsLabelEXT, {
     "VUID-vkCmdInsertDebugUtilsLabelEXT-commandBuffer-recording",
@@ -1396,7 +1396,7 @@ static const vvl::unordered_map<Func, CommandValidationInfo> kCommandValidationT
     CommandScope::Both, kVUIDUndefined,
     CommandScope::Both, kVUIDUndefined,
     kVUIDUndefined,
-    false, false, false,
+    true, false, false,
 }},
 {Func::vkCmdInitializeGraphScratchMemoryAMDX, {
     "VUID-vkCmdInitializeGraphScratchMemoryAMDX-commandBuffer-recording",

--- a/scripts/generators/command_validation_generator.py
+++ b/scripts/generators/command_validation_generator.py
@@ -156,14 +156,6 @@ class CommandValidationOutputGenerator(BaseGenerator):
             is_action = 'true' if 'action' in command.tasks else 'false'
             is_synchronization = 'true' if 'synchronization' in command.tasks else 'false'
 
-            # These should not be marked as action/sync/state commands
-            # https://gitlab.khronos.org/vulkan/vulkan/-/issues/4558
-            if command.name in ['vkCmdBeginDebugUtilsLabelEXT','vkCmdEndDebugUtilsLabelEXT', 'vkCmdInsertDebugUtilsLabelEXT',
-                                'vkCmdDebugMarkerBeginEXT', 'vkCmdDebugMarkerEndEXT', 'vkCmdDebugMarkerInsertEXT']:
-                is_state = 'false'
-                is_action = 'false'
-                is_synchronization = 'false'
-
             vuid = 'kVUIDUndefined'
             if is_action == 'true' or is_synchronization == 'true':
                 vuid = getVUID(self.valid_vuids, f'VUID-{alias_name}-suspended')


### PR DESCRIPTION
discussed in https://gitlab.khronos.org/vulkan/vulkan/-/issues/4558 and the 1.4.335 headers/xml has the correct information now