### PR TITLE
layers: Add multisampledRenderToSingleSampled VU

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1683,6 +1683,11 @@ class CoreChecks : public vvl::DeviceProxy {
     bool ValidateRenderingAttachmentInfoResolveMode(VkCommandBuffer commandBuffer, const VkRenderingInfo& rendering_info,
                                                     const VkRenderingAttachmentInfo& attachment_info,
                                                     const vvl::ImageView& image_view_state, const Location& attachment_loc) const;
+    bool ValidateRenderingAttachmentInfoMultisampledResolveMode(VkCommandBuffer commandBuffer,
+                                                                const VkRenderingInfo& rendering_info,
+                                                                const VkRenderingAttachmentInfo& attachment_info,
+                                                                const vvl::ImageView& image_view_state,
+                                                                const Location& attachment_loc) const;
     bool ValidateRenderingAttachmentInfoFeedbackLoop(VkCommandBuffer commandBuffer,
                                                      const VkRenderingAttachmentInfo& attachment_info,
                                                      const vvl::ImageView& image_view_state, const Location& attachment_loc) const;

--- a/tests/unit/dynamic_state.cpp
+++ b/tests/unit/dynamic_state.cpp
@@ -5792,6 +5792,8 @@ TEST_F(NegativeDynamicState, DynamicRasterizationSamplesWithMSRTSS) {
     color_attachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
     color_attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
     color_attachment.clearValue.color = m_clear_color;
+    color_attachment.resolveMode = VK_RESOLVE_MODE_AVERAGE_BIT;
+    color_attachment.resolveImageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
     VkRenderingInfo rendering_info = vku::InitStructHelper(&msrtss_info);
     rendering_info.renderArea = {{0, 0}, {32, 32}};

--- a/tests/unit/pipeline.cpp
+++ b/tests/unit/pipeline.cpp
@@ -3422,6 +3422,8 @@ TEST_F(NegativePipeline, MismatchedRasterizationSamples) {
     VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
     color_attachment.imageView = image_view;
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    color_attachment.resolveMode = VK_RESOLVE_MODE_AVERAGE_BIT;
+    color_attachment.resolveImageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
     VkMultisampledRenderToSingleSampledInfoEXT rtss = vku::InitStructHelper();
     rtss.multisampledRenderToSingleSampledEnable = VK_TRUE;

--- a/tests/unit/render_pass.cpp
+++ b/tests/unit/render_pass.cpp
@@ -3059,6 +3059,7 @@ TEST_F(NegativeRenderPass, MultisampledRenderToSingleSampled3) {
     auto one_count_image_view_ci = one_count_image.BasicViewCreatInfo();
     vkt::ImageView one_count_image_view(*m_device, one_count_image_view_ci);
     color_attachment.imageView = one_count_image_view;
+    m_errorMonitor->SetDesiredError("VUID-VkRenderingAttachmentInfo-None-12256");
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-imageView-06859");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();


### PR DESCRIPTION
Adds `VUID-VkRenderingAttachmentInfo-None-12256` from 1.4.336 (https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/7902/diffs)

Realized with the change it makes sense to move it all to a single `ValidateRenderingAttachmentInfoMultisampledResolveMode`