### PR TITLE
layers: Add SourceLanguage based error hints

### DIFF
--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -1209,10 +1209,18 @@ Module::StaticData::StaticData(const Module& module_state, bool parse, Stateless
             }
 
             case spv::OpLine:
-            case spv::OpSource: {
                 using_legacy_debug_info = true;
                 break;
-            }
+
+            case spv::OpSource:
+                // We might just have "OpSource GLSL 450", but we want to know if it is making use of the File/Source operands
+                if (insn.Length() > 3) {
+                    using_legacy_debug_info = true;
+                }
+                // It would be very cursed to have OpSource from multiple shader languages at once
+                source_language = (spv::SourceLanguage)insn.Word(1);
+                break;
+
             case spv::OpExtInstImport: {
                 if (strcmp(insn.GetAsString(2), "GLSL.std.450") == 0) {
                     extended.glsl_std450 = insn.ResultId();

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -650,6 +650,9 @@ struct Module {
         vvl::unordered_map<uint32_t, DecorationSet> decorations;
         DecorationSet empty_decoration;  // all zero values, allows use to return a reference and not a copy each time
 
+        // Some cases we can give better hints knowing the source shader language
+        spv::SourceLanguage source_language{spv::SourceLanguageUnknown};
+
         // Execution Modes are tied to a Function <id>, multiple EntryPoints can point to the same Funciton <id>
         // Keep a mapping so each EntryPoint can grab a reference to it
         vvl::unordered_map<uint32_t, ExecutionModeSet> execution_modes;


### PR DESCRIPTION
https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8398 is an example where people are going to grab the latest and get VVL errors for HLSL/Slang and good to save people time and point them directly to the known issues on the shading language side of things