### PR TITLE
build: Create a spirv_tools_utils.h file

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -409,6 +409,8 @@ vvl_sources = [
   "layers/utils/ray_tracing_utils.h",
   "layers/utils/shader_utils.cpp",
   "layers/utils/shader_utils.h",
+  "layers/utils/spirv_tools_utils.cpp",
+  "layers/utils/spirv_tools_utils.h",
   "layers/utils/sync_utils.cpp",
   "layers/utils/sync_utils.h",
   "layers/utils/text_utils.cpp",

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -472,6 +472,8 @@ target_sources(vvl PRIVATE
     thread_tracker/thread_safety_validation.h
     utils/shader_utils.cpp
     utils/shader_utils.h
+    utils/spirv_tools_utils.cpp
+    utils/spirv_tools_utils.h
     layer_options.cpp
     layer_options.h
     layer_options_validation.h

--- a/layers/core_checks/cc_device.cpp
+++ b/layers/core_checks/cc_device.cpp
@@ -38,6 +38,7 @@
 #include "generated/dispatch_functions.h"
 #include "error_message/error_strings.h"
 #include "utils/file_system_utils.h"
+#include "utils/spirv_tools_utils.h"
 #include "containers/container_utils.h"
 
 bool CoreChecks::ValidateDeviceQueueFamily(uint32_t queue_family, const Location &loc, const char *vuid,

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
@@ -25,6 +25,7 @@
 #include "chassis/chassis_modification_state.h"
 #include "gpuav/core/gpuav_constants.h"
 #include "utils/shader_utils.h"
+#include "utils/spirv_tools_utils.h"
 
 #include "gpuav/shaders/gpuav_shaders_constants.h"
 #include "gpuav/shaders/gpuav_error_codes.h"

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -43,6 +43,7 @@
 #include "state_tracker/descriptor_mode.h"
 #include "chassis/chassis_modification_state.h"
 #include "spirv-tools/optimizer.hpp"
+#include "utils/spirv_tools_utils.h"
 
 // Used for debugging
 #include "utils/keyboard.h"

--- a/layers/utils/shader_utils.h
+++ b/layers/utils/shader_utils.h
@@ -24,12 +24,6 @@
 #include "containers/custom_containers.h"
 #include "utils/lock_utils.h"
 
-#include <spirv-tools/libspirv.hpp>
-
-struct DeviceFeatures;
-struct DeviceExtensions;
-class APIVersion;
-
 enum class ShaderObjectStage : uint32_t {
     VERTEX = 0u,
     TESSELLATION_CONTROL,
@@ -109,11 +103,5 @@ class ValidationCache {
     vvl::unordered_set<uint32_t> good_shader_hashes_;
     mutable std::shared_mutex lock_;
 };
-
-spv_target_env PickSpirvEnv(const APIVersion &api_version, bool spirv_1_4);
-
-void AdjustValidatorOptions(const DeviceExtensions &device_extensions, const DeviceFeatures &enabled_features,
-                            spv_target_env spirv_environment, spvtools::ValidatorOptions &out_options, uint32_t *out_hash,
-                            std::string &out_command);
 
 void DumpSpirvToFile(const std::string &file_name, const uint32_t *spirv, size_t spirv_dwords_count);

--- a/layers/utils/spirv_tools_utils.cpp
+++ b/layers/utils/spirv_tools_utils.cpp
@@ -1,0 +1,134 @@
+/* Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (C) 2015-2025 Google Inc.
+ * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "spirv_tools_utils.h"
+
+#include "generated/device_features.h"
+#include "generated/vk_api_version.h"
+#include "generated/vk_extension_helper.h"
+#include "utils/hash_util.h"
+
+#include <sstream>
+
+spv_target_env PickSpirvEnv(const APIVersion &api_version, bool spirv_1_4) {
+    if (api_version >= VK_API_VERSION_1_4) {
+        return SPV_ENV_VULKAN_1_4;
+    } else if (api_version >= VK_API_VERSION_1_3) {
+        return SPV_ENV_VULKAN_1_3;
+    } else if (api_version >= VK_API_VERSION_1_2) {
+        return SPV_ENV_VULKAN_1_2;
+    } else if (api_version >= VK_API_VERSION_1_1) {
+        if (spirv_1_4) {
+            return SPV_ENV_VULKAN_1_1_SPIRV_1_4;
+        } else {
+            return SPV_ENV_VULKAN_1_1;
+        }
+    }
+    return SPV_ENV_VULKAN_1_0;
+}
+
+// Some Vulkan extensions/features are just all done in spirv-val behind optional settings
+void AdjustValidatorOptions(const DeviceExtensions &device_extensions, const DeviceFeatures &enabled_features,
+                            spv_target_env spirv_environment, spvtools::ValidatorOptions &out_options, uint32_t *out_hash,
+                            std::string &out_command) {
+    struct Settings {
+        bool relax_block_layout;
+        bool uniform_buffer_standard_layout;
+        bool scalar_block_layout;
+        bool workgroup_scalar_block_layout;
+        bool allow_local_size_id;
+        bool allow_offset_texture_operand;
+        bool allow_vulkan_32_bit_bitwise;
+    } settings;
+
+    // VK_KHR_relaxed_block_layout never had a feature bit so just enabling the extension allows relaxed layout
+    // Was promotoed in Vulkan 1.1 so anyone using Vulkan 1.1 also gets this for free
+    settings.relax_block_layout = IsExtEnabled(device_extensions.vk_khr_relaxed_block_layout);
+    // The rest of the settings are controlled from a feature bit, which are set correctly in the state tracking. Regardless of
+    // Vulkan version used, the feature bit is needed (also described in the spec).
+    settings.uniform_buffer_standard_layout = enabled_features.uniformBufferStandardLayout == VK_TRUE;
+    settings.scalar_block_layout = enabled_features.scalarBlockLayout == VK_TRUE;
+    settings.workgroup_scalar_block_layout = enabled_features.workgroupMemoryExplicitLayoutScalarBlockLayout == VK_TRUE;
+    settings.allow_local_size_id = enabled_features.maintenance4 == VK_TRUE;
+    settings.allow_offset_texture_operand = enabled_features.maintenance8 == VK_TRUE;
+    settings.allow_vulkan_32_bit_bitwise = enabled_features.maintenance9 == VK_TRUE;
+
+    std::stringstream ss;
+    ss << "spirv-val <input.spv>";
+
+    if (settings.relax_block_layout) {
+        ss << " --relax-block-layout";
+        out_options.SetRelaxBlockLayout(true);
+    }
+    if (settings.uniform_buffer_standard_layout) {
+        ss << " --uniform-buffer-standard-layout";
+        out_options.SetUniformBufferStandardLayout(true);
+    }
+    if (settings.scalar_block_layout) {
+        ss << " --scalar-block-layout";
+        out_options.SetScalarBlockLayout(true);
+    }
+    if (settings.workgroup_scalar_block_layout) {
+        ss << " --workgroup-scalar-block-layout";
+        out_options.SetWorkgroupScalarBlockLayout(true);
+    }
+    if (settings.allow_local_size_id) {
+        ss << " --allow-localsizeid";
+        out_options.SetAllowLocalSizeId(true);
+    }
+    if (settings.allow_offset_texture_operand) {
+        ss << " --allow-offset-texture-operand";
+        out_options.SetAllowOffsetTextureOperand(true);
+    }
+    if (settings.allow_vulkan_32_bit_bitwise) {
+        ss << " --allow-vulkan-32-bit-bitwise";
+        out_options.SetAllowVulkan32BitBitwise(true);
+    }
+
+    switch (spirv_environment) {
+        case SPV_ENV_VULKAN_1_4:
+            ss << " --target-env vulkan1.4";
+            break;
+        case SPV_ENV_VULKAN_1_3:
+            ss << " --target-env vulkan1.3";
+            break;
+        case SPV_ENV_VULKAN_1_2:
+            ss << " --target-env vulkan1.2";
+            break;
+        case SPV_ENV_VULKAN_1_1:
+            ss << " --target-env vulkan1.1";
+            break;
+        case SPV_ENV_VULKAN_1_0:
+            ss << " --target-env vulkan1.0";
+            break;
+        default:
+            break;
+    }
+
+    // Faster validation without friendly names.
+    out_options.SetFriendlyNames(false);
+
+    // The spv_validator_options_t in libspirv.h is hidden so we can't just hash that struct, so instead need to create our own.
+    if (out_hash) {
+        *out_hash = hash_util::Hash32(&settings, sizeof(Settings));
+    }
+
+    ss << "\n";
+    out_command = ss.str();
+}

--- a/layers/utils/spirv_tools_utils.h
+++ b/layers/utils/spirv_tools_utils.h
@@ -1,0 +1,34 @@
+/* Copyright (c) 2015-2025 The Khronos Group Inc.
+ * Copyright (c) 2015-2025 Valve Corporation
+ * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (C) 2015-2025 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * The Shader Validation file is in charge of taking the Shader Module data and validating it
+ */
+
+#pragma once
+
+#include <vulkan/vulkan_core.h>
+#include <spirv-tools/libspirv.hpp>
+
+struct DeviceFeatures;
+struct DeviceExtensions;
+class APIVersion;
+
+spv_target_env PickSpirvEnv(const APIVersion &api_version, bool spirv_1_4);
+
+void AdjustValidatorOptions(const DeviceExtensions &device_extensions, const DeviceFeatures &enabled_features,
+                            spv_target_env spirv_environment, spvtools::ValidatorOptions &out_options, uint32_t *out_hash,
+                            std::string &out_command);


### PR DESCRIPTION
Goal is not having everyone grab `#include <spirv-tools/libspirv.hpp>` unless they are one of the 3 files that need it

(it was in our `last_bound_state.h` and everyone was grabbing it)