### PR TITLE
sync: Add original access flags to barrier message

### DIFF
--- a/layers/sync/sync_barrier.cpp
+++ b/layers/sync/sync_barrier.cpp
@@ -168,8 +168,10 @@ SyncBarrier::SyncBarrier(const SyncExecScope &src_exec, VkAccessFlags2 src_acces
                          VkAccessFlags2 dst_access_mask)
     : src_exec_scope(src_exec),
       src_access_scope(AccessScope(src_exec.valid_accesses, src_access_mask)),
+      original_src_access(src_access_mask),
       dst_exec_scope(dst_exec),
-      dst_access_scope(AccessScope(dst_exec.valid_accesses, dst_access_mask)) {}
+      dst_access_scope(AccessScope(dst_exec.valid_accesses, dst_access_mask)),
+      original_dst_access(dst_access_mask) {}
 
 SyncBarrier::SyncBarrier(VkQueueFlags queue_flags, const VkSubpassDependency2 &subpass) {
     const auto barrier = vku::FindStructInPNextChain<VkMemoryBarrier2>(subpass.pNext);
@@ -177,18 +179,22 @@ SyncBarrier::SyncBarrier(VkQueueFlags queue_flags, const VkSubpassDependency2 &s
         auto src = SyncExecScope::MakeSrc(queue_flags, barrier->srcStageMask);
         src_exec_scope = src;
         src_access_scope = AccessScope(src.valid_accesses, barrier->srcAccessMask);
+        original_src_access = barrier->srcAccessMask;
 
         auto dst = SyncExecScope::MakeDst(queue_flags, barrier->dstStageMask);
         dst_exec_scope = dst;
         dst_access_scope = AccessScope(dst.valid_accesses, barrier->dstAccessMask);
+        original_dst_access = barrier->dstAccessMask;
     } else {
         auto src = SyncExecScope::MakeSrc(queue_flags, subpass.srcStageMask);
         src_exec_scope = src;
         src_access_scope = AccessScope(src.valid_accesses, subpass.srcAccessMask);
+        original_src_access = subpass.srcAccessMask;
 
         auto dst = SyncExecScope::MakeDst(queue_flags, subpass.dstStageMask);
         dst_exec_scope = dst;
         dst_access_scope = AccessScope(dst.valid_accesses, subpass.dstAccessMask);
+        original_dst_access = subpass.dstAccessMask;
     }
 }
 

--- a/layers/sync/sync_barrier.h
+++ b/layers/sync/sync_barrier.h
@@ -43,8 +43,11 @@ struct SyncBarrier {
     struct AllAccess {};
     SyncExecScope src_exec_scope;
     SyncAccessFlags src_access_scope;
+    VkAccessFlags2 original_src_access = VK_ACCESS_2_NONE;
+
     SyncExecScope dst_exec_scope;
     SyncAccessFlags dst_access_scope;
+    VkAccessFlags2 original_dst_access = VK_ACCESS_2_NONE;
 
     SyncBarrier() = default;
     SyncBarrier(const SyncExecScope &src_exec, const SyncExecScope &dst_exec);

--- a/layers/sync/sync_error_messages.cpp
+++ b/layers/sync/sync_error_messages.cpp
@@ -415,12 +415,10 @@ std::string ErrorMessages::ImageBarrierError(const HazardResult& hazard, const C
 
     std::stringstream ss;
     ss << "\npImageMemoryBarriers[" << barrier.barrier_index << "]: {\n";
-    ss << "  source accesses = "
-       << FormatSyncAccesses(barrier.barrier.src_access_scope, context.GetSyncState(), context.GetQueueFlags(), false) << ",\n";
-    ss << "  destination accesses = "
-       << FormatSyncAccesses(barrier.barrier.dst_access_scope, context.GetSyncState(), context.GetQueueFlags(), false) << ",\n";
     ss << "  srcStageMask = " << string_VkPipelineStageFlags2(barrier.barrier.src_exec_scope.mask_param) << ",\n";
+    ss << "  srcAccessMask = " << string_VkAccessFlags2(barrier.barrier.original_src_access) << ",\n";
     ss << "  dstStageMask = " << string_VkPipelineStageFlags2(barrier.barrier.dst_exec_scope.mask_param) << ",\n";
+    ss << "  dstAccessMask = " << string_VkAccessFlags2(barrier.barrier.original_dst_access) << ",\n";
     ss << "}\n";
     additional_info.message_end_text = ss.str();
 


### PR DESCRIPTION
Had to do this long time ago. Will add a test later during the week.

Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9773
