### PR TITLE
layers: Add No Task shader caes for 10883

### DIFF
--- a/layers/core_checks/cc_shader_object.cpp
+++ b/layers/core_checks/cc_shader_object.cpp
@@ -916,10 +916,10 @@ bool CoreChecks::ValidateDrawShaderObjectMesh(const LastBound& last_bound_state,
                     FormatHandle(mesh_shader_handle).c_str(), FormatHandle(task_shader_handle).c_str());
             }
 
-            if (const vvl::ShaderObject* task_state = last_bound_state.GetShaderObjectState(ShaderObjectStage::TASK)) {
-                if (task_state->spirv && mesh_state->entrypoint) {
-                    skip |= ValidateTaskPayload(*task_state->spirv, *mesh_state->entrypoint, vuid.loc());
-                }
+            if (mesh_state->entrypoint) {
+                const vvl::ShaderObject* task_state = last_bound_state.GetShaderObjectState(ShaderObjectStage::TASK);
+                const spirv::Module* task_module = (task_state && task_state->spirv) ? task_state->spirv.get() : nullptr;
+                skip |= ValidateTaskPayload(task_module, *mesh_state->entrypoint, vuid.loc());
             }
         }
     }

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -2303,7 +2303,7 @@ class CoreChecks : public vvl::DeviceProxy {
                                   uint32_t total_workgroup_shared_memory, const Location& loc) const;
     bool ValidateMeshShaderLimits(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
                                   uint32_t total_workgroup_shared_memory, const Location& loc) const;
-    bool ValidateTaskPayload(const spirv::Module& task_state, const spirv::EntryPoint& mesh_entrypoint, const Location& loc) const;
+    bool ValidateTaskPayload(const spirv::Module* task_state, const spirv::EntryPoint& mesh_entrypoint, const Location& loc) const;
 
     bool PreCallValidateResetQueryPoolEXT(VkDevice device, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount,
                                           const ErrorObject& error_obj) const override;

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -2307,7 +2307,7 @@ TaskPayloadVariable::TaskPayloadVariable(const Module& module_state, const Instr
                                          const ParsedInfo& parsed)
     : VariableBase(module_state, insn, stage, parsed), size(0) {
     if (module_state.static_data_.has_specialization_constants) {
-        size = kInvalidValue;
+        size = kSpecConstant;
     } else {
         const Instruction* type = module_state.GetVariablePointerType(insn);
         size = module_state.GetTypeBytesSize(type);

--- a/tests/unit/gpu_av_indirect_buffer.cpp
+++ b/tests/unit/gpu_av_indirect_buffer.cpp
@@ -14,6 +14,7 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/buffer_helper.h"
+#include "shader_templates.h"
 
 class NegativeGpuAVIndirectBuffer : public GpuAVTest {};
 
@@ -383,19 +384,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, Mesh) {
     uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
     *count_ptr = 3;
 
-    const char *mesh_shader_source = R"glsl(
-        #version 450
-        #extension GL_EXT_mesh_shader : require
-        layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
-        layout(max_vertices = 3, max_primitives = 1) out;
-        layout(triangles) out;
-        struct Task {
-          uint baseID;
-        };
-        taskPayloadSharedEXT Task IN;
-        void main() {}
-    )glsl";
-    VkShaderObj mesh_shader(*m_device, mesh_shader_source, VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_3);
+    VkShaderObj mesh_shader(*m_device, kMeshMinimalGlsl, VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_3);
     CreatePipelineHelper mesh_pipe(*this);
     mesh_pipe.shader_stages_[0] = mesh_shader.GetStageCreateInfo();
     mesh_pipe.CreateGraphicsPipeline();

--- a/tests/unit/gpu_av_indirect_buffer_positive.cpp
+++ b/tests/unit/gpu_av_indirect_buffer_positive.cpp
@@ -16,6 +16,7 @@
 #include "../framework/buffer_helper.h"
 #include "../framework/ray_tracing_objects.h"
 #include "../framework/shader_object_helper.h"
+#include "shader_templates.h"
 
 class PositiveGpuAVIndirectBuffer : public GpuAVTest {};
 
@@ -146,19 +147,7 @@ TEST_F(PositiveGpuAVIndirectBuffer, Mesh) {
     uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
     *count_ptr = 3;
 
-    const char *mesh_shader_source = R"glsl(
-        #version 450
-        #extension GL_EXT_mesh_shader : require
-        layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
-        layout(max_vertices = 3, max_primitives = 1) out;
-        layout(triangles) out;
-        struct Task {
-            uint baseID;
-        };
-        taskPayloadSharedEXT Task IN;
-        void main() {}
-    )glsl";
-    VkShaderObj mesh_shader(*m_device, mesh_shader_source, VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_3);
+    VkShaderObj mesh_shader(*m_device, kMeshMinimalGlsl, VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_3);
     CreatePipelineHelper mesh_pipe(*this);
     mesh_pipe.shader_stages_[0] = mesh_shader.GetStageCreateInfo();
     mesh_pipe.CreateGraphicsPipeline();
@@ -207,19 +196,8 @@ TEST_F(PositiveGpuAVIndirectBuffer, MeshSingleCommand) {
     vkt::Buffer count_buffer(*m_device, sizeof(uint32_t), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, kHostVisibleMemProps);
     uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
     *count_ptr = 3;
-    const char *mesh_shader_source = R"glsl(
-        #version 450
-        #extension GL_EXT_mesh_shader : require
-        layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
-        layout(max_vertices = 3, max_primitives = 1) out;
-        layout(triangles) out;
-        struct Task {
-            uint baseID;
-        };
-        taskPayloadSharedEXT Task IN;
-        void main() {}
-    )glsl";
-    VkShaderObj mesh_shader(*m_device, mesh_shader_source, VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_3);
+
+    VkShaderObj mesh_shader(*m_device, kMeshMinimalGlsl, VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_3);
     CreatePipelineHelper mesh_pipe(*this);
     mesh_pipe.shader_stages_[0] = mesh_shader.GetStageCreateInfo();
     mesh_pipe.CreateGraphicsPipeline();

--- a/tests/unit/shader_mesh.cpp
+++ b/tests/unit/shader_mesh.cpp
@@ -294,20 +294,38 @@ TEST_F(NegativeShaderMesh, MeshAndTaskShaderDerivatives) {
 }
 
 TEST_F(NegativeShaderMesh, MeshShaderPayloadMemoryOverLimit) {
-    TEST_DESCRIPTION("Validate Mesh shader shared memory limit");
-
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::taskShader);
     AddRequiredFeature(vkt::Feature::meshShader);
-
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
+
+    if (!IsPlatformMockICD()) {
+        GTEST_SKIP() << "Hard to get limit tests to work everywhere without being too complex";
+    }
 
     VkPhysicalDeviceMeshShaderPropertiesEXT mesh_shader_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(mesh_shader_properties);
 
     const uint32_t max_mesh_payload_and_shared_memory_size = mesh_shader_properties.maxMeshPayloadAndSharedMemorySize;
     const uint32_t max_mesh_payload_and_shared_ints = max_mesh_payload_and_shared_memory_size / 4;
+
+    std::stringstream task_source;
+    task_source << R"glsl(
+            #version 460
+            #extension GL_EXT_mesh_shader : require
+            struct Task {
+                uint baseID[)glsl";
+    task_source << (max_mesh_payload_and_shared_ints / 2 + 1);
+    task_source << R"glsl(];
+            };
+            taskPayloadSharedEXT Task IN;
+            void main(){
+                IN.baseID[0] = 0;
+                EmitMeshTasksEXT(1u, 1u, 1u);
+            }
+        )glsl";
 
     std::stringstream mesh_source;
     mesh_source << R"glsl(
@@ -327,20 +345,25 @@ TEST_F(NegativeShaderMesh, MeshShaderPayloadMemoryOverLimit) {
             void main(){}
         )glsl";
 
+    VkShaderObj task(*m_device, task_source.str().c_str(), VK_SHADER_STAGE_TASK_BIT_EXT, SPV_ENV_VULKAN_1_2);
     VkShaderObj mesh(*m_device, mesh_source.str().c_str(), VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_2);
-    const auto set_info = [&](CreatePipelineHelper &helper) { helper.shader_stages_ = {mesh.GetStageCreateInfo()}; };
+    const auto set_info = [&](CreatePipelineHelper &helper) {
+        helper.shader_stages_ = {task.GetStageCreateInfo(), mesh.GetStageCreateInfo()};
+    };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-maxMeshPayloadAndSharedMemorySize-08755");
 }
 
 TEST_F(NegativeShaderMesh, MeshShaderPayloadSpecConstantSet) {
-    TEST_DESCRIPTION("Validate Mesh shader shared memory limit");
-
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_EXT_MESH_SHADER_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::meshShader);
-
+    AddRequiredFeature(vkt::Feature::taskShader);
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
+
+    if (!IsPlatformMockICD()) {
+        GTEST_SKIP() << "Hard to get limit tests to work everywhere without being too complex";
+    }
 
     VkPhysicalDeviceMeshShaderPropertiesEXT mesh_shader_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(mesh_shader_properties);
@@ -348,19 +371,33 @@ TEST_F(NegativeShaderMesh, MeshShaderPayloadSpecConstantSet) {
     const uint32_t max_mesh_payload_and_shared_memory_size = mesh_shader_properties.maxMeshPayloadAndSharedMemorySize;
     const uint32_t max_mesh_payload_and_shared_ints = max_mesh_payload_and_shared_memory_size / 4;
 
+    const char *task_source = R"glsl(
+        #version 460
+        #extension GL_EXT_mesh_shader : require
+        layout(constant_id = 0) const int SIZE = 64;
+        struct Task {
+            uint baseID[SIZE];
+        };
+        taskPayloadSharedEXT Task IN;
+        void main() {
+            IN.baseID[0] = 0;
+            EmitMeshTasksEXT(1u, 1u, 1u);
+        }
+    )glsl";
+
     const char *mesh_source = R"glsl(
-            #version 460
-            #extension GL_EXT_mesh_shader : require
-            layout(max_vertices = 3, max_primitives=1) out;
-            layout(triangles) out;
-            layout(constant_id = 0) const int SIZE = 64;
-            struct Task {
-                uint baseID[SIZE];
-            };
-            taskPayloadSharedEXT Task IN;
-            shared int a[SIZE];
-            void main(){}
-        )glsl";
+        #version 460
+        #extension GL_EXT_mesh_shader : require
+        layout(max_vertices = 3, max_primitives=1) out;
+        layout(triangles) out;
+        layout(constant_id = 0) const int SIZE = 64;
+        struct Task {
+            uint baseID[SIZE];
+        };
+        taskPayloadSharedEXT Task IN;
+        shared int a[SIZE];
+        void main(){}
+    )glsl";
 
     uint32_t size = max_mesh_payload_and_shared_ints / 2 + 1;
 
@@ -375,8 +412,12 @@ TEST_F(NegativeShaderMesh, MeshShaderPayloadSpecConstantSet) {
     spec_info.dataSize = sizeof(uint32_t);
     spec_info.pData = &size;
 
+    VkShaderObj task(*m_device, task_source, VK_SHADER_STAGE_TASK_BIT_EXT, SPV_ENV_VULKAN_1_2);
     VkShaderObj mesh(*m_device, mesh_source, VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_GLSL, &spec_info);
-    const auto set_info = [&](CreatePipelineHelper &helper) { helper.shader_stages_ = {mesh.GetStageCreateInfo()};};
+    const auto set_info = [&](CreatePipelineHelper &helper) {
+        helper.shader_stages_ = {task.GetStageCreateInfo(), mesh.GetStageCreateInfo()};
+        ;
+    };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-RuntimeSpirv-maxMeshPayloadAndSharedMemorySize-08755");
 }
 


### PR DESCRIPTION
adds a case for ` VUID-RuntimeSpirv-MeshEXT-10883` where the Mesh shader has a `TaskPayloadWorkgroupEXT` but there is just not Task shader at all to do the matching