### PR TITLE
layers: Fix BuiltIn for PrimitiveShadingRateKHR

### DIFF
--- a/layers/best_practices/bp_pipeline.cpp
+++ b/layers/best_practices/bp_pipeline.cpp
@@ -517,7 +517,7 @@ bool BestPractices::ValidateShaderStage(const ShaderStageState& stage_state, con
         }
 
         if (IsExtEnabled(extensions.vk_khr_maintenance4)) {
-            if (module_state.static_data_.has_builtin_workgroup_size) {
+            if (module_state.static_data_.has_built_in_workgroup_size) {
                 skip |= LogWarning("BestPractices-SpirvDeprecated_WorkgroupSize", device, loc,
                                    "is using the SPIR-V Workgroup built-in which SPIR-V 1.6 deprecated. When using "
                                    "VK_KHR_maintenance4 or Vulkan 1.3+, the new SPIR-V LocalSizeId execution mode should be used "

--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -976,7 +976,7 @@ bool CoreChecks::ValidateDrawDynamicStateVertex(const LastBound& last_bound_stat
 
         if (((bound_stages & (VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT | VK_SHADER_STAGE_GEOMETRY_BIT)) == 0) &&
             topology == VK_PRIMITIVE_TOPOLOGY_POINT_LIST) {
-            if (!vert_entrypoint->written_builtin_point_size && !enabled_features.maintenance5) {
+            if (!vert_entrypoint->written_built_in_point_size && !enabled_features.maintenance5) {
                 skip |= LogError(vuid.primitive_topology_point_size_10748, cb_state.Handle(), vuid.loc(),
                                  "The bound vertex shader (%s) has a PointSize that is not written to, but the bound topology "
                                  "is set to VK_PRIMITIVE_TOPOLOGY_POINT_LIST.",

--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -1835,7 +1835,7 @@ bool CoreChecks::ValidateDrawFragmentShadingRate(const LastBound &last_bound_sta
                 continue;
             }
             if (pipeline->IsDynamic(CB_DYNAMIC_STATE_VIEWPORT_WITH_COUNT) && cb_state.dynamic_state_value.viewport_count != 1) {
-                if (stage_state.entrypoint && stage_state.entrypoint->written_builtin_primitive_shading_rate_khr) {
+                if (stage_state.entrypoint && stage_state.entrypoint->written_built_in_primitive_shading_rate_khr) {
                     skip |=
                         LogError(vuid.viewport_count_primitive_shading_rate_04552, stage_state.module_state->Handle(), vuid.loc(),
                                  "%s shader of currently bound pipeline statically writes to PrimitiveShadingRateKHR built-in, "
@@ -1850,7 +1850,7 @@ bool CoreChecks::ValidateDrawFragmentShadingRate(const LastBound &last_bound_sta
         for (uint32_t stage = 0; stage < kShaderObjectStageCount; ++stage) {
             const auto shader_object = last_bound_state.GetShaderObjectState(static_cast<ShaderObjectStage>(stage));
             if (shader_object && shader_object->entrypoint &&
-                shader_object->entrypoint->written_builtin_primitive_shading_rate_khr) {
+                shader_object->entrypoint->written_built_in_primitive_shading_rate_khr) {
                 if (cb_state.dynamic_state_value.viewport_count != 1) {
                     skip |= LogError(vuid.set_viewport_with_count_08642, cb_state.Handle(), vuid.loc(),
                                      "%s shader of currently bound pipeline statically writes to PrimitiveShadingRateKHR built-in, "

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -1325,7 +1325,7 @@ bool CoreChecks::ValidateGraphicsPipelineMeshTask(const vvl::Pipeline &pipeline,
         return skip;
     }
 
-    if (task_state && mesh_state->spirv_state && mesh_state->spirv_state->static_data_.has_builtin_draw_index) {
+    if (task_state && mesh_state->spirv_state && mesh_state->spirv_state->static_data_.has_built_in_draw_index) {
         // There is a dedicated equivalent for shader object
         skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-pStages-09631", device, create_info_loc,
                          "The pipeline is being created with a Task and Mesh shader bound, but the Mesh Shader "
@@ -4258,7 +4258,7 @@ bool CoreChecks::ValidateMultiViewShaders(const vvl::Pipeline &pipeline, const L
         // Stage may not have SPIR-V data (e.g. due to the use of shader module identifier or in Vulkan SC)
         if (!stage.spirv_state) continue;
 
-        if (stage.spirv_state->static_data_.has_builtin_layer) {
+        if (stage.spirv_state->static_data_.has_built_in_layer) {
             // Special case for GLSL and Mesh Shading discussed in https://gitlab.khronos.org/vulkan/vulkan/-/issues/4194
             const char *vuid = dynamic_rendering ? "VUID-VkGraphicsPipelineCreateInfo-renderPass-06059"
                                                  : "VUID-VkGraphicsPipelineCreateInfo-renderPass-06050";
@@ -4359,7 +4359,7 @@ bool CoreChecks::ValidateDrawPipelineFramebuffer(const vvl::CommandBuffer &cb_st
 
     for (auto &stage_state : pipeline.stage_states) {
         const VkShaderStageFlagBits stage = stage_state.GetStage();
-        if (stage_state.entrypoint && stage_state.entrypoint->written_builtin_layer &&
+        if (stage_state.entrypoint && stage_state.entrypoint->written_built_in_layer &&
             cb_state.active_framebuffer->create_info.layers == 1) {
             if (cb_state.active_render_pass && cb_state.active_render_pass->has_multiview_enabled) {
                 // If using MultiView, you should already have hit an error that Framebuffer Layer must be 1, but due to things like

--- a/layers/core_checks/cc_shader_object.cpp
+++ b/layers/core_checks/cc_shader_object.cpp
@@ -242,7 +242,7 @@ bool CoreChecks::ValidateCreateShadersMesh(const VkShaderCreateInfoEXT& create_i
                                            const Location& create_info_loc) const {
     bool skip = false;
     if (create_info.flags & VK_SHADER_CREATE_NO_TASK_SHADER_BIT_EXT) return skip;
-    if (spirv.static_data_.has_builtin_draw_index) {
+    if (spirv.static_data_.has_built_in_draw_index) {
         skip |= LogError(
             "VUID-vkCreateShadersEXT-pCreateInfos-09632", device, create_info_loc,
             "the mesh Shader Object being created uses DrawIndex (gl_DrawID) which will be an undefined value when reading.");

--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -1347,23 +1347,23 @@ bool CoreChecks::ValidatePointSizeShaderState(const spirv::Module &module_state,
     const bool maintenance5 = enabled_features.maintenance5;
 
     if (stage == VK_SHADER_STAGE_GEOMETRY_BIT && output_points) {
-        if (enabled_features.shaderTessellationAndGeometryPointSize && !entrypoint.written_builtin_point_size &&
+        if (enabled_features.shaderTessellationAndGeometryPointSize && !entrypoint.written_built_in_point_size &&
             entrypoint.emit_vertex_geometry && !maintenance5) {
             skip |= LogError(
                 "VUID-VkGraphicsPipelineCreateInfo-shaderTessellationAndGeometryPointSize-08776", module_state.handle(), loc,
                 "SPIR-V (Geometry stage) PointSize is not written, but shaderTessellationAndGeometryPointSize was enabled.");
-        } else if (!enabled_features.shaderTessellationAndGeometryPointSize && entrypoint.written_builtin_point_size) {
+        } else if (!enabled_features.shaderTessellationAndGeometryPointSize && entrypoint.written_built_in_point_size) {
             skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-Geometry-07726", module_state.handle(), loc,
                              "SPIR-V (Geometry stage) PointSize is written to, but shaderTessellationAndGeometryPointSize was not "
                              "enabled (gl_PointSize must NOT be written and a default of 1.0 is assumed).");
         }
     } else if (stage == VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT &&
                ((pipeline.create_info_shaders & VK_SHADER_STAGE_GEOMETRY_BIT) == 0) && point_mode) {
-        if (enabled_features.shaderTessellationAndGeometryPointSize && !entrypoint.written_builtin_point_size && !maintenance5) {
+        if (enabled_features.shaderTessellationAndGeometryPointSize && !entrypoint.written_built_in_point_size && !maintenance5) {
             skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-TessellationEvaluation-07723", module_state.handle(), loc,
                              "SPIR-V (Tessellation Evaluation stage) PointSize is not written, but "
                              "shaderTessellationAndGeometryPointSize was enabled.");
-        } else if (!enabled_features.shaderTessellationAndGeometryPointSize && entrypoint.written_builtin_point_size) {
+        } else if (!enabled_features.shaderTessellationAndGeometryPointSize && entrypoint.written_built_in_point_size) {
             skip |=
                 LogError("VUID-VkGraphicsPipelineCreateInfo-TessellationEvaluation-07724", module_state.handle(), loc,
                          "SPIR-V (Tessellation Evaluation stage) PointSize is written to, shaderTessellationAndGeometryPointSize "
@@ -1372,7 +1372,7 @@ bool CoreChecks::ValidatePointSizeShaderState(const spirv::Module &module_state,
     } else if (stage == VK_SHADER_STAGE_VERTEX_BIT &&
                ((pipeline.create_info_shaders & (VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT | VK_SHADER_STAGE_GEOMETRY_BIT)) ==
                 0)) {
-        if (!entrypoint.written_builtin_point_size && IsPointTopology(pipeline.topology_at_rasterizer) && !maintenance5) {
+        if (!entrypoint.written_built_in_point_size && IsPointTopology(pipeline.topology_at_rasterizer) && !maintenance5) {
             skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-topology-08773", module_state.handle(), loc,
                              "SPIR-V (Vertex) PointSize is not written to, but Pipeline topology is set to "
                              "VK_PRIMITIVE_TOPOLOGY_POINT_LIST.");
@@ -1391,7 +1391,7 @@ bool CoreChecks::ValidatePrimitiveRateShaderState(const spirv::Module &module_st
     if (!phys_dev_ext_props.fragment_shading_rate_props.primitiveFragmentShadingRateWithMultipleViewports &&
         (pipeline.pipeline_type == VK_PIPELINE_BIND_POINT_GRAPHICS) && viewport_state) {
         if (!pipeline.IsDynamic(CB_DYNAMIC_STATE_VIEWPORT_WITH_COUNT) && viewport_state->viewportCount > 1 &&
-            entrypoint.written_builtin_primitive_shading_rate_khr) {
+            entrypoint.written_built_in_primitive_shading_rate_khr) {
             skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-primitiveFragmentShadingRateWithMultipleViewports-04503",
                              module_state.handle(), loc,
                              "SPIR-V (%s) statically writes to PrimitiveShadingRateKHR built-in, but "
@@ -1400,7 +1400,7 @@ bool CoreChecks::ValidatePrimitiveRateShaderState(const spirv::Module &module_st
                              string_VkShaderStageFlagBits(stage));
         }
 
-        if (entrypoint.written_builtin_primitive_shading_rate_khr && entrypoint.written_builtin_viewport_index) {
+        if (entrypoint.written_built_in_primitive_shading_rate_khr && entrypoint.written_built_in_viewport_index) {
             skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-primitiveFragmentShadingRateWithMultipleViewports-04504",
                              module_state.handle(), loc,
                              "SPIR-V (%s) statically writes to both PrimitiveShadingRateKHR and "
@@ -1409,7 +1409,7 @@ bool CoreChecks::ValidatePrimitiveRateShaderState(const spirv::Module &module_st
                              string_VkShaderStageFlagBits(stage));
         }
 
-        if (entrypoint.written_builtin_primitive_shading_rate_khr && entrypoint.written_builtin_viewport_mask_nv) {
+        if (entrypoint.written_built_in_primitive_shading_rate_khr && entrypoint.written_built_in_viewport_mask_nv) {
             skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-primitiveFragmentShadingRateWithMultipleViewports-04505",
                              module_state.handle(), loc,
                              "SPIR-V (%s) statically writes to both PrimitiveShadingRateKHR and "
@@ -2064,7 +2064,7 @@ bool CoreChecks::ValidateShaderStage(const ShaderStageState &stage_state, const 
 
     skip |= ValidateImageWrite(module_state, loc);
     skip |= ValidateShaderExecutionModes(module_state, entrypoint, stage, pipeline, loc);
-    skip |= ValidateBuiltinLimits(module_state, entrypoint, pipeline, loc);
+    skip |= ValidateBuiltInLimits(module_state, entrypoint, pipeline, loc);
     skip |= ValidatePushConstantUsage(module_state, entrypoint, pipeline, stage_state, loc);
     if (enabled_features.cooperativeMatrix) {
         skip |= ValidateCooperativeMatrix(module_state, entrypoint, stage_state, local_size, loc);

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -934,7 +934,7 @@ class CoreChecks : public vvl::DeviceProxy {
                                        const Location& loc) const;
     bool ValidatePushConstantUsage(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
                                    const vvl::Pipeline* pipeline, const ShaderStageState& stage_state, const Location& loc) const;
-    bool ValidateBuiltinLimits(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
+    bool ValidateBuiltInLimits(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
                                const vvl::Pipeline* pipeline, const Location& loc) const;
     bool ValidatePrimitiveTopology(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
                                    const vvl::Pipeline& pipeline, const Location& loc) const;

--- a/layers/gpuav/spirv/pass.cpp
+++ b/layers/gpuav/spirv/pass.cpp
@@ -44,7 +44,7 @@ bool Pass::Run() {
     return modified;
 }
 
-const Variable& Pass::GetBuiltinVariable(uint32_t built_in) {
+const Variable& Pass::GetBuiltInVariable(uint32_t built_in) {
     uint32_t variable_id = 0;
     for (const auto& annotation : module_.annotations_) {
         if (annotation->Opcode() == spv::OpDecorate && annotation->Word(2) == spv::DecorationBuiltIn &&
@@ -131,7 +131,7 @@ uint32_t Pass::GetStageInfo(Function& function, const BasicBlock& target_block_i
 
         // Gets BuiltIn variable and creates a valid OpLoad of it
         auto create_load = [this, &block, &inst_it](spv::BuiltIn built_in) {
-            const Variable& variable = GetBuiltinVariable(built_in);
+            const Variable& variable = GetBuiltInVariable(built_in);
             const Type* pointer_type = variable.PointerType(type_manager_);
             const uint32_t load_id = module_.TakeNextId();
             block.CreateInstruction(spv::OpLoad, {pointer_type->Id(), load_id, variable.Id()}, &inst_it);
@@ -177,7 +177,7 @@ uint32_t Pass::GetStageInfo(Function& function, const BasicBlock& target_block_i
             case spv::ExecutionModelTaskEXT:
             case spv::ExecutionModelMeshEXT: {
                 // This can be both a uvec3 or ivec3 so need to cast if ivec3
-                const Variable& variable = GetBuiltinVariable(spv::BuiltInGlobalInvocationId);
+                const Variable& variable = GetBuiltInVariable(spv::BuiltInGlobalInvocationId);
                 const Type* pointer_type = variable.PointerType(type_manager_);
                 const uint32_t load_id = module_.TakeNextId();
                 block.CreateInstruction(spv::OpLoad, {pointer_type->Id(), load_id, variable.Id()}, &inst_it);

--- a/layers/gpuav/spirv/pass.h
+++ b/layers/gpuav/spirv/pass.h
@@ -56,7 +56,7 @@ class Pass {
     bool Run();
 
     // Finds (and creates if needed) decoration and returns the OpVariable it points to
-    const Variable& GetBuiltinVariable(uint32_t built_in);
+    const Variable& GetBuiltInVariable(uint32_t built_in);
 
     // Returns the ID for OpCompositeConstruct it creates
     uint32_t GetStageInfo(Function& function, const BasicBlock& target_block_it, InstructionIt& out_inst_it);

--- a/layers/gpuav/spirv/type_manager.cpp
+++ b/layers/gpuav/spirv/type_manager.cpp
@@ -403,7 +403,7 @@ const Type& TypeManager::GetTypePointerBuiltInInput(spv::BuiltIn built_in) {
             return GetTypePointer(spv::StorageClassInput, vec4);
         }
         default: {
-            assert(false && "unhandled builtin");
+            assert(false && "unhandled BuiltIn");
             return *(id_to_type_.begin()->second);
         }
     }

--- a/layers/state_tracker/last_bound_state.cpp
+++ b/layers/state_tracker/last_bound_state.cpp
@@ -720,8 +720,8 @@ bool LastBound::IsSampleShadingEnabled() const {
         if (variable.storage_class != spv::StorageClassInput) {
             continue;
         }
-        if (variable.decorations.Has(spirv::DecorationSet::sample_bit) || variable.decorations.builtin == spv::BuiltInSampleId ||
-            variable.decorations.builtin == spv::BuiltInSamplePosition) {
+        if (variable.decorations.Has(spirv::DecorationSet::sample_bit) || variable.decorations.built_in == spv::BuiltInSampleId ||
+            variable.decorations.built_in == spv::BuiltInSamplePosition) {
             return true;
         }
     }
@@ -762,12 +762,12 @@ std::string LastBound::DescribeSampleShading() const {
                 ss << "implicitly in the fragment shader because there is a Sample decorated input variable.";
                 is_implicit = true;
                 break;
-            } else if (variable.decorations.builtin == spv::BuiltInSampleId) {
+            } else if (variable.decorations.built_in == spv::BuiltInSampleId) {
                 ss << "implicitly in the fragment shader because there is a SampleId BuiltIn decorated input variable. "
                       "(gl_SampleID)";
                 is_implicit = true;
                 break;
-            } else if (variable.decorations.builtin == spv::BuiltInSamplePosition) {
+            } else if (variable.decorations.built_in == spv::BuiltInSamplePosition) {
                 ss << "implicitly in the fragment shader because there is a SamplePosition BuiltIn decorated input variable. "
                       "(gl_SamplePosition)";
                 is_implicit = true;

--- a/layers/state_tracker/shader_instruction.cpp
+++ b/layers/state_tracker/shader_instruction.cpp
@@ -16,6 +16,7 @@
 #include <sstream>
 #include "state_tracker/shader_instruction.h"
 #include "generated/spirv_grammar_helper.h"
+#include "state_tracker/shader_module.h"
 
 namespace spirv {
 
@@ -177,7 +178,7 @@ spv::BuiltIn Instruction::GetBuiltIn() const {
         return static_cast<spv::BuiltIn>(Word(4));
     } else {
         assert(false);  // non valid Opcode
-        return spv::BuiltInMax;
+        return spirv::kInvalidBuiltIn;
     }
 }
 

--- a/layers/stateless/sl_spirv.h
+++ b/layers/stateless/sl_spirv.h
@@ -84,6 +84,8 @@ class SpirvValidator : public Logger {
                                             VkShaderStageFlagBits stage, const Location& loc) const;
     bool ValidateShaderStageInputOutputLimits(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
                                               const spirv::StatelessData& stateless_data, const Location& loc) const;
+    bool ValidateShaderStageInterfaceVariables(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
+                                               const spirv::StatelessData& stateless_data, const Location& loc) const;
     bool ValidateShaderFloatControl(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
                                     const spirv::StatelessData& stateless_data, const Location& loc) const;
     bool ValidateExecutionModes(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,

--- a/layers/vulkan/generated/spirv_grammar_helper.cpp
+++ b/layers/vulkan/generated/spirv_grammar_helper.cpp
@@ -1817,7 +1817,7 @@ const char* string_SpvDecoration(uint32_t decoration) {
     }
 }
 
-const char* string_SpvBuiltIn(uint32_t built_in) {
+const char* string_SpvBuiltIn(spv::BuiltIn built_in) {
     switch (built_in) {
         case spv::BuiltInPosition:
             return "Position";

--- a/layers/vulkan/generated/spirv_grammar_helper.h
+++ b/layers/vulkan/generated/spirv_grammar_helper.h
@@ -35,7 +35,7 @@ const char* string_SpvStorageClass(uint32_t storage_class);
 const char* string_SpvExecutionModel(uint32_t execution_model);
 const char* string_SpvExecutionMode(uint32_t execution_mode);
 const char* string_SpvDecoration(uint32_t decoration);
-const char* string_SpvBuiltIn(uint32_t built_in);
+const char* string_SpvBuiltIn(spv::BuiltIn built_in);
 const char* string_SpvDim(uint32_t dim);
 std::string string_SpvCooperativeMatrixOperands(uint32_t mask);
 

--- a/scripts/generators/spirv_grammar_generator.py
+++ b/scripts/generators/spirv_grammar_generator.py
@@ -286,7 +286,7 @@ class SpirvGrammarHelperOutputGenerator(BaseGenerator):
             const char* string_SpvExecutionModel(uint32_t execution_model);
             const char* string_SpvExecutionMode(uint32_t execution_mode);
             const char* string_SpvDecoration(uint32_t decoration);
-            const char* string_SpvBuiltIn(uint32_t built_in);
+            const char* string_SpvBuiltIn(spv::BuiltIn built_in);
             const char* string_SpvDim(uint32_t dim);
             std::string string_SpvCooperativeMatrixOperands(uint32_t mask);
             ''')
@@ -596,7 +596,7 @@ class SpirvGrammarHelperOutputGenerator(BaseGenerator):
                 }}
             }}
 
-            const char* string_SpvBuiltIn(uint32_t built_in) {{
+            const char* string_SpvBuiltIn(spv::BuiltIn built_in) {{
                 switch(built_in) {{
             {"".join([f"""        case spv::BuiltIn{x}:
                         return "{x}";


### PR DESCRIPTION
Added `VUID-PrimitiveShadingRateKHR-PrimitiveShadingRateKHR-12275` (very simple VU) but exposed a but in the `BuiltIn` logic and realize half the issue is the inconsistencies... so now

1. Uses `Spv::BuiltIn` over `uint32_t`
2. it is `built_in` or `BuiltIn` not `builtin`