### PR TITLE
layers: Clean up semaphore state

### DIFF
--- a/layers/core_checks/cc_submit.cpp
+++ b/layers/core_checks/cc_submit.cpp
@@ -56,7 +56,7 @@ void QueueSubmissionValidator::Validate(const vvl::QueueSubmission& submission) 
     // Ensure that timeline signals are monotonically increasing values
     for (uint32_t i = 0; i < (uint32_t)submission.signal_semaphores.size(); ++i) {
         const auto& signal = submission.signal_semaphores[i];
-        const uint64_t current_payload = signal.semaphore->CompletedPayload();
+        const uint64_t current_payload = signal.semaphore->CurrentPayload();
 
         // Check only the case where the signal value is less than the current payload.
         // Equality (also invalid) is handled during QueueSubmit. We can do such an early

--- a/layers/core_checks/cc_synchronization.h
+++ b/layers/core_checks/cc_synchronization.h
@@ -45,8 +45,9 @@ struct SemaphoreSubmitState {
     bool CanWaitBinary(const vvl::Semaphore &semaphore_state) const;
     bool CanSignalBinary(const vvl::Semaphore &semaphore_state, VkQueue &other_queue, vvl::Func &other_acquire_command) const;
 
-    bool CheckTimelineMaxDiff(const vvl::Semaphore &semaphore_state, uint64_t value, std::string &where, uint64_t &bad_value);
-    bool CheckTimelineSignalValue(const vvl::Semaphore &semaphore_state, uint64_t value, std::string &where, uint64_t &bad_value);
+    std::optional<uint64_t> CheckTimelineMaxDiff(const vvl::Semaphore &semaphore_state, uint64_t value, const char *&payload_type);
+    std::optional<uint64_t> CheckTimelineSignalTooSmall(const vvl::Semaphore &semaphore_state, uint64_t value,
+                                                        const char *&payload_type);
 
     VkQueue AnotherQueueWaits(const vvl::Semaphore &semaphore_state) const;
 


### PR DESCRIPTION
Recent semaphore performance fixes created opportunities to further simplify and clean up semaphore state tracking.