### PR TITLE
layers: Remove redundant VkPhysicalDeviceLimits

### DIFF
--- a/layers/stateless/sl_cmd_buffer_dynamic.cpp
+++ b/layers/stateless/sl_cmd_buffer_dynamic.cpp
@@ -33,13 +33,13 @@ bool Device::manual_PreCallValidateCmdSetViewportWithCount(VkCommandBuffer comma
                              "(%" PRIu32 ") is not 1, but the multiViewport feature is not enabled.", viewportCount);
         }
     } else {  // multiViewport enabled
-        if (viewportCount < 1 || viewportCount > device_limits.maxViewports) {
+        if (viewportCount < 1 || viewportCount > phys_dev_props.limits.maxViewports) {
             skip |= LogError("VUID-vkCmdSetViewportWithCount-viewportCount-03394", commandBuffer,
                              error_obj.location.dot(Field::viewportCount),
                              "(%" PRIu32
                              ") must "
                              "not be greater than VkPhysicalDeviceLimits::maxViewports (%" PRIu32 ").",
-                             viewportCount, device_limits.maxViewports);
+                             viewportCount, phys_dev_props.limits.maxViewports);
         }
     }
 
@@ -67,10 +67,11 @@ bool Device::manual_PreCallValidateCmdSetScissorWithCount(VkCommandBuffer comman
         if (scissorCount == 0) {
             skip |= LogError("VUID-vkCmdSetScissorWithCount-scissorCount-03397", commandBuffer,
                              error_obj.location.dot(Field::scissorCount), "(%" PRIu32 ") must be greater than zero.", scissorCount);
-        } else if (scissorCount > device_limits.maxViewports) {
-            skip |= LogError(
-                "VUID-vkCmdSetScissorWithCount-scissorCount-03397", commandBuffer, error_obj.location.dot(Field::scissorCount),
-                "(%" PRIu32 ") must not be greater than maxViewports (%" PRIu32 ").", scissorCount, device_limits.maxViewports);
+        } else if (scissorCount > phys_dev_props.limits.maxViewports) {
+            skip |= LogError("VUID-vkCmdSetScissorWithCount-scissorCount-03397", commandBuffer,
+                             error_obj.location.dot(Field::scissorCount),
+                             "(%" PRIu32 ") must not be greater than maxViewports (%" PRIu32 ").", scissorCount,
+                             phys_dev_props.limits.maxViewports);
         }
     }
 
@@ -116,18 +117,18 @@ bool Device::manual_PreCallValidateCmdSetVertexInputEXT(VkCommandBuffer commandB
     bool skip = false;
     const auto &error_obj = context.error_obj;
 
-    if (vertexBindingDescriptionCount > device_limits.maxVertexInputBindings) {
+    if (vertexBindingDescriptionCount > phys_dev_props.limits.maxVertexInputBindings) {
         skip |= LogError("VUID-vkCmdSetVertexInputEXT-vertexBindingDescriptionCount-04791", commandBuffer,
                          error_obj.location.dot(Field::vertexBindingDescriptionCount),
                          "(%" PRIu32 ") is greater than the maxVertexInputBindings limit (%" PRIu32 ").",
-                         vertexBindingDescriptionCount, device_limits.maxVertexInputBindings);
+                         vertexBindingDescriptionCount, phys_dev_props.limits.maxVertexInputBindings);
     }
 
-    if (vertexAttributeDescriptionCount > device_limits.maxVertexInputAttributes) {
+    if (vertexAttributeDescriptionCount > phys_dev_props.limits.maxVertexInputAttributes) {
         skip |= LogError("VUID-vkCmdSetVertexInputEXT-vertexAttributeDescriptionCount-04792", commandBuffer,
                          error_obj.location.dot(Field::vertexAttributeDescriptionCount),
                          "(%" PRIu32 ") is greater than the maxVertexInputAttributes limit (%" PRIu32 ").",
-                         vertexAttributeDescriptionCount, device_limits.maxVertexInputAttributes);
+                         vertexAttributeDescriptionCount, phys_dev_props.limits.maxVertexInputAttributes);
     }
 
     for (uint32_t attribute = 0; attribute < vertexAttributeDescriptionCount; ++attribute) {
@@ -176,16 +177,16 @@ bool Device::manual_PreCallValidateCmdSetVertexInputEXT(VkCommandBuffer commandB
 
     for (uint32_t binding = 0; binding < vertexBindingDescriptionCount; ++binding) {
         const Location binding_loc = error_obj.location.dot(Field::pVertexBindingDescriptions, binding);
-        if (pVertexBindingDescriptions[binding].binding > device_limits.maxVertexInputBindings) {
+        if (pVertexBindingDescriptions[binding].binding > phys_dev_props.limits.maxVertexInputBindings) {
             skip |= LogError("VUID-VkVertexInputBindingDescription2EXT-binding-04796", commandBuffer,
                              binding_loc.dot(Field::binding), "(%" PRIu32 ") is greater than maxVertexInputBindings (%" PRIu32 ").",
-                             pVertexBindingDescriptions[binding].binding, device_limits.maxVertexInputBindings);
+                             pVertexBindingDescriptions[binding].binding, phys_dev_props.limits.maxVertexInputBindings);
         }
 
-        if (pVertexBindingDescriptions[binding].stride > device_limits.maxVertexInputBindingStride) {
+        if (pVertexBindingDescriptions[binding].stride > phys_dev_props.limits.maxVertexInputBindingStride) {
             skip |= LogError("VUID-VkVertexInputBindingDescription2EXT-stride-04797", commandBuffer, binding_loc.dot(Field::stride),
                              "(%" PRIu32 ") is greater than maxVertexInputBindingStride (%" PRIu32 ").",
-                             pVertexBindingDescriptions[binding].stride, device_limits.maxVertexInputBindingStride);
+                             pVertexBindingDescriptions[binding].stride, phys_dev_props.limits.maxVertexInputBindingStride);
         }
 
         if (pVertexBindingDescriptions[binding].divisor == 0 && (!enabled_features.vertexAttributeInstanceRateZeroDivisor)) {
@@ -223,25 +224,25 @@ bool Device::manual_PreCallValidateCmdSetVertexInputEXT(VkCommandBuffer commandB
 
     for (uint32_t attribute = 0; attribute < vertexAttributeDescriptionCount; ++attribute) {
         const Location attribute_loc = error_obj.location.dot(Field::pVertexAttributeDescriptions, attribute);
-        if (pVertexAttributeDescriptions[attribute].location > device_limits.maxVertexInputAttributes) {
+        if (pVertexAttributeDescriptions[attribute].location > phys_dev_props.limits.maxVertexInputAttributes) {
             skip |= LogError("VUID-VkVertexInputAttributeDescription2EXT-location-06228", commandBuffer,
                              attribute_loc.dot(Field::location),
                              "(%" PRIu32 ") is greater than maxVertexInputAttributes (%" PRIu32 ").",
-                             pVertexAttributeDescriptions[attribute].location, device_limits.maxVertexInputAttributes);
+                             pVertexAttributeDescriptions[attribute].location, phys_dev_props.limits.maxVertexInputAttributes);
         }
 
-        if (pVertexAttributeDescriptions[attribute].binding > device_limits.maxVertexInputBindings) {
+        if (pVertexAttributeDescriptions[attribute].binding > phys_dev_props.limits.maxVertexInputBindings) {
             skip |=
                 LogError("VUID-VkVertexInputAttributeDescription2EXT-binding-06229", commandBuffer,
                          attribute_loc.dot(Field::binding), "(%" PRIu32 ") is greater than maxVertexInputBindings (%" PRIu32 ").",
-                         pVertexAttributeDescriptions[attribute].binding, device_limits.maxVertexInputBindings);
+                         pVertexAttributeDescriptions[attribute].binding, phys_dev_props.limits.maxVertexInputBindings);
         }
 
-        if (pVertexAttributeDescriptions[attribute].offset > device_limits.maxVertexInputAttributeOffset) {
+        if (pVertexAttributeDescriptions[attribute].offset > phys_dev_props.limits.maxVertexInputAttributeOffset) {
             skip |=
                 LogError("VUID-VkVertexInputAttributeDescription2EXT-offset-06230", commandBuffer, attribute_loc.dot(Field::offset),
                          "(%" PRIu32 ") is greater than maxVertexInputAttributeOffset (%" PRIu32 ").",
-                         pVertexAttributeDescriptions[attribute].offset, device_limits.maxVertexInputAttributeOffset);
+                         pVertexAttributeDescriptions[attribute].offset, phys_dev_props.limits.maxVertexInputAttributeOffset);
         }
 
         VkFormatProperties properties;
@@ -345,11 +346,11 @@ bool Device::manual_PreCallValidateCmdSetExclusiveScissorNV(VkCommandBuffer comm
         }
     } else {  // multiViewport enabled
         const uint64_t sum = static_cast<uint64_t>(firstExclusiveScissor) + static_cast<uint64_t>(exclusiveScissorCount);
-        if (sum > device_limits.maxViewports) {
+        if (sum > phys_dev_props.limits.maxViewports) {
             skip |= LogError("VUID-vkCmdSetExclusiveScissorNV-firstExclusiveScissor-02034", commandBuffer, error_obj.location,
                              "firstExclusiveScissor (%" PRIu32 ") + exclusiveScissorCount (%" PRIu32 ") is %" PRIu64
                              " which is greater than VkPhysicalDeviceLimits::maxViewports (%" PRIu32 ").",
-                             firstExclusiveScissor, exclusiveScissorCount, sum, device_limits.maxViewports);
+                             firstExclusiveScissor, exclusiveScissorCount, sum, phys_dev_props.limits.maxViewports);
         }
     }
 
@@ -393,11 +394,11 @@ bool Device::manual_PreCallValidateCmdSetViewportWScalingNV(VkCommandBuffer comm
     bool skip = false;
     const auto &error_obj = context.error_obj;
     const uint64_t sum = static_cast<uint64_t>(firstViewport) + static_cast<uint64_t>(viewportCount);
-    if ((sum < 1) || (sum > device_limits.maxViewports)) {
+    if ((sum < 1) || (sum > phys_dev_props.limits.maxViewports)) {
         skip |= LogError("VUID-vkCmdSetViewportWScalingNV-firstViewport-01324", commandBuffer, error_obj.location,
                          "firstViewport (%" PRIu32 ") + viewportCount (%" PRIu32 ") is %" PRIu64
                          ", which must be between 1 and VkPhysicalDeviceLimits::maxViewports (%" PRIu32 "), inclusive.",
-                         firstViewport, viewportCount, sum, device_limits.maxViewports);
+                         firstViewport, viewportCount, sum, phys_dev_props.limits.maxViewports);
     }
 
     return skip;
@@ -424,11 +425,11 @@ bool Device::manual_PreCallValidateCmdSetViewportShadingRatePaletteNV(VkCommandB
     }
 
     const uint64_t sum = static_cast<uint64_t>(firstViewport) + static_cast<uint64_t>(viewportCount);
-    if (sum > device_limits.maxViewports) {
+    if (sum > phys_dev_props.limits.maxViewports) {
         skip |= LogError("VUID-vkCmdSetViewportShadingRatePaletteNV-firstViewport-02067", commandBuffer, error_obj.location,
                          "firstViewport (%" PRIu32 ") + viewportCount (%" PRIu32 ") is %" PRIu64
                          ") which is greater than VkPhysicalDeviceLimits::maxViewports (%" PRIu32 ").",
-                         firstViewport, viewportCount, sum, device_limits.maxViewports);
+                         firstViewport, viewportCount, sum, phys_dev_props.limits.maxViewports);
     }
 
     return skip;
@@ -474,11 +475,11 @@ bool Device::manual_PreCallValidateCmdSetViewport(VkCommandBuffer commandBuffer,
         }
     } else {  // multiViewport enabled
         const uint64_t sum = static_cast<uint64_t>(firstViewport) + static_cast<uint64_t>(viewportCount);
-        if (sum > device_limits.maxViewports) {
+        if (sum > phys_dev_props.limits.maxViewports) {
             skip |= LogError("VUID-vkCmdSetViewport-firstViewport-01223", commandBuffer, error_obj.location,
                              "firstViewport (%" PRIu32 ") + viewportCount (%" PRIu32 ") is %" PRIu64
                              " which is greater than maxViewports (%" PRIu32 ").",
-                             firstViewport, viewportCount, sum, device_limits.maxViewports);
+                             firstViewport, viewportCount, sum, phys_dev_props.limits.maxViewports);
         }
     }
 
@@ -524,11 +525,11 @@ bool Device::manual_PreCallValidateCmdSetScissor(VkCommandBuffer commandBuffer, 
         }
     } else {  // multiViewport enabled
         const uint64_t sum = static_cast<uint64_t>(firstScissor) + static_cast<uint64_t>(scissorCount);
-        if (sum > device_limits.maxViewports) {
+        if (sum > phys_dev_props.limits.maxViewports) {
             skip |= LogError("VUID-vkCmdSetScissor-firstScissor-00592", commandBuffer, error_obj.location,
                              "firstScissor (%" PRIu32 ") + scissorCount (%" PRIu32 ") is %" PRIu64
                              " which is greater than maxViewports (%" PRIu32 ").",
-                             firstScissor, scissorCount, sum, device_limits.maxViewports);
+                             firstScissor, scissorCount, sum, phys_dev_props.limits.maxViewports);
         }
     }
 

--- a/layers/stateless/sl_descriptor.cpp
+++ b/layers/stateless/sl_descriptor.cpp
@@ -63,7 +63,7 @@ bool Device::ValidateCoarseSampleOrderCustomNV(const VkCoarseSampleOrderCustomNV
     }
 
     if (order.sampleCount == 0 || (order.sampleCount & (order.sampleCount - 1)) ||
-        !(order.sampleCount & device_limits.framebufferNoAttachmentsSampleCounts)) {
+        !(order.sampleCount & phys_dev_props.limits.framebufferNoAttachmentsSampleCounts)) {
         skip |= LogError("VUID-VkCoarseSampleOrderCustomNV-sampleCount-02074", device, order_loc.dot(Field::sampleCount),
                          "(%" PRIu32
                          ") must correspond to a sample count enumerated in VkSampleCountFlags whose corresponding bit "
@@ -345,10 +345,10 @@ bool Device::ValidateSamplerCreateInfo(const VkSamplerCreateInfo &create_info, c
     bool skip = false;
 
     if (create_info.anisotropyEnable == VK_TRUE) {
-        if (!IsBetweenInclusive(create_info.maxAnisotropy, 1.0F, device_limits.maxSamplerAnisotropy)) {
+        if (!IsBetweenInclusive(create_info.maxAnisotropy, 1.0F, phys_dev_props.limits.maxSamplerAnisotropy)) {
             skip |= LogError("VUID-VkSamplerCreateInfo-anisotropyEnable-01071", device, create_info_loc.dot(Field::maxAnisotropy),
                              "is %f but must be in the range of [1.0, %f] (maxSamplerAnistropy).", create_info.maxAnisotropy,
-                             device_limits.maxSamplerAnisotropy);
+                             phys_dev_props.limits.maxSamplerAnisotropy);
         }
 
         // Anistropy cannot be enabled in sampler unless enabled as a feature
@@ -445,9 +445,10 @@ bool Device::ValidateSamplerCreateInfo(const VkSamplerCreateInfo &create_info, c
     }
 
     // Check mipLodBias to device limit
-    if (create_info.mipLodBias > device_limits.maxSamplerLodBias) {
+    if (create_info.mipLodBias > phys_dev_props.limits.maxSamplerLodBias) {
         skip |= LogError("VUID-VkSamplerCreateInfo-mipLodBias-01069", device, create_info_loc.dot(Field::mipLodBias),
-                         "(%f) is greater than maxSamplerLodBias (%f)", create_info.mipLodBias, device_limits.maxSamplerLodBias);
+                         "(%f) is greater than maxSamplerLodBias (%f)", create_info.mipLodBias,
+                         phys_dev_props.limits.maxSamplerLodBias);
     }
 
     if (vku::FindStructInPNextChain<VkSamplerYcbcrConversionInfo>(create_info.pNext)) {

--- a/layers/stateless/sl_framebuffer.cpp
+++ b/layers/stateless/sl_framebuffer.cpp
@@ -76,20 +76,20 @@ bool Device::manual_PreCallValidateCreateFramebuffer(VkDevice device, const VkFr
         skip |= LogError("VUID-VkFramebufferCreateInfo-layers-00889", device, create_info_loc.dot(Field::layers), "is zero.");
     }
 
-    if (pCreateInfo->width > device_limits.maxFramebufferWidth) {
+    if (pCreateInfo->width > phys_dev_props.limits.maxFramebufferWidth) {
         skip |= LogError("VUID-VkFramebufferCreateInfo-width-00886", device, create_info_loc.dot(Field::width),
                          "(%" PRIu32 ") is greater than maxFramebufferWidth (%" PRIu32 ").", pCreateInfo->width,
-                         device_limits.maxFramebufferWidth);
+                         phys_dev_props.limits.maxFramebufferWidth);
     }
-    if (pCreateInfo->height > device_limits.maxFramebufferHeight) {
+    if (pCreateInfo->height > phys_dev_props.limits.maxFramebufferHeight) {
         skip |= LogError("VUID-VkFramebufferCreateInfo-height-00888", device, create_info_loc.dot(Field::height),
                          "(%" PRIu32 ") is greater than maxFramebufferHeight (%" PRIu32 ").", pCreateInfo->height,
-                         device_limits.maxFramebufferHeight);
+                         phys_dev_props.limits.maxFramebufferHeight);
     }
-    if (pCreateInfo->layers > device_limits.maxFramebufferLayers) {
+    if (pCreateInfo->layers > phys_dev_props.limits.maxFramebufferLayers) {
         skip |= LogError("VUID-VkFramebufferCreateInfo-layers-00890", device, create_info_loc.dot(Field::layers),
                          "(%" PRIu32 ") is greater than maxFramebufferLayers (%" PRIu32 ").", pCreateInfo->layers,
-                         device_limits.maxFramebufferLayers);
+                         phys_dev_props.limits.maxFramebufferLayers);
     }
 
     return skip;

--- a/layers/stateless/sl_image.cpp
+++ b/layers/stateless/sl_image.cpp
@@ -529,22 +529,22 @@ bool Device::ValidateCreateImageStencilUsage(const VkImageCreateInfo &create_inf
 
     if (vkuFormatIsDepthOrStencil(create_info.format)) {
         if ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT) != 0) {
-            if (create_info.extent.width > device_limits.maxFramebufferWidth) {
+            if (create_info.extent.width > phys_dev_props.limits.maxFramebufferWidth) {
                 skip |= LogError("VUID-VkImageCreateInfo-Format-02536", device,
                                  create_info_loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage),
                                  "includes VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT and image width (%" PRIu32
                                  ") exceeds device "
                                  "maxFramebufferWidth (%" PRIu32 ")",
-                                 create_info.extent.width, device_limits.maxFramebufferWidth);
+                                 create_info.extent.width, phys_dev_props.limits.maxFramebufferWidth);
             }
 
-            if (create_info.extent.height > device_limits.maxFramebufferHeight) {
+            if (create_info.extent.height > phys_dev_props.limits.maxFramebufferHeight) {
                 skip |= LogError("VUID-VkImageCreateInfo-format-02537", device,
                                  create_info_loc.pNext(Struct::VkImageStencilUsageCreateInfo, Field::stencilUsage),
                                  "includes VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT and image height (%" PRIu32
                                  ") exceeds device "
                                  "maxFramebufferHeight (%" PRIu32 ")",
-                                 create_info.extent.height, device_limits.maxFramebufferHeight);
+                                 create_info.extent.height, phys_dev_props.limits.maxFramebufferHeight);
             }
         }
 

--- a/layers/stateless/sl_instance_device.cpp
+++ b/layers/stateless/sl_instance_device.cpp
@@ -336,8 +336,6 @@ void Instance::PreCallRecordDestroyInstance(VkInstance instance, const VkAllocat
 }
 
 void Device::FinishDeviceSetup(const VkDeviceCreateInfo *pCreateInfo, const Location &loc) {
-    memcpy(&device_limits, &phys_dev_props.limits, sizeof(VkPhysicalDeviceLimits));
-
     std::vector<VkExtensionProperties> ext_props{};
     uint32_t ext_count = 0;
     DispatchEnumerateDeviceExtensionProperties(physical_device, nullptr, &ext_count, nullptr);

--- a/layers/stateless/sl_ray_tracing.cpp
+++ b/layers/stateless/sl_ray_tracing.cpp
@@ -1912,34 +1912,35 @@ bool Device::manual_PreCallValidateCmdTraceRaysKHR(VkCommandBuffer commandBuffer
                          width, depth, height, phys_dev_ext_props.ray_tracing_props_khr.maxRayDispatchInvocationCount);
     }
 
-    const uint64_t max_width = static_cast<uint64_t>(device_limits.maxComputeWorkGroupCount[0]) *
-                               static_cast<uint64_t>(device_limits.maxComputeWorkGroupSize[0]);
+    const uint64_t max_width = static_cast<uint64_t>(phys_dev_props.limits.maxComputeWorkGroupCount[0]) *
+                               static_cast<uint64_t>(phys_dev_props.limits.maxComputeWorkGroupSize[0]);
     if (width > max_width) {
-        skip |= LogError("VUID-vkCmdTraceRaysKHR-width-03638", commandBuffer, error_obj.location.dot(Field::width),
-                         "(%" PRIu32
-                         ") must be less than or equal to maxComputeWorkGroupCount[0] x maxComputeWorkGroupSize[0] (%" PRIu32
-                         " x %" PRIu32 " = %" PRIu64 ").",
-                         width, device_limits.maxComputeWorkGroupCount[0], device_limits.maxComputeWorkGroupSize[0], max_width);
+        skip |= LogError(
+            "VUID-vkCmdTraceRaysKHR-width-03638", commandBuffer, error_obj.location.dot(Field::width),
+            "(%" PRIu32 ") must be less than or equal to maxComputeWorkGroupCount[0] x maxComputeWorkGroupSize[0] (%" PRIu32
+            " x %" PRIu32 " = %" PRIu64 ").",
+            width, phys_dev_props.limits.maxComputeWorkGroupCount[0], phys_dev_props.limits.maxComputeWorkGroupSize[0], max_width);
     }
 
-    const uint64_t max_height = static_cast<uint64_t>(device_limits.maxComputeWorkGroupCount[1]) *
-                                static_cast<uint64_t>(device_limits.maxComputeWorkGroupSize[1]);
+    const uint64_t max_height = static_cast<uint64_t>(phys_dev_props.limits.maxComputeWorkGroupCount[1]) *
+                                static_cast<uint64_t>(phys_dev_props.limits.maxComputeWorkGroupSize[1]);
     if (height > max_height) {
         skip |= LogError("VUID-vkCmdTraceRaysKHR-height-03639", commandBuffer, error_obj.location.dot(Field::height),
                          "(%" PRIu32
                          ") must be less than or equal to maxComputeWorkGroupCount[1] x maxComputeWorkGroupSize[1] (%" PRIu32
                          " x %" PRIu32 " = %" PRIu64 ").",
-                         height, device_limits.maxComputeWorkGroupCount[1], device_limits.maxComputeWorkGroupSize[1], max_height);
+                         height, phys_dev_props.limits.maxComputeWorkGroupCount[1],
+                         phys_dev_props.limits.maxComputeWorkGroupSize[1], max_height);
     }
 
-    const uint64_t max_depth = static_cast<uint64_t>(device_limits.maxComputeWorkGroupCount[2]) *
-                               static_cast<uint64_t>(device_limits.maxComputeWorkGroupSize[2]);
+    const uint64_t max_depth = static_cast<uint64_t>(phys_dev_props.limits.maxComputeWorkGroupCount[2]) *
+                               static_cast<uint64_t>(phys_dev_props.limits.maxComputeWorkGroupSize[2]);
     if (depth > max_depth) {
-        skip |= LogError("VUID-vkCmdTraceRaysKHR-depth-03640", commandBuffer, error_obj.location.dot(Field::depth),
-                         "(%" PRIu32
-                         ") must be less than or equal to maxComputeWorkGroupCount[2] x maxComputeWorkGroupSize[2] (%" PRIu32
-                         " x %" PRIu32 " = %" PRIu64 ").",
-                         depth, device_limits.maxComputeWorkGroupCount[2], device_limits.maxComputeWorkGroupSize[2], max_depth);
+        skip |= LogError(
+            "VUID-vkCmdTraceRaysKHR-depth-03640", commandBuffer, error_obj.location.dot(Field::depth),
+            "(%" PRIu32 ") must be less than or equal to maxComputeWorkGroupCount[2] x maxComputeWorkGroupSize[2] (%" PRIu32
+            " x %" PRIu32 " = %" PRIu64 ").",
+            depth, phys_dev_props.limits.maxComputeWorkGroupCount[2], phys_dev_props.limits.maxComputeWorkGroupSize[2], max_depth);
     }
     return skip;
 }

--- a/layers/stateless/sl_render_pass.cpp
+++ b/layers/stateless/sl_render_pass.cpp
@@ -68,7 +68,7 @@ bool Device::ValidateCreateRenderPass(VkDevice device, const VkRenderPassCreateI
                                       const VkAllocationCallbacks *pAllocator, VkRenderPass *pRenderPass,
                                       const ErrorObject &error_obj) const {
     bool skip = false;
-    uint32_t max_color_attachments = device_limits.maxColorAttachments;
+    uint32_t max_color_attachments = phys_dev_props.limits.maxColorAttachments;
     const bool use_rp2 = error_obj.location.function != Func::vkCreateRenderPass;
     const char *vuid = nullptr;
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
@@ -738,13 +738,13 @@ bool Device::manual_PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuff
                          "viewMask and layerCount are both zero");
     }
 
-    if (pRenderingInfo->colorAttachmentCount > device_limits.maxColorAttachments) {
+    if (pRenderingInfo->colorAttachmentCount > phys_dev_props.limits.maxColorAttachments) {
         skip |= LogError("VUID-VkRenderingInfo-colorAttachmentCount-06106", commandBuffer,
                          rendering_info_loc.dot(Field::colorAttachmentCount),
                          "(%" PRIu32
                          ") must be less than or equal to "
                          "maxColorAttachments (%" PRIu32 ").",
-                         pRenderingInfo->colorAttachmentCount, device_limits.maxColorAttachments);
+                         pRenderingInfo->colorAttachmentCount, phys_dev_props.limits.maxColorAttachments);
     }
 
     if ((pRenderingInfo->flags & VK_RENDERING_CONTENTS_INLINE_BIT_KHR) != 0 && !enabled_features.nestedCommandBuffer &&
@@ -759,10 +759,10 @@ bool Device::manual_PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuff
             LogError("VUID-VkRenderingInfo-flags-11514", commandBuffer, rendering_info_loc.dot(Field::flags),
                      "is %s, but customResolve feature were not enabled.", string_VkRenderingFlags(pRenderingInfo->flags).c_str());
     }
-    if (pRenderingInfo->layerCount > device_limits.maxFramebufferLayers) {
+    if (pRenderingInfo->layerCount > phys_dev_props.limits.maxFramebufferLayers) {
         skip |= LogError("VUID-VkRenderingInfo-layerCount-07817", commandBuffer, rendering_info_loc.dot(Field::layerCount),
                          "(%" PRIu32 ") is greater than maxFramebufferLayers (%" PRIu32 ").", pRenderingInfo->layerCount,
-                         device_limits.maxFramebufferLayers);
+                         phys_dev_props.limits.maxFramebufferLayers);
     }
 
     if (!enabled_features.multiview && (pRenderingInfo->viewMask != 0)) {

--- a/layers/stateless/sl_shader_object.cpp
+++ b/layers/stateless/sl_shader_object.cpp
@@ -201,10 +201,10 @@ bool Device::manual_PreCallValidateCreateShadersEXT(VkDevice device, uint32_t cr
 
         skip |= ValidatePushConstantRange(create_info.pushConstantRangeCount, create_info.pPushConstantRanges, create_info_loc);
 
-        if (create_info.setLayoutCount > device_limits.maxBoundDescriptorSets) {
+        if (create_info.setLayoutCount > phys_dev_props.limits.maxBoundDescriptorSets) {
             skip |= LogError("VUID-VkShaderCreateInfoEXT-setLayoutCount-12257", device, create_info_loc.dot(Field::setLayoutCount),
                              "(%" PRIu32 ") exceeds the maxBoundDescriptorSets limit (%" PRIu32 ").", create_info.setLayoutCount,
-                             device_limits.maxBoundDescriptorSets);
+                             phys_dev_props.limits.maxBoundDescriptorSets);
         }
     }
 

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -445,7 +445,6 @@ class Device : public vvl::base::Device {
     ~Device() {}
 
     Instance *instance;
-    VkPhysicalDeviceLimits device_limits = {};
 
     // This was a special case where it was decided to use the extension version for validation
     // https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/5671


### PR DESCRIPTION
We use to have an extra `VkPhysicalDeviceLimits` due to Stateless not having access to the `phys_dev_props.limits` before refactoring the chassis

It is really annoying that some places in stateless where using `device_limits` others using `phys_dev_props.limits`.... now we only have 1 option for everywhere