### PR TITLE
layers: Fix getting same pNext twice

### DIFF
--- a/layers/core_checks/cc_image_layout.cpp
+++ b/layers/core_checks/cc_image_layout.cpp
@@ -598,10 +598,8 @@ bool CoreChecks::ValidateFramebufferAndRenderPassLayouts(const vvl::CommandBuffe
         // If a separate layout is specified, look for that.
         const auto *attachment_desc_stencil_layout =
             vku::FindStructInPNextChain<VkAttachmentDescriptionStencilLayout>(render_pass_info->pAttachments[i].pNext);
-        if (const auto *attachment_description_stencil_layout =
-                vku::FindStructInPNextChain<VkAttachmentDescriptionStencilLayout>(render_pass_info->pAttachments[i].pNext);
-            attachment_description_stencil_layout) {
-            attachment_stencil_initial_layout = attachment_description_stencil_layout->stencilInitialLayout;
+        if (attachment_desc_stencil_layout) {
+            attachment_stencil_initial_layout = attachment_desc_stencil_layout->stencilInitialLayout;
         }
 
         std::shared_ptr<const CommandBufferImageLayoutMap> image_layout_map;


### PR DESCRIPTION
We were getting
`vku::FindStructInPNextChain<VkAttachmentDescriptionStencilLayout>(render_pass_info->pAttachments[i].pNext)`
twice for no reason.

It is also used below, so it should be outside of the if