### PR TITLE
layers: Remove SafeModule

### DIFF
--- a/layers/chassis/dispatch_object_manual.cpp
+++ b/layers/chassis/dispatch_object_manual.cpp
@@ -404,6 +404,12 @@ StatelessDeviceData::StatelessDeviceData(vvl::dispatch::Instance *instance, VkPh
                                              &phys_dev_ext_props.fragment_density_map2_props);
     instance->GetPhysicalDeviceExtProperties(physical_device, extensions.vk_ext_fragment_density_map_offset,
                                              &phys_dev_ext_props.fragment_density_map_offset_props);
+    // TODO - mgiht be more cases like this where the properties are aliased, should have a more unified way to handle these
+    if (IsExtEnabled(extensions.vk_qcom_fragment_density_map_offset) &&
+        !IsExtEnabled(extensions.vk_ext_fragment_density_map_offset)) {
+        instance->GetPhysicalDeviceExtProperties(physical_device, extensions.vk_qcom_fragment_density_map_offset,
+                                                 &phys_dev_ext_props.fragment_density_map_offset_props);
+    }
     instance->GetPhysicalDeviceExtProperties(physical_device, extensions.vk_valve_fragment_density_map_layered,
                                              &phys_dev_ext_props.fragment_density_map_layered_props);
     instance->GetPhysicalDeviceExtProperties(physical_device, extensions.vk_khr_performance_query,

--- a/layers/core_checks/cc_buffer.cpp
+++ b/layers/core_checks/cc_buffer.cpp
@@ -268,7 +268,7 @@ bool CoreChecks::PreCallValidateCreateBufferView(VkDevice device, const VkBuffer
             if (phys_dev_props_core13.storageTexelBufferOffsetSingleTexelAlignment) {
                 alignment_requirement = std::min(alignment_requirement, texel_block_size);
             }
-            if (SafeModulo(pCreateInfo->offset, alignment_requirement) != 0) {
+            if (!IsIntegerMultipleOf(pCreateInfo->offset, alignment_requirement)) {
                 std::stringstream ss;
                 ss << "was created with VK_BUFFER_USAGE_2_STORAGE_TEXEL_BUFFER_BIT, so the offset (" << pCreateInfo->offset
                    << ") must be a multiple of " << alignment_requirement << "\n";
@@ -296,7 +296,7 @@ bool CoreChecks::PreCallValidateCreateBufferView(VkDevice device, const VkBuffer
             if (phys_dev_props_core13.uniformTexelBufferOffsetSingleTexelAlignment) {
                 alignment_requirement = std::min(alignment_requirement, texel_block_size);
             }
-            if (SafeModulo(pCreateInfo->offset, alignment_requirement) != 0) {
+            if (!IsIntegerMultipleOf(pCreateInfo->offset, alignment_requirement)) {
                 std::stringstream ss;
                 ss << "was created with VK_BUFFER_USAGE_2_UNIFORM_TEXEL_BUFFER_BIT, so the offset (" << pCreateInfo->offset
                    << ") must be a multiple of " << alignment_requirement << "\n";

--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -609,8 +609,8 @@ bool CoreChecks::ValidateDrawDynamicStatePipelineValue(const LastBound& last_bou
             DispatchGetPhysicalDeviceMultisamplePropertiesEXT(physical_device, cb_state.dynamic_state_value.rasterization_samples,
                                                               &multisample_prop);
 
-            if (SafeModulo(multisample_prop.maxSampleLocationGridSize.width,
-                           sample_locations->sampleLocationsInfo.sampleLocationGridSize.width) != 0) {
+            if (!IsIntegerMultipleOf(multisample_prop.maxSampleLocationGridSize.width,
+                                     sample_locations->sampleLocationsInfo.sampleLocationGridSize.width)) {
                 skip |= LogError(vuid.sample_locations_enable_07936, objlist, vuid.loc(),
                                  "VkMultisamplePropertiesEXT::maxSampleLocationGridSize.width (%" PRIu32
                                  ") with rasterization samples %s is not evenly divided by "
@@ -619,8 +619,8 @@ bool CoreChecks::ValidateDrawDynamicStatePipelineValue(const LastBound& last_bou
                                  string_VkSampleCountFlagBits(cb_state.dynamic_state_value.rasterization_samples),
                                  sample_locations->sampleLocationsInfo.sampleLocationGridSize.width);
             }
-            if (SafeModulo(multisample_prop.maxSampleLocationGridSize.height,
-                           sample_locations->sampleLocationsInfo.sampleLocationGridSize.height) != 0) {
+            if (!IsIntegerMultipleOf(multisample_prop.maxSampleLocationGridSize.height,
+                                     sample_locations->sampleLocationsInfo.sampleLocationGridSize.height)) {
                 skip |= LogError(vuid.sample_locations_enable_07937, objlist, vuid.loc(),
                                  "VkMultisamplePropertiesEXT::maxSampleLocationGridSize.height (%" PRIu32
                                  ") with rasterization samples %s is not evenly divided by "
@@ -1028,7 +1028,7 @@ bool CoreChecks::ValidateDrawDynamicStateFragment(const LastBound& last_bound_st
                 VkMultisamplePropertiesEXT multisample_prop = vku::InitStructHelper();
                 DispatchGetPhysicalDeviceMultisamplePropertiesEXT(physical_device, rasterization_samples, &multisample_prop);
                 const auto& gridSize = cb_state.dynamic_state_value.sample_locations_info.sampleLocationGridSize;
-                if (SafeModulo(multisample_prop.maxSampleLocationGridSize.width, gridSize.width) != 0) {
+                if (!IsIntegerMultipleOf(multisample_prop.maxSampleLocationGridSize.width, gridSize.width)) {
                     const LogObjectList objlist(cb_state.Handle(), frag_spirv_state->handle());
                     skip |= LogError(vuid.sample_locations_enable_07485, objlist, vuid.loc(),
                                      "VkMultisamplePropertiesEXT::maxSampleLocationGridSize.width (%" PRIu32
@@ -1038,7 +1038,7 @@ bool CoreChecks::ValidateDrawDynamicStateFragment(const LastBound& last_bound_st
                                      multisample_prop.maxSampleLocationGridSize.width,
                                      string_VkSampleCountFlagBits(rasterization_samples), gridSize.width);
                 }
-                if (SafeModulo(multisample_prop.maxSampleLocationGridSize.height, gridSize.height) != 0) {
+                if (!IsIntegerMultipleOf(multisample_prop.maxSampleLocationGridSize.height, gridSize.height)) {
                     const LogObjectList objlist(cb_state.Handle(), frag_spirv_state->handle());
                     skip |= LogError(vuid.sample_locations_enable_07486, objlist, vuid.loc(),
                                      "VkMultisamplePropertiesEXT::maxSampleLocationGridSize.height (%" PRIu32

--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -752,18 +752,17 @@ bool CoreChecks::PreCallValidateCmdDrawIndirectByteCountEXT(VkCommandBuffer comm
                          phys_dev_ext_props.transform_feedback_props.maxTransformFeedbackBufferDataStride);
     }
 
-    if (SafeModulo(counterBufferOffset, 4) != 0) {
+    if (!IsIntegerMultipleOf(counterBufferOffset, 4)) {
         skip |= LogError(
             "VUID-vkCmdDrawIndirectByteCountEXT-counterBufferOffset-04568", cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS),
             error_obj.location.dot(Field::counterBufferOffset), "(%" PRIu64 ") must be a multiple of 4.", counterBufferOffset);
     }
-    // VUs being added in https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/6310
-    if (SafeModulo(counterOffset, 4) != 0) {
+    if (!IsIntegerMultipleOf(counterOffset, 4)) {
         skip |= LogError("VUID-vkCmdDrawIndirectByteCountEXT-counterOffset-09474",
                          cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS), error_obj.location.dot(Field::counterOffset),
                          "(%" PRIu32 ") must be a multiple of 4.", counterOffset);
     }
-    if (SafeModulo(vertexStride, 4) != 0) {
+    if (!IsIntegerMultipleOf(vertexStride, 4)) {
         skip |= LogError("VUID-vkCmdDrawIndirectByteCountEXT-vertexStride-09475",
                          cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS), error_obj.location.dot(Field::vertexStride),
                          "(%" PRIu32 ") must be a multiple of 4.", vertexStride);
@@ -787,14 +786,14 @@ bool CoreChecks::PreCallValidateCmdTraceRaysNV(VkCommandBuffer commandBuffer, Vk
 
     skip |= ValidateActionState(last_bound_state, vuid);
 
-    if (SafeModulo(callableShaderBindingOffset, phys_dev_ext_props.ray_tracing_props_nv.shaderGroupBaseAlignment) != 0) {
+    if (!IsIntegerMultipleOf(callableShaderBindingOffset, phys_dev_ext_props.ray_tracing_props_nv.shaderGroupBaseAlignment)) {
         skip |= LogError("VUID-vkCmdTraceRaysNV-callableShaderBindingOffset-02462",
                          cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR),
                          error_obj.location.dot(Field::callableShaderBindingOffset),
                          "must be a multiple of "
                          "VkPhysicalDeviceRayTracingPropertiesNV::shaderGroupBaseAlignment.");
     }
-    if (SafeModulo(callableShaderBindingStride, phys_dev_ext_props.ray_tracing_props_nv.shaderGroupHandleSize) != 0) {
+    if (!IsIntegerMultipleOf(callableShaderBindingStride, phys_dev_ext_props.ray_tracing_props_nv.shaderGroupHandleSize)) {
         skip |= LogError("VUID-vkCmdTraceRaysNV-callableShaderBindingStride-02465",
                          cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR),
                          error_obj.location.dot(Field::callableShaderBindingStride),
@@ -810,14 +809,14 @@ bool CoreChecks::PreCallValidateCmdTraceRaysNV(VkCommandBuffer commandBuffer, Vk
     }
 
     // hitShader
-    if (SafeModulo(hitShaderBindingOffset, phys_dev_ext_props.ray_tracing_props_nv.shaderGroupBaseAlignment) != 0) {
+    if (!IsIntegerMultipleOf(hitShaderBindingOffset, phys_dev_ext_props.ray_tracing_props_nv.shaderGroupBaseAlignment)) {
         skip |= LogError("VUID-vkCmdTraceRaysNV-hitShaderBindingOffset-02460",
                          cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR),
                          error_obj.location.dot(Field::hitShaderBindingOffset),
                          "must be a multiple of "
                          "VkPhysicalDeviceRayTracingPropertiesNV::shaderGroupBaseAlignment.");
     }
-    if (SafeModulo(hitShaderBindingStride, phys_dev_ext_props.ray_tracing_props_nv.shaderGroupHandleSize) != 0) {
+    if (!IsIntegerMultipleOf(hitShaderBindingStride, phys_dev_ext_props.ray_tracing_props_nv.shaderGroupHandleSize)) {
         skip |= LogError("VUID-vkCmdTraceRaysNV-hitShaderBindingStride-02464",
                          cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR),
                          error_obj.location.dot(Field::hitShaderBindingStride),
@@ -833,14 +832,14 @@ bool CoreChecks::PreCallValidateCmdTraceRaysNV(VkCommandBuffer commandBuffer, Vk
     }
 
     // missShader
-    if (SafeModulo(missShaderBindingOffset, phys_dev_ext_props.ray_tracing_props_nv.shaderGroupBaseAlignment) != 0) {
+    if (!IsIntegerMultipleOf(missShaderBindingOffset, phys_dev_ext_props.ray_tracing_props_nv.shaderGroupBaseAlignment)) {
         skip |= LogError("VUID-vkCmdTraceRaysNV-missShaderBindingOffset-02458",
                          cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR),
                          error_obj.location.dot(Field::missShaderBindingOffset),
                          "must be a multiple of "
                          "VkPhysicalDeviceRayTracingPropertiesNV::shaderGroupBaseAlignment.");
     }
-    if (SafeModulo(missShaderBindingStride, phys_dev_ext_props.ray_tracing_props_nv.shaderGroupHandleSize) != 0) {
+    if (!IsIntegerMultipleOf(missShaderBindingStride, phys_dev_ext_props.ray_tracing_props_nv.shaderGroupHandleSize)) {
         skip |= LogError("VUID-vkCmdTraceRaysNV-missShaderBindingStride-02463",
                          cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR),
                          error_obj.location.dot(Field::missShaderBindingStride),
@@ -856,7 +855,7 @@ bool CoreChecks::PreCallValidateCmdTraceRaysNV(VkCommandBuffer commandBuffer, Vk
     }
 
     // raygenShader
-    if (SafeModulo(raygenShaderBindingOffset, phys_dev_ext_props.ray_tracing_props_nv.shaderGroupBaseAlignment) != 0) {
+    if (!IsIntegerMultipleOf(raygenShaderBindingOffset, phys_dev_ext_props.ray_tracing_props_nv.shaderGroupBaseAlignment)) {
         skip |= LogError("VUID-vkCmdTraceRaysNV-raygenShaderBindingOffset-02456",
                          cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR),
                          error_obj.location.dot(Field::raygenShaderBindingOffset),
@@ -2373,11 +2372,11 @@ bool CoreChecks::ValidateDrawVertexBinding(const LastBound &last_bound, const vv
                     vtx_attrib_req_alignment = SafeDivision(vtx_attrib_req_alignment, vkuFormatComponentCount(attr_desc.format));
                 }
 
-                if (SafeModulo(attrib_address, vtx_attrib_req_alignment) != 0) {
+                if (!IsPointerAligned(attrib_address, vtx_attrib_req_alignment)) {
                     LogObjectList objlist(last_bound.cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS));
                     objlist.add(vertex_buffer_state->Handle());
                     skip |= LogError(vuid.vertex_binding_attribute_02721, objlist, vuid.loc(),
-                                     "Format %s has an alignment of %" PRIu64 " but the alignment of attribAddress (%" PRIu64
+                                     "Format %s has an alignment of %" PRIu64 " but the alignment of attribAddress (0x%" PRIx64
                                      ") is not aligned in pVertexAttributeDescriptions[%" PRIu32 "] (binding=%" PRIu32
                                      " location=%" PRIu32 ") where attribAddress = vertex buffer offset (%" PRIu64
                                      ") + binding stride (%" PRIu64 ") + attribute offset (%" PRIu32 ").",

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -2386,13 +2386,13 @@ bool CoreChecks::ValidateImageViewCreateInfo(const VkImageViewCreateInfo &create
     skip |= ValidateImageViewSampleWeightQCOM(create_info, image_state, create_info_loc);
 
     // If Chroma subsampled format ( _420_ or _422_ )
-    if (vkuFormatIsXChromaSubsampled(view_format) && (SafeModulo(image_state.create_info.extent.width, 2) != 0)) {
+    if (vkuFormatIsXChromaSubsampled(view_format) && !IsIntegerMultipleOf(image_state.create_info.extent.width, 2)) {
         skip |= LogError("VUID-VkImageViewCreateInfo-format-04714", device, create_info_loc.dot(Field::format),
                          "(%s) is X Chroma Subsampled (has _422 or _420 suffix) so the image width (%" PRIu32
                          ") must be a multiple of 2.",
                          string_VkFormat(view_format), image_state.create_info.extent.width);
     }
-    if (vkuFormatIsYChromaSubsampled(view_format) && (SafeModulo(image_state.create_info.extent.height, 2) != 0)) {
+    if (vkuFormatIsYChromaSubsampled(view_format) && !IsIntegerMultipleOf(image_state.create_info.extent.height, 2)) {
         skip |= LogError("VUID-VkImageViewCreateInfo-format-04715", device, create_info_loc.dot(Field::format),
                          "(%s) is Y Chroma Subsampled (has _420 suffix) so the image height (%" PRIu32 ") must be a multiple of 2.",
                          string_VkFormat(view_format), image_state.create_info.extent.height);

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -2392,7 +2392,7 @@ bool CoreChecks::ValidateGraphicsPipelineMultisampleState(const vvl::Pipeline &p
             const VkExtent2D max_grid_size = multisample_prop.maxSampleLocationGridSize;
 
             // Note order or "divide" in "sampleLocationsInfo must evenly divide VkMultisamplePropertiesEXT"
-            if (SafeModulo(max_grid_size.width, grid_size.width) != 0) {
+            if (!IsIntegerMultipleOf(max_grid_size.width, grid_size.width)) {
                 skip |=
                     LogError("VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-07610", device,
                              sample_info_loc.dot(Field::sampleLocationGridSize).dot(Field::width),
@@ -2400,7 +2400,7 @@ bool CoreChecks::ValidateGraphicsPipelineMultisampleState(const vvl::Pipeline &p
                              ") is not evenly divided by VkMultisamplePropertiesEXT::sampleLocationGridSize.width (%" PRIu32 ").",
                              grid_size.width, max_grid_size.width);
             }
-            if (SafeModulo(max_grid_size.height, grid_size.height) != 0) {
+            if (!IsIntegerMultipleOf(max_grid_size.height, grid_size.height)) {
                 skip |=
                     LogError("VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-07611", device,
                              sample_info_loc.dot(Field::sampleLocationGridSize).dot(Field::height),

--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -107,7 +107,7 @@ bool CoreChecks::PreCallValidateBindAccelerationStructureMemoryNV(VkDevice devic
         }
 
         // Validate memory requirements alignment
-        if (SafeModulo(info.memoryOffset, as_state->memory_requirements.alignment) != 0) {
+        if (!IsIntegerMultipleOf(info.memoryOffset, as_state->memory_requirements.alignment)) {
             skip |= LogError("VUID-VkBindAccelerationStructureMemoryInfoNV-memoryOffset-03623", info.accelerationStructure,
                              bind_info_loc.dot(Field::memoryOffset),
                              "(%" PRIu64 ") must be a multiple of the alignment (%" PRIu64
@@ -593,7 +593,7 @@ bool CoreChecks::ValidateAccelerationBuffers(VkCommandBuffer cmd_buffer, uint32_
                     min_component_bits_size = std::min(format_info.components[component_i].size, min_component_bits_size);
                 }
                 const uint32_t min_component_byte_size = min_component_bits_size / 8;
-                if (SafeModulo(triangles.vertexData.deviceAddress, min_component_byte_size) != 0) {
+                if (!IsPointerAligned(triangles.vertexData.deviceAddress, min_component_byte_size)) {
                     skip |= LogError(pick_vuid("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03711",
                                                "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03711"),
                                      cmd_buffer, p_geom_geom_triangles_loc.dot(Field::vertexData).dot(Field::deviceAddress),
@@ -603,10 +603,10 @@ bool CoreChecks::ValidateAccelerationBuffers(VkCommandBuffer cmd_buffer, uint32_
                                      triangles.vertexData.deviceAddress, min_component_byte_size,
                                      string_VkFormat(triangles.vertexFormat));
                 }
-                if (SafeModulo(triangles.vertexStride, min_component_byte_size) != 0) {
+                if (!IsIntegerMultipleOf(triangles.vertexStride, min_component_byte_size)) {
                     skip |= LogError("VUID-VkAccelerationStructureGeometryTrianglesDataKHR-vertexStride-03735", cmd_buffer,
                                      p_geom_geom_triangles_loc.dot(Field::vertexStride),
-                                     "is %" PRIu64 " and is not aligned to the minimum component byte size (%" PRIu32
+                                     "is %" PRIu64 " and is not a multiple to the minimum component byte size (%" PRIu32
                                      ") of its corresponding vertex "
                                      "format (%s).",
                                      triangles.vertexStride, min_component_byte_size, string_VkFormat(triangles.vertexFormat));
@@ -728,7 +728,7 @@ bool CoreChecks::ValidateAccelerationBuffers(VkCommandBuffer cmd_buffer, uint32_
             } else {
                 if (vkuFormatIsPacked(sphere_struct->vertexFormat)) {
                     const uint32_t format_block_size = vkuFormatTexelBlockSize(sphere_struct->vertexFormat);
-                    if (SafeModulo(sphere_struct->vertexStride, format_block_size) != 0) {
+                    if (!IsIntegerMultipleOf(sphere_struct->vertexStride, format_block_size)) {
                         skip |=
                             LogError("VUID-VkAccelerationStructureGeometrySpheresDataNV-vertexStride-10431", cmd_buffer,
                                      p_geom_geom_spheres_loc.dot(Field::vertexStride),
@@ -746,7 +746,7 @@ bool CoreChecks::ValidateAccelerationBuffers(VkCommandBuffer cmd_buffer, uint32_
                         min_component_bits_size = std::min(format_info.components[component_i].size, min_component_bits_size);
                     }
                     const uint32_t min_component_byte_size = min_component_bits_size / 8;
-                    if (SafeModulo(sphere_struct->vertexData.deviceAddress, min_component_byte_size) != 0) {
+                    if (!IsPointerAligned(sphere_struct->vertexData.deviceAddress, min_component_byte_size)) {
                         skip |= LogError(pick_vuid("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03711",
                                                    "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03711"),
                                          cmd_buffer, p_geom_geom_spheres_loc.dot(Field::vertexData).dot(Field::deviceAddress),
@@ -756,7 +756,7 @@ bool CoreChecks::ValidateAccelerationBuffers(VkCommandBuffer cmd_buffer, uint32_
                                          sphere_struct->vertexData.deviceAddress, min_component_byte_size,
                                          string_VkFormat(sphere_struct->vertexFormat));
                     }
-                    if (SafeModulo(sphere_struct->vertexStride, min_component_byte_size) != 0) {
+                    if (!IsIntegerMultipleOf(sphere_struct->vertexStride, min_component_byte_size)) {
                         skip |= LogError("VUID-VkAccelerationStructureGeometrySpheresDataNV-vertexStride-10431", cmd_buffer,
                                          p_geom_geom_spheres_loc.dot(Field::vertexStride),
                                          "is %" PRIu64 " and is not aligned to the minimum component byte size (%" PRIu32
@@ -846,7 +846,7 @@ bool CoreChecks::ValidateAccelerationBuffers(VkCommandBuffer cmd_buffer, uint32_
             else {
                 if (vkuFormatIsPacked(sphere_linear_struct->vertexFormat)) {
                     const uint32_t format_block_size = vkuFormatTexelBlockSize(sphere_linear_struct->vertexFormat);
-                    if (SafeModulo(sphere_linear_struct->vertexStride, format_block_size) != 0) {
+                    if (!IsIntegerMultipleOf(sphere_linear_struct->vertexStride, format_block_size)) {
                         skip |= LogError("VUID-VkAccelerationStructureGeometryLinearSweptSpheresDataNV-vertexFormat-10423",
                                          cmd_buffer, p_geom_geom_linear_spheres_loc.dot(Field::vertexStride),
                                          "is %" PRIu64 " and is not aligned to the texel block size (%" PRIu32
@@ -863,7 +863,7 @@ bool CoreChecks::ValidateAccelerationBuffers(VkCommandBuffer cmd_buffer, uint32_
                         min_component_bits_size = std::min(format_info.components[component_i].size, min_component_bits_size);
                     }
                     const uint32_t min_component_byte_size = min_component_bits_size / 8;
-                    if (SafeModulo(sphere_linear_struct->vertexData.deviceAddress, min_component_byte_size) != 0) {
+                    if (!IsPointerAligned(sphere_linear_struct->vertexData.deviceAddress, min_component_byte_size)) {
                         skip |=
                             LogError(pick_vuid("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03711",
                                                "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03711"),
@@ -874,7 +874,7 @@ bool CoreChecks::ValidateAccelerationBuffers(VkCommandBuffer cmd_buffer, uint32_
                                      sphere_linear_struct->vertexData.deviceAddress, min_component_byte_size,
                                      string_VkFormat(sphere_linear_struct->vertexFormat));
                     }
-                    if (SafeModulo(sphere_linear_struct->vertexStride, min_component_byte_size) != 0) {
+                    if (!IsIntegerMultipleOf(sphere_linear_struct->vertexStride, min_component_byte_size)) {
                         skip |= LogError("VUID-VkAccelerationStructureGeometryLinearSweptSpheresDataNV-vertexStride-10421",
                                          cmd_buffer, p_geom_geom_linear_spheres_loc.dot(Field::vertexStride),
                                          "is %" PRIu64 " and is not aligned to the minimum component byte size (%" PRIu32
@@ -2333,19 +2333,19 @@ bool CoreChecks::PreCallValidateCmdBuildPartitionedAccelerationStructuresNV(
                                                                 build_size_info.buildScratchSize,
                                                                 build_size_info.accelerationStructureSize);
 
-    if (SafeModulo(pBuildInfo->srcAccelerationStructureData, 256) != 0) {
+    if (!IsPointerAligned(pBuildInfo->srcAccelerationStructureData, 256)) {
         skip |= LogError("VUID-vkCmdBuildPartitionedAccelerationStructuresNV-pBuildInfo-10544", commandBuffer,
                          error_obj.location.dot(Field::pBuildInfo).dot(Field::srcAccelerationStructureData),
                          "(0x%" PRIx64 ") must be aligned to 256 bytes", pBuildInfo->srcAccelerationStructureData);
     }
 
-    if (SafeModulo(pBuildInfo->dstAccelerationStructureData, 256) != 0) {
+    if (!IsPointerAligned(pBuildInfo->dstAccelerationStructureData, 256)) {
         skip |= LogError("VUID-vkCmdBuildPartitionedAccelerationStructuresNV-pBuildInfo-10545", commandBuffer,
                          error_obj.location.dot(Field::pBuildInfo).dot(Field::dstAccelerationStructureData),
                          "(0x%" PRIx64 ") must be aligned to 256 bytes", pBuildInfo->dstAccelerationStructureData);
     }
 
-    if (SafeModulo(pBuildInfo->scratchData, 256) != 0) {
+    if (!IsPointerAligned(pBuildInfo->scratchData, 256)) {
         skip |= LogError("VUID-vkCmdBuildPartitionedAccelerationStructuresNV-pBuildInfo-10542", commandBuffer,
                          error_obj.location.dot(Field::pBuildInfo).dot(Field::scratchData),
                          "(0x%" PRIx64 ") must be aligned to 256 bytes", pBuildInfo->scratchData);
@@ -2576,7 +2576,7 @@ bool CoreChecks::ValidateBuildPartitionedAccelerationStructureInfoNV(
                                                                build_acceleration_structure_size);
     }
 
-    if (SafeModulo(build_info.srcInfosCount, 4) != 0) {
+    if (!IsPointerAligned(build_info.srcInfosCount, 4)) {
         skip |= LogError("VUID-VkBuildPartitionedAccelerationStructureInfoNV-srcInfosCount-10563", device,
                          build_info_loc.dot(Field::srcInfosCount), "(0x%" PRIx64 ") must be aligned to 256 bytes",
                          build_info.srcInfosCount);
@@ -2633,7 +2633,7 @@ bool CoreChecks::PreCallValidateCmdBuildClusterAccelerationStructureIndirectNV(
                                                                pCommandInfos->scratchData);
     }
 
-    if (SafeModulo(pCommandInfos->scratchData, phys_dev_ext_props.cluster_acceleration_props.clusterScratchByteAlignment) != 0) {
+    if (!IsPointerAligned(pCommandInfos->scratchData, phys_dev_ext_props.cluster_acceleration_props.clusterScratchByteAlignment)) {
         skip |= LogError(
             "VUID-vkCmdBuildClusterAccelerationStructureIndirectNV-scratchData-10447", commandBuffer,
             command_infos_loc.dot(Field::scratchData),
@@ -2853,7 +2853,7 @@ bool CoreChecks::ValidateClusterAccelerationStructureCommandsInfoNV(
                 "(0x%" PRIx64
                 ") must be a valid address if input::opMode is VK_CLUSTER_ACCELERATION_STRUCTURE_OP_MODE_IMPLICIT_DESTINATIONS_NV",
                 command_infos.dstImplicitData);
-        } else if (SafeModulo(command_infos.dstImplicitData, alignment_type) != 0) {
+        } else if (!IsPointerAligned(command_infos.dstImplicitData, alignment_type)) {
             skip |= LogError(vuid, objlist, command_infos_loc.dot(Field::dstImplicitData),
                              "(0x%" PRIx64 ") must be aligned to (%" PRIu32
                              ") depending on the input::opMode (%s) and input::opType (%s)",
@@ -2949,7 +2949,7 @@ bool CoreChecks::ValidateClusterAccelerationStructureCommandsInfoNV(
                          string_VkClusterAccelerationStructureOpTypeNV(command_infos.input.opType), stride_min);
     }
 
-    if (SafeModulo(command_infos.scratchData, phys_dev_ext_props.cluster_acceleration_props.clusterScratchByteAlignment) != 0) {
+    if (!IsPointerAligned(command_infos.scratchData, phys_dev_ext_props.cluster_acceleration_props.clusterScratchByteAlignment)) {
         skip |= LogError(
             "VUID-VkClusterAccelerationStructureCommandsInfoNV-scratchData-10480", objlist,
             command_infos_loc.dot(Field::scratchData),
@@ -2958,7 +2958,7 @@ bool CoreChecks::ValidateClusterAccelerationStructureCommandsInfoNV(
             command_infos.scratchData, phys_dev_ext_props.cluster_acceleration_props.clusterScratchByteAlignment);
     }
 
-    if (SafeModulo(command_infos.srcInfosCount, 4)) {
+    if (!IsPointerAligned(command_infos.srcInfosCount, 4)) {
         skip |= LogError("VUID-VkClusterAccelerationStructureCommandsInfoNV-srcInfosCount-10481", objlist,
                          command_infos_loc.dot(Field::srcInfosCount), "(0x%" PRIx64 ") must be 4-byte aligned",
                          command_infos.srcInfosCount);

--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -774,7 +774,7 @@ bool CoreChecks::ValidateFragmentDensityMapOffsetEnd(const vvl::CommandBuffer &c
         const VkOffset2D &layer_offset = fdm_offset_end_info.pFragmentDensityOffsets[i];
         if (layer_offset.x != 0 || layer_offset.y != 0) {
             const uint32_t width = phys_dev_ext_props.fragment_density_map_offset_props.fragmentDensityOffsetGranularity.width;
-            if (SafeModulo(layer_offset.x, width) != 0) {
+            if (!IsIntegerMultipleOf(layer_offset.x, width)) {
                 const LogObjectList objlist(cb_state.Handle(), rp_state.Handle());
                 skip |=
                     LogError("VUID-VkRenderPassFragmentDensityMapOffsetEndInfoEXT-x-06512", objlist,
@@ -784,7 +784,7 @@ bool CoreChecks::ValidateFragmentDensityMapOffsetEnd(const vvl::CommandBuffer &c
             }
 
             const uint32_t height = phys_dev_ext_props.fragment_density_map_offset_props.fragmentDensityOffsetGranularity.height;
-            if (SafeModulo(layer_offset.y, height) != 0) {
+            if (!IsIntegerMultipleOf(layer_offset.y, height)) {
                 const LogObjectList objlist(cb_state.Handle(), rp_state.Handle());
                 skip |=
                     LogError("VUID-VkRenderPassFragmentDensityMapOffsetEndInfoEXT-y-06513", objlist,

--- a/layers/core_checks/cc_video.cpp
+++ b/layers/core_checks/cc_video.cpp
@@ -4311,7 +4311,7 @@ bool CoreChecks::PreCallValidateBindVideoSessionMemoryKHR(VkDevice device, VkVid
                     }
                 }
 
-                if (SafeModulo(bind_info.memoryOffset, mem_binding_info->requirements.alignment) != 0) {
+                if (!IsIntegerMultipleOf(bind_info.memoryOffset, mem_binding_info->requirements.alignment)) {
                     skip |= LogError("VUID-vkBindVideoSessionMemoryKHR-pBindSessionMemoryInfos-07199", videoSession,
                                      error_obj.location.dot(Field::pBindSessionMemoryInfos, i).dot(Field::memoryOffset),
                                      "(%" PRIuLEAST64 ") but must be an integer multiple of the alignment value %" PRIuLEAST64

--- a/layers/stateless/sl_buffer.cpp
+++ b/layers/stateless/sl_buffer.cpp
@@ -132,7 +132,7 @@ bool Device::manual_PreCallValidateCreateBufferView(VkDevice device, const VkBuf
                              "(%" PRIuLEAST64 ") does not equal VK_WHOLE_SIZE, range must be greater than 0.", range);
         }
 
-        if (SafeModulo(range, texel_block_size) != 0) {
+        if (!IsIntegerMultipleOf(range, texel_block_size)) {
             skip |= LogError("VUID-VkBufferViewCreateInfo-range-00929", pCreateInfo->buffer, create_info_loc.dot(Field::range),
                              "(%" PRIuLEAST64
                              ") does not equal VK_WHOLE_SIZE, so it must be a multiple of the texel block size (%" PRIuLEAST64

--- a/layers/stateless/sl_cmd_buffer.cpp
+++ b/layers/stateless/sl_cmd_buffer.cpp
@@ -302,12 +302,12 @@ bool Device::ValidateCmdPushConstants(VkCommandBuffer commandBuffer, uint32_t of
                          max_push_constants_size);
     }
 
-    if (SafeModulo(size, 4) != 0) {
+    if (!IsIntegerMultipleOf(size, 4)) {
         const char *vuid = is_2 ? "VUID-VkPushConstantsInfo-size-00369" : "VUID-vkCmdPushConstants-size-00369";
         skip |= LogError(vuid, commandBuffer, loc.dot(Field::size), "(%" PRIu32 ") must be a multiple of 4.", size);
     }
 
-    if (SafeModulo(offset, 4) != 0) {
+    if (!IsIntegerMultipleOf(offset, 4)) {
         const char *vuid = is_2 ? "VUID-VkPushConstantsInfo-offset-00368" : "VUID-vkCmdPushConstants-offset-00368";
         skip |= LogError(vuid, commandBuffer, loc.dot(Field::offset), "(%" PRIu32 ") must be a multiple of 4.", offset);
     }

--- a/layers/stateless/sl_descriptor.cpp
+++ b/layers/stateless/sl_descriptor.cpp
@@ -872,7 +872,7 @@ bool Device::manual_PreCallValidateCreateDescriptorPool(VkDevice device, const V
                                  "is zero.");
             }
             if (pCreateInfo->pPoolSizes[i].type == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK) {
-                if (SafeModulo(pCreateInfo->pPoolSizes[i].descriptorCount, 4) != 0) {
+                if (!IsIntegerMultipleOf(pCreateInfo->pPoolSizes[i].descriptorCount, 4)) {
                     skip |= LogError("VUID-VkDescriptorPoolSize-type-02218", device, pool_loc.dot(Field::descriptorCount),
                                      "is %" PRIu32 " (not a multiple of 4), but type is VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK.",
                                      pCreateInfo->pPoolSizes[i].descriptorCount);
@@ -1246,7 +1246,7 @@ bool Device::ValidateCmdSetDescriptorBufferOffsets(VkCommandBuffer commandBuffer
         }
 
         const VkDeviceAddress offset = pOffsets[i];
-        if (SafeModulo(offset, phys_dev_ext_props.descriptor_buffer_props.descriptorBufferOffsetAlignment) != 0) {
+        if (!IsIntegerMultipleOf(offset, phys_dev_ext_props.descriptor_buffer_props.descriptorBufferOffsetAlignment)) {
             const char *vuid = is_2 ? "VUID-VkSetDescriptorBufferOffsetsInfoEXT-pOffsets-08061"
                                     : "VUID-vkCmdSetDescriptorBufferOffsetsEXT-pOffsets-08061";
             const LogObjectList objlist(commandBuffer, layout);

--- a/layers/stateless/sl_device_generated_commands.cpp
+++ b/layers/stateless/sl_device_generated_commands.cpp
@@ -315,7 +315,7 @@ bool Device::ValidateIndirectCommandsLayoutToken(const Context& context, const V
                              "(%" PRIu32 ") is greater than maxIndirectCommandsTokenOffset (%" PRIu32 ")", token.offset,
                              props.maxIndirectCommandsTokenOffset);
         }
-        if (SafeModulo(token.offset, 4) != 0) {
+        if (!IsIntegerMultipleOf(token.offset, 4)) {
             skip |= LogError("VUID-VkIndirectCommandsLayoutTokenEXT-offset-11125", device, token_loc.dot(Field::offset),
                              "(%" PRIu32 ") is not aligned to 4.", token.offset);
         }
@@ -489,9 +489,9 @@ bool Device::ValidateGeneratedCommandsInfo(VkCommandBuffer command_buffer,
                                            const Location& info_loc) const {
     bool skip = false;
 
-    if (generated_commands_info.sequenceCountAddress != 0 && SafeModulo(generated_commands_info.sequenceCountAddress, 4) != 0) {
+    if (generated_commands_info.sequenceCountAddress != 0 && !IsPointerAligned(generated_commands_info.sequenceCountAddress, 4)) {
         skip |= LogError("VUID-VkGeneratedCommandsInfoEXT-sequenceCountAddress-11073", command_buffer,
-                         info_loc.dot(Field::sequenceCountAddress), "(%" PRIuLEAST64 ") is not aligned to 4.",
+                         info_loc.dot(Field::sequenceCountAddress), "(0x%" PRIx64 ") is not aligned to 4.",
                          generated_commands_info.sequenceCountAddress);
     }
     if (generated_commands_info.maxSequenceCount == 0) {
@@ -499,10 +499,10 @@ bool Device::ValidateGeneratedCommandsInfo(VkCommandBuffer command_buffer,
                          info_loc.dot(Field::maxSequenceCount), "is zero.");
     }
 
-    if (SafeModulo(generated_commands_info.indirectAddress, 4) != 0) {
+    if (!IsPointerAligned(generated_commands_info.indirectAddress, 4)) {
         skip |=
             LogError("VUID-VkGeneratedCommandsInfoEXT-indirectAddress-11074", command_buffer, info_loc.dot(Field::indirectAddress),
-                     "(%" PRIuLEAST64 ") is not aligned to 4.", generated_commands_info.indirectAddress);
+                     "(0x%" PRIx64 ") is not aligned to 4.", generated_commands_info.indirectAddress);
     }
 
     if (generated_commands_info.indirectAddressSize == 0) {

--- a/layers/stateless/sl_image.cpp
+++ b/layers/stateless/sl_image.cpp
@@ -344,13 +344,13 @@ bool Device::manual_PreCallValidateCreateImage(VkDevice device, const VkImageCre
     }
 
     // If Chroma subsampled format ( _420_ or _422_ )
-    if (vkuFormatIsXChromaSubsampled(image_format) && (SafeModulo(pCreateInfo->extent.width, 2) != 0)) {
+    if (vkuFormatIsXChromaSubsampled(image_format) && !IsIntegerMultipleOf(pCreateInfo->extent.width, 2)) {
         skip |=
             LogError("VUID-VkImageCreateInfo-format-04712", device, create_info_loc.dot(Field::format),
                      "(%s) is X Chroma Subsampled (has _422 or _420 suffix) so the width (%" PRIu32 ") must be a multiple of 2.",
                      string_VkFormat(image_format), pCreateInfo->extent.width);
     }
-    if (vkuFormatIsYChromaSubsampled(image_format) && (SafeModulo(pCreateInfo->extent.height, 2) != 0)) {
+    if (vkuFormatIsYChromaSubsampled(image_format) && !IsIntegerMultipleOf(pCreateInfo->extent.height, 2)) {
         skip |= LogError("VUID-VkImageCreateInfo-format-04713", device, create_info_loc.dot(Field::format),
                          "(%s) is Y Chroma Subsampled (has _420 suffix) so the height (%" PRIu32 ") must be a multiple of 2.",
                          string_VkFormat(image_format), pCreateInfo->extent.height);

--- a/layers/utils/math_utils.h
+++ b/layers/utils/math_utils.h
@@ -138,13 +138,13 @@ static inline bool IsIntegerMultipleOf(const VkOffset2D& value, const VkOffset2D
     return IsIntegerMultipleOf(value.x, granularity.x) && IsIntegerMultipleOf(value.y, granularity.y);
 }
 
-// Perform a zero-tolerant modulo operation
-static inline VkDeviceSize SafeModulo(VkDeviceSize dividend, VkDeviceSize divisor) {
-    VkDeviceSize result = 0;
-    if (divisor != 0) {
-        result = dividend % divisor;
-    }
-    return result;
+static inline bool IsPointerAligned(const void* address, VkDeviceSize alignment) {
+    auto ptr = reinterpret_cast<std::uintptr_t>(address);
+    return alignment != 0 && (ptr % alignment == 0);
+}
+
+static inline bool IsPointerAligned(VkDeviceAddress address, VkDeviceSize alignment) {
+    return alignment != 0 && (address % alignment == 0);
 }
 
 static inline VkDeviceSize SafeDivision(VkDeviceSize dividend, VkDeviceSize divisor) {


### PR DESCRIPTION
Remove the `SafeModule` for `IsIntegerMultipleOf` or the new `IsPointerAligned`

While doing this, I spotted many spots where should have improved error messages

From this PR, shows we never used `SafeModule` to actually do anything other than check for something be aligned/multiple 