### PR TITLE
layers: Make set layout canonical ids a device state

### DIFF
--- a/layers/chassis/chassis_manual.cpp
+++ b/layers/chassis/chassis_manual.cpp
@@ -418,15 +418,6 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice gpu, const VkDevice
         vo->FinishDeviceSetup(modified_create_info.ptr(), record_obj.location);
     }
 
-    // Clear global dictionary that stores canonical ids of descriptor set layouts.
-    //
-    // NOTE: we also have the following global dicts related to pipeline layout that do not cause
-    // troubles yet, but in case of issues or part of effort of removing globals they should be considered:
-    //   pipeline_layout_set_layouts_dict
-    //   pipeline_layout_compat_dict
-    //   push_constant_ranges_dict
-    ClearDescriptorSetLayoutCanonicalIdDict();
-
     return result;
 }
 

--- a/layers/state_tracker/descriptor_sets.cpp
+++ b/layers/state_tracker/descriptor_sets.cpp
@@ -197,15 +197,6 @@ using DescriptorSetLayout = vvl::DescriptorSetLayout;
 using DescriptorSetLayoutDef = vvl::DescriptorSetLayoutDef;
 using DescriptorSetLayoutId = vvl::DescriptorSetLayoutId;
 
-// Canonical dictionary of DescriptorSetLayoutDef (without any handle/device specific information)
-vvl::DescriptorSetLayoutDict descriptor_set_layout_dict;
-
-static DescriptorSetLayoutId GetCanonicalId(const VkDescriptorSetLayoutCreateInfo *p_create_info, vvl::DeviceState &device_state) {
-    return descriptor_set_layout_dict.LookUp(DescriptorSetLayoutDef(device_state, p_create_info));
-}
-
-void ClearDescriptorSetLayoutCanonicalIdDict() { descriptor_set_layout_dict.Clear(); }
-
 std::string DescriptorSetLayoutDef::DescribeDifference(uint32_t index, const DescriptorSetLayoutDef &other) const {
     std::ostringstream ss;
     ss << "Set " << index << " ";
@@ -599,7 +590,7 @@ bool vvl::DescriptorSetLayout::IsCompatible(DescriptorSetLayout const *rh_ds_lay
 vvl::DescriptorSetLayout::DescriptorSetLayout(vvl::DeviceState &device_state, const VkDescriptorSetLayoutCreateInfo *pCreateInfo,
                                               const VkDescriptorSetLayout handle)
     : StateObject(handle, kVulkanObjectTypeDescriptorSetLayout),
-      layout_id_(GetCanonicalId(pCreateInfo, device_state)),
+      layout_id_(device_state.GetCanonicalId(pCreateInfo)),
       desc_set_layout_ci(pCreateInfo) {
     const bool is_descriptor_buffer = (pCreateInfo->flags & VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT) != 0;
     if (is_descriptor_buffer) {

--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -34,10 +34,6 @@
 class CoreChecks;
 struct DeviceExtensions;
 
-// TODO: there was a problem that global state persisted between test runs on CI machines.
-// Ideally is too rework these dictionaries so they are not global and part of state tracker.
-void ClearDescriptorSetLayoutCanonicalIdDict();
-
 namespace vvl {
 class Sampler;
 class DescriptorSet;

--- a/layers/state_tracker/pipeline_layout_state.cpp
+++ b/layers/state_tracker/pipeline_layout_state.cpp
@@ -23,6 +23,17 @@
 #include "state_tracker/state_tracker.h"
 #include "state_tracker/descriptor_sets.h"
 
+// NOTE: The following canonical id dictionaries are global and thread-safe objects:
+//      pipeline_layout_set_layouts_dict
+//      pipeline_layout_compat_dict
+//      push_constant_ranges_dict
+//
+// So far we did not have any issues with them. However, we had issues with DescriptorSetLayoutId
+// canonical ids (can survice between test sessions and then incorrectly accessed by another device).
+// That issue was solved by making DescriptorSetLayoutId dictionary local to DeviceState
+// (DeviceState::descriptor_set_layout_canonical_ids_). If there are any issues with these global
+// maps consider making them per-device or per-instance state.
+
 // Dictionary of canonical form of the pipeline set layout of descriptor set layouts
 static PipelineLayoutSetLayoutsDict pipeline_layout_set_layouts_dict;
 

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -32,7 +32,6 @@
 #include "state_tracker/tensor_state.h"
 #include "state_tracker/device_state.h"
 #include "state_tracker/queue_state.h"
-#include "state_tracker/descriptor_sets.h"
 #include "state_tracker/cmd_buffer_state.h"
 #include "state_tracker/pipeline_state.h"
 #include "state_tracker/render_pass_state.h"
@@ -147,6 +146,10 @@ std::vector<std::shared_ptr<const ImageView>> DeviceState::GetAttachmentViews(co
                                                                               const Framebuffer &fb_state) const {
     auto get_fn = [this](VkImageView handle) { return this->Get<ImageView>(handle); };
     return GetAttachmentViewsImpl<std::shared_ptr<const ImageView>>(rp_begin, fb_state, get_fn);
+}
+
+DescriptorSetLayoutId DeviceState::GetCanonicalId(const VkDescriptorSetLayoutCreateInfo *p_create_info) {
+    return descriptor_set_layout_canonical_ids_.LookUp(DescriptorSetLayoutDef(*this, p_create_info));
 }
 
 #ifdef VK_USE_PLATFORM_ANDROID_KHR

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -23,6 +23,7 @@
 #include <vulkan/vulkan_core.h>
 #include "chassis/validation_object.h"
 #include "utils/hash_vk_types.h"
+#include "state_tracker/descriptor_sets.h"      // DescriptorSetLayoutDict can't be forward declared
 #include "state_tracker/video_session_state.h"  // TODO - Remove from this header
 #include "state_tracker/special_supported.h"
 #include "device_state.h"
@@ -1910,6 +1911,9 @@ class DeviceState : public vvl::base::Device {
         return {};
     }
 
+    // Get device-specific canonical id for the provided set layout definition
+    DescriptorSetLayoutId GetCanonicalId(const VkDescriptorSetLayoutCreateInfo* p_create_info);
+
     // the VK_EXTERNAL_*_HANDLE_TYPE_OPAQUE_* handles are designed to created/exported in Vulkan, that means we can track the
     // values and compare when re-importing later. While FD and Win32 have differnt handles to access the struct, the information
     // needed is non-platform specific Vulkan values.
@@ -2015,6 +2019,9 @@ class DeviceState : public vvl::base::Device {
     // Keep track of identifier -> state
     vvl::unordered_map<VkShaderModuleIdentifierEXT, std::shared_ptr<vvl::ShaderModule>> shader_identifier_map_;
     mutable std::shared_mutex shader_identifier_map_lock_;
+
+    // Canonical ids of the set layouts created from *this* device.
+    vvl::DescriptorSetLayoutDict descriptor_set_layout_canonical_ids_;
 
     // If vkGetMemoryFdKHR is called, keep track of fd handle -> allocation info
     vvl::unordered_map<int, ExternalOpaqueInfo> fd_handle_map_;


### PR DESCRIPTION
This solution is applied only to `DescriptorSetLayoutId` canonical ids and replaces the previous solution where we manually cleared global map, which affected other devices and instances.

Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11204