### PR TITLE
gpuav: Fix lifetime management of desc set layout

### DIFF
--- a/layers/gpuav/core/gpuav.h
+++ b/layers/gpuav/core/gpuav.h
@@ -256,7 +256,7 @@ class Validator : public GpuShaderInstrumentor {
     // We find ourselves constantly needing to create some resource for the "lifetime of GPU-AV"
     // We don't want a messy global space to managae it and use this to allow each check to manage the resource where it is used.
     // The goal is the first time we need the resource, we create it then, and afterwards, its cached and we can regain
-    vko::SharedResourcesCache<true> shared_resources_manager;
+    vko::SharedResourcesCache<true> shared_resources_cache;
 
     PFN_vkSetDeviceLoaderData vk_set_device_loader_data_;
 

--- a/layers/gpuav/core/gpuav_record.cpp
+++ b/layers/gpuav/core/gpuav_record.cpp
@@ -255,10 +255,10 @@ void Instance::PostCallRecordGetPhysicalDeviceProperties2(VkPhysicalDevice physi
 // Clean up device-related resources
 void Validator::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks *pAllocator,
                                            const RecordObject &record_obj) {
-    // Need to destroy substate before memory backed in things like shared_resources_manager are cleared
+    // Need to destroy substate before memory backed in things like shared_resources_cache are cleared
     DestroySubstate();
 
-    shared_resources_manager.Clear();
+    shared_resources_cache.Clear();
 
     global_indices_buffer_.Destroy();
     global_resource_descriptor_buffer_.Destroy();

--- a/layers/gpuav/core/gpuav_setup.cpp
+++ b/layers/gpuav/core/gpuav_setup.cpp
@@ -46,39 +46,39 @@ void Validator::Created(vvl::CommandBuffer &cb_state) {
 void Validator::Created(vvl::Queue &queue) { queue.SetSubState(container_type, std::make_unique<QueueSubState>(*this, queue)); }
 
 void Validator::Created(vvl::Image &obj) {
-    DescriptorHeap &desc_heap = shared_resources_manager.Get<DescriptorHeap>();
+    DescriptorHeap &desc_heap = shared_resources_cache.Get<DescriptorHeap>();
     obj.SetSubState(container_type, std::make_unique<ImageSubState>(obj, desc_heap));
 }
 void Validator::Created(vvl::ImageView &obj) {
-    DescriptorHeap &desc_heap = shared_resources_manager.Get<DescriptorHeap>();
+    DescriptorHeap &desc_heap = shared_resources_cache.Get<DescriptorHeap>();
     obj.SetSubState(container_type, std::make_unique<ImageViewSubState>(obj, desc_heap));
 }
 void Validator::Created(vvl::Buffer &obj) {
-    DescriptorHeap &desc_heap = shared_resources_manager.Get<DescriptorHeap>();
+    DescriptorHeap &desc_heap = shared_resources_cache.Get<DescriptorHeap>();
     obj.SetSubState(container_type, std::make_unique<BufferSubState>(obj, desc_heap));
 }
 void Validator::Created(vvl::BufferView &obj) {
-    DescriptorHeap &desc_heap = shared_resources_manager.Get<DescriptorHeap>();
+    DescriptorHeap &desc_heap = shared_resources_cache.Get<DescriptorHeap>();
     obj.SetSubState(container_type, std::make_unique<BufferViewSubState>(obj, desc_heap));
 }
 void Validator::Created(vvl::Sampler &obj) {
-    DescriptorHeap &desc_heap = shared_resources_manager.Get<DescriptorHeap>();
+    DescriptorHeap &desc_heap = shared_resources_cache.Get<DescriptorHeap>();
     obj.SetSubState(container_type, std::make_unique<SamplerSubState>(obj, desc_heap));
 }
 void Validator::Created(vvl::AccelerationStructureNV &obj) {
-    DescriptorHeap &desc_heap = shared_resources_manager.Get<DescriptorHeap>();
+    DescriptorHeap &desc_heap = shared_resources_cache.Get<DescriptorHeap>();
     obj.SetSubState(container_type, std::make_unique<AccelerationStructureNVSubState>(obj, desc_heap));
 }
 void Validator::Created(vvl::AccelerationStructureKHR &obj) {
-    DescriptorHeap &desc_heap = shared_resources_manager.Get<DescriptorHeap>();
+    DescriptorHeap &desc_heap = shared_resources_cache.Get<DescriptorHeap>();
     obj.SetSubState(container_type, std::make_unique<AccelerationStructureKHRSubState>(obj, desc_heap));
 }
 void Validator::Created(vvl::Tensor &obj) {
-    DescriptorHeap &desc_heap = shared_resources_manager.Get<DescriptorHeap>();
+    DescriptorHeap &desc_heap = shared_resources_cache.Get<DescriptorHeap>();
     obj.SetSubState(container_type, std::make_unique<TensorSubState>(obj, desc_heap));
 }
 void Validator::Created(vvl::TensorView &obj) {
-    DescriptorHeap &desc_heap = shared_resources_manager.Get<DescriptorHeap>();
+    DescriptorHeap &desc_heap = shared_resources_cache.Get<DescriptorHeap>();
     obj.SetSubState(container_type, std::make_unique<TensorViewSubState>(obj, desc_heap));
 }
 void Validator::Created(vvl::ShaderObject &obj) { obj.SetSubState(container_type, std::make_unique<ShaderObjectSubState>(obj)); }

--- a/layers/gpuav/core/gpuav_validation_pipeline.h
+++ b/layers/gpuav/core/gpuav_validation_pipeline.h
@@ -69,9 +69,9 @@ void BindShaderResourcesHelper(Validator& gpuav, CommandBufferSubState& cb_state
 template <typename ShaderResources>
 class ComputePipeline {
   public:
-    ComputePipeline(Validator& gpuav, const Location& loc, VkDescriptorSetLayout additional_desc_set_layout = VK_NULL_HANDLE) {
+    ComputePipeline(Validator& gpuav, const Location& loc, VkDescriptorSetLayout error_logging_desc_set = VK_NULL_HANDLE) {
         std::vector<VkDescriptorSetLayoutBinding> specific_bindings = ShaderResources::GetDescriptorSetLayoutBindings();
-        valid = internal::CreateComputePipelineHelper(gpuav, loc, specific_bindings, additional_desc_set_layout,
+        valid = internal::CreateComputePipelineHelper(gpuav, loc, specific_bindings, error_logging_desc_set,
                                                       sizeof(ShaderResources::push_constants),
                                                       uint32_t(ShaderResources::GetSpirvSize()), ShaderResources::GetSpirv(),
                                                       device, specific_desc_set_layout, pipeline_layout, shader_module, pipeline);

--- a/layers/gpuav/instrumentation/descriptor_checks.cpp
+++ b/layers/gpuav/instrumentation/descriptor_checks.cpp
@@ -92,7 +92,7 @@ struct DescriptorChecksCbState {
 
 void DescriptorChecksOnFinishDeviceSetup(Validator& gpuav) {
     if (!gpuav.gpuav_settings.shader_instrumentation.descriptor_checks) {
-        gpuav.shared_resources_manager.GetOrCreate<DescriptorHeap>(gpuav, 0);
+        gpuav.shared_resources_cache.GetOrCreate<DescriptorHeap>(gpuav, 0);
         return;
     }
 
@@ -105,7 +105,7 @@ void DescriptorChecksOnFinishDeviceSetup(Validator& gpuav) {
         num_descs = glsl::kDebugInputBindlessMaxDescriptors;
     }
 
-    gpuav.shared_resources_manager.GetOrCreate<DescriptorHeap>(gpuav, num_descs);
+    gpuav.shared_resources_cache.GetOrCreate<DescriptorHeap>(gpuav, num_descs);
 }
 
 void RegisterDescriptorChecksValidation(Validator& gpuav, CommandBufferSubState& cb) {
@@ -123,7 +123,7 @@ void RegisterDescriptorChecksValidation(Validator& gpuav, CommandBufferSubState&
             dc_cb_state.last_bound_desc_sets_state_ssbo.Clear();
             auto desc_state_ssbo =
                 static_cast<glsl::BoundDescriptorSetsStateSSBO*>(dc_cb_state.last_bound_desc_sets_state_ssbo.offset_mapped_ptr);
-            desc_state_ssbo->descriptor_init_status = gpuav.shared_resources_manager.Get<DescriptorHeap>().GetDeviceAddress();
+            desc_state_ssbo->descriptor_init_status = gpuav.shared_resources_cache.Get<DescriptorHeap>().GetDeviceAddress();
 
             for (size_t bound_ds_i = 0; bound_ds_i < desc_binding_cmd.bound_descriptor_sets.size(); ++bound_ds_i) {
                 auto& bound_ds = desc_binding_cmd.bound_descriptor_sets[bound_ds_i];

--- a/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
@@ -423,7 +423,7 @@ void UpdateInstrumentationDescSet(Validator &gpuav, CommandBufferSubState &cb_st
                 vertex_attribute_fetch_limits_buffer_bi.range = vertex_attribute_fetch_limits_buffer_range.size;
             } else {
                 // Point all non-indexed draws to our global buffer that will bypass the check in shader
-                VertexAttributeFetchOff &resource = gpuav.shared_resources_manager.GetOrCreate<VertexAttributeFetchOff>(gpuav);
+                VertexAttributeFetchOff &resource = gpuav.shared_resources_cache.GetOrCreate<VertexAttributeFetchOff>(gpuav);
                 if (!resource.valid) return;
                 vertex_attribute_fetch_limits_buffer_bi.buffer = resource.buffer.VkHandle();
                 vertex_attribute_fetch_limits_buffer_bi.offset = 0;

--- a/layers/gpuav/validation_cmd/gpuav_copy_buffer_to_image.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_copy_buffer_to_image.cpp
@@ -88,11 +88,11 @@ void CopyBufferToImage(Validator &gpuav, const Location &loc, CommandBufferSubSt
         return;
     }
 
-    ValidationCommandsCommon &val_cmd_common =
-        cb_state.shared_resources_cache.GetOrCreate<ValidationCommandsCommon>(gpuav, cb_state, loc);
+    ValidationCommandsGpuavState &val_cmd_gpuav_state =
+        gpuav.shared_resources_cache.GetOrCreate<ValidationCommandsGpuavState>(gpuav, loc);
     valpipe::ComputePipeline<CopyBufferToImageValidationShader> &validation_pipeline =
-        gpuav.shared_resources_manager.GetOrCreate<valpipe::ComputePipeline<CopyBufferToImageValidationShader>>(
-            gpuav, loc, val_cmd_common.error_logging_desc_set_layout_);
+        gpuav.shared_resources_cache.GetOrCreate<valpipe::ComputePipeline<CopyBufferToImageValidationShader>>(
+            gpuav, loc, val_cmd_gpuav_state.error_logging_desc_set_layout_);
     if (!validation_pipeline.valid) {
         gpuav.InternalError(cb_state.VkHandle(), loc, "Failed to create CopyBufferToImageValidationShader.");
         return;

--- a/layers/gpuav/validation_cmd/gpuav_copy_memory_indirect.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_copy_memory_indirect.cpp
@@ -74,11 +74,11 @@ void CopyMemoryIndirect(Validator &gpuav, const Location &loc, CommandBufferSubS
         return;
     }
 
-    ValidationCommandsCommon &val_cmd_common =
-        cb_state.shared_resources_cache.GetOrCreate<ValidationCommandsCommon>(gpuav, cb_state, loc);
+    ValidationCommandsGpuavState &val_cmd_gpuav_state =
+        gpuav.shared_resources_cache.GetOrCreate<ValidationCommandsGpuavState>(gpuav, loc);
     valpipe::ComputePipeline<CopyMemoryIndirectValidationShader> &validation_pipeline =
-        gpuav.shared_resources_manager.GetOrCreate<valpipe::ComputePipeline<CopyMemoryIndirectValidationShader>>(
-            gpuav, loc, val_cmd_common.error_logging_desc_set_layout_);
+        gpuav.shared_resources_cache.GetOrCreate<valpipe::ComputePipeline<CopyMemoryIndirectValidationShader>>(
+            gpuav, loc, val_cmd_gpuav_state.error_logging_desc_set_layout_);
     if (!validation_pipeline.valid) {
         gpuav.InternalError(cb_state.VkHandle(), loc, "Failed to create CopyMemoryIndirectValidationShader.");
         return;

--- a/layers/gpuav/validation_cmd/gpuav_dispatch.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_dispatch.cpp
@@ -59,12 +59,11 @@ void DispatchIndirect(Validator &gpuav, const Location &loc, CommandBufferSubSta
         return;
     }
 
-    ValidationCommandsCommon &val_cmd_common =
-        cb_state.shared_resources_cache.GetOrCreate<ValidationCommandsCommon>(gpuav, cb_state, loc);
-
+    ValidationCommandsGpuavState &val_cmd_gpuav_state =
+        gpuav.shared_resources_cache.GetOrCreate<ValidationCommandsGpuavState>(gpuav, loc);
     valpipe::ComputePipeline<DispatchValidationShader> &validation_pipeline =
-        gpuav.shared_resources_manager.GetOrCreate<valpipe::ComputePipeline<DispatchValidationShader>>(
-            gpuav, loc, val_cmd_common.error_logging_desc_set_layout_);
+        gpuav.shared_resources_cache.GetOrCreate<valpipe::ComputePipeline<DispatchValidationShader>>(
+            gpuav, loc, val_cmd_gpuav_state.error_logging_desc_set_layout_);
     if (!validation_pipeline.valid) {
         gpuav.InternalError(cb_state.VkHandle(), loc, "Failed to create DispatchValidationShader.");
         return;

--- a/layers/gpuav/validation_cmd/gpuav_draw.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_draw.cpp
@@ -133,16 +133,16 @@ void FirstInstance(Validator &gpuav, CommandBufferSubState &cb_state, const Loca
                                             error_logger_i = cb_state.GetErrorLoggerIndex(),
                                             loc](Validator &gpuav, CommandBufferSubState &cb_state) {
         SharedDrawValidationResources &shared_draw_validation_resources =
-            gpuav.shared_resources_manager.GetOrCreate<SharedDrawValidationResources>(gpuav);
+            gpuav.shared_resources_cache.GetOrCreate<SharedDrawValidationResources>(gpuav);
         if (!shared_draw_validation_resources.valid) {
             gpuav.InternalError(cb_state.VkHandle(), loc, "Failed to create SharedDrawValidationResources.");
             return;
         }
-        ValidationCommandsCommon &val_cmd_common =
-            cb_state.shared_resources_cache.GetOrCreate<ValidationCommandsCommon>(gpuav, cb_state, loc);
+        ValidationCommandsGpuavState &val_cmd_gpuav_state =
+            gpuav.shared_resources_cache.GetOrCreate<ValidationCommandsGpuavState>(gpuav, loc);
         valpipe::ComputePipeline<FirstInstanceValidationShader> &validation_pipeline =
-            gpuav.shared_resources_manager.GetOrCreate<valpipe::ComputePipeline<FirstInstanceValidationShader>>(
-                gpuav, loc, val_cmd_common.error_logging_desc_set_layout_);
+            gpuav.shared_resources_cache.GetOrCreate<valpipe::ComputePipeline<FirstInstanceValidationShader>>(
+                gpuav, loc, val_cmd_gpuav_state.error_logging_desc_set_layout_);
         if (!validation_pipeline.valid) {
             gpuav.InternalError(cb_state.VkHandle(), loc, "Failed to create FirstInstanceValidationShader.");
             return;
@@ -327,17 +327,16 @@ void CountBuffer(Validator &gpuav, CommandBufferSubState &cb_state, const Locati
                                             draw_i = cb_state.draw_index, error_logger_i = cb_state.GetErrorLoggerIndex(),
                                             loc](Validator &gpuav, CommandBufferSubState &cb_state) {
         SharedDrawValidationResources &shared_draw_validation_resources =
-            gpuav.shared_resources_manager.GetOrCreate<SharedDrawValidationResources>(gpuav);
+            gpuav.shared_resources_cache.GetOrCreate<SharedDrawValidationResources>(gpuav);
         if (!shared_draw_validation_resources.valid) {
             gpuav.InternalError(cb_state.VkHandle(), loc, "Failed to create SharedDrawValidationResources.");
             return;
         }
-        ValidationCommandsCommon &val_cmd_common =
-            cb_state.shared_resources_cache.GetOrCreate<ValidationCommandsCommon>(gpuav, cb_state, loc);
-
+        ValidationCommandsGpuavState &val_cmd_gpuav_state =
+            gpuav.shared_resources_cache.GetOrCreate<ValidationCommandsGpuavState>(gpuav, loc);
         valpipe::ComputePipeline<CountBufferValidationShader> &validation_pipeline =
-            gpuav.shared_resources_manager.GetOrCreate<valpipe::ComputePipeline<CountBufferValidationShader>>(
-                gpuav, loc, val_cmd_common.error_logging_desc_set_layout_);
+            gpuav.shared_resources_cache.GetOrCreate<valpipe::ComputePipeline<CountBufferValidationShader>>(
+                gpuav, loc, val_cmd_gpuav_state.error_logging_desc_set_layout_);
         if (!validation_pipeline.valid) {
             gpuav.InternalError(cb_state.VkHandle(), loc, "Failed to create CountBufferValidationShader.");
             return;
@@ -485,16 +484,16 @@ void DrawMeshIndirect(Validator &gpuav, CommandBufferSubState &cb_state, const L
          api_count_buffer_offset, api_draw_count, is_task_shader, draw_i = cb_state.draw_index,
          error_logger_i = cb_state.GetErrorLoggerIndex(), loc](Validator &gpuav, CommandBufferSubState &cb_state) {
             SharedDrawValidationResources &shared_draw_validation_resources =
-                gpuav.shared_resources_manager.GetOrCreate<SharedDrawValidationResources>(gpuav);
+                gpuav.shared_resources_cache.GetOrCreate<SharedDrawValidationResources>(gpuav);
             if (!shared_draw_validation_resources.valid) {
                 gpuav.InternalError(cb_state.VkHandle(), loc, "Failed to create SharedDrawValidationResources.");
                 return;
             }
-            ValidationCommandsCommon &val_cmd_common =
-                cb_state.shared_resources_cache.GetOrCreate<ValidationCommandsCommon>(gpuav, cb_state, loc);
+            ValidationCommandsGpuavState &val_cmd_gpuav_state =
+                gpuav.shared_resources_cache.GetOrCreate<ValidationCommandsGpuavState>(gpuav, loc);
             valpipe::ComputePipeline<MeshValidationShader> &validation_pipeline =
-                gpuav.shared_resources_manager.GetOrCreate<valpipe::ComputePipeline<MeshValidationShader>>(
-                    gpuav, loc, val_cmd_common.error_logging_desc_set_layout_);
+                gpuav.shared_resources_cache.GetOrCreate<valpipe::ComputePipeline<MeshValidationShader>>(
+                    gpuav, loc, val_cmd_gpuav_state.error_logging_desc_set_layout_);
             if (!validation_pipeline.valid) {
                 gpuav.InternalError(cb_state.VkHandle(), loc, "Failed to create MeshValidationShader.");
                 return;
@@ -782,22 +781,22 @@ void DrawIndexedIndirectIndexBuffer(Validator &gpuav, CommandBufferSubState &cb_
                                             draw_i = cb_state.draw_index, error_logger_i = cb_state.GetErrorLoggerIndex(),
                                             loc](Validator &gpuav, CommandBufferSubState &cb_state) {
         SharedDrawValidationResources &shared_draw_validation_resources =
-            gpuav.shared_resources_manager.GetOrCreate<SharedDrawValidationResources>(gpuav);
+            gpuav.shared_resources_cache.GetOrCreate<SharedDrawValidationResources>(gpuav);
         if (!shared_draw_validation_resources.valid) {
             gpuav.InternalError(cb_state.VkHandle(), loc, "Failed to create SharedDrawValidationResources.");
             return;
         }
         valpipe::ComputePipeline<SetupDrawCountDispatchIndirectShader> &setup_validation_dispatch_pipeline =
-            gpuav.shared_resources_manager.GetOrCreate<valpipe::ComputePipeline<SetupDrawCountDispatchIndirectShader>>(gpuav, loc);
+            gpuav.shared_resources_cache.GetOrCreate<valpipe::ComputePipeline<SetupDrawCountDispatchIndirectShader>>(gpuav, loc);
         if (!setup_validation_dispatch_pipeline.valid) {
             gpuav.InternalError(cb_state.VkHandle(), loc, "Failed to create SetupDrawCountDispatchIndirectShader.");
             return;
         }
-        ValidationCommandsCommon &val_cmd_common =
-            cb_state.shared_resources_cache.GetOrCreate<ValidationCommandsCommon>(gpuav, cb_state, loc);
+        ValidationCommandsGpuavState &val_cmd_gpuav_state =
+            gpuav.shared_resources_cache.GetOrCreate<ValidationCommandsGpuavState>(gpuav, loc);
         valpipe::ComputePipeline<DrawIndexedIndirectIndexBufferShader> &validation_pipeline =
-            gpuav.shared_resources_manager.GetOrCreate<valpipe::ComputePipeline<DrawIndexedIndirectIndexBufferShader>>(
-                gpuav, loc, val_cmd_common.error_logging_desc_set_layout_);
+            gpuav.shared_resources_cache.GetOrCreate<valpipe::ComputePipeline<DrawIndexedIndirectIndexBufferShader>>(
+                gpuav, loc, val_cmd_gpuav_state.error_logging_desc_set_layout_);
         if (!validation_pipeline.valid) {
             gpuav.InternalError(cb_state.VkHandle(), loc, "Failed to create DrawIndexedIndirectIndexBufferShader.");
             return;

--- a/layers/gpuav/validation_cmd/gpuav_validation_cmd_common.h
+++ b/layers/gpuav/validation_cmd/gpuav_validation_cmd_common.h
@@ -54,12 +54,23 @@ template <typename ShaderResources>
     return true;
 }
 
-class ValidationCommandsCommon {
+class ValidationCommandsGpuavState {
   public:
-    ValidationCommandsCommon(Validator& gpuav, CommandBufferSubState& cb, const Location& loc);
-    ~ValidationCommandsCommon();
+    ValidationCommandsGpuavState(Validator& gpuav, const Location& loc);
+    ~ValidationCommandsGpuavState();
 
     VkDescriptorSetLayout error_logging_desc_set_layout_ = VK_NULL_HANDLE;
+
+  private:
+    Validator& gpuav_;
+};
+
+class ValidationCommandsCbState {
+  public:
+    ValidationCommandsCbState(Validator& gpuav, CommandBufferSubState& cb, VkDescriptorSetLayout error_logging_desc_set_layout,
+                              const Location& loc);
+    ~ValidationCommandsCbState();
+
     VkDescriptorSet error_logging_desc_set_ = VK_NULL_HANDLE;
     VkDescriptorPool validation_cmd_desc_pool_ = VK_NULL_HANDLE;
 


### PR DESCRIPTION
Descriptor set layout describing error logging resources was allocated per command buffer, but used in the validation pipelines created once per device when creating its pipeline layout. => Resetting command buffer state would destroy the descriptor set layout, invalidating the pipeline layout.
Descriptor set layout lifetime is now tied to that of the device.