### PR TITLE
bp: Remove noise for extension special case

### DIFF
--- a/layers/best_practices/bp_instance_device.cpp
+++ b/layers/best_practices/bp_instance_device.cpp
@@ -27,6 +27,8 @@ bool bp_state::Instance::ValidateSpecialUseExtensions(const Location& loc, vvl::
     bool skip = false;
     const std::string special_uses = GetSpecialUse(extension);
 
+    // We don't report "devtools" or "debugging" because if the user is using the validation layers, they likely want these
+    // extensions and giving a warning/info about it is just noise.
     if (!special_uses.empty()) {
         const char* const format =
             "Attempting to enable extension %s, but this extension is intended to support %s "
@@ -39,12 +41,6 @@ bool bp_state::Instance::ValidateSpecialUseExtensions(const Location& loc, vvl::
         if (special_uses.find("d3demulation") != std::string::npos) {
             skip |= LogWarning(vuid, instance, loc, format, String(extension),
                                "D3D emulation layers, and applications ported from D3D, by adding functionality specific to D3D");
-        }
-        if (special_uses.find("devtools") != std::string::npos) {
-            skip |= LogWarning(vuid, instance, loc, format, String(extension), "developer tools such as capture-replay libraries");
-        }
-        if (special_uses.find("debugging") != std::string::npos) {
-            skip |= LogWarning(vuid, instance, loc, format, String(extension), "use by applications when debugging");
         }
         if (special_uses.find("glemulation") != std::string::npos) {
             skip |= LogWarning(

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -225,8 +225,8 @@ VkPhysicalDeviceProperties2 VkLayerTest::GetPhysicalDeviceProperties2(VkPhysical
 
 class VkBestPracticesLayerTest : public VkLayerTest {
   public:
-    void InitBestPracticesFramework(const char *ValidationChecksToEnable = "");
-    void InitBestPractices(const char *ValidationChecksToEnable = "");
+    void InitBestPracticesFramework(const char* vendor_checks_to_enable = nullptr);
+    void InitBestPractices(const char* vendor_checks_to_enable = nullptr);
 
   protected:
     VkValidationFeatureEnableEXT enables_[1] = {VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT};


### PR DESCRIPTION
As someone who [helped](https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/3497#note_230909) get these `special usage` tags in the XML, I realize now how dumb the `devtools`/`debugging` is for the Best Practice layer... if you are using the Validation Layers, of course you might be using these

The original "goal" was when we didn't have extension proposal documents and didn't know "why" new extensions where appearing. The `devtools`/`debugging` is more useful in the spec, less so here as a warning (or even info message)