### PR TITLE
layers: Add layers and tests for VUs 09921, 09917, 09870

### DIFF
--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -552,6 +552,8 @@ struct EntryPoint {
     std::shared_ptr<const TaskPayloadVariable> task_payload_variable;
     const std::vector<ResourceInterfaceVariable> resource_interface_variables;
     const std::vector<StageInterfaceVariable> stage_interface_variables;
+    const std::vector<const Instruction *> datagraph_constants;
+
     // Easier to lookup without having to check for the is_builtin bool
     // "Built-in interface variables" - vkspec.html#interfaces-iointerfaces-builtin
     std::vector<const StageInterfaceVariable *> built_in_variables;
@@ -594,6 +596,8 @@ struct EntryPoint {
                                                                           const ParsedInfo &parsed);
     static std::vector<ResourceInterfaceVariable> GetResourceInterfaceVariables(const Module &module_state, EntryPoint &entrypoint,
                                                                                 const ParsedInfo &parsed);
+    static std::vector<const Instruction *> GetDataGraphConstants(const Module& module_state, EntryPoint& entrypoint);
+
     static bool IsBuiltInWritten(spv::BuiltIn built_in, const Module &module_state, const StageInterfaceVariable &variable,
                                  const ParsedInfo &parsed);
 };

--- a/tests/framework/data_graph_objects.h
+++ b/tests/framework/data_graph_objects.h
@@ -72,7 +72,9 @@ class DataGraphPipelineHelper {
     virtual ~DataGraphPipelineHelper();
     void Destroy();
 
-    static std::string GetSpirvBasicDataGraph(const char *inserted_line = "");
+    static inline std::string GetSpirvBasicDataGraph() { return GetSpirvModifyableDataGraph(); };
+    static std::string GetSpirvModifyableDataGraph(const ModifiableShaderParameters& params = ModifiableShaderParameters());
+    static std::string GetSpirvConstantDataGraph();
     static std::string GetSpirvMultiEntryTwoDataGraph();
     static inline std::string GetSpirvBasicShader() { return GetSpirvModifiableShader(); };
     static std::string GetSpirvModifiableShader(const ModifiableShaderParameters &params = ModifiableShaderParameters());

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -422,8 +422,12 @@ class DataGraphTest : public VkLayerTest {
     void InitBasicDataGraph();
     static void CheckSessionMemory(const vkt::DataGraphPipelineSession& session);
     static std::vector<VkBindDataGraphPipelineSessionMemoryInfoARM> InitSessionBindInfo(const vkt::DataGraphPipelineSession& session, const std::vector<vkt::DeviceMemory>& device_mem);
+    static VkTensorDescriptionARM DefaultDesc();
+    static VkTensorDescriptionARM DefaultConstantTensorDesc();
+    static VkDataGraphPipelineConstantARM GetConstant(const VkTensorDescriptionARM &desc = defaultConstantTensorDesc);
 
     static const std::string IncorrectSpirvMessage;
+    static const VkTensorDescriptionARM defaultConstantTensorDesc;
 };
 
 class WsiTest : public VkLayerTest {

--- a/tests/unit/tensor_positive.cpp
+++ b/tests/unit/tensor_positive.cpp
@@ -30,7 +30,7 @@ VkTensorDescriptionARM TensorTest::DefaultDesc() {
     static VkTensorDescriptionARM desc = vku::InitStructHelper();
     desc.tiling = VK_TENSOR_TILING_LINEAR_ARM;
     desc.format = VK_FORMAT_R8_SINT;
-    desc.dimensionCount = 1;
+    desc.dimensionCount = dimensions.size();
     desc.pDimensions = dimensions.data();
     desc.pStrides = strides.data();
     desc.usage = VK_TENSOR_USAGE_SHADER_BIT_ARM;
@@ -44,7 +44,7 @@ VkTensorDescriptionARM TensorTest::TensorShaderDesc() {
     static VkTensorDescriptionARM desc = vku::InitStructHelper();
     desc.tiling = VK_TENSOR_TILING_LINEAR_ARM;
     desc.format = VK_FORMAT_R32_SINT;
-    desc.dimensionCount = 1;
+    desc.dimensionCount = dimensions.size();
     desc.pDimensions = dimensions.data();
     desc.pStrides = nullptr;
     desc.usage = VK_TENSOR_USAGE_SHADER_BIT_ARM;


### PR DESCRIPTION
- storing constants in spirv to `EntryPoint::datagraph_constants`
- rearranged layers (`ValidateDataGraphPipelineShaderModuleSpirv`), unit tests and related spirv code to process constants _dynamically_, not _statically_ as previously done (incorrect)
- added new checks and tests