### PR TITLE
layers: Apply Clang-Format 21

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,4 +5,5 @@ IndentWidth: 4
 AccessModifierOffset: -2
 ColumnLimit: 132
 SortIncludes: false
+PointerAlignment: Left
 ...

--- a/layers/vulkan/generated/command_validation.cpp
+++ b/layers/vulkan/generated/command_validation.cpp
@@ -23,11 +23,9 @@
 
 #include "command_validation.h"
 #include "containers/custom_containers.h"
-
-extern const char *kVUIDUndefined;
-
-using Func = vvl::Func;
 // clang-format off
+extern const char *kVUIDUndefined;
+using Func = vvl::Func;
 static const auto &GetCommandValidationTable() {
 static const vvl::unordered_map<Func, CommandValidationInfo> kCommandValidationTable {
 {Func::vkCmdCopyBuffer, {
@@ -2580,12 +2578,12 @@ static const vvl::unordered_map<Func, CommandValidationInfo> kCommandValidationT
 };
 return kCommandValidationTable;
 }
-// clang-format on
 
-const CommandValidationInfo &GetCommandValidationInfo(vvl::Func command) {
+const CommandValidationInfo& GetCommandValidationInfo(vvl::Func command) {
     auto info_it = GetCommandValidationTable().find(command);
     assert(info_it != GetCommandValidationTable().end());
     return info_it->second;
 }
+// clang-format on
 
 // NOLINTEND

--- a/layers/vulkan/generated/device_features.cpp
+++ b/layers/vulkan/generated/device_features.cpp
@@ -26,15 +26,15 @@
 #include "generated/vk_extension_helper.h"
 #include <vulkan/utility/vk_struct_helper.hpp>
 
-void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatures *features, const APIVersion &api_version) {
+void GetEnabledDeviceFeatures(const VkDeviceCreateInfo* pCreateInfo, DeviceFeatures* features, const APIVersion& api_version) {
     // Initialize all to false
     *features = {};
 
     // handle VkPhysicalDeviceFeatures specially as it is not part of the pNext chain,
     // and when it is (through VkPhysicalDeviceFeatures2), it requires an extra indirection.
-    const VkPhysicalDeviceFeatures *core_features = pCreateInfo->pEnabledFeatures;
+    const VkPhysicalDeviceFeatures* core_features = pCreateInfo->pEnabledFeatures;
     if (core_features == nullptr) {
-        const VkPhysicalDeviceFeatures2 *features2 = vku::FindStructInPNextChain<VkPhysicalDeviceFeatures2>(pCreateInfo->pNext);
+        const VkPhysicalDeviceFeatures2* features2 = vku::FindStructInPNextChain<VkPhysicalDeviceFeatures2>(pCreateInfo->pNext);
         if (features2 != nullptr) {
             core_features = &features2->features;
         }
@@ -97,18 +97,18 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
         features->inheritedQueries = core_features->inheritedQueries == VK_TRUE;
     }
 
-    for (const VkBaseInStructure *pNext = reinterpret_cast<const VkBaseInStructure *>(pCreateInfo->pNext); pNext != nullptr;
+    for (const VkBaseInStructure* pNext = reinterpret_cast<const VkBaseInStructure*>(pCreateInfo->pNext); pNext != nullptr;
          pNext = pNext->pNext) {
         switch (pNext->sType) {
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_FEATURES: {
-                const VkPhysicalDeviceProtectedMemoryFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceProtectedMemoryFeatures *>(pNext);
+                const VkPhysicalDeviceProtectedMemoryFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceProtectedMemoryFeatures*>(pNext);
                 features->protectedMemory |= enabled->protectedMemory == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES: {
-                const VkPhysicalDevice16BitStorageFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDevice16BitStorageFeatures *>(pNext);
+                const VkPhysicalDevice16BitStorageFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDevice16BitStorageFeatures*>(pNext);
                 features->storageBuffer16BitAccess |= enabled->storageBuffer16BitAccess == VK_TRUE;
                 features->uniformAndStorageBuffer16BitAccess |= enabled->uniformAndStorageBuffer16BitAccess == VK_TRUE;
                 features->storagePushConstant16 |= enabled->storagePushConstant16 == VK_TRUE;
@@ -116,34 +116,34 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES: {
-                const VkPhysicalDeviceVariablePointersFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceVariablePointersFeatures *>(pNext);
+                const VkPhysicalDeviceVariablePointersFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceVariablePointersFeatures*>(pNext);
                 features->variablePointersStorageBuffer |= enabled->variablePointersStorageBuffer == VK_TRUE;
                 features->variablePointers |= enabled->variablePointers == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_YCBCR_CONVERSION_FEATURES: {
-                const VkPhysicalDeviceSamplerYcbcrConversionFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceSamplerYcbcrConversionFeatures *>(pNext);
+                const VkPhysicalDeviceSamplerYcbcrConversionFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceSamplerYcbcrConversionFeatures*>(pNext);
                 features->samplerYcbcrConversion |= enabled->samplerYcbcrConversion == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES: {
-                const VkPhysicalDeviceMultiviewFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMultiviewFeatures *>(pNext);
+                const VkPhysicalDeviceMultiviewFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMultiviewFeatures*>(pNext);
                 features->multiview |= enabled->multiview == VK_TRUE;
                 features->multiviewGeometryShader |= enabled->multiviewGeometryShader == VK_TRUE;
                 features->multiviewTessellationShader |= enabled->multiviewTessellationShader == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES: {
-                const VkPhysicalDeviceShaderDrawParametersFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderDrawParametersFeatures *>(pNext);
+                const VkPhysicalDeviceShaderDrawParametersFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderDrawParametersFeatures*>(pNext);
                 features->shaderDrawParameters |= enabled->shaderDrawParameters == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES: {
-                const VkPhysicalDeviceVulkan11Features *enabled = reinterpret_cast<const VkPhysicalDeviceVulkan11Features *>(pNext);
+                const VkPhysicalDeviceVulkan11Features* enabled = reinterpret_cast<const VkPhysicalDeviceVulkan11Features*>(pNext);
                 features->storageBuffer16BitAccess |= enabled->storageBuffer16BitAccess == VK_TRUE;
                 features->uniformAndStorageBuffer16BitAccess |= enabled->uniformAndStorageBuffer16BitAccess == VK_TRUE;
                 features->storagePushConstant16 |= enabled->storagePushConstant16 == VK_TRUE;
@@ -159,7 +159,7 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES: {
-                const VkPhysicalDeviceVulkan12Features *enabled = reinterpret_cast<const VkPhysicalDeviceVulkan12Features *>(pNext);
+                const VkPhysicalDeviceVulkan12Features* enabled = reinterpret_cast<const VkPhysicalDeviceVulkan12Features*>(pNext);
                 features->samplerMirrorClampToEdge |= enabled->samplerMirrorClampToEdge == VK_TRUE;
                 features->drawIndirectCount |= enabled->drawIndirectCount == VK_TRUE;
                 features->storageBuffer8BitAccess |= enabled->storageBuffer8BitAccess == VK_TRUE;
@@ -228,8 +228,8 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES: {
-                const VkPhysicalDeviceVulkanMemoryModelFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceVulkanMemoryModelFeatures *>(pNext);
+                const VkPhysicalDeviceVulkanMemoryModelFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceVulkanMemoryModelFeatures*>(pNext);
                 features->vulkanMemoryModel |= enabled->vulkanMemoryModel == VK_TRUE;
                 features->vulkanMemoryModelDeviceScope |= enabled->vulkanMemoryModelDeviceScope == VK_TRUE;
                 features->vulkanMemoryModelAvailabilityVisibilityChains |=
@@ -237,50 +237,50 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES: {
-                const VkPhysicalDeviceHostQueryResetFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceHostQueryResetFeatures *>(pNext);
+                const VkPhysicalDeviceHostQueryResetFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceHostQueryResetFeatures*>(pNext);
                 features->hostQueryReset |= enabled->hostQueryReset == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES: {
-                const VkPhysicalDeviceTimelineSemaphoreFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceTimelineSemaphoreFeatures *>(pNext);
+                const VkPhysicalDeviceTimelineSemaphoreFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceTimelineSemaphoreFeatures*>(pNext);
                 features->timelineSemaphore |= enabled->timelineSemaphore == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES: {
-                const VkPhysicalDeviceBufferDeviceAddressFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceBufferDeviceAddressFeatures *>(pNext);
+                const VkPhysicalDeviceBufferDeviceAddressFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceBufferDeviceAddressFeatures*>(pNext);
                 features->bufferDeviceAddress |= enabled->bufferDeviceAddress == VK_TRUE;
                 features->bufferDeviceAddressCaptureReplay |= enabled->bufferDeviceAddressCaptureReplay == VK_TRUE;
                 features->bufferDeviceAddressMultiDevice |= enabled->bufferDeviceAddressMultiDevice == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES: {
-                const VkPhysicalDevice8BitStorageFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDevice8BitStorageFeatures *>(pNext);
+                const VkPhysicalDevice8BitStorageFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDevice8BitStorageFeatures*>(pNext);
                 features->storageBuffer8BitAccess |= enabled->storageBuffer8BitAccess == VK_TRUE;
                 features->uniformAndStorageBuffer8BitAccess |= enabled->uniformAndStorageBuffer8BitAccess == VK_TRUE;
                 features->storagePushConstant8 |= enabled->storagePushConstant8 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES: {
-                const VkPhysicalDeviceShaderAtomicInt64Features *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderAtomicInt64Features *>(pNext);
+                const VkPhysicalDeviceShaderAtomicInt64Features* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderAtomicInt64Features*>(pNext);
                 features->shaderBufferInt64Atomics |= enabled->shaderBufferInt64Atomics == VK_TRUE;
                 features->shaderSharedInt64Atomics |= enabled->shaderSharedInt64Atomics == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES: {
-                const VkPhysicalDeviceShaderFloat16Int8Features *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderFloat16Int8Features *>(pNext);
+                const VkPhysicalDeviceShaderFloat16Int8Features* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderFloat16Int8Features*>(pNext);
                 features->shaderFloat16 |= enabled->shaderFloat16 == VK_TRUE;
                 features->shaderInt8 |= enabled->shaderInt8 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES: {
-                const VkPhysicalDeviceDescriptorIndexingFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDescriptorIndexingFeatures *>(pNext);
+                const VkPhysicalDeviceDescriptorIndexingFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDescriptorIndexingFeatures*>(pNext);
                 features->shaderInputAttachmentArrayDynamicIndexing |=
                     enabled->shaderInputAttachmentArrayDynamicIndexing == VK_TRUE;
                 features->shaderUniformTexelBufferArrayDynamicIndexing |=
@@ -321,37 +321,37 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES: {
-                const VkPhysicalDeviceScalarBlockLayoutFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceScalarBlockLayoutFeatures *>(pNext);
+                const VkPhysicalDeviceScalarBlockLayoutFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceScalarBlockLayoutFeatures*>(pNext);
                 features->scalarBlockLayout |= enabled->scalarBlockLayout == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES: {
-                const VkPhysicalDeviceUniformBufferStandardLayoutFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceUniformBufferStandardLayoutFeatures *>(pNext);
+                const VkPhysicalDeviceUniformBufferStandardLayoutFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceUniformBufferStandardLayoutFeatures*>(pNext);
                 features->uniformBufferStandardLayout |= enabled->uniformBufferStandardLayout == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_EXTENDED_TYPES_FEATURES: {
-                const VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures *>(pNext);
+                const VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures*>(pNext);
                 features->shaderSubgroupExtendedTypes |= enabled->shaderSubgroupExtendedTypes == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGELESS_FRAMEBUFFER_FEATURES: {
-                const VkPhysicalDeviceImagelessFramebufferFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceImagelessFramebufferFeatures *>(pNext);
+                const VkPhysicalDeviceImagelessFramebufferFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceImagelessFramebufferFeatures*>(pNext);
                 features->imagelessFramebuffer |= enabled->imagelessFramebuffer == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SEPARATE_DEPTH_STENCIL_LAYOUTS_FEATURES: {
-                const VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures *>(pNext);
+                const VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures*>(pNext);
                 features->separateDepthStencilLayouts |= enabled->separateDepthStencilLayouts == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES: {
-                const VkPhysicalDeviceVulkan13Features *enabled = reinterpret_cast<const VkPhysicalDeviceVulkan13Features *>(pNext);
+                const VkPhysicalDeviceVulkan13Features* enabled = reinterpret_cast<const VkPhysicalDeviceVulkan13Features*>(pNext);
                 features->robustImageAccess |= enabled->robustImageAccess == VK_TRUE;
                 features->inlineUniformBlock |= enabled->inlineUniformBlock == VK_TRUE;
                 features->descriptorBindingInlineUniformBlockUpdateAfterBind |=
@@ -371,88 +371,88 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIVATE_DATA_FEATURES: {
-                const VkPhysicalDevicePrivateDataFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePrivateDataFeatures *>(pNext);
+                const VkPhysicalDevicePrivateDataFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePrivateDataFeatures*>(pNext);
                 features->privateData |= enabled->privateData == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES: {
-                const VkPhysicalDeviceSynchronization2Features *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceSynchronization2Features *>(pNext);
+                const VkPhysicalDeviceSynchronization2Features* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceSynchronization2Features*>(pNext);
                 features->synchronization2 |= enabled->synchronization2 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXTURE_COMPRESSION_ASTC_HDR_FEATURES: {
-                const VkPhysicalDeviceTextureCompressionASTCHDRFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceTextureCompressionASTCHDRFeatures *>(pNext);
+                const VkPhysicalDeviceTextureCompressionASTCHDRFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceTextureCompressionASTCHDRFeatures*>(pNext);
                 features->textureCompressionASTC_HDR |= enabled->textureCompressionASTC_HDR == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_4_FEATURES: {
-                const VkPhysicalDeviceMaintenance4Features *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMaintenance4Features *>(pNext);
+                const VkPhysicalDeviceMaintenance4Features* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMaintenance4Features*>(pNext);
                 features->maintenance4 |= enabled->maintenance4 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_TERMINATE_INVOCATION_FEATURES: {
-                const VkPhysicalDeviceShaderTerminateInvocationFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderTerminateInvocationFeatures *>(pNext);
+                const VkPhysicalDeviceShaderTerminateInvocationFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderTerminateInvocationFeatures*>(pNext);
                 features->shaderTerminateInvocation |= enabled->shaderTerminateInvocation == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DEMOTE_TO_HELPER_INVOCATION_FEATURES: {
-                const VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures *>(pNext);
+                const VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures*>(pNext);
                 features->shaderDemoteToHelperInvocation |= enabled->shaderDemoteToHelperInvocation == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES: {
-                const VkPhysicalDevicePipelineCreationCacheControlFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePipelineCreationCacheControlFeatures *>(pNext);
+                const VkPhysicalDevicePipelineCreationCacheControlFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePipelineCreationCacheControlFeatures*>(pNext);
                 features->pipelineCreationCacheControl |= enabled->pipelineCreationCacheControl == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ZERO_INITIALIZE_WORKGROUP_MEMORY_FEATURES: {
-                const VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures *>(pNext);
+                const VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures*>(pNext);
                 features->shaderZeroInitializeWorkgroupMemory |= enabled->shaderZeroInitializeWorkgroupMemory == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES: {
-                const VkPhysicalDeviceImageRobustnessFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceImageRobustnessFeatures *>(pNext);
+                const VkPhysicalDeviceImageRobustnessFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceImageRobustnessFeatures*>(pNext);
                 features->robustImageAccess |= enabled->robustImageAccess == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES: {
-                const VkPhysicalDeviceSubgroupSizeControlFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceSubgroupSizeControlFeatures *>(pNext);
+                const VkPhysicalDeviceSubgroupSizeControlFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceSubgroupSizeControlFeatures*>(pNext);
                 features->subgroupSizeControl |= enabled->subgroupSizeControl == VK_TRUE;
                 features->computeFullSubgroups |= enabled->computeFullSubgroups == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_FEATURES: {
-                const VkPhysicalDeviceInlineUniformBlockFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceInlineUniformBlockFeatures *>(pNext);
+                const VkPhysicalDeviceInlineUniformBlockFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceInlineUniformBlockFeatures*>(pNext);
                 features->inlineUniformBlock |= enabled->inlineUniformBlock == VK_TRUE;
                 features->descriptorBindingInlineUniformBlockUpdateAfterBind |=
                     enabled->descriptorBindingInlineUniformBlockUpdateAfterBind == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_FEATURES: {
-                const VkPhysicalDeviceShaderIntegerDotProductFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderIntegerDotProductFeatures *>(pNext);
+                const VkPhysicalDeviceShaderIntegerDotProductFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderIntegerDotProductFeatures*>(pNext);
                 features->shaderIntegerDotProduct |= enabled->shaderIntegerDotProduct == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES: {
-                const VkPhysicalDeviceDynamicRenderingFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDynamicRenderingFeatures *>(pNext);
+                const VkPhysicalDeviceDynamicRenderingFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDynamicRenderingFeatures*>(pNext);
                 features->dynamicRendering |= enabled->dynamicRendering == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_4_FEATURES: {
-                const VkPhysicalDeviceVulkan14Features *enabled = reinterpret_cast<const VkPhysicalDeviceVulkan14Features *>(pNext);
+                const VkPhysicalDeviceVulkan14Features* enabled = reinterpret_cast<const VkPhysicalDeviceVulkan14Features*>(pNext);
                 features->globalPriorityQuery |= enabled->globalPriorityQuery == VK_TRUE;
                 features->shaderSubgroupRotate |= enabled->shaderSubgroupRotate == VK_TRUE;
                 features->shaderSubgroupRotateClustered |= enabled->shaderSubgroupRotateClustered == VK_TRUE;
@@ -477,69 +477,69 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GLOBAL_PRIORITY_QUERY_FEATURES: {
-                const VkPhysicalDeviceGlobalPriorityQueryFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceGlobalPriorityQueryFeatures *>(pNext);
+                const VkPhysicalDeviceGlobalPriorityQueryFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceGlobalPriorityQueryFeatures*>(pNext);
                 features->globalPriorityQuery |= enabled->globalPriorityQuery == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INDEX_TYPE_UINT8_FEATURES: {
-                const VkPhysicalDeviceIndexTypeUint8Features *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceIndexTypeUint8Features *>(pNext);
+                const VkPhysicalDeviceIndexTypeUint8Features* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceIndexTypeUint8Features*>(pNext);
                 features->indexTypeUint8 |= enabled->indexTypeUint8 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_FEATURES: {
-                const VkPhysicalDeviceMaintenance5Features *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMaintenance5Features *>(pNext);
+                const VkPhysicalDeviceMaintenance5Features* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMaintenance5Features*>(pNext);
                 features->maintenance5 |= enabled->maintenance5 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_6_FEATURES: {
-                const VkPhysicalDeviceMaintenance6Features *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMaintenance6Features *>(pNext);
+                const VkPhysicalDeviceMaintenance6Features* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMaintenance6Features*>(pNext);
                 features->maintenance6 |= enabled->maintenance6 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_IMAGE_COPY_FEATURES: {
-                const VkPhysicalDeviceHostImageCopyFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceHostImageCopyFeatures *>(pNext);
+                const VkPhysicalDeviceHostImageCopyFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceHostImageCopyFeatures*>(pNext);
                 features->hostImageCopy |= enabled->hostImageCopy == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_ROTATE_FEATURES: {
-                const VkPhysicalDeviceShaderSubgroupRotateFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderSubgroupRotateFeatures *>(pNext);
+                const VkPhysicalDeviceShaderSubgroupRotateFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderSubgroupRotateFeatures*>(pNext);
                 features->shaderSubgroupRotate |= enabled->shaderSubgroupRotate == VK_TRUE;
                 features->shaderSubgroupRotateClustered |= enabled->shaderSubgroupRotateClustered == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT_CONTROLS_2_FEATURES: {
-                const VkPhysicalDeviceShaderFloatControls2Features *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderFloatControls2Features *>(pNext);
+                const VkPhysicalDeviceShaderFloatControls2Features* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderFloatControls2Features*>(pNext);
                 features->shaderFloatControls2 |= enabled->shaderFloatControls2 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_EXPECT_ASSUME_FEATURES: {
-                const VkPhysicalDeviceShaderExpectAssumeFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderExpectAssumeFeatures *>(pNext);
+                const VkPhysicalDeviceShaderExpectAssumeFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderExpectAssumeFeatures*>(pNext);
                 features->shaderExpectAssume |= enabled->shaderExpectAssume == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_PROTECTED_ACCESS_FEATURES: {
-                const VkPhysicalDevicePipelineProtectedAccessFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePipelineProtectedAccessFeatures *>(pNext);
+                const VkPhysicalDevicePipelineProtectedAccessFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePipelineProtectedAccessFeatures*>(pNext);
                 features->pipelineProtectedAccess |= enabled->pipelineProtectedAccess == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_ROBUSTNESS_FEATURES: {
-                const VkPhysicalDevicePipelineRobustnessFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePipelineRobustnessFeatures *>(pNext);
+                const VkPhysicalDevicePipelineRobustnessFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePipelineRobustnessFeatures*>(pNext);
                 features->pipelineRobustness |= enabled->pipelineRobustness == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES: {
-                const VkPhysicalDeviceLineRasterizationFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceLineRasterizationFeatures *>(pNext);
+                const VkPhysicalDeviceLineRasterizationFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceLineRasterizationFeatures*>(pNext);
                 features->rectangularLines |= enabled->rectangularLines == VK_TRUE;
                 features->bresenhamLines |= enabled->bresenhamLines == VK_TRUE;
                 features->smoothLines |= enabled->smoothLines == VK_TRUE;
@@ -549,28 +549,28 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES: {
-                const VkPhysicalDeviceVertexAttributeDivisorFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceVertexAttributeDivisorFeatures *>(pNext);
+                const VkPhysicalDeviceVertexAttributeDivisorFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceVertexAttributeDivisorFeatures*>(pNext);
                 features->vertexAttributeInstanceRateDivisor |= enabled->vertexAttributeInstanceRateDivisor == VK_TRUE;
                 features->vertexAttributeInstanceRateZeroDivisor |= enabled->vertexAttributeInstanceRateZeroDivisor == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_LOCAL_READ_FEATURES: {
-                const VkPhysicalDeviceDynamicRenderingLocalReadFeatures *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDynamicRenderingLocalReadFeatures *>(pNext);
+                const VkPhysicalDeviceDynamicRenderingLocalReadFeatures* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDynamicRenderingLocalReadFeatures*>(pNext);
                 features->dynamicRenderingLocalRead |= enabled->dynamicRenderingLocalRead == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PERFORMANCE_QUERY_FEATURES_KHR: {
-                const VkPhysicalDevicePerformanceQueryFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePerformanceQueryFeaturesKHR *>(pNext);
+                const VkPhysicalDevicePerformanceQueryFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePerformanceQueryFeaturesKHR*>(pNext);
                 features->performanceCounterQueryPools |= enabled->performanceCounterQueryPools == VK_TRUE;
                 features->performanceCounterMultipleQueryPools |= enabled->performanceCounterMultipleQueryPools == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_BFLOAT16_FEATURES_KHR: {
-                const VkPhysicalDeviceShaderBfloat16FeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderBfloat16FeaturesKHR *>(pNext);
+                const VkPhysicalDeviceShaderBfloat16FeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderBfloat16FeaturesKHR*>(pNext);
                 features->shaderBFloat16Type |= enabled->shaderBFloat16Type == VK_TRUE;
                 features->shaderBFloat16DotProduct |= enabled->shaderBFloat16DotProduct == VK_TRUE;
                 features->shaderBFloat16CooperativeMatrix |= enabled->shaderBFloat16CooperativeMatrix == VK_TRUE;
@@ -578,8 +578,8 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
             }
 #ifdef VK_ENABLE_BETA_EXTENSIONS
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_FEATURES_KHR: {
-                const VkPhysicalDevicePortabilitySubsetFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(pNext);
+                const VkPhysicalDevicePortabilitySubsetFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(pNext);
                 features->constantAlphaColorBlendFactors |= enabled->constantAlphaColorBlendFactors == VK_TRUE;
                 features->events |= enabled->events == VK_TRUE;
                 features->imageViewFormatReinterpretation |= enabled->imageViewFormatReinterpretation == VK_TRUE;
@@ -599,59 +599,59 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
             }
 #endif  // VK_ENABLE_BETA_EXTENSIONS
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CLOCK_FEATURES_KHR: {
-                const VkPhysicalDeviceShaderClockFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderClockFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceShaderClockFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderClockFeaturesKHR*>(pNext);
                 features->shaderSubgroupClock |= enabled->shaderSubgroupClock == VK_TRUE;
                 features->shaderDeviceClock |= enabled->shaderDeviceClock == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_FEATURES_KHR: {
-                const VkPhysicalDeviceFragmentShadingRateFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceFragmentShadingRateFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceFragmentShadingRateFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceFragmentShadingRateFeaturesKHR*>(pNext);
                 features->pipelineFragmentShadingRate |= enabled->pipelineFragmentShadingRate == VK_TRUE;
                 features->primitiveFragmentShadingRate |= enabled->primitiveFragmentShadingRate == VK_TRUE;
                 features->attachmentFragmentShadingRate |= enabled->attachmentFragmentShadingRate == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_QUAD_CONTROL_FEATURES_KHR: {
-                const VkPhysicalDeviceShaderQuadControlFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderQuadControlFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceShaderQuadControlFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderQuadControlFeaturesKHR*>(pNext);
                 features->shaderQuadControl |= enabled->shaderQuadControl == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_WAIT_FEATURES_KHR: {
-                const VkPhysicalDevicePresentWaitFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePresentWaitFeaturesKHR *>(pNext);
+                const VkPhysicalDevicePresentWaitFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePresentWaitFeaturesKHR*>(pNext);
                 features->presentWait |= enabled->presentWait == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_EXECUTABLE_PROPERTIES_FEATURES_KHR: {
-                const VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR *>(pNext);
+                const VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR*>(pNext);
                 features->pipelineExecutableInfo |= enabled->pipelineExecutableInfo == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_ID_FEATURES_KHR: {
-                const VkPhysicalDevicePresentIdFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePresentIdFeaturesKHR *>(pNext);
+                const VkPhysicalDevicePresentIdFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePresentIdFeaturesKHR*>(pNext);
                 features->presentId |= enabled->presentId == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_FEATURES_KHR: {
-                const VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR*>(pNext);
                 features->fragmentShaderBarycentric |= enabled->fragmentShaderBarycentric == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_UNIFORM_CONTROL_FLOW_FEATURES_KHR: {
-                const VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR*>(pNext);
                 features->shaderSubgroupUniformControlFlow |= enabled->shaderSubgroupUniformControlFlow == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_WORKGROUP_MEMORY_EXPLICIT_LAYOUT_FEATURES_KHR: {
-                const VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR*>(pNext);
                 features->workgroupMemoryExplicitLayout |= enabled->workgroupMemoryExplicitLayout == VK_TRUE;
                 features->workgroupMemoryExplicitLayoutScalarBlockLayout |=
                     enabled->workgroupMemoryExplicitLayoutScalarBlockLayout == VK_TRUE;
@@ -660,360 +660,360 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_MAINTENANCE_1_FEATURES_KHR: {
-                const VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR *>(pNext);
+                const VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR*>(pNext);
                 features->rayTracingMaintenance1 |= enabled->rayTracingMaintenance1 == VK_TRUE;
                 features->rayTracingPipelineTraceRaysIndirect2 |= enabled->rayTracingPipelineTraceRaysIndirect2 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_UNTYPED_POINTERS_FEATURES_KHR: {
-                const VkPhysicalDeviceShaderUntypedPointersFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderUntypedPointersFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceShaderUntypedPointersFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderUntypedPointersFeaturesKHR*>(pNext);
                 features->shaderUntypedPointers |= enabled->shaderUntypedPointers == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_MAXIMAL_RECONVERGENCE_FEATURES_KHR: {
-                const VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR*>(pNext);
                 features->shaderMaximalReconvergence |= enabled->shaderMaximalReconvergence == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_ID_2_FEATURES_KHR: {
-                const VkPhysicalDevicePresentId2FeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePresentId2FeaturesKHR *>(pNext);
+                const VkPhysicalDevicePresentId2FeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePresentId2FeaturesKHR*>(pNext);
                 features->presentId2 |= enabled->presentId2 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_WAIT_2_FEATURES_KHR: {
-                const VkPhysicalDevicePresentWait2FeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePresentWait2FeaturesKHR *>(pNext);
+                const VkPhysicalDevicePresentWait2FeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePresentWait2FeaturesKHR*>(pNext);
                 features->presentWait2 |= enabled->presentWait2 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_POSITION_FETCH_FEATURES_KHR: {
-                const VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR*>(pNext);
                 features->rayTracingPositionFetch |= enabled->rayTracingPositionFetch == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_BINARY_FEATURES_KHR: {
-                const VkPhysicalDevicePipelineBinaryFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePipelineBinaryFeaturesKHR *>(pNext);
+                const VkPhysicalDevicePipelineBinaryFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePipelineBinaryFeaturesKHR*>(pNext);
                 features->pipelineBinaries |= enabled->pipelineBinaries == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SWAPCHAIN_MAINTENANCE_1_FEATURES_KHR: {
-                const VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR *>(pNext);
+                const VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR*>(pNext);
                 features->swapchainMaintenance1 |= enabled->swapchainMaintenance1 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_KHR: {
-                const VkPhysicalDeviceCooperativeMatrixFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceCooperativeMatrixFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixFeaturesKHR*>(pNext);
                 features->cooperativeMatrix |= enabled->cooperativeMatrix == VK_TRUE;
                 features->cooperativeMatrixRobustBufferAccess |= enabled->cooperativeMatrixRobustBufferAccess == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMPUTE_SHADER_DERIVATIVES_FEATURES_KHR: {
-                const VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR*>(pNext);
                 features->computeDerivativeGroupQuads |= enabled->computeDerivativeGroupQuads == VK_TRUE;
                 features->computeDerivativeGroupLinear |= enabled->computeDerivativeGroupLinear == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_ENCODE_AV1_FEATURES_KHR: {
-                const VkPhysicalDeviceVideoEncodeAV1FeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceVideoEncodeAV1FeaturesKHR *>(pNext);
+                const VkPhysicalDeviceVideoEncodeAV1FeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceVideoEncodeAV1FeaturesKHR*>(pNext);
                 features->videoEncodeAV1 |= enabled->videoEncodeAV1 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_DECODE_VP9_FEATURES_KHR: {
-                const VkPhysicalDeviceVideoDecodeVP9FeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceVideoDecodeVP9FeaturesKHR *>(pNext);
+                const VkPhysicalDeviceVideoDecodeVP9FeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceVideoDecodeVP9FeaturesKHR*>(pNext);
                 features->videoDecodeVP9 |= enabled->videoDecodeVP9 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_MAINTENANCE_1_FEATURES_KHR: {
-                const VkPhysicalDeviceVideoMaintenance1FeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceVideoMaintenance1FeaturesKHR *>(pNext);
+                const VkPhysicalDeviceVideoMaintenance1FeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceVideoMaintenance1FeaturesKHR*>(pNext);
                 features->videoMaintenance1 |= enabled->videoMaintenance1 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_UNIFIED_IMAGE_LAYOUTS_FEATURES_KHR: {
-                const VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR*>(pNext);
                 features->unifiedImageLayouts |= enabled->unifiedImageLayouts == VK_TRUE;
                 features->unifiedImageLayoutsVideo |= enabled->unifiedImageLayoutsVideo == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COPY_MEMORY_INDIRECT_FEATURES_KHR: {
-                const VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR*>(pNext);
                 features->indirectMemoryCopy |= enabled->indirectMemoryCopy == VK_TRUE;
                 features->indirectMemoryToImageCopy |= enabled->indirectMemoryToImageCopy == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_ENCODE_INTRA_REFRESH_FEATURES_KHR: {
-                const VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR*>(pNext);
                 features->videoEncodeIntraRefresh |= enabled->videoEncodeIntraRefresh == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_ENCODE_QUANTIZATION_MAP_FEATURES_KHR: {
-                const VkPhysicalDeviceVideoEncodeQuantizationMapFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceVideoEncodeQuantizationMapFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceVideoEncodeQuantizationMapFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceVideoEncodeQuantizationMapFeaturesKHR*>(pNext);
                 features->videoEncodeQuantizationMap |= enabled->videoEncodeQuantizationMap == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_RELAXED_EXTENDED_INSTRUCTION_FEATURES_KHR: {
-                const VkPhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR*>(pNext);
                 features->shaderRelaxedExtendedInstruction |= enabled->shaderRelaxedExtendedInstruction == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_7_FEATURES_KHR: {
-                const VkPhysicalDeviceMaintenance7FeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMaintenance7FeaturesKHR *>(pNext);
+                const VkPhysicalDeviceMaintenance7FeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMaintenance7FeaturesKHR*>(pNext);
                 features->maintenance7 |= enabled->maintenance7 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_8_FEATURES_KHR: {
-                const VkPhysicalDeviceMaintenance8FeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMaintenance8FeaturesKHR *>(pNext);
+                const VkPhysicalDeviceMaintenance8FeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMaintenance8FeaturesKHR*>(pNext);
                 features->maintenance8 |= enabled->maintenance8 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FMA_FEATURES_KHR: {
-                const VkPhysicalDeviceShaderFmaFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderFmaFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceShaderFmaFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderFmaFeaturesKHR*>(pNext);
                 features->shaderFmaFloat16 |= enabled->shaderFmaFloat16 == VK_TRUE;
                 features->shaderFmaFloat32 |= enabled->shaderFmaFloat32 == VK_TRUE;
                 features->shaderFmaFloat64 |= enabled->shaderFmaFloat64 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_9_FEATURES_KHR: {
-                const VkPhysicalDeviceMaintenance9FeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMaintenance9FeaturesKHR *>(pNext);
+                const VkPhysicalDeviceMaintenance9FeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMaintenance9FeaturesKHR*>(pNext);
                 features->maintenance9 |= enabled->maintenance9 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_MAINTENANCE_2_FEATURES_KHR: {
-                const VkPhysicalDeviceVideoMaintenance2FeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceVideoMaintenance2FeaturesKHR *>(pNext);
+                const VkPhysicalDeviceVideoMaintenance2FeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceVideoMaintenance2FeaturesKHR*>(pNext);
                 features->videoMaintenance2 |= enabled->videoMaintenance2 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLAMP_ZERO_ONE_FEATURES_KHR: {
-                const VkPhysicalDeviceDepthClampZeroOneFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDepthClampZeroOneFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceDepthClampZeroOneFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDepthClampZeroOneFeaturesKHR*>(pNext);
                 features->depthClampZeroOne |= enabled->depthClampZeroOne == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_KHR: {
-                const VkPhysicalDeviceRobustness2FeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceRobustness2FeaturesKHR *>(pNext);
+                const VkPhysicalDeviceRobustness2FeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceRobustness2FeaturesKHR*>(pNext);
                 features->robustBufferAccess2 |= enabled->robustBufferAccess2 == VK_TRUE;
                 features->robustImageAccess2 |= enabled->robustImageAccess2 == VK_TRUE;
                 features->nullDescriptor |= enabled->nullDescriptor == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_MODE_FIFO_LATEST_READY_FEATURES_KHR: {
-                const VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR *>(pNext);
+                const VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR*>(pNext);
                 features->presentModeFifoLatestReady |= enabled->presentModeFifoLatestReady == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_10_FEATURES_KHR: {
-                const VkPhysicalDeviceMaintenance10FeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMaintenance10FeaturesKHR *>(pNext);
+                const VkPhysicalDeviceMaintenance10FeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMaintenance10FeaturesKHR*>(pNext);
                 features->maintenance10 |= enabled->maintenance10 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT: {
-                const VkPhysicalDeviceTransformFeedbackFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceTransformFeedbackFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceTransformFeedbackFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceTransformFeedbackFeaturesEXT*>(pNext);
                 features->transformFeedback |= enabled->transformFeedback == VK_TRUE;
                 features->geometryStreams |= enabled->geometryStreams == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CORNER_SAMPLED_IMAGE_FEATURES_NV: {
-                const VkPhysicalDeviceCornerSampledImageFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceCornerSampledImageFeaturesNV *>(pNext);
+                const VkPhysicalDeviceCornerSampledImageFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceCornerSampledImageFeaturesNV*>(pNext);
                 features->cornerSampledImage |= enabled->cornerSampledImage == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ASTC_DECODE_FEATURES_EXT: {
-                const VkPhysicalDeviceASTCDecodeFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceASTCDecodeFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceASTCDecodeFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceASTCDecodeFeaturesEXT*>(pNext);
                 features->decodeModeSharedExponent |= enabled->decodeModeSharedExponent == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONDITIONAL_RENDERING_FEATURES_EXT: {
-                const VkPhysicalDeviceConditionalRenderingFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceConditionalRenderingFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceConditionalRenderingFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceConditionalRenderingFeaturesEXT*>(pNext);
                 features->conditionalRendering |= enabled->conditionalRendering == VK_TRUE;
                 features->inheritedConditionalRendering |= enabled->inheritedConditionalRendering == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_ENABLE_FEATURES_EXT: {
-                const VkPhysicalDeviceDepthClipEnableFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDepthClipEnableFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceDepthClipEnableFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDepthClipEnableFeaturesEXT*>(pNext);
                 features->depthClipEnable |= enabled->depthClipEnable == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RELAXED_LINE_RASTERIZATION_FEATURES_IMG: {
-                const VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG *>(pNext);
+                const VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG*>(pNext);
                 features->relaxedLineRasterization |= enabled->relaxedLineRasterization == VK_TRUE;
                 break;
             }
 #ifdef VK_ENABLE_BETA_EXTENSIONS
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ENQUEUE_FEATURES_AMDX: {
-                const VkPhysicalDeviceShaderEnqueueFeaturesAMDX *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderEnqueueFeaturesAMDX *>(pNext);
+                const VkPhysicalDeviceShaderEnqueueFeaturesAMDX* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderEnqueueFeaturesAMDX*>(pNext);
                 features->shaderEnqueue |= enabled->shaderEnqueue == VK_TRUE;
                 features->shaderMeshEnqueue |= enabled->shaderMeshEnqueue == VK_TRUE;
                 break;
             }
 #endif  // VK_ENABLE_BETA_EXTENSIONS
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_FEATURES_EXT: {
-                const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT*>(pNext);
                 features->advancedBlendCoherentOperations |= enabled->advancedBlendCoherentOperations == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SM_BUILTINS_FEATURES_NV: {
-                const VkPhysicalDeviceShaderSMBuiltinsFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderSMBuiltinsFeaturesNV *>(pNext);
+                const VkPhysicalDeviceShaderSMBuiltinsFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderSMBuiltinsFeaturesNV*>(pNext);
                 features->shaderSMBuiltins |= enabled->shaderSMBuiltins == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADING_RATE_IMAGE_FEATURES_NV: {
-                const VkPhysicalDeviceShadingRateImageFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShadingRateImageFeaturesNV *>(pNext);
+                const VkPhysicalDeviceShadingRateImageFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShadingRateImageFeaturesNV*>(pNext);
                 features->shadingRateImage |= enabled->shadingRateImage == VK_TRUE;
                 features->shadingRateCoarseSampleOrder |= enabled->shadingRateCoarseSampleOrder == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_REPRESENTATIVE_FRAGMENT_TEST_FEATURES_NV: {
-                const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV *>(pNext);
+                const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV*>(pNext);
                 features->representativeFragmentTest |= enabled->representativeFragmentTest == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_NV: {
-                const VkPhysicalDeviceMeshShaderFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMeshShaderFeaturesNV *>(pNext);
+                const VkPhysicalDeviceMeshShaderFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMeshShaderFeaturesNV*>(pNext);
                 features->taskShader |= enabled->taskShader == VK_TRUE;
                 features->meshShader |= enabled->meshShader == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_IMAGE_FOOTPRINT_FEATURES_NV: {
-                const VkPhysicalDeviceShaderImageFootprintFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderImageFootprintFeaturesNV *>(pNext);
+                const VkPhysicalDeviceShaderImageFootprintFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderImageFootprintFeaturesNV*>(pNext);
                 features->imageFootprint |= enabled->imageFootprint == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXCLUSIVE_SCISSOR_FEATURES_NV: {
-                const VkPhysicalDeviceExclusiveScissorFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceExclusiveScissorFeaturesNV *>(pNext);
+                const VkPhysicalDeviceExclusiveScissorFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceExclusiveScissorFeaturesNV*>(pNext);
                 features->exclusiveScissor |= enabled->exclusiveScissor == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_TIMING_FEATURES_EXT: {
-                const VkPhysicalDevicePresentTimingFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePresentTimingFeaturesEXT *>(pNext);
+                const VkPhysicalDevicePresentTimingFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePresentTimingFeaturesEXT*>(pNext);
                 features->presentTiming |= enabled->presentTiming == VK_TRUE;
                 features->presentAtAbsoluteTime |= enabled->presentAtAbsoluteTime == VK_TRUE;
                 features->presentAtRelativeTime |= enabled->presentAtRelativeTime == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_FUNCTIONS_2_FEATURES_INTEL: {
-                const VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL *>(pNext);
+                const VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL*>(pNext);
                 features->shaderIntegerFunctions2 |= enabled->shaderIntegerFunctions2 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_FEATURES_EXT: {
-                const VkPhysicalDeviceFragmentDensityMapFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceFragmentDensityMapFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapFeaturesEXT*>(pNext);
                 features->fragmentDensityMap |= enabled->fragmentDensityMap == VK_TRUE;
                 features->fragmentDensityMapDynamic |= enabled->fragmentDensityMapDynamic == VK_TRUE;
                 features->fragmentDensityMapNonSubsampledImages |= enabled->fragmentDensityMapNonSubsampledImages == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COHERENT_MEMORY_FEATURES_AMD: {
-                const VkPhysicalDeviceCoherentMemoryFeaturesAMD *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceCoherentMemoryFeaturesAMD *>(pNext);
+                const VkPhysicalDeviceCoherentMemoryFeaturesAMD* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceCoherentMemoryFeaturesAMD*>(pNext);
                 features->deviceCoherentMemory |= enabled->deviceCoherentMemory == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_IMAGE_ATOMIC_INT64_FEATURES_EXT: {
-                const VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT *>(pNext);
+                const VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT*>(pNext);
                 features->shaderImageInt64Atomics |= enabled->shaderImageInt64Atomics == VK_TRUE;
                 features->sparseImageInt64Atomics |= enabled->sparseImageInt64Atomics == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PRIORITY_FEATURES_EXT: {
-                const VkPhysicalDeviceMemoryPriorityFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMemoryPriorityFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceMemoryPriorityFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMemoryPriorityFeaturesEXT*>(pNext);
                 features->memoryPriority |= enabled->memoryPriority == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEDICATED_ALLOCATION_IMAGE_ALIASING_FEATURES_NV: {
-                const VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV *>(pNext);
+                const VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV*>(pNext);
                 features->dedicatedAllocationImageAliasing |= enabled->dedicatedAllocationImageAliasing == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_EXT: {
-                const VkPhysicalDeviceBufferDeviceAddressFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceBufferDeviceAddressFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceBufferDeviceAddressFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceBufferDeviceAddressFeaturesEXT*>(pNext);
                 features->bufferDeviceAddressEXT |= enabled->bufferDeviceAddress == VK_TRUE;
                 features->bufferDeviceAddressCaptureReplayEXT |= enabled->bufferDeviceAddressCaptureReplay == VK_TRUE;
                 features->bufferDeviceAddressMultiDeviceEXT |= enabled->bufferDeviceAddressMultiDevice == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_NV: {
-                const VkPhysicalDeviceCooperativeMatrixFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixFeaturesNV *>(pNext);
+                const VkPhysicalDeviceCooperativeMatrixFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixFeaturesNV*>(pNext);
                 features->cooperativeMatrix |= enabled->cooperativeMatrix == VK_TRUE;
                 features->cooperativeMatrixRobustBufferAccess |= enabled->cooperativeMatrixRobustBufferAccess == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COVERAGE_REDUCTION_MODE_FEATURES_NV: {
-                const VkPhysicalDeviceCoverageReductionModeFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceCoverageReductionModeFeaturesNV *>(pNext);
+                const VkPhysicalDeviceCoverageReductionModeFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceCoverageReductionModeFeaturesNV*>(pNext);
                 features->coverageReductionMode |= enabled->coverageReductionMode == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_INTERLOCK_FEATURES_EXT: {
-                const VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT*>(pNext);
                 features->fragmentShaderSampleInterlock |= enabled->fragmentShaderSampleInterlock == VK_TRUE;
                 features->fragmentShaderPixelInterlock |= enabled->fragmentShaderPixelInterlock == VK_TRUE;
                 features->fragmentShaderShadingRateInterlock |= enabled->fragmentShaderShadingRateInterlock == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_IMAGE_ARRAYS_FEATURES_EXT: {
-                const VkPhysicalDeviceYcbcrImageArraysFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceYcbcrImageArraysFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceYcbcrImageArraysFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceYcbcrImageArraysFeaturesEXT*>(pNext);
                 features->ycbcrImageArrays |= enabled->ycbcrImageArrays == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROVOKING_VERTEX_FEATURES_EXT: {
-                const VkPhysicalDeviceProvokingVertexFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceProvokingVertexFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceProvokingVertexFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceProvokingVertexFeaturesEXT*>(pNext);
                 features->provokingVertexLast |= enabled->provokingVertexLast == VK_TRUE;
                 features->transformFeedbackPreservesProvokingVertex |=
                     enabled->transformFeedbackPreservesProvokingVertex == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_FEATURES_EXT: {
-                const VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceShaderAtomicFloatFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(pNext);
                 features->shaderBufferFloat32Atomics |= enabled->shaderBufferFloat32Atomics == VK_TRUE;
                 features->shaderBufferFloat32AtomicAdd |= enabled->shaderBufferFloat32AtomicAdd == VK_TRUE;
                 features->shaderBufferFloat64Atomics |= enabled->shaderBufferFloat64Atomics == VK_TRUE;
@@ -1029,22 +1029,22 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT: {
-                const VkPhysicalDeviceExtendedDynamicStateFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceExtendedDynamicStateFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceExtendedDynamicStateFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceExtendedDynamicStateFeaturesEXT*>(pNext);
                 features->extendedDynamicState |= enabled->extendedDynamicState == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAP_MEMORY_PLACED_FEATURES_EXT: {
-                const VkPhysicalDeviceMapMemoryPlacedFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMapMemoryPlacedFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceMapMemoryPlacedFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMapMemoryPlacedFeaturesEXT*>(pNext);
                 features->memoryMapPlaced |= enabled->memoryMapPlaced == VK_TRUE;
                 features->memoryMapRangePlaced |= enabled->memoryMapRangePlaced == VK_TRUE;
                 features->memoryUnmapReserve |= enabled->memoryUnmapReserve == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_2_FEATURES_EXT: {
-                const VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(pNext);
+                const VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(pNext);
                 features->shaderBufferFloat16Atomics |= enabled->shaderBufferFloat16Atomics == VK_TRUE;
                 features->shaderBufferFloat16AtomicAdd |= enabled->shaderBufferFloat16AtomicAdd == VK_TRUE;
                 features->shaderBufferFloat16AtomicMinMax |= enabled->shaderBufferFloat16AtomicMinMax == VK_TRUE;
@@ -1060,26 +1060,26 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_FEATURES_NV: {
-                const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV *>(pNext);
+                const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV*>(pNext);
                 features->deviceGeneratedCommandsNV |= enabled->deviceGeneratedCommands == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INHERITED_VIEWPORT_SCISSOR_FEATURES_NV: {
-                const VkPhysicalDeviceInheritedViewportScissorFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceInheritedViewportScissorFeaturesNV *>(pNext);
+                const VkPhysicalDeviceInheritedViewportScissorFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceInheritedViewportScissorFeaturesNV*>(pNext);
                 features->inheritedViewportScissor2D |= enabled->inheritedViewportScissor2D == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_FEATURES_EXT: {
-                const VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT*>(pNext);
                 features->texelBufferAlignment |= enabled->texelBufferAlignment == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_BIAS_CONTROL_FEATURES_EXT: {
-                const VkPhysicalDeviceDepthBiasControlFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDepthBiasControlFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceDepthBiasControlFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDepthBiasControlFeaturesEXT*>(pNext);
                 features->depthBiasControl |= enabled->depthBiasControl == VK_TRUE;
                 features->leastRepresentableValueForceUnormRepresentation |=
                     enabled->leastRepresentableValueForceUnormRepresentation == VK_TRUE;
@@ -1088,41 +1088,41 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_MEMORY_REPORT_FEATURES_EXT: {
-                const VkPhysicalDeviceDeviceMemoryReportFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDeviceMemoryReportFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceDeviceMemoryReportFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDeviceMemoryReportFeaturesEXT*>(pNext);
                 features->deviceMemoryReport |= enabled->deviceMemoryReport == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT: {
-                const VkPhysicalDeviceCustomBorderColorFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceCustomBorderColorFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceCustomBorderColorFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceCustomBorderColorFeaturesEXT*>(pNext);
                 features->customBorderColors |= enabled->customBorderColors == VK_TRUE;
                 features->customBorderColorWithoutFormat |= enabled->customBorderColorWithoutFormat == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_BARRIER_FEATURES_NV: {
-                const VkPhysicalDevicePresentBarrierFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePresentBarrierFeaturesNV *>(pNext);
+                const VkPhysicalDevicePresentBarrierFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePresentBarrierFeaturesNV*>(pNext);
                 features->presentBarrier |= enabled->presentBarrier == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DIAGNOSTICS_CONFIG_FEATURES_NV: {
-                const VkPhysicalDeviceDiagnosticsConfigFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDiagnosticsConfigFeaturesNV *>(pNext);
+                const VkPhysicalDeviceDiagnosticsConfigFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDiagnosticsConfigFeaturesNV*>(pNext);
                 features->diagnosticsConfig |= enabled->diagnosticsConfig == VK_TRUE;
                 break;
             }
 #ifdef VK_ENABLE_BETA_EXTENSIONS
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUDA_KERNEL_LAUNCH_FEATURES_NV: {
-                const VkPhysicalDeviceCudaKernelLaunchFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceCudaKernelLaunchFeaturesNV *>(pNext);
+                const VkPhysicalDeviceCudaKernelLaunchFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceCudaKernelLaunchFeaturesNV*>(pNext);
                 features->cudaKernelLaunchFeatures |= enabled->cudaKernelLaunchFeatures == VK_TRUE;
                 break;
             }
 #endif  // VK_ENABLE_BETA_EXTENSIONS
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TILE_SHADING_FEATURES_QCOM: {
-                const VkPhysicalDeviceTileShadingFeaturesQCOM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceTileShadingFeaturesQCOM *>(pNext);
+                const VkPhysicalDeviceTileShadingFeaturesQCOM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceTileShadingFeaturesQCOM*>(pNext);
                 features->tileShading |= enabled->tileShading == VK_TRUE;
                 features->tileShadingFragmentStage |= enabled->tileShadingFragmentStage == VK_TRUE;
                 features->tileShadingColorAttachments |= enabled->tileShadingColorAttachments == VK_TRUE;
@@ -1140,8 +1140,8 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_FEATURES_EXT: {
-                const VkPhysicalDeviceDescriptorBufferFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDescriptorBufferFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceDescriptorBufferFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDescriptorBufferFeaturesEXT*>(pNext);
                 features->descriptorBuffer |= enabled->descriptorBuffer == VK_TRUE;
                 features->descriptorBufferCaptureReplay |= enabled->descriptorBufferCaptureReplay == VK_TRUE;
                 features->descriptorBufferImageLayoutIgnored |= enabled->descriptorBufferImageLayoutIgnored == VK_TRUE;
@@ -1149,73 +1149,73 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GRAPHICS_PIPELINE_LIBRARY_FEATURES_EXT: {
-                const VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT*>(pNext);
                 features->graphicsPipelineLibrary |= enabled->graphicsPipelineLibrary == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_EARLY_AND_LATE_FRAGMENT_TESTS_FEATURES_AMD: {
-                const VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD *>(pNext);
+                const VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD*>(pNext);
                 features->shaderEarlyAndLateFragmentTests |= enabled->shaderEarlyAndLateFragmentTests == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_ENUMS_FEATURES_NV: {
-                const VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV *>(pNext);
+                const VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV*>(pNext);
                 features->fragmentShadingRateEnums |= enabled->fragmentShadingRateEnums == VK_TRUE;
                 features->supersampleFragmentShadingRates |= enabled->supersampleFragmentShadingRates == VK_TRUE;
                 features->noInvocationFragmentShadingRates |= enabled->noInvocationFragmentShadingRates == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_MOTION_BLUR_FEATURES_NV: {
-                const VkPhysicalDeviceRayTracingMotionBlurFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceRayTracingMotionBlurFeaturesNV *>(pNext);
+                const VkPhysicalDeviceRayTracingMotionBlurFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceRayTracingMotionBlurFeaturesNV*>(pNext);
                 features->rayTracingMotionBlur |= enabled->rayTracingMotionBlur == VK_TRUE;
                 features->rayTracingMotionBlurPipelineTraceRaysIndirect |=
                     enabled->rayTracingMotionBlurPipelineTraceRaysIndirect == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_2_PLANE_444_FORMATS_FEATURES_EXT: {
-                const VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT*>(pNext);
                 features->ycbcr2plane444Formats |= enabled->ycbcr2plane444Formats == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_2_FEATURES_EXT: {
-                const VkPhysicalDeviceFragmentDensityMap2FeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceFragmentDensityMap2FeaturesEXT *>(pNext);
+                const VkPhysicalDeviceFragmentDensityMap2FeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceFragmentDensityMap2FeaturesEXT*>(pNext);
                 features->fragmentDensityMapDeferred |= enabled->fragmentDensityMapDeferred == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_COMPRESSION_CONTROL_FEATURES_EXT: {
-                const VkPhysicalDeviceImageCompressionControlFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceImageCompressionControlFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceImageCompressionControlFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceImageCompressionControlFeaturesEXT*>(pNext);
                 features->imageCompressionControl |= enabled->imageCompressionControl == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ATTACHMENT_FEEDBACK_LOOP_LAYOUT_FEATURES_EXT: {
-                const VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT*>(pNext);
                 features->attachmentFeedbackLoopLayout |= enabled->attachmentFeedbackLoopLayout == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_4444_FORMATS_FEATURES_EXT: {
-                const VkPhysicalDevice4444FormatsFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDevice4444FormatsFeaturesEXT *>(pNext);
+                const VkPhysicalDevice4444FormatsFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDevice4444FormatsFeaturesEXT*>(pNext);
                 features->formatA4R4G4B4 |= enabled->formatA4R4G4B4 == VK_TRUE;
                 features->formatA4B4G4R4 |= enabled->formatA4B4G4R4 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FAULT_FEATURES_EXT: {
-                const VkPhysicalDeviceFaultFeaturesEXT *enabled = reinterpret_cast<const VkPhysicalDeviceFaultFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceFaultFeaturesEXT* enabled = reinterpret_cast<const VkPhysicalDeviceFaultFeaturesEXT*>(pNext);
                 features->deviceFault |= enabled->deviceFault == VK_TRUE;
                 features->deviceFaultVendorBinary |= enabled->deviceFaultVendorBinary == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_FEATURES_EXT: {
-                const VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT*>(pNext);
                 features->rasterizationOrderColorAttachmentAccess |= enabled->rasterizationOrderColorAttachmentAccess == VK_TRUE;
                 features->rasterizationOrderDepthAttachmentAccess |= enabled->rasterizationOrderDepthAttachmentAccess == VK_TRUE;
                 features->rasterizationOrderStencilAttachmentAccess |=
@@ -1223,95 +1223,95 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RGBA10X6_FORMATS_FEATURES_EXT: {
-                const VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT*>(pNext);
                 features->formatRgba10x6WithoutYCbCrSampler |= enabled->formatRgba10x6WithoutYCbCrSampler == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MUTABLE_DESCRIPTOR_TYPE_FEATURES_EXT: {
-                const VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT*>(pNext);
                 features->mutableDescriptorType |= enabled->mutableDescriptorType == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_INPUT_DYNAMIC_STATE_FEATURES_EXT: {
-                const VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT*>(pNext);
                 features->vertexInputDynamicState |= enabled->vertexInputDynamicState == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ADDRESS_BINDING_REPORT_FEATURES_EXT: {
-                const VkPhysicalDeviceAddressBindingReportFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceAddressBindingReportFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceAddressBindingReportFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceAddressBindingReportFeaturesEXT*>(pNext);
                 features->reportAddressBinding |= enabled->reportAddressBinding == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_CONTROL_FEATURES_EXT: {
-                const VkPhysicalDeviceDepthClipControlFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDepthClipControlFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceDepthClipControlFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDepthClipControlFeaturesEXT*>(pNext);
                 features->depthClipControl |= enabled->depthClipControl == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIMITIVE_TOPOLOGY_LIST_RESTART_FEATURES_EXT: {
-                const VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT *>(pNext);
+                const VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT*>(pNext);
                 features->primitiveTopologyListRestart |= enabled->primitiveTopologyListRestart == VK_TRUE;
                 features->primitiveTopologyPatchListRestart |= enabled->primitiveTopologyPatchListRestart == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBPASS_SHADING_FEATURES_HUAWEI: {
-                const VkPhysicalDeviceSubpassShadingFeaturesHUAWEI *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceSubpassShadingFeaturesHUAWEI *>(pNext);
+                const VkPhysicalDeviceSubpassShadingFeaturesHUAWEI* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceSubpassShadingFeaturesHUAWEI*>(pNext);
                 features->subpassShading |= enabled->subpassShading == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INVOCATION_MASK_FEATURES_HUAWEI: {
-                const VkPhysicalDeviceInvocationMaskFeaturesHUAWEI *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceInvocationMaskFeaturesHUAWEI *>(pNext);
+                const VkPhysicalDeviceInvocationMaskFeaturesHUAWEI* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceInvocationMaskFeaturesHUAWEI*>(pNext);
                 features->invocationMask |= enabled->invocationMask == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_RDMA_FEATURES_NV: {
-                const VkPhysicalDeviceExternalMemoryRDMAFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceExternalMemoryRDMAFeaturesNV *>(pNext);
+                const VkPhysicalDeviceExternalMemoryRDMAFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceExternalMemoryRDMAFeaturesNV*>(pNext);
                 features->externalMemoryRDMA |= enabled->externalMemoryRDMA == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_PROPERTIES_FEATURES_EXT: {
-                const VkPhysicalDevicePipelinePropertiesFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePipelinePropertiesFeaturesEXT *>(pNext);
+                const VkPhysicalDevicePipelinePropertiesFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePipelinePropertiesFeaturesEXT*>(pNext);
                 features->pipelinePropertiesIdentifier |= enabled->pipelinePropertiesIdentifier == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAME_BOUNDARY_FEATURES_EXT: {
-                const VkPhysicalDeviceFrameBoundaryFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceFrameBoundaryFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceFrameBoundaryFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceFrameBoundaryFeaturesEXT*>(pNext);
                 features->frameBoundary |= enabled->frameBoundary == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_FEATURES_EXT: {
-                const VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT*>(pNext);
                 features->multisampledRenderToSingleSampled |= enabled->multisampledRenderToSingleSampled == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT: {
-                const VkPhysicalDeviceExtendedDynamicState2FeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceExtendedDynamicState2FeaturesEXT *>(pNext);
+                const VkPhysicalDeviceExtendedDynamicState2FeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceExtendedDynamicState2FeaturesEXT*>(pNext);
                 features->extendedDynamicState2 |= enabled->extendedDynamicState2 == VK_TRUE;
                 features->extendedDynamicState2LogicOp |= enabled->extendedDynamicState2LogicOp == VK_TRUE;
                 features->extendedDynamicState2PatchControlPoints |= enabled->extendedDynamicState2PatchControlPoints == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COLOR_WRITE_ENABLE_FEATURES_EXT: {
-                const VkPhysicalDeviceColorWriteEnableFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceColorWriteEnableFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceColorWriteEnableFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceColorWriteEnableFeaturesEXT*>(pNext);
                 features->colorWriteEnable |= enabled->colorWriteEnable == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIMITIVES_GENERATED_QUERY_FEATURES_EXT: {
-                const VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT *>(pNext);
+                const VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT*>(pNext);
                 features->primitivesGeneratedQuery |= enabled->primitivesGeneratedQuery == VK_TRUE;
                 features->primitivesGeneratedQueryWithRasterizerDiscard |=
                     enabled->primitivesGeneratedQueryWithRasterizerDiscard == VK_TRUE;
@@ -1320,41 +1320,41 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_ENCODE_RGB_CONVERSION_FEATURES_VALVE: {
-                const VkPhysicalDeviceVideoEncodeRgbConversionFeaturesVALVE *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceVideoEncodeRgbConversionFeaturesVALVE *>(pNext);
+                const VkPhysicalDeviceVideoEncodeRgbConversionFeaturesVALVE* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceVideoEncodeRgbConversionFeaturesVALVE*>(pNext);
                 features->videoEncodeRgbConversion |= enabled->videoEncodeRgbConversion == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_VIEW_MIN_LOD_FEATURES_EXT: {
-                const VkPhysicalDeviceImageViewMinLodFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceImageViewMinLodFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceImageViewMinLodFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceImageViewMinLodFeaturesEXT*>(pNext);
                 features->minLod |= enabled->minLod == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTI_DRAW_FEATURES_EXT: {
-                const VkPhysicalDeviceMultiDrawFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMultiDrawFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceMultiDrawFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMultiDrawFeaturesEXT*>(pNext);
                 features->multiDraw |= enabled->multiDraw == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_2D_VIEW_OF_3D_FEATURES_EXT: {
-                const VkPhysicalDeviceImage2DViewOf3DFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceImage2DViewOf3DFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceImage2DViewOf3DFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceImage2DViewOf3DFeaturesEXT*>(pNext);
                 features->image2DViewOf3D |= enabled->image2DViewOf3D == VK_TRUE;
                 features->sampler2DViewOf3D |= enabled->sampler2DViewOf3D == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_TILE_IMAGE_FEATURES_EXT: {
-                const VkPhysicalDeviceShaderTileImageFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderTileImageFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceShaderTileImageFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderTileImageFeaturesEXT*>(pNext);
                 features->shaderTileImageColorReadAccess |= enabled->shaderTileImageColorReadAccess == VK_TRUE;
                 features->shaderTileImageDepthReadAccess |= enabled->shaderTileImageDepthReadAccess == VK_TRUE;
                 features->shaderTileImageStencilReadAccess |= enabled->shaderTileImageStencilReadAccess == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_OPACITY_MICROMAP_FEATURES_EXT: {
-                const VkPhysicalDeviceOpacityMicromapFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceOpacityMicromapFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceOpacityMicromapFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceOpacityMicromapFeaturesEXT*>(pNext);
                 features->micromap |= enabled->micromap == VK_TRUE;
                 features->micromapCaptureReplay |= enabled->micromapCaptureReplay == VK_TRUE;
                 features->micromapHostCommands |= enabled->micromapHostCommands == VK_TRUE;
@@ -1362,132 +1362,132 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
             }
 #ifdef VK_ENABLE_BETA_EXTENSIONS
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISPLACEMENT_MICROMAP_FEATURES_NV: {
-                const VkPhysicalDeviceDisplacementMicromapFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDisplacementMicromapFeaturesNV *>(pNext);
+                const VkPhysicalDeviceDisplacementMicromapFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDisplacementMicromapFeaturesNV*>(pNext);
                 features->displacementMicromap |= enabled->displacementMicromap == VK_TRUE;
                 break;
             }
 #endif  // VK_ENABLE_BETA_EXTENSIONS
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CLUSTER_CULLING_SHADER_FEATURES_HUAWEI: {
-                const VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI *>(pNext);
+                const VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI*>(pNext);
                 features->clustercullingShader |= enabled->clustercullingShader == VK_TRUE;
                 features->multiviewClusterCullingShader |= enabled->multiviewClusterCullingShader == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CLUSTER_CULLING_SHADER_VRS_FEATURES_HUAWEI: {
-                const VkPhysicalDeviceClusterCullingShaderVrsFeaturesHUAWEI *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceClusterCullingShaderVrsFeaturesHUAWEI *>(pNext);
+                const VkPhysicalDeviceClusterCullingShaderVrsFeaturesHUAWEI* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceClusterCullingShaderVrsFeaturesHUAWEI*>(pNext);
                 features->clusterShadingRate |= enabled->clusterShadingRate == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BORDER_COLOR_SWIZZLE_FEATURES_EXT: {
-                const VkPhysicalDeviceBorderColorSwizzleFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceBorderColorSwizzleFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceBorderColorSwizzleFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceBorderColorSwizzleFeaturesEXT*>(pNext);
                 features->borderColorSwizzle |= enabled->borderColorSwizzle == VK_TRUE;
                 features->borderColorSwizzleFromImage |= enabled->borderColorSwizzleFromImage == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PAGEABLE_DEVICE_LOCAL_MEMORY_FEATURES_EXT: {
-                const VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT *>(pNext);
+                const VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT*>(pNext);
                 features->pageableDeviceLocalMemory |= enabled->pageableDeviceLocalMemory == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCHEDULING_CONTROLS_FEATURES_ARM: {
-                const VkPhysicalDeviceSchedulingControlsFeaturesARM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceSchedulingControlsFeaturesARM *>(pNext);
+                const VkPhysicalDeviceSchedulingControlsFeaturesARM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceSchedulingControlsFeaturesARM*>(pNext);
                 features->schedulingControls |= enabled->schedulingControls == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_SLICED_VIEW_OF_3D_FEATURES_EXT: {
-                const VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT*>(pNext);
                 features->imageSlicedViewOf3D |= enabled->imageSlicedViewOf3D == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_SET_HOST_MAPPING_FEATURES_VALVE: {
-                const VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE *>(pNext);
+                const VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE*>(pNext);
                 features->descriptorSetHostMapping |= enabled->descriptorSetHostMapping == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_NON_SEAMLESS_CUBE_MAP_FEATURES_EXT: {
-                const VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT*>(pNext);
                 features->nonSeamlessCubeMap |= enabled->nonSeamlessCubeMap == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RENDER_PASS_STRIPED_FEATURES_ARM: {
-                const VkPhysicalDeviceRenderPassStripedFeaturesARM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceRenderPassStripedFeaturesARM *>(pNext);
+                const VkPhysicalDeviceRenderPassStripedFeaturesARM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceRenderPassStripedFeaturesARM*>(pNext);
                 features->renderPassStriped |= enabled->renderPassStriped == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_OFFSET_FEATURES_EXT: {
-                const VkPhysicalDeviceFragmentDensityMapOffsetFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapOffsetFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceFragmentDensityMapOffsetFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapOffsetFeaturesEXT*>(pNext);
                 features->fragmentDensityMapOffset |= enabled->fragmentDensityMapOffset == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COPY_MEMORY_INDIRECT_FEATURES_NV: {
-                const VkPhysicalDeviceCopyMemoryIndirectFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceCopyMemoryIndirectFeaturesNV *>(pNext);
+                const VkPhysicalDeviceCopyMemoryIndirectFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceCopyMemoryIndirectFeaturesNV*>(pNext);
                 features->indirectCopy |= enabled->indirectCopy == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_DECOMPRESSION_FEATURES_EXT: {
-                const VkPhysicalDeviceMemoryDecompressionFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMemoryDecompressionFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceMemoryDecompressionFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMemoryDecompressionFeaturesEXT*>(pNext);
                 features->memoryDecompression |= enabled->memoryDecompression == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_COMPUTE_FEATURES_NV: {
-                const VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV *>(pNext);
+                const VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV*>(pNext);
                 features->deviceGeneratedCompute |= enabled->deviceGeneratedCompute == VK_TRUE;
                 features->deviceGeneratedComputePipelines |= enabled->deviceGeneratedComputePipelines == VK_TRUE;
                 features->deviceGeneratedComputeCaptureReplay |= enabled->deviceGeneratedComputeCaptureReplay == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_LINEAR_SWEPT_SPHERES_FEATURES_NV: {
-                const VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV *>(pNext);
+                const VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV*>(pNext);
                 features->spheres |= enabled->spheres == VK_TRUE;
                 features->linearSweptSpheres |= enabled->linearSweptSpheres == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINEAR_COLOR_ATTACHMENT_FEATURES_NV: {
-                const VkPhysicalDeviceLinearColorAttachmentFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceLinearColorAttachmentFeaturesNV *>(pNext);
+                const VkPhysicalDeviceLinearColorAttachmentFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceLinearColorAttachmentFeaturesNV*>(pNext);
                 features->linearColorAttachment |= enabled->linearColorAttachment == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_COMPRESSION_CONTROL_SWAPCHAIN_FEATURES_EXT: {
-                const VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT*>(pNext);
                 features->imageCompressionControlSwapchain |= enabled->imageCompressionControlSwapchain == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_PROCESSING_FEATURES_QCOM: {
-                const VkPhysicalDeviceImageProcessingFeaturesQCOM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceImageProcessingFeaturesQCOM *>(pNext);
+                const VkPhysicalDeviceImageProcessingFeaturesQCOM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceImageProcessingFeaturesQCOM*>(pNext);
                 features->textureSampleWeighted |= enabled->textureSampleWeighted == VK_TRUE;
                 features->textureBoxFilter |= enabled->textureBoxFilter == VK_TRUE;
                 features->textureBlockMatch |= enabled->textureBlockMatch == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_NESTED_COMMAND_BUFFER_FEATURES_EXT: {
-                const VkPhysicalDeviceNestedCommandBufferFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceNestedCommandBufferFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceNestedCommandBufferFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceNestedCommandBufferFeaturesEXT*>(pNext);
                 features->nestedCommandBuffer |= enabled->nestedCommandBuffer == VK_TRUE;
                 features->nestedCommandBufferRendering |= enabled->nestedCommandBufferRendering == VK_TRUE;
                 features->nestedCommandBufferSimultaneousUse |= enabled->nestedCommandBufferSimultaneousUse == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT: {
-                const VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(pNext);
+                const VkPhysicalDeviceExtendedDynamicState3FeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(pNext);
                 features->extendedDynamicState3TessellationDomainOrigin |=
                     enabled->extendedDynamicState3TessellationDomainOrigin == VK_TRUE;
                 features->extendedDynamicState3DepthClampEnable |= enabled->extendedDynamicState3DepthClampEnable == VK_TRUE;
@@ -1539,14 +1539,14 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBPASS_MERGE_FEEDBACK_FEATURES_EXT: {
-                const VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT*>(pNext);
                 features->subpassMergeFeedback |= enabled->subpassMergeFeedback == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TENSOR_FEATURES_ARM: {
-                const VkPhysicalDeviceTensorFeaturesARM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceTensorFeaturesARM *>(pNext);
+                const VkPhysicalDeviceTensorFeaturesARM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceTensorFeaturesARM*>(pNext);
                 features->tensorNonPacked |= enabled->tensorNonPacked == VK_TRUE;
                 features->shaderTensorAccess |= enabled->shaderTensorAccess == VK_TRUE;
                 features->shaderStorageTensorArrayDynamicIndexing |= enabled->shaderStorageTensorArrayDynamicIndexing == VK_TRUE;
@@ -1558,121 +1558,121 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_TENSOR_FEATURES_ARM: {
-                const VkPhysicalDeviceDescriptorBufferTensorFeaturesARM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDescriptorBufferTensorFeaturesARM *>(pNext);
+                const VkPhysicalDeviceDescriptorBufferTensorFeaturesARM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDescriptorBufferTensorFeaturesARM*>(pNext);
                 features->descriptorBufferTensorDescriptors |= enabled->descriptorBufferTensorDescriptors == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_MODULE_IDENTIFIER_FEATURES_EXT: {
-                const VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT*>(pNext);
                 features->shaderModuleIdentifier |= enabled->shaderModuleIdentifier == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_OPTICAL_FLOW_FEATURES_NV: {
-                const VkPhysicalDeviceOpticalFlowFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceOpticalFlowFeaturesNV *>(pNext);
+                const VkPhysicalDeviceOpticalFlowFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceOpticalFlowFeaturesNV*>(pNext);
                 features->opticalFlow |= enabled->opticalFlow == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LEGACY_DITHERING_FEATURES_EXT: {
-                const VkPhysicalDeviceLegacyDitheringFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceLegacyDitheringFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceLegacyDitheringFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceLegacyDitheringFeaturesEXT*>(pNext);
                 features->legacyDithering |= enabled->legacyDithering == VK_TRUE;
                 break;
             }
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FORMAT_RESOLVE_FEATURES_ANDROID: {
-                const VkPhysicalDeviceExternalFormatResolveFeaturesANDROID *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceExternalFormatResolveFeaturesANDROID *>(pNext);
+                const VkPhysicalDeviceExternalFormatResolveFeaturesANDROID* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceExternalFormatResolveFeaturesANDROID*>(pNext);
                 features->externalFormatResolve |= enabled->externalFormatResolve == VK_TRUE;
                 break;
             }
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ANTI_LAG_FEATURES_AMD: {
-                const VkPhysicalDeviceAntiLagFeaturesAMD *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceAntiLagFeaturesAMD *>(pNext);
+                const VkPhysicalDeviceAntiLagFeaturesAMD* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceAntiLagFeaturesAMD*>(pNext);
                 features->antiLag |= enabled->antiLag == VK_TRUE;
                 break;
             }
 #ifdef VK_ENABLE_BETA_EXTENSIONS
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DENSE_GEOMETRY_FORMAT_FEATURES_AMDX: {
-                const VkPhysicalDeviceDenseGeometryFormatFeaturesAMDX *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDenseGeometryFormatFeaturesAMDX *>(pNext);
+                const VkPhysicalDeviceDenseGeometryFormatFeaturesAMDX* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDenseGeometryFormatFeaturesAMDX*>(pNext);
                 features->denseGeometryFormat |= enabled->denseGeometryFormat == VK_TRUE;
                 break;
             }
 #endif  // VK_ENABLE_BETA_EXTENSIONS
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_OBJECT_FEATURES_EXT: {
-                const VkPhysicalDeviceShaderObjectFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderObjectFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceShaderObjectFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderObjectFeaturesEXT*>(pNext);
                 features->shaderObject |= enabled->shaderObject == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TILE_PROPERTIES_FEATURES_QCOM: {
-                const VkPhysicalDeviceTilePropertiesFeaturesQCOM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceTilePropertiesFeaturesQCOM *>(pNext);
+                const VkPhysicalDeviceTilePropertiesFeaturesQCOM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceTilePropertiesFeaturesQCOM*>(pNext);
                 features->tileProperties |= enabled->tileProperties == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_AMIGO_PROFILING_FEATURES_SEC: {
-                const VkPhysicalDeviceAmigoProfilingFeaturesSEC *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceAmigoProfilingFeaturesSEC *>(pNext);
+                const VkPhysicalDeviceAmigoProfilingFeaturesSEC* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceAmigoProfilingFeaturesSEC*>(pNext);
                 features->amigoProfiling |= enabled->amigoProfiling == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_VIEWPORTS_FEATURES_QCOM: {
-                const VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM *>(pNext);
+                const VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM*>(pNext);
                 features->multiviewPerViewViewports |= enabled->multiviewPerViewViewports == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_INVOCATION_REORDER_FEATURES_NV: {
-                const VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV *>(pNext);
+                const VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV*>(pNext);
                 features->rayTracingInvocationReorder |= enabled->rayTracingInvocationReorder == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_VECTOR_FEATURES_NV: {
-                const VkPhysicalDeviceCooperativeVectorFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceCooperativeVectorFeaturesNV *>(pNext);
+                const VkPhysicalDeviceCooperativeVectorFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceCooperativeVectorFeaturesNV*>(pNext);
                 features->cooperativeVector |= enabled->cooperativeVector == VK_TRUE;
                 features->cooperativeVectorTraining |= enabled->cooperativeVectorTraining == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_SPARSE_ADDRESS_SPACE_FEATURES_NV: {
-                const VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV *>(pNext);
+                const VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV*>(pNext);
                 features->extendedSparseAddressSpace |= enabled->extendedSparseAddressSpace == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LEGACY_VERTEX_ATTRIBUTES_FEATURES_EXT: {
-                const VkPhysicalDeviceLegacyVertexAttributesFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceLegacyVertexAttributesFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceLegacyVertexAttributesFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceLegacyVertexAttributesFeaturesEXT*>(pNext);
                 features->legacyVertexAttributes |= enabled->legacyVertexAttributes == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_BUILTINS_FEATURES_ARM: {
-                const VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM *>(pNext);
+                const VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM*>(pNext);
                 features->shaderCoreBuiltins |= enabled->shaderCoreBuiltins == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_LIBRARY_GROUP_HANDLES_FEATURES_EXT: {
-                const VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT *>(pNext);
+                const VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT*>(pNext);
                 features->pipelineLibraryGroupHandles |= enabled->pipelineLibraryGroupHandles == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_FEATURES_EXT: {
-                const VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT*>(pNext);
                 features->dynamicRenderingUnusedAttachments |= enabled->dynamicRenderingUnusedAttachments == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DATA_GRAPH_FEATURES_ARM: {
-                const VkPhysicalDeviceDataGraphFeaturesARM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDataGraphFeaturesARM *>(pNext);
+                const VkPhysicalDeviceDataGraphFeaturesARM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDataGraphFeaturesARM*>(pNext);
                 features->dataGraph |= enabled->dataGraph == VK_TRUE;
                 features->dataGraphUpdateAfterBind |= enabled->dataGraphUpdateAfterBind == VK_TRUE;
                 features->dataGraphSpecializationConstants |= enabled->dataGraphSpecializationConstants == VK_TRUE;
@@ -1681,151 +1681,151 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_RENDER_AREAS_FEATURES_QCOM: {
-                const VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM *>(pNext);
+                const VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM*>(pNext);
                 features->multiviewPerViewRenderAreas |= enabled->multiviewPerViewRenderAreas == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PER_STAGE_DESCRIPTOR_SET_FEATURES_NV: {
-                const VkPhysicalDevicePerStageDescriptorSetFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePerStageDescriptorSetFeaturesNV *>(pNext);
+                const VkPhysicalDevicePerStageDescriptorSetFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePerStageDescriptorSetFeaturesNV*>(pNext);
                 features->perStageDescriptorSet |= enabled->perStageDescriptorSet == VK_TRUE;
                 features->dynamicPipelineLayout |= enabled->dynamicPipelineLayout == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_PROCESSING_2_FEATURES_QCOM: {
-                const VkPhysicalDeviceImageProcessing2FeaturesQCOM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceImageProcessing2FeaturesQCOM *>(pNext);
+                const VkPhysicalDeviceImageProcessing2FeaturesQCOM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceImageProcessing2FeaturesQCOM*>(pNext);
                 features->textureBlockMatch2 |= enabled->textureBlockMatch2 == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUBIC_WEIGHTS_FEATURES_QCOM: {
-                const VkPhysicalDeviceCubicWeightsFeaturesQCOM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceCubicWeightsFeaturesQCOM *>(pNext);
+                const VkPhysicalDeviceCubicWeightsFeaturesQCOM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceCubicWeightsFeaturesQCOM*>(pNext);
                 features->selectableCubicWeights |= enabled->selectableCubicWeights == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_DEGAMMA_FEATURES_QCOM: {
-                const VkPhysicalDeviceYcbcrDegammaFeaturesQCOM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceYcbcrDegammaFeaturesQCOM *>(pNext);
+                const VkPhysicalDeviceYcbcrDegammaFeaturesQCOM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceYcbcrDegammaFeaturesQCOM*>(pNext);
                 features->ycbcrDegamma |= enabled->ycbcrDegamma == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUBIC_CLAMP_FEATURES_QCOM: {
-                const VkPhysicalDeviceCubicClampFeaturesQCOM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceCubicClampFeaturesQCOM *>(pNext);
+                const VkPhysicalDeviceCubicClampFeaturesQCOM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceCubicClampFeaturesQCOM*>(pNext);
                 features->cubicRangeClamp |= enabled->cubicRangeClamp == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ATTACHMENT_FEEDBACK_LOOP_DYNAMIC_STATE_FEATURES_EXT: {
-                const VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT*>(pNext);
                 features->attachmentFeedbackLoopDynamicState |= enabled->attachmentFeedbackLoopDynamicState == VK_TRUE;
                 break;
             }
 #ifdef VK_USE_PLATFORM_SCREEN_QNX
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_SCREEN_BUFFER_FEATURES_QNX: {
-                const VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX *>(pNext);
+                const VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX*>(pNext);
                 features->screenBufferImport |= enabled->screenBufferImport == VK_TRUE;
                 break;
             }
 #endif  // VK_USE_PLATFORM_SCREEN_QNX
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_POOL_OVERALLOCATION_FEATURES_NV: {
-                const VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV *>(pNext);
+                const VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV*>(pNext);
                 features->descriptorPoolOverallocation |= enabled->descriptorPoolOverallocation == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TILE_MEMORY_HEAP_FEATURES_QCOM: {
-                const VkPhysicalDeviceTileMemoryHeapFeaturesQCOM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceTileMemoryHeapFeaturesQCOM *>(pNext);
+                const VkPhysicalDeviceTileMemoryHeapFeaturesQCOM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceTileMemoryHeapFeaturesQCOM*>(pNext);
                 features->tileMemoryHeap |= enabled->tileMemoryHeap == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAW_ACCESS_CHAINS_FEATURES_NV: {
-                const VkPhysicalDeviceRawAccessChainsFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceRawAccessChainsFeaturesNV *>(pNext);
+                const VkPhysicalDeviceRawAccessChainsFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceRawAccessChainsFeaturesNV*>(pNext);
                 features->shaderRawAccessChains |= enabled->shaderRawAccessChains == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMMAND_BUFFER_INHERITANCE_FEATURES_NV: {
-                const VkPhysicalDeviceCommandBufferInheritanceFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceCommandBufferInheritanceFeaturesNV *>(pNext);
+                const VkPhysicalDeviceCommandBufferInheritanceFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceCommandBufferInheritanceFeaturesNV*>(pNext);
                 features->commandBufferInheritance |= enabled->commandBufferInheritance == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT16_VECTOR_FEATURES_NV: {
-                const VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV *>(pNext);
+                const VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV*>(pNext);
                 features->shaderFloat16VectorAtomics |= enabled->shaderFloat16VectorAtomics == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_REPLICATED_COMPOSITES_FEATURES_EXT: {
-                const VkPhysicalDeviceShaderReplicatedCompositesFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderReplicatedCompositesFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceShaderReplicatedCompositesFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderReplicatedCompositesFeaturesEXT*>(pNext);
                 features->shaderReplicatedComposites |= enabled->shaderReplicatedComposites == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT8_FEATURES_EXT: {
-                const VkPhysicalDeviceShaderFloat8FeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderFloat8FeaturesEXT *>(pNext);
+                const VkPhysicalDeviceShaderFloat8FeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderFloat8FeaturesEXT*>(pNext);
                 features->shaderFloat8 |= enabled->shaderFloat8 == VK_TRUE;
                 features->shaderFloat8CooperativeMatrix |= enabled->shaderFloat8CooperativeMatrix == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_VALIDATION_FEATURES_NV: {
-                const VkPhysicalDeviceRayTracingValidationFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceRayTracingValidationFeaturesNV *>(pNext);
+                const VkPhysicalDeviceRayTracingValidationFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceRayTracingValidationFeaturesNV*>(pNext);
                 features->rayTracingValidation |= enabled->rayTracingValidation == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CLUSTER_ACCELERATION_STRUCTURE_FEATURES_NV: {
-                const VkPhysicalDeviceClusterAccelerationStructureFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceClusterAccelerationStructureFeaturesNV *>(pNext);
+                const VkPhysicalDeviceClusterAccelerationStructureFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceClusterAccelerationStructureFeaturesNV*>(pNext);
                 features->clusterAccelerationStructure |= enabled->clusterAccelerationStructure == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PARTITIONED_ACCELERATION_STRUCTURE_FEATURES_NV: {
-                const VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV *>(pNext);
+                const VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV*>(pNext);
                 features->partitionedAccelerationStructure |= enabled->partitionedAccelerationStructure == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_FEATURES_EXT: {
-                const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT*>(pNext);
                 features->deviceGeneratedCommands |= enabled->deviceGeneratedCommands == VK_TRUE;
                 features->dynamicGeneratedPipelineLayout |= enabled->dynamicGeneratedPipelineLayout == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ALIGNMENT_CONTROL_FEATURES_MESA: {
-                const VkPhysicalDeviceImageAlignmentControlFeaturesMESA *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceImageAlignmentControlFeaturesMESA *>(pNext);
+                const VkPhysicalDeviceImageAlignmentControlFeaturesMESA* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceImageAlignmentControlFeaturesMESA*>(pNext);
                 features->imageAlignmentControl |= enabled->imageAlignmentControl == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_INVOCATION_REORDER_FEATURES_EXT: {
-                const VkPhysicalDeviceRayTracingInvocationReorderFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceRayTracingInvocationReorderFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderFeaturesEXT*>(pNext);
                 features->rayTracingInvocationReorder |= enabled->rayTracingInvocationReorder == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLAMP_CONTROL_FEATURES_EXT: {
-                const VkPhysicalDeviceDepthClampControlFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDepthClampControlFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceDepthClampControlFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDepthClampControlFeaturesEXT*>(pNext);
                 features->depthClampControl |= enabled->depthClampControl == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HDR_VIVID_FEATURES_HUAWEI: {
-                const VkPhysicalDeviceHdrVividFeaturesHUAWEI *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceHdrVividFeaturesHUAWEI *>(pNext);
+                const VkPhysicalDeviceHdrVividFeaturesHUAWEI* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceHdrVividFeaturesHUAWEI*>(pNext);
                 features->hdrVivid |= enabled->hdrVivid == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_2_FEATURES_NV: {
-                const VkPhysicalDeviceCooperativeMatrix2FeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceCooperativeMatrix2FeaturesNV *>(pNext);
+                const VkPhysicalDeviceCooperativeMatrix2FeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceCooperativeMatrix2FeaturesNV*>(pNext);
                 features->cooperativeMatrixWorkgroupScope |= enabled->cooperativeMatrixWorkgroupScope == VK_TRUE;
                 features->cooperativeMatrixFlexibleDimensions |= enabled->cooperativeMatrixFlexibleDimensions == VK_TRUE;
                 features->cooperativeMatrixReductions |= enabled->cooperativeMatrixReductions == VK_TRUE;
@@ -1836,88 +1836,88 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_OPACITY_MICROMAP_FEATURES_ARM: {
-                const VkPhysicalDevicePipelineOpacityMicromapFeaturesARM *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePipelineOpacityMicromapFeaturesARM *>(pNext);
+                const VkPhysicalDevicePipelineOpacityMicromapFeaturesARM* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePipelineOpacityMicromapFeaturesARM*>(pNext);
                 features->pipelineOpacityMicromap |= enabled->pipelineOpacityMicromap == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PERFORMANCE_COUNTERS_BY_REGION_FEATURES_ARM: {
-                const VkPhysicalDevicePerformanceCountersByRegionFeaturesARM *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePerformanceCountersByRegionFeaturesARM *>(pNext);
+                const VkPhysicalDevicePerformanceCountersByRegionFeaturesARM* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePerformanceCountersByRegionFeaturesARM*>(pNext);
                 features->performanceCountersByRegion |= enabled->performanceCountersByRegion == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_ROBUSTNESS_FEATURES_EXT: {
-                const VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT*>(pNext);
                 features->vertexAttributeRobustness |= enabled->vertexAttributeRobustness == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FORMAT_PACK_FEATURES_ARM: {
-                const VkPhysicalDeviceFormatPackFeaturesARM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceFormatPackFeaturesARM *>(pNext);
+                const VkPhysicalDeviceFormatPackFeaturesARM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceFormatPackFeaturesARM*>(pNext);
                 features->formatPack |= enabled->formatPack == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_LAYERED_FEATURES_VALVE: {
-                const VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE *>(pNext);
+                const VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE*>(pNext);
                 features->fragmentDensityMapLayered |= enabled->fragmentDensityMapLayered == VK_TRUE;
                 break;
             }
 #ifdef VK_ENABLE_BETA_EXTENSIONS
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_METERING_FEATURES_NV: {
-                const VkPhysicalDevicePresentMeteringFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePresentMeteringFeaturesNV *>(pNext);
+                const VkPhysicalDevicePresentMeteringFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePresentMeteringFeaturesNV*>(pNext);
                 features->presentMetering |= enabled->presentMetering == VK_TRUE;
                 break;
             }
 #endif  // VK_ENABLE_BETA_EXTENSIONS
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ZERO_INITIALIZE_DEVICE_MEMORY_FEATURES_EXT: {
-                const VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT*>(pNext);
                 features->zeroInitializeDeviceMemory |= enabled->zeroInitializeDeviceMemory == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_64_BIT_INDEXING_FEATURES_EXT: {
-                const VkPhysicalDeviceShader64BitIndexingFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShader64BitIndexingFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceShader64BitIndexingFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShader64BitIndexingFeaturesEXT*>(pNext);
                 features->shader64BitIndexing |= enabled->shader64BitIndexing == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_RESOLVE_FEATURES_EXT: {
-                const VkPhysicalDeviceCustomResolveFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceCustomResolveFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceCustomResolveFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceCustomResolveFeaturesEXT*>(pNext);
                 features->customResolve |= enabled->customResolve == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DATA_GRAPH_MODEL_FEATURES_QCOM: {
-                const VkPhysicalDeviceDataGraphModelFeaturesQCOM *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceDataGraphModelFeaturesQCOM *>(pNext);
+                const VkPhysicalDeviceDataGraphModelFeaturesQCOM* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceDataGraphModelFeaturesQCOM*>(pNext);
                 features->dataGraphModel |= enabled->dataGraphModel == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_CACHE_INCREMENTAL_MODE_FEATURES_SEC: {
-                const VkPhysicalDevicePipelineCacheIncrementalModeFeaturesSEC *enabled =
-                    reinterpret_cast<const VkPhysicalDevicePipelineCacheIncrementalModeFeaturesSEC *>(pNext);
+                const VkPhysicalDevicePipelineCacheIncrementalModeFeaturesSEC* enabled =
+                    reinterpret_cast<const VkPhysicalDevicePipelineCacheIncrementalModeFeaturesSEC*>(pNext);
                 features->pipelineCacheIncrementalMode |= enabled->pipelineCacheIncrementalMode == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_UNIFORM_BUFFER_UNSIZED_ARRAY_FEATURES_EXT: {
-                const VkPhysicalDeviceShaderUniformBufferUnsizedArrayFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceShaderUniformBufferUnsizedArrayFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceShaderUniformBufferUnsizedArrayFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceShaderUniformBufferUnsizedArrayFeaturesEXT*>(pNext);
                 features->shaderUniformBufferUnsizedArray |= enabled->shaderUniformBufferUnsizedArray == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMPUTE_OCCUPANCY_PRIORITY_FEATURES_NV: {
-                const VkPhysicalDeviceComputeOccupancyPriorityFeaturesNV *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceComputeOccupancyPriorityFeaturesNV *>(pNext);
+                const VkPhysicalDeviceComputeOccupancyPriorityFeaturesNV* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceComputeOccupancyPriorityFeaturesNV*>(pNext);
                 features->computeOccupancyPriority |= enabled->computeOccupancyPriority == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR: {
-                const VkPhysicalDeviceAccelerationStructureFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceAccelerationStructureFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceAccelerationStructureFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceAccelerationStructureFeaturesKHR*>(pNext);
                 features->accelerationStructure |= enabled->accelerationStructure == VK_TRUE;
                 features->accelerationStructureCaptureReplay |= enabled->accelerationStructureCaptureReplay == VK_TRUE;
                 features->accelerationStructureIndirectBuild |= enabled->accelerationStructureIndirectBuild == VK_TRUE;
@@ -1927,8 +1927,8 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR: {
-                const VkPhysicalDeviceRayTracingPipelineFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceRayTracingPipelineFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceRayTracingPipelineFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceRayTracingPipelineFeaturesKHR*>(pNext);
                 features->rayTracingPipeline |= enabled->rayTracingPipeline == VK_TRUE;
                 features->rayTracingPipelineShaderGroupHandleCaptureReplay |=
                     enabled->rayTracingPipelineShaderGroupHandleCaptureReplay == VK_TRUE;
@@ -1939,14 +1939,14 @@ void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatu
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_QUERY_FEATURES_KHR: {
-                const VkPhysicalDeviceRayQueryFeaturesKHR *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceRayQueryFeaturesKHR *>(pNext);
+                const VkPhysicalDeviceRayQueryFeaturesKHR* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceRayQueryFeaturesKHR*>(pNext);
                 features->rayQuery |= enabled->rayQuery == VK_TRUE;
                 break;
             }
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT: {
-                const VkPhysicalDeviceMeshShaderFeaturesEXT *enabled =
-                    reinterpret_cast<const VkPhysicalDeviceMeshShaderFeaturesEXT *>(pNext);
+                const VkPhysicalDeviceMeshShaderFeaturesEXT* enabled =
+                    reinterpret_cast<const VkPhysicalDeviceMeshShaderFeaturesEXT*>(pNext);
                 features->taskShader |= enabled->taskShader == VK_TRUE;
                 features->meshShader |= enabled->meshShader == VK_TRUE;
                 features->multiviewMeshShader |= enabled->multiviewMeshShader == VK_TRUE;

--- a/layers/vulkan/generated/device_features.h
+++ b/layers/vulkan/generated/device_features.h
@@ -1068,6 +1068,6 @@ struct DeviceFeatures {
     bool zeroInitializeDeviceMemory;
 };
 
-void GetEnabledDeviceFeatures(const VkDeviceCreateInfo *pCreateInfo, DeviceFeatures *features, const APIVersion &api_version);
+void GetEnabledDeviceFeatures(const VkDeviceCreateInfo* pCreateInfo, DeviceFeatures* features, const APIVersion& api_version);
 
 // NOLINTEND

--- a/layers/vulkan/generated/dispatch_object.cpp
+++ b/layers/vulkan/generated/dispatch_object.cpp
@@ -756,7 +756,9 @@ void Device::FreeMemory(VkDevice device, VkDeviceMemory memory, const VkAllocati
 VkResult Device::MapMemory(VkDevice device, VkDeviceMemory memory, VkDeviceSize offset, VkDeviceSize size, VkMemoryMapFlags flags,
                            void** ppData) {
     if (!wrap_handles) return device_dispatch_table.MapMemory(device, memory, offset, size, flags, ppData);
-    { memory = Unwrap(memory); }
+    {
+        memory = Unwrap(memory);
+    }
     VkResult result = device_dispatch_table.MapMemory(device, memory, offset, size, flags, ppData);
 
     return result;
@@ -764,7 +766,9 @@ VkResult Device::MapMemory(VkDevice device, VkDeviceMemory memory, VkDeviceSize 
 
 void Device::UnmapMemory(VkDevice device, VkDeviceMemory memory) {
     if (!wrap_handles) return device_dispatch_table.UnmapMemory(device, memory);
-    { memory = Unwrap(memory); }
+    {
+        memory = Unwrap(memory);
+    }
     device_dispatch_table.UnmapMemory(device, memory);
 }
 
@@ -817,7 +821,9 @@ VkResult Device::InvalidateMappedMemoryRanges(VkDevice device, uint32_t memoryRa
 
 void Device::GetDeviceMemoryCommitment(VkDevice device, VkDeviceMemory memory, VkDeviceSize* pCommittedMemoryInBytes) {
     if (!wrap_handles) return device_dispatch_table.GetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes);
-    { memory = Unwrap(memory); }
+    {
+        memory = Unwrap(memory);
+    }
     device_dispatch_table.GetDeviceMemoryCommitment(device, memory, pCommittedMemoryInBytes);
 }
 
@@ -845,13 +851,17 @@ VkResult Device::BindImageMemory(VkDevice device, VkImage image, VkDeviceMemory 
 
 void Device::GetBufferMemoryRequirements(VkDevice device, VkBuffer buffer, VkMemoryRequirements* pMemoryRequirements) {
     if (!wrap_handles) return device_dispatch_table.GetBufferMemoryRequirements(device, buffer, pMemoryRequirements);
-    { buffer = Unwrap(buffer); }
+    {
+        buffer = Unwrap(buffer);
+    }
     device_dispatch_table.GetBufferMemoryRequirements(device, buffer, pMemoryRequirements);
 }
 
 void Device::GetImageMemoryRequirements(VkDevice device, VkImage image, VkMemoryRequirements* pMemoryRequirements) {
     if (!wrap_handles) return device_dispatch_table.GetImageMemoryRequirements(device, image, pMemoryRequirements);
-    { image = Unwrap(image); }
+    {
+        image = Unwrap(image);
+    }
     device_dispatch_table.GetImageMemoryRequirements(device, image, pMemoryRequirements);
 }
 
@@ -860,7 +870,9 @@ void Device::GetImageSparseMemoryRequirements(VkDevice device, VkImage image, ui
     if (!wrap_handles)
         return device_dispatch_table.GetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount,
                                                                       pSparseMemoryRequirements);
-    { image = Unwrap(image); }
+    {
+        image = Unwrap(image);
+    }
     device_dispatch_table.GetImageSparseMemoryRequirements(device, image, pSparseMemoryRequirementCount, pSparseMemoryRequirements);
 }
 
@@ -988,7 +1000,9 @@ VkResult Device::ResetFences(VkDevice device, uint32_t fenceCount, const VkFence
 
 VkResult Device::GetFenceStatus(VkDevice device, VkFence fence) {
     if (!wrap_handles) return device_dispatch_table.GetFenceStatus(device, fence);
-    { fence = Unwrap(fence); }
+    {
+        fence = Unwrap(fence);
+    }
     VkResult result = device_dispatch_table.GetFenceStatus(device, fence);
 
     return result;
@@ -1050,7 +1064,9 @@ VkResult Device::GetQueryPoolResults(VkDevice device, VkQueryPool queryPool, uin
                                      size_t dataSize, void* pData, VkDeviceSize stride, VkQueryResultFlags flags) {
     if (!wrap_handles)
         return device_dispatch_table.GetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags);
-    { queryPool = Unwrap(queryPool); }
+    {
+        queryPool = Unwrap(queryPool);
+    }
     VkResult result =
         device_dispatch_table.GetQueryPoolResults(device, queryPool, firstQuery, queryCount, dataSize, pData, stride, flags);
 
@@ -1110,7 +1126,9 @@ void Device::DestroyImage(VkDevice device, VkImage image, const VkAllocationCall
 void Device::GetImageSubresourceLayout(VkDevice device, VkImage image, const VkImageSubresource* pSubresource,
                                        VkSubresourceLayout* pLayout) {
     if (!wrap_handles) return device_dispatch_table.GetImageSubresourceLayout(device, image, pSubresource, pLayout);
-    { image = Unwrap(image); }
+    {
+        image = Unwrap(image);
+    }
     device_dispatch_table.GetImageSubresourceLayout(device, image, pSubresource, pLayout);
 }
 
@@ -1157,7 +1175,9 @@ VkResult Device::CreateCommandPool(VkDevice device, const VkCommandPoolCreateInf
 
 VkResult Device::ResetCommandPool(VkDevice device, VkCommandPool commandPool, VkCommandPoolResetFlags flags) {
     if (!wrap_handles) return device_dispatch_table.ResetCommandPool(device, commandPool, flags);
-    { commandPool = Unwrap(commandPool); }
+    {
+        commandPool = Unwrap(commandPool);
+    }
     VkResult result = device_dispatch_table.ResetCommandPool(device, commandPool, flags);
 
     return result;
@@ -1224,14 +1244,18 @@ void Device::CmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkImage srcImag
 void Device::CmdUpdateBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset, VkDeviceSize dataSize,
                              const void* pData) {
     if (!wrap_handles) return device_dispatch_table.CmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData);
-    { dstBuffer = Unwrap(dstBuffer); }
+    {
+        dstBuffer = Unwrap(dstBuffer);
+    }
     device_dispatch_table.CmdUpdateBuffer(commandBuffer, dstBuffer, dstOffset, dataSize, pData);
 }
 
 void Device::CmdFillBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset, VkDeviceSize size,
                            uint32_t data) {
     if (!wrap_handles) return device_dispatch_table.CmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data);
-    { dstBuffer = Unwrap(dstBuffer); }
+    {
+        dstBuffer = Unwrap(dstBuffer);
+    }
     device_dispatch_table.CmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data);
 }
 
@@ -1280,26 +1304,34 @@ void Device::CmdPipelineBarrier(VkCommandBuffer commandBuffer, VkPipelineStageFl
 
 void Device::CmdBeginQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query, VkQueryControlFlags flags) {
     if (!wrap_handles) return device_dispatch_table.CmdBeginQuery(commandBuffer, queryPool, query, flags);
-    { queryPool = Unwrap(queryPool); }
+    {
+        queryPool = Unwrap(queryPool);
+    }
     device_dispatch_table.CmdBeginQuery(commandBuffer, queryPool, query, flags);
 }
 
 void Device::CmdEndQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query) {
     if (!wrap_handles) return device_dispatch_table.CmdEndQuery(commandBuffer, queryPool, query);
-    { queryPool = Unwrap(queryPool); }
+    {
+        queryPool = Unwrap(queryPool);
+    }
     device_dispatch_table.CmdEndQuery(commandBuffer, queryPool, query);
 }
 
 void Device::CmdResetQueryPool(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount) {
     if (!wrap_handles) return device_dispatch_table.CmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount);
-    { queryPool = Unwrap(queryPool); }
+    {
+        queryPool = Unwrap(queryPool);
+    }
     device_dispatch_table.CmdResetQueryPool(commandBuffer, queryPool, firstQuery, queryCount);
 }
 
 void Device::CmdWriteTimestamp(VkCommandBuffer commandBuffer, VkPipelineStageFlagBits pipelineStage, VkQueryPool queryPool,
                                uint32_t query) {
     if (!wrap_handles) return device_dispatch_table.CmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query);
-    { queryPool = Unwrap(queryPool); }
+    {
+        queryPool = Unwrap(queryPool);
+    }
     device_dispatch_table.CmdWriteTimestamp(commandBuffer, pipelineStage, queryPool, query);
 }
 
@@ -1340,7 +1372,9 @@ void Device::DestroyEvent(VkDevice device, VkEvent event, const VkAllocationCall
 
 VkResult Device::GetEventStatus(VkDevice device, VkEvent event) {
     if (!wrap_handles) return device_dispatch_table.GetEventStatus(device, event);
-    { event = Unwrap(event); }
+    {
+        event = Unwrap(event);
+    }
     VkResult result = device_dispatch_table.GetEventStatus(device, event);
 
     return result;
@@ -1348,7 +1382,9 @@ VkResult Device::GetEventStatus(VkDevice device, VkEvent event) {
 
 VkResult Device::SetEvent(VkDevice device, VkEvent event) {
     if (!wrap_handles) return device_dispatch_table.SetEvent(device, event);
-    { event = Unwrap(event); }
+    {
+        event = Unwrap(event);
+    }
     VkResult result = device_dispatch_table.SetEvent(device, event);
 
     return result;
@@ -1356,7 +1392,9 @@ VkResult Device::SetEvent(VkDevice device, VkEvent event) {
 
 VkResult Device::ResetEvent(VkDevice device, VkEvent event) {
     if (!wrap_handles) return device_dispatch_table.ResetEvent(device, event);
-    { event = Unwrap(event); }
+    {
+        event = Unwrap(event);
+    }
     VkResult result = device_dispatch_table.ResetEvent(device, event);
 
     return result;
@@ -1436,7 +1474,9 @@ void Device::DestroyPipelineCache(VkDevice device, VkPipelineCache pipelineCache
 
 VkResult Device::GetPipelineCacheData(VkDevice device, VkPipelineCache pipelineCache, size_t* pDataSize, void* pData) {
     if (!wrap_handles) return device_dispatch_table.GetPipelineCacheData(device, pipelineCache, pDataSize, pData);
-    { pipelineCache = Unwrap(pipelineCache); }
+    {
+        pipelineCache = Unwrap(pipelineCache);
+    }
     VkResult result = device_dispatch_table.GetPipelineCacheData(device, pipelineCache, pDataSize, pData);
 
     return result;
@@ -1641,7 +1681,9 @@ void Device::UpdateDescriptorSets(VkDevice device, uint32_t descriptorWriteCount
 
 void Device::CmdBindPipeline(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint, VkPipeline pipeline) {
     if (!wrap_handles) return device_dispatch_table.CmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline);
-    { pipeline = Unwrap(pipeline); }
+    {
+        pipeline = Unwrap(pipeline);
+    }
     device_dispatch_table.CmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline);
 }
 
@@ -1671,7 +1713,9 @@ void Device::CmdClearColorImage(VkCommandBuffer commandBuffer, VkImage image, Vk
                                 const VkClearColorValue* pColor, uint32_t rangeCount, const VkImageSubresourceRange* pRanges) {
     if (!wrap_handles)
         return device_dispatch_table.CmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges);
-    { image = Unwrap(image); }
+    {
+        image = Unwrap(image);
+    }
     device_dispatch_table.CmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges);
 }
 
@@ -1681,19 +1725,25 @@ void Device::CmdDispatch(VkCommandBuffer commandBuffer, uint32_t groupCountX, ui
 
 void Device::CmdDispatchIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset) {
     if (!wrap_handles) return device_dispatch_table.CmdDispatchIndirect(commandBuffer, buffer, offset);
-    { buffer = Unwrap(buffer); }
+    {
+        buffer = Unwrap(buffer);
+    }
     device_dispatch_table.CmdDispatchIndirect(commandBuffer, buffer, offset);
 }
 
 void Device::CmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask) {
     if (!wrap_handles) return device_dispatch_table.CmdSetEvent(commandBuffer, event, stageMask);
-    { event = Unwrap(event); }
+    {
+        event = Unwrap(event);
+    }
     device_dispatch_table.CmdSetEvent(commandBuffer, event, stageMask);
 }
 
 void Device::CmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask) {
     if (!wrap_handles) return device_dispatch_table.CmdResetEvent(commandBuffer, event, stageMask);
-    { event = Unwrap(event); }
+    {
+        event = Unwrap(event);
+    }
     device_dispatch_table.CmdResetEvent(commandBuffer, event, stageMask);
 }
 
@@ -1752,7 +1802,9 @@ void Device::CmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, c
 void Device::CmdPushConstants(VkCommandBuffer commandBuffer, VkPipelineLayout layout, VkShaderStageFlags stageFlags,
                               uint32_t offset, uint32_t size, const void* pValues) {
     if (!wrap_handles) return device_dispatch_table.CmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues);
-    { layout = Unwrap(layout); }
+    {
+        layout = Unwrap(layout);
+    }
     device_dispatch_table.CmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues);
 }
 
@@ -1792,7 +1844,9 @@ void Device::DestroyFramebuffer(VkDevice device, VkFramebuffer framebuffer, cons
 
 void Device::GetRenderAreaGranularity(VkDevice device, VkRenderPass renderPass, VkExtent2D* pGranularity) {
     if (!wrap_handles) return device_dispatch_table.GetRenderAreaGranularity(device, renderPass, pGranularity);
-    { renderPass = Unwrap(renderPass); }
+    {
+        renderPass = Unwrap(renderPass);
+    }
     device_dispatch_table.GetRenderAreaGranularity(device, renderPass, pGranularity);
 }
 
@@ -1836,7 +1890,9 @@ void Device::CmdSetStencilReference(VkCommandBuffer commandBuffer, VkStencilFace
 
 void Device::CmdBindIndexBuffer(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, VkIndexType indexType) {
     if (!wrap_handles) return device_dispatch_table.CmdBindIndexBuffer(commandBuffer, buffer, offset, indexType);
-    { buffer = Unwrap(buffer); }
+    {
+        buffer = Unwrap(buffer);
+    }
     device_dispatch_table.CmdBindIndexBuffer(commandBuffer, buffer, offset, indexType);
 }
 
@@ -1872,14 +1928,18 @@ void Device::CmdDrawIndexed(VkCommandBuffer commandBuffer, uint32_t indexCount, 
 void Device::CmdDrawIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, uint32_t drawCount,
                              uint32_t stride) {
     if (!wrap_handles) return device_dispatch_table.CmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride);
-    { buffer = Unwrap(buffer); }
+    {
+        buffer = Unwrap(buffer);
+    }
     device_dispatch_table.CmdDrawIndirect(commandBuffer, buffer, offset, drawCount, stride);
 }
 
 void Device::CmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, uint32_t drawCount,
                                     uint32_t stride) {
     if (!wrap_handles) return device_dispatch_table.CmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride);
-    { buffer = Unwrap(buffer); }
+    {
+        buffer = Unwrap(buffer);
+    }
     device_dispatch_table.CmdDrawIndexedIndirect(commandBuffer, buffer, offset, drawCount, stride);
 }
 
@@ -1902,7 +1962,9 @@ void Device::CmdClearDepthStencilImage(VkCommandBuffer commandBuffer, VkImage im
     if (!wrap_handles)
         return device_dispatch_table.CmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount,
                                                                pRanges);
-    { image = Unwrap(image); }
+    {
+        image = Unwrap(image);
+    }
     device_dispatch_table.CmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges);
 }
 
@@ -2071,7 +2133,9 @@ void Instance::GetPhysicalDeviceSparseImageFormatProperties2(VkPhysicalDevice ph
 
 void Device::TrimCommandPool(VkDevice device, VkCommandPool commandPool, VkCommandPoolTrimFlags flags) {
     if (!wrap_handles) return device_dispatch_table.TrimCommandPool(device, commandPool, flags);
-    { commandPool = Unwrap(commandPool); }
+    {
+        commandPool = Unwrap(commandPool);
+    }
     device_dispatch_table.TrimCommandPool(device, commandPool, flags);
 }
 
@@ -2149,13 +2213,17 @@ void Device::DestroySamplerYcbcrConversion(VkDevice device, VkSamplerYcbcrConver
 
 void Device::ResetQueryPool(VkDevice device, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount) {
     if (!wrap_handles) return device_dispatch_table.ResetQueryPool(device, queryPool, firstQuery, queryCount);
-    { queryPool = Unwrap(queryPool); }
+    {
+        queryPool = Unwrap(queryPool);
+    }
     device_dispatch_table.ResetQueryPool(device, queryPool, firstQuery, queryCount);
 }
 
 VkResult Device::GetSemaphoreCounterValue(VkDevice device, VkSemaphore semaphore, uint64_t* pValue) {
     if (!wrap_handles) return device_dispatch_table.GetSemaphoreCounterValue(device, semaphore, pValue);
-    { semaphore = Unwrap(semaphore); }
+    {
+        semaphore = Unwrap(semaphore);
+    }
     VkResult result = device_dispatch_table.GetSemaphoreCounterValue(device, semaphore, pValue);
 
     return result;
@@ -2390,7 +2458,9 @@ void Device::CmdPipelineBarrier2(VkCommandBuffer commandBuffer, const VkDependen
 
 void Device::CmdWriteTimestamp2(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage, VkQueryPool queryPool, uint32_t query) {
     if (!wrap_handles) return device_dispatch_table.CmdWriteTimestamp2(commandBuffer, stage, queryPool, query);
-    { queryPool = Unwrap(queryPool); }
+    {
+        queryPool = Unwrap(queryPool);
+    }
     device_dispatch_table.CmdWriteTimestamp2(commandBuffer, stage, queryPool, query);
 }
 
@@ -2565,7 +2635,9 @@ void Device::CmdSetEvent2(VkCommandBuffer commandBuffer, VkEvent event, const Vk
 
 void Device::CmdResetEvent2(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2 stageMask) {
     if (!wrap_handles) return device_dispatch_table.CmdResetEvent2(commandBuffer, event, stageMask);
-    { event = Unwrap(event); }
+    {
+        event = Unwrap(event);
+    }
     device_dispatch_table.CmdResetEvent2(commandBuffer, event, stageMask);
 }
 
@@ -2823,7 +2895,9 @@ void Device::GetDeviceImageSubresourceLayout(VkDevice device, const VkDeviceImag
 void Device::GetImageSubresourceLayout2(VkDevice device, VkImage image, const VkImageSubresource2* pSubresource,
                                         VkSubresourceLayout2* pLayout) {
     if (!wrap_handles) return device_dispatch_table.GetImageSubresourceLayout2(device, image, pSubresource, pLayout);
-    { image = Unwrap(image); }
+    {
+        image = Unwrap(image);
+    }
     device_dispatch_table.GetImageSubresourceLayout2(device, image, pSubresource, pLayout);
 }
 
@@ -3069,7 +3143,9 @@ void Device::CmdSetLineStipple(VkCommandBuffer commandBuffer, uint32_t lineStipp
 void Device::CmdBindIndexBuffer2(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, VkDeviceSize size,
                                  VkIndexType indexType) {
     if (!wrap_handles) return device_dispatch_table.CmdBindIndexBuffer2(commandBuffer, buffer, offset, size, indexType);
-    { buffer = Unwrap(buffer); }
+    {
+        buffer = Unwrap(buffer);
+    }
     device_dispatch_table.CmdBindIndexBuffer2(commandBuffer, buffer, offset, size, indexType);
 }
 
@@ -3097,7 +3173,9 @@ VkResult Instance::GetPhysicalDeviceSurfaceSupportKHR(VkPhysicalDevice physicalD
                                                       VkSurfaceKHR surface, VkBool32* pSupported) {
     if (!wrap_handles)
         return instance_dispatch_table.GetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported);
-    { surface = Unwrap(surface); }
+    {
+        surface = Unwrap(surface);
+    }
     VkResult result =
         instance_dispatch_table.GetPhysicalDeviceSurfaceSupportKHR(physicalDevice, queueFamilyIndex, surface, pSupported);
 
@@ -3108,7 +3186,9 @@ VkResult Instance::GetPhysicalDeviceSurfaceCapabilitiesKHR(VkPhysicalDevice phys
                                                            VkSurfaceCapabilitiesKHR* pSurfaceCapabilities) {
     if (!wrap_handles)
         return instance_dispatch_table.GetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities);
-    { surface = Unwrap(surface); }
+    {
+        surface = Unwrap(surface);
+    }
     VkResult result =
         instance_dispatch_table.GetPhysicalDeviceSurfaceCapabilitiesKHR(physicalDevice, surface, pSurfaceCapabilities);
 
@@ -3120,7 +3200,9 @@ VkResult Instance::GetPhysicalDeviceSurfaceFormatsKHR(VkPhysicalDevice physicalD
     if (!wrap_handles)
         return instance_dispatch_table.GetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount,
                                                                           pSurfaceFormats);
-    { surface = Unwrap(surface); }
+    {
+        surface = Unwrap(surface);
+    }
     VkResult result =
         instance_dispatch_table.GetPhysicalDeviceSurfaceFormatsKHR(physicalDevice, surface, pSurfaceFormatCount, pSurfaceFormats);
 
@@ -3132,7 +3214,9 @@ VkResult Instance::GetPhysicalDeviceSurfacePresentModesKHR(VkPhysicalDevice phys
     if (!wrap_handles)
         return instance_dispatch_table.GetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount,
                                                                                pPresentModes);
-    { surface = Unwrap(surface); }
+    {
+        surface = Unwrap(surface);
+    }
     VkResult result =
         instance_dispatch_table.GetPhysicalDeviceSurfacePresentModesKHR(physicalDevice, surface, pPresentModeCount, pPresentModes);
 
@@ -3188,7 +3272,9 @@ VkResult Device::GetDeviceGroupPresentCapabilitiesKHR(VkDevice device,
 VkResult Device::GetDeviceGroupSurfacePresentModesKHR(VkDevice device, VkSurfaceKHR surface,
                                                       VkDeviceGroupPresentModeFlagsKHR* pModes) {
     if (!wrap_handles) return device_dispatch_table.GetDeviceGroupSurfacePresentModesKHR(device, surface, pModes);
-    { surface = Unwrap(surface); }
+    {
+        surface = Unwrap(surface);
+    }
     VkResult result = device_dispatch_table.GetDeviceGroupSurfacePresentModesKHR(device, surface, pModes);
 
     return result;
@@ -3198,7 +3284,9 @@ VkResult Instance::GetPhysicalDevicePresentRectanglesKHR(VkPhysicalDevice physic
                                                          uint32_t* pRectCount, VkRect2D* pRects) {
     if (!wrap_handles)
         return instance_dispatch_table.GetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects);
-    { surface = Unwrap(surface); }
+    {
+        surface = Unwrap(surface);
+    }
     VkResult result = instance_dispatch_table.GetPhysicalDevicePresentRectanglesKHR(physicalDevice, surface, pRectCount, pRects);
 
     return result;
@@ -3234,7 +3322,9 @@ VkResult Instance::CreateDisplayModeKHR(VkPhysicalDevice physicalDevice, VkDispl
                                         const VkDisplayModeCreateInfoKHR* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                         VkDisplayModeKHR* pMode) {
     if (!wrap_handles) return instance_dispatch_table.CreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode);
-    { display = Unwrap(display); }
+    {
+        display = Unwrap(display);
+    }
     VkResult result = instance_dispatch_table.CreateDisplayModeKHR(physicalDevice, display, pCreateInfo, pAllocator, pMode);
     if (result == VK_SUCCESS) {
         *pMode = WrapNew(*pMode);
@@ -3246,7 +3336,9 @@ VkResult Instance::GetDisplayPlaneCapabilitiesKHR(VkPhysicalDevice physicalDevic
                                                   VkDisplayPlaneCapabilitiesKHR* pCapabilities) {
     if (!wrap_handles)
         return instance_dispatch_table.GetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities);
-    { mode = Unwrap(mode); }
+    {
+        mode = Unwrap(mode);
+    }
     VkResult result = instance_dispatch_table.GetDisplayPlaneCapabilitiesKHR(physicalDevice, mode, planeIndex, pCapabilities);
 
     return result;
@@ -3443,7 +3535,9 @@ VkResult Device::GetVideoSessionMemoryRequirementsKHR(VkDevice device, VkVideoSe
     if (!wrap_handles)
         return device_dispatch_table.GetVideoSessionMemoryRequirementsKHR(device, videoSession, pMemoryRequirementsCount,
                                                                           pMemoryRequirements);
-    { videoSession = Unwrap(videoSession); }
+    {
+        videoSession = Unwrap(videoSession);
+    }
     VkResult result = device_dispatch_table.GetVideoSessionMemoryRequirementsKHR(device, videoSession, pMemoryRequirementsCount,
                                                                                  pMemoryRequirements);
 
@@ -3508,7 +3602,9 @@ VkResult Device::CreateVideoSessionParametersKHR(VkDevice device, const VkVideoS
 VkResult Device::UpdateVideoSessionParametersKHR(VkDevice device, VkVideoSessionParametersKHR videoSessionParameters,
                                                  const VkVideoSessionParametersUpdateInfoKHR* pUpdateInfo) {
     if (!wrap_handles) return device_dispatch_table.UpdateVideoSessionParametersKHR(device, videoSessionParameters, pUpdateInfo);
-    { videoSessionParameters = Unwrap(videoSessionParameters); }
+    {
+        videoSessionParameters = Unwrap(videoSessionParameters);
+    }
     VkResult result = device_dispatch_table.UpdateVideoSessionParametersKHR(device, videoSessionParameters, pUpdateInfo);
 
     return result;
@@ -3703,7 +3799,9 @@ void Device::CmdDispatchBaseKHR(VkCommandBuffer commandBuffer, uint32_t baseGrou
 
 void Device::TrimCommandPoolKHR(VkDevice device, VkCommandPool commandPool, VkCommandPoolTrimFlags flags) {
     if (!wrap_handles) return device_dispatch_table.TrimCommandPoolKHR(device, commandPool, flags);
-    { commandPool = Unwrap(commandPool); }
+    {
+        commandPool = Unwrap(commandPool);
+    }
     device_dispatch_table.TrimCommandPoolKHR(device, commandPool, flags);
 }
 
@@ -3955,7 +4053,9 @@ void Device::CmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpass
 
 VkResult Device::GetSwapchainStatusKHR(VkDevice device, VkSwapchainKHR swapchain) {
     if (!wrap_handles) return device_dispatch_table.GetSwapchainStatusKHR(device, swapchain);
-    { swapchain = Unwrap(swapchain); }
+    {
+        swapchain = Unwrap(swapchain);
+    }
     VkResult result = device_dispatch_table.GetSwapchainStatusKHR(device, swapchain);
 
     return result;
@@ -4274,7 +4374,9 @@ void Device::CmdDrawIndexedIndirectCountKHR(VkCommandBuffer commandBuffer, VkBuf
 
 VkResult Device::GetSemaphoreCounterValueKHR(VkDevice device, VkSemaphore semaphore, uint64_t* pValue) {
     if (!wrap_handles) return device_dispatch_table.GetSemaphoreCounterValueKHR(device, semaphore, pValue);
-    { semaphore = Unwrap(semaphore); }
+    {
+        semaphore = Unwrap(semaphore);
+    }
     VkResult result = device_dispatch_table.GetSemaphoreCounterValueKHR(device, semaphore, pValue);
 
     return result;
@@ -4344,7 +4446,9 @@ void Device::CmdSetRenderingInputAttachmentIndicesKHR(VkCommandBuffer commandBuf
 
 VkResult Device::WaitForPresentKHR(VkDevice device, VkSwapchainKHR swapchain, uint64_t presentId, uint64_t timeout) {
     if (!wrap_handles) return device_dispatch_table.WaitForPresentKHR(device, swapchain, presentId, timeout);
-    { swapchain = Unwrap(swapchain); }
+    {
+        swapchain = Unwrap(swapchain);
+    }
     VkResult result = device_dispatch_table.WaitForPresentKHR(device, swapchain, presentId, timeout);
 
     return result;
@@ -4428,7 +4532,9 @@ void Device::DestroyDeferredOperationKHR(VkDevice device, VkDeferredOperationKHR
 
 uint32_t Device::GetDeferredOperationMaxConcurrencyKHR(VkDevice device, VkDeferredOperationKHR operation) {
     if (!wrap_handles) return device_dispatch_table.GetDeferredOperationMaxConcurrencyKHR(device, operation);
-    { operation = Unwrap(operation); }
+    {
+        operation = Unwrap(operation);
+    }
     uint32_t result = device_dispatch_table.GetDeferredOperationMaxConcurrencyKHR(device, operation);
 
     return result;
@@ -4648,7 +4754,9 @@ void Device::CmdSetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event, const
 
 void Device::CmdResetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2 stageMask) {
     if (!wrap_handles) return device_dispatch_table.CmdResetEvent2KHR(commandBuffer, event, stageMask);
-    { event = Unwrap(event); }
+    {
+        event = Unwrap(event);
+    }
     device_dispatch_table.CmdResetEvent2KHR(commandBuffer, event, stageMask);
 }
 
@@ -4729,7 +4837,9 @@ void Device::CmdPipelineBarrier2KHR(VkCommandBuffer commandBuffer, const VkDepen
 void Device::CmdWriteTimestamp2KHR(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage, VkQueryPool queryPool,
                                    uint32_t query) {
     if (!wrap_handles) return device_dispatch_table.CmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query);
-    { queryPool = Unwrap(queryPool); }
+    {
+        queryPool = Unwrap(queryPool);
+    }
     device_dispatch_table.CmdWriteTimestamp2KHR(commandBuffer, stage, queryPool, query);
 }
 
@@ -4918,7 +5028,9 @@ void Device::GetDeviceImageSparseMemoryRequirementsKHR(VkDevice device, const Vk
 void Device::CmdBindIndexBuffer2KHR(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, VkDeviceSize size,
                                     VkIndexType indexType) {
     if (!wrap_handles) return device_dispatch_table.CmdBindIndexBuffer2KHR(commandBuffer, buffer, offset, size, indexType);
-    { buffer = Unwrap(buffer); }
+    {
+        buffer = Unwrap(buffer);
+    }
     device_dispatch_table.CmdBindIndexBuffer2KHR(commandBuffer, buffer, offset, size, indexType);
 }
 
@@ -4935,13 +5047,17 @@ void Device::GetDeviceImageSubresourceLayoutKHR(VkDevice device, const VkDeviceI
 void Device::GetImageSubresourceLayout2KHR(VkDevice device, VkImage image, const VkImageSubresource2* pSubresource,
                                            VkSubresourceLayout2* pLayout) {
     if (!wrap_handles) return device_dispatch_table.GetImageSubresourceLayout2KHR(device, image, pSubresource, pLayout);
-    { image = Unwrap(image); }
+    {
+        image = Unwrap(image);
+    }
     device_dispatch_table.GetImageSubresourceLayout2KHR(device, image, pSubresource, pLayout);
 }
 
 VkResult Device::WaitForPresent2KHR(VkDevice device, VkSwapchainKHR swapchain, const VkPresentWait2InfoKHR* pPresentWait2Info) {
     if (!wrap_handles) return device_dispatch_table.WaitForPresent2KHR(device, swapchain, pPresentWait2Info);
-    { swapchain = Unwrap(swapchain); }
+    {
+        swapchain = Unwrap(swapchain);
+    }
     VkResult result = device_dispatch_table.WaitForPresent2KHR(device, swapchain, pPresentWait2Info);
 
     return result;
@@ -5331,13 +5447,17 @@ void Device::CmdEndTransformFeedbackEXT(VkCommandBuffer commandBuffer, uint32_t 
 void Device::CmdBeginQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query,
                                      VkQueryControlFlags flags, uint32_t index) {
     if (!wrap_handles) return device_dispatch_table.CmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index);
-    { queryPool = Unwrap(queryPool); }
+    {
+        queryPool = Unwrap(queryPool);
+    }
     device_dispatch_table.CmdBeginQueryIndexedEXT(commandBuffer, queryPool, query, flags, index);
 }
 
 void Device::CmdEndQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t query, uint32_t index) {
     if (!wrap_handles) return device_dispatch_table.CmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index);
-    { queryPool = Unwrap(queryPool); }
+    {
+        queryPool = Unwrap(queryPool);
+    }
     device_dispatch_table.CmdEndQueryIndexedEXT(commandBuffer, queryPool, query, index);
 }
 
@@ -5347,7 +5467,9 @@ void Device::CmdDrawIndirectByteCountEXT(VkCommandBuffer commandBuffer, uint32_t
     if (!wrap_handles)
         return device_dispatch_table.CmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer,
                                                                  counterBufferOffset, counterOffset, vertexStride);
-    { counterBuffer = Unwrap(counterBuffer); }
+    {
+        counterBuffer = Unwrap(counterBuffer);
+    }
     device_dispatch_table.CmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer,
                                                       counterBufferOffset, counterOffset, vertexStride);
 }
@@ -5461,7 +5583,9 @@ uint64_t Device::GetImageViewHandle64NVX(VkDevice device, const VkImageViewHandl
 
 VkResult Device::GetImageViewAddressNVX(VkDevice device, VkImageView imageView, VkImageViewAddressPropertiesNVX* pProperties) {
     if (!wrap_handles) return device_dispatch_table.GetImageViewAddressNVX(device, imageView, pProperties);
-    { imageView = Unwrap(imageView); }
+    {
+        imageView = Unwrap(imageView);
+    }
     VkResult result = device_dispatch_table.GetImageViewAddressNVX(device, imageView, pProperties);
 
     return result;
@@ -5497,7 +5621,9 @@ void Device::CmdDrawIndexedIndirectCountAMD(VkCommandBuffer commandBuffer, VkBuf
 VkResult Device::GetShaderInfoAMD(VkDevice device, VkPipeline pipeline, VkShaderStageFlagBits shaderStage,
                                   VkShaderInfoTypeAMD infoType, size_t* pInfoSize, void* pInfo) {
     if (!wrap_handles) return device_dispatch_table.GetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, pInfo);
-    { pipeline = Unwrap(pipeline); }
+    {
+        pipeline = Unwrap(pipeline);
+    }
     VkResult result = device_dispatch_table.GetShaderInfoAMD(device, pipeline, shaderStage, infoType, pInfoSize, pInfo);
 
     return result;
@@ -5530,7 +5656,9 @@ VkResult Instance::GetPhysicalDeviceExternalImageFormatPropertiesNV(
 VkResult Device::GetMemoryWin32HandleNV(VkDevice device, VkDeviceMemory memory, VkExternalMemoryHandleTypeFlagsNV handleType,
                                         HANDLE* pHandle) {
     if (!wrap_handles) return device_dispatch_table.GetMemoryWin32HandleNV(device, memory, handleType, pHandle);
-    { memory = Unwrap(memory); }
+    {
+        memory = Unwrap(memory);
+    }
     VkResult result = device_dispatch_table.GetMemoryWin32HandleNV(device, memory, handleType, pHandle);
 
     return result;
@@ -5580,7 +5708,9 @@ void Device::CmdSetViewportWScalingNV(VkCommandBuffer commandBuffer, uint32_t fi
 
 VkResult Instance::ReleaseDisplayEXT(VkPhysicalDevice physicalDevice, VkDisplayKHR display) {
     if (!wrap_handles) return instance_dispatch_table.ReleaseDisplayEXT(physicalDevice, display);
-    { display = Unwrap(display); }
+    {
+        display = Unwrap(display);
+    }
     VkResult result = instance_dispatch_table.ReleaseDisplayEXT(physicalDevice, display);
 
     return result;
@@ -5589,7 +5719,9 @@ VkResult Instance::ReleaseDisplayEXT(VkPhysicalDevice physicalDevice, VkDisplayK
 
 VkResult Instance::AcquireXlibDisplayEXT(VkPhysicalDevice physicalDevice, Display* dpy, VkDisplayKHR display) {
     if (!wrap_handles) return instance_dispatch_table.AcquireXlibDisplayEXT(physicalDevice, dpy, display);
-    { display = Unwrap(display); }
+    {
+        display = Unwrap(display);
+    }
     VkResult result = instance_dispatch_table.AcquireXlibDisplayEXT(physicalDevice, dpy, display);
 
     return result;
@@ -5611,7 +5743,9 @@ VkResult Instance::GetPhysicalDeviceSurfaceCapabilities2EXT(VkPhysicalDevice phy
                                                             VkSurfaceCapabilities2EXT* pSurfaceCapabilities) {
     if (!wrap_handles)
         return instance_dispatch_table.GetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities);
-    { surface = Unwrap(surface); }
+    {
+        surface = Unwrap(surface);
+    }
     VkResult result =
         instance_dispatch_table.GetPhysicalDeviceSurfaceCapabilities2EXT(physicalDevice, surface, pSurfaceCapabilities);
 
@@ -5620,7 +5754,9 @@ VkResult Instance::GetPhysicalDeviceSurfaceCapabilities2EXT(VkPhysicalDevice phy
 
 VkResult Device::DisplayPowerControlEXT(VkDevice device, VkDisplayKHR display, const VkDisplayPowerInfoEXT* pDisplayPowerInfo) {
     if (!wrap_handles) return device_dispatch_table.DisplayPowerControlEXT(device, display, pDisplayPowerInfo);
-    { display = Unwrap(display); }
+    {
+        display = Unwrap(display);
+    }
     VkResult result = device_dispatch_table.DisplayPowerControlEXT(device, display, pDisplayPowerInfo);
 
     return result;
@@ -5640,7 +5776,9 @@ VkResult Device::RegisterDeviceEventEXT(VkDevice device, const VkDeviceEventInfo
 VkResult Device::RegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, const VkDisplayEventInfoEXT* pDisplayEventInfo,
                                          const VkAllocationCallbacks* pAllocator, VkFence* pFence) {
     if (!wrap_handles) return device_dispatch_table.RegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence);
-    { display = Unwrap(display); }
+    {
+        display = Unwrap(display);
+    }
     VkResult result = device_dispatch_table.RegisterDisplayEventEXT(device, display, pDisplayEventInfo, pAllocator, pFence);
     if (result == VK_SUCCESS) {
         *pFence = WrapNew(*pFence);
@@ -5651,7 +5789,9 @@ VkResult Device::RegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, 
 VkResult Device::GetSwapchainCounterEXT(VkDevice device, VkSwapchainKHR swapchain, VkSurfaceCounterFlagBitsEXT counter,
                                         uint64_t* pCounterValue) {
     if (!wrap_handles) return device_dispatch_table.GetSwapchainCounterEXT(device, swapchain, counter, pCounterValue);
-    { swapchain = Unwrap(swapchain); }
+    {
+        swapchain = Unwrap(swapchain);
+    }
     VkResult result = device_dispatch_table.GetSwapchainCounterEXT(device, swapchain, counter, pCounterValue);
 
     return result;
@@ -5660,7 +5800,9 @@ VkResult Device::GetSwapchainCounterEXT(VkDevice device, VkSwapchainKHR swapchai
 VkResult Device::GetRefreshCycleDurationGOOGLE(VkDevice device, VkSwapchainKHR swapchain,
                                                VkRefreshCycleDurationGOOGLE* pDisplayTimingProperties) {
     if (!wrap_handles) return device_dispatch_table.GetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProperties);
-    { swapchain = Unwrap(swapchain); }
+    {
+        swapchain = Unwrap(swapchain);
+    }
     VkResult result = device_dispatch_table.GetRefreshCycleDurationGOOGLE(device, swapchain, pDisplayTimingProperties);
 
     return result;
@@ -5671,7 +5813,9 @@ VkResult Device::GetPastPresentationTimingGOOGLE(VkDevice device, VkSwapchainKHR
     if (!wrap_handles)
         return device_dispatch_table.GetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount,
                                                                      pPresentationTimings);
-    { swapchain = Unwrap(swapchain); }
+    {
+        swapchain = Unwrap(swapchain);
+    }
     VkResult result =
         device_dispatch_table.GetPastPresentationTimingGOOGLE(device, swapchain, pPresentationTimingCount, pPresentationTimings);
 
@@ -5868,7 +6012,9 @@ VkResult Device::CreateExecutionGraphPipelinesAMDX(VkDevice device, VkPipelineCa
 VkResult Device::GetExecutionGraphPipelineScratchSizeAMDX(VkDevice device, VkPipeline executionGraph,
                                                           VkExecutionGraphPipelineScratchSizeAMDX* pSizeInfo) {
     if (!wrap_handles) return device_dispatch_table.GetExecutionGraphPipelineScratchSizeAMDX(device, executionGraph, pSizeInfo);
-    { executionGraph = Unwrap(executionGraph); }
+    {
+        executionGraph = Unwrap(executionGraph);
+    }
     VkResult result = device_dispatch_table.GetExecutionGraphPipelineScratchSizeAMDX(device, executionGraph, pSizeInfo);
 
     return result;
@@ -5879,7 +6025,9 @@ VkResult Device::GetExecutionGraphPipelineNodeIndexAMDX(VkDevice device, VkPipel
                                                         uint32_t* pNodeIndex) {
     if (!wrap_handles)
         return device_dispatch_table.GetExecutionGraphPipelineNodeIndexAMDX(device, executionGraph, pNodeInfo, pNodeIndex);
-    { executionGraph = Unwrap(executionGraph); }
+    {
+        executionGraph = Unwrap(executionGraph);
+    }
     VkResult result = device_dispatch_table.GetExecutionGraphPipelineNodeIndexAMDX(device, executionGraph, pNodeInfo, pNodeIndex);
 
     return result;
@@ -5889,7 +6037,9 @@ void Device::CmdInitializeGraphScratchMemoryAMDX(VkCommandBuffer commandBuffer, 
                                                  VkDeviceSize scratchSize) {
     if (!wrap_handles)
         return device_dispatch_table.CmdInitializeGraphScratchMemoryAMDX(commandBuffer, executionGraph, scratch, scratchSize);
-    { executionGraph = Unwrap(executionGraph); }
+    {
+        executionGraph = Unwrap(executionGraph);
+    }
     device_dispatch_table.CmdInitializeGraphScratchMemoryAMDX(commandBuffer, executionGraph, scratch, scratchSize);
 }
 
@@ -5921,7 +6071,9 @@ void Instance::GetPhysicalDeviceMultisamplePropertiesEXT(VkPhysicalDevice physic
 VkResult Device::GetImageDrmFormatModifierPropertiesEXT(VkDevice device, VkImage image,
                                                         VkImageDrmFormatModifierPropertiesEXT* pProperties) {
     if (!wrap_handles) return device_dispatch_table.GetImageDrmFormatModifierPropertiesEXT(device, image, pProperties);
-    { image = Unwrap(image); }
+    {
+        image = Unwrap(image);
+    }
     VkResult result = device_dispatch_table.GetImageDrmFormatModifierPropertiesEXT(device, image, pProperties);
 
     return result;
@@ -5968,7 +6120,9 @@ VkResult Device::MergeValidationCachesEXT(VkDevice device, VkValidationCacheEXT 
 
 VkResult Device::GetValidationCacheDataEXT(VkDevice device, VkValidationCacheEXT validationCache, size_t* pDataSize, void* pData) {
     if (!wrap_handles) return device_dispatch_table.GetValidationCacheDataEXT(device, validationCache, pDataSize, pData);
-    { validationCache = Unwrap(validationCache); }
+    {
+        validationCache = Unwrap(validationCache);
+    }
     VkResult result = device_dispatch_table.GetValidationCacheDataEXT(device, validationCache, pDataSize, pData);
 
     return result;
@@ -5976,7 +6130,9 @@ VkResult Device::GetValidationCacheDataEXT(VkDevice device, VkValidationCacheEXT
 
 void Device::CmdBindShadingRateImageNV(VkCommandBuffer commandBuffer, VkImageView imageView, VkImageLayout imageLayout) {
     if (!wrap_handles) return device_dispatch_table.CmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout);
-    { imageView = Unwrap(imageView); }
+    {
+        imageView = Unwrap(imageView);
+    }
     device_dispatch_table.CmdBindShadingRateImageNV(commandBuffer, imageView, imageLayout);
 }
 
@@ -6169,7 +6325,9 @@ VkResult Device::GetRayTracingShaderGroupHandlesKHR(VkDevice device, VkPipeline 
                                                     size_t dataSize, void* pData) {
     if (!wrap_handles)
         return device_dispatch_table.GetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData);
-    { pipeline = Unwrap(pipeline); }
+    {
+        pipeline = Unwrap(pipeline);
+    }
     VkResult result =
         device_dispatch_table.GetRayTracingShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount, dataSize, pData);
 
@@ -6180,7 +6338,9 @@ VkResult Device::GetRayTracingShaderGroupHandlesNV(VkDevice device, VkPipeline p
                                                    size_t dataSize, void* pData) {
     if (!wrap_handles)
         return device_dispatch_table.GetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData);
-    { pipeline = Unwrap(pipeline); }
+    {
+        pipeline = Unwrap(pipeline);
+    }
     VkResult result =
         device_dispatch_table.GetRayTracingShaderGroupHandlesNV(device, pipeline, firstGroup, groupCount, dataSize, pData);
 
@@ -6191,7 +6351,9 @@ VkResult Device::GetAccelerationStructureHandleNV(VkDevice device, VkAcceleratio
                                                   void* pData) {
     if (!wrap_handles)
         return device_dispatch_table.GetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData);
-    { accelerationStructure = Unwrap(accelerationStructure); }
+    {
+        accelerationStructure = Unwrap(accelerationStructure);
+    }
     VkResult result = device_dispatch_table.GetAccelerationStructureHandleNV(device, accelerationStructure, dataSize, pData);
 
     return result;
@@ -6222,7 +6384,9 @@ void Device::CmdWriteAccelerationStructuresPropertiesNV(VkCommandBuffer commandB
 
 VkResult Device::CompileDeferredNV(VkDevice device, VkPipeline pipeline, uint32_t shader) {
     if (!wrap_handles) return device_dispatch_table.CompileDeferredNV(device, pipeline, shader);
-    { pipeline = Unwrap(pipeline); }
+    {
+        pipeline = Unwrap(pipeline);
+    }
     VkResult result = device_dispatch_table.CompileDeferredNV(device, pipeline, shader);
 
     return result;
@@ -6241,14 +6405,18 @@ void Device::CmdWriteBufferMarkerAMD(VkCommandBuffer commandBuffer, VkPipelineSt
                                      VkDeviceSize dstOffset, uint32_t marker) {
     if (!wrap_handles)
         return device_dispatch_table.CmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker);
-    { dstBuffer = Unwrap(dstBuffer); }
+    {
+        dstBuffer = Unwrap(dstBuffer);
+    }
     device_dispatch_table.CmdWriteBufferMarkerAMD(commandBuffer, pipelineStage, dstBuffer, dstOffset, marker);
 }
 
 void Device::CmdWriteBufferMarker2AMD(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage, VkBuffer dstBuffer,
                                       VkDeviceSize dstOffset, uint32_t marker) {
     if (!wrap_handles) return device_dispatch_table.CmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker);
-    { dstBuffer = Unwrap(dstBuffer); }
+    {
+        dstBuffer = Unwrap(dstBuffer);
+    }
     device_dispatch_table.CmdWriteBufferMarker2AMD(commandBuffer, stage, dstBuffer, dstOffset, marker);
 }
 
@@ -6291,7 +6459,9 @@ void Device::CmdDrawMeshTasksNV(VkCommandBuffer commandBuffer, uint32_t taskCoun
 void Device::CmdDrawMeshTasksIndirectNV(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, uint32_t drawCount,
                                         uint32_t stride) {
     if (!wrap_handles) return device_dispatch_table.CmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride);
-    { buffer = Unwrap(buffer); }
+    {
+        buffer = Unwrap(buffer);
+    }
     device_dispatch_table.CmdDrawMeshTasksIndirectNV(commandBuffer, buffer, offset, drawCount, stride);
 }
 
@@ -6334,7 +6504,9 @@ void Device::GetQueueCheckpointData2NV(VkQueue queue, uint32_t* pCheckpointDataC
 
 VkResult Device::SetSwapchainPresentTimingQueueSizeEXT(VkDevice device, VkSwapchainKHR swapchain, uint32_t size) {
     if (!wrap_handles) return device_dispatch_table.SetSwapchainPresentTimingQueueSizeEXT(device, swapchain, size);
-    { swapchain = Unwrap(swapchain); }
+    {
+        swapchain = Unwrap(swapchain);
+    }
     VkResult result = device_dispatch_table.SetSwapchainPresentTimingQueueSizeEXT(device, swapchain, size);
 
     return result;
@@ -6346,7 +6518,9 @@ VkResult Device::GetSwapchainTimingPropertiesEXT(VkDevice device, VkSwapchainKHR
     if (!wrap_handles)
         return device_dispatch_table.GetSwapchainTimingPropertiesEXT(device, swapchain, pSwapchainTimingProperties,
                                                                      pSwapchainTimingPropertiesCounter);
-    { swapchain = Unwrap(swapchain); }
+    {
+        swapchain = Unwrap(swapchain);
+    }
     VkResult result = device_dispatch_table.GetSwapchainTimingPropertiesEXT(device, swapchain, pSwapchainTimingProperties,
                                                                             pSwapchainTimingPropertiesCounter);
 
@@ -6359,7 +6533,9 @@ VkResult Device::GetSwapchainTimeDomainPropertiesEXT(VkDevice device, VkSwapchai
     if (!wrap_handles)
         return device_dispatch_table.GetSwapchainTimeDomainPropertiesEXT(device, swapchain, pSwapchainTimeDomainProperties,
                                                                          pTimeDomainsCounter);
-    { swapchain = Unwrap(swapchain); }
+    {
+        swapchain = Unwrap(swapchain);
+    }
     VkResult result = device_dispatch_table.GetSwapchainTimeDomainPropertiesEXT(device, swapchain, pSwapchainTimeDomainProperties,
                                                                                 pTimeDomainsCounter);
 
@@ -6431,7 +6607,9 @@ VkResult Device::AcquirePerformanceConfigurationINTEL(VkDevice device,
 
 VkResult Device::QueueSetPerformanceConfigurationINTEL(VkQueue queue, VkPerformanceConfigurationINTEL configuration) {
     if (!wrap_handles) return device_dispatch_table.QueueSetPerformanceConfigurationINTEL(queue, configuration);
-    { configuration = Unwrap(configuration); }
+    {
+        configuration = Unwrap(configuration);
+    }
     VkResult result = device_dispatch_table.QueueSetPerformanceConfigurationINTEL(queue, configuration);
 
     return result;
@@ -6446,7 +6624,9 @@ VkResult Device::GetPerformanceParameterINTEL(VkDevice device, VkPerformancePara
 
 void Device::SetLocalDimmingAMD(VkDevice device, VkSwapchainKHR swapChain, VkBool32 localDimmingEnable) {
     if (!wrap_handles) return device_dispatch_table.SetLocalDimmingAMD(device, swapChain, localDimmingEnable);
-    { swapChain = Unwrap(swapChain); }
+    {
+        swapChain = Unwrap(swapChain);
+    }
     device_dispatch_table.SetLocalDimmingAMD(device, swapChain, localDimmingEnable);
 }
 #ifdef VK_USE_PLATFORM_FUCHSIA
@@ -6538,7 +6718,9 @@ VkResult Instance::GetPhysicalDeviceSurfacePresentModes2EXT(VkPhysicalDevice phy
 
 VkResult Device::AcquireFullScreenExclusiveModeEXT(VkDevice device, VkSwapchainKHR swapchain) {
     if (!wrap_handles) return device_dispatch_table.AcquireFullScreenExclusiveModeEXT(device, swapchain);
-    { swapchain = Unwrap(swapchain); }
+    {
+        swapchain = Unwrap(swapchain);
+    }
     VkResult result = device_dispatch_table.AcquireFullScreenExclusiveModeEXT(device, swapchain);
 
     return result;
@@ -6546,7 +6728,9 @@ VkResult Device::AcquireFullScreenExclusiveModeEXT(VkDevice device, VkSwapchainK
 
 VkResult Device::ReleaseFullScreenExclusiveModeEXT(VkDevice device, VkSwapchainKHR swapchain) {
     if (!wrap_handles) return device_dispatch_table.ReleaseFullScreenExclusiveModeEXT(device, swapchain);
-    { swapchain = Unwrap(swapchain); }
+    {
+        swapchain = Unwrap(swapchain);
+    }
     VkResult result = device_dispatch_table.ReleaseFullScreenExclusiveModeEXT(device, swapchain);
 
     return result;
@@ -6591,7 +6775,9 @@ void Device::CmdSetLineStippleEXT(VkCommandBuffer commandBuffer, uint32_t lineSt
 
 void Device::ResetQueryPoolEXT(VkDevice device, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount) {
     if (!wrap_handles) return device_dispatch_table.ResetQueryPoolEXT(device, queryPool, firstQuery, queryCount);
-    { queryPool = Unwrap(queryPool); }
+    {
+        queryPool = Unwrap(queryPool);
+    }
     device_dispatch_table.ResetQueryPoolEXT(device, queryPool, firstQuery, queryCount);
 }
 
@@ -6750,7 +6936,9 @@ VkResult Device::TransitionImageLayoutEXT(VkDevice device, uint32_t transitionCo
 void Device::GetImageSubresourceLayout2EXT(VkDevice device, VkImage image, const VkImageSubresource2* pSubresource,
                                            VkSubresourceLayout2* pLayout) {
     if (!wrap_handles) return device_dispatch_table.GetImageSubresourceLayout2EXT(device, image, pSubresource, pLayout);
-    { image = Unwrap(image); }
+    {
+        image = Unwrap(image);
+    }
     device_dispatch_table.GetImageSubresourceLayout2EXT(device, image, pSubresource, pLayout);
 }
 
@@ -6881,7 +7069,9 @@ void Device::CmdBindPipelineShaderGroupNV(VkCommandBuffer commandBuffer, VkPipel
                                           uint32_t groupIndex) {
     if (!wrap_handles)
         return device_dispatch_table.CmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex);
-    { pipeline = Unwrap(pipeline); }
+    {
+        pipeline = Unwrap(pipeline);
+    }
     device_dispatch_table.CmdBindPipelineShaderGroupNV(commandBuffer, pipelineBindPoint, pipeline, groupIndex);
 }
 
@@ -6927,7 +7117,9 @@ void Device::CmdSetDepthBias2EXT(VkCommandBuffer commandBuffer, const VkDepthBia
 
 VkResult Instance::AcquireDrmDisplayEXT(VkPhysicalDevice physicalDevice, int32_t drmFd, VkDisplayKHR display) {
     if (!wrap_handles) return instance_dispatch_table.AcquireDrmDisplayEXT(physicalDevice, drmFd, display);
-    { display = Unwrap(display); }
+    {
+        display = Unwrap(display);
+    }
     VkResult result = instance_dispatch_table.AcquireDrmDisplayEXT(physicalDevice, drmFd, display);
 
     return result;
@@ -7001,7 +7193,9 @@ VkResult Device::CreateCudaModuleNV(VkDevice device, const VkCudaModuleCreateInf
 
 VkResult Device::GetCudaModuleCacheNV(VkDevice device, VkCudaModuleNV module, size_t* pCacheSize, void* pCacheData) {
     if (!wrap_handles) return device_dispatch_table.GetCudaModuleCacheNV(device, module, pCacheSize, pCacheData);
-    { module = Unwrap(module); }
+    {
+        module = Unwrap(module);
+    }
     VkResult result = device_dispatch_table.GetCudaModuleCacheNV(device, module, pCacheSize, pCacheData);
 
     return result;
@@ -7074,14 +7268,18 @@ void Device::CmdEndPerTileExecutionQCOM(VkCommandBuffer commandBuffer, const VkP
 
 void Device::GetDescriptorSetLayoutSizeEXT(VkDevice device, VkDescriptorSetLayout layout, VkDeviceSize* pLayoutSizeInBytes) {
     if (!wrap_handles) return device_dispatch_table.GetDescriptorSetLayoutSizeEXT(device, layout, pLayoutSizeInBytes);
-    { layout = Unwrap(layout); }
+    {
+        layout = Unwrap(layout);
+    }
     device_dispatch_table.GetDescriptorSetLayoutSizeEXT(device, layout, pLayoutSizeInBytes);
 }
 
 void Device::GetDescriptorSetLayoutBindingOffsetEXT(VkDevice device, VkDescriptorSetLayout layout, uint32_t binding,
                                                     VkDeviceSize* pOffset) {
     if (!wrap_handles) return device_dispatch_table.GetDescriptorSetLayoutBindingOffsetEXT(device, layout, binding, pOffset);
-    { layout = Unwrap(layout); }
+    {
+        layout = Unwrap(layout);
+    }
     device_dispatch_table.GetDescriptorSetLayoutBindingOffsetEXT(device, layout, binding, pOffset);
 }
 
@@ -7110,7 +7308,9 @@ void Device::CmdSetDescriptorBufferOffsetsEXT(VkCommandBuffer commandBuffer, VkP
     if (!wrap_handles)
         return device_dispatch_table.CmdSetDescriptorBufferOffsetsEXT(commandBuffer, pipelineBindPoint, layout, firstSet, setCount,
                                                                       pBufferIndices, pOffsets);
-    { layout = Unwrap(layout); }
+    {
+        layout = Unwrap(layout);
+    }
     device_dispatch_table.CmdSetDescriptorBufferOffsetsEXT(commandBuffer, pipelineBindPoint, layout, firstSet, setCount,
                                                            pBufferIndices, pOffsets);
 }
@@ -7119,7 +7319,9 @@ void Device::CmdBindDescriptorBufferEmbeddedSamplersEXT(VkCommandBuffer commandB
                                                         VkPipelineLayout layout, uint32_t set) {
     if (!wrap_handles)
         return device_dispatch_table.CmdBindDescriptorBufferEmbeddedSamplersEXT(commandBuffer, pipelineBindPoint, layout, set);
-    { layout = Unwrap(layout); }
+    {
+        layout = Unwrap(layout);
+    }
     device_dispatch_table.CmdBindDescriptorBufferEmbeddedSamplersEXT(commandBuffer, pipelineBindPoint, layout, set);
 }
 
@@ -7245,7 +7447,9 @@ VkResult Device::GetDeviceFaultInfoEXT(VkDevice device, VkDeviceFaultCountsEXT* 
 
 VkResult Instance::AcquireWinrtDisplayNV(VkPhysicalDevice physicalDevice, VkDisplayKHR display) {
     if (!wrap_handles) return instance_dispatch_table.AcquireWinrtDisplayNV(physicalDevice, display);
-    { display = Unwrap(display); }
+    {
+        display = Unwrap(display);
+    }
     VkResult result = instance_dispatch_table.AcquireWinrtDisplayNV(physicalDevice, display);
 
     return result;
@@ -7379,7 +7583,9 @@ VkResult Device::SetBufferCollectionImageConstraintsFUCHSIA(VkDevice device, VkB
                                                             const VkImageConstraintsInfoFUCHSIA* pImageConstraintsInfo) {
     if (!wrap_handles)
         return device_dispatch_table.SetBufferCollectionImageConstraintsFUCHSIA(device, collection, pImageConstraintsInfo);
-    { collection = Unwrap(collection); }
+    {
+        collection = Unwrap(collection);
+    }
     VkResult result = device_dispatch_table.SetBufferCollectionImageConstraintsFUCHSIA(device, collection, pImageConstraintsInfo);
 
     return result;
@@ -7389,7 +7595,9 @@ VkResult Device::SetBufferCollectionBufferConstraintsFUCHSIA(VkDevice device, Vk
                                                              const VkBufferConstraintsInfoFUCHSIA* pBufferConstraintsInfo) {
     if (!wrap_handles)
         return device_dispatch_table.SetBufferCollectionBufferConstraintsFUCHSIA(device, collection, pBufferConstraintsInfo);
-    { collection = Unwrap(collection); }
+    {
+        collection = Unwrap(collection);
+    }
     VkResult result = device_dispatch_table.SetBufferCollectionBufferConstraintsFUCHSIA(device, collection, pBufferConstraintsInfo);
 
     return result;
@@ -7405,7 +7613,9 @@ void Device::DestroyBufferCollectionFUCHSIA(VkDevice device, VkBufferCollectionF
 VkResult Device::GetBufferCollectionPropertiesFUCHSIA(VkDevice device, VkBufferCollectionFUCHSIA collection,
                                                       VkBufferCollectionPropertiesFUCHSIA* pProperties) {
     if (!wrap_handles) return device_dispatch_table.GetBufferCollectionPropertiesFUCHSIA(device, collection, pProperties);
-    { collection = Unwrap(collection); }
+    {
+        collection = Unwrap(collection);
+    }
     VkResult result = device_dispatch_table.GetBufferCollectionPropertiesFUCHSIA(device, collection, pProperties);
 
     return result;
@@ -7416,7 +7626,9 @@ VkResult Device::GetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI(VkDevice device, 
                                                                VkExtent2D* pMaxWorkgroupSize) {
     if (!wrap_handles)
         return device_dispatch_table.GetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI(device, renderpass, pMaxWorkgroupSize);
-    { renderpass = Unwrap(renderpass); }
+    {
+        renderpass = Unwrap(renderpass);
+    }
     VkResult result = device_dispatch_table.GetDeviceSubpassShadingMaxWorkgroupSizeHUAWEI(device, renderpass, pMaxWorkgroupSize);
 
     return result;
@@ -7428,7 +7640,9 @@ void Device::CmdSubpassShadingHUAWEI(VkCommandBuffer commandBuffer) {
 
 void Device::CmdBindInvocationMaskHUAWEI(VkCommandBuffer commandBuffer, VkImageView imageView, VkImageLayout imageLayout) {
     if (!wrap_handles) return device_dispatch_table.CmdBindInvocationMaskHUAWEI(commandBuffer, imageView, imageLayout);
-    { imageView = Unwrap(imageView); }
+    {
+        imageView = Unwrap(imageView);
+    }
     device_dispatch_table.CmdBindInvocationMaskHUAWEI(commandBuffer, imageView, imageLayout);
 }
 
@@ -7833,13 +8047,17 @@ void Device::CmdDrawClusterHUAWEI(VkCommandBuffer commandBuffer, uint32_t groupC
 
 void Device::CmdDrawClusterIndirectHUAWEI(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset) {
     if (!wrap_handles) return device_dispatch_table.CmdDrawClusterIndirectHUAWEI(commandBuffer, buffer, offset);
-    { buffer = Unwrap(buffer); }
+    {
+        buffer = Unwrap(buffer);
+    }
     device_dispatch_table.CmdDrawClusterIndirectHUAWEI(commandBuffer, buffer, offset);
 }
 
 void Device::SetDeviceMemoryPriorityEXT(VkDevice device, VkDeviceMemory memory, float priority) {
     if (!wrap_handles) return device_dispatch_table.SetDeviceMemoryPriorityEXT(device, memory, priority);
-    { memory = Unwrap(memory); }
+    {
+        memory = Unwrap(memory);
+    }
     device_dispatch_table.SetDeviceMemoryPriorityEXT(device, memory, priority);
 }
 
@@ -7866,7 +8084,9 @@ void Device::GetDescriptorSetLayoutHostMappingInfoVALVE(VkDevice device,
 
 void Device::GetDescriptorSetHostMappingVALVE(VkDevice device, VkDescriptorSet descriptorSet, void** ppData) {
     if (!wrap_handles) return device_dispatch_table.GetDescriptorSetHostMappingVALVE(device, descriptorSet, ppData);
-    { descriptorSet = Unwrap(descriptorSet); }
+    {
+        descriptorSet = Unwrap(descriptorSet);
+    }
     device_dispatch_table.GetDescriptorSetHostMappingVALVE(device, descriptorSet, ppData);
 }
 
@@ -7881,7 +8101,9 @@ void Device::CmdCopyMemoryToImageIndirectNV(VkCommandBuffer commandBuffer, VkDev
     if (!wrap_handles)
         return device_dispatch_table.CmdCopyMemoryToImageIndirectNV(commandBuffer, copyBufferAddress, copyCount, stride, dstImage,
                                                                     dstImageLayout, pImageSubresources);
-    { dstImage = Unwrap(dstImage); }
+    {
+        dstImage = Unwrap(dstImage);
+    }
     device_dispatch_table.CmdCopyMemoryToImageIndirectNV(commandBuffer, copyBufferAddress, copyCount, stride, dstImage,
                                                          dstImageLayout, pImageSubresources);
 }
@@ -7929,7 +8151,9 @@ void Device::GetPipelineIndirectMemoryRequirementsNV(VkDevice device, const VkCo
 void Device::CmdUpdatePipelineIndirectBufferNV(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                                VkPipeline pipeline) {
     if (!wrap_handles) return device_dispatch_table.CmdUpdatePipelineIndirectBufferNV(commandBuffer, pipelineBindPoint, pipeline);
-    { pipeline = Unwrap(pipeline); }
+    {
+        pipeline = Unwrap(pipeline);
+    }
     device_dispatch_table.CmdUpdatePipelineIndirectBufferNV(commandBuffer, pipelineBindPoint, pipeline);
 }
 
@@ -8281,7 +8505,9 @@ VkResult Device::GetTensorViewOpaqueCaptureDescriptorDataARM(VkDevice device, co
 
 void Device::GetShaderModuleIdentifierEXT(VkDevice device, VkShaderModule shaderModule, VkShaderModuleIdentifierEXT* pIdentifier) {
     if (!wrap_handles) return device_dispatch_table.GetShaderModuleIdentifierEXT(device, shaderModule, pIdentifier);
-    { shaderModule = Unwrap(shaderModule); }
+    {
+        shaderModule = Unwrap(shaderModule);
+    }
     device_dispatch_table.GetShaderModuleIdentifierEXT(device, shaderModule, pIdentifier);
 }
 
@@ -8344,7 +8570,9 @@ VkResult Device::BindOpticalFlowSessionImageNV(VkDevice device, VkOpticalFlowSes
 void Device::CmdOpticalFlowExecuteNV(VkCommandBuffer commandBuffer, VkOpticalFlowSessionNV session,
                                      const VkOpticalFlowExecuteInfoNV* pExecuteInfo) {
     if (!wrap_handles) return device_dispatch_table.CmdOpticalFlowExecuteNV(commandBuffer, session, pExecuteInfo);
-    { session = Unwrap(session); }
+    {
+        session = Unwrap(session);
+    }
     device_dispatch_table.CmdOpticalFlowExecuteNV(commandBuffer, session, pExecuteInfo);
 }
 
@@ -8360,7 +8588,9 @@ void Device::DestroyShaderEXT(VkDevice device, VkShaderEXT shader, const VkAlloc
 
 VkResult Device::GetShaderBinaryDataEXT(VkDevice device, VkShaderEXT shader, size_t* pDataSize, void* pData) {
     if (!wrap_handles) return device_dispatch_table.GetShaderBinaryDataEXT(device, shader, pDataSize, pData);
-    { shader = Unwrap(shader); }
+    {
+        shader = Unwrap(shader);
+    }
     VkResult result = device_dispatch_table.GetShaderBinaryDataEXT(device, shader, pDataSize, pData);
 
     return result;
@@ -8392,7 +8622,9 @@ VkResult Device::GetFramebufferTilePropertiesQCOM(VkDevice device, VkFramebuffer
                                                   VkTilePropertiesQCOM* pProperties) {
     if (!wrap_handles)
         return device_dispatch_table.GetFramebufferTilePropertiesQCOM(device, framebuffer, pPropertiesCount, pProperties);
-    { framebuffer = Unwrap(framebuffer); }
+    {
+        framebuffer = Unwrap(framebuffer);
+    }
     VkResult result = device_dispatch_table.GetFramebufferTilePropertiesQCOM(device, framebuffer, pPropertiesCount, pProperties);
 
     return result;
@@ -8467,7 +8699,9 @@ void Device::CmdConvertCooperativeVectorMatrixNV(VkCommandBuffer commandBuffer, 
 
 VkResult Device::SetLatencySleepModeNV(VkDevice device, VkSwapchainKHR swapchain, const VkLatencySleepModeInfoNV* pSleepModeInfo) {
     if (!wrap_handles) return device_dispatch_table.SetLatencySleepModeNV(device, swapchain, pSleepModeInfo);
-    { swapchain = Unwrap(swapchain); }
+    {
+        swapchain = Unwrap(swapchain);
+    }
     VkResult result = device_dispatch_table.SetLatencySleepModeNV(device, swapchain, pSleepModeInfo);
 
     return result;
@@ -8495,13 +8729,17 @@ VkResult Device::LatencySleepNV(VkDevice device, VkSwapchainKHR swapchain, const
 
 void Device::SetLatencyMarkerNV(VkDevice device, VkSwapchainKHR swapchain, const VkSetLatencyMarkerInfoNV* pLatencyMarkerInfo) {
     if (!wrap_handles) return device_dispatch_table.SetLatencyMarkerNV(device, swapchain, pLatencyMarkerInfo);
-    { swapchain = Unwrap(swapchain); }
+    {
+        swapchain = Unwrap(swapchain);
+    }
     device_dispatch_table.SetLatencyMarkerNV(device, swapchain, pLatencyMarkerInfo);
 }
 
 void Device::GetLatencyTimingsNV(VkDevice device, VkSwapchainKHR swapchain, VkGetLatencyMarkerInfoNV* pLatencyMarkerInfo) {
     if (!wrap_handles) return device_dispatch_table.GetLatencyTimingsNV(device, swapchain, pLatencyMarkerInfo);
-    { swapchain = Unwrap(swapchain); }
+    {
+        swapchain = Unwrap(swapchain);
+    }
     device_dispatch_table.GetLatencyTimingsNV(device, swapchain, pLatencyMarkerInfo);
 }
 
@@ -8616,7 +8854,9 @@ void Device::DestroyDataGraphPipelineSessionARM(VkDevice device, VkDataGraphPipe
 void Device::CmdDispatchDataGraphARM(VkCommandBuffer commandBuffer, VkDataGraphPipelineSessionARM session,
                                      const VkDataGraphPipelineDispatchInfoARM* pInfo) {
     if (!wrap_handles) return device_dispatch_table.CmdDispatchDataGraphARM(commandBuffer, session, pInfo);
-    { session = Unwrap(session); }
+    {
+        session = Unwrap(session);
+    }
     device_dispatch_table.CmdDispatchDataGraphARM(commandBuffer, session, pInfo);
 }
 
@@ -9352,7 +9592,9 @@ VkResult Device::GetRayTracingCaptureReplayShaderGroupHandlesKHR(VkDevice device
     if (!wrap_handles)
         return device_dispatch_table.GetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup, groupCount,
                                                                                      dataSize, pData);
-    { pipeline = Unwrap(pipeline); }
+    {
+        pipeline = Unwrap(pipeline);
+    }
     VkResult result = device_dispatch_table.GetRayTracingCaptureReplayShaderGroupHandlesKHR(device, pipeline, firstGroup,
                                                                                             groupCount, dataSize, pData);
 
@@ -9372,7 +9614,9 @@ void Device::CmdTraceRaysIndirectKHR(VkCommandBuffer commandBuffer,
 VkDeviceSize Device::GetRayTracingShaderGroupStackSizeKHR(VkDevice device, VkPipeline pipeline, uint32_t group,
                                                           VkShaderGroupShaderKHR groupShader) {
     if (!wrap_handles) return device_dispatch_table.GetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader);
-    { pipeline = Unwrap(pipeline); }
+    {
+        pipeline = Unwrap(pipeline);
+    }
     VkDeviceSize result = device_dispatch_table.GetRayTracingShaderGroupStackSizeKHR(device, pipeline, group, groupShader);
 
     return result;
@@ -9389,7 +9633,9 @@ void Device::CmdDrawMeshTasksEXT(VkCommandBuffer commandBuffer, uint32_t groupCo
 void Device::CmdDrawMeshTasksIndirectEXT(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, uint32_t drawCount,
                                          uint32_t stride) {
     if (!wrap_handles) return device_dispatch_table.CmdDrawMeshTasksIndirectEXT(commandBuffer, buffer, offset, drawCount, stride);
-    { buffer = Unwrap(buffer); }
+    {
+        buffer = Unwrap(buffer);
+    }
     device_dispatch_table.CmdDrawMeshTasksIndirectEXT(commandBuffer, buffer, offset, drawCount, stride);
 }
 

--- a/layers/vulkan/generated/feature_not_present.cpp
+++ b/layers/vulkan/generated/feature_not_present.cpp
@@ -26,14 +26,14 @@
 namespace vvl {
 namespace dispatch {
 
-void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDeviceCreateInfo &create_info) {
+void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDeviceCreateInfo& create_info) {
     std::stringstream ss;
     ss << "returned VK_ERROR_FEATURE_NOT_PRESENT because the following features were not supported on this physical device:\n";
 
     // First do 1.0 VkPhysicalDeviceFeatures
     {
-        const auto *features2 = vku::FindStructInPNextChain<VkPhysicalDeviceFeatures2>(create_info.pNext);
-        const VkPhysicalDeviceFeatures &enabling =
+        const auto* features2 = vku::FindStructInPNextChain<VkPhysicalDeviceFeatures2>(create_info.pNext);
+        const VkPhysicalDeviceFeatures& enabling =
             create_info.pEnabledFeatures ? *create_info.pEnabledFeatures : features2->features;
 
         VkPhysicalDeviceFeatures supported = {};
@@ -205,15 +205,15 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
         }
     }
     VkPhysicalDeviceFeatures2 features_2 = vku::InitStructHelper();
-    for (const VkBaseInStructure *current = static_cast<const VkBaseInStructure *>(create_info.pNext); current != nullptr;
+    for (const VkBaseInStructure* current = static_cast<const VkBaseInStructure*>(create_info.pNext); current != nullptr;
          current = current->pNext) {
         switch (current->sType) {
             case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES: {
                 VkPhysicalDevice16BitStorageFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevice16BitStorageFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDevice16BitStorageFeatures *>(current);
+                const VkPhysicalDevice16BitStorageFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDevice16BitStorageFeatures*>(current);
                 if (enabling->storageBuffer16BitAccess && !supported.storageBuffer16BitAccess) {
                     ss << "VkPhysicalDevice16BitStorageFeatures::storageBuffer16BitAccess is not supported\n";
                 }
@@ -232,8 +232,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevice4444FormatsFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevice4444FormatsFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDevice4444FormatsFeaturesEXT *>(current);
+                const VkPhysicalDevice4444FormatsFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDevice4444FormatsFeaturesEXT*>(current);
                 if (enabling->formatA4R4G4B4 && !supported.formatA4R4G4B4) {
                     ss << "VkPhysicalDevice4444FormatsFeaturesEXT::formatA4R4G4B4 is not supported\n";
                 }
@@ -246,8 +246,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevice8BitStorageFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevice8BitStorageFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDevice8BitStorageFeatures *>(current);
+                const VkPhysicalDevice8BitStorageFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDevice8BitStorageFeatures*>(current);
                 if (enabling->storageBuffer8BitAccess && !supported.storageBuffer8BitAccess) {
                     ss << "VkPhysicalDevice8BitStorageFeatures::storageBuffer8BitAccess is not supported\n";
                 }
@@ -263,8 +263,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceASTCDecodeFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceASTCDecodeFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceASTCDecodeFeaturesEXT *>(current);
+                const VkPhysicalDeviceASTCDecodeFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceASTCDecodeFeaturesEXT*>(current);
                 if (enabling->decodeModeSharedExponent && !supported.decodeModeSharedExponent) {
                     ss << "VkPhysicalDeviceASTCDecodeFeaturesEXT::decodeModeSharedExponent is not supported\n";
                 }
@@ -274,8 +274,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceAccelerationStructureFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceAccelerationStructureFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceAccelerationStructureFeaturesKHR *>(current);
+                const VkPhysicalDeviceAccelerationStructureFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceAccelerationStructureFeaturesKHR*>(current);
                 if (enabling->accelerationStructure && !supported.accelerationStructure) {
                     ss << "VkPhysicalDeviceAccelerationStructureFeaturesKHR::accelerationStructure is not supported\n";
                 }
@@ -299,8 +299,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceAddressBindingReportFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceAddressBindingReportFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceAddressBindingReportFeaturesEXT *>(current);
+                const VkPhysicalDeviceAddressBindingReportFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceAddressBindingReportFeaturesEXT*>(current);
                 if (enabling->reportAddressBinding && !supported.reportAddressBinding) {
                     ss << "VkPhysicalDeviceAddressBindingReportFeaturesEXT::reportAddressBinding is not supported\n";
                 }
@@ -310,8 +310,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceAmigoProfilingFeaturesSEC supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceAmigoProfilingFeaturesSEC *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceAmigoProfilingFeaturesSEC *>(current);
+                const VkPhysicalDeviceAmigoProfilingFeaturesSEC* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceAmigoProfilingFeaturesSEC*>(current);
                 if (enabling->amigoProfiling && !supported.amigoProfiling) {
                     ss << "VkPhysicalDeviceAmigoProfilingFeaturesSEC::amigoProfiling is not supported\n";
                 }
@@ -321,8 +321,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceAntiLagFeaturesAMD supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceAntiLagFeaturesAMD *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceAntiLagFeaturesAMD *>(current);
+                const VkPhysicalDeviceAntiLagFeaturesAMD* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceAntiLagFeaturesAMD*>(current);
                 if (enabling->antiLag && !supported.antiLag) {
                     ss << "VkPhysicalDeviceAntiLagFeaturesAMD::antiLag is not supported\n";
                 }
@@ -332,8 +332,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT *>(current);
+                const VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT*>(current);
                 if (enabling->attachmentFeedbackLoopDynamicState && !supported.attachmentFeedbackLoopDynamicState) {
                     ss << "VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT::attachmentFeedbackLoopDynamicState is "
                           "not supported\n";
@@ -344,8 +344,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT *>(current);
+                const VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT*>(current);
                 if (enabling->attachmentFeedbackLoopLayout && !supported.attachmentFeedbackLoopLayout) {
                     ss << "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT::attachmentFeedbackLoopLayout is not "
                           "supported\n";
@@ -356,8 +356,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT *>(current);
+                const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT*>(current);
                 if (enabling->advancedBlendCoherentOperations && !supported.advancedBlendCoherentOperations) {
                     ss << "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT::advancedBlendCoherentOperations is not supported\n";
                 }
@@ -367,8 +367,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceBorderColorSwizzleFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceBorderColorSwizzleFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceBorderColorSwizzleFeaturesEXT *>(current);
+                const VkPhysicalDeviceBorderColorSwizzleFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceBorderColorSwizzleFeaturesEXT*>(current);
                 if (enabling->borderColorSwizzle && !supported.borderColorSwizzle) {
                     ss << "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT::borderColorSwizzle is not supported\n";
                 }
@@ -381,8 +381,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceBufferDeviceAddressFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceBufferDeviceAddressFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceBufferDeviceAddressFeatures *>(current);
+                const VkPhysicalDeviceBufferDeviceAddressFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceBufferDeviceAddressFeatures*>(current);
                 if (enabling->bufferDeviceAddress && !supported.bufferDeviceAddress) {
                     ss << "VkPhysicalDeviceBufferDeviceAddressFeatures::bufferDeviceAddress is not supported\n";
                 }
@@ -398,8 +398,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceBufferDeviceAddressFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceBufferDeviceAddressFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceBufferDeviceAddressFeaturesEXT *>(current);
+                const VkPhysicalDeviceBufferDeviceAddressFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceBufferDeviceAddressFeaturesEXT*>(current);
                 if (enabling->bufferDeviceAddress && !supported.bufferDeviceAddress) {
                     ss << "VkPhysicalDeviceBufferDeviceAddressFeaturesEXT::bufferDeviceAddress is not supported\n";
                 }
@@ -415,8 +415,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceClusterAccelerationStructureFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceClusterAccelerationStructureFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceClusterAccelerationStructureFeaturesNV *>(current);
+                const VkPhysicalDeviceClusterAccelerationStructureFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceClusterAccelerationStructureFeaturesNV*>(current);
                 if (enabling->clusterAccelerationStructure && !supported.clusterAccelerationStructure) {
                     ss << "VkPhysicalDeviceClusterAccelerationStructureFeaturesNV::clusterAccelerationStructure is not supported\n";
                 }
@@ -426,8 +426,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI *>(current);
+                const VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI*>(current);
                 if (enabling->clustercullingShader && !supported.clustercullingShader) {
                     ss << "VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI::clustercullingShader is not supported\n";
                 }
@@ -440,8 +440,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceCoherentMemoryFeaturesAMD supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceCoherentMemoryFeaturesAMD *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceCoherentMemoryFeaturesAMD *>(current);
+                const VkPhysicalDeviceCoherentMemoryFeaturesAMD* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceCoherentMemoryFeaturesAMD*>(current);
                 if (enabling->deviceCoherentMemory && !supported.deviceCoherentMemory) {
                     ss << "VkPhysicalDeviceCoherentMemoryFeaturesAMD::deviceCoherentMemory is not supported\n";
                 }
@@ -451,8 +451,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceColorWriteEnableFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceColorWriteEnableFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceColorWriteEnableFeaturesEXT *>(current);
+                const VkPhysicalDeviceColorWriteEnableFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceColorWriteEnableFeaturesEXT*>(current);
                 if (enabling->colorWriteEnable && !supported.colorWriteEnable) {
                     ss << "VkPhysicalDeviceColorWriteEnableFeaturesEXT::colorWriteEnable is not supported\n";
                 }
@@ -462,8 +462,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceCommandBufferInheritanceFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceCommandBufferInheritanceFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceCommandBufferInheritanceFeaturesNV *>(current);
+                const VkPhysicalDeviceCommandBufferInheritanceFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceCommandBufferInheritanceFeaturesNV*>(current);
                 if (enabling->commandBufferInheritance && !supported.commandBufferInheritance) {
                     ss << "VkPhysicalDeviceCommandBufferInheritanceFeaturesNV::commandBufferInheritance is not supported\n";
                 }
@@ -473,8 +473,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceComputeOccupancyPriorityFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceComputeOccupancyPriorityFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceComputeOccupancyPriorityFeaturesNV *>(current);
+                const VkPhysicalDeviceComputeOccupancyPriorityFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceComputeOccupancyPriorityFeaturesNV*>(current);
                 if (enabling->computeOccupancyPriority && !supported.computeOccupancyPriority) {
                     ss << "VkPhysicalDeviceComputeOccupancyPriorityFeaturesNV::computeOccupancyPriority is not supported\n";
                 }
@@ -484,8 +484,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR *>(current);
+                const VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR*>(current);
                 if (enabling->computeDerivativeGroupQuads && !supported.computeDerivativeGroupQuads) {
                     ss << "VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR::computeDerivativeGroupQuads is not supported\n";
                 }
@@ -498,8 +498,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceConditionalRenderingFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceConditionalRenderingFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceConditionalRenderingFeaturesEXT *>(current);
+                const VkPhysicalDeviceConditionalRenderingFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceConditionalRenderingFeaturesEXT*>(current);
                 if (enabling->conditionalRendering && !supported.conditionalRendering) {
                     ss << "VkPhysicalDeviceConditionalRenderingFeaturesEXT::conditionalRendering is not supported\n";
                 }
@@ -512,8 +512,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceCooperativeMatrix2FeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceCooperativeMatrix2FeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceCooperativeMatrix2FeaturesNV *>(current);
+                const VkPhysicalDeviceCooperativeMatrix2FeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceCooperativeMatrix2FeaturesNV*>(current);
                 if (enabling->cooperativeMatrixWorkgroupScope && !supported.cooperativeMatrixWorkgroupScope) {
                     ss << "VkPhysicalDeviceCooperativeMatrix2FeaturesNV::cooperativeMatrixWorkgroupScope is not supported\n";
                 }
@@ -541,8 +541,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceCooperativeMatrixFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceCooperativeMatrixFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixFeaturesKHR *>(current);
+                const VkPhysicalDeviceCooperativeMatrixFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixFeaturesKHR*>(current);
                 if (enabling->cooperativeMatrix && !supported.cooperativeMatrix) {
                     ss << "VkPhysicalDeviceCooperativeMatrixFeaturesKHR::cooperativeMatrix is not supported\n";
                 }
@@ -555,8 +555,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceCooperativeMatrixFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceCooperativeMatrixFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixFeaturesNV *>(current);
+                const VkPhysicalDeviceCooperativeMatrixFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixFeaturesNV*>(current);
                 if (enabling->cooperativeMatrix && !supported.cooperativeMatrix) {
                     ss << "VkPhysicalDeviceCooperativeMatrixFeaturesNV::cooperativeMatrix is not supported\n";
                 }
@@ -569,8 +569,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceCooperativeVectorFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceCooperativeVectorFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceCooperativeVectorFeaturesNV *>(current);
+                const VkPhysicalDeviceCooperativeVectorFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceCooperativeVectorFeaturesNV*>(current);
                 if (enabling->cooperativeVector && !supported.cooperativeVector) {
                     ss << "VkPhysicalDeviceCooperativeVectorFeaturesNV::cooperativeVector is not supported\n";
                 }
@@ -583,8 +583,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR *>(current);
+                const VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR*>(current);
                 if (enabling->indirectMemoryCopy && !supported.indirectMemoryCopy) {
                     ss << "VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR::indirectMemoryCopy is not supported\n";
                 }
@@ -597,8 +597,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceCopyMemoryIndirectFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceCopyMemoryIndirectFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceCopyMemoryIndirectFeaturesNV *>(current);
+                const VkPhysicalDeviceCopyMemoryIndirectFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceCopyMemoryIndirectFeaturesNV*>(current);
                 if (enabling->indirectCopy && !supported.indirectCopy) {
                     ss << "VkPhysicalDeviceCopyMemoryIndirectFeaturesNV::indirectCopy is not supported\n";
                 }
@@ -608,8 +608,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceCornerSampledImageFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceCornerSampledImageFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceCornerSampledImageFeaturesNV *>(current);
+                const VkPhysicalDeviceCornerSampledImageFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceCornerSampledImageFeaturesNV*>(current);
                 if (enabling->cornerSampledImage && !supported.cornerSampledImage) {
                     ss << "VkPhysicalDeviceCornerSampledImageFeaturesNV::cornerSampledImage is not supported\n";
                 }
@@ -619,8 +619,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceCoverageReductionModeFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceCoverageReductionModeFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceCoverageReductionModeFeaturesNV *>(current);
+                const VkPhysicalDeviceCoverageReductionModeFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceCoverageReductionModeFeaturesNV*>(current);
                 if (enabling->coverageReductionMode && !supported.coverageReductionMode) {
                     ss << "VkPhysicalDeviceCoverageReductionModeFeaturesNV::coverageReductionMode is not supported\n";
                 }
@@ -630,8 +630,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceCubicClampFeaturesQCOM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceCubicClampFeaturesQCOM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceCubicClampFeaturesQCOM *>(current);
+                const VkPhysicalDeviceCubicClampFeaturesQCOM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceCubicClampFeaturesQCOM*>(current);
                 if (enabling->cubicRangeClamp && !supported.cubicRangeClamp) {
                     ss << "VkPhysicalDeviceCubicClampFeaturesQCOM::cubicRangeClamp is not supported\n";
                 }
@@ -641,8 +641,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceCubicWeightsFeaturesQCOM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceCubicWeightsFeaturesQCOM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceCubicWeightsFeaturesQCOM *>(current);
+                const VkPhysicalDeviceCubicWeightsFeaturesQCOM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceCubicWeightsFeaturesQCOM*>(current);
                 if (enabling->selectableCubicWeights && !supported.selectableCubicWeights) {
                     ss << "VkPhysicalDeviceCubicWeightsFeaturesQCOM::selectableCubicWeights is not supported\n";
                 }
@@ -653,8 +653,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceCudaKernelLaunchFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceCudaKernelLaunchFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceCudaKernelLaunchFeaturesNV *>(current);
+                const VkPhysicalDeviceCudaKernelLaunchFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceCudaKernelLaunchFeaturesNV*>(current);
                 if (enabling->cudaKernelLaunchFeatures && !supported.cudaKernelLaunchFeatures) {
                     ss << "VkPhysicalDeviceCudaKernelLaunchFeaturesNV::cudaKernelLaunchFeatures is not supported\n";
                 }
@@ -665,8 +665,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceCustomBorderColorFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceCustomBorderColorFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceCustomBorderColorFeaturesEXT *>(current);
+                const VkPhysicalDeviceCustomBorderColorFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceCustomBorderColorFeaturesEXT*>(current);
                 if (enabling->customBorderColors && !supported.customBorderColors) {
                     ss << "VkPhysicalDeviceCustomBorderColorFeaturesEXT::customBorderColors is not supported\n";
                 }
@@ -679,8 +679,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceCustomResolveFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceCustomResolveFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceCustomResolveFeaturesEXT *>(current);
+                const VkPhysicalDeviceCustomResolveFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceCustomResolveFeaturesEXT*>(current);
                 if (enabling->customResolve && !supported.customResolve) {
                     ss << "VkPhysicalDeviceCustomResolveFeaturesEXT::customResolve is not supported\n";
                 }
@@ -690,8 +690,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDataGraphFeaturesARM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDataGraphFeaturesARM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDataGraphFeaturesARM *>(current);
+                const VkPhysicalDeviceDataGraphFeaturesARM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDataGraphFeaturesARM*>(current);
                 if (enabling->dataGraph && !supported.dataGraph) {
                     ss << "VkPhysicalDeviceDataGraphFeaturesARM::dataGraph is not supported\n";
                 }
@@ -713,8 +713,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDataGraphModelFeaturesQCOM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDataGraphModelFeaturesQCOM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDataGraphModelFeaturesQCOM *>(current);
+                const VkPhysicalDeviceDataGraphModelFeaturesQCOM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDataGraphModelFeaturesQCOM*>(current);
                 if (enabling->dataGraphModel && !supported.dataGraphModel) {
                     ss << "VkPhysicalDeviceDataGraphModelFeaturesQCOM::dataGraphModel is not supported\n";
                 }
@@ -724,8 +724,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV *>(current);
+                const VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV*>(current);
                 if (enabling->dedicatedAllocationImageAliasing && !supported.dedicatedAllocationImageAliasing) {
                     ss << "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV::dedicatedAllocationImageAliasing is not "
                           "supported\n";
@@ -737,8 +737,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDenseGeometryFormatFeaturesAMDX supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDenseGeometryFormatFeaturesAMDX *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDenseGeometryFormatFeaturesAMDX *>(current);
+                const VkPhysicalDeviceDenseGeometryFormatFeaturesAMDX* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDenseGeometryFormatFeaturesAMDX*>(current);
                 if (enabling->denseGeometryFormat && !supported.denseGeometryFormat) {
                     ss << "VkPhysicalDeviceDenseGeometryFormatFeaturesAMDX::denseGeometryFormat is not supported\n";
                 }
@@ -749,8 +749,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDepthBiasControlFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDepthBiasControlFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDepthBiasControlFeaturesEXT *>(current);
+                const VkPhysicalDeviceDepthBiasControlFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDepthBiasControlFeaturesEXT*>(current);
                 if (enabling->depthBiasControl && !supported.depthBiasControl) {
                     ss << "VkPhysicalDeviceDepthBiasControlFeaturesEXT::depthBiasControl is not supported\n";
                 }
@@ -771,8 +771,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDepthClampControlFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDepthClampControlFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDepthClampControlFeaturesEXT *>(current);
+                const VkPhysicalDeviceDepthClampControlFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDepthClampControlFeaturesEXT*>(current);
                 if (enabling->depthClampControl && !supported.depthClampControl) {
                     ss << "VkPhysicalDeviceDepthClampControlFeaturesEXT::depthClampControl is not supported\n";
                 }
@@ -782,8 +782,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDepthClampZeroOneFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDepthClampZeroOneFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDepthClampZeroOneFeaturesKHR *>(current);
+                const VkPhysicalDeviceDepthClampZeroOneFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDepthClampZeroOneFeaturesKHR*>(current);
                 if (enabling->depthClampZeroOne && !supported.depthClampZeroOne) {
                     ss << "VkPhysicalDeviceDepthClampZeroOneFeaturesKHR::depthClampZeroOne is not supported\n";
                 }
@@ -793,8 +793,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDepthClipControlFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDepthClipControlFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDepthClipControlFeaturesEXT *>(current);
+                const VkPhysicalDeviceDepthClipControlFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDepthClipControlFeaturesEXT*>(current);
                 if (enabling->depthClipControl && !supported.depthClipControl) {
                     ss << "VkPhysicalDeviceDepthClipControlFeaturesEXT::depthClipControl is not supported\n";
                 }
@@ -804,8 +804,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDepthClipEnableFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDepthClipEnableFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDepthClipEnableFeaturesEXT *>(current);
+                const VkPhysicalDeviceDepthClipEnableFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDepthClipEnableFeaturesEXT*>(current);
                 if (enabling->depthClipEnable && !supported.depthClipEnable) {
                     ss << "VkPhysicalDeviceDepthClipEnableFeaturesEXT::depthClipEnable is not supported\n";
                 }
@@ -815,8 +815,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDescriptorBufferFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDescriptorBufferFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDescriptorBufferFeaturesEXT *>(current);
+                const VkPhysicalDeviceDescriptorBufferFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDescriptorBufferFeaturesEXT*>(current);
                 if (enabling->descriptorBuffer && !supported.descriptorBuffer) {
                     ss << "VkPhysicalDeviceDescriptorBufferFeaturesEXT::descriptorBuffer is not supported\n";
                 }
@@ -835,8 +835,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDescriptorBufferTensorFeaturesARM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDescriptorBufferTensorFeaturesARM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDescriptorBufferTensorFeaturesARM *>(current);
+                const VkPhysicalDeviceDescriptorBufferTensorFeaturesARM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDescriptorBufferTensorFeaturesARM*>(current);
                 if (enabling->descriptorBufferTensorDescriptors && !supported.descriptorBufferTensorDescriptors) {
                     ss << "VkPhysicalDeviceDescriptorBufferTensorFeaturesARM::descriptorBufferTensorDescriptors is not supported\n";
                 }
@@ -846,8 +846,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDescriptorIndexingFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDescriptorIndexingFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDescriptorIndexingFeatures *>(current);
+                const VkPhysicalDeviceDescriptorIndexingFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDescriptorIndexingFeatures*>(current);
                 if (enabling->shaderInputAttachmentArrayDynamicIndexing && !supported.shaderInputAttachmentArrayDynamicIndexing) {
                     ss << "VkPhysicalDeviceDescriptorIndexingFeatures::shaderInputAttachmentArrayDynamicIndexing is not "
                           "supported\n";
@@ -942,8 +942,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV *>(current);
+                const VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV*>(current);
                 if (enabling->descriptorPoolOverallocation && !supported.descriptorPoolOverallocation) {
                     ss << "VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV::descriptorPoolOverallocation is not supported\n";
                 }
@@ -953,8 +953,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE *>(current);
+                const VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE*>(current);
                 if (enabling->descriptorSetHostMapping && !supported.descriptorSetHostMapping) {
                     ss << "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE::descriptorSetHostMapping is not supported\n";
                 }
@@ -964,8 +964,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV *>(current);
+                const VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV*>(current);
                 if (enabling->deviceGeneratedCompute && !supported.deviceGeneratedCompute) {
                     ss << "VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV::deviceGeneratedCompute is not supported\n";
                 }
@@ -983,8 +983,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT *>(current);
+                const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT*>(current);
                 if (enabling->deviceGeneratedCommands && !supported.deviceGeneratedCommands) {
                     ss << "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT::deviceGeneratedCommands is not supported\n";
                 }
@@ -997,8 +997,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV *>(current);
+                const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV*>(current);
                 if (enabling->deviceGeneratedCommands && !supported.deviceGeneratedCommands) {
                     ss << "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV::deviceGeneratedCommands is not supported\n";
                 }
@@ -1008,8 +1008,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDeviceMemoryReportFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDeviceMemoryReportFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDeviceMemoryReportFeaturesEXT *>(current);
+                const VkPhysicalDeviceDeviceMemoryReportFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDeviceMemoryReportFeaturesEXT*>(current);
                 if (enabling->deviceMemoryReport && !supported.deviceMemoryReport) {
                     ss << "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT::deviceMemoryReport is not supported\n";
                 }
@@ -1019,8 +1019,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDiagnosticsConfigFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDiagnosticsConfigFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDiagnosticsConfigFeaturesNV *>(current);
+                const VkPhysicalDeviceDiagnosticsConfigFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDiagnosticsConfigFeaturesNV*>(current);
                 if (enabling->diagnosticsConfig && !supported.diagnosticsConfig) {
                     ss << "VkPhysicalDeviceDiagnosticsConfigFeaturesNV::diagnosticsConfig is not supported\n";
                 }
@@ -1031,8 +1031,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDisplacementMicromapFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDisplacementMicromapFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDisplacementMicromapFeaturesNV *>(current);
+                const VkPhysicalDeviceDisplacementMicromapFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDisplacementMicromapFeaturesNV*>(current);
                 if (enabling->displacementMicromap && !supported.displacementMicromap) {
                     ss << "VkPhysicalDeviceDisplacementMicromapFeaturesNV::displacementMicromap is not supported\n";
                 }
@@ -1043,8 +1043,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDynamicRenderingFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDynamicRenderingFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDynamicRenderingFeatures *>(current);
+                const VkPhysicalDeviceDynamicRenderingFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDynamicRenderingFeatures*>(current);
                 if (enabling->dynamicRendering && !supported.dynamicRendering) {
                     ss << "VkPhysicalDeviceDynamicRenderingFeatures::dynamicRendering is not supported\n";
                 }
@@ -1054,8 +1054,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDynamicRenderingLocalReadFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDynamicRenderingLocalReadFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDynamicRenderingLocalReadFeatures *>(current);
+                const VkPhysicalDeviceDynamicRenderingLocalReadFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDynamicRenderingLocalReadFeatures*>(current);
                 if (enabling->dynamicRenderingLocalRead && !supported.dynamicRenderingLocalRead) {
                     ss << "VkPhysicalDeviceDynamicRenderingLocalReadFeatures::dynamicRenderingLocalRead is not supported\n";
                 }
@@ -1065,8 +1065,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT *>(current);
+                const VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT*>(current);
                 if (enabling->dynamicRenderingUnusedAttachments && !supported.dynamicRenderingUnusedAttachments) {
                     ss << "VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT::dynamicRenderingUnusedAttachments is not "
                           "supported\n";
@@ -1077,8 +1077,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceExclusiveScissorFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceExclusiveScissorFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceExclusiveScissorFeaturesNV *>(current);
+                const VkPhysicalDeviceExclusiveScissorFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceExclusiveScissorFeaturesNV*>(current);
                 if (enabling->exclusiveScissor && !supported.exclusiveScissor) {
                     ss << "VkPhysicalDeviceExclusiveScissorFeaturesNV::exclusiveScissor is not supported\n";
                 }
@@ -1088,8 +1088,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceExtendedDynamicState2FeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceExtendedDynamicState2FeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceExtendedDynamicState2FeaturesEXT *>(current);
+                const VkPhysicalDeviceExtendedDynamicState2FeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceExtendedDynamicState2FeaturesEXT*>(current);
                 if (enabling->extendedDynamicState2 && !supported.extendedDynamicState2) {
                     ss << "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT::extendedDynamicState2 is not supported\n";
                 }
@@ -1106,8 +1106,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceExtendedDynamicState3FeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(current);
+                const VkPhysicalDeviceExtendedDynamicState3FeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(current);
                 if (enabling->extendedDynamicState3TessellationDomainOrigin &&
                     !supported.extendedDynamicState3TessellationDomainOrigin) {
                     ss << "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT::extendedDynamicState3TessellationDomainOrigin is not "
@@ -1246,8 +1246,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceExtendedDynamicStateFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceExtendedDynamicStateFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceExtendedDynamicStateFeaturesEXT *>(current);
+                const VkPhysicalDeviceExtendedDynamicStateFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceExtendedDynamicStateFeaturesEXT*>(current);
                 if (enabling->extendedDynamicState && !supported.extendedDynamicState) {
                     ss << "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT::extendedDynamicState is not supported\n";
                 }
@@ -1257,8 +1257,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV *>(current);
+                const VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV*>(current);
                 if (enabling->extendedSparseAddressSpace && !supported.extendedSparseAddressSpace) {
                     ss << "VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV::extendedSparseAddressSpace is not supported\n";
                 }
@@ -1269,8 +1269,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceExternalFormatResolveFeaturesANDROID supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceExternalFormatResolveFeaturesANDROID *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceExternalFormatResolveFeaturesANDROID *>(current);
+                const VkPhysicalDeviceExternalFormatResolveFeaturesANDROID* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceExternalFormatResolveFeaturesANDROID*>(current);
                 if (enabling->externalFormatResolve && !supported.externalFormatResolve) {
                     ss << "VkPhysicalDeviceExternalFormatResolveFeaturesANDROID::externalFormatResolve is not supported\n";
                 }
@@ -1281,8 +1281,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceExternalMemoryRDMAFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceExternalMemoryRDMAFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceExternalMemoryRDMAFeaturesNV *>(current);
+                const VkPhysicalDeviceExternalMemoryRDMAFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceExternalMemoryRDMAFeaturesNV*>(current);
                 if (enabling->externalMemoryRDMA && !supported.externalMemoryRDMA) {
                     ss << "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV::externalMemoryRDMA is not supported\n";
                 }
@@ -1293,8 +1293,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX *>(current);
+                const VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX*>(current);
                 if (enabling->screenBufferImport && !supported.screenBufferImport) {
                     ss << "VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX::screenBufferImport is not supported\n";
                 }
@@ -1305,8 +1305,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceFaultFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceFaultFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceFaultFeaturesEXT *>(current);
+                const VkPhysicalDeviceFaultFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceFaultFeaturesEXT*>(current);
                 if (enabling->deviceFault && !supported.deviceFault) {
                     ss << "VkPhysicalDeviceFaultFeaturesEXT::deviceFault is not supported\n";
                 }
@@ -1319,8 +1319,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceFormatPackFeaturesARM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceFormatPackFeaturesARM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceFormatPackFeaturesARM *>(current);
+                const VkPhysicalDeviceFormatPackFeaturesARM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceFormatPackFeaturesARM*>(current);
                 if (enabling->formatPack && !supported.formatPack) {
                     ss << "VkPhysicalDeviceFormatPackFeaturesARM::formatPack is not supported\n";
                 }
@@ -1330,8 +1330,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceFragmentDensityMap2FeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceFragmentDensityMap2FeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceFragmentDensityMap2FeaturesEXT *>(current);
+                const VkPhysicalDeviceFragmentDensityMap2FeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceFragmentDensityMap2FeaturesEXT*>(current);
                 if (enabling->fragmentDensityMapDeferred && !supported.fragmentDensityMapDeferred) {
                     ss << "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT::fragmentDensityMapDeferred is not supported\n";
                 }
@@ -1341,8 +1341,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceFragmentDensityMapFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceFragmentDensityMapFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapFeaturesEXT *>(current);
+                const VkPhysicalDeviceFragmentDensityMapFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapFeaturesEXT*>(current);
                 if (enabling->fragmentDensityMap && !supported.fragmentDensityMap) {
                     ss << "VkPhysicalDeviceFragmentDensityMapFeaturesEXT::fragmentDensityMap is not supported\n";
                 }
@@ -1358,8 +1358,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE *>(current);
+                const VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE*>(current);
                 if (enabling->fragmentDensityMapLayered && !supported.fragmentDensityMapLayered) {
                     ss << "VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE::fragmentDensityMapLayered is not supported\n";
                 }
@@ -1369,8 +1369,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceFragmentDensityMapOffsetFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceFragmentDensityMapOffsetFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapOffsetFeaturesEXT *>(current);
+                const VkPhysicalDeviceFragmentDensityMapOffsetFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapOffsetFeaturesEXT*>(current);
                 if (enabling->fragmentDensityMapOffset && !supported.fragmentDensityMapOffset) {
                     ss << "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesEXT::fragmentDensityMapOffset is not supported\n";
                 }
@@ -1380,8 +1380,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR *>(current);
+                const VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR*>(current);
                 if (enabling->fragmentShaderBarycentric && !supported.fragmentShaderBarycentric) {
                     ss << "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR::fragmentShaderBarycentric is not supported\n";
                 }
@@ -1391,8 +1391,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT *>(current);
+                const VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT*>(current);
                 if (enabling->fragmentShaderSampleInterlock && !supported.fragmentShaderSampleInterlock) {
                     ss << "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT::fragmentShaderSampleInterlock is not supported\n";
                 }
@@ -1409,8 +1409,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV *>(current);
+                const VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV*>(current);
                 if (enabling->fragmentShadingRateEnums && !supported.fragmentShadingRateEnums) {
                     ss << "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV::fragmentShadingRateEnums is not supported\n";
                 }
@@ -1426,8 +1426,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceFragmentShadingRateFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceFragmentShadingRateFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceFragmentShadingRateFeaturesKHR *>(current);
+                const VkPhysicalDeviceFragmentShadingRateFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceFragmentShadingRateFeaturesKHR*>(current);
                 if (enabling->pipelineFragmentShadingRate && !supported.pipelineFragmentShadingRate) {
                     ss << "VkPhysicalDeviceFragmentShadingRateFeaturesKHR::pipelineFragmentShadingRate is not supported\n";
                 }
@@ -1443,8 +1443,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceFrameBoundaryFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceFrameBoundaryFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceFrameBoundaryFeaturesEXT *>(current);
+                const VkPhysicalDeviceFrameBoundaryFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceFrameBoundaryFeaturesEXT*>(current);
                 if (enabling->frameBoundary && !supported.frameBoundary) {
                     ss << "VkPhysicalDeviceFrameBoundaryFeaturesEXT::frameBoundary is not supported\n";
                 }
@@ -1454,8 +1454,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceGlobalPriorityQueryFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceGlobalPriorityQueryFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceGlobalPriorityQueryFeatures *>(current);
+                const VkPhysicalDeviceGlobalPriorityQueryFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceGlobalPriorityQueryFeatures*>(current);
                 if (enabling->globalPriorityQuery && !supported.globalPriorityQuery) {
                     ss << "VkPhysicalDeviceGlobalPriorityQueryFeatures::globalPriorityQuery is not supported\n";
                 }
@@ -1465,8 +1465,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT *>(current);
+                const VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT*>(current);
                 if (enabling->graphicsPipelineLibrary && !supported.graphicsPipelineLibrary) {
                     ss << "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT::graphicsPipelineLibrary is not supported\n";
                 }
@@ -1476,8 +1476,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceHdrVividFeaturesHUAWEI supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceHdrVividFeaturesHUAWEI *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceHdrVividFeaturesHUAWEI *>(current);
+                const VkPhysicalDeviceHdrVividFeaturesHUAWEI* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceHdrVividFeaturesHUAWEI*>(current);
                 if (enabling->hdrVivid && !supported.hdrVivid) {
                     ss << "VkPhysicalDeviceHdrVividFeaturesHUAWEI::hdrVivid is not supported\n";
                 }
@@ -1487,8 +1487,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceHostImageCopyFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceHostImageCopyFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceHostImageCopyFeatures *>(current);
+                const VkPhysicalDeviceHostImageCopyFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceHostImageCopyFeatures*>(current);
                 if (enabling->hostImageCopy && !supported.hostImageCopy) {
                     ss << "VkPhysicalDeviceHostImageCopyFeatures::hostImageCopy is not supported\n";
                 }
@@ -1498,8 +1498,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceHostQueryResetFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceHostQueryResetFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceHostQueryResetFeatures *>(current);
+                const VkPhysicalDeviceHostQueryResetFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceHostQueryResetFeatures*>(current);
                 if (enabling->hostQueryReset && !supported.hostQueryReset) {
                     ss << "VkPhysicalDeviceHostQueryResetFeatures::hostQueryReset is not supported\n";
                 }
@@ -1509,8 +1509,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceImage2DViewOf3DFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceImage2DViewOf3DFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceImage2DViewOf3DFeaturesEXT *>(current);
+                const VkPhysicalDeviceImage2DViewOf3DFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceImage2DViewOf3DFeaturesEXT*>(current);
                 if (enabling->image2DViewOf3D && !supported.image2DViewOf3D) {
                     ss << "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT::image2DViewOf3D is not supported\n";
                 }
@@ -1523,8 +1523,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceImageAlignmentControlFeaturesMESA supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceImageAlignmentControlFeaturesMESA *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceImageAlignmentControlFeaturesMESA *>(current);
+                const VkPhysicalDeviceImageAlignmentControlFeaturesMESA* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceImageAlignmentControlFeaturesMESA*>(current);
                 if (enabling->imageAlignmentControl && !supported.imageAlignmentControl) {
                     ss << "VkPhysicalDeviceImageAlignmentControlFeaturesMESA::imageAlignmentControl is not supported\n";
                 }
@@ -1534,8 +1534,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceImageCompressionControlFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceImageCompressionControlFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceImageCompressionControlFeaturesEXT *>(current);
+                const VkPhysicalDeviceImageCompressionControlFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceImageCompressionControlFeaturesEXT*>(current);
                 if (enabling->imageCompressionControl && !supported.imageCompressionControl) {
                     ss << "VkPhysicalDeviceImageCompressionControlFeaturesEXT::imageCompressionControl is not supported\n";
                 }
@@ -1545,8 +1545,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT *>(current);
+                const VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT*>(current);
                 if (enabling->imageCompressionControlSwapchain && !supported.imageCompressionControlSwapchain) {
                     ss << "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT::imageCompressionControlSwapchain is not "
                           "supported\n";
@@ -1557,8 +1557,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceImageProcessing2FeaturesQCOM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceImageProcessing2FeaturesQCOM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceImageProcessing2FeaturesQCOM *>(current);
+                const VkPhysicalDeviceImageProcessing2FeaturesQCOM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceImageProcessing2FeaturesQCOM*>(current);
                 if (enabling->textureBlockMatch2 && !supported.textureBlockMatch2) {
                     ss << "VkPhysicalDeviceImageProcessing2FeaturesQCOM::textureBlockMatch2 is not supported\n";
                 }
@@ -1568,8 +1568,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceImageProcessingFeaturesQCOM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceImageProcessingFeaturesQCOM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceImageProcessingFeaturesQCOM *>(current);
+                const VkPhysicalDeviceImageProcessingFeaturesQCOM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceImageProcessingFeaturesQCOM*>(current);
                 if (enabling->textureSampleWeighted && !supported.textureSampleWeighted) {
                     ss << "VkPhysicalDeviceImageProcessingFeaturesQCOM::textureSampleWeighted is not supported\n";
                 }
@@ -1585,8 +1585,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceImageRobustnessFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceImageRobustnessFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceImageRobustnessFeatures *>(current);
+                const VkPhysicalDeviceImageRobustnessFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceImageRobustnessFeatures*>(current);
                 if (enabling->robustImageAccess && !supported.robustImageAccess) {
                     ss << "VkPhysicalDeviceImageRobustnessFeatures::robustImageAccess is not supported\n";
                 }
@@ -1596,8 +1596,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT *>(current);
+                const VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT*>(current);
                 if (enabling->imageSlicedViewOf3D && !supported.imageSlicedViewOf3D) {
                     ss << "VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT::imageSlicedViewOf3D is not supported\n";
                 }
@@ -1607,8 +1607,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceImageViewMinLodFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceImageViewMinLodFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceImageViewMinLodFeaturesEXT *>(current);
+                const VkPhysicalDeviceImageViewMinLodFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceImageViewMinLodFeaturesEXT*>(current);
                 if (enabling->minLod && !supported.minLod) {
                     ss << "VkPhysicalDeviceImageViewMinLodFeaturesEXT::minLod is not supported\n";
                 }
@@ -1618,8 +1618,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceImagelessFramebufferFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceImagelessFramebufferFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceImagelessFramebufferFeatures *>(current);
+                const VkPhysicalDeviceImagelessFramebufferFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceImagelessFramebufferFeatures*>(current);
                 if (enabling->imagelessFramebuffer && !supported.imagelessFramebuffer) {
                     ss << "VkPhysicalDeviceImagelessFramebufferFeatures::imagelessFramebuffer is not supported\n";
                 }
@@ -1629,8 +1629,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceIndexTypeUint8Features supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceIndexTypeUint8Features *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceIndexTypeUint8Features *>(current);
+                const VkPhysicalDeviceIndexTypeUint8Features* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceIndexTypeUint8Features*>(current);
                 if (enabling->indexTypeUint8 && !supported.indexTypeUint8) {
                     ss << "VkPhysicalDeviceIndexTypeUint8Features::indexTypeUint8 is not supported\n";
                 }
@@ -1640,8 +1640,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceInheritedViewportScissorFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceInheritedViewportScissorFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceInheritedViewportScissorFeaturesNV *>(current);
+                const VkPhysicalDeviceInheritedViewportScissorFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceInheritedViewportScissorFeaturesNV*>(current);
                 if (enabling->inheritedViewportScissor2D && !supported.inheritedViewportScissor2D) {
                     ss << "VkPhysicalDeviceInheritedViewportScissorFeaturesNV::inheritedViewportScissor2D is not supported\n";
                 }
@@ -1651,8 +1651,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceInlineUniformBlockFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceInlineUniformBlockFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceInlineUniformBlockFeatures *>(current);
+                const VkPhysicalDeviceInlineUniformBlockFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceInlineUniformBlockFeatures*>(current);
                 if (enabling->inlineUniformBlock && !supported.inlineUniformBlock) {
                     ss << "VkPhysicalDeviceInlineUniformBlockFeatures::inlineUniformBlock is not supported\n";
                 }
@@ -1667,8 +1667,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceInvocationMaskFeaturesHUAWEI supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceInvocationMaskFeaturesHUAWEI *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceInvocationMaskFeaturesHUAWEI *>(current);
+                const VkPhysicalDeviceInvocationMaskFeaturesHUAWEI* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceInvocationMaskFeaturesHUAWEI*>(current);
                 if (enabling->invocationMask && !supported.invocationMask) {
                     ss << "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI::invocationMask is not supported\n";
                 }
@@ -1678,8 +1678,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceLegacyDitheringFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceLegacyDitheringFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceLegacyDitheringFeaturesEXT *>(current);
+                const VkPhysicalDeviceLegacyDitheringFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceLegacyDitheringFeaturesEXT*>(current);
                 if (enabling->legacyDithering && !supported.legacyDithering) {
                     ss << "VkPhysicalDeviceLegacyDitheringFeaturesEXT::legacyDithering is not supported\n";
                 }
@@ -1689,8 +1689,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceLegacyVertexAttributesFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceLegacyVertexAttributesFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceLegacyVertexAttributesFeaturesEXT *>(current);
+                const VkPhysicalDeviceLegacyVertexAttributesFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceLegacyVertexAttributesFeaturesEXT*>(current);
                 if (enabling->legacyVertexAttributes && !supported.legacyVertexAttributes) {
                     ss << "VkPhysicalDeviceLegacyVertexAttributesFeaturesEXT::legacyVertexAttributes is not supported\n";
                 }
@@ -1700,8 +1700,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceLineRasterizationFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceLineRasterizationFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceLineRasterizationFeatures *>(current);
+                const VkPhysicalDeviceLineRasterizationFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceLineRasterizationFeatures*>(current);
                 if (enabling->rectangularLines && !supported.rectangularLines) {
                     ss << "VkPhysicalDeviceLineRasterizationFeatures::rectangularLines is not supported\n";
                 }
@@ -1726,8 +1726,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceLinearColorAttachmentFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceLinearColorAttachmentFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceLinearColorAttachmentFeaturesNV *>(current);
+                const VkPhysicalDeviceLinearColorAttachmentFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceLinearColorAttachmentFeaturesNV*>(current);
                 if (enabling->linearColorAttachment && !supported.linearColorAttachment) {
                     ss << "VkPhysicalDeviceLinearColorAttachmentFeaturesNV::linearColorAttachment is not supported\n";
                 }
@@ -1737,8 +1737,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMaintenance10FeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMaintenance10FeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMaintenance10FeaturesKHR *>(current);
+                const VkPhysicalDeviceMaintenance10FeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMaintenance10FeaturesKHR*>(current);
                 if (enabling->maintenance10 && !supported.maintenance10) {
                     ss << "VkPhysicalDeviceMaintenance10FeaturesKHR::maintenance10 is not supported\n";
                 }
@@ -1748,8 +1748,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMaintenance4Features supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMaintenance4Features *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMaintenance4Features *>(current);
+                const VkPhysicalDeviceMaintenance4Features* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMaintenance4Features*>(current);
                 if (enabling->maintenance4 && !supported.maintenance4) {
                     ss << "VkPhysicalDeviceMaintenance4Features::maintenance4 is not supported\n";
                 }
@@ -1759,8 +1759,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMaintenance5Features supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMaintenance5Features *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMaintenance5Features *>(current);
+                const VkPhysicalDeviceMaintenance5Features* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMaintenance5Features*>(current);
                 if (enabling->maintenance5 && !supported.maintenance5) {
                     ss << "VkPhysicalDeviceMaintenance5Features::maintenance5 is not supported\n";
                 }
@@ -1770,8 +1770,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMaintenance6Features supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMaintenance6Features *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMaintenance6Features *>(current);
+                const VkPhysicalDeviceMaintenance6Features* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMaintenance6Features*>(current);
                 if (enabling->maintenance6 && !supported.maintenance6) {
                     ss << "VkPhysicalDeviceMaintenance6Features::maintenance6 is not supported\n";
                 }
@@ -1781,8 +1781,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMaintenance7FeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMaintenance7FeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMaintenance7FeaturesKHR *>(current);
+                const VkPhysicalDeviceMaintenance7FeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMaintenance7FeaturesKHR*>(current);
                 if (enabling->maintenance7 && !supported.maintenance7) {
                     ss << "VkPhysicalDeviceMaintenance7FeaturesKHR::maintenance7 is not supported\n";
                 }
@@ -1792,8 +1792,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMaintenance8FeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMaintenance8FeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMaintenance8FeaturesKHR *>(current);
+                const VkPhysicalDeviceMaintenance8FeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMaintenance8FeaturesKHR*>(current);
                 if (enabling->maintenance8 && !supported.maintenance8) {
                     ss << "VkPhysicalDeviceMaintenance8FeaturesKHR::maintenance8 is not supported\n";
                 }
@@ -1803,8 +1803,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMaintenance9FeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMaintenance9FeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMaintenance9FeaturesKHR *>(current);
+                const VkPhysicalDeviceMaintenance9FeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMaintenance9FeaturesKHR*>(current);
                 if (enabling->maintenance9 && !supported.maintenance9) {
                     ss << "VkPhysicalDeviceMaintenance9FeaturesKHR::maintenance9 is not supported\n";
                 }
@@ -1814,8 +1814,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMapMemoryPlacedFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMapMemoryPlacedFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMapMemoryPlacedFeaturesEXT *>(current);
+                const VkPhysicalDeviceMapMemoryPlacedFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMapMemoryPlacedFeaturesEXT*>(current);
                 if (enabling->memoryMapPlaced && !supported.memoryMapPlaced) {
                     ss << "VkPhysicalDeviceMapMemoryPlacedFeaturesEXT::memoryMapPlaced is not supported\n";
                 }
@@ -1831,8 +1831,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMemoryDecompressionFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMemoryDecompressionFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMemoryDecompressionFeaturesEXT *>(current);
+                const VkPhysicalDeviceMemoryDecompressionFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMemoryDecompressionFeaturesEXT*>(current);
                 if (enabling->memoryDecompression && !supported.memoryDecompression) {
                     ss << "VkPhysicalDeviceMemoryDecompressionFeaturesEXT::memoryDecompression is not supported\n";
                 }
@@ -1842,8 +1842,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMemoryPriorityFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMemoryPriorityFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMemoryPriorityFeaturesEXT *>(current);
+                const VkPhysicalDeviceMemoryPriorityFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMemoryPriorityFeaturesEXT*>(current);
                 if (enabling->memoryPriority && !supported.memoryPriority) {
                     ss << "VkPhysicalDeviceMemoryPriorityFeaturesEXT::memoryPriority is not supported\n";
                 }
@@ -1853,8 +1853,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMeshShaderFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMeshShaderFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMeshShaderFeaturesEXT *>(current);
+                const VkPhysicalDeviceMeshShaderFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMeshShaderFeaturesEXT*>(current);
                 if (enabling->taskShader && !supported.taskShader) {
                     ss << "VkPhysicalDeviceMeshShaderFeaturesEXT::taskShader is not supported\n";
                 }
@@ -1876,8 +1876,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMeshShaderFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMeshShaderFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMeshShaderFeaturesNV *>(current);
+                const VkPhysicalDeviceMeshShaderFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMeshShaderFeaturesNV*>(current);
                 if (enabling->taskShader && !supported.taskShader) {
                     ss << "VkPhysicalDeviceMeshShaderFeaturesNV::taskShader is not supported\n";
                 }
@@ -1890,8 +1890,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMultiDrawFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMultiDrawFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMultiDrawFeaturesEXT *>(current);
+                const VkPhysicalDeviceMultiDrawFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMultiDrawFeaturesEXT*>(current);
                 if (enabling->multiDraw && !supported.multiDraw) {
                     ss << "VkPhysicalDeviceMultiDrawFeaturesEXT::multiDraw is not supported\n";
                 }
@@ -1901,8 +1901,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT *>(current);
+                const VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT*>(current);
                 if (enabling->multisampledRenderToSingleSampled && !supported.multisampledRenderToSingleSampled) {
                     ss << "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT::multisampledRenderToSingleSampled is not "
                           "supported\n";
@@ -1913,8 +1913,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMultiviewFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMultiviewFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMultiviewFeatures *>(current);
+                const VkPhysicalDeviceMultiviewFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMultiviewFeatures*>(current);
                 if (enabling->multiview && !supported.multiview) {
                     ss << "VkPhysicalDeviceMultiviewFeatures::multiview is not supported\n";
                 }
@@ -1930,8 +1930,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM *>(current);
+                const VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM*>(current);
                 if (enabling->multiviewPerViewRenderAreas && !supported.multiviewPerViewRenderAreas) {
                     ss << "VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM::multiviewPerViewRenderAreas is not supported\n";
                 }
@@ -1941,8 +1941,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM *>(current);
+                const VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM*>(current);
                 if (enabling->multiviewPerViewViewports && !supported.multiviewPerViewViewports) {
                     ss << "VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM::multiviewPerViewViewports is not supported\n";
                 }
@@ -1952,8 +1952,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT *>(current);
+                const VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT*>(current);
                 if (enabling->mutableDescriptorType && !supported.mutableDescriptorType) {
                     ss << "VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT::mutableDescriptorType is not supported\n";
                 }
@@ -1963,8 +1963,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceNestedCommandBufferFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceNestedCommandBufferFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceNestedCommandBufferFeaturesEXT *>(current);
+                const VkPhysicalDeviceNestedCommandBufferFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceNestedCommandBufferFeaturesEXT*>(current);
                 if (enabling->nestedCommandBuffer && !supported.nestedCommandBuffer) {
                     ss << "VkPhysicalDeviceNestedCommandBufferFeaturesEXT::nestedCommandBuffer is not supported\n";
                 }
@@ -1980,8 +1980,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT *>(current);
+                const VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT*>(current);
                 if (enabling->nonSeamlessCubeMap && !supported.nonSeamlessCubeMap) {
                     ss << "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT::nonSeamlessCubeMap is not supported\n";
                 }
@@ -1991,8 +1991,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceOpacityMicromapFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceOpacityMicromapFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceOpacityMicromapFeaturesEXT *>(current);
+                const VkPhysicalDeviceOpacityMicromapFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceOpacityMicromapFeaturesEXT*>(current);
                 if (enabling->micromap && !supported.micromap) {
                     ss << "VkPhysicalDeviceOpacityMicromapFeaturesEXT::micromap is not supported\n";
                 }
@@ -2008,8 +2008,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceOpticalFlowFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceOpticalFlowFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceOpticalFlowFeaturesNV *>(current);
+                const VkPhysicalDeviceOpticalFlowFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceOpticalFlowFeaturesNV*>(current);
                 if (enabling->opticalFlow && !supported.opticalFlow) {
                     ss << "VkPhysicalDeviceOpticalFlowFeaturesNV::opticalFlow is not supported\n";
                 }
@@ -2019,8 +2019,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT *>(current);
+                const VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT*>(current);
                 if (enabling->pageableDeviceLocalMemory && !supported.pageableDeviceLocalMemory) {
                     ss << "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT::pageableDeviceLocalMemory is not supported\n";
                 }
@@ -2030,8 +2030,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV *>(current);
+                const VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV*>(current);
                 if (enabling->partitionedAccelerationStructure && !supported.partitionedAccelerationStructure) {
                     ss << "VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV::partitionedAccelerationStructure is not "
                           "supported\n";
@@ -2042,8 +2042,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePerStageDescriptorSetFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePerStageDescriptorSetFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePerStageDescriptorSetFeaturesNV *>(current);
+                const VkPhysicalDevicePerStageDescriptorSetFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePerStageDescriptorSetFeaturesNV*>(current);
                 if (enabling->perStageDescriptorSet && !supported.perStageDescriptorSet) {
                     ss << "VkPhysicalDevicePerStageDescriptorSetFeaturesNV::perStageDescriptorSet is not supported\n";
                 }
@@ -2056,8 +2056,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePerformanceCountersByRegionFeaturesARM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePerformanceCountersByRegionFeaturesARM *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePerformanceCountersByRegionFeaturesARM *>(current);
+                const VkPhysicalDevicePerformanceCountersByRegionFeaturesARM* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePerformanceCountersByRegionFeaturesARM*>(current);
                 if (enabling->performanceCountersByRegion && !supported.performanceCountersByRegion) {
                     ss << "VkPhysicalDevicePerformanceCountersByRegionFeaturesARM::performanceCountersByRegion is not supported\n";
                 }
@@ -2067,8 +2067,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePerformanceQueryFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePerformanceQueryFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePerformanceQueryFeaturesKHR *>(current);
+                const VkPhysicalDevicePerformanceQueryFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePerformanceQueryFeaturesKHR*>(current);
                 if (enabling->performanceCounterQueryPools && !supported.performanceCounterQueryPools) {
                     ss << "VkPhysicalDevicePerformanceQueryFeaturesKHR::performanceCounterQueryPools is not supported\n";
                 }
@@ -2081,8 +2081,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePipelineBinaryFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePipelineBinaryFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePipelineBinaryFeaturesKHR *>(current);
+                const VkPhysicalDevicePipelineBinaryFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePipelineBinaryFeaturesKHR*>(current);
                 if (enabling->pipelineBinaries && !supported.pipelineBinaries) {
                     ss << "VkPhysicalDevicePipelineBinaryFeaturesKHR::pipelineBinaries is not supported\n";
                 }
@@ -2092,8 +2092,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePipelineCacheIncrementalModeFeaturesSEC supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePipelineCacheIncrementalModeFeaturesSEC *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePipelineCacheIncrementalModeFeaturesSEC *>(current);
+                const VkPhysicalDevicePipelineCacheIncrementalModeFeaturesSEC* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePipelineCacheIncrementalModeFeaturesSEC*>(current);
                 if (enabling->pipelineCacheIncrementalMode && !supported.pipelineCacheIncrementalMode) {
                     ss << "VkPhysicalDevicePipelineCacheIncrementalModeFeaturesSEC::pipelineCacheIncrementalMode is not "
                           "supported\n";
@@ -2104,8 +2104,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePipelineCreationCacheControlFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePipelineCreationCacheControlFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePipelineCreationCacheControlFeatures *>(current);
+                const VkPhysicalDevicePipelineCreationCacheControlFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePipelineCreationCacheControlFeatures*>(current);
                 if (enabling->pipelineCreationCacheControl && !supported.pipelineCreationCacheControl) {
                     ss << "VkPhysicalDevicePipelineCreationCacheControlFeatures::pipelineCreationCacheControl is not supported\n";
                 }
@@ -2115,8 +2115,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR *>(current);
+                const VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR*>(current);
                 if (enabling->pipelineExecutableInfo && !supported.pipelineExecutableInfo) {
                     ss << "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR::pipelineExecutableInfo is not supported\n";
                 }
@@ -2126,8 +2126,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT *>(current);
+                const VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT*>(current);
                 if (enabling->pipelineLibraryGroupHandles && !supported.pipelineLibraryGroupHandles) {
                     ss << "VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT::pipelineLibraryGroupHandles is not supported\n";
                 }
@@ -2137,8 +2137,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePipelineOpacityMicromapFeaturesARM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePipelineOpacityMicromapFeaturesARM *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePipelineOpacityMicromapFeaturesARM *>(current);
+                const VkPhysicalDevicePipelineOpacityMicromapFeaturesARM* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePipelineOpacityMicromapFeaturesARM*>(current);
                 if (enabling->pipelineOpacityMicromap && !supported.pipelineOpacityMicromap) {
                     ss << "VkPhysicalDevicePipelineOpacityMicromapFeaturesARM::pipelineOpacityMicromap is not supported\n";
                 }
@@ -2148,8 +2148,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePipelinePropertiesFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePipelinePropertiesFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePipelinePropertiesFeaturesEXT *>(current);
+                const VkPhysicalDevicePipelinePropertiesFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePipelinePropertiesFeaturesEXT*>(current);
                 if (enabling->pipelinePropertiesIdentifier && !supported.pipelinePropertiesIdentifier) {
                     ss << "VkPhysicalDevicePipelinePropertiesFeaturesEXT::pipelinePropertiesIdentifier is not supported\n";
                 }
@@ -2159,8 +2159,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePipelineProtectedAccessFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePipelineProtectedAccessFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePipelineProtectedAccessFeatures *>(current);
+                const VkPhysicalDevicePipelineProtectedAccessFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePipelineProtectedAccessFeatures*>(current);
                 if (enabling->pipelineProtectedAccess && !supported.pipelineProtectedAccess) {
                     ss << "VkPhysicalDevicePipelineProtectedAccessFeatures::pipelineProtectedAccess is not supported\n";
                 }
@@ -2170,8 +2170,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePipelineRobustnessFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePipelineRobustnessFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePipelineRobustnessFeatures *>(current);
+                const VkPhysicalDevicePipelineRobustnessFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePipelineRobustnessFeatures*>(current);
                 if (enabling->pipelineRobustness && !supported.pipelineRobustness) {
                     ss << "VkPhysicalDevicePipelineRobustnessFeatures::pipelineRobustness is not supported\n";
                 }
@@ -2182,8 +2182,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePortabilitySubsetFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePortabilitySubsetFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(current);
+                const VkPhysicalDevicePortabilitySubsetFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(current);
                 if (enabling->constantAlphaColorBlendFactors && !supported.constantAlphaColorBlendFactors) {
                     ss << "VkPhysicalDevicePortabilitySubsetFeaturesKHR::constantAlphaColorBlendFactors is not supported\n";
                 }
@@ -2236,8 +2236,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePresentBarrierFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePresentBarrierFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePresentBarrierFeaturesNV *>(current);
+                const VkPhysicalDevicePresentBarrierFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePresentBarrierFeaturesNV*>(current);
                 if (enabling->presentBarrier && !supported.presentBarrier) {
                     ss << "VkPhysicalDevicePresentBarrierFeaturesNV::presentBarrier is not supported\n";
                 }
@@ -2247,8 +2247,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePresentId2FeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePresentId2FeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePresentId2FeaturesKHR *>(current);
+                const VkPhysicalDevicePresentId2FeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePresentId2FeaturesKHR*>(current);
                 if (enabling->presentId2 && !supported.presentId2) {
                     ss << "VkPhysicalDevicePresentId2FeaturesKHR::presentId2 is not supported\n";
                 }
@@ -2258,8 +2258,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePresentIdFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePresentIdFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePresentIdFeaturesKHR *>(current);
+                const VkPhysicalDevicePresentIdFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePresentIdFeaturesKHR*>(current);
                 if (enabling->presentId && !supported.presentId) {
                     ss << "VkPhysicalDevicePresentIdFeaturesKHR::presentId is not supported\n";
                 }
@@ -2270,8 +2270,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePresentMeteringFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePresentMeteringFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePresentMeteringFeaturesNV *>(current);
+                const VkPhysicalDevicePresentMeteringFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePresentMeteringFeaturesNV*>(current);
                 if (enabling->presentMetering && !supported.presentMetering) {
                     ss << "VkPhysicalDevicePresentMeteringFeaturesNV::presentMetering is not supported\n";
                 }
@@ -2282,8 +2282,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR *>(current);
+                const VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR*>(current);
                 if (enabling->presentModeFifoLatestReady && !supported.presentModeFifoLatestReady) {
                     ss << "VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR::presentModeFifoLatestReady is not supported\n";
                 }
@@ -2293,8 +2293,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePresentTimingFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePresentTimingFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePresentTimingFeaturesEXT *>(current);
+                const VkPhysicalDevicePresentTimingFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePresentTimingFeaturesEXT*>(current);
                 if (enabling->presentTiming && !supported.presentTiming) {
                     ss << "VkPhysicalDevicePresentTimingFeaturesEXT::presentTiming is not supported\n";
                 }
@@ -2310,8 +2310,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePresentWait2FeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePresentWait2FeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePresentWait2FeaturesKHR *>(current);
+                const VkPhysicalDevicePresentWait2FeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePresentWait2FeaturesKHR*>(current);
                 if (enabling->presentWait2 && !supported.presentWait2) {
                     ss << "VkPhysicalDevicePresentWait2FeaturesKHR::presentWait2 is not supported\n";
                 }
@@ -2321,8 +2321,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePresentWaitFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePresentWaitFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePresentWaitFeaturesKHR *>(current);
+                const VkPhysicalDevicePresentWaitFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePresentWaitFeaturesKHR*>(current);
                 if (enabling->presentWait && !supported.presentWait) {
                     ss << "VkPhysicalDevicePresentWaitFeaturesKHR::presentWait is not supported\n";
                 }
@@ -2332,8 +2332,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT *>(current);
+                const VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT*>(current);
                 if (enabling->primitiveTopologyListRestart && !supported.primitiveTopologyListRestart) {
                     ss << "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT::primitiveTopologyListRestart is not "
                           "supported\n";
@@ -2348,8 +2348,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT *>(current);
+                const VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT*>(current);
                 if (enabling->primitivesGeneratedQuery && !supported.primitivesGeneratedQuery) {
                     ss << "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT::primitivesGeneratedQuery is not supported\n";
                 }
@@ -2368,8 +2368,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDevicePrivateDataFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDevicePrivateDataFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDevicePrivateDataFeatures *>(current);
+                const VkPhysicalDevicePrivateDataFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDevicePrivateDataFeatures*>(current);
                 if (enabling->privateData && !supported.privateData) {
                     ss << "VkPhysicalDevicePrivateDataFeatures::privateData is not supported\n";
                 }
@@ -2379,8 +2379,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceProtectedMemoryFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceProtectedMemoryFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceProtectedMemoryFeatures *>(current);
+                const VkPhysicalDeviceProtectedMemoryFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceProtectedMemoryFeatures*>(current);
                 if (enabling->protectedMemory && !supported.protectedMemory) {
                     ss << "VkPhysicalDeviceProtectedMemoryFeatures::protectedMemory is not supported\n";
                 }
@@ -2390,8 +2390,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceProvokingVertexFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceProvokingVertexFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceProvokingVertexFeaturesEXT *>(current);
+                const VkPhysicalDeviceProvokingVertexFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceProvokingVertexFeaturesEXT*>(current);
                 if (enabling->provokingVertexLast && !supported.provokingVertexLast) {
                     ss << "VkPhysicalDeviceProvokingVertexFeaturesEXT::provokingVertexLast is not supported\n";
                 }
@@ -2405,8 +2405,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT *>(current);
+                const VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT*>(current);
                 if (enabling->formatRgba10x6WithoutYCbCrSampler && !supported.formatRgba10x6WithoutYCbCrSampler) {
                     ss << "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT::formatRgba10x6WithoutYCbCrSampler is not supported\n";
                 }
@@ -2416,8 +2416,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT *>(current);
+                const VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT*>(current);
                 if (enabling->rasterizationOrderColorAttachmentAccess && !supported.rasterizationOrderColorAttachmentAccess) {
                     ss << "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT::rasterizationOrderColorAttachmentAccess "
                           "is not supported\n";
@@ -2436,8 +2436,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceRawAccessChainsFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceRawAccessChainsFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceRawAccessChainsFeaturesNV *>(current);
+                const VkPhysicalDeviceRawAccessChainsFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceRawAccessChainsFeaturesNV*>(current);
                 if (enabling->shaderRawAccessChains && !supported.shaderRawAccessChains) {
                     ss << "VkPhysicalDeviceRawAccessChainsFeaturesNV::shaderRawAccessChains is not supported\n";
                 }
@@ -2447,8 +2447,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceRayQueryFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceRayQueryFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceRayQueryFeaturesKHR *>(current);
+                const VkPhysicalDeviceRayQueryFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceRayQueryFeaturesKHR*>(current);
                 if (enabling->rayQuery && !supported.rayQuery) {
                     ss << "VkPhysicalDeviceRayQueryFeaturesKHR::rayQuery is not supported\n";
                 }
@@ -2458,8 +2458,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceRayTracingInvocationReorderFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceRayTracingInvocationReorderFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderFeaturesEXT *>(current);
+                const VkPhysicalDeviceRayTracingInvocationReorderFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderFeaturesEXT*>(current);
                 if (enabling->rayTracingInvocationReorder && !supported.rayTracingInvocationReorder) {
                     ss << "VkPhysicalDeviceRayTracingInvocationReorderFeaturesEXT::rayTracingInvocationReorder is not supported\n";
                 }
@@ -2469,8 +2469,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV *>(current);
+                const VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV*>(current);
                 if (enabling->rayTracingInvocationReorder && !supported.rayTracingInvocationReorder) {
                     ss << "VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV::rayTracingInvocationReorder is not supported\n";
                 }
@@ -2480,8 +2480,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV *>(current);
+                const VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV*>(current);
                 if (enabling->spheres && !supported.spheres) {
                     ss << "VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV::spheres is not supported\n";
                 }
@@ -2494,8 +2494,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR *>(current);
+                const VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR*>(current);
                 if (enabling->rayTracingMaintenance1 && !supported.rayTracingMaintenance1) {
                     ss << "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR::rayTracingMaintenance1 is not supported\n";
                 }
@@ -2509,8 +2509,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceRayTracingMotionBlurFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceRayTracingMotionBlurFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceRayTracingMotionBlurFeaturesNV *>(current);
+                const VkPhysicalDeviceRayTracingMotionBlurFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceRayTracingMotionBlurFeaturesNV*>(current);
                 if (enabling->rayTracingMotionBlur && !supported.rayTracingMotionBlur) {
                     ss << "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV::rayTracingMotionBlur is not supported\n";
                 }
@@ -2525,8 +2525,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceRayTracingPipelineFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceRayTracingPipelineFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceRayTracingPipelineFeaturesKHR *>(current);
+                const VkPhysicalDeviceRayTracingPipelineFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceRayTracingPipelineFeaturesKHR*>(current);
                 if (enabling->rayTracingPipeline && !supported.rayTracingPipeline) {
                     ss << "VkPhysicalDeviceRayTracingPipelineFeaturesKHR::rayTracingPipeline is not supported\n";
                 }
@@ -2552,8 +2552,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR *>(current);
+                const VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR*>(current);
                 if (enabling->rayTracingPositionFetch && !supported.rayTracingPositionFetch) {
                     ss << "VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR::rayTracingPositionFetch is not supported\n";
                 }
@@ -2563,8 +2563,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceRayTracingValidationFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceRayTracingValidationFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceRayTracingValidationFeaturesNV *>(current);
+                const VkPhysicalDeviceRayTracingValidationFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceRayTracingValidationFeaturesNV*>(current);
                 if (enabling->rayTracingValidation && !supported.rayTracingValidation) {
                     ss << "VkPhysicalDeviceRayTracingValidationFeaturesNV::rayTracingValidation is not supported\n";
                 }
@@ -2574,8 +2574,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG *>(current);
+                const VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG*>(current);
                 if (enabling->relaxedLineRasterization && !supported.relaxedLineRasterization) {
                     ss << "VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG::relaxedLineRasterization is not supported\n";
                 }
@@ -2585,8 +2585,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceRenderPassStripedFeaturesARM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceRenderPassStripedFeaturesARM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceRenderPassStripedFeaturesARM *>(current);
+                const VkPhysicalDeviceRenderPassStripedFeaturesARM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceRenderPassStripedFeaturesARM*>(current);
                 if (enabling->renderPassStriped && !supported.renderPassStriped) {
                     ss << "VkPhysicalDeviceRenderPassStripedFeaturesARM::renderPassStriped is not supported\n";
                 }
@@ -2596,8 +2596,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV *>(current);
+                const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV*>(current);
                 if (enabling->representativeFragmentTest && !supported.representativeFragmentTest) {
                     ss << "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV::representativeFragmentTest is not supported\n";
                 }
@@ -2607,8 +2607,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceRobustness2FeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceRobustness2FeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceRobustness2FeaturesKHR *>(current);
+                const VkPhysicalDeviceRobustness2FeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceRobustness2FeaturesKHR*>(current);
                 if (enabling->robustBufferAccess2 && !supported.robustBufferAccess2) {
                     ss << "VkPhysicalDeviceRobustness2FeaturesKHR::robustBufferAccess2 is not supported\n";
                 }
@@ -2624,8 +2624,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceSamplerYcbcrConversionFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceSamplerYcbcrConversionFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceSamplerYcbcrConversionFeatures *>(current);
+                const VkPhysicalDeviceSamplerYcbcrConversionFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceSamplerYcbcrConversionFeatures*>(current);
                 if (enabling->samplerYcbcrConversion && !supported.samplerYcbcrConversion) {
                     ss << "VkPhysicalDeviceSamplerYcbcrConversionFeatures::samplerYcbcrConversion is not supported\n";
                 }
@@ -2635,8 +2635,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceScalarBlockLayoutFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceScalarBlockLayoutFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceScalarBlockLayoutFeatures *>(current);
+                const VkPhysicalDeviceScalarBlockLayoutFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceScalarBlockLayoutFeatures*>(current);
                 if (enabling->scalarBlockLayout && !supported.scalarBlockLayout) {
                     ss << "VkPhysicalDeviceScalarBlockLayoutFeatures::scalarBlockLayout is not supported\n";
                 }
@@ -2646,8 +2646,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceSchedulingControlsFeaturesARM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceSchedulingControlsFeaturesARM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceSchedulingControlsFeaturesARM *>(current);
+                const VkPhysicalDeviceSchedulingControlsFeaturesARM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceSchedulingControlsFeaturesARM*>(current);
                 if (enabling->schedulingControls && !supported.schedulingControls) {
                     ss << "VkPhysicalDeviceSchedulingControlsFeaturesARM::schedulingControls is not supported\n";
                 }
@@ -2657,8 +2657,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures *>(current);
+                const VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures*>(current);
                 if (enabling->separateDepthStencilLayouts && !supported.separateDepthStencilLayouts) {
                     ss << "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures::separateDepthStencilLayouts is not supported\n";
                 }
@@ -2668,8 +2668,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShader64BitIndexingFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShader64BitIndexingFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShader64BitIndexingFeaturesEXT *>(current);
+                const VkPhysicalDeviceShader64BitIndexingFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShader64BitIndexingFeaturesEXT*>(current);
                 if (enabling->shader64BitIndexing && !supported.shader64BitIndexing) {
                     ss << "VkPhysicalDeviceShader64BitIndexingFeaturesEXT::shader64BitIndexing is not supported\n";
                 }
@@ -2679,8 +2679,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV *>(current);
+                const VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV*>(current);
                 if (enabling->shaderFloat16VectorAtomics && !supported.shaderFloat16VectorAtomics) {
                     ss << "VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV::shaderFloat16VectorAtomics is not supported\n";
                 }
@@ -2690,8 +2690,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(current);
+                const VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(current);
                 if (enabling->shaderBufferFloat16Atomics && !supported.shaderBufferFloat16Atomics) {
                     ss << "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT::shaderBufferFloat16Atomics is not supported\n";
                 }
@@ -2734,8 +2734,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderAtomicFloatFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(current);
+                const VkPhysicalDeviceShaderAtomicFloatFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(current);
                 if (enabling->shaderBufferFloat32Atomics && !supported.shaderBufferFloat32Atomics) {
                     ss << "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT::shaderBufferFloat32Atomics is not supported\n";
                 }
@@ -2778,8 +2778,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderAtomicInt64Features supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderAtomicInt64Features *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderAtomicInt64Features *>(current);
+                const VkPhysicalDeviceShaderAtomicInt64Features* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderAtomicInt64Features*>(current);
                 if (enabling->shaderBufferInt64Atomics && !supported.shaderBufferInt64Atomics) {
                     ss << "VkPhysicalDeviceShaderAtomicInt64Features::shaderBufferInt64Atomics is not supported\n";
                 }
@@ -2792,8 +2792,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderBfloat16FeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderBfloat16FeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderBfloat16FeaturesKHR *>(current);
+                const VkPhysicalDeviceShaderBfloat16FeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderBfloat16FeaturesKHR*>(current);
                 if (enabling->shaderBFloat16Type && !supported.shaderBFloat16Type) {
                     ss << "VkPhysicalDeviceShaderBfloat16FeaturesKHR::shaderBFloat16Type is not supported\n";
                 }
@@ -2809,8 +2809,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderClockFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderClockFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderClockFeaturesKHR *>(current);
+                const VkPhysicalDeviceShaderClockFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderClockFeaturesKHR*>(current);
                 if (enabling->shaderSubgroupClock && !supported.shaderSubgroupClock) {
                     ss << "VkPhysicalDeviceShaderClockFeaturesKHR::shaderSubgroupClock is not supported\n";
                 }
@@ -2823,8 +2823,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM *>(current);
+                const VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM*>(current);
                 if (enabling->shaderCoreBuiltins && !supported.shaderCoreBuiltins) {
                     ss << "VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM::shaderCoreBuiltins is not supported\n";
                 }
@@ -2834,8 +2834,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures *>(current);
+                const VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures*>(current);
                 if (enabling->shaderDemoteToHelperInvocation && !supported.shaderDemoteToHelperInvocation) {
                     ss << "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures::shaderDemoteToHelperInvocation is not "
                           "supported\n";
@@ -2846,8 +2846,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderDrawParametersFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderDrawParametersFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderDrawParametersFeatures *>(current);
+                const VkPhysicalDeviceShaderDrawParametersFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderDrawParametersFeatures*>(current);
                 if (enabling->shaderDrawParameters && !supported.shaderDrawParameters) {
                     ss << "VkPhysicalDeviceShaderDrawParametersFeatures::shaderDrawParameters is not supported\n";
                 }
@@ -2857,8 +2857,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD *>(current);
+                const VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD*>(current);
                 if (enabling->shaderEarlyAndLateFragmentTests && !supported.shaderEarlyAndLateFragmentTests) {
                     ss << "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD::shaderEarlyAndLateFragmentTests is not "
                           "supported\n";
@@ -2870,8 +2870,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderEnqueueFeaturesAMDX supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderEnqueueFeaturesAMDX *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderEnqueueFeaturesAMDX *>(current);
+                const VkPhysicalDeviceShaderEnqueueFeaturesAMDX* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderEnqueueFeaturesAMDX*>(current);
                 if (enabling->shaderEnqueue && !supported.shaderEnqueue) {
                     ss << "VkPhysicalDeviceShaderEnqueueFeaturesAMDX::shaderEnqueue is not supported\n";
                 }
@@ -2885,8 +2885,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderExpectAssumeFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderExpectAssumeFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderExpectAssumeFeatures *>(current);
+                const VkPhysicalDeviceShaderExpectAssumeFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderExpectAssumeFeatures*>(current);
                 if (enabling->shaderExpectAssume && !supported.shaderExpectAssume) {
                     ss << "VkPhysicalDeviceShaderExpectAssumeFeatures::shaderExpectAssume is not supported\n";
                 }
@@ -2896,8 +2896,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderFloat16Int8Features supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderFloat16Int8Features *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderFloat16Int8Features *>(current);
+                const VkPhysicalDeviceShaderFloat16Int8Features* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderFloat16Int8Features*>(current);
                 if (enabling->shaderFloat16 && !supported.shaderFloat16) {
                     ss << "VkPhysicalDeviceShaderFloat16Int8Features::shaderFloat16 is not supported\n";
                 }
@@ -2910,8 +2910,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderFloat8FeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderFloat8FeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderFloat8FeaturesEXT *>(current);
+                const VkPhysicalDeviceShaderFloat8FeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderFloat8FeaturesEXT*>(current);
                 if (enabling->shaderFloat8 && !supported.shaderFloat8) {
                     ss << "VkPhysicalDeviceShaderFloat8FeaturesEXT::shaderFloat8 is not supported\n";
                 }
@@ -2924,8 +2924,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderFloatControls2Features supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderFloatControls2Features *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderFloatControls2Features *>(current);
+                const VkPhysicalDeviceShaderFloatControls2Features* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderFloatControls2Features*>(current);
                 if (enabling->shaderFloatControls2 && !supported.shaderFloatControls2) {
                     ss << "VkPhysicalDeviceShaderFloatControls2Features::shaderFloatControls2 is not supported\n";
                 }
@@ -2935,8 +2935,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderFmaFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderFmaFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderFmaFeaturesKHR *>(current);
+                const VkPhysicalDeviceShaderFmaFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderFmaFeaturesKHR*>(current);
                 if (enabling->shaderFmaFloat16 && !supported.shaderFmaFloat16) {
                     ss << "VkPhysicalDeviceShaderFmaFeaturesKHR::shaderFmaFloat16 is not supported\n";
                 }
@@ -2952,8 +2952,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT *>(current);
+                const VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT*>(current);
                 if (enabling->shaderImageInt64Atomics && !supported.shaderImageInt64Atomics) {
                     ss << "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT::shaderImageInt64Atomics is not supported\n";
                 }
@@ -2966,8 +2966,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderImageFootprintFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderImageFootprintFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderImageFootprintFeaturesNV *>(current);
+                const VkPhysicalDeviceShaderImageFootprintFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderImageFootprintFeaturesNV*>(current);
                 if (enabling->imageFootprint && !supported.imageFootprint) {
                     ss << "VkPhysicalDeviceShaderImageFootprintFeaturesNV::imageFootprint is not supported\n";
                 }
@@ -2977,8 +2977,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderIntegerDotProductFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderIntegerDotProductFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderIntegerDotProductFeatures *>(current);
+                const VkPhysicalDeviceShaderIntegerDotProductFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderIntegerDotProductFeatures*>(current);
                 if (enabling->shaderIntegerDotProduct && !supported.shaderIntegerDotProduct) {
                     ss << "VkPhysicalDeviceShaderIntegerDotProductFeatures::shaderIntegerDotProduct is not supported\n";
                 }
@@ -2988,8 +2988,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL *>(current);
+                const VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL*>(current);
                 if (enabling->shaderIntegerFunctions2 && !supported.shaderIntegerFunctions2) {
                     ss << "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL::shaderIntegerFunctions2 is not supported\n";
                 }
@@ -2999,8 +2999,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR *>(current);
+                const VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR*>(current);
                 if (enabling->shaderMaximalReconvergence && !supported.shaderMaximalReconvergence) {
                     ss << "VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR::shaderMaximalReconvergence is not supported\n";
                 }
@@ -3010,8 +3010,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT *>(current);
+                const VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT*>(current);
                 if (enabling->shaderModuleIdentifier && !supported.shaderModuleIdentifier) {
                     ss << "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT::shaderModuleIdentifier is not supported\n";
                 }
@@ -3021,8 +3021,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderObjectFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderObjectFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderObjectFeaturesEXT *>(current);
+                const VkPhysicalDeviceShaderObjectFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderObjectFeaturesEXT*>(current);
                 if (enabling->shaderObject && !supported.shaderObject) {
                     ss << "VkPhysicalDeviceShaderObjectFeaturesEXT::shaderObject is not supported\n";
                 }
@@ -3032,8 +3032,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderQuadControlFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderQuadControlFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderQuadControlFeaturesKHR *>(current);
+                const VkPhysicalDeviceShaderQuadControlFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderQuadControlFeaturesKHR*>(current);
                 if (enabling->shaderQuadControl && !supported.shaderQuadControl) {
                     ss << "VkPhysicalDeviceShaderQuadControlFeaturesKHR::shaderQuadControl is not supported\n";
                 }
@@ -3043,8 +3043,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR *>(current);
+                const VkPhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR*>(current);
                 if (enabling->shaderRelaxedExtendedInstruction && !supported.shaderRelaxedExtendedInstruction) {
                     ss << "VkPhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR::shaderRelaxedExtendedInstruction is not "
                           "supported\n";
@@ -3055,8 +3055,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderReplicatedCompositesFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderReplicatedCompositesFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderReplicatedCompositesFeaturesEXT *>(current);
+                const VkPhysicalDeviceShaderReplicatedCompositesFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderReplicatedCompositesFeaturesEXT*>(current);
                 if (enabling->shaderReplicatedComposites && !supported.shaderReplicatedComposites) {
                     ss << "VkPhysicalDeviceShaderReplicatedCompositesFeaturesEXT::shaderReplicatedComposites is not supported\n";
                 }
@@ -3066,8 +3066,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderSMBuiltinsFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderSMBuiltinsFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderSMBuiltinsFeaturesNV *>(current);
+                const VkPhysicalDeviceShaderSMBuiltinsFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderSMBuiltinsFeaturesNV*>(current);
                 if (enabling->shaderSMBuiltins && !supported.shaderSMBuiltins) {
                     ss << "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV::shaderSMBuiltins is not supported\n";
                 }
@@ -3077,8 +3077,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures *>(current);
+                const VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures*>(current);
                 if (enabling->shaderSubgroupExtendedTypes && !supported.shaderSubgroupExtendedTypes) {
                     ss << "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures::shaderSubgroupExtendedTypes is not supported\n";
                 }
@@ -3088,8 +3088,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderSubgroupRotateFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderSubgroupRotateFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderSubgroupRotateFeatures *>(current);
+                const VkPhysicalDeviceShaderSubgroupRotateFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderSubgroupRotateFeatures*>(current);
                 if (enabling->shaderSubgroupRotate && !supported.shaderSubgroupRotate) {
                     ss << "VkPhysicalDeviceShaderSubgroupRotateFeatures::shaderSubgroupRotate is not supported\n";
                 }
@@ -3102,8 +3102,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR *>(current);
+                const VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR*>(current);
                 if (enabling->shaderSubgroupUniformControlFlow && !supported.shaderSubgroupUniformControlFlow) {
                     ss << "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR::shaderSubgroupUniformControlFlow is not "
                           "supported\n";
@@ -3114,8 +3114,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderTerminateInvocationFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderTerminateInvocationFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderTerminateInvocationFeatures *>(current);
+                const VkPhysicalDeviceShaderTerminateInvocationFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderTerminateInvocationFeatures*>(current);
                 if (enabling->shaderTerminateInvocation && !supported.shaderTerminateInvocation) {
                     ss << "VkPhysicalDeviceShaderTerminateInvocationFeatures::shaderTerminateInvocation is not supported\n";
                 }
@@ -3125,8 +3125,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderTileImageFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderTileImageFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderTileImageFeaturesEXT *>(current);
+                const VkPhysicalDeviceShaderTileImageFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderTileImageFeaturesEXT*>(current);
                 if (enabling->shaderTileImageColorReadAccess && !supported.shaderTileImageColorReadAccess) {
                     ss << "VkPhysicalDeviceShaderTileImageFeaturesEXT::shaderTileImageColorReadAccess is not supported\n";
                 }
@@ -3142,8 +3142,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderUniformBufferUnsizedArrayFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderUniformBufferUnsizedArrayFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderUniformBufferUnsizedArrayFeaturesEXT *>(current);
+                const VkPhysicalDeviceShaderUniformBufferUnsizedArrayFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderUniformBufferUnsizedArrayFeaturesEXT*>(current);
                 if (enabling->shaderUniformBufferUnsizedArray && !supported.shaderUniformBufferUnsizedArray) {
                     ss << "VkPhysicalDeviceShaderUniformBufferUnsizedArrayFeaturesEXT::shaderUniformBufferUnsizedArray is not "
                           "supported\n";
@@ -3154,8 +3154,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShaderUntypedPointersFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShaderUntypedPointersFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShaderUntypedPointersFeaturesKHR *>(current);
+                const VkPhysicalDeviceShaderUntypedPointersFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShaderUntypedPointersFeaturesKHR*>(current);
                 if (enabling->shaderUntypedPointers && !supported.shaderUntypedPointers) {
                     ss << "VkPhysicalDeviceShaderUntypedPointersFeaturesKHR::shaderUntypedPointers is not supported\n";
                 }
@@ -3165,8 +3165,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceShadingRateImageFeaturesNV supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceShadingRateImageFeaturesNV *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceShadingRateImageFeaturesNV *>(current);
+                const VkPhysicalDeviceShadingRateImageFeaturesNV* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceShadingRateImageFeaturesNV*>(current);
                 if (enabling->shadingRateImage && !supported.shadingRateImage) {
                     ss << "VkPhysicalDeviceShadingRateImageFeaturesNV::shadingRateImage is not supported\n";
                 }
@@ -3179,8 +3179,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceSubgroupSizeControlFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceSubgroupSizeControlFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceSubgroupSizeControlFeatures *>(current);
+                const VkPhysicalDeviceSubgroupSizeControlFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceSubgroupSizeControlFeatures*>(current);
                 if (enabling->subgroupSizeControl && !supported.subgroupSizeControl) {
                     ss << "VkPhysicalDeviceSubgroupSizeControlFeatures::subgroupSizeControl is not supported\n";
                 }
@@ -3193,8 +3193,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT *>(current);
+                const VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT*>(current);
                 if (enabling->subpassMergeFeedback && !supported.subpassMergeFeedback) {
                     ss << "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT::subpassMergeFeedback is not supported\n";
                 }
@@ -3204,8 +3204,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceSubpassShadingFeaturesHUAWEI supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceSubpassShadingFeaturesHUAWEI *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceSubpassShadingFeaturesHUAWEI *>(current);
+                const VkPhysicalDeviceSubpassShadingFeaturesHUAWEI* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceSubpassShadingFeaturesHUAWEI*>(current);
                 if (enabling->subpassShading && !supported.subpassShading) {
                     ss << "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI::subpassShading is not supported\n";
                 }
@@ -3215,8 +3215,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR *>(current);
+                const VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR*>(current);
                 if (enabling->swapchainMaintenance1 && !supported.swapchainMaintenance1) {
                     ss << "VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR::swapchainMaintenance1 is not supported\n";
                 }
@@ -3226,8 +3226,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceSynchronization2Features supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceSynchronization2Features *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceSynchronization2Features *>(current);
+                const VkPhysicalDeviceSynchronization2Features* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceSynchronization2Features*>(current);
                 if (enabling->synchronization2 && !supported.synchronization2) {
                     ss << "VkPhysicalDeviceSynchronization2Features::synchronization2 is not supported\n";
                 }
@@ -3237,8 +3237,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceTensorFeaturesARM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceTensorFeaturesARM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceTensorFeaturesARM *>(current);
+                const VkPhysicalDeviceTensorFeaturesARM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceTensorFeaturesARM*>(current);
                 if (enabling->tensorNonPacked && !supported.tensorNonPacked) {
                     ss << "VkPhysicalDeviceTensorFeaturesARM::tensorNonPacked is not supported\n";
                 }
@@ -3264,8 +3264,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT *>(current);
+                const VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT*>(current);
                 if (enabling->texelBufferAlignment && !supported.texelBufferAlignment) {
                     ss << "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT::texelBufferAlignment is not supported\n";
                 }
@@ -3275,8 +3275,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceTextureCompressionASTCHDRFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceTextureCompressionASTCHDRFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceTextureCompressionASTCHDRFeatures *>(current);
+                const VkPhysicalDeviceTextureCompressionASTCHDRFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceTextureCompressionASTCHDRFeatures*>(current);
                 if (enabling->textureCompressionASTC_HDR && !supported.textureCompressionASTC_HDR) {
                     ss << "VkPhysicalDeviceTextureCompressionASTCHDRFeatures::textureCompressionASTC_HDR is not supported\n";
                 }
@@ -3286,8 +3286,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceTileMemoryHeapFeaturesQCOM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceTileMemoryHeapFeaturesQCOM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceTileMemoryHeapFeaturesQCOM *>(current);
+                const VkPhysicalDeviceTileMemoryHeapFeaturesQCOM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceTileMemoryHeapFeaturesQCOM*>(current);
                 if (enabling->tileMemoryHeap && !supported.tileMemoryHeap) {
                     ss << "VkPhysicalDeviceTileMemoryHeapFeaturesQCOM::tileMemoryHeap is not supported\n";
                 }
@@ -3297,8 +3297,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceTilePropertiesFeaturesQCOM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceTilePropertiesFeaturesQCOM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceTilePropertiesFeaturesQCOM *>(current);
+                const VkPhysicalDeviceTilePropertiesFeaturesQCOM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceTilePropertiesFeaturesQCOM*>(current);
                 if (enabling->tileProperties && !supported.tileProperties) {
                     ss << "VkPhysicalDeviceTilePropertiesFeaturesQCOM::tileProperties is not supported\n";
                 }
@@ -3308,8 +3308,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceTileShadingFeaturesQCOM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceTileShadingFeaturesQCOM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceTileShadingFeaturesQCOM *>(current);
+                const VkPhysicalDeviceTileShadingFeaturesQCOM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceTileShadingFeaturesQCOM*>(current);
                 if (enabling->tileShading && !supported.tileShading) {
                     ss << "VkPhysicalDeviceTileShadingFeaturesQCOM::tileShading is not supported\n";
                 }
@@ -3358,8 +3358,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceTimelineSemaphoreFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceTimelineSemaphoreFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceTimelineSemaphoreFeatures *>(current);
+                const VkPhysicalDeviceTimelineSemaphoreFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceTimelineSemaphoreFeatures*>(current);
                 if (enabling->timelineSemaphore && !supported.timelineSemaphore) {
                     ss << "VkPhysicalDeviceTimelineSemaphoreFeatures::timelineSemaphore is not supported\n";
                 }
@@ -3369,8 +3369,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceTransformFeedbackFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceTransformFeedbackFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceTransformFeedbackFeaturesEXT *>(current);
+                const VkPhysicalDeviceTransformFeedbackFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceTransformFeedbackFeaturesEXT*>(current);
                 if (enabling->transformFeedback && !supported.transformFeedback) {
                     ss << "VkPhysicalDeviceTransformFeedbackFeaturesEXT::transformFeedback is not supported\n";
                 }
@@ -3383,8 +3383,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR *>(current);
+                const VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR*>(current);
                 if (enabling->unifiedImageLayouts && !supported.unifiedImageLayouts) {
                     ss << "VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR::unifiedImageLayouts is not supported\n";
                 }
@@ -3397,8 +3397,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceUniformBufferStandardLayoutFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceUniformBufferStandardLayoutFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceUniformBufferStandardLayoutFeatures *>(current);
+                const VkPhysicalDeviceUniformBufferStandardLayoutFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceUniformBufferStandardLayoutFeatures*>(current);
                 if (enabling->uniformBufferStandardLayout && !supported.uniformBufferStandardLayout) {
                     ss << "VkPhysicalDeviceUniformBufferStandardLayoutFeatures::uniformBufferStandardLayout is not supported\n";
                 }
@@ -3408,8 +3408,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceVariablePointersFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceVariablePointersFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceVariablePointersFeatures *>(current);
+                const VkPhysicalDeviceVariablePointersFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceVariablePointersFeatures*>(current);
                 if (enabling->variablePointersStorageBuffer && !supported.variablePointersStorageBuffer) {
                     ss << "VkPhysicalDeviceVariablePointersFeatures::variablePointersStorageBuffer is not supported\n";
                 }
@@ -3422,8 +3422,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceVertexAttributeDivisorFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceVertexAttributeDivisorFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceVertexAttributeDivisorFeatures *>(current);
+                const VkPhysicalDeviceVertexAttributeDivisorFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceVertexAttributeDivisorFeatures*>(current);
                 if (enabling->vertexAttributeInstanceRateDivisor && !supported.vertexAttributeInstanceRateDivisor) {
                     ss << "VkPhysicalDeviceVertexAttributeDivisorFeatures::vertexAttributeInstanceRateDivisor is not supported\n";
                 }
@@ -3437,8 +3437,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT *>(current);
+                const VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT*>(current);
                 if (enabling->vertexAttributeRobustness && !supported.vertexAttributeRobustness) {
                     ss << "VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT::vertexAttributeRobustness is not supported\n";
                 }
@@ -3448,8 +3448,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT *>(current);
+                const VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT*>(current);
                 if (enabling->vertexInputDynamicState && !supported.vertexInputDynamicState) {
                     ss << "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT::vertexInputDynamicState is not supported\n";
                 }
@@ -3459,8 +3459,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceVideoDecodeVP9FeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceVideoDecodeVP9FeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceVideoDecodeVP9FeaturesKHR *>(current);
+                const VkPhysicalDeviceVideoDecodeVP9FeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceVideoDecodeVP9FeaturesKHR*>(current);
                 if (enabling->videoDecodeVP9 && !supported.videoDecodeVP9) {
                     ss << "VkPhysicalDeviceVideoDecodeVP9FeaturesKHR::videoDecodeVP9 is not supported\n";
                 }
@@ -3470,8 +3470,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceVideoEncodeAV1FeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceVideoEncodeAV1FeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceVideoEncodeAV1FeaturesKHR *>(current);
+                const VkPhysicalDeviceVideoEncodeAV1FeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceVideoEncodeAV1FeaturesKHR*>(current);
                 if (enabling->videoEncodeAV1 && !supported.videoEncodeAV1) {
                     ss << "VkPhysicalDeviceVideoEncodeAV1FeaturesKHR::videoEncodeAV1 is not supported\n";
                 }
@@ -3481,8 +3481,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR *>(current);
+                const VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR*>(current);
                 if (enabling->videoEncodeIntraRefresh && !supported.videoEncodeIntraRefresh) {
                     ss << "VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR::videoEncodeIntraRefresh is not supported\n";
                 }
@@ -3492,8 +3492,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceVideoEncodeQuantizationMapFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceVideoEncodeQuantizationMapFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceVideoEncodeQuantizationMapFeaturesKHR *>(current);
+                const VkPhysicalDeviceVideoEncodeQuantizationMapFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceVideoEncodeQuantizationMapFeaturesKHR*>(current);
                 if (enabling->videoEncodeQuantizationMap && !supported.videoEncodeQuantizationMap) {
                     ss << "VkPhysicalDeviceVideoEncodeQuantizationMapFeaturesKHR::videoEncodeQuantizationMap is not supported\n";
                 }
@@ -3503,8 +3503,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceVideoEncodeRgbConversionFeaturesVALVE supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceVideoEncodeRgbConversionFeaturesVALVE *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceVideoEncodeRgbConversionFeaturesVALVE *>(current);
+                const VkPhysicalDeviceVideoEncodeRgbConversionFeaturesVALVE* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceVideoEncodeRgbConversionFeaturesVALVE*>(current);
                 if (enabling->videoEncodeRgbConversion && !supported.videoEncodeRgbConversion) {
                     ss << "VkPhysicalDeviceVideoEncodeRgbConversionFeaturesVALVE::videoEncodeRgbConversion is not supported\n";
                 }
@@ -3514,8 +3514,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceVideoMaintenance1FeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceVideoMaintenance1FeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceVideoMaintenance1FeaturesKHR *>(current);
+                const VkPhysicalDeviceVideoMaintenance1FeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceVideoMaintenance1FeaturesKHR*>(current);
                 if (enabling->videoMaintenance1 && !supported.videoMaintenance1) {
                     ss << "VkPhysicalDeviceVideoMaintenance1FeaturesKHR::videoMaintenance1 is not supported\n";
                 }
@@ -3525,8 +3525,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceVideoMaintenance2FeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceVideoMaintenance2FeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceVideoMaintenance2FeaturesKHR *>(current);
+                const VkPhysicalDeviceVideoMaintenance2FeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceVideoMaintenance2FeaturesKHR*>(current);
                 if (enabling->videoMaintenance2 && !supported.videoMaintenance2) {
                     ss << "VkPhysicalDeviceVideoMaintenance2FeaturesKHR::videoMaintenance2 is not supported\n";
                 }
@@ -3536,8 +3536,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceVulkan11Features supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceVulkan11Features *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceVulkan11Features *>(current);
+                const VkPhysicalDeviceVulkan11Features* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceVulkan11Features*>(current);
                 if (enabling->storageBuffer16BitAccess && !supported.storageBuffer16BitAccess) {
                     ss << "VkPhysicalDeviceVulkan11Features::storageBuffer16BitAccess is not supported\n";
                 }
@@ -3580,8 +3580,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceVulkan12Features supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceVulkan12Features *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceVulkan12Features *>(current);
+                const VkPhysicalDeviceVulkan12Features* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceVulkan12Features*>(current);
                 if (enabling->samplerMirrorClampToEdge && !supported.samplerMirrorClampToEdge) {
                     ss << "VkPhysicalDeviceVulkan12Features::samplerMirrorClampToEdge is not supported\n";
                 }
@@ -3741,8 +3741,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceVulkan13Features supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceVulkan13Features *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceVulkan13Features *>(current);
+                const VkPhysicalDeviceVulkan13Features* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceVulkan13Features*>(current);
                 if (enabling->robustImageAccess && !supported.robustImageAccess) {
                     ss << "VkPhysicalDeviceVulkan13Features::robustImageAccess is not supported\n";
                 }
@@ -3795,8 +3795,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceVulkan14Features supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceVulkan14Features *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceVulkan14Features *>(current);
+                const VkPhysicalDeviceVulkan14Features* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceVulkan14Features*>(current);
                 if (enabling->globalPriorityQuery && !supported.globalPriorityQuery) {
                     ss << "VkPhysicalDeviceVulkan14Features::globalPriorityQuery is not supported\n";
                 }
@@ -3866,8 +3866,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceVulkanMemoryModelFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceVulkanMemoryModelFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceVulkanMemoryModelFeatures *>(current);
+                const VkPhysicalDeviceVulkanMemoryModelFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceVulkanMemoryModelFeatures*>(current);
                 if (enabling->vulkanMemoryModel && !supported.vulkanMemoryModel) {
                     ss << "VkPhysicalDeviceVulkanMemoryModelFeatures::vulkanMemoryModel is not supported\n";
                 }
@@ -3885,8 +3885,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR *>(current);
+                const VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR*>(current);
                 if (enabling->workgroupMemoryExplicitLayout && !supported.workgroupMemoryExplicitLayout) {
                     ss << "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR::workgroupMemoryExplicitLayout is not "
                           "supported\n";
@@ -3910,8 +3910,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT *>(current);
+                const VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT*>(current);
                 if (enabling->ycbcr2plane444Formats && !supported.ycbcr2plane444Formats) {
                     ss << "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT::ycbcr2plane444Formats is not supported\n";
                 }
@@ -3921,8 +3921,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceYcbcrDegammaFeaturesQCOM supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceYcbcrDegammaFeaturesQCOM *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceYcbcrDegammaFeaturesQCOM *>(current);
+                const VkPhysicalDeviceYcbcrDegammaFeaturesQCOM* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceYcbcrDegammaFeaturesQCOM*>(current);
                 if (enabling->ycbcrDegamma && !supported.ycbcrDegamma) {
                     ss << "VkPhysicalDeviceYcbcrDegammaFeaturesQCOM::ycbcrDegamma is not supported\n";
                 }
@@ -3932,8 +3932,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceYcbcrImageArraysFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceYcbcrImageArraysFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceYcbcrImageArraysFeaturesEXT *>(current);
+                const VkPhysicalDeviceYcbcrImageArraysFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceYcbcrImageArraysFeaturesEXT*>(current);
                 if (enabling->ycbcrImageArrays && !supported.ycbcrImageArrays) {
                     ss << "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT::ycbcrImageArrays is not supported\n";
                 }
@@ -3943,8 +3943,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT *>(current);
+                const VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT*>(current);
                 if (enabling->zeroInitializeDeviceMemory && !supported.zeroInitializeDeviceMemory) {
                     ss << "VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT::zeroInitializeDeviceMemory is not supported\n";
                 }
@@ -3954,8 +3954,8 @@ void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDevice
                 VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures supported = vku::InitStructHelper();
                 features_2.pNext = &supported;
                 DispatchGetPhysicalDeviceFeatures2(gpu, &features_2);
-                const VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures *enabling =
-                    reinterpret_cast<const VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures *>(current);
+                const VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures* enabling =
+                    reinterpret_cast<const VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures*>(current);
                 if (enabling->shaderZeroInitializeWorkgroupMemory && !supported.shaderZeroInitializeWorkgroupMemory) {
                     ss << "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures::shaderZeroInitializeWorkgroupMemory is not "
                           "supported\n";

--- a/layers/vulkan/generated/feature_requirements_helper.cpp
+++ b/layers/vulkan/generated/feature_requirements_helper.cpp
@@ -29,11 +29,11 @@
 #include <vulkan/utility/vk_struct_helper.hpp>
 
 namespace vkt {
-FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **inout_pnext_chain) {
+FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void** inout_pnext_chain) {
     switch (feature) {
         case Feature::storageBuffer16BitAccess:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan11Features;
@@ -46,7 +46,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->storageBuffer16BitAccess, "VkPhysicalDeviceVulkan11Features::storageBuffer16BitAccess"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDevice16BitStorageFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDevice16BitStorageFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDevice16BitStorageFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDevice16BitStorageFeatures;
@@ -61,7 +61,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::storageInputOutput16:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan11Features;
@@ -74,7 +74,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->storageInputOutput16, "VkPhysicalDeviceVulkan11Features::storageInputOutput16"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDevice16BitStorageFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDevice16BitStorageFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDevice16BitStorageFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDevice16BitStorageFeatures;
@@ -89,7 +89,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::storagePushConstant16:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan11Features;
@@ -102,7 +102,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->storagePushConstant16, "VkPhysicalDeviceVulkan11Features::storagePushConstant16"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDevice16BitStorageFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDevice16BitStorageFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDevice16BitStorageFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDevice16BitStorageFeatures;
@@ -117,7 +117,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::uniformAndStorageBuffer16BitAccess:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan11Features;
@@ -131,7 +131,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->uniformAndStorageBuffer16BitAccess,
                         "VkPhysicalDeviceVulkan11Features::uniformAndStorageBuffer16BitAccess"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDevice16BitStorageFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDevice16BitStorageFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDevice16BitStorageFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDevice16BitStorageFeatures;
@@ -146,7 +146,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                         "VkPhysicalDevice16BitStorageFeatures::uniformAndStorageBuffer16BitAccess"};
             }
         case Feature::formatA4B4G4R4: {
-            auto vk_struct = const_cast<VkPhysicalDevice4444FormatsFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDevice4444FormatsFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDevice4444FormatsFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevice4444FormatsFeaturesEXT;
@@ -161,7 +161,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::formatA4R4G4B4: {
-            auto vk_struct = const_cast<VkPhysicalDevice4444FormatsFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDevice4444FormatsFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDevice4444FormatsFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevice4444FormatsFeaturesEXT;
@@ -177,7 +177,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::storageBuffer8BitAccess:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -190,7 +190,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->storageBuffer8BitAccess, "VkPhysicalDeviceVulkan12Features::storageBuffer8BitAccess"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDevice8BitStorageFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDevice8BitStorageFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDevice8BitStorageFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDevice8BitStorageFeatures;
@@ -205,7 +205,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::storagePushConstant8:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -218,7 +218,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->storagePushConstant8, "VkPhysicalDeviceVulkan12Features::storagePushConstant8"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDevice8BitStorageFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDevice8BitStorageFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDevice8BitStorageFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDevice8BitStorageFeatures;
@@ -233,7 +233,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::uniformAndStorageBuffer8BitAccess:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -247,7 +247,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->uniformAndStorageBuffer8BitAccess,
                         "VkPhysicalDeviceVulkan12Features::uniformAndStorageBuffer8BitAccess"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDevice8BitStorageFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDevice8BitStorageFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDevice8BitStorageFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDevice8BitStorageFeatures;
@@ -262,7 +262,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                         "VkPhysicalDevice8BitStorageFeatures::uniformAndStorageBuffer8BitAccess"};
             }
         case Feature::decodeModeSharedExponent: {
-            auto vk_struct = const_cast<VkPhysicalDeviceASTCDecodeFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceASTCDecodeFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceASTCDecodeFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceASTCDecodeFeaturesEXT;
@@ -277,7 +277,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::accelerationStructure: {
-            auto vk_struct = const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceAccelerationStructureFeaturesKHR;
@@ -292,7 +292,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::accelerationStructureCaptureReplay: {
-            auto vk_struct = const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceAccelerationStructureFeaturesKHR;
@@ -308,7 +308,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::accelerationStructureHostCommands: {
-            auto vk_struct = const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceAccelerationStructureFeaturesKHR;
@@ -324,7 +324,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::accelerationStructureIndirectBuild: {
-            auto vk_struct = const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceAccelerationStructureFeaturesKHR;
@@ -340,7 +340,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::descriptorBindingAccelerationStructureUpdateAfterBind: {
-            auto vk_struct = const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceAccelerationStructureFeaturesKHR;
@@ -356,7 +356,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::reportAddressBinding: {
-            auto vk_struct = const_cast<VkPhysicalDeviceAddressBindingReportFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceAddressBindingReportFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceAddressBindingReportFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceAddressBindingReportFeaturesEXT;
@@ -371,7 +371,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::amigoProfiling: {
-            auto vk_struct = const_cast<VkPhysicalDeviceAmigoProfilingFeaturesSEC *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceAmigoProfilingFeaturesSEC*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceAmigoProfilingFeaturesSEC>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceAmigoProfilingFeaturesSEC;
@@ -386,7 +386,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::antiLag: {
-            auto vk_struct = const_cast<VkPhysicalDeviceAntiLagFeaturesAMD *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceAntiLagFeaturesAMD*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceAntiLagFeaturesAMD>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceAntiLagFeaturesAMD;
@@ -401,7 +401,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::attachmentFeedbackLoopDynamicState: {
-            auto vk_struct = const_cast<VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT;
@@ -417,7 +417,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::attachmentFeedbackLoopLayout: {
-            auto vk_struct = const_cast<VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT;
@@ -433,7 +433,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::advancedBlendCoherentOperations: {
-            auto vk_struct = const_cast<VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT;
@@ -449,7 +449,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::borderColorSwizzle: {
-            auto vk_struct = const_cast<VkPhysicalDeviceBorderColorSwizzleFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceBorderColorSwizzleFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceBorderColorSwizzleFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceBorderColorSwizzleFeaturesEXT;
@@ -464,7 +464,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::borderColorSwizzleFromImage: {
-            auto vk_struct = const_cast<VkPhysicalDeviceBorderColorSwizzleFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceBorderColorSwizzleFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceBorderColorSwizzleFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceBorderColorSwizzleFeaturesEXT;
@@ -481,7 +481,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::bufferDeviceAddress:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -494,7 +494,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->bufferDeviceAddress, "VkPhysicalDeviceVulkan12Features::bufferDeviceAddress"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceBufferDeviceAddressFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceBufferDeviceAddressFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceBufferDeviceAddressFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceBufferDeviceAddressFeatures;
@@ -509,7 +509,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::bufferDeviceAddressCaptureReplay:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -523,7 +523,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->bufferDeviceAddressCaptureReplay,
                         "VkPhysicalDeviceVulkan12Features::bufferDeviceAddressCaptureReplay"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceBufferDeviceAddressFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceBufferDeviceAddressFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceBufferDeviceAddressFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceBufferDeviceAddressFeatures;
@@ -539,7 +539,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::bufferDeviceAddressMultiDevice:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -553,7 +553,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->bufferDeviceAddressMultiDevice,
                         "VkPhysicalDeviceVulkan12Features::bufferDeviceAddressMultiDevice"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceBufferDeviceAddressFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceBufferDeviceAddressFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceBufferDeviceAddressFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceBufferDeviceAddressFeatures;
@@ -568,7 +568,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                         "VkPhysicalDeviceBufferDeviceAddressFeatures::bufferDeviceAddressMultiDevice"};
             }
         case Feature::clusterAccelerationStructure: {
-            auto vk_struct = const_cast<VkPhysicalDeviceClusterAccelerationStructureFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceClusterAccelerationStructureFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceClusterAccelerationStructureFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceClusterAccelerationStructureFeaturesNV;
@@ -584,7 +584,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::clustercullingShader: {
-            auto vk_struct = const_cast<VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI;
@@ -599,7 +599,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::multiviewClusterCullingShader: {
-            auto vk_struct = const_cast<VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI;
@@ -615,7 +615,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::deviceCoherentMemory: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCoherentMemoryFeaturesAMD *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCoherentMemoryFeaturesAMD*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCoherentMemoryFeaturesAMD>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCoherentMemoryFeaturesAMD;
@@ -630,7 +630,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::colorWriteEnable: {
-            auto vk_struct = const_cast<VkPhysicalDeviceColorWriteEnableFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceColorWriteEnableFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceColorWriteEnableFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceColorWriteEnableFeaturesEXT;
@@ -645,7 +645,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::commandBufferInheritance: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCommandBufferInheritanceFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCommandBufferInheritanceFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCommandBufferInheritanceFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCommandBufferInheritanceFeaturesNV;
@@ -661,7 +661,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::computeOccupancyPriority: {
-            auto vk_struct = const_cast<VkPhysicalDeviceComputeOccupancyPriorityFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceComputeOccupancyPriorityFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceComputeOccupancyPriorityFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceComputeOccupancyPriorityFeaturesNV;
@@ -677,7 +677,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::computeDerivativeGroupLinear: {
-            auto vk_struct = const_cast<VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR;
@@ -693,7 +693,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::computeDerivativeGroupQuads: {
-            auto vk_struct = const_cast<VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR;
@@ -709,7 +709,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::conditionalRendering: {
-            auto vk_struct = const_cast<VkPhysicalDeviceConditionalRenderingFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceConditionalRenderingFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceConditionalRenderingFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceConditionalRenderingFeaturesEXT;
@@ -724,7 +724,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::inheritedConditionalRendering: {
-            auto vk_struct = const_cast<VkPhysicalDeviceConditionalRenderingFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceConditionalRenderingFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceConditionalRenderingFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceConditionalRenderingFeaturesEXT;
@@ -740,7 +740,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::cooperativeMatrixBlockLoads: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrix2FeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrix2FeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCooperativeMatrix2FeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCooperativeMatrix2FeaturesNV;
@@ -756,7 +756,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::cooperativeMatrixConversions: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrix2FeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrix2FeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCooperativeMatrix2FeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCooperativeMatrix2FeaturesNV;
@@ -772,7 +772,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::cooperativeMatrixFlexibleDimensions: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrix2FeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrix2FeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCooperativeMatrix2FeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCooperativeMatrix2FeaturesNV;
@@ -788,7 +788,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::cooperativeMatrixPerElementOperations: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrix2FeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrix2FeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCooperativeMatrix2FeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCooperativeMatrix2FeaturesNV;
@@ -804,7 +804,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::cooperativeMatrixReductions: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrix2FeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrix2FeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCooperativeMatrix2FeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCooperativeMatrix2FeaturesNV;
@@ -820,7 +820,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::cooperativeMatrixTensorAddressing: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrix2FeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrix2FeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCooperativeMatrix2FeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCooperativeMatrix2FeaturesNV;
@@ -836,7 +836,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::cooperativeMatrixWorkgroupScope: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrix2FeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrix2FeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCooperativeMatrix2FeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCooperativeMatrix2FeaturesNV;
@@ -852,7 +852,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::cooperativeMatrix: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrixFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrixFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCooperativeMatrixFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCooperativeMatrixFeaturesKHR;
@@ -867,7 +867,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::cooperativeMatrixRobustBufferAccess: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrixFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrixFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCooperativeMatrixFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCooperativeMatrixFeaturesKHR;
@@ -883,7 +883,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::cooperativeVector: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeVectorFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeVectorFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCooperativeVectorFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCooperativeVectorFeaturesNV;
@@ -898,7 +898,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::cooperativeVectorTraining: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeVectorFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeVectorFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCooperativeVectorFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCooperativeVectorFeaturesNV;
@@ -914,7 +914,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::indirectMemoryCopy: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR;
@@ -929,7 +929,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::indirectMemoryToImageCopy: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR;
@@ -945,7 +945,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::indirectCopy: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCopyMemoryIndirectFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCopyMemoryIndirectFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCopyMemoryIndirectFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCopyMemoryIndirectFeaturesNV;
@@ -960,7 +960,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::cornerSampledImage: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCornerSampledImageFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCornerSampledImageFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCornerSampledImageFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCornerSampledImageFeaturesNV;
@@ -975,7 +975,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::coverageReductionMode: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCoverageReductionModeFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCoverageReductionModeFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCoverageReductionModeFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCoverageReductionModeFeaturesNV;
@@ -990,7 +990,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::cubicRangeClamp: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCubicClampFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCubicClampFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCubicClampFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCubicClampFeaturesQCOM;
@@ -1005,7 +1005,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::selectableCubicWeights: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCubicWeightsFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCubicWeightsFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCubicWeightsFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCubicWeightsFeaturesQCOM;
@@ -1021,7 +1021,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::cudaKernelLaunchFeatures: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCudaKernelLaunchFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCudaKernelLaunchFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCudaKernelLaunchFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCudaKernelLaunchFeaturesNV;
@@ -1037,7 +1037,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #endif  // VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::customBorderColorWithoutFormat: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCustomBorderColorFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCustomBorderColorFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCustomBorderColorFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCustomBorderColorFeaturesEXT;
@@ -1053,7 +1053,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::customBorderColors: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCustomBorderColorFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCustomBorderColorFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCustomBorderColorFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCustomBorderColorFeaturesEXT;
@@ -1068,7 +1068,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::customResolve: {
-            auto vk_struct = const_cast<VkPhysicalDeviceCustomResolveFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceCustomResolveFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceCustomResolveFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceCustomResolveFeaturesEXT;
@@ -1083,7 +1083,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::dataGraph: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDataGraphFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDataGraphFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDataGraphFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDataGraphFeaturesARM;
@@ -1098,7 +1098,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::dataGraphDescriptorBuffer: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDataGraphFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDataGraphFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDataGraphFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDataGraphFeaturesARM;
@@ -1113,7 +1113,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::dataGraphShaderModule: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDataGraphFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDataGraphFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDataGraphFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDataGraphFeaturesARM;
@@ -1128,7 +1128,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::dataGraphSpecializationConstants: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDataGraphFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDataGraphFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDataGraphFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDataGraphFeaturesARM;
@@ -1144,7 +1144,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::dataGraphUpdateAfterBind: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDataGraphFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDataGraphFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDataGraphFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDataGraphFeaturesARM;
@@ -1159,7 +1159,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::dataGraphModel: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDataGraphModelFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDataGraphModelFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDataGraphModelFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDataGraphModelFeaturesQCOM;
@@ -1174,7 +1174,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::dedicatedAllocationImageAliasing: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV;
@@ -1191,7 +1191,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::denseGeometryFormat: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDenseGeometryFormatFeaturesAMDX *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDenseGeometryFormatFeaturesAMDX*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDenseGeometryFormatFeaturesAMDX>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDenseGeometryFormatFeaturesAMDX;
@@ -1207,7 +1207,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #endif  // VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::depthBiasControl: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDepthBiasControlFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDepthBiasControlFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDepthBiasControlFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDepthBiasControlFeaturesEXT;
@@ -1222,7 +1222,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::depthBiasExact: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDepthBiasControlFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDepthBiasControlFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDepthBiasControlFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDepthBiasControlFeaturesEXT;
@@ -1237,7 +1237,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::floatRepresentation: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDepthBiasControlFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDepthBiasControlFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDepthBiasControlFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDepthBiasControlFeaturesEXT;
@@ -1252,7 +1252,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::leastRepresentableValueForceUnormRepresentation: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDepthBiasControlFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDepthBiasControlFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDepthBiasControlFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDepthBiasControlFeaturesEXT;
@@ -1268,7 +1268,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::depthClampControl: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDepthClampControlFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDepthClampControlFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDepthClampControlFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDepthClampControlFeaturesEXT;
@@ -1283,7 +1283,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::depthClampZeroOne: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDepthClampZeroOneFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDepthClampZeroOneFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDepthClampZeroOneFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDepthClampZeroOneFeaturesKHR;
@@ -1298,7 +1298,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::depthClipControl: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDepthClipControlFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDepthClipControlFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDepthClipControlFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDepthClipControlFeaturesEXT;
@@ -1313,7 +1313,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::depthClipEnable: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDepthClipEnableFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDepthClipEnableFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDepthClipEnableFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDepthClipEnableFeaturesEXT;
@@ -1328,7 +1328,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::descriptorBuffer: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorBufferFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorBufferFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorBufferFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDescriptorBufferFeaturesEXT;
@@ -1343,7 +1343,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::descriptorBufferCaptureReplay: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorBufferFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorBufferFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorBufferFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDescriptorBufferFeaturesEXT;
@@ -1359,7 +1359,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::descriptorBufferImageLayoutIgnored: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorBufferFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorBufferFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorBufferFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDescriptorBufferFeaturesEXT;
@@ -1375,7 +1375,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::descriptorBufferPushDescriptors: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorBufferFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorBufferFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorBufferFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDescriptorBufferFeaturesEXT;
@@ -1391,7 +1391,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::descriptorBufferTensorDescriptors: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorBufferTensorFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorBufferTensorFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorBufferTensorFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDescriptorBufferTensorFeaturesARM;
@@ -1408,7 +1408,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::descriptorBindingPartiallyBound:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1422,7 +1422,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->descriptorBindingPartiallyBound,
                         "VkPhysicalDeviceVulkan12Features::descriptorBindingPartiallyBound"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1438,7 +1438,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::descriptorBindingSampledImageUpdateAfterBind:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1452,7 +1452,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->descriptorBindingSampledImageUpdateAfterBind,
                         "VkPhysicalDeviceVulkan12Features::descriptorBindingSampledImageUpdateAfterBind"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1468,7 +1468,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::descriptorBindingStorageBufferUpdateAfterBind:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1482,7 +1482,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->descriptorBindingStorageBufferUpdateAfterBind,
                         "VkPhysicalDeviceVulkan12Features::descriptorBindingStorageBufferUpdateAfterBind"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1498,7 +1498,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::descriptorBindingStorageImageUpdateAfterBind:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1512,7 +1512,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->descriptorBindingStorageImageUpdateAfterBind,
                         "VkPhysicalDeviceVulkan12Features::descriptorBindingStorageImageUpdateAfterBind"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1528,7 +1528,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::descriptorBindingStorageTexelBufferUpdateAfterBind:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1542,7 +1542,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->descriptorBindingStorageTexelBufferUpdateAfterBind,
                         "VkPhysicalDeviceVulkan12Features::descriptorBindingStorageTexelBufferUpdateAfterBind"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1558,7 +1558,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::descriptorBindingUniformBufferUpdateAfterBind:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1572,7 +1572,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->descriptorBindingUniformBufferUpdateAfterBind,
                         "VkPhysicalDeviceVulkan12Features::descriptorBindingUniformBufferUpdateAfterBind"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1588,7 +1588,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::descriptorBindingUniformTexelBufferUpdateAfterBind:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1602,7 +1602,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->descriptorBindingUniformTexelBufferUpdateAfterBind,
                         "VkPhysicalDeviceVulkan12Features::descriptorBindingUniformTexelBufferUpdateAfterBind"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1618,7 +1618,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::descriptorBindingUpdateUnusedWhilePending:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1632,7 +1632,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->descriptorBindingUpdateUnusedWhilePending,
                         "VkPhysicalDeviceVulkan12Features::descriptorBindingUpdateUnusedWhilePending"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1648,7 +1648,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::descriptorBindingVariableDescriptorCount:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1662,7 +1662,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->descriptorBindingVariableDescriptorCount,
                         "VkPhysicalDeviceVulkan12Features::descriptorBindingVariableDescriptorCount"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1678,7 +1678,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::runtimeDescriptorArray:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1691,7 +1691,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->runtimeDescriptorArray, "VkPhysicalDeviceVulkan12Features::runtimeDescriptorArray"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1706,7 +1706,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::shaderInputAttachmentArrayDynamicIndexing:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1720,7 +1720,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->shaderInputAttachmentArrayDynamicIndexing,
                         "VkPhysicalDeviceVulkan12Features::shaderInputAttachmentArrayDynamicIndexing"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1736,7 +1736,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::shaderInputAttachmentArrayNonUniformIndexing:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1750,7 +1750,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->shaderInputAttachmentArrayNonUniformIndexing,
                         "VkPhysicalDeviceVulkan12Features::shaderInputAttachmentArrayNonUniformIndexing"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1766,7 +1766,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::shaderSampledImageArrayNonUniformIndexing:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1780,7 +1780,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->shaderSampledImageArrayNonUniformIndexing,
                         "VkPhysicalDeviceVulkan12Features::shaderSampledImageArrayNonUniformIndexing"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1796,7 +1796,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::shaderStorageBufferArrayNonUniformIndexing:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1810,7 +1810,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->shaderStorageBufferArrayNonUniformIndexing,
                         "VkPhysicalDeviceVulkan12Features::shaderStorageBufferArrayNonUniformIndexing"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1826,7 +1826,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::shaderStorageImageArrayNonUniformIndexing:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1840,7 +1840,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->shaderStorageImageArrayNonUniformIndexing,
                         "VkPhysicalDeviceVulkan12Features::shaderStorageImageArrayNonUniformIndexing"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1856,7 +1856,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::shaderStorageTexelBufferArrayDynamicIndexing:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1870,7 +1870,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->shaderStorageTexelBufferArrayDynamicIndexing,
                         "VkPhysicalDeviceVulkan12Features::shaderStorageTexelBufferArrayDynamicIndexing"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1886,7 +1886,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::shaderStorageTexelBufferArrayNonUniformIndexing:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1900,7 +1900,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->shaderStorageTexelBufferArrayNonUniformIndexing,
                         "VkPhysicalDeviceVulkan12Features::shaderStorageTexelBufferArrayNonUniformIndexing"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1916,7 +1916,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::shaderUniformBufferArrayNonUniformIndexing:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1930,7 +1930,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->shaderUniformBufferArrayNonUniformIndexing,
                         "VkPhysicalDeviceVulkan12Features::shaderUniformBufferArrayNonUniformIndexing"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1946,7 +1946,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::shaderUniformTexelBufferArrayDynamicIndexing:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1960,7 +1960,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->shaderUniformTexelBufferArrayDynamicIndexing,
                         "VkPhysicalDeviceVulkan12Features::shaderUniformTexelBufferArrayDynamicIndexing"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -1976,7 +1976,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::shaderUniformTexelBufferArrayNonUniformIndexing:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -1990,7 +1990,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->shaderUniformTexelBufferArrayNonUniformIndexing,
                         "VkPhysicalDeviceVulkan12Features::shaderUniformTexelBufferArrayNonUniformIndexing"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
@@ -2005,7 +2005,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                         "VkPhysicalDeviceDescriptorIndexingFeatures::shaderUniformTexelBufferArrayNonUniformIndexing"};
             }
         case Feature::descriptorPoolOverallocation: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV;
@@ -2021,7 +2021,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::descriptorSetHostMapping: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE;
@@ -2037,7 +2037,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::deviceGeneratedCompute: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV;
@@ -2053,7 +2053,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::deviceGeneratedComputeCaptureReplay: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV;
@@ -2069,7 +2069,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::deviceGeneratedComputePipelines: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV;
@@ -2085,7 +2085,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::deviceGeneratedCommands: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT;
@@ -2101,7 +2101,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::dynamicGeneratedPipelineLayout: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT;
@@ -2117,7 +2117,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::deviceMemoryReport: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDeviceMemoryReportFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDeviceMemoryReportFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDeviceMemoryReportFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDeviceMemoryReportFeaturesEXT;
@@ -2132,7 +2132,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::diagnosticsConfig: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDiagnosticsConfigFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDiagnosticsConfigFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDiagnosticsConfigFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDiagnosticsConfigFeaturesNV;
@@ -2148,7 +2148,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::displacementMicromap: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDisplacementMicromapFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDisplacementMicromapFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDisplacementMicromapFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDisplacementMicromapFeaturesNV;
@@ -2165,7 +2165,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::dynamicRendering:
             if (api_version >= VK_API_VERSION_1_3) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan13Features;
@@ -2178,7 +2178,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->dynamicRendering, "VkPhysicalDeviceVulkan13Features::dynamicRendering"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDynamicRenderingFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDynamicRenderingFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDynamicRenderingFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDynamicRenderingFeatures;
@@ -2193,7 +2193,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::dynamicRenderingLocalRead:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -2206,7 +2206,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->dynamicRenderingLocalRead, "VkPhysicalDeviceVulkan14Features::dynamicRenderingLocalRead"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceDynamicRenderingLocalReadFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceDynamicRenderingLocalReadFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceDynamicRenderingLocalReadFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceDynamicRenderingLocalReadFeatures;
@@ -2221,7 +2221,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                         "VkPhysicalDeviceDynamicRenderingLocalReadFeatures::dynamicRenderingLocalRead"};
             }
         case Feature::dynamicRenderingUnusedAttachments: {
-            auto vk_struct = const_cast<VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT;
@@ -2237,7 +2237,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::exclusiveScissor: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExclusiveScissorFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExclusiveScissorFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExclusiveScissorFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExclusiveScissorFeaturesNV;
@@ -2252,7 +2252,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState2: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState2FeaturesEXT;
@@ -2267,7 +2267,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState2LogicOp: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState2FeaturesEXT;
@@ -2283,7 +2283,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState2PatchControlPoints: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState2FeaturesEXT;
@@ -2299,7 +2299,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3AlphaToCoverageEnable: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2315,7 +2315,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3AlphaToOneEnable: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2331,7 +2331,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3ColorBlendAdvanced: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2347,7 +2347,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3ColorBlendEnable: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2363,7 +2363,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3ColorBlendEquation: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2379,7 +2379,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3ColorWriteMask: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2395,7 +2395,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3ConservativeRasterizationMode: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2411,7 +2411,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3CoverageModulationMode: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2427,7 +2427,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3CoverageModulationTable: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2443,7 +2443,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3CoverageModulationTableEnable: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2459,7 +2459,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3CoverageReductionMode: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2475,7 +2475,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3CoverageToColorEnable: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2491,7 +2491,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3CoverageToColorLocation: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2507,7 +2507,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3DepthClampEnable: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2523,7 +2523,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3DepthClipEnable: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2539,7 +2539,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3DepthClipNegativeOneToOne: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2555,7 +2555,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3ExtraPrimitiveOverestimationSize: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2571,7 +2571,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3LineRasterizationMode: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2587,7 +2587,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3LineStippleEnable: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2603,7 +2603,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3LogicOpEnable: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2619,7 +2619,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3PolygonMode: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2635,7 +2635,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3ProvokingVertexMode: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2651,7 +2651,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3RasterizationSamples: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2667,7 +2667,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3RasterizationStream: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2683,7 +2683,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3RepresentativeFragmentTestEnable: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2699,7 +2699,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3SampleLocationsEnable: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2715,7 +2715,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3SampleMask: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2731,7 +2731,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3ShadingRateImageEnable: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2747,7 +2747,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3TessellationDomainOrigin: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2763,7 +2763,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3ViewportSwizzle: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2779,7 +2779,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState3ViewportWScalingEnable: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
@@ -2795,7 +2795,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedDynamicState: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedDynamicStateFeaturesEXT;
@@ -2810,7 +2810,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::extendedSparseAddressSpace: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV;
@@ -2827,7 +2827,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
 
         case Feature::externalFormatResolve: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExternalFormatResolveFeaturesANDROID *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExternalFormatResolveFeaturesANDROID*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExternalFormatResolveFeaturesANDROID>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExternalFormatResolveFeaturesANDROID;
@@ -2844,7 +2844,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
 
         case Feature::externalMemoryRDMA: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExternalMemoryRDMAFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExternalMemoryRDMAFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExternalMemoryRDMAFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExternalMemoryRDMAFeaturesNV;
@@ -2860,7 +2860,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_USE_PLATFORM_SCREEN_QNX
 
         case Feature::screenBufferImport: {
-            auto vk_struct = const_cast<VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX;
@@ -2876,7 +2876,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #endif  // VK_USE_PLATFORM_SCREEN_QNX
 
         case Feature::deviceFault: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFaultFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFaultFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFaultFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFaultFeaturesEXT;
@@ -2891,7 +2891,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::deviceFaultVendorBinary: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFaultFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFaultFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFaultFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFaultFeaturesEXT;
@@ -2906,7 +2906,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::formatPack: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFormatPackFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFormatPackFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFormatPackFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFormatPackFeaturesARM;
@@ -2921,7 +2921,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::fragmentDensityMapDeferred: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFragmentDensityMap2FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentDensityMap2FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFragmentDensityMap2FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFragmentDensityMap2FeaturesEXT;
@@ -2937,7 +2937,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::fragmentDensityMap: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFragmentDensityMapFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentDensityMapFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFragmentDensityMapFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFragmentDensityMapFeaturesEXT;
@@ -2952,7 +2952,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::fragmentDensityMapDynamic: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFragmentDensityMapFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentDensityMapFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFragmentDensityMapFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFragmentDensityMapFeaturesEXT;
@@ -2968,7 +2968,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::fragmentDensityMapNonSubsampledImages: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFragmentDensityMapFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentDensityMapFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFragmentDensityMapFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFragmentDensityMapFeaturesEXT;
@@ -2984,7 +2984,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::fragmentDensityMapLayered: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE;
@@ -3000,7 +3000,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::fragmentDensityMapOffset: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFragmentDensityMapOffsetFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentDensityMapOffsetFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFragmentDensityMapOffsetFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFragmentDensityMapOffsetFeaturesEXT;
@@ -3016,7 +3016,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::fragmentShaderBarycentric: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR;
@@ -3032,7 +3032,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::fragmentShaderPixelInterlock: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT;
@@ -3048,7 +3048,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::fragmentShaderSampleInterlock: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT;
@@ -3064,7 +3064,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::fragmentShaderShadingRateInterlock: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT;
@@ -3080,7 +3080,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::fragmentShadingRateEnums: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV;
@@ -3096,7 +3096,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::noInvocationFragmentShadingRates: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV;
@@ -3112,7 +3112,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::supersampleFragmentShadingRates: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV;
@@ -3128,7 +3128,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::attachmentFragmentShadingRate: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShadingRateFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShadingRateFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFragmentShadingRateFeaturesKHR;
@@ -3144,7 +3144,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::pipelineFragmentShadingRate: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShadingRateFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShadingRateFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFragmentShadingRateFeaturesKHR;
@@ -3160,7 +3160,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::primitiveFragmentShadingRate: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShadingRateFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShadingRateFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFragmentShadingRateFeaturesKHR;
@@ -3176,7 +3176,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::frameBoundary: {
-            auto vk_struct = const_cast<VkPhysicalDeviceFrameBoundaryFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceFrameBoundaryFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceFrameBoundaryFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceFrameBoundaryFeaturesEXT;
@@ -3192,7 +3192,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::globalPriorityQuery:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -3205,7 +3205,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->globalPriorityQuery, "VkPhysicalDeviceVulkan14Features::globalPriorityQuery"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceGlobalPriorityQueryFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceGlobalPriorityQueryFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceGlobalPriorityQueryFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceGlobalPriorityQueryFeatures;
@@ -3219,7 +3219,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->globalPriorityQuery, "VkPhysicalDeviceGlobalPriorityQueryFeatures::globalPriorityQuery"};
             }
         case Feature::graphicsPipelineLibrary: {
-            auto vk_struct = const_cast<VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT;
@@ -3235,7 +3235,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::hdrVivid: {
-            auto vk_struct = const_cast<VkPhysicalDeviceHdrVividFeaturesHUAWEI *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceHdrVividFeaturesHUAWEI*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceHdrVividFeaturesHUAWEI>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceHdrVividFeaturesHUAWEI;
@@ -3251,7 +3251,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::hostImageCopy:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -3264,7 +3264,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->hostImageCopy, "VkPhysicalDeviceVulkan14Features::hostImageCopy"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceHostImageCopyFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceHostImageCopyFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceHostImageCopyFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceHostImageCopyFeatures;
@@ -3279,7 +3279,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::hostQueryReset:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -3292,7 +3292,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->hostQueryReset, "VkPhysicalDeviceVulkan12Features::hostQueryReset"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceHostQueryResetFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceHostQueryResetFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceHostQueryResetFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceHostQueryResetFeatures;
@@ -3306,7 +3306,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->hostQueryReset, "VkPhysicalDeviceHostQueryResetFeatures::hostQueryReset"};
             }
         case Feature::image2DViewOf3D: {
-            auto vk_struct = const_cast<VkPhysicalDeviceImage2DViewOf3DFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceImage2DViewOf3DFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceImage2DViewOf3DFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceImage2DViewOf3DFeaturesEXT;
@@ -3321,7 +3321,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::sampler2DViewOf3D: {
-            auto vk_struct = const_cast<VkPhysicalDeviceImage2DViewOf3DFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceImage2DViewOf3DFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceImage2DViewOf3DFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceImage2DViewOf3DFeaturesEXT;
@@ -3336,7 +3336,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::imageAlignmentControl: {
-            auto vk_struct = const_cast<VkPhysicalDeviceImageAlignmentControlFeaturesMESA *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceImageAlignmentControlFeaturesMESA*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceImageAlignmentControlFeaturesMESA>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceImageAlignmentControlFeaturesMESA;
@@ -3351,7 +3351,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::imageCompressionControl: {
-            auto vk_struct = const_cast<VkPhysicalDeviceImageCompressionControlFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceImageCompressionControlFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceImageCompressionControlFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceImageCompressionControlFeaturesEXT;
@@ -3367,7 +3367,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::imageCompressionControlSwapchain: {
-            auto vk_struct = const_cast<VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT;
@@ -3383,7 +3383,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::textureBlockMatch2: {
-            auto vk_struct = const_cast<VkPhysicalDeviceImageProcessing2FeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceImageProcessing2FeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceImageProcessing2FeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceImageProcessing2FeaturesQCOM;
@@ -3398,7 +3398,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::textureBlockMatch: {
-            auto vk_struct = const_cast<VkPhysicalDeviceImageProcessingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceImageProcessingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceImageProcessingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceImageProcessingFeaturesQCOM;
@@ -3413,7 +3413,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::textureBoxFilter: {
-            auto vk_struct = const_cast<VkPhysicalDeviceImageProcessingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceImageProcessingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceImageProcessingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceImageProcessingFeaturesQCOM;
@@ -3428,7 +3428,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::textureSampleWeighted: {
-            auto vk_struct = const_cast<VkPhysicalDeviceImageProcessingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceImageProcessingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceImageProcessingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceImageProcessingFeaturesQCOM;
@@ -3444,7 +3444,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::robustImageAccess:
             if (api_version >= VK_API_VERSION_1_3) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan13Features;
@@ -3457,7 +3457,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->robustImageAccess, "VkPhysicalDeviceVulkan13Features::robustImageAccess"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceImageRobustnessFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceImageRobustnessFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceImageRobustnessFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceImageRobustnessFeatures;
@@ -3471,7 +3471,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->robustImageAccess, "VkPhysicalDeviceImageRobustnessFeatures::robustImageAccess"};
             }
         case Feature::imageSlicedViewOf3D: {
-            auto vk_struct = const_cast<VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT;
@@ -3486,7 +3486,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::minLod: {
-            auto vk_struct = const_cast<VkPhysicalDeviceImageViewMinLodFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceImageViewMinLodFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceImageViewMinLodFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceImageViewMinLodFeaturesEXT;
@@ -3502,7 +3502,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::imagelessFramebuffer:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -3515,7 +3515,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->imagelessFramebuffer, "VkPhysicalDeviceVulkan12Features::imagelessFramebuffer"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceImagelessFramebufferFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceImagelessFramebufferFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceImagelessFramebufferFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceImagelessFramebufferFeatures;
@@ -3530,7 +3530,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::indexTypeUint8:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -3543,7 +3543,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->indexTypeUint8, "VkPhysicalDeviceVulkan14Features::indexTypeUint8"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceIndexTypeUint8Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceIndexTypeUint8Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceIndexTypeUint8Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceIndexTypeUint8Features;
@@ -3557,7 +3557,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->indexTypeUint8, "VkPhysicalDeviceIndexTypeUint8Features::indexTypeUint8"};
             }
         case Feature::inheritedViewportScissor2D: {
-            auto vk_struct = const_cast<VkPhysicalDeviceInheritedViewportScissorFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceInheritedViewportScissorFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceInheritedViewportScissorFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceInheritedViewportScissorFeaturesNV;
@@ -3574,7 +3574,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::descriptorBindingInlineUniformBlockUpdateAfterBind:
             if (api_version >= VK_API_VERSION_1_3) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan13Features;
@@ -3588,7 +3588,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->descriptorBindingInlineUniformBlockUpdateAfterBind,
                         "VkPhysicalDeviceVulkan13Features::descriptorBindingInlineUniformBlockUpdateAfterBind"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceInlineUniformBlockFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceInlineUniformBlockFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceInlineUniformBlockFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceInlineUniformBlockFeatures;
@@ -3604,7 +3604,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::inlineUniformBlock:
             if (api_version >= VK_API_VERSION_1_3) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan13Features;
@@ -3617,7 +3617,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->inlineUniformBlock, "VkPhysicalDeviceVulkan13Features::inlineUniformBlock"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceInlineUniformBlockFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceInlineUniformBlockFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceInlineUniformBlockFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceInlineUniformBlockFeatures;
@@ -3631,7 +3631,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->inlineUniformBlock, "VkPhysicalDeviceInlineUniformBlockFeatures::inlineUniformBlock"};
             }
         case Feature::invocationMask: {
-            auto vk_struct = const_cast<VkPhysicalDeviceInvocationMaskFeaturesHUAWEI *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceInvocationMaskFeaturesHUAWEI*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceInvocationMaskFeaturesHUAWEI>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceInvocationMaskFeaturesHUAWEI;
@@ -3646,7 +3646,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::legacyDithering: {
-            auto vk_struct = const_cast<VkPhysicalDeviceLegacyDitheringFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceLegacyDitheringFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceLegacyDitheringFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceLegacyDitheringFeaturesEXT;
@@ -3661,7 +3661,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::legacyVertexAttributes: {
-            auto vk_struct = const_cast<VkPhysicalDeviceLegacyVertexAttributesFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceLegacyVertexAttributesFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceLegacyVertexAttributesFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceLegacyVertexAttributesFeaturesEXT;
@@ -3678,7 +3678,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::bresenhamLines:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -3691,7 +3691,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->bresenhamLines, "VkPhysicalDeviceVulkan14Features::bresenhamLines"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceLineRasterizationFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceLineRasterizationFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceLineRasterizationFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceLineRasterizationFeatures;
@@ -3706,7 +3706,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::rectangularLines:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -3719,7 +3719,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->rectangularLines, "VkPhysicalDeviceVulkan14Features::rectangularLines"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceLineRasterizationFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceLineRasterizationFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceLineRasterizationFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceLineRasterizationFeatures;
@@ -3734,7 +3734,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::smoothLines:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -3747,7 +3747,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->smoothLines, "VkPhysicalDeviceVulkan14Features::smoothLines"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceLineRasterizationFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceLineRasterizationFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceLineRasterizationFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceLineRasterizationFeatures;
@@ -3762,7 +3762,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::stippledBresenhamLines:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -3775,7 +3775,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->stippledBresenhamLines, "VkPhysicalDeviceVulkan14Features::stippledBresenhamLines"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceLineRasterizationFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceLineRasterizationFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceLineRasterizationFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceLineRasterizationFeatures;
@@ -3790,7 +3790,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::stippledRectangularLines:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -3803,7 +3803,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->stippledRectangularLines, "VkPhysicalDeviceVulkan14Features::stippledRectangularLines"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceLineRasterizationFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceLineRasterizationFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceLineRasterizationFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceLineRasterizationFeatures;
@@ -3819,7 +3819,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::stippledSmoothLines:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -3832,7 +3832,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->stippledSmoothLines, "VkPhysicalDeviceVulkan14Features::stippledSmoothLines"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceLineRasterizationFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceLineRasterizationFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceLineRasterizationFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceLineRasterizationFeatures;
@@ -3846,7 +3846,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->stippledSmoothLines, "VkPhysicalDeviceLineRasterizationFeatures::stippledSmoothLines"};
             }
         case Feature::linearColorAttachment: {
-            auto vk_struct = const_cast<VkPhysicalDeviceLinearColorAttachmentFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceLinearColorAttachmentFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceLinearColorAttachmentFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceLinearColorAttachmentFeaturesNV;
@@ -3861,7 +3861,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::maintenance10: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMaintenance10FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMaintenance10FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMaintenance10FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMaintenance10FeaturesKHR;
@@ -3877,7 +3877,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::maintenance4:
             if (api_version >= VK_API_VERSION_1_3) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan13Features;
@@ -3890,7 +3890,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->maintenance4, "VkPhysicalDeviceVulkan13Features::maintenance4"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceMaintenance4Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceMaintenance4Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceMaintenance4Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceMaintenance4Features;
@@ -3905,7 +3905,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::maintenance5:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -3918,7 +3918,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->maintenance5, "VkPhysicalDeviceVulkan14Features::maintenance5"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceMaintenance5Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceMaintenance5Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceMaintenance5Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceMaintenance5Features;
@@ -3933,7 +3933,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::maintenance6:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -3946,7 +3946,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->maintenance6, "VkPhysicalDeviceVulkan14Features::maintenance6"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceMaintenance6Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceMaintenance6Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceMaintenance6Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceMaintenance6Features;
@@ -3960,7 +3960,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->maintenance6, "VkPhysicalDeviceMaintenance6Features::maintenance6"};
             }
         case Feature::maintenance7: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMaintenance7FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMaintenance7FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMaintenance7FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMaintenance7FeaturesKHR;
@@ -3975,7 +3975,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::maintenance8: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMaintenance8FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMaintenance8FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMaintenance8FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMaintenance8FeaturesKHR;
@@ -3990,7 +3990,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::maintenance9: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMaintenance9FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMaintenance9FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMaintenance9FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMaintenance9FeaturesKHR;
@@ -4005,7 +4005,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::memoryMapPlaced: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMapMemoryPlacedFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMapMemoryPlacedFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMapMemoryPlacedFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMapMemoryPlacedFeaturesEXT;
@@ -4020,7 +4020,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::memoryMapRangePlaced: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMapMemoryPlacedFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMapMemoryPlacedFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMapMemoryPlacedFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMapMemoryPlacedFeaturesEXT;
@@ -4035,7 +4035,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::memoryUnmapReserve: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMapMemoryPlacedFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMapMemoryPlacedFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMapMemoryPlacedFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMapMemoryPlacedFeaturesEXT;
@@ -4050,7 +4050,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::memoryDecompression: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMemoryDecompressionFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMemoryDecompressionFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMemoryDecompressionFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMemoryDecompressionFeaturesEXT;
@@ -4065,7 +4065,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::memoryPriority: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMemoryPriorityFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMemoryPriorityFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMemoryPriorityFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMemoryPriorityFeaturesEXT;
@@ -4080,7 +4080,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::meshShaderQueries: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMeshShaderFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMeshShaderFeaturesEXT;
@@ -4095,7 +4095,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::multiviewMeshShader: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMeshShaderFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMeshShaderFeaturesEXT;
@@ -4110,7 +4110,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::primitiveFragmentShadingRateMeshShader: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMeshShaderFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMeshShaderFeaturesEXT;
@@ -4126,7 +4126,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::meshShader: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMeshShaderFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMeshShaderFeaturesEXT;
@@ -4141,7 +4141,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::taskShader: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMeshShaderFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMeshShaderFeaturesEXT;
@@ -4156,7 +4156,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::multiDraw: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMultiDrawFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMultiDrawFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMultiDrawFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMultiDrawFeaturesEXT;
@@ -4171,7 +4171,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::multisampledRenderToSingleSampled: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT;
@@ -4188,7 +4188,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::multiview:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan11Features;
@@ -4201,7 +4201,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->multiview, "VkPhysicalDeviceVulkan11Features::multiview"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceMultiviewFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceMultiviewFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceMultiviewFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceMultiviewFeatures;
@@ -4216,7 +4216,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::multiviewGeometryShader:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan11Features;
@@ -4229,7 +4229,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->multiviewGeometryShader, "VkPhysicalDeviceVulkan11Features::multiviewGeometryShader"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceMultiviewFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceMultiviewFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceMultiviewFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceMultiviewFeatures;
@@ -4244,7 +4244,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::multiviewTessellationShader:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan11Features;
@@ -4257,7 +4257,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->multiviewTessellationShader, "VkPhysicalDeviceVulkan11Features::multiviewTessellationShader"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceMultiviewFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceMultiviewFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceMultiviewFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceMultiviewFeatures;
@@ -4271,7 +4271,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->multiviewTessellationShader, "VkPhysicalDeviceMultiviewFeatures::multiviewTessellationShader"};
             }
         case Feature::multiviewPerViewRenderAreas: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM;
@@ -4287,7 +4287,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::multiviewPerViewViewports: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM;
@@ -4303,7 +4303,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::mutableDescriptorType: {
-            auto vk_struct = const_cast<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT;
@@ -4318,7 +4318,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::nestedCommandBuffer: {
-            auto vk_struct = const_cast<VkPhysicalDeviceNestedCommandBufferFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceNestedCommandBufferFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceNestedCommandBufferFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceNestedCommandBufferFeaturesEXT;
@@ -4333,7 +4333,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::nestedCommandBufferRendering: {
-            auto vk_struct = const_cast<VkPhysicalDeviceNestedCommandBufferFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceNestedCommandBufferFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceNestedCommandBufferFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceNestedCommandBufferFeaturesEXT;
@@ -4349,7 +4349,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::nestedCommandBufferSimultaneousUse: {
-            auto vk_struct = const_cast<VkPhysicalDeviceNestedCommandBufferFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceNestedCommandBufferFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceNestedCommandBufferFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceNestedCommandBufferFeaturesEXT;
@@ -4365,7 +4365,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::nonSeamlessCubeMap: {
-            auto vk_struct = const_cast<VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT;
@@ -4380,7 +4380,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::micromap: {
-            auto vk_struct = const_cast<VkPhysicalDeviceOpacityMicromapFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceOpacityMicromapFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceOpacityMicromapFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceOpacityMicromapFeaturesEXT;
@@ -4395,7 +4395,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::micromapCaptureReplay: {
-            auto vk_struct = const_cast<VkPhysicalDeviceOpacityMicromapFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceOpacityMicromapFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceOpacityMicromapFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceOpacityMicromapFeaturesEXT;
@@ -4410,7 +4410,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::micromapHostCommands: {
-            auto vk_struct = const_cast<VkPhysicalDeviceOpacityMicromapFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceOpacityMicromapFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceOpacityMicromapFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceOpacityMicromapFeaturesEXT;
@@ -4425,7 +4425,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::opticalFlow: {
-            auto vk_struct = const_cast<VkPhysicalDeviceOpticalFlowFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceOpticalFlowFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceOpticalFlowFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceOpticalFlowFeaturesNV;
@@ -4440,7 +4440,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::pageableDeviceLocalMemory: {
-            auto vk_struct = const_cast<VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT;
@@ -4456,7 +4456,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::partitionedAccelerationStructure: {
-            auto vk_struct = const_cast<VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV;
@@ -4472,7 +4472,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::dynamicPipelineLayout: {
-            auto vk_struct = const_cast<VkPhysicalDevicePerStageDescriptorSetFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePerStageDescriptorSetFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePerStageDescriptorSetFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePerStageDescriptorSetFeaturesNV;
@@ -4487,7 +4487,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::perStageDescriptorSet: {
-            auto vk_struct = const_cast<VkPhysicalDevicePerStageDescriptorSetFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePerStageDescriptorSetFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePerStageDescriptorSetFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePerStageDescriptorSetFeaturesNV;
@@ -4502,7 +4502,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::performanceCountersByRegion: {
-            auto vk_struct = const_cast<VkPhysicalDevicePerformanceCountersByRegionFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePerformanceCountersByRegionFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePerformanceCountersByRegionFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePerformanceCountersByRegionFeaturesARM;
@@ -4518,7 +4518,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::performanceCounterMultipleQueryPools: {
-            auto vk_struct = const_cast<VkPhysicalDevicePerformanceQueryFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePerformanceQueryFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePerformanceQueryFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePerformanceQueryFeaturesKHR;
@@ -4534,7 +4534,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::performanceCounterQueryPools: {
-            auto vk_struct = const_cast<VkPhysicalDevicePerformanceQueryFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePerformanceQueryFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePerformanceQueryFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePerformanceQueryFeaturesKHR;
@@ -4550,7 +4550,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::pipelineBinaries: {
-            auto vk_struct = const_cast<VkPhysicalDevicePipelineBinaryFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePipelineBinaryFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePipelineBinaryFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePipelineBinaryFeaturesKHR;
@@ -4565,7 +4565,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::pipelineCacheIncrementalMode: {
-            auto vk_struct = const_cast<VkPhysicalDevicePipelineCacheIncrementalModeFeaturesSEC *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePipelineCacheIncrementalModeFeaturesSEC*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePipelineCacheIncrementalModeFeaturesSEC>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePipelineCacheIncrementalModeFeaturesSEC;
@@ -4582,7 +4582,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::pipelineCreationCacheControl:
             if (api_version >= VK_API_VERSION_1_3) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan13Features;
@@ -4595,7 +4595,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->pipelineCreationCacheControl, "VkPhysicalDeviceVulkan13Features::pipelineCreationCacheControl"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDevicePipelineCreationCacheControlFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDevicePipelineCreationCacheControlFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDevicePipelineCreationCacheControlFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDevicePipelineCreationCacheControlFeatures;
@@ -4610,7 +4610,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                         "VkPhysicalDevicePipelineCreationCacheControlFeatures::pipelineCreationCacheControl"};
             }
         case Feature::pipelineExecutableInfo: {
-            auto vk_struct = const_cast<VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR;
@@ -4626,7 +4626,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::pipelineLibraryGroupHandles: {
-            auto vk_struct = const_cast<VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT;
@@ -4642,7 +4642,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::pipelineOpacityMicromap: {
-            auto vk_struct = const_cast<VkPhysicalDevicePipelineOpacityMicromapFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePipelineOpacityMicromapFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePipelineOpacityMicromapFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePipelineOpacityMicromapFeaturesARM;
@@ -4658,7 +4658,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::pipelinePropertiesIdentifier: {
-            auto vk_struct = const_cast<VkPhysicalDevicePipelinePropertiesFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePipelinePropertiesFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePipelinePropertiesFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePipelinePropertiesFeaturesEXT;
@@ -4675,7 +4675,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::pipelineProtectedAccess:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -4688,7 +4688,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->pipelineProtectedAccess, "VkPhysicalDeviceVulkan14Features::pipelineProtectedAccess"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDevicePipelineProtectedAccessFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDevicePipelineProtectedAccessFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDevicePipelineProtectedAccessFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDevicePipelineProtectedAccessFeatures;
@@ -4704,7 +4704,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::pipelineRobustness:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -4717,7 +4717,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->pipelineRobustness, "VkPhysicalDeviceVulkan14Features::pipelineRobustness"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDevicePipelineRobustnessFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDevicePipelineRobustnessFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDevicePipelineRobustnessFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDevicePipelineRobustnessFeatures;
@@ -4732,26 +4732,26 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
-                case Feature::constantAlphaColorBlendFactors : {
-                auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
-                    vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
-                if (!vk_struct) {
-                    vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
-                    *vk_struct = vku::InitStructHelper();
-                    if (*inout_pnext_chain) {
-                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
-                    } else {
-                        *inout_pnext_chain = vk_struct;
-                    }
+            case Feature::constantAlphaColorBlendFactors: {
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
                 }
-                return {&vk_struct->constantAlphaColorBlendFactors,
-                        "VkPhysicalDevicePortabilitySubsetFeaturesKHR::constantAlphaColorBlendFactors"};
             }
+            return {&vk_struct->constantAlphaColorBlendFactors,
+                    "VkPhysicalDevicePortabilitySubsetFeaturesKHR::constantAlphaColorBlendFactors"};
+        }
 #endif  // VK_ENABLE_BETA_EXTENSIONS
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::events: {
-            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
@@ -4768,7 +4768,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::imageView2DOn3DImage: {
-            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
@@ -4785,7 +4785,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::imageViewFormatReinterpretation: {
-            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
@@ -4803,7 +4803,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::imageViewFormatSwizzle: {
-            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
@@ -4820,7 +4820,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::multisampleArrayImage: {
-            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
@@ -4837,7 +4837,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::mutableComparisonSamplers: {
-            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
@@ -4855,7 +4855,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::pointPolygons: {
-            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
@@ -4872,7 +4872,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::samplerMipLodBias: {
-            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
@@ -4889,7 +4889,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::separateStencilMaskRef: {
-            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
@@ -4906,7 +4906,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::shaderSampleRateInterpolationFunctions: {
-            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
@@ -4924,7 +4924,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::tessellationIsolines: {
-            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
@@ -4941,7 +4941,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::tessellationPointMode: {
-            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
@@ -4958,7 +4958,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::triangleFans: {
-            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
@@ -4975,7 +4975,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::vertexAttributeAccessBeyondStride: {
-            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
@@ -4992,7 +4992,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #endif  // VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::presentBarrier: {
-            auto vk_struct = const_cast<VkPhysicalDevicePresentBarrierFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePresentBarrierFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePresentBarrierFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePresentBarrierFeaturesNV;
@@ -5007,7 +5007,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::presentId2: {
-            auto vk_struct = const_cast<VkPhysicalDevicePresentId2FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePresentId2FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePresentId2FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePresentId2FeaturesKHR;
@@ -5022,7 +5022,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::presentId: {
-            auto vk_struct = const_cast<VkPhysicalDevicePresentIdFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePresentIdFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePresentIdFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePresentIdFeaturesKHR;
@@ -5038,7 +5038,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::presentMetering: {
-            auto vk_struct = const_cast<VkPhysicalDevicePresentMeteringFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePresentMeteringFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePresentMeteringFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePresentMeteringFeaturesNV;
@@ -5054,7 +5054,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #endif  // VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::presentModeFifoLatestReady: {
-            auto vk_struct = const_cast<VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR;
@@ -5070,7 +5070,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::presentAtAbsoluteTime: {
-            auto vk_struct = const_cast<VkPhysicalDevicePresentTimingFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePresentTimingFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePresentTimingFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePresentTimingFeaturesEXT;
@@ -5085,7 +5085,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::presentAtRelativeTime: {
-            auto vk_struct = const_cast<VkPhysicalDevicePresentTimingFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePresentTimingFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePresentTimingFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePresentTimingFeaturesEXT;
@@ -5100,7 +5100,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::presentTiming: {
-            auto vk_struct = const_cast<VkPhysicalDevicePresentTimingFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePresentTimingFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePresentTimingFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePresentTimingFeaturesEXT;
@@ -5115,7 +5115,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::presentWait2: {
-            auto vk_struct = const_cast<VkPhysicalDevicePresentWait2FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePresentWait2FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePresentWait2FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePresentWait2FeaturesKHR;
@@ -5130,7 +5130,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::presentWait: {
-            auto vk_struct = const_cast<VkPhysicalDevicePresentWaitFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePresentWaitFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePresentWaitFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePresentWaitFeaturesKHR;
@@ -5145,7 +5145,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::primitiveTopologyListRestart: {
-            auto vk_struct = const_cast<VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT;
@@ -5161,7 +5161,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::primitiveTopologyPatchListRestart: {
-            auto vk_struct = const_cast<VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT;
@@ -5177,7 +5177,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::primitivesGeneratedQuery: {
-            auto vk_struct = const_cast<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT;
@@ -5193,7 +5193,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::primitivesGeneratedQueryWithNonZeroStreams: {
-            auto vk_struct = const_cast<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT;
@@ -5209,7 +5209,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::primitivesGeneratedQueryWithRasterizerDiscard: {
-            auto vk_struct = const_cast<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT;
@@ -5226,7 +5226,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::privateData:
             if (api_version >= VK_API_VERSION_1_3) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan13Features;
@@ -5239,7 +5239,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->privateData, "VkPhysicalDeviceVulkan13Features::privateData"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDevicePrivateDataFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDevicePrivateDataFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDevicePrivateDataFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDevicePrivateDataFeatures;
@@ -5254,7 +5254,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::protectedMemory:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan11Features;
@@ -5267,7 +5267,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->protectedMemory, "VkPhysicalDeviceVulkan11Features::protectedMemory"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceProtectedMemoryFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceProtectedMemoryFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceProtectedMemoryFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceProtectedMemoryFeatures;
@@ -5281,7 +5281,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->protectedMemory, "VkPhysicalDeviceProtectedMemoryFeatures::protectedMemory"};
             }
         case Feature::provokingVertexLast: {
-            auto vk_struct = const_cast<VkPhysicalDeviceProvokingVertexFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceProvokingVertexFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceProvokingVertexFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceProvokingVertexFeaturesEXT;
@@ -5296,7 +5296,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::transformFeedbackPreservesProvokingVertex: {
-            auto vk_struct = const_cast<VkPhysicalDeviceProvokingVertexFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceProvokingVertexFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceProvokingVertexFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceProvokingVertexFeaturesEXT;
@@ -5312,7 +5312,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::formatRgba10x6WithoutYCbCrSampler: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT;
@@ -5328,7 +5328,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::rasterizationOrderColorAttachmentAccess: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT;
@@ -5344,7 +5344,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::rasterizationOrderDepthAttachmentAccess: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT;
@@ -5360,7 +5360,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::rasterizationOrderStencilAttachmentAccess: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT;
@@ -5376,7 +5376,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderRawAccessChains: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRawAccessChainsFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRawAccessChainsFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRawAccessChainsFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRawAccessChainsFeaturesNV;
@@ -5391,7 +5391,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::rayQuery: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRayQueryFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRayQueryFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRayQueryFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRayQueryFeaturesKHR;
@@ -5406,7 +5406,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::rayTracingInvocationReorder: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingInvocationReorderFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingInvocationReorderFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingInvocationReorderFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRayTracingInvocationReorderFeaturesEXT;
@@ -5422,7 +5422,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::linearSweptSpheres: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV;
@@ -5437,7 +5437,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::spheres: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV;
@@ -5452,7 +5452,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::rayTracingMaintenance1: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR;
@@ -5468,7 +5468,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::rayTracingPipelineTraceRaysIndirect2: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR;
@@ -5484,7 +5484,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::rayTracingMotionBlur: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingMotionBlurFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingMotionBlurFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingMotionBlurFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRayTracingMotionBlurFeaturesNV;
@@ -5499,7 +5499,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::rayTracingMotionBlurPipelineTraceRaysIndirect: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingMotionBlurFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingMotionBlurFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingMotionBlurFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRayTracingMotionBlurFeaturesNV;
@@ -5515,7 +5515,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::rayTracingPipeline: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRayTracingPipelineFeaturesKHR;
@@ -5530,7 +5530,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::rayTracingPipelineShaderGroupHandleCaptureReplay: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRayTracingPipelineFeaturesKHR;
@@ -5546,7 +5546,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::rayTracingPipelineShaderGroupHandleCaptureReplayMixed: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRayTracingPipelineFeaturesKHR;
@@ -5562,7 +5562,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::rayTracingPipelineTraceRaysIndirect: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRayTracingPipelineFeaturesKHR;
@@ -5578,7 +5578,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::rayTraversalPrimitiveCulling: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRayTracingPipelineFeaturesKHR;
@@ -5594,7 +5594,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::rayTracingPositionFetch: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR;
@@ -5610,7 +5610,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::rayTracingValidation: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingValidationFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingValidationFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingValidationFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRayTracingValidationFeaturesNV;
@@ -5625,7 +5625,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::relaxedLineRasterization: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG;
@@ -5641,7 +5641,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::renderPassStriped: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRenderPassStripedFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRenderPassStripedFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRenderPassStripedFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRenderPassStripedFeaturesARM;
@@ -5656,7 +5656,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::representativeFragmentTest: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV;
@@ -5672,7 +5672,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::nullDescriptor: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRobustness2FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRobustness2FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRobustness2FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRobustness2FeaturesKHR;
@@ -5687,7 +5687,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::robustBufferAccess2: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRobustness2FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRobustness2FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRobustness2FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRobustness2FeaturesKHR;
@@ -5702,7 +5702,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::robustImageAccess2: {
-            auto vk_struct = const_cast<VkPhysicalDeviceRobustness2FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceRobustness2FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceRobustness2FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceRobustness2FeaturesKHR;
@@ -5718,7 +5718,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::samplerYcbcrConversion:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan11Features;
@@ -5731,7 +5731,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->samplerYcbcrConversion, "VkPhysicalDeviceVulkan11Features::samplerYcbcrConversion"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceSamplerYcbcrConversionFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceSamplerYcbcrConversionFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceSamplerYcbcrConversionFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceSamplerYcbcrConversionFeatures;
@@ -5747,7 +5747,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::scalarBlockLayout:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -5760,7 +5760,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->scalarBlockLayout, "VkPhysicalDeviceVulkan12Features::scalarBlockLayout"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceScalarBlockLayoutFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceScalarBlockLayoutFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceScalarBlockLayoutFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceScalarBlockLayoutFeatures;
@@ -5774,7 +5774,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->scalarBlockLayout, "VkPhysicalDeviceScalarBlockLayoutFeatures::scalarBlockLayout"};
             }
         case Feature::schedulingControls: {
-            auto vk_struct = const_cast<VkPhysicalDeviceSchedulingControlsFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceSchedulingControlsFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceSchedulingControlsFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceSchedulingControlsFeaturesARM;
@@ -5790,7 +5790,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::separateDepthStencilLayouts:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -5803,7 +5803,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->separateDepthStencilLayouts, "VkPhysicalDeviceVulkan12Features::separateDepthStencilLayouts"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures;
@@ -5818,7 +5818,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                         "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures::separateDepthStencilLayouts"};
             }
         case Feature::shader64BitIndexing: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShader64BitIndexingFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShader64BitIndexingFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShader64BitIndexingFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShader64BitIndexingFeaturesEXT;
@@ -5833,7 +5833,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderFloat16VectorAtomics: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV;
@@ -5849,7 +5849,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderBufferFloat16AtomicAdd: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
@@ -5865,7 +5865,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderBufferFloat16AtomicMinMax: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
@@ -5881,7 +5881,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderBufferFloat16Atomics: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
@@ -5897,7 +5897,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderBufferFloat32AtomicMinMax: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
@@ -5913,7 +5913,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderBufferFloat64AtomicMinMax: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
@@ -5929,7 +5929,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderImageFloat32AtomicMinMax: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
@@ -5945,7 +5945,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderSharedFloat16AtomicAdd: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
@@ -5961,7 +5961,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderSharedFloat16AtomicMinMax: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
@@ -5977,7 +5977,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderSharedFloat16Atomics: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
@@ -5993,7 +5993,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderSharedFloat32AtomicMinMax: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
@@ -6009,7 +6009,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderSharedFloat64AtomicMinMax: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
@@ -6025,7 +6025,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::sparseImageFloat32AtomicMinMax: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
@@ -6041,7 +6041,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderBufferFloat32AtomicAdd: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
@@ -6057,7 +6057,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderBufferFloat32Atomics: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
@@ -6073,7 +6073,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderBufferFloat64AtomicAdd: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
@@ -6089,7 +6089,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderBufferFloat64Atomics: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
@@ -6105,7 +6105,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderImageFloat32AtomicAdd: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
@@ -6121,7 +6121,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderImageFloat32Atomics: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
@@ -6137,7 +6137,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderSharedFloat32AtomicAdd: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
@@ -6153,7 +6153,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderSharedFloat32Atomics: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
@@ -6169,7 +6169,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderSharedFloat64AtomicAdd: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
@@ -6185,7 +6185,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderSharedFloat64Atomics: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
@@ -6201,7 +6201,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::sparseImageFloat32AtomicAdd: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
@@ -6217,7 +6217,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::sparseImageFloat32Atomics: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
@@ -6234,7 +6234,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::shaderBufferInt64Atomics:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -6247,7 +6247,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->shaderBufferInt64Atomics, "VkPhysicalDeviceVulkan12Features::shaderBufferInt64Atomics"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicInt64Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicInt64Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicInt64Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceShaderAtomicInt64Features;
@@ -6263,7 +6263,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::shaderSharedInt64Atomics:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -6276,7 +6276,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->shaderSharedInt64Atomics, "VkPhysicalDeviceVulkan12Features::shaderSharedInt64Atomics"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicInt64Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicInt64Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicInt64Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceShaderAtomicInt64Features;
@@ -6291,7 +6291,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                         "VkPhysicalDeviceShaderAtomicInt64Features::shaderSharedInt64Atomics"};
             }
         case Feature::shaderBFloat16CooperativeMatrix: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderBfloat16FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderBfloat16FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderBfloat16FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderBfloat16FeaturesKHR;
@@ -6307,7 +6307,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderBFloat16DotProduct: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderBfloat16FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderBfloat16FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderBfloat16FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderBfloat16FeaturesKHR;
@@ -6322,7 +6322,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderBFloat16Type: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderBfloat16FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderBfloat16FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderBfloat16FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderBfloat16FeaturesKHR;
@@ -6337,7 +6337,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderDeviceClock: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderClockFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderClockFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderClockFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderClockFeaturesKHR;
@@ -6352,7 +6352,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderSubgroupClock: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderClockFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderClockFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderClockFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderClockFeaturesKHR;
@@ -6367,7 +6367,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderCoreBuiltins: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM;
@@ -6383,7 +6383,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::shaderDemoteToHelperInvocation:
             if (api_version >= VK_API_VERSION_1_3) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan13Features;
@@ -6397,7 +6397,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->shaderDemoteToHelperInvocation,
                         "VkPhysicalDeviceVulkan13Features::shaderDemoteToHelperInvocation"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures;
@@ -6413,7 +6413,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::shaderDrawParameters:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan11Features;
@@ -6426,7 +6426,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->shaderDrawParameters, "VkPhysicalDeviceVulkan11Features::shaderDrawParameters"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceShaderDrawParametersFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderDrawParametersFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceShaderDrawParametersFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceShaderDrawParametersFeatures;
@@ -6440,7 +6440,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->shaderDrawParameters, "VkPhysicalDeviceShaderDrawParametersFeatures::shaderDrawParameters"};
             }
         case Feature::shaderEarlyAndLateFragmentTests: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD;
@@ -6457,7 +6457,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::shaderEnqueue: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderEnqueueFeaturesAMDX *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderEnqueueFeaturesAMDX*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderEnqueueFeaturesAMDX>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderEnqueueFeaturesAMDX;
@@ -6474,7 +6474,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
         case Feature::shaderMeshEnqueue: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderEnqueueFeaturesAMDX *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderEnqueueFeaturesAMDX*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderEnqueueFeaturesAMDX>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderEnqueueFeaturesAMDX;
@@ -6491,7 +6491,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::shaderExpectAssume:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -6504,7 +6504,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->shaderExpectAssume, "VkPhysicalDeviceVulkan14Features::shaderExpectAssume"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceShaderExpectAssumeFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderExpectAssumeFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceShaderExpectAssumeFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceShaderExpectAssumeFeatures;
@@ -6519,7 +6519,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::shaderFloat16:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -6532,7 +6532,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->shaderFloat16, "VkPhysicalDeviceVulkan12Features::shaderFloat16"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceShaderFloat16Int8Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderFloat16Int8Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceShaderFloat16Int8Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceShaderFloat16Int8Features;
@@ -6547,7 +6547,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::shaderInt8:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -6560,7 +6560,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->shaderInt8, "VkPhysicalDeviceVulkan12Features::shaderInt8"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceShaderFloat16Int8Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderFloat16Int8Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceShaderFloat16Int8Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceShaderFloat16Int8Features;
@@ -6574,7 +6574,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->shaderInt8, "VkPhysicalDeviceShaderFloat16Int8Features::shaderInt8"};
             }
         case Feature::shaderFloat8: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderFloat8FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderFloat8FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderFloat8FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderFloat8FeaturesEXT;
@@ -6589,7 +6589,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderFloat8CooperativeMatrix: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderFloat8FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderFloat8FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderFloat8FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderFloat8FeaturesEXT;
@@ -6606,7 +6606,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::shaderFloatControls2:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -6619,7 +6619,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->shaderFloatControls2, "VkPhysicalDeviceVulkan14Features::shaderFloatControls2"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceShaderFloatControls2Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderFloatControls2Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceShaderFloatControls2Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceShaderFloatControls2Features;
@@ -6633,7 +6633,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->shaderFloatControls2, "VkPhysicalDeviceShaderFloatControls2Features::shaderFloatControls2"};
             }
         case Feature::shaderFmaFloat16: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderFmaFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderFmaFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderFmaFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderFmaFeaturesKHR;
@@ -6648,7 +6648,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderFmaFloat32: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderFmaFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderFmaFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderFmaFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderFmaFeaturesKHR;
@@ -6663,7 +6663,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderFmaFloat64: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderFmaFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderFmaFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderFmaFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderFmaFeaturesKHR;
@@ -6678,7 +6678,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderImageInt64Atomics: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT;
@@ -6694,7 +6694,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::sparseImageInt64Atomics: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT;
@@ -6710,7 +6710,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::imageFootprint: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderImageFootprintFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderImageFootprintFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderImageFootprintFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderImageFootprintFeaturesNV;
@@ -6726,7 +6726,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::shaderIntegerDotProduct:
             if (api_version >= VK_API_VERSION_1_3) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan13Features;
@@ -6739,7 +6739,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->shaderIntegerDotProduct, "VkPhysicalDeviceVulkan13Features::shaderIntegerDotProduct"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceShaderIntegerDotProductFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderIntegerDotProductFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceShaderIntegerDotProductFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceShaderIntegerDotProductFeatures;
@@ -6754,7 +6754,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                         "VkPhysicalDeviceShaderIntegerDotProductFeatures::shaderIntegerDotProduct"};
             }
         case Feature::shaderIntegerFunctions2: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL;
@@ -6770,7 +6770,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderMaximalReconvergence: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR;
@@ -6786,7 +6786,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderModuleIdentifier: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT;
@@ -6802,7 +6802,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderObject: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderObjectFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderObjectFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderObjectFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderObjectFeaturesEXT;
@@ -6817,7 +6817,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderQuadControl: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderQuadControlFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderQuadControlFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderQuadControlFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderQuadControlFeaturesKHR;
@@ -6832,7 +6832,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderRelaxedExtendedInstruction: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR;
@@ -6848,7 +6848,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderReplicatedComposites: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderReplicatedCompositesFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderReplicatedCompositesFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderReplicatedCompositesFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderReplicatedCompositesFeaturesEXT;
@@ -6864,7 +6864,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderSMBuiltins: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderSMBuiltinsFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderSMBuiltinsFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderSMBuiltinsFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderSMBuiltinsFeaturesNV;
@@ -6880,7 +6880,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::shaderSubgroupExtendedTypes:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -6893,7 +6893,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->shaderSubgroupExtendedTypes, "VkPhysicalDeviceVulkan12Features::shaderSubgroupExtendedTypes"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures;
@@ -6909,7 +6909,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::shaderSubgroupRotate:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -6922,7 +6922,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->shaderSubgroupRotate, "VkPhysicalDeviceVulkan14Features::shaderSubgroupRotate"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceShaderSubgroupRotateFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderSubgroupRotateFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceShaderSubgroupRotateFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceShaderSubgroupRotateFeatures;
@@ -6937,7 +6937,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::shaderSubgroupRotateClustered:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -6951,7 +6951,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->shaderSubgroupRotateClustered,
                         "VkPhysicalDeviceVulkan14Features::shaderSubgroupRotateClustered"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceShaderSubgroupRotateFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderSubgroupRotateFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceShaderSubgroupRotateFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceShaderSubgroupRotateFeatures;
@@ -6966,7 +6966,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                         "VkPhysicalDeviceShaderSubgroupRotateFeatures::shaderSubgroupRotateClustered"};
             }
         case Feature::shaderSubgroupUniformControlFlow: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR;
@@ -6983,7 +6983,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::shaderTerminateInvocation:
             if (api_version >= VK_API_VERSION_1_3) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan13Features;
@@ -6996,7 +6996,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->shaderTerminateInvocation, "VkPhysicalDeviceVulkan13Features::shaderTerminateInvocation"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceShaderTerminateInvocationFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderTerminateInvocationFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceShaderTerminateInvocationFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceShaderTerminateInvocationFeatures;
@@ -7011,7 +7011,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                         "VkPhysicalDeviceShaderTerminateInvocationFeatures::shaderTerminateInvocation"};
             }
         case Feature::shaderTileImageColorReadAccess: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderTileImageFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderTileImageFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderTileImageFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderTileImageFeaturesEXT;
@@ -7027,7 +7027,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderTileImageDepthReadAccess: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderTileImageFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderTileImageFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderTileImageFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderTileImageFeaturesEXT;
@@ -7043,7 +7043,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderTileImageStencilReadAccess: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderTileImageFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderTileImageFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderTileImageFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderTileImageFeaturesEXT;
@@ -7059,7 +7059,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderUniformBufferUnsizedArray: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderUniformBufferUnsizedArrayFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderUniformBufferUnsizedArrayFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderUniformBufferUnsizedArrayFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderUniformBufferUnsizedArrayFeaturesEXT;
@@ -7075,7 +7075,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderUntypedPointers: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShaderUntypedPointersFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderUntypedPointersFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShaderUntypedPointersFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShaderUntypedPointersFeaturesKHR;
@@ -7090,7 +7090,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shadingRateCoarseSampleOrder: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShadingRateImageFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShadingRateImageFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShadingRateImageFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShadingRateImageFeaturesNV;
@@ -7106,7 +7106,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shadingRateImage: {
-            auto vk_struct = const_cast<VkPhysicalDeviceShadingRateImageFeaturesNV *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceShadingRateImageFeaturesNV*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceShadingRateImageFeaturesNV>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceShadingRateImageFeaturesNV;
@@ -7122,7 +7122,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::computeFullSubgroups:
             if (api_version >= VK_API_VERSION_1_3) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan13Features;
@@ -7135,7 +7135,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->computeFullSubgroups, "VkPhysicalDeviceVulkan13Features::computeFullSubgroups"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceSubgroupSizeControlFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceSubgroupSizeControlFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceSubgroupSizeControlFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceSubgroupSizeControlFeatures;
@@ -7150,7 +7150,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::subgroupSizeControl:
             if (api_version >= VK_API_VERSION_1_3) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan13Features;
@@ -7163,7 +7163,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->subgroupSizeControl, "VkPhysicalDeviceVulkan13Features::subgroupSizeControl"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceSubgroupSizeControlFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceSubgroupSizeControlFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceSubgroupSizeControlFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceSubgroupSizeControlFeatures;
@@ -7177,7 +7177,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->subgroupSizeControl, "VkPhysicalDeviceSubgroupSizeControlFeatures::subgroupSizeControl"};
             }
         case Feature::subpassMergeFeedback: {
-            auto vk_struct = const_cast<VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT;
@@ -7192,7 +7192,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::subpassShading: {
-            auto vk_struct = const_cast<VkPhysicalDeviceSubpassShadingFeaturesHUAWEI *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceSubpassShadingFeaturesHUAWEI*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceSubpassShadingFeaturesHUAWEI>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceSubpassShadingFeaturesHUAWEI;
@@ -7207,7 +7207,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::swapchainMaintenance1: {
-            auto vk_struct = const_cast<VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR;
@@ -7223,7 +7223,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::synchronization2:
             if (api_version >= VK_API_VERSION_1_3) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan13Features;
@@ -7236,7 +7236,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->synchronization2, "VkPhysicalDeviceVulkan13Features::synchronization2"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceSynchronization2Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceSynchronization2Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceSynchronization2Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceSynchronization2Features;
@@ -7250,7 +7250,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->synchronization2, "VkPhysicalDeviceSynchronization2Features::synchronization2"};
             }
         case Feature::descriptorBindingStorageTensorUpdateAfterBind: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTensorFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTensorFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTensorFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTensorFeaturesARM;
@@ -7266,7 +7266,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderStorageTensorArrayDynamicIndexing: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTensorFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTensorFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTensorFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTensorFeaturesARM;
@@ -7282,7 +7282,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderStorageTensorArrayNonUniformIndexing: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTensorFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTensorFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTensorFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTensorFeaturesARM;
@@ -7298,7 +7298,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderTensorAccess: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTensorFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTensorFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTensorFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTensorFeaturesARM;
@@ -7313,7 +7313,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tensorNonPacked: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTensorFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTensorFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTensorFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTensorFeaturesARM;
@@ -7328,7 +7328,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tensors: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTensorFeaturesARM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTensorFeaturesARM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTensorFeaturesARM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTensorFeaturesARM;
@@ -7343,7 +7343,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::texelBufferAlignment: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT;
@@ -7359,7 +7359,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::textureCompressionASTC_HDR:
             if (api_version >= VK_API_VERSION_1_3) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan13Features;
@@ -7372,7 +7372,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->textureCompressionASTC_HDR, "VkPhysicalDeviceVulkan13Features::textureCompressionASTC_HDR"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceTextureCompressionASTCHDRFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceTextureCompressionASTCHDRFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceTextureCompressionASTCHDRFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceTextureCompressionASTCHDRFeatures;
@@ -7387,7 +7387,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                         "VkPhysicalDeviceTextureCompressionASTCHDRFeatures::textureCompressionASTC_HDR"};
             }
         case Feature::tileMemoryHeap: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTileMemoryHeapFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTileMemoryHeapFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTileMemoryHeapFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTileMemoryHeapFeaturesQCOM;
@@ -7402,7 +7402,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tileProperties: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTilePropertiesFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTilePropertiesFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTilePropertiesFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTilePropertiesFeaturesQCOM;
@@ -7417,7 +7417,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tileShading: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTileShadingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTileShadingFeaturesQCOM;
@@ -7432,7 +7432,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tileShadingAnisotropicApron: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTileShadingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTileShadingFeaturesQCOM;
@@ -7448,7 +7448,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tileShadingApron: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTileShadingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTileShadingFeaturesQCOM;
@@ -7463,7 +7463,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tileShadingAtomicOps: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTileShadingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTileShadingFeaturesQCOM;
@@ -7478,7 +7478,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tileShadingColorAttachments: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTileShadingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTileShadingFeaturesQCOM;
@@ -7494,7 +7494,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tileShadingDepthAttachments: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTileShadingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTileShadingFeaturesQCOM;
@@ -7510,7 +7510,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tileShadingDispatchTile: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTileShadingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTileShadingFeaturesQCOM;
@@ -7525,7 +7525,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tileShadingFragmentStage: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTileShadingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTileShadingFeaturesQCOM;
@@ -7540,7 +7540,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tileShadingImageProcessing: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTileShadingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTileShadingFeaturesQCOM;
@@ -7555,7 +7555,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tileShadingInputAttachments: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTileShadingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTileShadingFeaturesQCOM;
@@ -7571,7 +7571,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tileShadingPerTileDispatch: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTileShadingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTileShadingFeaturesQCOM;
@@ -7586,7 +7586,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tileShadingPerTileDraw: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTileShadingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTileShadingFeaturesQCOM;
@@ -7601,7 +7601,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tileShadingSampledAttachments: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTileShadingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTileShadingFeaturesQCOM;
@@ -7617,7 +7617,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::tileShadingStencilAttachments: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTileShadingFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTileShadingFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTileShadingFeaturesQCOM;
@@ -7634,7 +7634,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::timelineSemaphore:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -7647,7 +7647,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->timelineSemaphore, "VkPhysicalDeviceVulkan12Features::timelineSemaphore"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceTimelineSemaphoreFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceTimelineSemaphoreFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceTimelineSemaphoreFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceTimelineSemaphoreFeatures;
@@ -7661,7 +7661,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->timelineSemaphore, "VkPhysicalDeviceTimelineSemaphoreFeatures::timelineSemaphore"};
             }
         case Feature::geometryStreams: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTransformFeedbackFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTransformFeedbackFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTransformFeedbackFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTransformFeedbackFeaturesEXT;
@@ -7676,7 +7676,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::transformFeedback: {
-            auto vk_struct = const_cast<VkPhysicalDeviceTransformFeedbackFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceTransformFeedbackFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceTransformFeedbackFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceTransformFeedbackFeaturesEXT;
@@ -7691,7 +7691,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::unifiedImageLayouts: {
-            auto vk_struct = const_cast<VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR;
@@ -7706,7 +7706,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::unifiedImageLayoutsVideo: {
-            auto vk_struct = const_cast<VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR;
@@ -7723,7 +7723,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::uniformBufferStandardLayout:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -7736,7 +7736,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->uniformBufferStandardLayout, "VkPhysicalDeviceVulkan12Features::uniformBufferStandardLayout"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceUniformBufferStandardLayoutFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceUniformBufferStandardLayoutFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceUniformBufferStandardLayoutFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceUniformBufferStandardLayoutFeatures;
@@ -7752,7 +7752,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::variablePointers:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan11Features;
@@ -7765,7 +7765,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->variablePointers, "VkPhysicalDeviceVulkan11Features::variablePointers"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceVariablePointersFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVariablePointersFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVariablePointersFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVariablePointersFeatures;
@@ -7780,7 +7780,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::variablePointersStorageBuffer:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan11Features;
@@ -7794,7 +7794,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->variablePointersStorageBuffer,
                         "VkPhysicalDeviceVulkan11Features::variablePointersStorageBuffer"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceVariablePointersFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVariablePointersFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVariablePointersFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVariablePointersFeatures;
@@ -7810,7 +7810,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::vertexAttributeInstanceRateDivisor:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -7824,7 +7824,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->vertexAttributeInstanceRateDivisor,
                         "VkPhysicalDeviceVulkan14Features::vertexAttributeInstanceRateDivisor"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceVertexAttributeDivisorFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVertexAttributeDivisorFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVertexAttributeDivisorFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVertexAttributeDivisorFeatures;
@@ -7840,7 +7840,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::vertexAttributeInstanceRateZeroDivisor:
             if (api_version >= VK_API_VERSION_1_4) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -7854,7 +7854,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->vertexAttributeInstanceRateZeroDivisor,
                         "VkPhysicalDeviceVulkan14Features::vertexAttributeInstanceRateZeroDivisor"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceVertexAttributeDivisorFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVertexAttributeDivisorFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVertexAttributeDivisorFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVertexAttributeDivisorFeatures;
@@ -7869,7 +7869,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                         "VkPhysicalDeviceVertexAttributeDivisorFeatures::vertexAttributeInstanceRateZeroDivisor"};
             }
         case Feature::vertexAttributeRobustness: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT;
@@ -7885,7 +7885,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::vertexInputDynamicState: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT;
@@ -7901,7 +7901,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::videoDecodeVP9: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVideoDecodeVP9FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVideoDecodeVP9FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVideoDecodeVP9FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVideoDecodeVP9FeaturesKHR;
@@ -7916,7 +7916,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::videoEncodeAV1: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVideoEncodeAV1FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVideoEncodeAV1FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVideoEncodeAV1FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVideoEncodeAV1FeaturesKHR;
@@ -7931,7 +7931,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::videoEncodeIntraRefresh: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR;
@@ -7947,7 +7947,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::videoEncodeQuantizationMap: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVideoEncodeQuantizationMapFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVideoEncodeQuantizationMapFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVideoEncodeQuantizationMapFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVideoEncodeQuantizationMapFeaturesKHR;
@@ -7963,7 +7963,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::videoEncodeRgbConversion: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVideoEncodeRgbConversionFeaturesVALVE *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVideoEncodeRgbConversionFeaturesVALVE*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVideoEncodeRgbConversionFeaturesVALVE>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVideoEncodeRgbConversionFeaturesVALVE;
@@ -7979,7 +7979,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::videoMaintenance1: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVideoMaintenance1FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVideoMaintenance1FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVideoMaintenance1FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVideoMaintenance1FeaturesKHR;
@@ -7994,7 +7994,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::videoMaintenance2: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVideoMaintenance2FeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVideoMaintenance2FeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVideoMaintenance2FeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVideoMaintenance2FeaturesKHR;
@@ -8009,7 +8009,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::descriptorIndexing: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -8024,7 +8024,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::drawIndirectCount: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -8039,7 +8039,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::samplerFilterMinmax: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -8054,7 +8054,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::samplerMirrorClampToEdge: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -8069,7 +8069,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderOutputLayer: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -8084,7 +8084,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::shaderOutputViewportIndex: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -8099,7 +8099,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::subgroupBroadcastDynamicId: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -8115,7 +8115,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
 
         case Feature::vulkanMemoryModel:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -8128,7 +8128,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->vulkanMemoryModel, "VkPhysicalDeviceVulkan12Features::vulkanMemoryModel"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkanMemoryModelFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkanMemoryModelFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkanMemoryModelFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkanMemoryModelFeatures;
@@ -8143,7 +8143,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::vulkanMemoryModelAvailabilityVisibilityChains:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -8157,7 +8157,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->vulkanMemoryModelAvailabilityVisibilityChains,
                         "VkPhysicalDeviceVulkan12Features::vulkanMemoryModelAvailabilityVisibilityChains"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkanMemoryModelFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkanMemoryModelFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkanMemoryModelFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkanMemoryModelFeatures;
@@ -8173,7 +8173,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::vulkanMemoryModelDeviceScope:
             if (api_version >= VK_API_VERSION_1_2) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan12Features;
@@ -8186,7 +8186,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 }
                 return {&vk_struct->vulkanMemoryModelDeviceScope, "VkPhysicalDeviceVulkan12Features::vulkanMemoryModelDeviceScope"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkanMemoryModelFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkanMemoryModelFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkanMemoryModelFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkanMemoryModelFeatures;
@@ -8202,7 +8202,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
         case Feature::shaderZeroInitializeWorkgroupMemory:
             if (api_version >= VK_API_VERSION_1_3) {
-                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceVulkan13Features;
@@ -8216,7 +8216,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                 return {&vk_struct->shaderZeroInitializeWorkgroupMemory,
                         "VkPhysicalDeviceVulkan13Features::shaderZeroInitializeWorkgroupMemory"};
             } else {
-                auto vk_struct = const_cast<VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures *>(
+                auto vk_struct = const_cast<VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures*>(
                     vku::FindStructInPNextChain<VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures>(*inout_pnext_chain));
                 if (!vk_struct) {
                     vk_struct = new VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures;
@@ -8231,7 +8231,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
                         "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures::shaderZeroInitializeWorkgroupMemory"};
             }
         case Feature::pushDescriptor: {
-            auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceVulkan14Features*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVulkan14Features>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceVulkan14Features;
@@ -8246,7 +8246,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::workgroupMemoryExplicitLayout: {
-            auto vk_struct = const_cast<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR;
@@ -8262,7 +8262,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::workgroupMemoryExplicitLayout16BitAccess: {
-            auto vk_struct = const_cast<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR;
@@ -8278,7 +8278,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::workgroupMemoryExplicitLayout8BitAccess: {
-            auto vk_struct = const_cast<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR;
@@ -8294,7 +8294,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::workgroupMemoryExplicitLayoutScalarBlockLayout: {
-            auto vk_struct = const_cast<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR;
@@ -8310,7 +8310,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::ycbcr2plane444Formats: {
-            auto vk_struct = const_cast<VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT;
@@ -8325,7 +8325,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::ycbcrDegamma: {
-            auto vk_struct = const_cast<VkPhysicalDeviceYcbcrDegammaFeaturesQCOM *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceYcbcrDegammaFeaturesQCOM*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceYcbcrDegammaFeaturesQCOM>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceYcbcrDegammaFeaturesQCOM;
@@ -8340,7 +8340,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::ycbcrImageArrays: {
-            auto vk_struct = const_cast<VkPhysicalDeviceYcbcrImageArraysFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceYcbcrImageArraysFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceYcbcrImageArraysFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceYcbcrImageArraysFeaturesEXT;
@@ -8355,7 +8355,7 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
         }
 
         case Feature::zeroInitializeDeviceMemory: {
-            auto vk_struct = const_cast<VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT *>(
+            auto vk_struct = const_cast<VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT*>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT>(*inout_pnext_chain));
             if (!vk_struct) {
                 vk_struct = new VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT;

--- a/layers/vulkan/generated/feature_requirements_helper.h
+++ b/layers/vulkan/generated/feature_requirements_helper.h
@@ -1059,13 +1059,13 @@ enum class Feature {
 };
 
 struct FeatureAndName {
-    VkBool32 *feature;
-    const char *name;
+    VkBool32* feature;
+    const char* name;
 };
 
 // Find or add the correct VkPhysicalDeviceFeature struct in `pnext_chain` based on `feature`,
 // a vkt::Feature enum value, and set feature to VK_TRUE
-FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **inout_pnext_chain);
+FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void** inout_pnext_chain);
 
 }  // namespace vkt
 

--- a/layers/vulkan/generated/pnext_chain_extraction.cpp
+++ b/layers/vulkan/generated/pnext_chain_extraction.cpp
@@ -28,3797 +28,3797 @@
 
 namespace vvl {
 
-void *PnextChainAdd(void *chain, void *new_struct) {
+void* PnextChainAdd(void* chain, void* new_struct) {
     assert(chain);
     assert(new_struct);
-    void *chain_end = vku::FindLastStructInPNextChain(chain);
-    auto *vk_base_struct = static_cast<VkBaseOutStructure *>(chain_end);
+    void* chain_end = vku::FindLastStructInPNextChain(chain);
+    auto* vk_base_struct = static_cast<VkBaseOutStructure*>(chain_end);
     assert(!vk_base_struct->pNext);
-    vk_base_struct->pNext = static_cast<VkBaseOutStructure *>(new_struct);
+    vk_base_struct->pNext = static_cast<VkBaseOutStructure*>(new_struct);
     return new_struct;
 }
 
-void PnextChainRemoveLast(void *chain) {
+void PnextChainRemoveLast(void* chain) {
     if (!chain) {
         return;
     }
-    auto *current = static_cast<VkBaseOutStructure *>(chain);
-    auto *prev = current;
+    auto* current = static_cast<VkBaseOutStructure*>(chain);
+    auto* prev = current;
     while (current->pNext) {
         prev = current;
-        current = static_cast<VkBaseOutStructure *>(current->pNext);
+        current = static_cast<VkBaseOutStructure*>(current->pNext);
     }
     prev->pNext = nullptr;
 }
 
-void PnextChainFree(void *chain) {
+void PnextChainFree(void* chain) {
     if (!chain) return;
-    auto header = reinterpret_cast<VkBaseOutStructure *>(chain);
+    auto header = reinterpret_cast<VkBaseOutStructure*>(chain);
     switch (header->sType) {
         case VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkShaderModuleCreateInfo *>(header);
+            delete reinterpret_cast<const VkShaderModuleCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineLayoutCreateInfo *>(header);
+            delete reinterpret_cast<const VkPipelineLayoutCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkMemoryDedicatedRequirements *>(header);
+            delete reinterpret_cast<const VkMemoryDedicatedRequirements*>(header);
             break;
         case VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkMemoryDedicatedAllocateInfo *>(header);
+            delete reinterpret_cast<const VkMemoryDedicatedAllocateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkMemoryAllocateFlagsInfo *>(header);
+            delete reinterpret_cast<const VkMemoryAllocateFlagsInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEVICE_GROUP_COMMAND_BUFFER_BEGIN_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDeviceGroupCommandBufferBeginInfo *>(header);
+            delete reinterpret_cast<const VkDeviceGroupCommandBufferBeginInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEVICE_GROUP_SUBMIT_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDeviceGroupSubmitInfo *>(header);
+            delete reinterpret_cast<const VkDeviceGroupSubmitInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEVICE_GROUP_BIND_SPARSE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDeviceGroupBindSparseInfo *>(header);
+            delete reinterpret_cast<const VkDeviceGroupBindSparseInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_BIND_BUFFER_MEMORY_DEVICE_GROUP_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkBindBufferMemoryDeviceGroupInfo *>(header);
+            delete reinterpret_cast<const VkBindBufferMemoryDeviceGroupInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_DEVICE_GROUP_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkBindImageMemoryDeviceGroupInfo *>(header);
+            delete reinterpret_cast<const VkBindImageMemoryDeviceGroupInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEVICE_GROUP_DEVICE_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDeviceGroupDeviceCreateInfo *>(header);
+            delete reinterpret_cast<const VkDeviceGroupDeviceCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFeatures2 *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFeatures2*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMAGE_VIEW_USAGE_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImageViewUsageCreateInfo *>(header);
+            delete reinterpret_cast<const VkImageViewUsageCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceProtectedMemoryFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceProtectedMemoryFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceProtectedMemoryProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceProtectedMemoryProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PROTECTED_SUBMIT_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkProtectedSubmitInfo *>(header);
+            delete reinterpret_cast<const VkProtectedSubmitInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_BIND_IMAGE_PLANE_MEMORY_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkBindImagePlaneMemoryInfo *>(header);
+            delete reinterpret_cast<const VkBindImagePlaneMemoryInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMAGE_PLANE_MEMORY_REQUIREMENTS_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImagePlaneMemoryRequirementsInfo *>(header);
+            delete reinterpret_cast<const VkImagePlaneMemoryRequirementsInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceExternalImageFormatInfo *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceExternalImageFormatInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXTERNAL_IMAGE_FORMAT_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExternalImageFormatProperties *>(header);
+            delete reinterpret_cast<const VkExternalImageFormatProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceIDProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceIDProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExternalMemoryImageCreateInfo *>(header);
+            delete reinterpret_cast<const VkExternalMemoryImageCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_BUFFER_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExternalMemoryBufferCreateInfo *>(header);
+            delete reinterpret_cast<const VkExternalMemoryBufferCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExportMemoryAllocateInfo *>(header);
+            delete reinterpret_cast<const VkExportMemoryAllocateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXPORT_FENCE_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExportFenceCreateInfo *>(header);
+            delete reinterpret_cast<const VkExportFenceCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExportSemaphoreCreateInfo *>(header);
+            delete reinterpret_cast<const VkExportSemaphoreCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceSubgroupProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceSubgroupProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevice16BitStorageFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDevice16BitStorageFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVariablePointersFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVariablePointersFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_3_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMaintenance3Properties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMaintenance3Properties*>(header);
             break;
         case VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSamplerYcbcrConversionInfo *>(header);
+            delete reinterpret_cast<const VkSamplerYcbcrConversionInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_YCBCR_CONVERSION_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceSamplerYcbcrConversionFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceSamplerYcbcrConversionFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_IMAGE_FORMAT_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSamplerYcbcrConversionImageFormatProperties *>(header);
+            delete reinterpret_cast<const VkSamplerYcbcrConversionImageFormatProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEVICE_GROUP_RENDER_PASS_BEGIN_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDeviceGroupRenderPassBeginInfo *>(header);
+            delete reinterpret_cast<const VkDeviceGroupRenderPassBeginInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_POINT_CLIPPING_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePointClippingProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePointClippingProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDER_PASS_INPUT_ATTACHMENT_ASPECT_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderPassInputAttachmentAspectCreateInfo *>(header);
+            delete reinterpret_cast<const VkRenderPassInputAttachmentAspectCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_DOMAIN_ORIGIN_STATE_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineTessellationDomainOriginStateCreateInfo *>(header);
+            delete reinterpret_cast<const VkPipelineTessellationDomainOriginStateCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderPassMultiviewCreateInfo *>(header);
+            delete reinterpret_cast<const VkRenderPassMultiviewCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMultiviewFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMultiviewFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMultiviewProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMultiviewProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderDrawParametersFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderDrawParametersFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVulkan11Features *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVulkan11Features*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVulkan11Properties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVulkan11Properties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVulkan12Features *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVulkan12Features*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVulkan12Properties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVulkan12Properties*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMAGE_FORMAT_LIST_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImageFormatListCreateInfo *>(header);
+            delete reinterpret_cast<const VkImageFormatListCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDriverProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDriverProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVulkanMemoryModelFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVulkanMemoryModelFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceHostQueryResetFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceHostQueryResetFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceTimelineSemaphoreFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceTimelineSemaphoreFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceTimelineSemaphoreProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceTimelineSemaphoreProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSemaphoreTypeCreateInfo *>(header);
+            delete reinterpret_cast<const VkSemaphoreTypeCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkTimelineSemaphoreSubmitInfo *>(header);
+            delete reinterpret_cast<const VkTimelineSemaphoreSubmitInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceBufferDeviceAddressFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceBufferDeviceAddressFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_BUFFER_OPAQUE_CAPTURE_ADDRESS_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkBufferOpaqueCaptureAddressCreateInfo *>(header);
+            delete reinterpret_cast<const VkBufferOpaqueCaptureAddressCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_MEMORY_OPAQUE_CAPTURE_ADDRESS_ALLOCATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkMemoryOpaqueCaptureAddressAllocateInfo *>(header);
+            delete reinterpret_cast<const VkMemoryOpaqueCaptureAddressAllocateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevice8BitStorageFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDevice8BitStorageFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderAtomicInt64Features *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderAtomicInt64Features*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderFloat16Int8Features *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderFloat16Int8Features*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFloatControlsProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFloatControlsProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDescriptorSetLayoutBindingFlagsCreateInfo *>(header);
+            delete reinterpret_cast<const VkDescriptorSetLayoutBindingFlagsCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDescriptorIndexingFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDescriptorIndexingFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDescriptorIndexingProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDescriptorIndexingProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDescriptorSetVariableDescriptorCountAllocateInfo *>(header);
+            delete reinterpret_cast<const VkDescriptorSetVariableDescriptorCountAllocateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_LAYOUT_SUPPORT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDescriptorSetVariableDescriptorCountLayoutSupport *>(header);
+            delete reinterpret_cast<const VkDescriptorSetVariableDescriptorCountLayoutSupport*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceScalarBlockLayoutFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceScalarBlockLayoutFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSamplerReductionModeCreateInfo *>(header);
+            delete reinterpret_cast<const VkSamplerReductionModeCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_FILTER_MINMAX_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceSamplerFilterMinmaxProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceSamplerFilterMinmaxProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceUniformBufferStandardLayoutFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceUniformBufferStandardLayoutFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_EXTENDED_TYPES_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_DEPTH_STENCIL_RESOLVE:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSubpassDescriptionDepthStencilResolve *>(header);
+            delete reinterpret_cast<const VkSubpassDescriptionDepthStencilResolve*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_STENCIL_RESOLVE_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDepthStencilResolveProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDepthStencilResolveProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMAGE_STENCIL_USAGE_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImageStencilUsageCreateInfo *>(header);
+            delete reinterpret_cast<const VkImageStencilUsageCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGELESS_FRAMEBUFFER_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceImagelessFramebufferFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceImagelessFramebufferFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_FRAMEBUFFER_ATTACHMENTS_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkFramebufferAttachmentsCreateInfo *>(header);
+            delete reinterpret_cast<const VkFramebufferAttachmentsCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDER_PASS_ATTACHMENT_BEGIN_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderPassAttachmentBeginInfo *>(header);
+            delete reinterpret_cast<const VkRenderPassAttachmentBeginInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SEPARATE_DEPTH_STENCIL_LAYOUTS_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_STENCIL_LAYOUT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkAttachmentReferenceStencilLayout *>(header);
+            delete reinterpret_cast<const VkAttachmentReferenceStencilLayout*>(header);
             break;
         case VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_STENCIL_LAYOUT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkAttachmentDescriptionStencilLayout *>(header);
+            delete reinterpret_cast<const VkAttachmentDescriptionStencilLayout*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVulkan13Features *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVulkan13Features*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVulkan13Properties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVulkan13Properties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIVATE_DATA_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePrivateDataFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePrivateDataFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEVICE_PRIVATE_DATA_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDevicePrivateDataCreateInfo *>(header);
+            delete reinterpret_cast<const VkDevicePrivateDataCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_MEMORY_BARRIER_2:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkMemoryBarrier2 *>(header);
+            delete reinterpret_cast<const VkMemoryBarrier2*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceSynchronization2Features *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceSynchronization2Features*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXTURE_COMPRESSION_ASTC_HDR_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceTextureCompressionASTCHDRFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceTextureCompressionASTCHDRFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_3:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkFormatProperties3 *>(header);
+            delete reinterpret_cast<const VkFormatProperties3*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_4_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMaintenance4Features *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMaintenance4Features*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_4_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMaintenance4Properties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMaintenance4Properties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_CREATION_FEEDBACK_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineCreationFeedbackCreateInfo *>(header);
+            delete reinterpret_cast<const VkPipelineCreationFeedbackCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_TERMINATE_INVOCATION_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderTerminateInvocationFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderTerminateInvocationFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DEMOTE_TO_HELPER_INVOCATION_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePipelineCreationCacheControlFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePipelineCreationCacheControlFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ZERO_INITIALIZE_WORKGROUP_MEMORY_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceImageRobustnessFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceImageRobustnessFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceSubgroupSizeControlFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceSubgroupSizeControlFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceSubgroupSizeControlProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceSubgroupSizeControlProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineShaderStageRequiredSubgroupSizeCreateInfo *>(header);
+            delete reinterpret_cast<const VkPipelineShaderStageRequiredSubgroupSizeCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceInlineUniformBlockFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceInlineUniformBlockFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceInlineUniformBlockProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceInlineUniformBlockProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkWriteDescriptorSetInlineUniformBlock *>(header);
+            delete reinterpret_cast<const VkWriteDescriptorSetInlineUniformBlock*>(header);
             break;
         case VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_INLINE_UNIFORM_BLOCK_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDescriptorPoolInlineUniformBlockCreateInfo *>(header);
+            delete reinterpret_cast<const VkDescriptorPoolInlineUniformBlockCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderIntegerDotProductFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderIntegerDotProductFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderIntegerDotProductProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderIntegerDotProductProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceTexelBufferAlignmentProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceTexelBufferAlignmentProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineRenderingCreateInfo *>(header);
+            delete reinterpret_cast<const VkPipelineRenderingCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDynamicRenderingFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDynamicRenderingFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_RENDERING_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkCommandBufferInheritanceRenderingInfo *>(header);
+            delete reinterpret_cast<const VkCommandBufferInheritanceRenderingInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_4_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVulkan14Features *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVulkan14Features*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_4_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVulkan14Properties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVulkan14Properties*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEVICE_QUEUE_GLOBAL_PRIORITY_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDeviceQueueGlobalPriorityCreateInfo *>(header);
+            delete reinterpret_cast<const VkDeviceQueueGlobalPriorityCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GLOBAL_PRIORITY_QUERY_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceGlobalPriorityQueryFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceGlobalPriorityQueryFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_QUEUE_FAMILY_GLOBAL_PRIORITY_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkQueueFamilyGlobalPriorityProperties *>(header);
+            delete reinterpret_cast<const VkQueueFamilyGlobalPriorityProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INDEX_TYPE_UINT8_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceIndexTypeUint8Features *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceIndexTypeUint8Features*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMaintenance5Features *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMaintenance5Features*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMaintenance5Properties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMaintenance5Properties*>(header);
             break;
         case VK_STRUCTURE_TYPE_BUFFER_USAGE_FLAGS_2_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkBufferUsageFlags2CreateInfo *>(header);
+            delete reinterpret_cast<const VkBufferUsageFlags2CreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_6_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMaintenance6Features *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMaintenance6Features*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_6_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMaintenance6Properties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMaintenance6Properties*>(header);
             break;
         case VK_STRUCTURE_TYPE_BIND_MEMORY_STATUS:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkBindMemoryStatus *>(header);
+            delete reinterpret_cast<const VkBindMemoryStatus*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_IMAGE_COPY_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceHostImageCopyFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceHostImageCopyFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_IMAGE_COPY_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceHostImageCopyProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceHostImageCopyProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_SUBRESOURCE_HOST_MEMCPY_SIZE:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSubresourceHostMemcpySize *>(header);
+            delete reinterpret_cast<const VkSubresourceHostMemcpySize*>(header);
             break;
         case VK_STRUCTURE_TYPE_HOST_IMAGE_COPY_DEVICE_PERFORMANCE_QUERY:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkHostImageCopyDevicePerformanceQuery *>(header);
+            delete reinterpret_cast<const VkHostImageCopyDevicePerformanceQuery*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_ROTATE_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderSubgroupRotateFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderSubgroupRotateFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT_CONTROLS_2_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderFloatControls2Features *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderFloatControls2Features*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_EXPECT_ASSUME_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderExpectAssumeFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderExpectAssumeFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineCreateFlags2CreateInfo *>(header);
+            delete reinterpret_cast<const VkPipelineCreateFlags2CreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PUSH_DESCRIPTOR_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePushDescriptorProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePushDescriptorProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_PROTECTED_ACCESS_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePipelineProtectedAccessFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePipelineProtectedAccessFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_ROBUSTNESS_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePipelineRobustnessFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePipelineRobustnessFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_ROBUSTNESS_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePipelineRobustnessProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePipelineRobustnessProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_ROBUSTNESS_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineRobustnessCreateInfo *>(header);
+            delete reinterpret_cast<const VkPipelineRobustnessCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceLineRasterizationFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceLineRasterizationFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceLineRasterizationProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceLineRasterizationProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_LINE_STATE_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineRasterizationLineStateCreateInfo *>(header);
+            delete reinterpret_cast<const VkPipelineRasterizationLineStateCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVertexAttributeDivisorProperties *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVertexAttributeDivisorProperties*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_DIVISOR_STATE_CREATE_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineVertexInputDivisorStateCreateInfo *>(header);
+            delete reinterpret_cast<const VkPipelineVertexInputDivisorStateCreateInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVertexAttributeDivisorFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVertexAttributeDivisorFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_LOCAL_READ_FEATURES:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDynamicRenderingLocalReadFeatures *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDynamicRenderingLocalReadFeatures*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_LOCATION_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderingAttachmentLocationInfo *>(header);
+            delete reinterpret_cast<const VkRenderingAttachmentLocationInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDERING_INPUT_ATTACHMENT_INDEX_INFO:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderingInputAttachmentIndexInfo *>(header);
+            delete reinterpret_cast<const VkRenderingInputAttachmentIndexInfo*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMAGE_SWAPCHAIN_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImageSwapchainCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkImageSwapchainCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_SWAPCHAIN_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkBindImageMemorySwapchainInfoKHR *>(header);
+            delete reinterpret_cast<const VkBindImageMemorySwapchainInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEVICE_GROUP_PRESENT_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDeviceGroupPresentInfoKHR *>(header);
+            delete reinterpret_cast<const VkDeviceGroupPresentInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEVICE_GROUP_SWAPCHAIN_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDeviceGroupSwapchainCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkDeviceGroupSwapchainCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_DISPLAY_PRESENT_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDisplayPresentInfoKHR *>(header);
+            delete reinterpret_cast<const VkDisplayPresentInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_QUEUE_FAMILY_QUERY_RESULT_STATUS_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkQueueFamilyQueryResultStatusPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkQueueFamilyQueryResultStatusPropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_QUEUE_FAMILY_VIDEO_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkQueueFamilyVideoPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkQueueFamilyVideoPropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoProfileInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoProfileInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_PROFILE_LIST_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoProfileListInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoProfileListInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeCapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeCapabilitiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_USAGE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeUsageInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeUsageInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH264CapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH264CapabilitiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_QUALITY_LEVEL_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH264QualityLevelPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH264QualityLevelPropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH264SessionCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH264SessionCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_ADD_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH264SessionParametersAddInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH264SessionParametersAddInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH264SessionParametersCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH264SessionParametersCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_GET_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH264SessionParametersGetInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH264SessionParametersGetInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_FEEDBACK_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH264SessionParametersFeedbackInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH264SessionParametersFeedbackInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_PICTURE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH264PictureInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH264PictureInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_DPB_SLOT_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH264DpbSlotInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH264DpbSlotInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_PROFILE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH264ProfileInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH264ProfileInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_RATE_CONTROL_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH264RateControlInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH264RateControlInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_RATE_CONTROL_LAYER_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH264RateControlLayerInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH264RateControlLayerInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_GOP_REMAINING_FRAME_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH264GopRemainingFrameInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH264GopRemainingFrameInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH265CapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH265CapabilitiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH265SessionCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH265SessionCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_QUALITY_LEVEL_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH265QualityLevelPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH265QualityLevelPropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_ADD_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH265SessionParametersAddInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH265SessionParametersAddInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH265SessionParametersCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH265SessionParametersCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_GET_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH265SessionParametersGetInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH265SessionParametersGetInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_FEEDBACK_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH265SessionParametersFeedbackInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH265SessionParametersFeedbackInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_PICTURE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH265PictureInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH265PictureInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_DPB_SLOT_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH265DpbSlotInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH265DpbSlotInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_PROFILE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH265ProfileInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH265ProfileInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_RATE_CONTROL_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH265RateControlInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH265RateControlInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_RATE_CONTROL_LAYER_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH265RateControlLayerInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH265RateControlLayerInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_GOP_REMAINING_FRAME_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH265GopRemainingFrameInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH265GopRemainingFrameInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_PROFILE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeH264ProfileInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeH264ProfileInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeH264CapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeH264CapabilitiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_SESSION_PARAMETERS_ADD_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeH264SessionParametersAddInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeH264SessionParametersAddInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_SESSION_PARAMETERS_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeH264SessionParametersCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeH264SessionParametersCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_PICTURE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeH264PictureInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeH264PictureInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_DPB_SLOT_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeH264DpbSlotInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeH264DpbSlotInfoKHR*>(header);
             break;
 #ifdef VK_USE_PLATFORM_WIN32_KHR
         case VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImportMemoryWin32HandleInfoKHR *>(header);
+            delete reinterpret_cast<const VkImportMemoryWin32HandleInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExportMemoryWin32HandleInfoKHR *>(header);
+            delete reinterpret_cast<const VkExportMemoryWin32HandleInfoKHR*>(header);
             break;
 #endif  // VK_USE_PLATFORM_WIN32_KHR
         case VK_STRUCTURE_TYPE_IMPORT_MEMORY_FD_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImportMemoryFdInfoKHR *>(header);
+            delete reinterpret_cast<const VkImportMemoryFdInfoKHR*>(header);
             break;
 #ifdef VK_USE_PLATFORM_WIN32_KHR
         case VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkWin32KeyedMutexAcquireReleaseInfoKHR *>(header);
+            delete reinterpret_cast<const VkWin32KeyedMutexAcquireReleaseInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExportSemaphoreWin32HandleInfoKHR *>(header);
+            delete reinterpret_cast<const VkExportSemaphoreWin32HandleInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_D3D12_FENCE_SUBMIT_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkD3D12FenceSubmitInfoKHR *>(header);
+            delete reinterpret_cast<const VkD3D12FenceSubmitInfoKHR*>(header);
             break;
 #endif  // VK_USE_PLATFORM_WIN32_KHR
         case VK_STRUCTURE_TYPE_PRESENT_REGIONS_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPresentRegionsKHR *>(header);
+            delete reinterpret_cast<const VkPresentRegionsKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_SHARED_PRESENT_SURFACE_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSharedPresentSurfaceCapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkSharedPresentSurfaceCapabilitiesKHR*>(header);
             break;
 #ifdef VK_USE_PLATFORM_WIN32_KHR
         case VK_STRUCTURE_TYPE_EXPORT_FENCE_WIN32_HANDLE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExportFenceWin32HandleInfoKHR *>(header);
+            delete reinterpret_cast<const VkExportFenceWin32HandleInfoKHR*>(header);
             break;
 #endif  // VK_USE_PLATFORM_WIN32_KHR
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PERFORMANCE_QUERY_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePerformanceQueryFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePerformanceQueryFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PERFORMANCE_QUERY_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePerformanceQueryPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePerformanceQueryPropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_QUERY_POOL_PERFORMANCE_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkQueryPoolPerformanceCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkQueryPoolPerformanceCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PERFORMANCE_QUERY_SUBMIT_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPerformanceQuerySubmitInfoKHR *>(header);
+            delete reinterpret_cast<const VkPerformanceQuerySubmitInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_BFLOAT16_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderBfloat16FeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderBfloat16FeaturesKHR*>(header);
             break;
 #ifdef VK_ENABLE_BETA_EXTENSIONS
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePortabilitySubsetFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePortabilitySubsetPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePortabilitySubsetPropertiesKHR*>(header);
             break;
 #endif  // VK_ENABLE_BETA_EXTENSIONS
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CLOCK_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderClockFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderClockFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_PROFILE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeH265ProfileInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeH265ProfileInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeH265CapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeH265CapabilitiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_SESSION_PARAMETERS_ADD_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeH265SessionParametersAddInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeH265SessionParametersAddInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_SESSION_PARAMETERS_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeH265SessionParametersCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeH265SessionParametersCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_PICTURE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeH265PictureInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeH265PictureInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_DPB_SLOT_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeH265DpbSlotInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeH265DpbSlotInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_FRAGMENT_SHADING_RATE_ATTACHMENT_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkFragmentShadingRateAttachmentInfoKHR *>(header);
+            delete reinterpret_cast<const VkFragmentShadingRateAttachmentInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_FRAGMENT_SHADING_RATE_STATE_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineFragmentShadingRateStateCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkPipelineFragmentShadingRateStateCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFragmentShadingRateFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentShadingRateFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFragmentShadingRatePropertiesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentShadingRatePropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderingFragmentShadingRateAttachmentInfoKHR *>(header);
+            delete reinterpret_cast<const VkRenderingFragmentShadingRateAttachmentInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_QUAD_CONTROL_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderQuadControlFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderQuadControlFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_SURFACE_PROTECTED_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSurfaceProtectedCapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkSurfaceProtectedCapabilitiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_WAIT_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePresentWaitFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePresentWaitFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_EXECUTABLE_PROPERTIES_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_LIBRARY_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineLibraryCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkPipelineLibraryCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PRESENT_ID_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPresentIdKHR *>(header);
+            delete reinterpret_cast<const VkPresentIdKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_ID_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePresentIdFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePresentIdFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeCapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeCapabilitiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_QUERY_POOL_VIDEO_ENCODE_FEEDBACK_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkQueryPoolVideoEncodeFeedbackCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkQueryPoolVideoEncodeFeedbackCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_USAGE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeUsageInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeUsageInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_RATE_CONTROL_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeRateControlInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeRateControlInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUALITY_LEVEL_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeQualityLevelInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeQualityLevelInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_UNIFORM_CONTROL_FLOW_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_WORKGROUP_MEMORY_EXPLICIT_LAYOUT_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_MAINTENANCE_1_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_UNTYPED_POINTERS_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderUntypedPointersFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderUntypedPointersFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_MAXIMAL_RECONVERGENCE_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderMaximalReconvergenceFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_PRESENT_ID_2_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSurfaceCapabilitiesPresentId2KHR *>(header);
+            delete reinterpret_cast<const VkSurfaceCapabilitiesPresentId2KHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PRESENT_ID_2_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPresentId2KHR *>(header);
+            delete reinterpret_cast<const VkPresentId2KHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_ID_2_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePresentId2FeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePresentId2FeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_PRESENT_WAIT_2_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSurfaceCapabilitiesPresentWait2KHR *>(header);
+            delete reinterpret_cast<const VkSurfaceCapabilitiesPresentWait2KHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_WAIT_2_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePresentWait2FeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePresentWait2FeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_POSITION_FETCH_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_BINARY_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePipelineBinaryFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePipelineBinaryFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_BINARY_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePipelineBinaryPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePipelineBinaryPropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEVICE_PIPELINE_BINARY_INTERNAL_CACHE_CONTROL_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDevicePipelineBinaryInternalCacheControlKHR *>(header);
+            delete reinterpret_cast<const VkDevicePipelineBinaryInternalCacheControlKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_BINARY_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineBinaryInfoKHR *>(header);
+            delete reinterpret_cast<const VkPipelineBinaryInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_SURFACE_PRESENT_MODE_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSurfacePresentModeKHR *>(header);
+            delete reinterpret_cast<const VkSurfacePresentModeKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_SURFACE_PRESENT_SCALING_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSurfacePresentScalingCapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkSurfacePresentScalingCapabilitiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_SURFACE_PRESENT_MODE_COMPATIBILITY_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSurfacePresentModeCompatibilityKHR *>(header);
+            delete reinterpret_cast<const VkSurfacePresentModeCompatibilityKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SWAPCHAIN_MAINTENANCE_1_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceSwapchainMaintenance1FeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_FENCE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSwapchainPresentFenceInfoKHR *>(header);
+            delete reinterpret_cast<const VkSwapchainPresentFenceInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_MODES_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSwapchainPresentModesCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkSwapchainPresentModesCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_MODE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSwapchainPresentModeInfoKHR *>(header);
+            delete reinterpret_cast<const VkSwapchainPresentModeInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_SCALING_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSwapchainPresentScalingCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkSwapchainPresentScalingCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixPropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMPUTE_SHADER_DERIVATIVES_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMPUTE_SHADER_DERIVATIVES_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceComputeShaderDerivativesPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceComputeShaderDerivativesPropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_AV1_PROFILE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeAV1ProfileInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeAV1ProfileInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_AV1_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeAV1CapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeAV1CapabilitiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_AV1_SESSION_PARAMETERS_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeAV1SessionParametersCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeAV1SessionParametersCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_AV1_PICTURE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeAV1PictureInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeAV1PictureInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_AV1_DPB_SLOT_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeAV1DpbSlotInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeAV1DpbSlotInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_ENCODE_AV1_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVideoEncodeAV1FeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVideoEncodeAV1FeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeAV1CapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeAV1CapabilitiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_QUALITY_LEVEL_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeAV1QualityLevelPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeAV1QualityLevelPropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_SESSION_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeAV1SessionCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeAV1SessionCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_SESSION_PARAMETERS_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeAV1SessionParametersCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeAV1SessionParametersCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_PICTURE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeAV1PictureInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeAV1PictureInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_DPB_SLOT_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeAV1DpbSlotInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeAV1DpbSlotInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_PROFILE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeAV1ProfileInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeAV1ProfileInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_GOP_REMAINING_FRAME_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeAV1GopRemainingFrameInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeAV1GopRemainingFrameInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_RATE_CONTROL_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeAV1RateControlInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeAV1RateControlInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_RATE_CONTROL_LAYER_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeAV1RateControlLayerInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeAV1RateControlLayerInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_DECODE_VP9_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVideoDecodeVP9FeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVideoDecodeVP9FeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_VP9_PROFILE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeVP9ProfileInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeVP9ProfileInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_VP9_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeVP9CapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeVP9CapabilitiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_VP9_PICTURE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeVP9PictureInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeVP9PictureInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_MAINTENANCE_1_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVideoMaintenance1FeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVideoMaintenance1FeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_INLINE_QUERY_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoInlineQueryInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoInlineQueryInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_UNIFIED_IMAGE_LAYOUTS_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceUnifiedImageLayoutsFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_ATTACHMENT_FEEDBACK_LOOP_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkAttachmentFeedbackLoopInfoEXT *>(header);
+            delete reinterpret_cast<const VkAttachmentFeedbackLoopInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COPY_MEMORY_INDIRECT_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCopyMemoryIndirectFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COPY_MEMORY_INDIRECT_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCopyMemoryIndirectPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCopyMemoryIndirectPropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_INTRA_REFRESH_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeIntraRefreshCapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeIntraRefreshCapabilitiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_SESSION_INTRA_REFRESH_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeSessionIntraRefreshCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeSessionIntraRefreshCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_INTRA_REFRESH_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeIntraRefreshInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeIntraRefreshInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_REFERENCE_INTRA_REFRESH_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoReferenceIntraRefreshInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoReferenceIntraRefreshInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_ENCODE_INTRA_REFRESH_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVideoEncodeIntraRefreshFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUANTIZATION_MAP_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeQuantizationMapCapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeQuantizationMapCapabilitiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_FORMAT_QUANTIZATION_MAP_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoFormatQuantizationMapPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoFormatQuantizationMapPropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUANTIZATION_MAP_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeQuantizationMapInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeQuantizationMapInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUANTIZATION_MAP_SESSION_PARAMETERS_CREATE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeQuantizationMapSessionParametersCreateInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeQuantizationMapSessionParametersCreateInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_ENCODE_QUANTIZATION_MAP_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVideoEncodeQuantizationMapFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVideoEncodeQuantizationMapFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_QUANTIZATION_MAP_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH264QuantizationMapCapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH264QuantizationMapCapabilitiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_QUANTIZATION_MAP_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeH265QuantizationMapCapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeH265QuantizationMapCapabilitiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_FORMAT_H265_QUANTIZATION_MAP_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoFormatH265QuantizationMapPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoFormatH265QuantizationMapPropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_AV1_QUANTIZATION_MAP_CAPABILITIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeAV1QuantizationMapCapabilitiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoEncodeAV1QuantizationMapCapabilitiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_FORMAT_AV1_QUANTIZATION_MAP_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoFormatAV1QuantizationMapPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkVideoFormatAV1QuantizationMapPropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_RELAXED_EXTENDED_INSTRUCTION_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderRelaxedExtendedInstructionFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_7_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMaintenance7FeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMaintenance7FeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_7_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMaintenance7PropertiesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMaintenance7PropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LAYERED_API_PROPERTIES_LIST_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceLayeredApiPropertiesListKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceLayeredApiPropertiesListKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LAYERED_API_VULKAN_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceLayeredApiVulkanPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceLayeredApiVulkanPropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_MEMORY_BARRIER_ACCESS_FLAGS_3_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkMemoryBarrierAccessFlags3KHR *>(header);
+            delete reinterpret_cast<const VkMemoryBarrierAccessFlags3KHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_8_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMaintenance8FeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMaintenance8FeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FMA_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderFmaFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderFmaFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_9_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMaintenance9FeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMaintenance9FeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_9_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMaintenance9PropertiesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMaintenance9PropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_QUEUE_FAMILY_OWNERSHIP_TRANSFER_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkQueueFamilyOwnershipTransferPropertiesKHR *>(header);
+            delete reinterpret_cast<const VkQueueFamilyOwnershipTransferPropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_MAINTENANCE_2_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVideoMaintenance2FeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVideoMaintenance2FeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_INLINE_SESSION_PARAMETERS_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeH264InlineSessionParametersInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeH264InlineSessionParametersInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_INLINE_SESSION_PARAMETERS_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeH265InlineSessionParametersInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeH265InlineSessionParametersInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_DECODE_AV1_INLINE_SESSION_PARAMETERS_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoDecodeAV1InlineSessionParametersInfoKHR *>(header);
+            delete reinterpret_cast<const VkVideoDecodeAV1InlineSessionParametersInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLAMP_ZERO_ONE_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDepthClampZeroOneFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDepthClampZeroOneFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRobustness2FeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRobustness2FeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRobustness2PropertiesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRobustness2PropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_MODE_FIFO_LATEST_READY_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePresentModeFifoLatestReadyFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_10_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMaintenance10FeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMaintenance10FeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_10_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMaintenance10PropertiesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMaintenance10PropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_FLAGS_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderingAttachmentFlagsInfoKHR *>(header);
+            delete reinterpret_cast<const VkRenderingAttachmentFlagsInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_RESOLVE_IMAGE_MODE_INFO_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkResolveImageModeInfoKHR *>(header);
+            delete reinterpret_cast<const VkResolveImageModeInfoKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDebugReportCallbackCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkDebugReportCallbackCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_RASTERIZATION_ORDER_AMD:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineRasterizationStateRasterizationOrderAMD *>(header);
+            delete reinterpret_cast<const VkPipelineRasterizationStateRasterizationOrderAMD*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_IMAGE_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDedicatedAllocationImageCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkDedicatedAllocationImageCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_BUFFER_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDedicatedAllocationBufferCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkDedicatedAllocationBufferCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_MEMORY_ALLOCATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDedicatedAllocationMemoryAllocateInfoNV *>(header);
+            delete reinterpret_cast<const VkDedicatedAllocationMemoryAllocateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceTransformFeedbackFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceTransformFeedbackFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceTransformFeedbackPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceTransformFeedbackPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_STREAM_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineRasterizationStateStreamCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkPipelineRasterizationStateStreamCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_CU_MODULE_TEXTURING_MODE_CREATE_INFO_NVX:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkCuModuleTexturingModeCreateInfoNVX *>(header);
+            delete reinterpret_cast<const VkCuModuleTexturingModeCreateInfoNVX*>(header);
             break;
         case VK_STRUCTURE_TYPE_TEXTURE_LOD_GATHER_FORMAT_PROPERTIES_AMD:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkTextureLODGatherFormatPropertiesAMD *>(header);
+            delete reinterpret_cast<const VkTextureLODGatherFormatPropertiesAMD*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CORNER_SAMPLED_IMAGE_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCornerSampledImageFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCornerSampledImageFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExternalMemoryImageCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkExternalMemoryImageCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExportMemoryAllocateInfoNV *>(header);
+            delete reinterpret_cast<const VkExportMemoryAllocateInfoNV*>(header);
             break;
 #ifdef VK_USE_PLATFORM_WIN32_KHR
         case VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImportMemoryWin32HandleInfoNV *>(header);
+            delete reinterpret_cast<const VkImportMemoryWin32HandleInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExportMemoryWin32HandleInfoNV *>(header);
+            delete reinterpret_cast<const VkExportMemoryWin32HandleInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkWin32KeyedMutexAcquireReleaseInfoNV *>(header);
+            delete reinterpret_cast<const VkWin32KeyedMutexAcquireReleaseInfoNV*>(header);
             break;
 #endif  // VK_USE_PLATFORM_WIN32_KHR
         case VK_STRUCTURE_TYPE_VALIDATION_FLAGS_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkValidationFlagsEXT *>(header);
+            delete reinterpret_cast<const VkValidationFlagsEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMAGE_VIEW_ASTC_DECODE_MODE_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImageViewASTCDecodeModeEXT *>(header);
+            delete reinterpret_cast<const VkImageViewASTCDecodeModeEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ASTC_DECODE_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceASTCDecodeFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceASTCDecodeFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONDITIONAL_RENDERING_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceConditionalRenderingFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceConditionalRenderingFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_CONDITIONAL_RENDERING_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkCommandBufferInheritanceConditionalRenderingInfoEXT *>(header);
+            delete reinterpret_cast<const VkCommandBufferInheritanceConditionalRenderingInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_W_SCALING_STATE_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineViewportWScalingStateCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkPipelineViewportWScalingStateCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_SWAPCHAIN_COUNTER_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSwapchainCounterCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkSwapchainCounterCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PRESENT_TIMES_INFO_GOOGLE:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPresentTimesInfoGOOGLE *>(header);
+            delete reinterpret_cast<const VkPresentTimesInfoGOOGLE*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_ATTRIBUTES_PROPERTIES_NVX:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX*>(header);
             break;
         case VK_STRUCTURE_TYPE_MULTIVIEW_PER_VIEW_ATTRIBUTES_INFO_NVX:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkMultiviewPerViewAttributesInfoNVX *>(header);
+            delete reinterpret_cast<const VkMultiviewPerViewAttributesInfoNVX*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_SWIZZLE_STATE_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineViewportSwizzleStateCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkPipelineViewportSwizzleStateCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISCARD_RECTANGLE_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDiscardRectanglePropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDiscardRectanglePropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineDiscardRectangleStateCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkPipelineDiscardRectangleStateCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONSERVATIVE_RASTERIZATION_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceConservativeRasterizationPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceConservativeRasterizationPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_CONSERVATIVE_STATE_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineRasterizationConservativeStateCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkPipelineRasterizationConservativeStateCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_ENABLE_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDepthClipEnableFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDepthClipEnableFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_DEPTH_CLIP_STATE_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineRasterizationDepthClipStateCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkPipelineRasterizationDepthClipStateCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RELAXED_LINE_RASTERIZATION_FEATURES_IMG:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDebugUtilsObjectNameInfoEXT *>(header);
+            delete reinterpret_cast<const VkDebugUtilsObjectNameInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDebugUtilsMessengerCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkDebugUtilsMessengerCreateInfoEXT*>(header);
             break;
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
         case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_USAGE_ANDROID:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkAndroidHardwareBufferUsageANDROID *>(header);
+            delete reinterpret_cast<const VkAndroidHardwareBufferUsageANDROID*>(header);
             break;
         case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_ANDROID:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkAndroidHardwareBufferFormatPropertiesANDROID *>(header);
+            delete reinterpret_cast<const VkAndroidHardwareBufferFormatPropertiesANDROID*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMPORT_ANDROID_HARDWARE_BUFFER_INFO_ANDROID:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImportAndroidHardwareBufferInfoANDROID *>(header);
+            delete reinterpret_cast<const VkImportAndroidHardwareBufferInfoANDROID*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExternalFormatANDROID *>(header);
+            delete reinterpret_cast<const VkExternalFormatANDROID*>(header);
             break;
         case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_2_ANDROID:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkAndroidHardwareBufferFormatProperties2ANDROID *>(header);
+            delete reinterpret_cast<const VkAndroidHardwareBufferFormatProperties2ANDROID*>(header);
             break;
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
 #ifdef VK_ENABLE_BETA_EXTENSIONS
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ENQUEUE_FEATURES_AMDX:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderEnqueueFeaturesAMDX *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderEnqueueFeaturesAMDX*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ENQUEUE_PROPERTIES_AMDX:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderEnqueuePropertiesAMDX *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderEnqueuePropertiesAMDX*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_NODE_CREATE_INFO_AMDX:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineShaderStageNodeCreateInfoAMDX *>(header);
+            delete reinterpret_cast<const VkPipelineShaderStageNodeCreateInfoAMDX*>(header);
             break;
 #endif  // VK_ENABLE_BETA_EXTENSIONS
         case VK_STRUCTURE_TYPE_ATTACHMENT_SAMPLE_COUNT_INFO_AMD:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkAttachmentSampleCountInfoAMD *>(header);
+            delete reinterpret_cast<const VkAttachmentSampleCountInfoAMD*>(header);
             break;
         case VK_STRUCTURE_TYPE_SAMPLE_LOCATIONS_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSampleLocationsInfoEXT *>(header);
+            delete reinterpret_cast<const VkSampleLocationsInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDER_PASS_SAMPLE_LOCATIONS_BEGIN_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderPassSampleLocationsBeginInfoEXT *>(header);
+            delete reinterpret_cast<const VkRenderPassSampleLocationsBeginInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_SAMPLE_LOCATIONS_STATE_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineSampleLocationsStateCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkPipelineSampleLocationsStateCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLE_LOCATIONS_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceSampleLocationsPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceSampleLocationsPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_ADVANCED_STATE_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineColorBlendAdvancedStateCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkPipelineColorBlendAdvancedStateCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_TO_COLOR_STATE_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineCoverageToColorStateCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkPipelineCoverageToColorStateCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_MODULATION_STATE_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineCoverageModulationStateCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkPipelineCoverageModulationStateCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SM_BUILTINS_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderSMBuiltinsPropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderSMBuiltinsPropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SM_BUILTINS_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderSMBuiltinsFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderSMBuiltinsFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDrmFormatModifierPropertiesListEXT *>(header);
+            delete reinterpret_cast<const VkDrmFormatModifierPropertiesListEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_DRM_FORMAT_MODIFIER_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceImageDrmFormatModifierInfoEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceImageDrmFormatModifierInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_LIST_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImageDrmFormatModifierListCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkImageDrmFormatModifierListCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_EXPLICIT_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImageDrmFormatModifierExplicitCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkImageDrmFormatModifierExplicitCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_2_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDrmFormatModifierPropertiesList2EXT *>(header);
+            delete reinterpret_cast<const VkDrmFormatModifierPropertiesList2EXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_SHADER_MODULE_VALIDATION_CACHE_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkShaderModuleValidationCacheCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkShaderModuleValidationCacheCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_SHADING_RATE_IMAGE_STATE_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineViewportShadingRateImageStateCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkPipelineViewportShadingRateImageStateCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADING_RATE_IMAGE_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShadingRateImageFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShadingRateImageFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADING_RATE_IMAGE_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShadingRateImagePropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShadingRateImagePropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_COARSE_SAMPLE_ORDER_STATE_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineViewportCoarseSampleOrderStateCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkPipelineViewportCoarseSampleOrderStateCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_ACCELERATION_STRUCTURE_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkWriteDescriptorSetAccelerationStructureNV *>(header);
+            delete reinterpret_cast<const VkWriteDescriptorSetAccelerationStructureNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRayTracingPropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRayTracingPropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_REPRESENTATIVE_FRAGMENT_TEST_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_REPRESENTATIVE_FRAGMENT_TEST_STATE_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineRepresentativeFragmentTestStateCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkPipelineRepresentativeFragmentTestStateCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_VIEW_IMAGE_FORMAT_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceImageViewImageFormatInfoEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceImageViewImageFormatInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_FILTER_CUBIC_IMAGE_VIEW_IMAGE_FORMAT_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkFilterCubicImageViewImageFormatPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkFilterCubicImageViewImageFormatPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMPORT_MEMORY_HOST_POINTER_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImportMemoryHostPointerInfoEXT *>(header);
+            delete reinterpret_cast<const VkImportMemoryHostPointerInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_HOST_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceExternalMemoryHostPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceExternalMemoryHostPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_COMPILER_CONTROL_CREATE_INFO_AMD:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineCompilerControlCreateInfoAMD *>(header);
+            delete reinterpret_cast<const VkPipelineCompilerControlCreateInfoAMD*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_AMD:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderCorePropertiesAMD *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderCorePropertiesAMD*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEVICE_MEMORY_OVERALLOCATION_CREATE_INFO_AMD:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDeviceMemoryOverallocationCreateInfoAMD *>(header);
+            delete reinterpret_cast<const VkDeviceMemoryOverallocationCreateInfoAMD*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT*>(header);
             break;
 #ifdef VK_USE_PLATFORM_GGP
         case VK_STRUCTURE_TYPE_PRESENT_FRAME_TOKEN_GGP:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPresentFrameTokenGGP *>(header);
+            delete reinterpret_cast<const VkPresentFrameTokenGGP*>(header);
             break;
 #endif  // VK_USE_PLATFORM_GGP
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMeshShaderFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMeshShaderFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMeshShaderPropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMeshShaderPropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_IMAGE_FOOTPRINT_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderImageFootprintFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderImageFootprintFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_EXCLUSIVE_SCISSOR_STATE_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineViewportExclusiveScissorStateCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkPipelineViewportExclusiveScissorStateCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXCLUSIVE_SCISSOR_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceExclusiveScissorFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceExclusiveScissorFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_QUEUE_FAMILY_CHECKPOINT_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkQueueFamilyCheckpointPropertiesNV *>(header);
+            delete reinterpret_cast<const VkQueueFamilyCheckpointPropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_QUEUE_FAMILY_CHECKPOINT_PROPERTIES_2_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkQueueFamilyCheckpointProperties2NV *>(header);
+            delete reinterpret_cast<const VkQueueFamilyCheckpointProperties2NV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_TIMING_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePresentTimingFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePresentTimingFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PRESENT_TIMING_SURFACE_CAPABILITIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPresentTimingSurfaceCapabilitiesEXT *>(header);
+            delete reinterpret_cast<const VkPresentTimingSurfaceCapabilitiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_SWAPCHAIN_CALIBRATED_TIMESTAMP_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSwapchainCalibratedTimestampInfoEXT *>(header);
+            delete reinterpret_cast<const VkSwapchainCalibratedTimestampInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PRESENT_TIMINGS_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPresentTimingsInfoEXT *>(header);
+            delete reinterpret_cast<const VkPresentTimingsInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_FUNCTIONS_2_FEATURES_INTEL:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL*>(header);
             break;
         case VK_STRUCTURE_TYPE_QUERY_POOL_PERFORMANCE_QUERY_CREATE_INFO_INTEL:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkQueryPoolPerformanceQueryCreateInfoINTEL *>(header);
+            delete reinterpret_cast<const VkQueryPoolPerformanceQueryCreateInfoINTEL*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PCI_BUS_INFO_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePCIBusInfoPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePCIBusInfoPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_DISPLAY_NATIVE_HDR_SURFACE_CAPABILITIES_AMD:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDisplayNativeHdrSurfaceCapabilitiesAMD *>(header);
+            delete reinterpret_cast<const VkDisplayNativeHdrSurfaceCapabilitiesAMD*>(header);
             break;
         case VK_STRUCTURE_TYPE_SWAPCHAIN_DISPLAY_NATIVE_HDR_CREATE_INFO_AMD:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSwapchainDisplayNativeHdrCreateInfoAMD *>(header);
+            delete reinterpret_cast<const VkSwapchainDisplayNativeHdrCreateInfoAMD*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDER_PASS_FRAGMENT_DENSITY_MAP_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderPassFragmentDensityMapCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkRenderPassFragmentDensityMapCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDERING_FRAGMENT_DENSITY_MAP_ATTACHMENT_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderingFragmentDensityMapAttachmentInfoEXT *>(header);
+            delete reinterpret_cast<const VkRenderingFragmentDensityMapAttachmentInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_2_AMD:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderCoreProperties2AMD *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderCoreProperties2AMD*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COHERENT_MEMORY_FEATURES_AMD:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCoherentMemoryFeaturesAMD *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCoherentMemoryFeaturesAMD*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_IMAGE_ATOMIC_INT64_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMemoryBudgetPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMemoryBudgetPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PRIORITY_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMemoryPriorityFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMemoryPriorityFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_MEMORY_PRIORITY_ALLOCATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkMemoryPriorityAllocateInfoEXT *>(header);
+            delete reinterpret_cast<const VkMemoryPriorityAllocateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEDICATED_ALLOCATION_IMAGE_ALIASING_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceBufferDeviceAddressFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceBufferDeviceAddressFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkBufferDeviceAddressCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkBufferDeviceAddressCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkValidationFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkValidationFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixPropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixPropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COVERAGE_REDUCTION_MODE_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCoverageReductionModeFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCoverageReductionModeFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_REDUCTION_STATE_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineCoverageReductionStateCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkPipelineCoverageReductionStateCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_INTERLOCK_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_IMAGE_ARRAYS_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceYcbcrImageArraysFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceYcbcrImageArraysFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROVOKING_VERTEX_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceProvokingVertexFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceProvokingVertexFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROVOKING_VERTEX_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceProvokingVertexPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceProvokingVertexPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_PROVOKING_VERTEX_STATE_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineRasterizationProvokingVertexStateCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkPipelineRasterizationProvokingVertexStateCreateInfoEXT*>(header);
             break;
 #ifdef VK_USE_PLATFORM_WIN32_KHR
         case VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSurfaceFullScreenExclusiveInfoEXT *>(header);
+            delete reinterpret_cast<const VkSurfaceFullScreenExclusiveInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_FULL_SCREEN_EXCLUSIVE_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSurfaceCapabilitiesFullScreenExclusiveEXT *>(header);
+            delete reinterpret_cast<const VkSurfaceCapabilitiesFullScreenExclusiveEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_WIN32_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSurfaceFullScreenExclusiveWin32InfoEXT *>(header);
+            delete reinterpret_cast<const VkSurfaceFullScreenExclusiveWin32InfoEXT*>(header);
             break;
 #endif  // VK_USE_PLATFORM_WIN32_KHR
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloatFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceExtendedDynamicStateFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceExtendedDynamicStateFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAP_MEMORY_PLACED_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMapMemoryPlacedFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMapMemoryPlacedFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAP_MEMORY_PLACED_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMapMemoryPlacedPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMapMemoryPlacedPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_MEMORY_MAP_PLACED_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkMemoryMapPlacedInfoEXT *>(header);
+            delete reinterpret_cast<const VkMemoryMapPlacedInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_2_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_SHADER_GROUPS_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkGraphicsPipelineShaderGroupsCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkGraphicsPipelineShaderGroupsCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INHERITED_VIEWPORT_SCISSOR_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceInheritedViewportScissorFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceInheritedViewportScissorFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_VIEWPORT_SCISSOR_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkCommandBufferInheritanceViewportScissorInfoNV *>(header);
+            delete reinterpret_cast<const VkCommandBufferInheritanceViewportScissorInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDER_PASS_TRANSFORM_BEGIN_INFO_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderPassTransformBeginInfoQCOM *>(header);
+            delete reinterpret_cast<const VkRenderPassTransformBeginInfoQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_RENDER_PASS_TRANSFORM_INFO_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkCommandBufferInheritanceRenderPassTransformInfoQCOM *>(header);
+            delete reinterpret_cast<const VkCommandBufferInheritanceRenderPassTransformInfoQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_BIAS_CONTROL_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDepthBiasControlFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDepthBiasControlFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEPTH_BIAS_REPRESENTATION_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDepthBiasRepresentationInfoEXT *>(header);
+            delete reinterpret_cast<const VkDepthBiasRepresentationInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_MEMORY_REPORT_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDeviceMemoryReportFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDeviceMemoryReportFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEVICE_DEVICE_MEMORY_REPORT_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDeviceDeviceMemoryReportCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkDeviceDeviceMemoryReportCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSamplerCustomBorderColorCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkSamplerCustomBorderColorCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCustomBorderColorPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCustomBorderColorPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCustomBorderColorFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCustomBorderColorFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_BARRIER_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePresentBarrierFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePresentBarrierFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_PRESENT_BARRIER_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSurfaceCapabilitiesPresentBarrierNV *>(header);
+            delete reinterpret_cast<const VkSurfaceCapabilitiesPresentBarrierNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_BARRIER_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSwapchainPresentBarrierCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkSwapchainPresentBarrierCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DIAGNOSTICS_CONFIG_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDiagnosticsConfigFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDiagnosticsConfigFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEVICE_DIAGNOSTICS_CONFIG_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDeviceDiagnosticsConfigCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkDeviceDiagnosticsConfigCreateInfoNV*>(header);
             break;
 #ifdef VK_ENABLE_BETA_EXTENSIONS
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUDA_KERNEL_LAUNCH_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCudaKernelLaunchFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCudaKernelLaunchFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUDA_KERNEL_LAUNCH_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCudaKernelLaunchPropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCudaKernelLaunchPropertiesNV*>(header);
             break;
 #endif  // VK_ENABLE_BETA_EXTENSIONS
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TILE_SHADING_FEATURES_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceTileShadingFeaturesQCOM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceTileShadingFeaturesQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TILE_SHADING_PROPERTIES_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceTileShadingPropertiesQCOM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceTileShadingPropertiesQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDER_PASS_TILE_SHADING_CREATE_INFO_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderPassTileShadingCreateInfoQCOM *>(header);
+            delete reinterpret_cast<const VkRenderPassTileShadingCreateInfoQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_QUERY_LOW_LATENCY_SUPPORT_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkQueryLowLatencySupportNV *>(header);
+            delete reinterpret_cast<const VkQueryLowLatencySupportNV*>(header);
             break;
 #ifdef VK_USE_PLATFORM_METAL_EXT
         case VK_STRUCTURE_TYPE_EXPORT_METAL_OBJECT_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExportMetalObjectCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkExportMetalObjectCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXPORT_METAL_DEVICE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExportMetalDeviceInfoEXT *>(header);
+            delete reinterpret_cast<const VkExportMetalDeviceInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXPORT_METAL_COMMAND_QUEUE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExportMetalCommandQueueInfoEXT *>(header);
+            delete reinterpret_cast<const VkExportMetalCommandQueueInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXPORT_METAL_BUFFER_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExportMetalBufferInfoEXT *>(header);
+            delete reinterpret_cast<const VkExportMetalBufferInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMPORT_METAL_BUFFER_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImportMetalBufferInfoEXT *>(header);
+            delete reinterpret_cast<const VkImportMetalBufferInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXPORT_METAL_TEXTURE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExportMetalTextureInfoEXT *>(header);
+            delete reinterpret_cast<const VkExportMetalTextureInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMPORT_METAL_TEXTURE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImportMetalTextureInfoEXT *>(header);
+            delete reinterpret_cast<const VkImportMetalTextureInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXPORT_METAL_IO_SURFACE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExportMetalIOSurfaceInfoEXT *>(header);
+            delete reinterpret_cast<const VkExportMetalIOSurfaceInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMPORT_METAL_IO_SURFACE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImportMetalIOSurfaceInfoEXT *>(header);
+            delete reinterpret_cast<const VkImportMetalIOSurfaceInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXPORT_METAL_SHARED_EVENT_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExportMetalSharedEventInfoEXT *>(header);
+            delete reinterpret_cast<const VkExportMetalSharedEventInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMPORT_METAL_SHARED_EVENT_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImportMetalSharedEventInfoEXT *>(header);
+            delete reinterpret_cast<const VkImportMetalSharedEventInfoEXT*>(header);
             break;
 #endif  // VK_USE_PLATFORM_METAL_EXT
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDescriptorBufferPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDescriptorBufferPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_DENSITY_MAP_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDescriptorBufferDensityMapPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDescriptorBufferDensityMapPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDescriptorBufferFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDescriptorBufferFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_DESCRIPTOR_BUFFER_BINDING_PUSH_DESCRIPTOR_BUFFER_HANDLE_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDescriptorBufferBindingPushDescriptorBufferHandleEXT *>(header);
+            delete reinterpret_cast<const VkDescriptorBufferBindingPushDescriptorBufferHandleEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_OPAQUE_CAPTURE_DESCRIPTOR_DATA_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkOpaqueCaptureDescriptorDataCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkOpaqueCaptureDescriptorDataCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GRAPHICS_PIPELINE_LIBRARY_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GRAPHICS_PIPELINE_LIBRARY_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_LIBRARY_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkGraphicsPipelineLibraryCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkGraphicsPipelineLibraryCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_EARLY_AND_LATE_FRAGMENT_TESTS_FEATURES_AMD:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_ENUMS_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_ENUMS_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_FRAGMENT_SHADING_RATE_ENUM_STATE_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineFragmentShadingRateEnumStateCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkPipelineFragmentShadingRateEnumStateCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_MOTION_TRIANGLES_DATA_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkAccelerationStructureGeometryMotionTrianglesDataNV *>(header);
+            delete reinterpret_cast<const VkAccelerationStructureGeometryMotionTrianglesDataNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_MOTION_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkAccelerationStructureMotionInfoNV *>(header);
+            delete reinterpret_cast<const VkAccelerationStructureMotionInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_MOTION_BLUR_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRayTracingMotionBlurFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRayTracingMotionBlurFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_2_PLANE_444_FORMATS_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_2_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMap2FeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMap2FeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_2_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMap2PropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMap2PropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_COPY_COMMAND_TRANSFORM_INFO_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkCopyCommandTransformInfoQCOM *>(header);
+            delete reinterpret_cast<const VkCopyCommandTransformInfoQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_COMPRESSION_CONTROL_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceImageCompressionControlFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceImageCompressionControlFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMAGE_COMPRESSION_CONTROL_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImageCompressionControlEXT *>(header);
+            delete reinterpret_cast<const VkImageCompressionControlEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMAGE_COMPRESSION_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImageCompressionPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkImageCompressionPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ATTACHMENT_FEEDBACK_LOOP_LAYOUT_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_4444_FORMATS_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevice4444FormatsFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDevice4444FormatsFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FAULT_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFaultFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFaultFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RGBA10X6_FORMATS_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MUTABLE_DESCRIPTOR_TYPE_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_MUTABLE_DESCRIPTOR_TYPE_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkMutableDescriptorTypeCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkMutableDescriptorTypeCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_INPUT_DYNAMIC_STATE_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRM_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDrmPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDrmPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ADDRESS_BINDING_REPORT_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceAddressBindingReportFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceAddressBindingReportFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEVICE_ADDRESS_BINDING_CALLBACK_DATA_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDeviceAddressBindingCallbackDataEXT *>(header);
+            delete reinterpret_cast<const VkDeviceAddressBindingCallbackDataEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_CONTROL_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDepthClipControlFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDepthClipControlFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_DEPTH_CLIP_CONTROL_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineViewportDepthClipControlCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkPipelineViewportDepthClipControlCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIMITIVE_TOPOLOGY_LIST_RESTART_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT*>(header);
             break;
 #ifdef VK_USE_PLATFORM_FUCHSIA
         case VK_STRUCTURE_TYPE_IMPORT_MEMORY_ZIRCON_HANDLE_INFO_FUCHSIA:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImportMemoryZirconHandleInfoFUCHSIA *>(header);
+            delete reinterpret_cast<const VkImportMemoryZirconHandleInfoFUCHSIA*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMPORT_MEMORY_BUFFER_COLLECTION_FUCHSIA:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImportMemoryBufferCollectionFUCHSIA *>(header);
+            delete reinterpret_cast<const VkImportMemoryBufferCollectionFUCHSIA*>(header);
             break;
         case VK_STRUCTURE_TYPE_BUFFER_COLLECTION_IMAGE_CREATE_INFO_FUCHSIA:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkBufferCollectionImageCreateInfoFUCHSIA *>(header);
+            delete reinterpret_cast<const VkBufferCollectionImageCreateInfoFUCHSIA*>(header);
             break;
         case VK_STRUCTURE_TYPE_BUFFER_COLLECTION_BUFFER_CREATE_INFO_FUCHSIA:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkBufferCollectionBufferCreateInfoFUCHSIA *>(header);
+            delete reinterpret_cast<const VkBufferCollectionBufferCreateInfoFUCHSIA*>(header);
             break;
 #endif  // VK_USE_PLATFORM_FUCHSIA
         case VK_STRUCTURE_TYPE_SUBPASS_SHADING_PIPELINE_CREATE_INFO_HUAWEI:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSubpassShadingPipelineCreateInfoHUAWEI *>(header);
+            delete reinterpret_cast<const VkSubpassShadingPipelineCreateInfoHUAWEI*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBPASS_SHADING_FEATURES_HUAWEI:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceSubpassShadingFeaturesHUAWEI *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceSubpassShadingFeaturesHUAWEI*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBPASS_SHADING_PROPERTIES_HUAWEI:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceSubpassShadingPropertiesHUAWEI *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceSubpassShadingPropertiesHUAWEI*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INVOCATION_MASK_FEATURES_HUAWEI:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceInvocationMaskFeaturesHUAWEI *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceInvocationMaskFeaturesHUAWEI*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_RDMA_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceExternalMemoryRDMAFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceExternalMemoryRDMAFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_PROPERTIES_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePipelinePropertiesFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePipelinePropertiesFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAME_BOUNDARY_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFrameBoundaryFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFrameBoundaryFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_FRAME_BOUNDARY_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkFrameBoundaryEXT *>(header);
+            delete reinterpret_cast<const VkFrameBoundaryEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_SUBPASS_RESOLVE_PERFORMANCE_QUERY_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSubpassResolvePerformanceQueryEXT *>(header);
+            delete reinterpret_cast<const VkSubpassResolvePerformanceQueryEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkMultisampledRenderToSingleSampledInfoEXT *>(header);
+            delete reinterpret_cast<const VkMultisampledRenderToSingleSampledInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceExtendedDynamicState2FeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceExtendedDynamicState2FeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COLOR_WRITE_ENABLE_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceColorWriteEnableFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceColorWriteEnableFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_COLOR_WRITE_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineColorWriteCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkPipelineColorWriteCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIMITIVES_GENERATED_QUERY_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_ENCODE_RGB_CONVERSION_FEATURES_VALVE:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVideoEncodeRgbConversionFeaturesVALVE *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVideoEncodeRgbConversionFeaturesVALVE*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_RGB_CONVERSION_CAPABILITIES_VALVE:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeRgbConversionCapabilitiesVALVE *>(header);
+            delete reinterpret_cast<const VkVideoEncodeRgbConversionCapabilitiesVALVE*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_PROFILE_RGB_CONVERSION_INFO_VALVE:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeProfileRgbConversionInfoVALVE *>(header);
+            delete reinterpret_cast<const VkVideoEncodeProfileRgbConversionInfoVALVE*>(header);
             break;
         case VK_STRUCTURE_TYPE_VIDEO_ENCODE_SESSION_RGB_CONVERSION_CREATE_INFO_VALVE:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkVideoEncodeSessionRgbConversionCreateInfoVALVE *>(header);
+            delete reinterpret_cast<const VkVideoEncodeSessionRgbConversionCreateInfoVALVE*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_VIEW_MIN_LOD_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceImageViewMinLodFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceImageViewMinLodFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMAGE_VIEW_MIN_LOD_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImageViewMinLodCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkImageViewMinLodCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTI_DRAW_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMultiDrawFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMultiDrawFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTI_DRAW_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMultiDrawPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMultiDrawPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_2D_VIEW_OF_3D_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceImage2DViewOf3DFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceImage2DViewOf3DFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_TILE_IMAGE_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderTileImageFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderTileImageFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_TILE_IMAGE_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderTileImagePropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderTileImagePropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_OPACITY_MICROMAP_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceOpacityMicromapFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceOpacityMicromapFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_OPACITY_MICROMAP_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceOpacityMicromapPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceOpacityMicromapPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_TRIANGLES_OPACITY_MICROMAP_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkAccelerationStructureTrianglesOpacityMicromapEXT *>(header);
+            delete reinterpret_cast<const VkAccelerationStructureTrianglesOpacityMicromapEXT*>(header);
             break;
 #ifdef VK_ENABLE_BETA_EXTENSIONS
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISPLACEMENT_MICROMAP_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDisplacementMicromapFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDisplacementMicromapFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISPLACEMENT_MICROMAP_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDisplacementMicromapPropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDisplacementMicromapPropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_TRIANGLES_DISPLACEMENT_MICROMAP_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkAccelerationStructureTrianglesDisplacementMicromapNV *>(header);
+            delete reinterpret_cast<const VkAccelerationStructureTrianglesDisplacementMicromapNV*>(header);
             break;
 #endif  // VK_ENABLE_BETA_EXTENSIONS
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CLUSTER_CULLING_SHADER_FEATURES_HUAWEI:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CLUSTER_CULLING_SHADER_PROPERTIES_HUAWEI:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceClusterCullingShaderPropertiesHUAWEI *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceClusterCullingShaderPropertiesHUAWEI*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CLUSTER_CULLING_SHADER_VRS_FEATURES_HUAWEI:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceClusterCullingShaderVrsFeaturesHUAWEI *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceClusterCullingShaderVrsFeaturesHUAWEI*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BORDER_COLOR_SWIZZLE_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceBorderColorSwizzleFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceBorderColorSwizzleFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_SAMPLER_BORDER_COLOR_COMPONENT_MAPPING_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSamplerBorderColorComponentMappingCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkSamplerBorderColorComponentMappingCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PAGEABLE_DEVICE_LOCAL_MEMORY_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderCorePropertiesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderCorePropertiesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_DEVICE_QUEUE_SHADER_CORE_CONTROL_CREATE_INFO_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDeviceQueueShaderCoreControlCreateInfoARM *>(header);
+            delete reinterpret_cast<const VkDeviceQueueShaderCoreControlCreateInfoARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCHEDULING_CONTROLS_FEATURES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceSchedulingControlsFeaturesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceSchedulingControlsFeaturesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCHEDULING_CONTROLS_PROPERTIES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceSchedulingControlsPropertiesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceSchedulingControlsPropertiesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_SLICED_VIEW_OF_3D_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMAGE_VIEW_SLICED_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImageViewSlicedCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkImageViewSlicedCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_SET_HOST_MAPPING_FEATURES_VALVE:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_NON_SEAMLESS_CUBE_MAP_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RENDER_PASS_STRIPED_FEATURES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRenderPassStripedFeaturesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRenderPassStripedFeaturesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RENDER_PASS_STRIPED_PROPERTIES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRenderPassStripedPropertiesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRenderPassStripedPropertiesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDER_PASS_STRIPE_BEGIN_INFO_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderPassStripeBeginInfoARM *>(header);
+            delete reinterpret_cast<const VkRenderPassStripeBeginInfoARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDER_PASS_STRIPE_SUBMIT_INFO_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderPassStripeSubmitInfoARM *>(header);
+            delete reinterpret_cast<const VkRenderPassStripeSubmitInfoARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_OFFSET_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapOffsetFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapOffsetFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_OFFSET_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapOffsetPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapOffsetPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDER_PASS_FRAGMENT_DENSITY_MAP_OFFSET_END_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderPassFragmentDensityMapOffsetEndInfoEXT *>(header);
+            delete reinterpret_cast<const VkRenderPassFragmentDensityMapOffsetEndInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COPY_MEMORY_INDIRECT_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCopyMemoryIndirectFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCopyMemoryIndirectFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_DECOMPRESSION_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMemoryDecompressionFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMemoryDecompressionFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_DECOMPRESSION_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMemoryDecompressionPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMemoryDecompressionPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_COMPUTE_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_INDIRECT_BUFFER_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkComputePipelineIndirectBufferInfoNV *>(header);
+            delete reinterpret_cast<const VkComputePipelineIndirectBufferInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_LINEAR_SWEPT_SPHERES_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRayTracingLinearSweptSpheresFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_LINEAR_SWEPT_SPHERES_DATA_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkAccelerationStructureGeometryLinearSweptSpheresDataNV *>(header);
+            delete reinterpret_cast<const VkAccelerationStructureGeometryLinearSweptSpheresDataNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_SPHERES_DATA_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkAccelerationStructureGeometrySpheresDataNV *>(header);
+            delete reinterpret_cast<const VkAccelerationStructureGeometrySpheresDataNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINEAR_COLOR_ATTACHMENT_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceLinearColorAttachmentFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceLinearColorAttachmentFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_COMPRESSION_CONTROL_SWAPCHAIN_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMAGE_VIEW_SAMPLE_WEIGHT_CREATE_INFO_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImageViewSampleWeightCreateInfoQCOM *>(header);
+            delete reinterpret_cast<const VkImageViewSampleWeightCreateInfoQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_PROCESSING_FEATURES_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceImageProcessingFeaturesQCOM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceImageProcessingFeaturesQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_PROCESSING_PROPERTIES_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceImageProcessingPropertiesQCOM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceImageProcessingPropertiesQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_NESTED_COMMAND_BUFFER_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceNestedCommandBufferFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceNestedCommandBufferFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_NESTED_COMMAND_BUFFER_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceNestedCommandBufferPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceNestedCommandBufferPropertiesEXT*>(header);
             break;
 #ifdef VK_USE_PLATFORM_OHOS
         case VK_STRUCTURE_TYPE_NATIVE_BUFFER_USAGE_OHOS:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkNativeBufferUsageOHOS *>(header);
+            delete reinterpret_cast<const VkNativeBufferUsageOHOS*>(header);
             break;
         case VK_STRUCTURE_TYPE_NATIVE_BUFFER_FORMAT_PROPERTIES_OHOS:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkNativeBufferFormatPropertiesOHOS *>(header);
+            delete reinterpret_cast<const VkNativeBufferFormatPropertiesOHOS*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMPORT_NATIVE_BUFFER_INFO_OHOS:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImportNativeBufferInfoOHOS *>(header);
+            delete reinterpret_cast<const VkImportNativeBufferInfoOHOS*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_OHOS:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExternalFormatOHOS *>(header);
+            delete reinterpret_cast<const VkExternalFormatOHOS*>(header);
             break;
 #endif  // VK_USE_PLATFORM_OHOS
         case VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_ACQUIRE_UNMODIFIED_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExternalMemoryAcquireUnmodifiedEXT *>(header);
+            delete reinterpret_cast<const VkExternalMemoryAcquireUnmodifiedEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceExtendedDynamicState3FeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceExtendedDynamicState3PropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceExtendedDynamicState3PropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBPASS_MERGE_FEEDBACK_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDER_PASS_CREATION_CONTROL_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderPassCreationControlEXT *>(header);
+            delete reinterpret_cast<const VkRenderPassCreationControlEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDER_PASS_CREATION_FEEDBACK_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderPassCreationFeedbackCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkRenderPassCreationFeedbackCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDER_PASS_SUBPASS_FEEDBACK_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderPassSubpassFeedbackCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkRenderPassSubpassFeedbackCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_DIRECT_DRIVER_LOADING_LIST_LUNARG:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDirectDriverLoadingListLUNARG *>(header);
+            delete reinterpret_cast<const VkDirectDriverLoadingListLUNARG*>(header);
             break;
         case VK_STRUCTURE_TYPE_TENSOR_DESCRIPTION_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkTensorDescriptionARM *>(header);
+            delete reinterpret_cast<const VkTensorDescriptionARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_TENSOR_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkWriteDescriptorSetTensorARM *>(header);
+            delete reinterpret_cast<const VkWriteDescriptorSetTensorARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_TENSOR_FORMAT_PROPERTIES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkTensorFormatPropertiesARM *>(header);
+            delete reinterpret_cast<const VkTensorFormatPropertiesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TENSOR_PROPERTIES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceTensorPropertiesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceTensorPropertiesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_TENSOR_MEMORY_BARRIER_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkTensorMemoryBarrierARM *>(header);
+            delete reinterpret_cast<const VkTensorMemoryBarrierARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_TENSOR_DEPENDENCY_INFO_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkTensorDependencyInfoARM *>(header);
+            delete reinterpret_cast<const VkTensorDependencyInfoARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TENSOR_FEATURES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceTensorFeaturesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceTensorFeaturesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO_TENSOR_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkMemoryDedicatedAllocateInfoTensorARM *>(header);
+            delete reinterpret_cast<const VkMemoryDedicatedAllocateInfoTensorARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_TENSOR_CREATE_INFO_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExternalMemoryTensorCreateInfoARM *>(header);
+            delete reinterpret_cast<const VkExternalMemoryTensorCreateInfoARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_TENSOR_FEATURES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDescriptorBufferTensorFeaturesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDescriptorBufferTensorFeaturesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_TENSOR_PROPERTIES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDescriptorBufferTensorPropertiesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDescriptorBufferTensorPropertiesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_DESCRIPTOR_GET_TENSOR_INFO_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDescriptorGetTensorInfoARM *>(header);
+            delete reinterpret_cast<const VkDescriptorGetTensorInfoARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_FRAME_BOUNDARY_TENSORS_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkFrameBoundaryTensorsARM *>(header);
+            delete reinterpret_cast<const VkFrameBoundaryTensorsARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_MODULE_IDENTIFIER_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_MODULE_IDENTIFIER_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_MODULE_IDENTIFIER_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineShaderStageModuleIdentifierCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkPipelineShaderStageModuleIdentifierCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_OPTICAL_FLOW_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceOpticalFlowFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceOpticalFlowFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_OPTICAL_FLOW_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceOpticalFlowPropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceOpticalFlowPropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_OPTICAL_FLOW_IMAGE_FORMAT_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkOpticalFlowImageFormatInfoNV *>(header);
+            delete reinterpret_cast<const VkOpticalFlowImageFormatInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_OPTICAL_FLOW_SESSION_CREATE_PRIVATE_DATA_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkOpticalFlowSessionCreatePrivateDataInfoNV *>(header);
+            delete reinterpret_cast<const VkOpticalFlowSessionCreatePrivateDataInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LEGACY_DITHERING_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceLegacyDitheringFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceLegacyDitheringFeaturesEXT*>(header);
             break;
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FORMAT_RESOLVE_FEATURES_ANDROID:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceExternalFormatResolveFeaturesANDROID *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceExternalFormatResolveFeaturesANDROID*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FORMAT_RESOLVE_PROPERTIES_ANDROID:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceExternalFormatResolvePropertiesANDROID *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceExternalFormatResolvePropertiesANDROID*>(header);
             break;
         case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_RESOLVE_PROPERTIES_ANDROID:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkAndroidHardwareBufferFormatResolvePropertiesANDROID *>(header);
+            delete reinterpret_cast<const VkAndroidHardwareBufferFormatResolvePropertiesANDROID*>(header);
             break;
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ANTI_LAG_FEATURES_AMD:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceAntiLagFeaturesAMD *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceAntiLagFeaturesAMD*>(header);
             break;
 #ifdef VK_ENABLE_BETA_EXTENSIONS
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DENSE_GEOMETRY_FORMAT_FEATURES_AMDX:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDenseGeometryFormatFeaturesAMDX *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDenseGeometryFormatFeaturesAMDX*>(header);
             break;
         case VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_DENSE_GEOMETRY_FORMAT_TRIANGLES_DATA_AMDX:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkAccelerationStructureDenseGeometryFormatTrianglesDataAMDX *>(header);
+            delete reinterpret_cast<const VkAccelerationStructureDenseGeometryFormatTrianglesDataAMDX*>(header);
             break;
 #endif  // VK_ENABLE_BETA_EXTENSIONS
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_OBJECT_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderObjectFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderObjectFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_OBJECT_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderObjectPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderObjectPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TILE_PROPERTIES_FEATURES_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceTilePropertiesFeaturesQCOM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceTilePropertiesFeaturesQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_AMIGO_PROFILING_FEATURES_SEC:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceAmigoProfilingFeaturesSEC *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceAmigoProfilingFeaturesSEC*>(header);
             break;
         case VK_STRUCTURE_TYPE_AMIGO_PROFILING_SUBMIT_INFO_SEC:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkAmigoProfilingSubmitInfoSEC *>(header);
+            delete reinterpret_cast<const VkAmigoProfilingSubmitInfoSEC*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_VIEWPORTS_FEATURES_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_INVOCATION_REORDER_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderPropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderPropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_INVOCATION_REORDER_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_VECTOR_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCooperativeVectorPropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCooperativeVectorPropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_VECTOR_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCooperativeVectorFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCooperativeVectorFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_SPARSE_ADDRESS_SPACE_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_SPARSE_ADDRESS_SPACE_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceExtendedSparseAddressSpacePropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceExtendedSparseAddressSpacePropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LEGACY_VERTEX_ATTRIBUTES_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceLegacyVertexAttributesFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceLegacyVertexAttributesFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LEGACY_VERTEX_ATTRIBUTES_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceLegacyVertexAttributesPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceLegacyVertexAttributesPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkLayerSettingsCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkLayerSettingsCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_BUILTINS_FEATURES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_BUILTINS_PROPERTIES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderCoreBuiltinsPropertiesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderCoreBuiltinsPropertiesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_LIBRARY_GROUP_HANDLES_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_LATENCY_SUBMISSION_PRESENT_ID_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkLatencySubmissionPresentIdNV *>(header);
+            delete reinterpret_cast<const VkLatencySubmissionPresentIdNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_SWAPCHAIN_LATENCY_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSwapchainLatencyCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkSwapchainLatencyCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_LATENCY_SURFACE_CAPABILITIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkLatencySurfaceCapabilitiesNV *>(header);
+            delete reinterpret_cast<const VkLatencySurfaceCapabilitiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DATA_GRAPH_FEATURES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDataGraphFeaturesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDataGraphFeaturesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_COMPILER_CONTROL_CREATE_INFO_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDataGraphPipelineCompilerControlCreateInfoARM *>(header);
+            delete reinterpret_cast<const VkDataGraphPipelineCompilerControlCreateInfoARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_SHADER_MODULE_CREATE_INFO_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDataGraphPipelineShaderModuleCreateInfoARM *>(header);
+            delete reinterpret_cast<const VkDataGraphPipelineShaderModuleCreateInfoARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_IDENTIFIER_CREATE_INFO_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDataGraphPipelineIdentifierCreateInfoARM *>(header);
+            delete reinterpret_cast<const VkDataGraphPipelineIdentifierCreateInfoARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_DATA_GRAPH_PROCESSING_ENGINE_CREATE_INFO_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDataGraphProcessingEngineCreateInfoARM *>(header);
+            delete reinterpret_cast<const VkDataGraphProcessingEngineCreateInfoARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_CONSTANT_TENSOR_SEMI_STRUCTURED_SPARSITY_INFO_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDataGraphPipelineConstantTensorSemiStructuredSparsityInfoARM *>(header);
+            delete reinterpret_cast<const VkDataGraphPipelineConstantTensorSemiStructuredSparsityInfoARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_RENDER_AREAS_FEATURES_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_MULTIVIEW_PER_VIEW_RENDER_AREAS_RENDER_PASS_BEGIN_INFO_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkMultiviewPerViewRenderAreasRenderPassBeginInfoQCOM *>(header);
+            delete reinterpret_cast<const VkMultiviewPerViewRenderAreasRenderPassBeginInfoQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PER_STAGE_DESCRIPTOR_SET_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePerStageDescriptorSetFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePerStageDescriptorSetFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_PROCESSING_2_FEATURES_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceImageProcessing2FeaturesQCOM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceImageProcessing2FeaturesQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_PROCESSING_2_PROPERTIES_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceImageProcessing2PropertiesQCOM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceImageProcessing2PropertiesQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_SAMPLER_BLOCK_MATCH_WINDOW_CREATE_INFO_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSamplerBlockMatchWindowCreateInfoQCOM *>(header);
+            delete reinterpret_cast<const VkSamplerBlockMatchWindowCreateInfoQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUBIC_WEIGHTS_FEATURES_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCubicWeightsFeaturesQCOM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCubicWeightsFeaturesQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_SAMPLER_CUBIC_WEIGHTS_CREATE_INFO_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSamplerCubicWeightsCreateInfoQCOM *>(header);
+            delete reinterpret_cast<const VkSamplerCubicWeightsCreateInfoQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_BLIT_IMAGE_CUBIC_WEIGHTS_INFO_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkBlitImageCubicWeightsInfoQCOM *>(header);
+            delete reinterpret_cast<const VkBlitImageCubicWeightsInfoQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_DEGAMMA_FEATURES_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceYcbcrDegammaFeaturesQCOM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceYcbcrDegammaFeaturesQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_YCBCR_DEGAMMA_CREATE_INFO_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSamplerYcbcrConversionYcbcrDegammaCreateInfoQCOM *>(header);
+            delete reinterpret_cast<const VkSamplerYcbcrConversionYcbcrDegammaCreateInfoQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUBIC_CLAMP_FEATURES_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCubicClampFeaturesQCOM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCubicClampFeaturesQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ATTACHMENT_FEEDBACK_LOOP_DYNAMIC_STATE_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT*>(header);
             break;
 #ifdef VK_USE_PLATFORM_SCREEN_QNX
         case VK_STRUCTURE_TYPE_SCREEN_BUFFER_FORMAT_PROPERTIES_QNX:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkScreenBufferFormatPropertiesQNX *>(header);
+            delete reinterpret_cast<const VkScreenBufferFormatPropertiesQNX*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMPORT_SCREEN_BUFFER_INFO_QNX:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImportScreenBufferInfoQNX *>(header);
+            delete reinterpret_cast<const VkImportScreenBufferInfoQNX*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_QNX:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExternalFormatQNX *>(header);
+            delete reinterpret_cast<const VkExternalFormatQNX*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_SCREEN_BUFFER_FEATURES_QNX:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX*>(header);
             break;
 #endif  // VK_USE_PLATFORM_SCREEN_QNX
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LAYERED_DRIVER_PROPERTIES_MSFT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceLayeredDriverPropertiesMSFT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceLayeredDriverPropertiesMSFT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_POOL_OVERALLOCATION_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TILE_MEMORY_HEAP_FEATURES_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceTileMemoryHeapFeaturesQCOM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceTileMemoryHeapFeaturesQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TILE_MEMORY_HEAP_PROPERTIES_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceTileMemoryHeapPropertiesQCOM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceTileMemoryHeapPropertiesQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_TILE_MEMORY_REQUIREMENTS_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkTileMemoryRequirementsQCOM *>(header);
+            delete reinterpret_cast<const VkTileMemoryRequirementsQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_TILE_MEMORY_BIND_INFO_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkTileMemoryBindInfoQCOM *>(header);
+            delete reinterpret_cast<const VkTileMemoryBindInfoQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_TILE_MEMORY_SIZE_INFO_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkTileMemorySizeInfoQCOM *>(header);
+            delete reinterpret_cast<const VkTileMemorySizeInfoQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_DISPLAY_SURFACE_STEREO_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDisplaySurfaceStereoCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkDisplaySurfaceStereoCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_DISPLAY_MODE_STEREO_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDisplayModeStereoPropertiesNV *>(header);
+            delete reinterpret_cast<const VkDisplayModeStereoPropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAW_ACCESS_CHAINS_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRawAccessChainsFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRawAccessChainsFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_EXTERNAL_COMPUTE_QUEUE_DEVICE_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkExternalComputeQueueDeviceCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkExternalComputeQueueDeviceCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_COMPUTE_QUEUE_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceExternalComputeQueuePropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceExternalComputeQueuePropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMMAND_BUFFER_INHERITANCE_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCommandBufferInheritanceFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCommandBufferInheritanceFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT16_VECTOR_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloat16VectorFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_REPLICATED_COMPOSITES_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderReplicatedCompositesFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderReplicatedCompositesFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT8_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderFloat8FeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderFloat8FeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_VALIDATION_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRayTracingValidationFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRayTracingValidationFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CLUSTER_ACCELERATION_STRUCTURE_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceClusterAccelerationStructureFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceClusterAccelerationStructureFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CLUSTER_ACCELERATION_STRUCTURE_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceClusterAccelerationStructurePropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceClusterAccelerationStructurePropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CLUSTER_ACCELERATION_STRUCTURE_CREATE_INFO_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRayTracingPipelineClusterAccelerationStructureCreateInfoNV *>(header);
+            delete reinterpret_cast<const VkRayTracingPipelineClusterAccelerationStructureCreateInfoNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PARTITIONED_ACCELERATION_STRUCTURE_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePartitionedAccelerationStructureFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PARTITIONED_ACCELERATION_STRUCTURE_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePartitionedAccelerationStructurePropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePartitionedAccelerationStructurePropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PARTITIONED_ACCELERATION_STRUCTURE_FLAGS_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPartitionedAccelerationStructureFlagsNV *>(header);
+            delete reinterpret_cast<const VkPartitionedAccelerationStructureFlagsNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_PARTITIONED_ACCELERATION_STRUCTURE_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkWriteDescriptorSetPartitionedAccelerationStructureNV *>(header);
+            delete reinterpret_cast<const VkWriteDescriptorSetPartitionedAccelerationStructureNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_GENERATED_COMMANDS_PIPELINE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkGeneratedCommandsPipelineInfoEXT *>(header);
+            delete reinterpret_cast<const VkGeneratedCommandsPipelineInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_GENERATED_COMMANDS_SHADER_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkGeneratedCommandsShaderInfoEXT *>(header);
+            delete reinterpret_cast<const VkGeneratedCommandsShaderInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ALIGNMENT_CONTROL_FEATURES_MESA:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceImageAlignmentControlFeaturesMESA *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceImageAlignmentControlFeaturesMESA*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ALIGNMENT_CONTROL_PROPERTIES_MESA:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceImageAlignmentControlPropertiesMESA *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceImageAlignmentControlPropertiesMESA*>(header);
             break;
         case VK_STRUCTURE_TYPE_IMAGE_ALIGNMENT_CONTROL_CREATE_INFO_MESA:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImageAlignmentControlCreateInfoMESA *>(header);
+            delete reinterpret_cast<const VkImageAlignmentControlCreateInfoMESA*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_INVOCATION_REORDER_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderPropertiesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_INVOCATION_REORDER_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLAMP_CONTROL_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDepthClampControlFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDepthClampControlFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_DEPTH_CLAMP_CONTROL_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineViewportDepthClampControlCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkPipelineViewportDepthClampControlCreateInfoEXT*>(header);
             break;
 #ifdef VK_USE_PLATFORM_OHOS
         case VK_STRUCTURE_TYPE_NATIVE_BUFFER_OHOS:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkNativeBufferOHOS *>(header);
+            delete reinterpret_cast<const VkNativeBufferOHOS*>(header);
             break;
         case VK_STRUCTURE_TYPE_SWAPCHAIN_IMAGE_CREATE_INFO_OHOS:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSwapchainImageCreateInfoOHOS *>(header);
+            delete reinterpret_cast<const VkSwapchainImageCreateInfoOHOS*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENTATION_PROPERTIES_OHOS:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePresentationPropertiesOHOS *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePresentationPropertiesOHOS*>(header);
             break;
 #endif  // VK_USE_PLATFORM_OHOS
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HDR_VIVID_FEATURES_HUAWEI:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceHdrVividFeaturesHUAWEI *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceHdrVividFeaturesHUAWEI*>(header);
             break;
         case VK_STRUCTURE_TYPE_HDR_VIVID_DYNAMIC_METADATA_HUAWEI:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkHdrVividDynamicMetadataHUAWEI *>(header);
+            delete reinterpret_cast<const VkHdrVividDynamicMetadataHUAWEI*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_2_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCooperativeMatrix2FeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCooperativeMatrix2FeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_2_PROPERTIES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCooperativeMatrix2PropertiesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCooperativeMatrix2PropertiesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_OPACITY_MICROMAP_FEATURES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePipelineOpacityMicromapFeaturesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePipelineOpacityMicromapFeaturesARM*>(header);
             break;
 #ifdef VK_USE_PLATFORM_METAL_EXT
         case VK_STRUCTURE_TYPE_IMPORT_MEMORY_METAL_HANDLE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkImportMemoryMetalHandleInfoEXT *>(header);
+            delete reinterpret_cast<const VkImportMemoryMetalHandleInfoEXT*>(header);
             break;
 #endif  // VK_USE_PLATFORM_METAL_EXT
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PERFORMANCE_COUNTERS_BY_REGION_FEATURES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePerformanceCountersByRegionFeaturesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePerformanceCountersByRegionFeaturesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PERFORMANCE_COUNTERS_BY_REGION_PROPERTIES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePerformanceCountersByRegionPropertiesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePerformanceCountersByRegionPropertiesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_RENDER_PASS_PERFORMANCE_COUNTERS_BY_REGION_BEGIN_INFO_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkRenderPassPerformanceCountersByRegionBeginInfoARM *>(header);
+            delete reinterpret_cast<const VkRenderPassPerformanceCountersByRegionBeginInfoARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_ROBUSTNESS_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceVertexAttributeRobustnessFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FORMAT_PACK_FEATURES_ARM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFormatPackFeaturesARM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFormatPackFeaturesARM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_LAYERED_FEATURES_VALVE:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapLayeredFeaturesVALVE*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_LAYERED_PROPERTIES_VALVE:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapLayeredPropertiesVALVE *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapLayeredPropertiesVALVE*>(header);
             break;
         case VK_STRUCTURE_TYPE_PIPELINE_FRAGMENT_DENSITY_MAP_LAYERED_CREATE_INFO_VALVE:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPipelineFragmentDensityMapLayeredCreateInfoVALVE *>(header);
+            delete reinterpret_cast<const VkPipelineFragmentDensityMapLayeredCreateInfoVALVE*>(header);
             break;
 #ifdef VK_ENABLE_BETA_EXTENSIONS
         case VK_STRUCTURE_TYPE_SET_PRESENT_CONFIG_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkSetPresentConfigNV *>(header);
+            delete reinterpret_cast<const VkSetPresentConfigNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_METERING_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePresentMeteringFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePresentMeteringFeaturesNV*>(header);
             break;
 #endif  // VK_ENABLE_BETA_EXTENSIONS
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ZERO_INITIALIZE_DEVICE_MEMORY_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceZeroInitializeDeviceMemoryFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_64_BIT_INDEXING_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShader64BitIndexingFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShader64BitIndexingFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_RESOLVE_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceCustomResolveFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceCustomResolveFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_CUSTOM_RESOLVE_CREATE_INFO_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkCustomResolveCreateInfoEXT *>(header);
+            delete reinterpret_cast<const VkCustomResolveCreateInfoEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_DATA_GRAPH_PIPELINE_BUILTIN_MODEL_CREATE_INFO_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkDataGraphPipelineBuiltinModelCreateInfoQCOM *>(header);
+            delete reinterpret_cast<const VkDataGraphPipelineBuiltinModelCreateInfoQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DATA_GRAPH_MODEL_FEATURES_QCOM:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceDataGraphModelFeaturesQCOM *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceDataGraphModelFeaturesQCOM*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_CACHE_INCREMENTAL_MODE_FEATURES_SEC:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDevicePipelineCacheIncrementalModeFeaturesSEC *>(header);
+            delete reinterpret_cast<const VkPhysicalDevicePipelineCacheIncrementalModeFeaturesSEC*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_UNIFORM_BUFFER_UNSIZED_ARRAY_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceShaderUniformBufferUnsizedArrayFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceShaderUniformBufferUnsizedArrayFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMPUTE_OCCUPANCY_PRIORITY_FEATURES_NV:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceComputeOccupancyPriorityFeaturesNV *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceComputeOccupancyPriorityFeaturesNV*>(header);
             break;
         case VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_ACCELERATION_STRUCTURE_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkWriteDescriptorSetAccelerationStructureKHR *>(header);
+            delete reinterpret_cast<const VkWriteDescriptorSetAccelerationStructureKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceAccelerationStructureFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceAccelerationStructureFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceAccelerationStructurePropertiesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceAccelerationStructurePropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRayTracingPipelineFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRayTracingPipelineFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_PROPERTIES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRayTracingPipelinePropertiesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRayTracingPipelinePropertiesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_QUERY_FEATURES_KHR:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceRayQueryFeaturesKHR *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceRayQueryFeaturesKHR*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMeshShaderFeaturesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMeshShaderFeaturesEXT*>(header);
             break;
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_PROPERTIES_EXT:
             PnextChainFree(header->pNext);
             header->pNext = nullptr;
-            delete reinterpret_cast<const VkPhysicalDeviceMeshShaderPropertiesEXT *>(header);
+            delete reinterpret_cast<const VkPhysicalDeviceMeshShaderPropertiesEXT*>(header);
             break;
         default:
             assert(false);
@@ -3827,12 +3827,12 @@ void PnextChainFree(void *chain) {
 }
 
 template <>
-void *PnextChainExtract(const void *in_pnext_chain, PnextChainVkPhysicalDeviceImageFormatInfo2 &out) {
-    void *chain_begin = nullptr;
-    void *chain_end = nullptr;
+void* PnextChainExtract(const void* in_pnext_chain, PnextChainVkPhysicalDeviceImageFormatInfo2& out) {
+    void* chain_begin = nullptr;
+    void* chain_end = nullptr;
 
-    if (auto *chain_struct = vku::FindStructInPNextChain<VkImageCompressionControlEXT>(in_pnext_chain)) {
-        auto &out_chain_struct = std::get<VkImageCompressionControlEXT>(out);
+    if (auto* chain_struct = vku::FindStructInPNextChain<VkImageCompressionControlEXT>(in_pnext_chain)) {
+        auto& out_chain_struct = std::get<VkImageCompressionControlEXT>(out);
         out_chain_struct = *chain_struct;
         out_chain_struct.pNext = nullptr;
         if (!chain_begin) {
@@ -3843,8 +3843,8 @@ void *PnextChainExtract(const void *in_pnext_chain, PnextChainVkPhysicalDeviceIm
         }
     }
 
-    if (auto *chain_struct = vku::FindStructInPNextChain<VkImageFormatListCreateInfo>(in_pnext_chain)) {
-        auto &out_chain_struct = std::get<VkImageFormatListCreateInfo>(out);
+    if (auto* chain_struct = vku::FindStructInPNextChain<VkImageFormatListCreateInfo>(in_pnext_chain)) {
+        auto& out_chain_struct = std::get<VkImageFormatListCreateInfo>(out);
         out_chain_struct = *chain_struct;
         out_chain_struct.pNext = nullptr;
         if (!chain_begin) {
@@ -3855,8 +3855,8 @@ void *PnextChainExtract(const void *in_pnext_chain, PnextChainVkPhysicalDeviceIm
         }
     }
 
-    if (auto *chain_struct = vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(in_pnext_chain)) {
-        auto &out_chain_struct = std::get<VkImageStencilUsageCreateInfo>(out);
+    if (auto* chain_struct = vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(in_pnext_chain)) {
+        auto& out_chain_struct = std::get<VkImageStencilUsageCreateInfo>(out);
         out_chain_struct = *chain_struct;
         out_chain_struct.pNext = nullptr;
         if (!chain_begin) {
@@ -3867,8 +3867,8 @@ void *PnextChainExtract(const void *in_pnext_chain, PnextChainVkPhysicalDeviceIm
         }
     }
 
-    if (auto *chain_struct = vku::FindStructInPNextChain<VkOpticalFlowImageFormatInfoNV>(in_pnext_chain)) {
-        auto &out_chain_struct = std::get<VkOpticalFlowImageFormatInfoNV>(out);
+    if (auto* chain_struct = vku::FindStructInPNextChain<VkOpticalFlowImageFormatInfoNV>(in_pnext_chain)) {
+        auto& out_chain_struct = std::get<VkOpticalFlowImageFormatInfoNV>(out);
         out_chain_struct = *chain_struct;
         out_chain_struct.pNext = nullptr;
         if (!chain_begin) {
@@ -3879,8 +3879,8 @@ void *PnextChainExtract(const void *in_pnext_chain, PnextChainVkPhysicalDeviceIm
         }
     }
 
-    if (auto *chain_struct = vku::FindStructInPNextChain<VkPhysicalDeviceExternalImageFormatInfo>(in_pnext_chain)) {
-        auto &out_chain_struct = std::get<VkPhysicalDeviceExternalImageFormatInfo>(out);
+    if (auto* chain_struct = vku::FindStructInPNextChain<VkPhysicalDeviceExternalImageFormatInfo>(in_pnext_chain)) {
+        auto& out_chain_struct = std::get<VkPhysicalDeviceExternalImageFormatInfo>(out);
         out_chain_struct = *chain_struct;
         out_chain_struct.pNext = nullptr;
         if (!chain_begin) {
@@ -3891,8 +3891,8 @@ void *PnextChainExtract(const void *in_pnext_chain, PnextChainVkPhysicalDeviceIm
         }
     }
 
-    if (auto *chain_struct = vku::FindStructInPNextChain<VkPhysicalDeviceImageDrmFormatModifierInfoEXT>(in_pnext_chain)) {
-        auto &out_chain_struct = std::get<VkPhysicalDeviceImageDrmFormatModifierInfoEXT>(out);
+    if (auto* chain_struct = vku::FindStructInPNextChain<VkPhysicalDeviceImageDrmFormatModifierInfoEXT>(in_pnext_chain)) {
+        auto& out_chain_struct = std::get<VkPhysicalDeviceImageDrmFormatModifierInfoEXT>(out);
         out_chain_struct = *chain_struct;
         out_chain_struct.pNext = nullptr;
         if (!chain_begin) {
@@ -3903,8 +3903,8 @@ void *PnextChainExtract(const void *in_pnext_chain, PnextChainVkPhysicalDeviceIm
         }
     }
 
-    if (auto *chain_struct = vku::FindStructInPNextChain<VkPhysicalDeviceImageViewImageFormatInfoEXT>(in_pnext_chain)) {
-        auto &out_chain_struct = std::get<VkPhysicalDeviceImageViewImageFormatInfoEXT>(out);
+    if (auto* chain_struct = vku::FindStructInPNextChain<VkPhysicalDeviceImageViewImageFormatInfoEXT>(in_pnext_chain)) {
+        auto& out_chain_struct = std::get<VkPhysicalDeviceImageViewImageFormatInfoEXT>(out);
         out_chain_struct = *chain_struct;
         out_chain_struct.pNext = nullptr;
         if (!chain_begin) {
@@ -3915,8 +3915,8 @@ void *PnextChainExtract(const void *in_pnext_chain, PnextChainVkPhysicalDeviceIm
         }
     }
 
-    if (auto *chain_struct = vku::FindStructInPNextChain<VkVideoProfileListInfoKHR>(in_pnext_chain)) {
-        auto &out_chain_struct = std::get<VkVideoProfileListInfoKHR>(out);
+    if (auto* chain_struct = vku::FindStructInPNextChain<VkVideoProfileListInfoKHR>(in_pnext_chain)) {
+        auto& out_chain_struct = std::get<VkVideoProfileListInfoKHR>(out);
         out_chain_struct = *chain_struct;
         out_chain_struct.pNext = nullptr;
         if (!chain_begin) {

--- a/layers/vulkan/generated/pnext_chain_extraction.h
+++ b/layers/vulkan/generated/pnext_chain_extraction.h
@@ -32,22 +32,22 @@
 namespace vvl {
 
 // Add element to the end of a pNext chain
-void *PnextChainAdd(void *chain, void *new_struct);
+void* PnextChainAdd(void* chain, void* new_struct);
 
 // Remove last element from a pNext chain
-void PnextChainRemoveLast(void *chain);
+void PnextChainRemoveLast(void* chain);
 
 // Free dynamically allocated pnext chain structs
-void PnextChainFree(void *chain);
+void PnextChainFree(void* chain);
 
 // Helper class relying on RAII to help with adding and removing an element from a pNext chain
 class PnextChainScopedAdd {
   public:
-    PnextChainScopedAdd(void *chain, void *new_struct) : chain(chain) { PnextChainAdd(chain, new_struct); }
+    PnextChainScopedAdd(void* chain, void* new_struct) : chain(chain) { PnextChainAdd(chain, new_struct); }
     ~PnextChainScopedAdd() { PnextChainRemoveLast(chain); }
 
   private:
-    void *chain = nullptr;
+    void* chain = nullptr;
 };
 
 // clang-format off

--- a/layers/vulkan/generated/spirv_validation_helper.cpp
+++ b/layers/vulkan/generated/spirv_validation_helper.cpp
@@ -45,14 +45,14 @@ struct FeaturePointer {
     // Default and nullptr constructor to create an empty FeaturePointer
     FeaturePointer() : IsEnabled(nullptr) {}
     FeaturePointer(std::nullptr_t ptr) : IsEnabled(nullptr) {}
-    FeaturePointer(bool DeviceFeatures::*ptr) : IsEnabled([=](const DeviceFeatures& features) { return features.*ptr; }) {}
+    FeaturePointer(bool DeviceFeatures::* ptr) : IsEnabled([=](const DeviceFeatures& features) { return features.*ptr; }) {}
 };
 
 // Each instance of the struct will only have a singel field non-null
 struct RequiredSpirvInfo {
     uint32_t version;
     FeaturePointer feature;
-    ExtEnabled DeviceExtensions::*extension;
+    ExtEnabled DeviceExtensions::* extension;
     const char* property;  // For human readability and make some capabilities unique
 };
 

--- a/layers/vulkan/generated/vk_extension_helper.h
+++ b/layers/vulkan/generated/vk_extension_helper.h
@@ -51,9 +51,9 @@ enum ExtEnabled : unsigned char {
 // Map of promoted extension information per version (a separate map exists for instance and device extensions).
 // The map is keyed by the version number (e.g. VK_API_VERSION_1_1) and each value is a pair consisting of the
 // version string (e.g. "VK_VERSION_1_1") and the set of name of the promoted extensions.
-typedef vvl::unordered_map<uint32_t, std::pair<const char *, vvl::unordered_set<vvl::Extension>>> PromotedExtensionInfoMap;
-const PromotedExtensionInfoMap &GetInstancePromotionInfoMap();
-const PromotedExtensionInfoMap &GetDevicePromotionInfoMap();
+typedef vvl::unordered_map<uint32_t, std::pair<const char*, vvl::unordered_set<vvl::Extension>>> PromotedExtensionInfoMap;
+const PromotedExtensionInfoMap& GetInstancePromotionInfoMap();
+const PromotedExtensionInfoMap& GetDevicePromotionInfoMap();
 
 /*
 This function is a helper to know if the extension is enabled.
@@ -134,21 +134,21 @@ struct InstanceExtensions {
     ExtEnabled vk_ohos_surface{kNotSupported};
 
     struct Requirement {
-        const ExtEnabled InstanceExtensions::*enabled;
-        const char *name;
+        const ExtEnabled InstanceExtensions::* enabled;
+        const char* name;
     };
     typedef std::vector<Requirement> RequirementVec;
     struct Info {
-        Info(ExtEnabled InstanceExtensions::*state_, const RequirementVec requirements_)
+        Info(ExtEnabled InstanceExtensions::* state_, const RequirementVec requirements_)
             : state(state_), requirements(requirements_) {}
-        ExtEnabled InstanceExtensions::*state;
+        ExtEnabled InstanceExtensions::* state;
         RequirementVec requirements;
     };
 
-    const Info &GetInfo(vvl::Extension extension_name) const;
+    const Info& GetInfo(vvl::Extension extension_name) const;
 
     InstanceExtensions() = default;
-    InstanceExtensions(APIVersion requested_api_version, const VkInstanceCreateInfo *pCreateInfo);
+    InstanceExtensions(APIVersion requested_api_version, const VkInstanceCreateInfo* pCreateInfo);
 };
 
 struct DeviceExtensions : public InstanceExtensions {
@@ -554,30 +554,30 @@ struct DeviceExtensions : public InstanceExtensions {
     ExtEnabled vk_ext_mesh_shader{kNotSupported};
 
     struct Requirement {
-        const ExtEnabled DeviceExtensions::*enabled;
-        const char *name;
+        const ExtEnabled DeviceExtensions::* enabled;
+        const char* name;
     };
     typedef std::vector<Requirement> RequirementVec;
     struct Info {
-        Info(ExtEnabled DeviceExtensions::*state_, const RequirementVec requirements_)
+        Info(ExtEnabled DeviceExtensions::* state_, const RequirementVec requirements_)
             : state(state_), requirements(requirements_) {}
-        ExtEnabled DeviceExtensions::*state;
+        ExtEnabled DeviceExtensions::* state;
         RequirementVec requirements;
     };
 
-    const Info &GetInfo(vvl::Extension extension_name) const;
+    const Info& GetInfo(vvl::Extension extension_name) const;
 
     DeviceExtensions() = default;
-    DeviceExtensions(const InstanceExtensions &instance_ext) : InstanceExtensions(instance_ext) {}
+    DeviceExtensions(const InstanceExtensions& instance_ext) : InstanceExtensions(instance_ext) {}
 
-    DeviceExtensions(const InstanceExtensions &instance_extensions, APIVersion requested_api_version,
-                     const VkDeviceCreateInfo *pCreateInfo = nullptr);
-    DeviceExtensions(const InstanceExtensions &instance_ext, APIVersion requested_api_version,
-                     const std::vector<VkExtensionProperties> &props);
+    DeviceExtensions(const InstanceExtensions& instance_extensions, APIVersion requested_api_version,
+                     const VkDeviceCreateInfo* pCreateInfo = nullptr);
+    DeviceExtensions(const InstanceExtensions& instance_ext, APIVersion requested_api_version,
+                     const std::vector<VkExtensionProperties>& props);
 };
 
-const InstanceExtensions::Info &GetInstanceVersionMap(const char *version);
-const DeviceExtensions::Info &GetDeviceVersionMap(const char *version);
+const InstanceExtensions::Info& GetInstanceVersionMap(const char* version);
+const DeviceExtensions::Info& GetDeviceVersionMap(const char* version);
 
 constexpr bool IsInstanceExtension(vvl::Extension extension) {
     switch (extension) {

--- a/scripts/generators/command_validation_generator.py
+++ b/scripts/generators/command_validation_generator.py
@@ -98,12 +98,10 @@ class CommandValidationOutputGenerator(BaseGenerator):
         out.append('''
             #include "command_validation.h"
             #include "containers/custom_containers.h"
-
-            extern const char *kVUIDUndefined;
-
-            using Func = vvl::Func;
             ''')
         out.append('// clang-format off\n')
+        out.append('extern const char *kVUIDUndefined;\n')
+        out.append('using Func = vvl::Func;\n')
         out.append('static const auto &GetCommandValidationTable() {\n')
         out.append('static const vvl::unordered_map<Func, CommandValidationInfo> kCommandValidationTable {\n')
         for command in [x for x in self.vk.commands.values() if x.name.startswith('vkCmd')]:
@@ -167,13 +165,13 @@ class CommandValidationOutputGenerator(BaseGenerator):
         out.append('};\n')
         out.append('return kCommandValidationTable;\n')
         out.append('}\n')
-        out.append('// clang-format on\n')
 
         out.append('''
-            const CommandValidationInfo& GetCommandValidationInfo(vvl::Func command) {
-                auto info_it = GetCommandValidationTable().find(command);
-                assert(info_it != GetCommandValidationTable().end());
-                return info_it->second;
-            }
+const CommandValidationInfo& GetCommandValidationInfo(vvl::Func command) {
+    auto info_it = GetCommandValidationTable().find(command);
+    assert(info_it != GetCommandValidationTable().end());
+    return info_it->second;
+}
             ''')
+        out.append('// clang-format on\n')
         self.write("".join(out))


### PR DESCRIPTION
Plan to add to https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/main/.git-blame-ignore-revs after

These are cases that are fixed in Clang-Format 21 (latest) but our Ubuntu 24.04 runners are still on Clang-Format 18, so it shouldn't try changing it, but applying now people as they grab the newer clang-format

even though I have `SKIP-CI`, it still runs the clang-format check