### PR TITLE
layers: Fix queryCount checks

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -2314,9 +2314,6 @@ class CoreChecks : public vvl::DeviceProxy {
                                           const ErrorObject& error_obj) const override;
     bool PreCallValidateResetQueryPool(VkDevice device, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount,
                                        const ErrorObject& error_obj) const override;
-    bool ValidateQueryPoolStride(const std::string& vuid_not_64, const std::string& vuid_64, const VkDeviceSize stride,
-                                 vvl::Field field_name, const uint64_t parameter_value, const VkQueryResultFlags flags,
-                                 const LogObjectList& objlist, const Location& loc) const;
     bool ValidateCmdDrawStrideWithStruct(const vvl::CommandBuffer& cb_state, const std::string& vuid, const uint32_t stride,
                                          Struct struct_name, const uint32_t struct_size, const Location& loc) const;
     bool ValidateCmdDrawStrideWithBuffer(const vvl::CommandBuffer& cb_state, const std::string& vuid, const uint32_t stride,

--- a/tests/unit/query_positive.cpp
+++ b/tests/unit/query_positive.cpp
@@ -139,7 +139,8 @@ TEST_F(PositiveQuery, BasicQuery) {
     m_command_buffer.End();
 
     m_default_queue->SubmitAndWait(m_command_buffer);
-    uint64_t samples_passed[4];
+    // alignas() for 32-bit machines
+    alignas(8) uint64_t samples_passed[4];
     vk::GetQueryPoolResults(*m_device, query_pool, 0, 2, sizeof(samples_passed), samples_passed, sizeof(uint64_t),
                             VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT);
 
@@ -162,8 +163,9 @@ TEST_F(PositiveQuery, DestroyQueryPoolBasedOnQueryPoolResults) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    std::array<uint64_t, 4> samples_passed = {};
-    constexpr uint64_t sizeof_samples_passed = samples_passed.size() * sizeof(uint64_t);
+    // alignas() for 32-bit machines
+    alignas(8) uint64_t samples_passed[4];
+    constexpr uint64_t sizeof_samples_passed = 4 * sizeof(uint64_t);
     constexpr VkDeviceSize sample_stride = sizeof(uint64_t);
 
     vkt::Buffer buffer(*m_device, sizeof_samples_passed, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
@@ -195,7 +197,7 @@ TEST_F(PositiveQuery, DestroyQueryPoolBasedOnQueryPoolResults) {
 
     m_default_queue->Submit(m_command_buffer);
 
-    VkResult res = vk::GetQueryPoolResults(*m_device, query_pool, 0, query_count, sizeof_samples_passed, samples_passed.data(),
+    VkResult res = vk::GetQueryPoolResults(*m_device, query_pool, 0, query_count, sizeof_samples_passed, samples_passed,
                                            sample_stride, query_flags);
 
     if (res == VK_SUCCESS) {


### PR DESCRIPTION
From 1.4.336 (https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/7476/diffs)

Fixes/updates checks where we only validate the `stride` if `queryCount` is greater than 1