### PR TITLE
layers: Validate suspend-resume mismatch within command buffer

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1662,6 +1662,8 @@ class CoreChecks : public vvl::DeviceProxy {
     bool ValidateBeginRenderingMultisampledRenderToSingleSampled(VkCommandBuffer commandBuffer,
                                                                  const VkRenderingInfo& rendering_info,
                                                                  const Location& rendering_info_loc) const;
+    bool ValidateBeginRenderingSuspendResumeMismatch(const vvl::CommandBuffer& cb_state, const VkRenderingInfo& rendering_info,
+                                                     const Location& rendering_info_loc) const;
     bool ValidateBeginRenderingColorAttachment(const vvl::CommandBuffer& cb_state, const VkRenderingInfo& rendering_info,
                                                const Location& rendering_info_loc) const;
     bool ValidateBeginRenderingDepthAttachment(const vvl::CommandBuffer& cb_state, const VkRenderingInfo& rendering_info,

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -845,6 +845,7 @@ void CommandBuffer::RecordBeginRendering(const VkRenderingInfo &rendering_info, 
     if (rendering_info.flags & VK_RENDERING_SUSPENDING_BIT) {
         last_suspend_state = SuspendState::Suspended;
     }
+    last_rendering_info = &rendering_info;
 
     has_render_pass_instance = true;
 

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -428,10 +428,14 @@ class CommandBuffer : public RefcountedStateObject, public SubStateManager<Comma
     // True if the *first* render pass instance specifies VK_RENDERING_RESUMING_BIT
     bool resumes_render_pass_instance;
 
-    // The suspension state at the end of the command buffer, based on previous render pass instances.
-    // Regular render pass instances (without RESUMING/SUSPENDING) do not change the suspend state.
+    // During recording, this tracks the current suspension state of the command buffer.
+    // When recording ends, this is the suspension state at the end of the command buffer.
+    // Render pass instances without RESUMING/SUSPENDING do not modify the suspension state.
     enum class SuspendState { Empty, Suspended, Resumed };
     SuspendState last_suspend_state;
+
+    // Rendering info from the last vkCmdBeginRendering.
+    std::optional<vku::safe_VkRenderingInfo> last_rendering_info;
 
     // Used by submit time validation to check for invalild commands when render pass instance is suspended.
     vvl::Func first_action_or_sync_command;


### PR DESCRIPTION
Part of https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11216. This does validation within a single command buffer. To address the issue the following PR will add validation on the boundary between command buffers.

> vkCmdBeginRenderingKHR(): pRenderingInfo->renderArea (offset = {0, 0}, extent = {2, 2}) does not match (offset = {0, 0}, extent = {1, 1}) used by the suspended rendering instance.

> vkCmdBeginRenderingKHR(): pRenderingInfo->pColorAttachments[0].imageView (VkImageView 0x0) does not match VkImageView 0x60000000006 used by the suspended rendering instance.

> vkCmdBeginRenderingKHR(): pRenderingInfo->pDepthAttachment is null, but it was not null in the suspended rendering instance.

> vkCmdBeginRenderingKHR(): pRenderingInfo->pDepthAttachment->clearValue.depthStencil (depth = 0.5, stencil = 66) does not match (depth = 1, stencil = 66) used by the suspended rendering instance.