### PR TITLE
layers: Use ostringstream over stringstream

### DIFF
--- a/layers/best_practices/bp_descriptor.cpp
+++ b/layers/best_practices/bp_descriptor.cpp
@@ -171,7 +171,7 @@ bool BestPractices::PreCallValidateCreateDescriptorPool(VkDevice device, const V
 
     const auto* mutable_descriptor_type_ci = vku::FindStructInPNextChain<VkMutableDescriptorTypeCreateInfoEXT>(pCreateInfo->pNext);
     if (mutable_descriptor_type_ci && mutable_descriptor_type_ci->mutableDescriptorTypeListCount > pCreateInfo->poolSizeCount) {
-        std::stringstream msg;
+        std::ostringstream msg;
         if (pCreateInfo->poolSizeCount == 1) {
             msg << "first element";
         } else {

--- a/layers/best_practices/bp_utils.cpp
+++ b/layers/best_practices/bp_utils.cpp
@@ -50,7 +50,7 @@ const char* VendorSpecificTag(BPVendorFlags vendors) {
     auto res = tag_map.find(vendors);
     if (res == tag_map.end()) {
         // Build the vendor tag string
-        std::stringstream vendor_tag;
+        std::ostringstream vendor_tag;
 
         vendor_tag << "[";
         bool first_vendor = true;

--- a/layers/containers/range.h
+++ b/layers/containers/range.h
@@ -126,14 +126,14 @@ class range_view {
 
 template <typename Range>
 std::string string_range(const Range &range) {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << "[" << range.begin << ", " << range.end << ')';
     return ss.str();
 }
 
 template <typename Range>
 std::string string_range_hex(const Range &range) {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << std::hex << "[0x" << range.begin << ", 0x" << range.end << ')';
     return ss.str();
 }

--- a/layers/core_checks/cc_buffer.cpp
+++ b/layers/core_checks/cc_buffer.cpp
@@ -269,7 +269,7 @@ bool CoreChecks::PreCallValidateCreateBufferView(VkDevice device, const VkBuffer
                 alignment_requirement = std::min(alignment_requirement, texel_block_size);
             }
             if (!IsIntegerMultipleOf(pCreateInfo->offset, alignment_requirement)) {
-                std::stringstream ss;
+                std::ostringstream ss;
                 ss << "was created with VK_BUFFER_USAGE_2_STORAGE_TEXEL_BUFFER_BIT, so the offset (" << pCreateInfo->offset
                    << ") must be a multiple of " << alignment_requirement << "\n";
                 if (phys_dev_props_core13.storageTexelBufferOffsetSingleTexelAlignment) {
@@ -297,7 +297,7 @@ bool CoreChecks::PreCallValidateCreateBufferView(VkDevice device, const VkBuffer
                 alignment_requirement = std::min(alignment_requirement, texel_block_size);
             }
             if (!IsIntegerMultipleOf(pCreateInfo->offset, alignment_requirement)) {
-                std::stringstream ss;
+                std::ostringstream ss;
                 ss << "was created with VK_BUFFER_USAGE_2_UNIFORM_TEXEL_BUFFER_BIT, so the offset (" << pCreateInfo->offset
                    << ") must be a multiple of " << alignment_requirement << "\n";
                 if (phys_dev_props_core13.uniformTexelBufferOffsetSingleTexelAlignment) {

--- a/layers/core_checks/cc_buffer_address.h
+++ b/layers/core_checks/cc_buffer_address.h
@@ -100,7 +100,7 @@ class BufferAddressValidation {
         vvl::span<vvl::Buffer* const> buffer_list = validator.GetBuffersByAddress(device_address);
         if (buffer_list.empty()) {
             NearestBufferResult nearest = validator.GetNearestBuffersByAddress(device_address);
-            std::stringstream ss;
+            std::ostringstream ss;
             ss << "(0x" << std::hex << device_address
                << ") is not a valid buffer address. No call to vkGetBufferDeviceAddress has this buffer in its range.";
             if (!nearest.above_buffers.empty()) {
@@ -196,7 +196,7 @@ bool BufferAddressValidation<ChecksCount>::LogInvalidBuffers(const CoreChecks& v
     // Some checks only care about the address, but for those that have a range, print it here so it is the same across all error
     // messages
     if (range_size != 0) {
-        std::stringstream ss;
+        std::ostringstream ss;
         ss << "[0x" << std::hex << device_address << ", 0x" << (device_address + range_size) << ") (";
         if (range_size == VK_WHOLE_SIZE) {
             ss << "VK_WHOLE_SIZE";
@@ -213,7 +213,7 @@ bool BufferAddressValidation<ChecksCount>::LogInvalidBuffers(const CoreChecks& v
         }
         error_msg_beginning = ss.str();
     } else {
-        std::stringstream ss;
+        std::ostringstream ss;
         ss << "(0x" << std::hex << device_address << ") has no buffer(s) associated that are valid.\n";
         error_msg_beginning = ss.str();
     }

--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -108,7 +108,7 @@ bool CoreChecks::ValidateCmd(const vvl::CommandBuffer &cb_state, const Location 
 
 // This is a single location to report when a command buffer is invalid (which means it is not in a "recording state")
 bool CoreChecks::ReportInvalidCommandBuffer(const vvl::CommandBuffer &cb_state, const Location &loc, const char *vuid) const {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << "was called in " << FormatHandle(cb_state) << " which ";
 
     assert(cb_state.state == CbState::InvalidIncomplete || cb_state.state == CbState::InvalidComplete);
@@ -966,7 +966,7 @@ class CoreChecks::ViewportScissorInheritanceTracker {
                     break;
             }
 
-            std::stringstream ss;
+            std::ostringstream ss;
             ss << "(" << log_.FormatHandle(secondary_state.Handle()).c_str() << ") consume inherited " << state_name << " ";
             if (format_index) {
                 if (index >= static_use_count) {

--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -1340,7 +1340,7 @@ bool CoreChecks::ValidateDrawRenderingAttachmentLocation(const vvl::CommandBuffe
         uint32_t pipeline_color_location = pipeline_color_locations ? pipeline_color_locations[i] : i;
         if (pipeline_color_location != cb_state.rendering_attachments.color_locations[i]) {
             const LogObjectList objlist(cb_state.Handle(), pipeline_state.Handle());
-            std::stringstream ss;
+            std::ostringstream ss;
             ss << "The pipeline VkRenderingAttachmentLocationInfo::pColorAttachmentLocations[" << i << "] is "
                << pipeline_color_location;
             if (!explicit_pipeline) {
@@ -1395,7 +1395,7 @@ bool CoreChecks::ValidateDrawRenderingInputAttachmentIndex(const vvl::CommandBuf
         uint32_t pipeline_color_index = pipeline_color_indexes ? pipeline_color_indexes[i] : i;
         if (pipeline_color_index != cb_state.rendering_attachments.color_indexes[i]) {
             const LogObjectList objlist(cb_state.Handle(), pipeline_state.Handle());
-            std::stringstream ss;
+            std::ostringstream ss;
             ss << "The pipeline VkRenderingInputAttachmentIndexInfo::pColorAttachmentInputIndices[" << i << "] is "
                << pipeline_color_index;
             if (!explicit_pipeline) {
@@ -1414,7 +1414,7 @@ bool CoreChecks::ValidateDrawRenderingInputAttachmentIndex(const vvl::CommandBuf
 
     if (!EqualValuesOrBothNull(pipeline_depth_index, cb_state.rendering_attachments.depth_index)) {
         const LogObjectList objlist(cb_state.Handle(), pipeline_state.Handle());
-        std::stringstream ss;
+        std::ostringstream ss;
         ss << "The pipeline VkRenderingInputAttachmentIndexInfo::pDepthInputAttachmentIndex is "
            << string_AttachmentPointer(pipeline_depth_index);
         if (!explicit_pipeline) {
@@ -1431,7 +1431,7 @@ bool CoreChecks::ValidateDrawRenderingInputAttachmentIndex(const vvl::CommandBuf
 
     if (!EqualValuesOrBothNull(pipeline_stencil_index, cb_state.rendering_attachments.stencil_index)) {
         const LogObjectList objlist(cb_state.Handle(), pipeline_state.Handle());
-        std::stringstream ss;
+        std::ostringstream ss;
         ss << "The pipeline VkRenderingInputAttachmentIndexInfo::pStencilInputAttachmentIndex is "
            << string_AttachmentPointer(pipeline_stencil_index);
         if (!explicit_pipeline) {

--- a/layers/core_checks/cc_copy_blit_resolve.cpp
+++ b/layers/core_checks/cc_copy_blit_resolve.cpp
@@ -45,7 +45,7 @@ struct ImageRegionIntersection {
     VkExtent3D extent = {1, 1, 1};
     bool has_intersection = false;
     std::string String() const noexcept {
-        std::stringstream ss;
+        std::ostringstream ss;
         ss << "\nsubresource : { aspectMask: " << string_VkImageAspectFlags(subresource.aspectMask)
            << ", mipLevel: " << subresource.mipLevel << ", baseArrayLayer: " << subresource.baseArrayLayer
            << ", layerCount: " << subresource.layerCount << " },\noffset : {" << string_VkOffset3D(offset) << "},\nextent : {"
@@ -272,7 +272,7 @@ bool CoreChecks::ValidateTransferGranularityExtent(const LogObjectList &objlist,
         }
 
         if (!(x_ok && y_ok && z_ok)) {
-            std::stringstream ss;
+            std::ostringstream ss;
             ss << "(" << string_VkExtent3D(region_extent)
                << ") is invalid with this command buffer's queue family minImageTransferGranularity ("
                << string_VkExtent3D(granularity) << ") for copying to/from " << FormatHandle(image_state) << " ("
@@ -330,7 +330,7 @@ static std::string DescribeValidAspectMaskForFormat(VkFormat format) {
         aspect_mask |= VK_IMAGE_ASPECT_PLANE_2_BIT;
     }
 
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << "Valid VkImageAspectFlags are " << string_VkImageAspectFlags(aspect_mask);
     return ss.str();
 }
@@ -421,14 +421,14 @@ struct ImageCopyRegion {
     }
 
     std::string DescribeSrcAndDstImage() const {
-        std::stringstream ss;
+        std::ostringstream ss;
         ss << "srcImage: " << src_state.DescribeSubresourceLayers(src_subresource)
            << "dstImage: " << dst_state.DescribeSubresourceLayers(dst_subresource);
         return ss.str();
     }
 
     std::string DescribeAdjustedExtent() const {
-        std::stringstream ss;
+        std::ostringstream ss;
         if (is_adjusted_extent) {
             ss << "The VkImageCopy::extent [" << string_VkExtent3D(extent) << "] is adjusted to ["
                << string_VkExtent3D(dst_adjusted_extent) << "] because it is going from ";
@@ -1536,7 +1536,7 @@ bool CoreChecks::ValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkImage src
                 const bool exception = src_image_type != dst_image_type && src_layer_count == VK_REMAINING_ARRAY_LAYERS &&
                                        dst_layer_count == VK_REMAINING_ARRAY_LAYERS;
                 if (!exception && normalized_src_layer_count != normalized_dst_layer_count) {
-                    std::stringstream ss;
+                    std::ostringstream ss;
                     ss << "(" << string_LayerCount(src_image_state->create_info, src_subresource) << ") does not match "
                        << dst_subresource_loc.dot(Field::layerCount).Fields() << " ("
                        << string_LayerCount(dst_image_state->create_info, dst_subresource) << ").";
@@ -1685,7 +1685,7 @@ bool CoreChecks::ValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkImage src
             // If size is still zero, then format is invalid and will be caught in another VU
             if ((src_format_size != dst_format_size) && (src_format_size != 0) && (dst_format_size != 0)) {
                 vuid = is_2 ? "VUID-VkCopyImageInfo2-None-01549" : "VUID-vkCmdCopyImage-None-01549";
-                std::stringstream ss;
+                std::ostringstream ss;
                 ss << "srcImage format " << string_VkFormat(src_plane_format);
                 if (is_src_multiplane) {
                     ss << " (which is the compatible format for plane "
@@ -2131,7 +2131,7 @@ bool CoreChecks::ValidateBufferBounds(const vvl::CommandBuffer &cb_state, const 
 
     if (buffer_state.create_info.size < buffer_copy_size) {
         const LogObjectList objlist(cb_state.Handle(), buffer_state.Handle(), image_state.Handle());
-        std::stringstream ss;
+        std::ostringstream ss;
         ss << "is trying to copy " << buffer_copy_size << " bytes to/from the (" << FormatHandle(buffer_state).c_str()
            << ") which exceeds the VkBuffer total size of " << buffer_state.create_info.size
            << " bytes.\nLast texel coordinate of the image is at {x = " << last_x << ", y = " << last_y << ", z = " << last_z
@@ -2678,7 +2678,7 @@ bool CoreChecks::ValidateMemoryImageCopyCommon(InfoPointer info_ptr, const Locat
 bool CoreChecks::ValidateHostCopyImageCreateInfos(const vvl::Image &src_image_state, const vvl::Image &dst_image_state,
                                                   const Location &loc) const {
     bool skip = false;
-    std::stringstream mismatch_stream{};
+    std::ostringstream mismatch_stream{};
     const VkImageCreateInfo &src_info = src_image_state.create_info;
     const VkImageCreateInfo &dst_info = dst_image_state.create_info;
 
@@ -2729,7 +2729,7 @@ bool CoreChecks::ValidateHostCopyImageCreateInfos(const vvl::Image &src_image_st
     }
 
     if (mismatch_stream.str().length() > 0) {
-        std::stringstream ss;
+        std::ostringstream ss;
         ss << "The creation parameters for srcImage and dstImage differ:\n" << mismatch_stream.str();
         LogObjectList objlist(src_image_state.Handle(), dst_image_state.Handle());
         skip |= LogError("VUID-VkCopyImageToImageInfo-srcImage-09069", objlist, loc, "%s.", ss.str().c_str());
@@ -2751,7 +2751,7 @@ bool CoreChecks::ValidateHostCopyImageLayout(const VkImage image, const VkImageL
         }
     }
 
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << "is " << string_VkImageLayout(image_layout)
        << " which is not one of the layouts returned in VkPhysicalDeviceHostImageCopyPropertiesEXT::" << String(supported_name)
        << "[" << layout_count << "]\nList of supported layouts:\n";

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -71,7 +71,7 @@ bool CoreChecks::VerifyDescriptorSetLayoutIsCompatibile(const vvl::DescriptorSet
     // Check descriptor counts
     const auto bound_total_count = to_bind_ds_layout_def->GetTotalDescriptorCount();
     if (reference_ds_layout_def->GetTotalDescriptorCount() != to_bind_ds_layout_def->GetTotalDescriptorCount()) {
-        std::stringstream error_str;
+        std::ostringstream error_str;
         error_str << FormatHandle(reference_dsl_handle) << " from pipeline layout has "
                   << reference_ds_layout_def->GetTotalDescriptorCount() << " total descriptors, but "
                   << FormatHandle(to_bind_dsl_handle) << ", trying to bind, has " << bound_total_count << " total descriptors";
@@ -84,7 +84,7 @@ bool CoreChecks::VerifyDescriptorSetLayoutIsCompatibile(const vvl::DescriptorSet
     for (const auto [binding_index, layout_binding] : vvl::enumerate(reference_ds_layout_def->GetBindings())) {
         const auto bound_binding = to_bind_ds_layout_def->GetBindingInfoFromIndex((uint32_t)binding_index);
         if (layout_binding.descriptorCount != bound_binding->descriptorCount) {
-            std::stringstream error_str;
+            std::ostringstream error_str;
             error_str << "Binding " << layout_binding.binding << " for " << FormatHandle(reference_dsl_handle)
                       << " from pipeline layout has a descriptorCount of " << layout_binding.descriptorCount << " but binding "
                       << layout_binding.binding << " for " << FormatHandle(to_bind_dsl_handle)
@@ -96,7 +96,7 @@ bool CoreChecks::VerifyDescriptorSetLayoutIsCompatibile(const vvl::DescriptorSet
             error_msg = error_str.str();
             return false;
         } else if (layout_binding.descriptorType != bound_binding->descriptorType) {
-            std::stringstream error_str;
+            std::ostringstream error_str;
             error_str << "Binding " << layout_binding.binding << " for " << FormatHandle(reference_dsl_handle)
                       << " from pipeline layout is type " << string_VkDescriptorType(layout_binding.descriptorType)
                       << " but binding " << layout_binding.binding << " for " << FormatHandle(to_bind_dsl_handle)
@@ -104,7 +104,7 @@ bool CoreChecks::VerifyDescriptorSetLayoutIsCompatibile(const vvl::DescriptorSet
             error_msg = error_str.str();
             return false;
         } else if (layout_binding.stageFlags != bound_binding->stageFlags) {
-            std::stringstream error_str;
+            std::ostringstream error_str;
             error_str << "Binding " << layout_binding.binding << " for " << FormatHandle(reference_dsl_handle)
                       << " from pipeline layout has stageFlags " << string_VkShaderStageFlags(layout_binding.stageFlags)
                       << " but binding " << layout_binding.binding << " for " << FormatHandle(to_bind_dsl_handle)
@@ -121,7 +121,7 @@ bool CoreChecks::VerifyDescriptorSetLayoutIsCompatibile(const vvl::DescriptorSet
     }
 
     if (reference_ds_layout_def->GetCreateFlags() != to_bind_ds_layout_def->GetCreateFlags()) {
-        std::stringstream error_str;
+        std::ostringstream error_str;
         error_str << FormatHandle(reference_dsl_handle) << " from pipeline layout was created with ("
                   << string_VkDescriptorSetLayoutCreateFlags(reference_ds_layout_def->GetCreateFlags()) << "), but "
                   << FormatHandle(to_bind_dsl_handle) << ", trying to bind, has ("
@@ -134,7 +134,7 @@ bool CoreChecks::VerifyDescriptorSetLayoutIsCompatibile(const vvl::DescriptorSet
     const auto &ds_layout_flags = reference_ds_layout_def->GetBindingFlags();
     const auto &bound_layout_flags = to_bind_ds_layout_def->GetBindingFlags();
     if (bound_layout_flags != ds_layout_flags) {
-        std::stringstream error_str;
+        std::ostringstream error_str;
         assert(ds_layout_flags.size() == bound_layout_flags.size());
         size_t i;
         for (i = 0; i < ds_layout_flags.size(); i++) {
@@ -1416,7 +1416,7 @@ bool CoreChecks::ValidateImageUpdate(const vvl::ImageView &view_state, VkImageLa
                 default:
                     break;
             }
-            std::stringstream error_str;
+            std::ostringstream error_str;
             error_str << "Descriptor update with descriptorType " << string_VkDescriptorType(type)
                       << " is being updated with invalid imageLayout " << string_VkImageLayout(image_layout) << " for image "
                       << FormatHandle(image_state->Handle()) << " in imageView " << FormatHandle(view_state.Handle())
@@ -1790,7 +1790,7 @@ bool CoreChecks::ValidateWriteUpdate(const vvl::DescriptorSet &dst_set, const Vk
             // stageFlags
             if (current_binding->count > 0) {
                 if (current_binding->type != descriptor_type) {
-                    std::stringstream extra;
+                    std::ostringstream extra;
                     // If using inline, easy to go outside of its range and not realize you are in the next descriptor
                     if (descriptor_type == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK) {
                         extra << "\nFor inline uniforms blocks, you might have your VkWriteDescriptorSet::dstArrayElement ("
@@ -2826,7 +2826,7 @@ bool CoreChecks::PreCallValidateCmdBindDescriptorBuffersEXT(VkCommandBuffer comm
 
     auto list_buffers = [this](std::vector<VkBuffer> &buffer_list) {
         vvl::unordered_set<VkBuffer> unique_buffers;
-        std::stringstream msg;
+        std::ostringstream msg;
         for (const VkBuffer &buffer : buffer_list) {
             msg << FormatHandle(buffer) << '\n';
             unique_buffers.insert(buffer);
@@ -3234,7 +3234,7 @@ bool CoreChecks::ValidateDescriptorAddressInfoTexelBufferAlignment(const VkDescr
             alignment_requirement = std::min(alignment_requirement, texel_block_size);
         }
         if (!IsPointerAligned(address_info.address, alignment_requirement)) {
-            std::stringstream ss;
+            std::ostringstream ss;
             ss << "(0x" << std::hex << address_info.address << std::dec << ") must be aligned to " << alignment_requirement << "\n";
             if (phys_dev_props_core13.storageTexelBufferOffsetSingleTexelAlignment) {
                 ss << "storageTexelBufferOffsetSingleTexelAlignment is VK_TRUE, so we take "
@@ -3260,7 +3260,7 @@ bool CoreChecks::ValidateDescriptorAddressInfoTexelBufferAlignment(const VkDescr
             alignment_requirement = std::min(alignment_requirement, texel_block_size);
         }
         if (!IsPointerAligned(address_info.address, alignment_requirement)) {
-            std::stringstream ss;
+            std::ostringstream ss;
             ss << "(0x" << std::hex << address_info.address << std::dec << ") must be a aligned to " << alignment_requirement
                << "\n";
             if (phys_dev_props_core13.uniformTexelBufferOffsetSingleTexelAlignment) {

--- a/layers/core_checks/cc_device_memory.cpp
+++ b/layers/core_checks/cc_device_memory.cpp
@@ -2879,7 +2879,7 @@ bool CoreChecks::ValidateBindDataGraphPipelineSessionMemoryARM(const VkBindDataG
         return bpr.bindPoint == bind_info.bindPoint;
     });
     if (bpr_match == bp_requirements.end()) {
-        std::stringstream required_bindpoints;
+        std::ostringstream required_bindpoints;
         for (auto &bpr : bp_requirements) {
             if (!required_bindpoints.str().empty()) {
                 required_bindpoints << ", ";

--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -2262,7 +2262,7 @@ bool CoreChecks::ValidateDrawVertexBinding(const LastBound &last_bound, const vv
     const bool robust_pipeline = last_bound.pipeline_state && last_bound.pipeline_state->uses_pipeline_vertex_robustness;
 
     auto print_binding = [has_dynamic_descriptions](const VertexBindingState binding_description) {
-        std::stringstream ss;
+        std::ostringstream ss;
         if (has_dynamic_descriptions) {
             ss << "the last call to vkCmdSetVertexInputEXT";
         } else {

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -1245,7 +1245,7 @@ bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffe
                                  "VK_IMAGE_ASPECT_COLOR_BIT but there are no color attachments in the renderpass.");
             } else if (clear_desc->colorAttachment >= color_attachment_count) {
                 auto describe_color_count = [is_dynamic_rendering, &cb_state]() {
-                    std::stringstream ss;
+                    std::ostringstream ss;
                     if (is_dynamic_rendering) {
                         ss << "VkRenderingInfo::colorAttachmentCount";
                     } else {

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -3352,7 +3352,7 @@ bool CoreChecks::ValidateGraphicsPipelineBindPoint(const vvl::CommandBuffer &cb_
         if ((discard_rectangle_state && discard_rectangle_state->discardRectangleCount != 0) ||
             (pipeline.IsDynamic(CB_DYNAMIC_STATE_DISCARD_RECTANGLE_ENABLE_EXT))) {
             if (!pipeline.IsDynamic(CB_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT)) {
-                std::stringstream msg;
+                std::ostringstream msg;
                 if (discard_rectangle_state) {
                     msg << "VkPipelineDiscardRectangleStateCreateInfoEXT::discardRectangleCount = "
                         << discard_rectangle_state->discardRectangleCount;

--- a/layers/core_checks/cc_query.cpp
+++ b/layers/core_checks/cc_query.cpp
@@ -439,7 +439,7 @@ bool CoreChecks::HasRequiredQueueFlags(const vvl::CommandBuffer &cb_state, const
 std::string CoreChecks::DescribeRequiredQueueFlag(const vvl::CommandBuffer &cb_state,
                                                   const vvl::PhysicalDevice &physical_device_state,
                                                   VkQueueFlags required_flags) const {
-    std::stringstream ss;
+    std::ostringstream ss;
     auto pool = cb_state.command_pool;
     const uint32_t queue_family_index = pool->queueFamilyIndex;
     const VkQueueFlags queue_flags = physical_device_state.queue_family_properties[queue_family_index].queueFlags;

--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -1773,7 +1773,7 @@ bool CoreChecks::ValidateRenderpassAttachmentUsage(const VkRenderPassCreateInfo2
                         (!subpass_depth_stencil_resolve ||
                          (subpass_depth_stencil_resolve->pDepthStencilResolveAttachment != VK_NULL_HANDLE &&
                           subpass_depth_stencil_resolve->pDepthStencilResolveAttachment->attachment != VK_ATTACHMENT_UNUSED))) {
-                        std::stringstream message;
+                        std::ostringstream message;
                         message << "has a VkMultisampledRenderToSingleSampledInfoEXT struct in its "
                                    "VkSubpassDescription2 pNext chain with multisampledRenderToSingleSampled set to "
                                    "VK_TRUE and pDepthStencilAttachment has a sample count of VK_SAMPLE_COUNT_1_BIT ";
@@ -2834,7 +2834,7 @@ bool CoreChecks::ValidateFragmentShadingRateAttachments(const VkRenderPassCreate
 
         // Lambda function turning a vector of integers into a string
         auto vector_to_string = [&](std::vector<uint32_t> vector) {
-            std::stringstream ss;
+            std::ostringstream ss;
             size_t size = vector.size();
             for (size_t i = 0; i < used_as_fragment_shading_rate_attachment.size(); i++) {
                 if (size == 2 && i == 1) {

--- a/layers/core_checks/cc_shader_interface.cpp
+++ b/layers/core_checks/cc_shader_interface.cpp
@@ -373,7 +373,7 @@ bool CoreChecks::ValidateInterfaceBetweenStages(const spirv::Module &producer, c
                 if (producer_stage == VK_SHADER_STAGE_MESH_BIT_EXT) {
                     if (input_var->is_per_primitive_ext != output_var->is_per_primitive_ext) {
                         const LogObjectList objlist(producer.handle(), consumer.handle());
-                        std::stringstream ss;
+                        std::ostringstream ss;
                         ss << "(SPIR-V Interface) at Location " << location << " Component " << component
                            << " in the Mesh stage is " << (output_var->is_per_primitive_ext ? "" : "not")
                            << " decorated with PerPrimitiveEXT while the Fragment stage is "
@@ -462,7 +462,7 @@ bool CoreChecks::ValidateInterfaceBetweenStages(const spirv::Module &producer, c
     }
 
     if (mismatch) {
-        std::stringstream msg;
+        std::ostringstream msg;
         msg << string_VkShaderStageFlagBits(producer_stage) << " Output Block {\n";
         for (size_t i = 0; i < output_built_in_block.size(); i++) {
             msg << '\t' << i << ": " << string_SpvBuiltIn(output_built_in_block[i]) << '\n';
@@ -578,7 +578,7 @@ bool CoreChecks::ValidateFsOutputsAgainstRenderPass(const spirv::Module &module_
 }
 
 static std::string DescribeMappedLocation(uint32_t shader, uint32_t rendering_info) {
-    std::stringstream msg;
+    std::ostringstream msg;
     if (shader == rendering_info) {
         msg << shader;
     } else {
@@ -655,7 +655,7 @@ bool CoreChecks::ValidateDrawDynamicRenderingFsOutputs(const LastBound &last_bou
                 const bool null_image_view = attachment_info.rendering_attachment_info &&
                                              attachment_info.rendering_attachment_info->imageView == VK_NULL_HANDLE;
                 const LogObjectList objlist = last_bound_state.cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS);
-                std::stringstream reason;
+                std::ostringstream reason;
                 if (null_image_view || location >= cb_state.rendering_attachments.color_locations.size()) {
                     reason << "there is no VkRenderingInfo::pColorAttachments[" << mapped_loc << "]";
                     if (null_image_view) {

--- a/layers/core_checks/cc_shader_object.cpp
+++ b/layers/core_checks/cc_shader_object.cpp
@@ -862,7 +862,7 @@ bool CoreChecks::ValidateDrawShaderObjectMesh(const LastBound& last_bound_state,
 
     if (has_task_shader || has_mesh_shader) {
         auto print_mesh_task = [this, has_task_shader, has_mesh_shader, mesh_shader_handle, task_shader_handle]() {
-            std::stringstream msg;
+            std::ostringstream msg;
             if (has_task_shader && has_mesh_shader) {
                 msg << "Task shader (" << FormatHandle(task_shader_handle).c_str() << ") and mesh shader ("
                     << FormatHandle(mesh_shader_handle).c_str() << ") are";
@@ -932,7 +932,7 @@ bool CoreChecks::ValidateDrawShaderObjectMesh(const LastBound& last_bound_state,
         const bool has_tese_shader = tese_shader_handle != VK_NULL_HANDLE;
         const bool has_geom_shader = geom_shader_handle != VK_NULL_HANDLE;
         if (has_vertex_shader || has_tesc_shader || has_tese_shader || has_geom_shader) {
-            std::stringstream msg;
+            std::ostringstream msg;
             if (has_vertex_shader) msg << "Vertex shader: " << FormatHandle(vertex_shader_handle) << '\n';
             if (has_tese_shader) msg << "Tessellation Eval shader: " << FormatHandle(tese_shader_handle) << '\n';
             if (has_tesc_shader) msg << "Tessellation Control shader: " << FormatHandle(tesc_shader_handle) << '\n';

--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -69,7 +69,7 @@ bool CoreChecks::ValidateShaderInputAttachment(const spirv::Module& module_state
     const auto input_attachments = subpass_description.pInputAttachments;
 
     auto print_index = [variable](uint32_t i) {
-        std::stringstream ss;
+        std::ostringstream ss;
         ss << variable.DescribeDescriptor() << " has an InputAttachmentIndex of "
            << variable.decorations.input_attachment_index_start;
         if (variable.IsArray()) {
@@ -300,7 +300,7 @@ static void TypeToDescriptorTypeSet(const spirv::Module &module_state, uint32_t 
 }
 
 static std::string string_DescriptorTypeSet(const vvl::unordered_set<uint32_t> &descriptor_type_set) {
-    std::stringstream ss;
+    std::ostringstream ss;
     for (auto it = descriptor_type_set.begin(); it != descriptor_type_set.end(); ++it) {
         if (ss.tellp()) ss << " or ";
         ss << string_VkDescriptorType(VkDescriptorType(*it));
@@ -1557,7 +1557,7 @@ bool CoreChecks::ValidateShaderInterfaceVariableDSL(const spirv::Module &module_
     }
 
     auto print_dsl_info = [&stage_state, &variable]() {
-        std::stringstream ss;
+        std::ostringstream ss;
         const bool has_pipeline = stage_state.shader_object_create_info == nullptr;
         if (has_pipeline) {
             ss << "VkPipelineLayoutCreateInfo::pSetLayouts[" << variable.decorations.set << "]";
@@ -1664,7 +1664,7 @@ bool CoreChecks::ValidateShaderYcbcrSampler(const spirv::Module& module_state, c
         }
 
         if (!variable.all_constant_integral_expressions) {
-            std::stringstream ss;
+            std::ostringstream ss;
             ss << variable.DescribeDescriptor()
                << " is an COMBINED_SAMPLED_IMAGE tied to an array of YCbCr samplers and it trying to be accessed with a "
                   "non-constant index value.\nRegardless if it is uniform or not, you can't dynamically index into an array of "
@@ -1758,7 +1758,7 @@ static const std::string GetShaderTileImageCapabilitiesString(const spirv::Modul
          {spv::CapabilityTileImageDepthReadAccessEXT, "TileImageDepthReadAccessEXT"},
          {spv::CapabilityTileImageStencilReadAccessEXT, "TileImageStencilReadAccessEXT"}}};
 
-    std::stringstream ss_capabilities;
+    std::ostringstream ss_capabilities;
     for (auto spv_capability : shader_tile_image_capabilities) {
         if (module_state.HasCapability(spv_capability.cap)) {
             if (ss_capabilities.tellp()) ss_capabilities << ", ";
@@ -1859,7 +1859,7 @@ bool CoreChecks::ValidateShaderStage(const ShaderStageState &stage_state, const 
 
     if (!stage_state.entrypoint) {
         const char *vuid = pipeline ? "VUID-VkPipelineShaderStageCreateInfo-pName-00707" : "VUID-VkShaderCreateInfoEXT-pName-08440";
-        std::stringstream err;
+        std::ostringstream err;
         err << "\"" << stage_state.GetPName() << "\" entry point not found for stage " << string_VkShaderStageFlagBits(stage)
             << ".";
         if (stage_state.spirv_state->static_data_.entry_points.size() == 1) {
@@ -1954,7 +1954,7 @@ bool CoreChecks::ValidateShaderStage(const ShaderStageState &stage_state, const 
                 }
 
                 if (map_entry.size != spec_const_size) {
-                    std::stringstream name;
+                    std::ostringstream name;
                     if (module_state_ptr->handle() != NullVulkanTypedHandle) {
                         name << "shader module " << FormatHandle(module_state_ptr->handle());
                     } else {
@@ -2727,7 +2727,7 @@ bool CoreChecks::ValidateTaskPayload(const spirv::Module *task_module, const spi
     }
 
     if (task_payload_size != mesh_payload_size) {
-        std::stringstream ss;
+        std::ostringstream ss;
         ss << "The Mesh Shader has a TaskPayloadWorkgroupEXT variable, but the Task Shader ";
         if (task_payload_size == 0) {
             ss << "never sets the TaskPayloadWorkgroupEXT variable in the call to OpEmitMeshTasksEXT";
@@ -2776,7 +2776,7 @@ bool CoreChecks::ValidateDataGraphPipelineShaderModuleSpirv(VkDevice device, con
     }
 
     if (!entry_point) {
-        std::stringstream wrong_names;
+        std::ostringstream wrong_names;
         for (const auto &ep : module_spirv.static_data_.entry_points) {
             if (!wrong_names.str().empty()) {
                 wrong_names << ", ";

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -221,7 +221,7 @@ bool SemaphoreSubmitState::ValidateWaitSemaphore(const Location &wait_semaphore_
 static std::string GetSemaphoreInUseBySwapchainMessage(const vvl::Semaphore::SwapchainWaitInfo &swapchain_info,
                                                        const vvl::Semaphore &semaphore_state, VkQueue queue,
                                                        bool swapchain_fence_supported, const Logger &logger) {
-    std::stringstream ss;
+    std::ostringstream ss;
 
     const std::string semaphore_str = logger.FormatHandle(semaphore_state.Handle());
     const std::string queue_str = logger.FormatHandle(queue);
@@ -326,7 +326,7 @@ bool SemaphoreSubmitState::ValidateBinarySignal(const Location &semaphore_loc, c
     VkQueue other_queue = VK_NULL_HANDLE;
     vvl::Func other_command = vvl::Func::Empty;
     if (!CanSignalBinary(semaphore_state, other_queue, other_command)) {
-        std::stringstream initiator;
+        std::ostringstream initiator;
         if (other_command != vvl::Func::Empty) {
             initiator << String(other_command);
         }

--- a/layers/core_checks/cc_wsi.cpp
+++ b/layers/core_checks/cc_wsi.cpp
@@ -446,7 +446,7 @@ bool CoreChecks::ValidateCreateSwapchain(const VkSwapchainCreateInfoKHR &create_
     // VkSurfaceCapabilitiesKHR::supportedTransforms.
     if (!create_info.preTransform || (create_info.preTransform & (create_info.preTransform - 1)) ||
         !(create_info.preTransform & surface_caps.supportedTransforms)) {
-        std::stringstream ss;
+        std::ostringstream ss;
         for (int i = 0; i < 32; i++) {
             if ((1 << i) & surface_caps.supportedTransforms) {
                 ss << "  " << string_VkSurfaceTransformFlagBitsKHR(static_cast<VkSurfaceTransformFlagBitsKHR>(1 << i)) << "\n";
@@ -461,7 +461,7 @@ bool CoreChecks::ValidateCreateSwapchain(const VkSwapchainCreateInfoKHR &create_
     // VkSurfaceCapabilitiesKHR::supportedCompositeAlpha
     if (!create_info.compositeAlpha || (create_info.compositeAlpha & (create_info.compositeAlpha - 1)) ||
         !((create_info.compositeAlpha) & surface_caps.supportedCompositeAlpha)) {
-        std::stringstream ss;
+        std::ostringstream ss;
         for (int i = 0; i < 32; i++) {
             if ((1 << i) & surface_caps.supportedCompositeAlpha) {
                 ss << "  " << string_VkCompositeAlphaFlagBitsKHR(static_cast<VkCompositeAlphaFlagBitsKHR>(1 << i)) << "\n";
@@ -543,7 +543,7 @@ bool CoreChecks::ValidateCreateSwapchain(const VkSwapchainCreateInfoKHR &create_
 
     // Found a case in the wild where |present_mode| was empty, not sure why, but skip to not have confusing error messages.
     if (!present_modes.empty() && std::find(present_modes.begin(), present_modes.end(), present_mode) == present_modes.end()) {
-        std::stringstream ss;
+        std::ostringstream ss;
         for (auto mode : present_modes) {
             ss << string_VkPresentModeKHR(mode) << " ";
         }

--- a/layers/drawdispatch/descriptor_validator.cpp
+++ b/layers/drawdispatch/descriptor_validator.cpp
@@ -54,7 +54,7 @@ static const char *GetActionType(Func command) {
 
 std::string DescriptorValidator::DescribeDescriptor(const spirv::ResourceInterfaceVariable &resource_variable, uint32_t index,
                                                     VkDescriptorType type) const {
-    std::stringstream ss;
+    std::ostringstream ss;
     switch (type) {
         case VK_DESCRIPTOR_TYPE_SAMPLER:
             ss << "sampler ";
@@ -476,7 +476,7 @@ bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVaria
             // This warning was added after being discussed in https://gitlab.khronos.org/vulkan/vulkan/-/issues/4128
             auto set = descriptor_set.Handle();
             const LogObjectList objlist(this->objlist, set, image_view);
-            std::stringstream msg;
+            std::ostringstream msg;
             msg << "the " << DescribeDescriptor(resource_variable, index, descriptor_type)
                 << " is accessed by a OpTypeImage that has a Format operand "
                 << string_SpirvImageFormat(resource_variable.info.vk_format) << " (equivalent to "
@@ -541,7 +541,7 @@ bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVaria
     if (!dev_proxy.disabled[image_layout_validation]) {
         if (const auto image_layout_map = cb_state.GetImageLayoutMap(image_state->VkHandle())) {
             auto describe_descriptor_callback = [this, &resource_variable, index, descriptor_type]() {
-                std::stringstream ss;
+                std::ostringstream ss;
                 ss << DescribeDescriptor(resource_variable, index, descriptor_type);
                 if (descriptor_set.IsPushDescriptor()) {
                     ss << " updated by vkCmdPushDescriptorSet";
@@ -1035,7 +1035,7 @@ bool DescriptorValidator::ValidateDescriptor(const spirv::ResourceInterfaceVaria
         // This warning was added after being discussed in https://gitlab.khronos.org/vulkan/vulkan/-/issues/4128
         auto set = descriptor_set.Handle();
         const LogObjectList objlist(this->objlist, set, buffer_view);
-        std::stringstream msg;
+        std::ostringstream msg;
         msg << "the " << DescribeDescriptor(resource_variable, index, descriptor_type)
             << " is accessed by a OpTypeImage that has a Format operand "
             << string_SpirvImageFormat(resource_variable.info.vk_format) << " (equivalent to "

--- a/layers/error_message/error_location.cpp
+++ b/layers/error_message/error_location.cpp
@@ -44,13 +44,13 @@ void Location::AppendFields(std::ostream& out) const {
 }
 
 std::string Location::Fields() const {
-    std::stringstream out;
+    std::ostringstream out;
     AppendFields(out);
     return out.str();
 }
 
 std::string Location::Message() const {
-    std::stringstream out;
+    std::ostringstream out;
     if (debug_region && !debug_region->empty()) {
         out << "[ Debug region: " << *debug_region << " ] ";
     }
@@ -65,7 +65,7 @@ std::string Location::Message() const {
 }
 
 std::string PrintPNextChain(vvl::Struct in_struct, const void* in_pNext) {
-    std::stringstream out;
+    std::ostringstream out;
 
     if (in_pNext) {
         // We might not have a good way to pass in the original struct

--- a/layers/error_message/error_strings.h
+++ b/layers/error_message/error_strings.h
@@ -37,50 +37,50 @@
 }
 
 [[maybe_unused]] static std::string string_VkExtent2D(VkExtent2D extent) {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << "width = " << extent.width << ", height = " << extent.height;
     return ss.str();
 }
 
 [[maybe_unused]] static std::string string_VkExtent3D(VkExtent3D extent) {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << "width = " << extent.width << ", height = " << extent.height << ", depth = " << extent.depth;
     return ss.str();
 }
 
 [[maybe_unused]] static std::string string_VkExtentDimensions(VkExtent2D extent) {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << extent.width << "x" << extent.height;
     return ss.str();
 }
 
 [[maybe_unused]] static std::string string_VkExtentDimensions(VkExtent3D extent) {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << extent.width << "x" << extent.height << "x" << extent.depth;
     return ss.str();
 }
 
 [[maybe_unused]] static std::string string_VkOffset2D(VkOffset2D offset) {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << "x = " << offset.x << ", y = " << offset.y;
     return ss.str();
 }
 
 [[maybe_unused]] static std::string string_VkOffset3D(VkOffset3D offset) {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << "x = " << offset.x << ", y = " << offset.y << ", z = " << offset.z;
     return ss.str();
 }
 
 [[maybe_unused]] static std::string string_VkRect2D(VkRect2D rect) {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << "offset = {" << rect.offset.x << ", " << rect.offset.y << "}, extent = {" << rect.extent.width << ", "
        << rect.extent.height << "}";
     return ss.str();
 }
 
 [[maybe_unused]] static std::string string_LevelCount(const VkImageCreateInfo &ci, VkImageSubresourceRange const &range) {
-    std::stringstream ss;
+    std::ostringstream ss;
     if (range.levelCount == VK_REMAINING_MIP_LEVELS) {
         const uint32_t level_count = ci.mipLevels - range.baseMipLevel;
         ss << "VK_REMAINING_MIP_LEVELS [mipLevels (" << ci.mipLevels << ") - baseMipLevel (" << range.baseMipLevel
@@ -92,7 +92,7 @@
 }
 
 [[maybe_unused]] static std::string string_LayerCount(const VkImageCreateInfo &ci, VkImageSubresourceRange const &range) {
-    std::stringstream ss;
+    std::ostringstream ss;
     if (range.layerCount == VK_REMAINING_ARRAY_LAYERS) {
         const uint32_t layer_count = ci.arrayLayers - range.baseArrayLayer;
         ss << "VK_REMAINING_ARRAY_LAYERS [arrayLayers (" << ci.arrayLayers << ") - baseArrayLayer (" << range.baseArrayLayer
@@ -104,7 +104,7 @@
 }
 
 [[maybe_unused]] static std::string string_LayerCount(const VkImageCreateInfo &ci, VkImageSubresourceLayers const &resource) {
-    std::stringstream ss;
+    std::ostringstream ss;
     if (resource.layerCount == VK_REMAINING_ARRAY_LAYERS) {
         const uint32_t layer_count = ci.arrayLayers - resource.baseArrayLayer;
         ss << "VK_REMAINING_ARRAY_LAYERS [arrayLayers (" << ci.arrayLayers << ") - baseArrayLayer (" << resource.baseArrayLayer
@@ -116,21 +116,21 @@
 }
 
 [[maybe_unused]] static std::string string_VkPushConstantRange(VkPushConstantRange range) {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << "range [" << range.offset << ", " << (range.offset + range.size) << ") for "
        << string_VkShaderStageFlags(range.stageFlags);
     return ss.str();
 }
 
 [[maybe_unused]] static std::string string_VkImageSubresource(VkImageSubresource subresource) {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << "aspectMask = " << string_VkImageAspectFlags(subresource.aspectMask) << ", mipLevel = " << subresource.mipLevel
        << ", arrayLayer = " << subresource.arrayLayer;
     return ss.str();
 }
 
 [[maybe_unused]] static std::string string_VkImageSubresourceLayers(VkImageSubresourceLayers subresource_layers) {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << "aspectMask = " << string_VkImageAspectFlags(subresource_layers.aspectMask)
        << ", mipLevel = " << subresource_layers.mipLevel << ", baseArrayLayer = " << subresource_layers.baseArrayLayer
        << ", layerCount = " << subresource_layers.layerCount;
@@ -138,7 +138,7 @@
 }
 
 [[maybe_unused]] static std::string string_VkImageSubresourceRange(VkImageSubresourceRange subresource_range) {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << "aspectMask = " << string_VkImageAspectFlags(subresource_range.aspectMask)
        << ", baseMipLevel = " << subresource_range.baseMipLevel << ", levelCount = " << subresource_range.levelCount
        << ", baseArrayLayer = " << subresource_range.baseArrayLayer << ", layerCount = " << subresource_range.layerCount;
@@ -146,7 +146,7 @@
 }
 
 [[maybe_unused]] static std::string string_VkComponentMapping(VkComponentMapping components) {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << "r swizzle = " << string_VkComponentSwizzle(components.r) << "\n";
     ss << "g swizzle = " << string_VkComponentSwizzle(components.g) << "\n";
     ss << "b swizzle = " << string_VkComponentSwizzle(components.b) << "\n";
@@ -158,7 +158,7 @@
 
 // Some VUs use the subset in VkPhysicalDeviceImageFormatInfo2 to refer to an VkImageCreateInfo
 [[maybe_unused]] static std::string string_VkPhysicalDeviceImageFormatInfo2(VkPhysicalDeviceImageFormatInfo2 info) {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << "format (" << string_VkFormat(info.format) << ")\n";
     ss << "type (" << string_VkImageType(info.type) << ")\n";
     ss << "tiling (" << string_VkImageTiling(info.tiling) << ")\n";
@@ -169,7 +169,7 @@
 
 // Same thing as VkPhysicalDeviceImageFormatInfo2 but given the actual VkImageCreateInfo
 [[maybe_unused]] static std::string string_VkPhysicalDeviceImageFormatInfo2(VkImageCreateInfo info) {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << "format (" << string_VkFormat(info.format) << ")\n";
     ss << "type (" << string_VkImageType(info.imageType) << ")\n";
     ss << "tiling (" << string_VkImageTiling(info.tiling) << ")\n";
@@ -179,7 +179,7 @@
 }
 
 [[maybe_unused]] static std::string string_VkStencilOpState(VkStencilOpState state) {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << " failOp (" << string_VkStencilOp(state.failOp) << ")\n";
     ss << " passOp (" << string_VkStencilOp(state.passOp) << ")\n";
     ss << " depthFailOp (" << string_VkStencilOp(state.depthFailOp) << ")\n";
@@ -192,8 +192,8 @@
 
 [[maybe_unused]] static std::string string_VkDependencyInfo(const Logger &logger, VkDependencyInfo set_dependency_info,
                                                             VkDependencyInfo dependency_info) {
-    std::stringstream set;
-    std::stringstream wait;
+    std::ostringstream set;
+    std::ostringstream wait;
     if (set_dependency_info.dependencyFlags != dependency_info.dependencyFlags) {
         set << std::string(string_VkDependencyFlags(set_dependency_info.dependencyFlags));
         wait << std::string(string_VkDependencyFlags(dependency_info.dependencyFlags));

--- a/layers/gpuav/core/gpuav_record.cpp
+++ b/layers/gpuav/core/gpuav_record.cpp
@@ -180,7 +180,7 @@ void Instance::ReserveBindingSlot(VkPhysicalDevice physicalDevice, VkPhysicalDev
     if (limits.maxBoundDescriptorSets == 0) return;
 
     if (limits.maxBoundDescriptorSets > kMaxAdjustedBoundDescriptorSet) {
-        std::stringstream ss;
+        std::ostringstream ss;
         ss << "A descriptor binding slot is required to store GPU-side information, but the device maxBoundDescriptorSets is "
            << limits.maxBoundDescriptorSets << " which is too large, so we will be trying to use slot "
            << kMaxAdjustedBoundDescriptorSet;
@@ -210,7 +210,7 @@ void Instance::PostCallRecordGetPhysicalDeviceProperties2(VkPhysicalDevice physi
     auto *desc_indexing_props = vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingProperties>(device_props2->pNext);
     if (desc_indexing_props &&
         desc_indexing_props->maxUpdateAfterBindDescriptorsInAllPools > glsl::kDebugInputBindlessMaxDescriptors) {
-        std::stringstream ss;
+        std::ostringstream ss;
         ss << "\tSetting VkPhysicalDeviceDescriptorIndexingProperties::maxUpdateAfterBindDescriptorsInAllPools to "
            << glsl::kDebugInputBindlessMaxDescriptors;
         adjustment_warnings += ss.str();
@@ -220,7 +220,7 @@ void Instance::PostCallRecordGetPhysicalDeviceProperties2(VkPhysicalDevice physi
 
     auto *vk12_props = vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Properties>(device_props2->pNext);
     if (vk12_props && vk12_props->maxUpdateAfterBindDescriptorsInAllPools > glsl::kDebugInputBindlessMaxDescriptors) {
-        std::stringstream ss;
+        std::ostringstream ss;
         ss << "\tSetting VkPhysicalDeviceVulkan12Properties::maxUpdateAfterBindDescriptorsInAllPools to "
            << glsl::kDebugInputBindlessMaxDescriptors;
         adjustment_warnings += ss.str();
@@ -233,7 +233,7 @@ void Instance::PostCallRecordGetPhysicalDeviceProperties2(VkPhysicalDevice physi
         if (desc_buffer_props->maxResourceDescriptorBufferBindings > 1) {
             desc_buffer_props->maxResourceDescriptorBufferBindings -= 1;
 
-            std::stringstream ss;
+            std::ostringstream ss;
             ss << "\tSetting VkPhysicalDeviceDescriptorBufferPropertiesEXT::maxResourceDescriptorBufferBindings to "
                << desc_buffer_props->maxResourceDescriptorBufferBindings;
             adjustment_warnings += ss.str();
@@ -251,7 +251,7 @@ void Instance::PostCallRecordGetPhysicalDeviceProperties2(VkPhysicalDevice physi
             desc_buffer_props->resourceDescriptorBufferAddressSpaceSize -= bytes_to_reserve;
             desc_buffer_props->descriptorBufferAddressSpaceSize -= bytes_to_reserve;
 
-            std::stringstream ss;
+            std::ostringstream ss;
             ss << "\tSetting VkPhysicalDeviceDescriptorBufferPropertiesEXT::descriptorBufferAddressSpaceSize to "
                << desc_buffer_props->resourceDescriptorBufferAddressSpaceSize << "and resourceDescriptorBufferAddressSpaceSize to "
                << desc_buffer_props->descriptorBufferAddressSpaceSize << " (reserving " << bytes_to_reserve << " bytes)";

--- a/layers/gpuav/debug_printf/debug_printf.cpp
+++ b/layers/gpuav/debug_printf/debug_printf.cpp
@@ -211,7 +211,7 @@ void AnalyzeAndGenerateMessage(Validator &gpuav, VkCommandBuffer command_buffer,
 
     uint32_t output_record_i = gpuav::kDebugPrintfOutputBufferData;  // get first OutputRecord index
     while (debug_output_buffer[output_record_i]) {
-        std::stringstream shader_message;
+        std::ostringstream shader_message;
 
         OutputRecord *debug_record = reinterpret_cast<OutputRecord *>(&debug_output_buffer[output_record_i]);
         // Lookup the VkShaderModule handle and SPIR-V code used to create the shader, using the unique shader ID value returned
@@ -383,7 +383,7 @@ void AnalyzeAndGenerateMessage(Validator &gpuav, VkCommandBuffer command_buffer,
     if ((output_record_i - gpuav::kDebugPrintfOutputBufferData) < output_buffer_dwords_counts) {
         // Originally we had this to log a warning, but if using the default settings, warnings are hidden.
         // We report this information the same we report the "real" debug printf message so we know it is seen
-        std::stringstream message;
+        std::ostringstream message;
         message << "[WARNING] Debug Printf message was truncated due to the buffer size ("
                 << gpuav.gpuav_settings.debug_printf_buffer_size << ") being too small for the messages consuming "
                 << output_buffer_dwords_counts

--- a/layers/gpuav/validation_cmd/gpuav_ray_tracing.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_ray_tracing.cpp
@@ -630,7 +630,7 @@ void BuildAccelerationStructures(Validator& gpuav, const Location& loc, CommandB
         const uint32_t blas_array_i = error_record[kValCmdErrorPayloadDword_3];
 
         const BlasArray blas_array = blas_arrays[blas_array_i];
-        std::stringstream invalid_blas_loc;
+        std::ostringstream invalid_blas_loc;
         invalid_blas_loc << "pInfos[" << blas_array.info_i << "].pGeometries[" << blas_array.geom_i
                          << "].geometry.instances<VkAccelerationStructureInstance" << (blas_array.is_array_of_pointers ? " *" : "")
                          << ">[" << as_instance_i << ']' << (blas_array.is_array_of_pointers ? "->" : ".")
@@ -647,8 +647,8 @@ void BuildAccelerationStructures(Validator& gpuav, const Location& loc, CommandB
             case kErrorSubCode_PreBuildAccelerationStructures_DestroyedASBuffer: {
                 auto& as_addr_to_as_buffer = gpuav.shared_resources_cache.Get<AccelerationStructuresAddrToStateObjectMap>();
                 auto found_as = as_addr_to_as_buffer.map.find(blas_in_tlas_addr);
-                std::stringstream ss_as;
-                std::stringstream ss_buffer;
+                std::ostringstream ss_as;
+                std::ostringstream ss_buffer;
                 if (found_as != as_addr_to_as_buffer.map.end()) {
                     ss_as << "Acceleration structure corresponding to reference: "
                           << gpuav.FormatHandle(found_as->second->VkHandle());
@@ -673,7 +673,7 @@ void BuildAccelerationStructures(Validator& gpuav, const Location& loc, CommandB
                 const BlasBuiltInCmd& blas_built_in_cmd = blas_built_in_cmd_array[blas_built_in_cmd_i];
                 auto& as_addr_to_as_buffer = gpuav.shared_resources_cache.Get<AccelerationStructuresAddrToStateObjectMap>();
                 auto found_as = as_addr_to_as_buffer.map.find(blas_in_tlas_addr);
-                std::stringstream error_ss;
+                std::ostringstream error_ss;
                 if (found_as != as_addr_to_as_buffer.map.end()) {
                     const vvl::range<VkDeviceAddress> blas_in_tlas_buffer_addr_range = found_as->second->GetDeviceAddressRange();
                     const vvl::range<VkDeviceAddress> blas_built_in_cmd_buffer_addr_range =

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -478,7 +478,7 @@ static bool ValidateLayerSettingsCreateInfo(const VkLayerSettingsCreateInfoEXT *
     if (!layer_settings) return valid;
     const Location loc(vvl::Func::vkCreateInstance, vvl::Field::pCreateInfo);
     const Location create_info_loc = loc.pNext(vvl::Struct::VkLayerSettingsCreateInfoEXT);
-    std::stringstream ss;
+    std::ostringstream ss;
 
     if (layer_settings->pSettings) {
         for (const auto [i, setting] : vvl::enumerate(layer_settings->pSettings, layer_settings->settingCount)) {
@@ -776,7 +776,7 @@ static void ProcessDebugReportSettings(ConfigAndEnvSettings *settings_data, VkuL
 // Set as deprecated for the first time in the 1.4.335 SDK release
 static std::string GetDeprecatedEnabledDisabledWarning(const std::vector<std::string>& enabled,
                                                        const std::vector<std::string>& disabled) {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << "Application is using deprecated";
     if (!enabled.empty()) {
         ss << " \"enables\" (VK_LAYER_ENABLES)";

--- a/layers/profiling/profiling.h
+++ b/layers/profiling/profiling.h
@@ -42,7 +42,7 @@
 #define VVL_TracyPlot(name, value) TracyPlot(name, int64_t(value))
 #define VVL_TracyMessageStream(message)                \
     {                                                  \
-        std::stringstream tracy_ss;                    \
+        std::ostringstream tracy_ss;                   \
         tracy_ss << message;                           \
         const std::string tracy_s = tracy_ss.str();    \
         TracyMessage(tracy_s.c_str(), tracy_s.size()); \

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -2327,7 +2327,7 @@ std::string CommandBuffer::GetDebugRegionName(const std::vector<LabelCommand> &l
 }
 
 std::string CommandBuffer::DescribeInvalidatedState(CBDynamicState dynamic_state) const {
-    std::stringstream ss;
+    std::ostringstream ss;
     if (dynamic_state_status.history[dynamic_state] && !dynamic_state_status.cb[dynamic_state]) {
         ss << " (There was a call to vkCmdBindPipeline";
         if (auto pipeline = dev_data.Get<vvl::Pipeline>(invalidated_state_pipe[dynamic_state])) {

--- a/layers/state_tracker/descriptor_sets.cpp
+++ b/layers/state_tracker/descriptor_sets.cpp
@@ -1620,7 +1620,7 @@ bool vvl::MutableDescriptor::Invalid() const {
 }
 
 std::string vvl::DslErrorSource::PrintMessage(const Logger &error_logger) const {
-    std::stringstream msg;
+    std::ostringstream msg;
     msg << "The VkDescriptorSetLayout was used to ";
     if (pipeline_layout_handle_ == VK_NULL_HANDLE) {
         msg << "allocate " << error_logger.FormatHandle(ds_handle_);

--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -361,7 +361,7 @@ VkExtent3D Image::GetEffectiveSubresourceExtent(const VkImageSubresourceRange &r
 }
 
 std::string Image::DescribeSubresourceLayers(const VkImageSubresourceLayers &subresource) const {
-    std::stringstream ss;
+    std::ostringstream ss;
     VkExtent3D subresource_extent = GetEffectiveSubresourceExtent(subresource);
     const VkFormat format = create_info.format;
     ss << "The " << string_VkImageType(create_info.imageType) << " VkImage was created with format " << string_VkFormat(format)
@@ -671,7 +671,7 @@ bool ImageView::OverlapSubresource(const ImageView &compare_view) const {
 }
 
 std::string ImageView::DescribeImageUsage(const Logger& logger) const {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << logger.FormatHandle(create_info.image) << " was created with "
        << string_VkImageUsageFlags(image_state->create_info.usage);
 

--- a/layers/state_tracker/last_bound_state.cpp
+++ b/layers/state_tracker/last_bound_state.cpp
@@ -255,7 +255,7 @@ bool LastBound::IsColorBlendEnabled(uint32_t i) const {
 }
 
 std::string LastBound::DescribeColorBlendEnabled(uint32_t i) const {
-    std::stringstream ss;
+    std::ostringstream ss;
     if (IsDynamic(CB_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT)) {
         if (cb_state.IsDynamicStateSet(CB_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT)) {
             ss << "vkCmdSetColorBlendEnableEXT::pColorBlendEnables[" << i << "] is ";
@@ -324,7 +324,7 @@ bool LastBound::IsDualBlending(uint32_t i) const {
 }
 
 std::string LastBound::DescribeBlendFactorEquation(uint32_t i) const {
-    std::stringstream ss;
+    std::ostringstream ss;
     if (IsDynamic(CB_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT)) {
         if (cb_state.IsDynamicStateSet(CB_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT)) {
             const VkColorBlendEquationEXT &eq = cb_state.dynamic_state_value.color_blend_equations[i];
@@ -749,7 +749,7 @@ float LastBound::GetMinSampleShading() const {
 }
 
 std::string LastBound::DescribeSampleShading() const {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << "Sample Shading was enbled ";
 
     bool is_implicit = false;

--- a/layers/state_tracker/sampler_state.cpp
+++ b/layers/state_tracker/sampler_state.cpp
@@ -69,7 +69,7 @@ bool SamplerYcbcrConversion::operator!=(const SamplerYcbcrConversion &rhs) const
 }
 
 std::string SamplerYcbcrConversion::Describe() const {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << " format (" << string_VkFormat(create_info.format) << ")\n";
     ss << " ycbcrModel (" << string_VkSamplerYcbcrModelConversion(create_info.ycbcrModel) << ")\n";
     ss << " ycbcrRange (" << string_VkSamplerYcbcrRange(create_info.ycbcrRange) << ")\n";

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -1850,7 +1850,7 @@ bool Module::HasRuntimeArray(uint32_t type_id) const {
 }
 
 std::string InterfaceSlot::Describe() const {
-    std::stringstream msg;
+    std::ostringstream msg;
     msg << "Location = " << Location() << " | Component = " << Component() << " | Type = " << string_SpvOpcode(type) << " "
         << bit_width << " bits";
     return msg.str();

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -2326,7 +2326,7 @@ bool DeviceState::PreCallValidateAllocateDescriptorSets(VkDevice device, const V
 // we calculated this
 std::string DeviceState::PrintDescriptorAllocation(const VkDescriptorSetAllocateInfo &allocate_info,
                                                    const vvl::DescriptorPool &pool_state, VkDescriptorType type) const {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << "Where " << string_VkDescriptorType(type) << " is found in the pool:\n";
     for (const auto [pool_size_i, pool_size] :
          vvl::enumerate(pool_state.create_info.pPoolSizes, pool_state.create_info.poolSizeCount)) {

--- a/layers/state_tracker/video_session_state.cpp
+++ b/layers/state_tracker/video_session_state.cpp
@@ -554,7 +554,7 @@ class RateControlStateMismatchRecorder {
 
   private:
     bool has_mismatch_{};
-    std::stringstream stream_{};
+    std::ostringstream stream_{};
     mutable std::string string_{};
 };
 
@@ -1062,7 +1062,7 @@ void VideoSessionParameters::AddEncodeH265(VkVideoEncodeH265SessionParametersAdd
 }
 
 std::string string_VideoProfileDesc(const vvl::VideoProfileDesc &profile) {
-    std::stringstream ss;
+    std::ostringstream ss;
     const vvl::VideoProfileDesc::Profile &internal_profile = profile.GetProfile();
 
     switch (internal_profile.base.videoCodecOperation) {
@@ -1248,7 +1248,7 @@ std::string string_VideoProfileDesc(const vvl::VideoProfileDesc &profile) {
 }
 
 std::string string_SupportedVideoProfiles(const SupportedVideoProfiles &profiles) {
-    std::stringstream ss;
+    std::ostringstream ss;
 
     if (!profiles.empty()) {
         for (const auto &profile : profiles) {

--- a/layers/stateless/sl_image.cpp
+++ b/layers/stateless/sl_image.cpp
@@ -726,7 +726,7 @@ bool Device::ValidateCreateImageFormatList(const VkImageCreateInfo &create_info,
                     found_compatible = true;
                 }
                 if (!found_compatible) {
-                    std::stringstream ss;
+                    std::ostringstream ss;
                     ss << "Plane 0 " << string_VkFormat(plane_0_format);
                     if (plane_count > 1) {
                         ss << "\nPlane 1 " << string_VkFormat(plane_1_format);

--- a/layers/stateless/sl_spirv.cpp
+++ b/layers/stateless/sl_spirv.cpp
@@ -1455,7 +1455,7 @@ bool SpirvValidator::ValidateExecutionModes(const spirv::Module &module_state, c
     if (entrypoint.execution_mode.Has(spirv::ExecutionModeSet::subgroup_uniform_control_flow_bit)) {
         if (!enabled_features.shaderSubgroupUniformControlFlow ||
             (phys_dev_ext_props.subgroup_props.supportedStages & stage) == 0 || stateless_data.has_invocation_repack_instruction) {
-            std::stringstream msg;
+            std::ostringstream msg;
             if (!enabled_features.shaderSubgroupUniformControlFlow) {
                 msg << "shaderSubgroupUniformControlFlow feature must be enabled";
             } else if ((phys_dev_ext_props.subgroup_props.supportedStages & stage) == 0) {

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -321,7 +321,7 @@ bool CommandBufferAccessContext::ValidateBeginRendering(const ErrorObject &error
         if (hazard.IsHazard()) {
             LogObjectList objlist(cb_state_->Handle(), attachment.view->Handle());
 
-            std::stringstream ss;
+            std::ostringstream ss;
             ss << vvl::String(vvl::Field::pRenderingInfo) << ".";
             ss << attachment.GetLocation(error_obj.location, i).Fields();
             ss << " (" << sync_state_.FormatHandle(attachment.view->Handle());
@@ -371,7 +371,7 @@ bool CommandBufferAccessContext::ValidateEndRendering(const ErrorObject &error_o
     for (uint32_t i = 0; i < (uint32_t)dynamic_rendering_info_->attachments.size(); i++) {
         const auto &attachment = dynamic_rendering_info_->attachments[i];
 
-        auto attachment_description = [this, &error_obj, &attachment, i](const auto &view, std::stringstream &ss) {
+        auto attachment_description = [this, &error_obj, &attachment, i](const auto &view, std::ostringstream &ss) {
             ss << vvl::String(vvl::Field::pRenderingInfo) << ".";
             ss << attachment.GetLocation(error_obj.location, uint32_t(i)).Fields();
             ss << " (" << sync_state_.FormatHandle(view->Handle());
@@ -386,7 +386,7 @@ bool CommandBufferAccessContext::ValidateEndRendering(const ErrorObject &error_o
             if (hazard.IsHazard()) {
                 LogObjectList objlist(cb_state_->Handle(), attachment.view->Handle());
 
-                std::stringstream ss;
+                std::ostringstream ss;
                 attachment_description(attachment.view, ss);
                 ss << ", resolveMode " << string_VkResolveModeFlagBits(attachment.info.resolveMode) << ")";
                 const std::string resource_description = ss.str();
@@ -403,7 +403,7 @@ bool CommandBufferAccessContext::ValidateEndRendering(const ErrorObject &error_o
             if (hazard.IsHazard()) {
                 LogObjectList objlist(cb_state_->Handle(), attachment.resolve_view->Handle());
 
-                std::stringstream ss;
+                std::ostringstream ss;
                 attachment_description(attachment.resolve_view, ss);
                 ss << ", resolveMode " << string_VkResolveModeFlagBits(attachment.info.resolveMode) << ")";
                 const std::string resource_description = ss.str();
@@ -424,7 +424,7 @@ bool CommandBufferAccessContext::ValidateEndRendering(const ErrorObject &error_o
             if (hazard.IsHazard()) {
                 LogObjectList objlist(cb_state_->Handle(), attachment.view->Handle());
 
-                std::stringstream ss;
+                std::ostringstream ss;
                 attachment_description(attachment.view, ss);
                 ss << ", storeOp " << string_VkAttachmentStoreOp(attachment.info.storeOp) << ")";
                 const std::string resource_description = ss.str();
@@ -1092,7 +1092,7 @@ bool CommandBufferAccessContext::ValidateClearAttachment(const Location &loc, co
             *info.attachment_view.image_state, subresource_range, offset, extent, info.attachment_view.is_depth_sliced,
             SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, SyncOrdering::kColorAttachment);
         if (hazard.IsHazard()) {
-            std::stringstream ss;
+            std::ostringstream ss;
             ss << string_VkImageAspectFlagBits(aspect);
             ss << " aspect of color attachment " << clear_attachment.colorAttachment;
             ss << " (" << sync_state_.FormatHandle(info.attachment_view) << ")";
@@ -1120,7 +1120,7 @@ bool CommandBufferAccessContext::ValidateClearAttachment(const Location &loc, co
                 SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, SyncOrdering::kDepthStencilAttachment);
 
             if (hazard.IsHazard()) {
-                std::stringstream ss;
+                std::ostringstream ss;
                 ss << string_VkImageAspectFlagBits(aspect);
                 ss << " aspect of depth-stencil attachment (";
                 ss << sync_state_.FormatHandle(info.attachment_view) << ")";

--- a/layers/sync/sync_error_messages.cpp
+++ b/layers/sync/sync_error_messages.cpp
@@ -48,7 +48,7 @@ std::string ErrorMessages::Error(const HazardResult& hazard, const CommandExecut
 std::string ErrorMessages::BufferError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context, vvl::Func command,
                                        const std::string& resource_description, const AccessRange range,
                                        AdditionalMessageInfo additional_info) const {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << "\nBuffer access region: {\n";
     ss << "  offset = " << range.begin << "\n";
     ss << "  size = " << range.end - range.begin << "\n";
@@ -64,7 +64,7 @@ std::string ErrorMessages::BufferCopyError(const HazardResult& hazard, const Com
     AdditionalMessageInfo additional_info;
     additional_info.properties.Add(kPropertyRegionIndex, region_index);
 
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << "\nBuffer copy region " << region_index << ": {\n";
     ss << "  offset = " << range.begin << ",\n";
     ss << "  size = " << range.end - range.begin << "\n";
@@ -80,13 +80,13 @@ std::string ErrorMessages::AccelerationStructureError(const HazardResult& hazard
                                                       const Location& as_location) const {
     AdditionalMessageInfo additional_info;
 
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << "The buffer backs ";
     ss << as_location.Fields();
     ss << " (" << validator_.FormatHandle(as) << "). ";
     additional_info.pre_synchronization_text = ss.str();
 
-    std::stringstream ss2;
+    std::ostringstream ss2;
     ss2 << "\nBuffer access region: {\n";
     ss2 << "  offset = " << range.begin << "\n";
     ss2 << "  size = " << range.end - range.begin << "\n";
@@ -113,7 +113,7 @@ std::string ErrorMessages::ImageCopyResolveBlitError(const HazardResult& hazard,
         action = "copy";
         message_type = "ImageCopyError";
     }
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << "\nImage " << action << " region " << region_index << ": {\n";
     ss << "  offset = {" << string_VkOffset3D(offset) << "},\n";
     ss << "  extent = {" << string_VkExtent3D(extent) << "},\n";
@@ -131,7 +131,7 @@ std::string ErrorMessages::ImageClearError(const HazardResult& hazard, const Com
                                                       vvl::Func command, const std::string& resource_description,
                                                       uint32_t subresource_range_index,
                                                       const VkImageSubresourceRange& subresource_range) const {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << "\nImage clear subresource range " << subresource_range_index << ": {\n";
     ss << "  " << string_VkImageSubresourceRange(subresource_range) << "\n";
     ss << "}\n";
@@ -147,7 +147,7 @@ static void PrepareCommonDescriptorMessage(Logger& logger, const vvl::Pipeline& 
                                            const vvl::DescriptorSet& descriptor_set, VkDescriptorType descriptor_type,
                                            uint32_t descriptor_binding, uint32_t descriptor_array_element,
                                            VkShaderStageFlagBits shader_stage, const char* resource_type,
-                                           AdditionalMessageInfo& additional_info, std::stringstream& ss) {
+                                           AdditionalMessageInfo& additional_info, std::ostringstream& ss) {
     const char* descriptor_type_str = string_VkDescriptorType(descriptor_type);
 
     additional_info.properties.Add(kPropertyDescriptorType, descriptor_type_str);
@@ -171,7 +171,7 @@ std::string ErrorMessages::BufferDescriptorError(const HazardResult& hazard, con
                                                  uint32_t descriptor_binding, uint32_t descriptor_array_element,
                                                  VkShaderStageFlagBits shader_stage) const {
     AdditionalMessageInfo additional_info;
-    std::stringstream ss;
+    std::ostringstream ss;
     PrepareCommonDescriptorMessage(validator_, pipeline, set_number, descriptor_set, descriptor_type, descriptor_binding,
                                    descriptor_array_element, shader_stage, "buffer", additional_info, ss);
     ss << ".";
@@ -187,7 +187,7 @@ std::string ErrorMessages::ImageDescriptorError(const HazardResult& hazard, cons
                                                 uint32_t descriptor_binding, uint32_t descriptor_array_element,
                                                 VkShaderStageFlagBits shader_stage, VkImageLayout image_layout) const {
     AdditionalMessageInfo additional_info;
-    std::stringstream ss;
+    std::ostringstream ss;
     PrepareCommonDescriptorMessage(validator_, pipeline, set_number, descriptor_set, descriptor_type, descriptor_binding,
                                    descriptor_array_element, shader_stage, "image", additional_info, ss);
     ss << ", image layout " << string_VkImageLayout(image_layout) << ".";
@@ -205,7 +205,7 @@ std::string ErrorMessages::AccelerationStructureDescriptorError(
     AdditionalMessageInfo additional_info;
     additional_info.access_action = "traces rays against";
 
-    std::stringstream ss;
+    std::ostringstream ss;
     PrepareCommonDescriptorMessage(validator_, pipeline, set_number, descriptor_set, descriptor_type, descriptor_binding,
                                    descriptor_array_element, shader_stage, "acceleration structure", additional_info, ss);
     ss << ".";
@@ -218,7 +218,7 @@ std::string ErrorMessages::ClearAttachmentError(const HazardResult& hazard, cons
                                                 vvl::Func command, const std::string& resource_description,
                                                 VkImageAspectFlagBits aspect, uint32_t clear_rect_index,
                                                 const VkClearRect& clear_rect) const {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << "\nClear region: {\n";
     ss << "  region_index = " << clear_rect_index << ",\n";
     ss << "  rect = {" << string_VkRect2D(clear_rect.rect) << "},\n";
@@ -254,7 +254,7 @@ static const char* GetLoadOpActionName(VkAttachmentLoadOp load_op) {
 
 static void CheckForLoadOpDontCareInsight(VkAttachmentLoadOp load_op, bool is_color, std::string& message_end_text) {
     if (load_op == VK_ATTACHMENT_LOAD_OP_DONT_CARE) {
-        std::stringstream ss;
+        std::ostringstream ss;
         ss << "\nVulkan insight: according to the specification VK_ATTACHMENT_LOAD_OP_DONT_CARE is a write access (";
         if (is_color) {
             ss << "VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT for color attachment";
@@ -413,7 +413,7 @@ std::string ErrorMessages::ImageBarrierError(const HazardResult& hazard, const C
     AdditionalMessageInfo additional_info;
     additional_info.access_action = "performs image layout transition on the";
 
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << "\npImageMemoryBarriers[" << barrier.barrier_index << "]: {\n";
     ss << "  srcStageMask = " << string_VkPipelineStageFlags2(barrier.barrier.src_exec_scope.mask_param) << ",\n";
     ss << "  srcAccessMask = " << string_VkAccessFlags2(barrier.barrier.original_src_access) << ",\n";
@@ -433,7 +433,7 @@ std::string ErrorMessages::FirstUseError(const HazardResult& hazard, const Comma
     AdditionalMessageInfo additional_info;
     additional_info.properties.Add(kPropertyCommandBufferIndex, command_buffer_index);
 
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << vvl::String(recorded_usage_info.command);
     if (!recorded_usage_info.debug_region_name.empty()) {
         ss << "[" << recorded_usage_info.debug_region_name << "]";
@@ -448,7 +448,7 @@ std::string ErrorMessages::FirstUseError(const HazardResult& hazard, const Comma
     }
     additional_info.access_initiator = ss.str();
 
-    std::stringstream ss2;
+    std::ostringstream ss2;
     if (prior_usage_info.queue) {
         if (prior_usage_info.cb) {
             ss2 << "(from " << validator_.FormatHandle(prior_usage_info.cb->Handle());

--- a/layers/sync/sync_renderpass.cpp
+++ b/layers/sync/sync_renderpass.cpp
@@ -47,7 +47,7 @@ class ValidateResolveAction {
             const SyncValidator &validator = cb_context_.GetSyncState();
 
             // TODO: this error message is not triggered by the tests
-            std::stringstream ss;
+            std::ostringstream ss;
             ss << validator.FormatHandle(view_gen.GetViewState()->Handle());
             ss << " (" << aspect_name << " " << resolve_action_name;
             ss << ", attachment " << src_at;
@@ -178,7 +178,7 @@ bool RenderPassAccessContext::ValidateLayoutTransitions(const CommandBufferAcces
             const Location loc(command);
 
             const vvl::ImageView *attachment_view = attachment_views[transition.attachment].GetViewState();
-            std::stringstream ss;
+            std::ostringstream ss;
             ss << "in subpass " << subpass << " of " << sync_state.FormatHandle(rp_state.Handle());
             ss << " on attachment " << transition.attachment << " (";
             ss << sync_state.FormatHandle(attachment_view->Handle());
@@ -257,7 +257,7 @@ bool RenderPassAccessContext::ValidateLoadOperation(const CommandBufferAccessCon
                 const SyncValidator &sync_state = cb_context.GetSyncState();
                 const Location loc(command);
 
-                std::stringstream ss;
+                std::ostringstream ss;
                 ss << "the " << aspect << " aspect of attachment " << i;
                 ss << " (" << sync_state.FormatHandle(view_gen.GetViewState()->Handle()) << ")";
                 ss << " in subpass " << subpass;
@@ -335,7 +335,7 @@ bool RenderPassAccessContext::ValidateStoreOperation(const CommandBufferAccessCo
                 const VkAttachmentStoreOp store_op = checked_stencil ? ci.stencilStoreOp : ci.storeOp;
                 const Location loc(command);
 
-                std::stringstream ss;
+                std::ostringstream ss;
                 ss << sync_state.FormatHandle(view_gen.GetViewState()->Handle());
                 ss << " (subpass " << current_subpass_ << " of " << sync_state.FormatHandle(rp_state_->Handle());
                 ss << ", attachment " << i;
@@ -539,7 +539,7 @@ bool RenderPassAccessContext::ValidateDrawSubpassAttachment(const CommandBufferA
         LogObjectList objlist(cb_context.GetCBState().Handle(), attachment_view.Handle(), attachment_image.Handle());
         const Location loc(command);
 
-        std::stringstream ss;
+        std::ostringstream ss;
         ss << attachment_description;
         ss << " (" << sync_state.FormatHandle(attachment_view.Handle());
         ss << ", " << sync_state.FormatHandle(attachment_image.Handle()) << ")";
@@ -563,7 +563,7 @@ bool RenderPassAccessContext::ValidateDrawSubpassAttachment(const CommandBufferA
                 current_context.DetectHazard(view_gen, AttachmentViewGen::Gen::kRenderArea,
                                              SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, SyncOrdering::kColorAttachment);
             if (hazard.IsHazard()) {
-                std::stringstream ss;
+                std::ostringstream ss;
                 ss << "color attachment " << location << " in subpass " << cmd_buffer.GetActiveSubpass();
                 const std::string attachment_description = ss.str();
                 skip |= report_atachment_hazard(hazard, *view_gen.GetViewState(), attachment_description);
@@ -594,7 +594,7 @@ bool RenderPassAccessContext::ValidateDrawSubpassAttachment(const CommandBufferA
                                                                SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE,
                                                                SyncOrdering::kDepthStencilAttachment);
             if (hazard.IsHazard()) {
-                std::stringstream ss;
+                std::ostringstream ss;
                 ss << "depth aspect of depth-stencil attachment  in subpass " << cmd_buffer.GetActiveSubpass();
                 const std::string attachment_description = ss.str();
                 skip |= report_atachment_hazard(hazard, view_state, attachment_description);
@@ -605,7 +605,7 @@ bool RenderPassAccessContext::ValidateDrawSubpassAttachment(const CommandBufferA
                                                                SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE,
                                                                SyncOrdering::kDepthStencilAttachment);
             if (hazard.IsHazard()) {
-                std::stringstream ss;
+                std::ostringstream ss;
                 ss << "stencil aspect of depth-stencil attachment  in subpass " << cmd_buffer.GetActiveSubpass();
                 const std::string attachment_description = ss.str();
                 skip |= report_atachment_hazard(hazard, view_state, attachment_description);
@@ -762,7 +762,7 @@ bool RenderPassAccessContext::ValidateFinalSubpassLayoutTransitions(const Comman
             const SyncValidator &sync_state = cb_context.GetSyncState();
             const Location loc(command);
 
-            std::stringstream ss;
+            std::ostringstream ss;
             ss << "on attachment " << transition.attachment << " (";
             ss << sync_state.FormatHandle(view_gen.GetViewState()->Handle());
             ss << ", " << sync_state.FormatHandle(view_gen.GetViewState()->image_state->Handle());

--- a/layers/sync/sync_reporting.cpp
+++ b/layers/sync/sync_reporting.cpp
@@ -109,7 +109,7 @@ static std::string FormatAccessProperty(const SyncAccessInfo &access) {
         // Print internal name for accesses that don't have corresponding Vulkan constants
         return access.name;
     }
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << string_VkPipelineStageFlagBits2(access.stage_mask);
     ss << "(";
     ss << string_VkAccessFlagBits2(access.access_mask);
@@ -329,7 +329,7 @@ static std::pair<bool, bool> GetPartialProtectedInfo(const SyncAccessInfo &acces
     return std::make_pair(is_stage_protected, is_access_protected);
 }
 
-static void ReportLayoutTransitionSynchronizationInsight(std::stringstream &ss, bool needs_execution_dependency,
+static void ReportLayoutTransitionSynchronizationInsight(std::ostringstream &ss, bool needs_execution_dependency,
                                                          VkPipelineStageFlags2 read_barriers = 0) {
     // TODO: analyse exact form of API is used (render pass layout transition, image barrier layout transition) and
     // print instructions for specific situation. Now we describe all possibilities.
@@ -361,7 +361,7 @@ std::string ReportProperties::FormatExtraPropertiesSection() const {
         return {};
     }
     const auto sorted = SortKeyValues(name_values);
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << "[Extra properties]\n";
     bool first = true;
     for (const NameValue &property : sorted) {
@@ -413,7 +413,7 @@ std::string FormatErrorMessage(const HazardResult &hazard, const CommandExecutio
     const bool missing_synchronization = (hazard_info.IsPriorWrite() && write_barriers.none()) ||
                                          (hazard_info.IsPriorRead() && read_barriers == VK_PIPELINE_STAGE_2_NONE);
 
-    std::stringstream ss;
+    std::ostringstream ss;
 
     // Brief description of what happened
     ss << string_SyncHazard(hazard_type) << " hazard detected";
@@ -557,7 +557,7 @@ std::string FormatSyncAccesses(const SyncAccessFlags &sync_accesses, const SyncV
     if (report_accesses.empty()) {
         return "0";
     }
-    std::stringstream out;
+    std::ostringstream out;
     bool first = true;
     for (const auto &[stages, accesses] : report_accesses) {
         if (!first) {
@@ -581,7 +581,7 @@ std::string FormatSyncAccesses(const SyncAccessFlags &sync_accesses, const SyncV
     return out.str();
 }
 
-void FormatVideoPictureResouce(const Logger &logger, const VkVideoPictureResourceInfoKHR &video_picture, std::stringstream &ss) {
+void FormatVideoPictureResouce(const Logger &logger, const VkVideoPictureResourceInfoKHR &video_picture, std::ostringstream &ss) {
     ss << "{";
     ss << logger.FormatHandle(video_picture.imageViewBinding);
     ss << ", codedOffset (" << string_VkOffset2D(video_picture.codedOffset) << ")";
@@ -591,7 +591,7 @@ void FormatVideoPictureResouce(const Logger &logger, const VkVideoPictureResourc
 }
 
 void FormatVideoQuantizationMap(const Logger &logger, const VkVideoEncodeQuantizationMapInfoKHR &quantization_map,
-                                std::stringstream &ss) {
+                                std::ostringstream &ss) {
     ss << "{";
     ss << logger.FormatHandle(quantization_map.quantizationMap);
     ss << ", quantizationMapExtent (" << string_VkExtent2D(quantization_map.quantizationMapExtent) << ")";

--- a/layers/sync/sync_reporting.h
+++ b/layers/sync/sync_reporting.h
@@ -72,9 +72,9 @@ std::string FormatErrorMessage(const HazardResult &hazard, const CommandExecutio
 std::string FormatSyncAccesses(const SyncAccessFlags &sync_accesses, const SyncValidator &device, VkQueueFlags allowed_queue_flags,
                                bool format_as_extra_property);
 
-void FormatVideoPictureResouce(const Logger &logger, const VkVideoPictureResourceInfoKHR &video_picture, std::stringstream &ss);
+void FormatVideoPictureResouce(const Logger &logger, const VkVideoPictureResourceInfoKHR &video_picture, std::ostringstream &ss);
 void FormatVideoQuantizationMap(const Logger &logger, const VkVideoEncodeQuantizationMapInfoKHR &quantization_map,
-                                std::stringstream &ss);
+                                std::ostringstream &ss);
 
 // Common properties
 inline constexpr const char *kPropertyMessageType = "message_type";

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -505,7 +505,7 @@ bool QueueBatchContext::DoQueuePresentValidate(const Location& loc, const Presen
 
             LogObjectList objlist(queue_state_->Handle(), swapchain_handle, image_handle);
 
-            std::stringstream ss;
+            std::ostringstream ss;
             ss << "swapchain image " << presented.image_index << " (";
             ss << sync_state_.FormatHandle(image_handle);
             ss << " from " << sync_state_.FormatHandle(swapchain_handle) << ")";

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -1848,7 +1848,7 @@ bool SyncValidator::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuff
     if (dst_resource) {
         auto hazard = context->DetectHazard(*vs_state, dst_resource, SYNC_VIDEO_DECODE_VIDEO_DECODE_WRITE);
         if (hazard.IsHazard()) {
-            std::stringstream ss;
+            std::ostringstream ss;
             ss << "decode output picture ";
             ss << Location(Func::Empty, Field::pDecodeInfo).dot(Field::dstPictureResource).Fields();
             ss << " ";
@@ -1866,7 +1866,7 @@ bool SyncValidator::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuff
         if (setup_resource && (setup_resource != dst_resource)) {
             auto hazard = context->DetectHazard(*vs_state, setup_resource, SYNC_VIDEO_DECODE_VIDEO_DECODE_WRITE);
             if (hazard.IsHazard()) {
-                std::stringstream ss;
+                std::ostringstream ss;
                 ss << "reconstructed picture ";
                 ss << Location(Func::Empty, Field::pDecodeInfo)
                           .dot(Field::pSetupReferenceSlot)
@@ -1889,7 +1889,7 @@ bool SyncValidator::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuff
             if (reference_resource) {
                 auto hazard = context->DetectHazard(*vs_state, reference_resource, SYNC_VIDEO_DECODE_VIDEO_DECODE_READ);
                 if (hazard.IsHazard()) {
-                    std::stringstream ss;
+                    std::ostringstream ss;
                     ss << "reference picture " << i << " ";
                     ss << Location(Func::Empty, Field::pDecodeInfo)
                               .dot(Field::pReferenceSlots, i)
@@ -1939,7 +1939,7 @@ bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuff
     if (auto src_resource = vvl::VideoPictureResource(*device_state, pEncodeInfo->srcPictureResource)) {
         auto hazard = context->DetectHazard(*vs_state, src_resource, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_READ);
         if (hazard.IsHazard()) {
-            std::stringstream ss;
+            std::ostringstream ss;
             ss << "encode input picture ";
             ss << Location(Func::Empty, Field::pEncodeInfo).dot(Field::srcPictureResource).Fields();
             ss << " ";
@@ -1958,7 +1958,7 @@ bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuff
         if (setup_resource) {
             auto hazard = context->DetectHazard(*vs_state, setup_resource, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_WRITE);
             if (hazard.IsHazard()) {
-                std::stringstream ss;
+                std::ostringstream ss;
                 ss << "reconstructed picture ";
                 ss << Location(Func::Empty, Field::pEncodeInfo)
                           .dot(Field::pSetupReferenceSlot)
@@ -1981,7 +1981,7 @@ bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuff
             if (reference_resource) {
                 auto hazard = context->DetectHazard(*vs_state, reference_resource, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_READ);
                 if (hazard.IsHazard()) {
-                    std::stringstream ss;
+                    std::ostringstream ss;
                     ss << "reference picture " << i << " ";
                     ss << Location(Func::Empty, Field::pEncodeInfo)
                               .dot(Field::pReferenceSlots, i)
@@ -2009,7 +2009,7 @@ bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuff
                 auto hazard = context->DetectHazard(*image_view_state, offset, extent, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_READ,
                                                     SyncOrdering::kOrderingNone);
                 if (hazard.IsHazard()) {
-                    std::stringstream ss;
+                    std::ostringstream ss;
                     ss << "quantization map ";
                     ss << Location(Func::Empty, Field::pEncodeInfo).dot(Field::quantizationMap).Fields();
                     ss << " ";
@@ -3106,7 +3106,7 @@ bool SyncValidator::PreCallValidateCmdBuildAccelerationStructuresKHR(
                 auto hazard = context.DetectHazard(geometry_data, SYNC_ACCELERATION_STRUCTURE_BUILD_SHADER_READ, geometry_range);
                 if (hazard.IsHazard()) {
                     const LogObjectList objlist(commandBuffer, geometry_data.Handle());
-                    std::stringstream ss;
+                    std::ostringstream ss;
                     ss << data_description << " ";
                     ss << FormatHandle(geometry_data.Handle());
                     const std::string resource_description = ss.str();

--- a/layers/thread_tracker/thread_safety_validation.h
+++ b/layers/thread_tracker/thread_safety_validation.h
@@ -218,7 +218,7 @@ class Counter {
 
   private:
     std::string GetErrorMessage(std::thread::id tid, std::thread::id other_tid) const {
-        std::stringstream err_str;
+        std::ostringstream err_str;
         err_str << "THREADING ERROR : object of type " << string_VulkanObjectType(object_type)
                 << " is simultaneously used in current thread " << tid << " and thread " << other_tid;
         return err_str.str();

--- a/layers/utils/image_utils.cpp
+++ b/layers/utils/image_utils.cpp
@@ -126,7 +126,7 @@ bool AreFormatsSizeCompatible(VkFormat a, VkFormat b, VkImageAspectFlags aspect_
 }
 
 std::string DescribeFormatsSizeCompatible(VkFormat a, VkFormat b) {
-    std::stringstream ss;
+    std::ostringstream ss;
     const bool is_a_a8 = a == VK_FORMAT_A8_UNORM;
     const bool is_b_a8 = b == VK_FORMAT_A8_UNORM;
     if ((is_a_a8 && !is_b_a8) || (!is_a_a8 && is_b_a8)) {

--- a/layers/utils/spirv_tools_utils.cpp
+++ b/layers/utils/spirv_tools_utils.cpp
@@ -69,7 +69,7 @@ void AdjustValidatorOptions(const DeviceExtensions &device_extensions, const Dev
     settings.allow_offset_texture_operand = enabled_features.maintenance8 == VK_TRUE;
     settings.allow_vulkan_32_bit_bitwise = enabled_features.maintenance9 == VK_TRUE;
 
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << "spirv-val <input.spv>";
 
     if (settings.relax_block_layout) {

--- a/layers/vulkan/generated/dynamic_state_helper.cpp
+++ b/layers/vulkan/generated/dynamic_state_helper.cpp
@@ -364,7 +364,7 @@ std::string DynamicStatesCommandsToString(CBDynamicFlags const& dynamic_states) 
 }
 
 std::string DescribeDynamicStateCommand(CBDynamicState dynamic_state) {
-    std::stringstream ss;
+    std::ostringstream ss;
     vvl::Func func = vvl::Func::Empty;
     switch (dynamic_state) {
         case CB_DYNAMIC_STATE_VIEWPORT:
@@ -610,7 +610,7 @@ static std::string_view stencil_test_enable_static{
     "VkPipelineDepthStencilStateCreateInfo::stencilTestEnable was VK_TRUE in the last bound graphics pipeline.\n"};
 
 std::string DescribeDynamicStateDependency(CBDynamicState dynamic_state, const vvl::Pipeline* pipeline) {
-    std::stringstream ss;
+    std::ostringstream ss;
     switch (dynamic_state) {
         case CB_DYNAMIC_STATE_DEPTH_BIAS:
             if (!pipeline || pipeline->IsDynamic(CB_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE)) {

--- a/layers/vulkan/generated/error_location_helper.cpp
+++ b/layers/vulkan/generated/error_location_helper.cpp
@@ -9199,7 +9199,7 @@ Func FindAlias(Func func) {
 // clang-format on
 
 std::string String(const Extensions& extensions) {
-    std::stringstream out;
+    std::ostringstream out;
     for (size_t i = 0; i < extensions.size(); i++) {
         out << String(extensions[i]);
         if (i + 1 != extensions.size()) {
@@ -9219,7 +9219,7 @@ std::string String(const Requirement& requirement) {
 }
 
 std::string String(const Requirements& requirements) {
-    std::stringstream out;
+    std::ostringstream out;
     for (size_t i = 0; i < requirements.size(); i++) {
         out << String(requirements[i]);
         if (i + 1 != requirements.size()) {

--- a/layers/vulkan/generated/feature_not_present.cpp
+++ b/layers/vulkan/generated/feature_not_present.cpp
@@ -27,7 +27,7 @@ namespace vvl {
 namespace dispatch {
 
 void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDeviceCreateInfo &create_info) {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << "returned VK_ERROR_FEATURE_NOT_PRESENT because the following features were not supported on this physical device:\n";
 
     // First do 1.0 VkPhysicalDeviceFeatures

--- a/layers/vulkan/generated/valid_flag_values.cpp
+++ b/layers/vulkan/generated/valid_flag_values.cpp
@@ -1719,7 +1719,7 @@ std::string stateless::Context::DescribeFlagBitmaskValue(vvl::FlagBitmask flag_b
             return string_VkAccelerationStructureCreateFlagsKHR(value);
 
         default:
-            std::stringstream ss;
+            std::ostringstream ss;
             ss << "0x" << std::hex << value;
             return ss.str();
     }
@@ -1749,7 +1749,7 @@ std::string stateless::Context::DescribeFlagBitmaskValue64(vvl::FlagBitmask flag
             return string_VkDataGraphPipelineSessionCreateFlagsARM(value);
 
         default:
-            std::stringstream ss;
+            std::ostringstream ss;
             ss << "0x" << std::hex << value;
             return ss.str();
     }

--- a/layers/vulkan/generated/vk_api_version.h
+++ b/layers/vulkan/generated/vk_api_version.h
@@ -79,7 +79,7 @@ static inline APIVersion NormalizeApiVersion(APIVersion specified_version) {
 
 // Convert integer API version to a string
 static inline std::string StringAPIVersion(APIVersion version) {
-    std::stringstream version_name;
+    std::ostringstream version_name;
     if (!version.Valid()) {
         return "<unrecognized>";
     }

--- a/scripts/generators/api_version_generator.py
+++ b/scripts/generators/api_version_generator.py
@@ -134,7 +134,7 @@ class ApiVersionOutputGenerator(BaseGenerator):
         out.append('''
             // Convert integer API version to a string
             static inline std::string StringAPIVersion(APIVersion version) {
-                std::stringstream version_name;
+                std::ostringstream version_name;
                 if (!version.Valid()) {
                     return "<unrecognized>";
                 }

--- a/scripts/generators/dynamic_state_generator.py
+++ b/scripts/generators/dynamic_state_generator.py
@@ -675,7 +675,7 @@ class DynamicStateOutputGenerator(BaseGenerator):
 
         out.append('''
             std::string DescribeDynamicStateCommand(CBDynamicState dynamic_state) {
-                std::stringstream ss;
+                std::ostringstream ss;
                 vvl::Func func = vvl::Func::Empty;
                 switch (dynamic_state) {
         ''')
@@ -707,7 +707,7 @@ class DynamicStateOutputGenerator(BaseGenerator):
             static std::string_view stencil_test_enable_static{"VkPipelineDepthStencilStateCreateInfo::stencilTestEnable was VK_TRUE in the last bound graphics pipeline.\\n"};
 
             std::string DescribeDynamicStateDependency(CBDynamicState dynamic_state, const vvl::Pipeline* pipeline) {
-                std::stringstream ss;
+                std::ostringstream ss;
                 switch (dynamic_state) {
         ''')
         for key, value in dynamic_state_map.items():

--- a/scripts/generators/error_location_helper_generator.py
+++ b/scripts/generators/error_location_helper_generator.py
@@ -292,7 +292,7 @@ Func FindAlias(Func func) {
 
         out.append('''
             std::string String(const Extensions& extensions) {
-                std::stringstream out;
+                std::ostringstream out;
                 for (size_t i = 0; i < extensions.size(); i++) {
                     out << String(extensions[i]);
                     if (i + 1 != extensions.size()) {
@@ -312,7 +312,7 @@ Func FindAlias(Func func) {
             }
 
             std::string String(const Requirements& requirements) {
-                std::stringstream out;
+                std::ostringstream out;
                 for (size_t i = 0; i < requirements.size(); i++) {
                     out << String(requirements[i]);
                     if (i + 1 != requirements.size()) {

--- a/scripts/generators/feature_not_present.py
+++ b/scripts/generators/feature_not_present.py
@@ -63,7 +63,7 @@ class FeatureNotPresentGenerator(BaseGenerator):
             namespace dispatch {
 
             void Instance::ReportErrorFeatureNotPresent(VkPhysicalDevice gpu, const VkDeviceCreateInfo &create_info) {
-                std::stringstream ss;
+                std::ostringstream ss;
                 ss << "returned VK_ERROR_FEATURE_NOT_PRESENT because the following features were not supported on this physical device:\\n";
 
                 // First do 1.0 VkPhysicalDeviceFeatures

--- a/scripts/generators/valid_flag_values_generator.py
+++ b/scripts/generators/valid_flag_values_generator.py
@@ -186,7 +186,7 @@ class ValidFlagValuesOutputGenerator(BaseGenerator):
         out.extend(guard_helper.add_guard(None))
         out.append('''
                     default:
-                        std::stringstream ss;
+                        std::ostringstream ss;
                         ss << "0x" << std::hex << value;
                         return ss.str();
                 }
@@ -202,7 +202,7 @@ class ValidFlagValuesOutputGenerator(BaseGenerator):
         out.extend(guard_helper.add_guard(None))
         out.append('''
                     default:
-                        std::stringstream ss;
+                        std::ostringstream ss;
                         ss << "0x" << std::hex << value;
                         return ss.str();
                 }

--- a/tests/framework/data_graph_objects.cpp
+++ b/tests/framework/data_graph_objects.cpp
@@ -22,7 +22,7 @@ void DataGraphPipelineHelper::CreateShaderModule(const char* spirv_source, const
 
     std::string error_msg;
     tools.SetMessageConsumer([&](spv_message_level_t, const char*, const spv_position_t& position, const char* message) {
-        std::stringstream ss;
+        std::ostringstream ss;
         ss << "on line " << position.line << ", column " << position.column << ": " << message;
         error_msg = ss.str();
     });
@@ -123,7 +123,7 @@ std::string DataGraphPipelineHelper::GetSpirvMultiEntryTwoDataGraph() {
 // - unused OpGraphConstantARM
 // - `inserted_line` to cause different errors
 std::string DataGraphPipelineHelper::GetSpirvModifyableDataGraph(const ModifiableShaderParameters& params) {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << R"(
                                   OpCapability GraphARM
                                   OpCapability TensorsARM
@@ -187,7 +187,7 @@ std::string DataGraphPipelineHelper::GetSpirvModifyableDataGraph(const Modifiabl
 // A command shader (for the majority of cases) that can be modified inserting
 // instructions in given sections. Without any insertions it's a basic shader.
 std::string DataGraphPipelineHelper::GetSpirvModifiableShader(const ModifiableShaderParameters& params) {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << R"(
 ; SPIRV
 ; Version: 1.6
@@ -239,7 +239,7 @@ std::string DataGraphPipelineHelper::GetSpirvModifiableShader(const ModifiableSh
 
 // spirv using a descriptor array
 std::string DataGraphPipelineHelper::GetSpirvTensorArrayDataGraph(bool is_runtime) {
-    std::stringstream ss;
+    std::ostringstream ss;
     ss << R"(
                             OpCapability GraphARM
                             OpCapability TensorsARM

--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -597,7 +597,7 @@ std::vector<std::string> get_args(android_app &app, const char *intent_extra_dat
     vm.DetachCurrentThread();
 
     // split args_str
-    std::stringstream ss(args_str);
+    std::istringstream ss(args_str);
     std::string arg;
     while (std::getline(ss, arg, ' ')) {
         if (!arg.empty()) args.emplace_back(arg);

--- a/tests/framework/render.cpp
+++ b/tests/framework/render.cpp
@@ -354,7 +354,7 @@ bool VkRenderFramework::IsExtensionsEnabled(const char *ext_name) const {
 }
 
 std::string VkRenderFramework::RequiredExtensionsNotSupported() const {
-    std::stringstream ss;
+    std::ostringstream ss;
     bool first = true;
     for (const auto &ext : m_required_extensions) {
         if (!CanEnableDeviceExtension(ext) && !CanEnableInstanceExtension(ext)) {

--- a/tests/framework/test_framework.cpp
+++ b/tests/framework/test_framework.cpp
@@ -119,7 +119,7 @@ static void CheckAndSetEnvironmentVariables() {
 
     bool found_json = false;
     bool vk_layer_env_vars_present = false;
-    std::stringstream error_log;  // Build up error log in case the validation json cannot be found
+    std::ostringstream error_log;  // Build up error log in case the validation json cannot be found
     for (const char *env_var : {"VK_LAYER_PATH", "VK_ADD_LAYER_PATH"}) {
         const std::vector<std::string> vk_layer_paths = GetVkEnvironmentVariable(env_var);
         if (!vk_layer_paths.empty()) {

--- a/tests/stress/gpu_av_stress.cpp
+++ b/tests/stress/gpu_av_stress.cpp
@@ -209,7 +209,7 @@ TEST_F(StressGpuAV, DescriptorIndexing2) {
     //         x[1].bn = floatBitsToUint(a * n);
     //     }
     const uint32_t field_count = 100;
-    std::stringstream cs_source;
+    std::ostringstream cs_source;
     cs_source << R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer SSBO {
@@ -267,7 +267,7 @@ TEST_F(StressGpuAV, DescriptorIndexingPushConstantAccess) {
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_}, {pc_range});
 
     const uint32_t count = 150;
-    std::stringstream cs_source;
+    std::ostringstream cs_source;
     cs_source << R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference2 : require
@@ -372,7 +372,7 @@ TEST_F(StressGpuAV, DescriptorIndexingGeneralBufferOOB) {
     //     a += dot(vec4(m[31].x, m[31].y, m[31].z, m[31].w), b);
     // }
     const uint32_t array_count = 32;
-    std::stringstream cs_source;
+    std::ostringstream cs_source;
     cs_source << R"glsl(
         #version 450
         layout(set = 0, binding = 0) buffer SSBO {
@@ -424,7 +424,7 @@ TEST_F(StressGpuAV, BufferDeviceAddress) {
     InitRenderTarget();
     const uint32_t count = 32;
 
-    std::stringstream cs_source;
+    std::ostringstream cs_source;
     cs_source << R"glsl(
         #version 450
         #extension GL_EXT_buffer_reference : enable

--- a/tests/unit/dynamic_state.cpp
+++ b/tests/unit/dynamic_state.cpp
@@ -2503,7 +2503,7 @@ TEST_F(NegativeDynamicState, ColorBlendAttchment) {
     constexpr uint32_t color_attachments = 2;
     InitRenderTarget(color_attachments);
 
-    std::stringstream fsSource;
+    std::ostringstream fsSource;
     fsSource << "#version 450\n";
     for (uint32_t i = 0; i < color_attachments; ++i) {
         fsSource << "layout(location = " << i << ") out vec4 c" << i << ";\n";

--- a/tests/unit/gpu_av_descriptor_post_process.cpp
+++ b/tests/unit/gpu_av_descriptor_post_process.cpp
@@ -2173,7 +2173,7 @@ TEST_F(NegativeGpuAVDescriptorPostProcess, LotsOfBindings) {
     InitRenderTarget();
 
     const uint32_t binding_count = 64;
-    std::stringstream fs_source;
+    std::ostringstream fs_source;
     fs_source << R"glsl(
         #version 450
         #extension GL_EXT_nonuniform_qualifier : enable

--- a/tests/unit/gpu_av_positive.cpp
+++ b/tests/unit/gpu_av_positive.cpp
@@ -1029,7 +1029,7 @@ TEST_P(PositiveGpuAVParameterized, SettingsCombinations) {
 static std::string GetGpuAvSettingsCombinationTestName(const testing::TestParamInfo<PositiveGpuAVParameterized::ParamType> &info) {
     std::vector<const char *> setting_names = std::get<0>(info.param);
     const uint32_t setting_values = std::get<1>(info.param);
-    std::stringstream test_name;
+    std::ostringstream test_name;
     for (auto [setting_name_i, setting_name] : vvl::enumerate(setting_names)) {
         const char *enabled_str = (setting_values & (1u << setting_name_i)) ? "_1" : "_0";
         if (setting_name_i != 0) {

--- a/tests/unit/gpu_av_ray_tracing.cpp
+++ b/tests/unit/gpu_av_ray_tracing.cpp
@@ -1637,12 +1637,12 @@ TEST_F(NegativeGpuAVRayTracing, InvalidBlasReference3) {
         // Destroy buffer, but BLAS will be referenced in a TLAS build command
         cube_blas.GetDstAS()->GetBuffer().Destroy();
 
-        std::stringstream expected_error_1;
+        std::ostringstream expected_error_1;
         expected_error_1 << "Infos\\[0\\].pGeometries\\[0\\].geometry.instances<VkAccelerationStructureInstance>\\[0\\]."
                             "accelerationStructureReference \\(0x"
                          << std::hex << cube_blas_addr << "\\).*underlying buffer.*VkAccelerationStructureKHR.*"
                          << CastFromHandle<uint64_t>(cube_blas.GetDstAS()->handle());
-        std::stringstream expected_error_2;
+        std::ostringstream expected_error_2;
         expected_error_2 << "Infos\\[0\\].pGeometries\\[0\\].geometry.instances<VkAccelerationStructureInstance>\\[1\\]."
                             "accelerationStructureReference \\(0x"
                          << std::hex << cube_blas_addr << "\\).*underlying buffer.*VkAccelerationStructureKHR.*"

--- a/tests/unit/pipeline_positive.cpp
+++ b/tests/unit/pipeline_positive.cpp
@@ -586,7 +586,7 @@ TEST_F(PositivePipeline, ViewportArray2NV) {
             (stage != TestStage::VERTEX) ? VK_PRIMITIVE_TOPOLOGY_PATCH_LIST : VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
         pipe.shader_stages_.clear();
 
-        std::stringstream vs_src, tes_src, geom_src;
+        std::ostringstream vs_src, tes_src, geom_src;
 
         vs_src << R"(
             #version 450

--- a/tests/unit/shader_compute.cpp
+++ b/tests/unit/shader_compute.cpp
@@ -26,7 +26,7 @@ TEST_F(NegativeShaderCompute, SharedMemoryOverLimit) {
     const uint32_t max_shared_memory_size = m_device->Physical().limits_.maxComputeSharedMemorySize;
     const uint32_t max_shared_ints = max_shared_memory_size / 4;
 
-    std::stringstream csSource;
+    std::ostringstream csSource;
     // Make sure compute pipeline has a compute shader stage set
     csSource << R"glsl(
         #version 450
@@ -53,7 +53,7 @@ TEST_F(NegativeShaderCompute, SharedMemoryBooleanOverLimit) {
     // "Boolean values considered as 32-bit integer values for the purpose of this calculation."
     const uint32_t max_shared_bools = max_shared_memory_size / 4;
 
-    std::stringstream csSource;
+    std::ostringstream csSource;
     // Make sure compute pipeline has a compute shader stage set
     csSource << R"glsl(
         #version 450
@@ -84,7 +84,7 @@ TEST_F(NegativeShaderCompute, SharedMemoryOverLimitWorkgroupMemoryExplicitLayout
     const uint32_t max_shared_memory_size = m_device->Physical().limits_.maxComputeSharedMemorySize;
     const uint32_t max_shared_ints = max_shared_memory_size / 4;
 
-    std::stringstream csSource;
+    std::ostringstream csSource;
     csSource << R"glsl(
         #version 450
         #extension GL_EXT_shared_memory_block : enable
@@ -121,7 +121,7 @@ TEST_F(NegativeShaderCompute, SharedMemorySpecConstantDefault) {
     const uint32_t max_shared_memory_size = m_device->Physical().limits_.maxComputeSharedMemorySize;
     const uint32_t max_shared_ints = max_shared_memory_size / 4;
 
-    std::stringstream cs_source;
+    std::ostringstream cs_source;
     cs_source << R"glsl(
         #version 450
         layout(constant_id = 0) const uint Condition = 1;
@@ -148,7 +148,7 @@ TEST_F(NegativeShaderCompute, SharedMemorySpecConstantSet) {
     const uint32_t max_shared_memory_size = m_device->Physical().limits_.maxComputeSharedMemorySize;
     const uint32_t max_shared_ints = max_shared_memory_size / 4;
 
-    std::stringstream cs_source;
+    std::ostringstream cs_source;
     cs_source << R"glsl(
         #version 450
         layout(constant_id = 0) const uint Condition = 0;
@@ -239,7 +239,7 @@ TEST_F(NegativeShaderCompute, WorkGroupSizeConstantDefault) {
 
     uint32_t x_size_limit = m_device->Physical().limits_.maxComputeWorkGroupSize[0];
 
-    std::stringstream spv_source;
+    std::ostringstream spv_source;
     spv_source << R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
@@ -278,7 +278,7 @@ TEST_F(NegativeShaderCompute, WorkGroupSizeSpecConstantDefault) {
 
     uint32_t x_size_limit = m_device->Physical().limits_.maxComputeWorkGroupSize[0];
 
-    std::stringstream spv_source;
+    std::ostringstream spv_source;
     spv_source << R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
@@ -319,7 +319,7 @@ TEST_F(NegativeShaderCompute, WorkGroupSizeLocalSizeId) {
 
     uint32_t x_size_limit = m_device->Physical().limits_.maxComputeWorkGroupSize[0];
 
-    std::stringstream spv_source;
+    std::ostringstream spv_source;
     spv_source << R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
@@ -358,7 +358,7 @@ TEST_F(NegativeShaderCompute, WorkGroupSizeLocalSizeIdSpecConstantDefault) {
 
     // layout(local_size_x_id = 18, local_size_z_id = 19) in;
     // layout(local_size_x = 32) in;
-    std::stringstream spv_source;
+    std::ostringstream spv_source;
     spv_source << R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
@@ -400,7 +400,7 @@ TEST_F(NegativeShaderCompute, WorkGroupSizeLocalSizeIdSpecConstantSet) {
 
     // layout(local_size_x_id = 18, local_size_z_id = 19) in;
     // layout(local_size_x = 32) in;
-    std::stringstream spv_source;
+    std::ostringstream spv_source;
     spv_source << R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
@@ -758,7 +758,7 @@ TEST_F(NegativeShaderCompute, CmdDispatchExceedLimits) {
     invocations_limit /= y_size_limit;
     z_size_limit = (z_size_limit > invocations_limit) ? invocations_limit : z_size_limit;
 
-    std::stringstream cs_text;
+    std::ostringstream cs_text;
     cs_text << "#version 450\n";
     cs_text << "layout(local_size_x = " << x_size_limit << ", ";
     cs_text << "local_size_y = " << y_size_limit << ",";

--- a/tests/unit/shader_compute_positive.cpp
+++ b/tests/unit/shader_compute_positive.cpp
@@ -27,7 +27,7 @@ TEST_F(PositiveShaderCompute, WorkGroupSizePrecedenceOverLocalSize) {
     uint32_t y_size_limit = m_device->Physical().limits_.maxComputeWorkGroupSize[1];
     uint32_t z_size_limit = m_device->Physical().limits_.maxComputeWorkGroupSize[2];
 
-    std::stringstream spv_source;
+    std::ostringstream spv_source;
     spv_source << R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
@@ -66,7 +66,7 @@ TEST_F(PositiveShaderCompute, WorkGroupSizeSpecConstantUnder) {
 
     uint32_t x_size_limit = m_device->Physical().limits_.maxComputeWorkGroupSize[0];
 
-    std::stringstream spv_source;
+    std::ostringstream spv_source;
     spv_source << R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
@@ -117,7 +117,7 @@ TEST_F(PositiveShaderCompute, WorkGroupSizeLocalSizeId) {
     AddRequiredFeature(vkt::Feature::maintenance4);
     RETURN_IF_SKIP(Init());
 
-    std::stringstream spv_source;
+    std::ostringstream spv_source;
     spv_source << R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
@@ -153,7 +153,7 @@ TEST_F(PositiveShaderCompute, WorkGroupSizeLocalSizeIdSpecConstant) {
 
     // layout(local_size_x_id = 18, local_size_z_id = 19) in;
     // layout(local_size_x = 32) in;
-    std::stringstream spv_source;
+    std::ostringstream spv_source;
     spv_source << R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"
@@ -206,7 +206,7 @@ TEST_F(PositiveShaderCompute, WorkGroupSizePrecedenceOverLocalSizeId) {
 
     uint32_t x_size_limit = m_device->Physical().limits_.maxComputeWorkGroupSize[0];
 
-    std::stringstream spv_source;
+    std::ostringstream spv_source;
     spv_source << R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"

--- a/tests/unit/shader_limits.cpp
+++ b/tests/unit/shader_limits.cpp
@@ -337,7 +337,7 @@ TEST_F(NegativeShaderLimits, OffsetMaxComputeSharedMemorySize) {
     //     vec4 x1[value];
     //     layout(offset = OVER_LIMIT) vec4 x2;
     // };
-    std::stringstream csSource;
+    std::ostringstream csSource;
     csSource << R"asm(
                OpCapability Shader
                OpCapability WorkgroupMemoryExplicitLayoutKHR
@@ -389,7 +389,7 @@ TEST_F(NegativeShaderLimits, MaxComputeSharedMemorySizeArrayStride) {
     // shared X {
     //     float x1[]; // ArrayStride 16, not 4
     // };
-    std::stringstream csSource;
+    std::ostringstream csSource;
     csSource << R"asm(
                OpCapability Shader
                OpCapability WorkgroupMemoryExplicitLayoutKHR

--- a/tests/unit/shader_limits_positive.cpp
+++ b/tests/unit/shader_limits_positive.cpp
@@ -56,7 +56,7 @@ TEST_F(PositiveShaderLimits, ComputeSharedMemoryWorkgroupMemoryExplicitLayout) {
     const uint32_t max_shared_memory_size = m_device->Physical().limits_.maxComputeSharedMemorySize;
     const uint32_t max_shared_vec4 = max_shared_memory_size / 16;
 
-    std::stringstream csSource;
+    std::ostringstream csSource;
     csSource << R"glsl(
         #version 450
         #extension GL_EXT_shared_memory_block : enable
@@ -87,7 +87,7 @@ TEST_F(PositiveShaderLimits, ComputeSharedMemoryAtLimit) {
     const uint32_t max_shared_memory_size = m_device->Physical().limits_.maxComputeSharedMemorySize;
     const uint32_t max_shared_ints = max_shared_memory_size / 4;
 
-    std::stringstream csSource;
+    std::ostringstream csSource;
     csSource << R"glsl(
         #version 450
         shared int a[)glsl";
@@ -110,7 +110,7 @@ TEST_F(PositiveShaderLimits, ComputeSharedMemoryBooleanAtLimit) {
     // "Boolean values considered as 32-bit integer values for the purpose of this calculation."
     const uint32_t max_shared_bools = max_shared_memory_size / 4;
 
-    std::stringstream csSource;
+    std::ostringstream csSource;
     csSource << R"glsl(
         #version 450
         shared bool a[)glsl";
@@ -140,7 +140,7 @@ TEST_F(PositiveShaderLimits, MeshSharedMemoryAtLimit) {
     const uint32_t max_shared_memory_size = mesh_shader_properties.maxMeshSharedMemorySize;
     const uint32_t max_shared_ints = max_shared_memory_size / 4;
 
-    std::stringstream mesh_source;
+    std::ostringstream mesh_source;
     mesh_source << R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : require
@@ -177,7 +177,7 @@ TEST_F(PositiveShaderLimits, TaskSharedMemoryAtLimit) {
     const uint32_t max_shared_memory_size = mesh_shader_properties.maxMeshSharedMemorySize;
     const uint32_t max_shared_ints = max_shared_memory_size / 4;
 
-    std::stringstream task_source;
+    std::ostringstream task_source;
     task_source << R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : require

--- a/tests/unit/shader_mesh.cpp
+++ b/tests/unit/shader_mesh.cpp
@@ -30,7 +30,7 @@ TEST_F(NegativeShaderMesh, SharedMemoryOverLimit) {
     const uint32_t max_shared_memory_size = mesh_shader_properties.maxMeshSharedMemorySize;
     const uint32_t max_shared_ints = max_shared_memory_size / 4;
 
-    std::stringstream mesh_source;
+    std::ostringstream mesh_source;
     mesh_source << R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : require
@@ -70,7 +70,7 @@ TEST_F(NegativeShaderMesh, SharedMemoryOverLimitWorkgroupMemoryExplicitLayout) {
     const uint32_t max_shared_memory_size = mesh_shader_properties.maxMeshSharedMemorySize;
     const uint32_t max_shared_ints = max_shared_memory_size / 4;
 
-    std::stringstream mesh_source;
+    std::ostringstream mesh_source;
     mesh_source << R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : require
@@ -119,7 +119,7 @@ TEST_F(NegativeShaderMesh, SharedMemorySpecConstantDefault) {
     const uint32_t max_shared_memory_size = mesh_shader_properties.maxMeshSharedMemorySize;
     const uint32_t max_shared_ints = max_shared_memory_size / 4;
 
-    std::stringstream mesh_source;
+    std::ostringstream mesh_source;
     mesh_source << R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : require
@@ -159,7 +159,7 @@ TEST_F(NegativeShaderMesh, SharedMemorySpecConstantSet) {
     const uint32_t max_shared_memory_size = mesh_shader_properties.maxMeshSharedMemorySize;
     const uint32_t max_shared_ints = max_shared_memory_size / 4;
 
-    std::stringstream mesh_source;
+    std::ostringstream mesh_source;
     mesh_source << R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : require
@@ -212,7 +212,7 @@ TEST_F(NegativeShaderMesh, TaskSharedMemoryOverLimit) {
     const uint32_t max_shared_memory_size = mesh_shader_properties.maxTaskSharedMemorySize;
     const uint32_t max_shared_ints = max_shared_memory_size / 4;
 
-    std::stringstream task_source;
+    std::ostringstream task_source;
     task_source << R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : require
@@ -311,7 +311,7 @@ TEST_F(NegativeShaderMesh, MeshShaderPayloadMemoryOverLimit) {
     const uint32_t max_mesh_payload_and_shared_memory_size = mesh_shader_properties.maxMeshPayloadAndSharedMemorySize;
     const uint32_t max_mesh_payload_and_shared_ints = max_mesh_payload_and_shared_memory_size / 4;
 
-    std::stringstream task_source;
+    std::ostringstream task_source;
     task_source << R"glsl(
             #version 460
             #extension GL_EXT_mesh_shader : require
@@ -327,7 +327,7 @@ TEST_F(NegativeShaderMesh, MeshShaderPayloadMemoryOverLimit) {
             }
         )glsl";
 
-    std::stringstream mesh_source;
+    std::ostringstream mesh_source;
     mesh_source << R"glsl(
             #version 460
             #extension GL_EXT_mesh_shader : require
@@ -437,7 +437,7 @@ TEST_F(NegativeShaderMesh, TaskPayloadMemoryOverLimit) {
 
     VkShaderObj mesh(*m_device, kMeshMinimalGlsl, VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_2);
 
-    std::stringstream task_source;
+    std::ostringstream task_source;
     task_source << R"glsl(
             #version 460
             #extension GL_EXT_mesh_shader : require
@@ -482,7 +482,7 @@ TEST_F(NegativeShaderMesh, TaskShaderAndPayloadMemoryOverLimit) {
 
     VkShaderObj mesh(*m_device, kMeshMinimalGlsl, VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_2);
 
-    std::stringstream task_source;
+    std::ostringstream task_source;
     task_source << R"glsl(
             #version 460
             #extension GL_EXT_mesh_shader : require

--- a/tests/unit/shader_mesh_positive.cpp
+++ b/tests/unit/shader_mesh_positive.cpp
@@ -35,7 +35,7 @@ TEST_F(PositiveShaderMesh, MeshShaderPayloadMemoryOverLimit) {
     const uint32_t max_mesh_payload_and_shared_memory_size = mesh_shader_properties.maxMeshPayloadAndSharedMemorySize;
     const uint32_t max_mesh_payload_and_shared_ints = max_mesh_payload_and_shared_memory_size / 4;
 
-    std::stringstream task_source;
+    std::ostringstream task_source;
     task_source << R"glsl(
             #version 460
             #extension GL_EXT_mesh_shader : require
@@ -51,7 +51,7 @@ TEST_F(PositiveShaderMesh, MeshShaderPayloadMemoryOverLimit) {
             }
         )glsl";
 
-    std::stringstream mesh_source;
+    std::ostringstream mesh_source;
     mesh_source << R"glsl(
             #version 460
             #extension GL_EXT_mesh_shader : require
@@ -161,7 +161,7 @@ TEST_F(PositiveShaderMesh, TaskSharedMemory) {
 
     VkShaderObj mesh(*m_device, kMeshMinimalGlsl, VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_2);
 
-    std::stringstream task_source;
+    std::ostringstream task_source;
     task_source << R"glsl(
         #version 460
         #extension GL_EXT_mesh_shader : require

--- a/tests/unit/shader_object.cpp
+++ b/tests/unit/shader_object.cpp
@@ -3609,7 +3609,7 @@ TEST_F(NegativeShaderObject, SharedMemoryOverLimit) {
     const uint32_t max_shared_memory_size = m_device->Physical().limits_.maxComputeSharedMemorySize;
     const uint32_t max_shared_ints = max_shared_memory_size / 4;
 
-    std::stringstream cs_src;
+    std::ostringstream cs_src;
     // Make sure compute pipeline has a compute shader stage set
     cs_src << R"glsl(
         #version 450
@@ -4113,7 +4113,7 @@ TEST_F(NegativeShaderObject, MaxTransformFeedbackStream) {
         GTEST_SKIP() << "maxTransformFeedbackStreams is zero";
     }
 
-    std::stringstream gsSource;
+    std::ostringstream gsSource;
     gsSource << R"asm(
                OpCapability Geometry
                OpCapability TransformFeedback
@@ -4178,7 +4178,7 @@ TEST_F(NegativeShaderObject, TransformFeedbackStride) {
         GTEST_SKIP() << "maxTransformFeedbackStreams is zero";
     }
 
-    std::stringstream vs_src;
+    std::ostringstream vs_src;
     vs_src << R"asm(
                OpCapability Shader
                OpCapability TransformFeedback
@@ -6775,7 +6775,7 @@ TEST_F(NegativeShaderObject, MeshShaderPayloadMemoryOverLimit) {
     const uint32_t max_mesh_payload_and_shared_memory_size = mesh_shader_properties.maxMeshPayloadAndSharedMemorySize;
     const uint32_t max_mesh_payload_and_shared_ints = max_mesh_payload_and_shared_memory_size / 4;
 
-    std::stringstream mesh_source;
+    std::ostringstream mesh_source;
     mesh_source << R"glsl(
             #version 460
             #extension GL_EXT_mesh_shader : require

--- a/tests/unit/shader_spirv_positive.cpp
+++ b/tests/unit/shader_spirv_positive.cpp
@@ -607,7 +607,7 @@ TEST_F(PositiveShaderSpirv, OpTypeArraySpecConstant) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(Init());
 
-    std::stringstream spv_source;
+    std::ostringstream spv_source;
     spv_source << R"(
                OpCapability Shader
           %1 = OpExtInstImport "GLSL.std.450"

--- a/tests/unit/shader_untyped.cpp
+++ b/tests/unit/shader_untyped.cpp
@@ -341,7 +341,7 @@ TEST_F(NegativeShaderUntyped, OffsetMaxComputeSharedMemorySize) {
     //     vec4 x1[value];
     //     layout(offset = OVER_LIMIT) vec4 x2;
     // };
-    std::stringstream csSource;
+    std::ostringstream csSource;
     csSource << R"asm(
                OpCapability Shader
                OpCapability WorkgroupMemoryExplicitLayoutKHR

--- a/tests/unit/subgroups.cpp
+++ b/tests/unit/subgroups.cpp
@@ -326,7 +326,7 @@ TEST_F(NegativeSubgroup, PipelineSubgroupSizeControl) {
     }
 
     if (subgroup_properties.maxSubgroupSize > 1) {
-        std::stringstream csSource;
+        std::ostringstream csSource;
         csSource << R"glsl(
         #version 450
         layout(local_size_x = )glsl";
@@ -345,7 +345,7 @@ TEST_F(NegativeSubgroup, PipelineSubgroupSizeControl) {
     }
 
     if (props11.subgroupSize > 1) {
-        std::stringstream csSource;
+        std::ostringstream csSource;
         csSource << R"glsl(
         #version 450
         layout(local_size_x = )glsl";
@@ -408,7 +408,7 @@ TEST_F(NegativeSubgroup, SubgroupSizeControlFeaturesNotEnabled) {
     VkPhysicalDeviceVulkan11Properties props11 = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(props11);
 
-    std::stringstream csSource;
+    std::ostringstream csSource;
     // Make sure compute pipeline has a compute shader stage set
     csSource << R"(
         #version 450
@@ -616,7 +616,7 @@ TEST_F(NegativeSubgroup, ComputeLocalWorkgroupSize) {
         std::ceil(std::sqrt(subgroup_size_control.requiredSubgroupSize * subgroup_properties.maxComputeWorkgroupSubgroups)));
 
     if (size <= 1024) {
-        std::stringstream csSource;
+        std::ostringstream csSource;
         csSource << R"glsl(
         #version 450
         layout(local_size_x=
@@ -644,7 +644,7 @@ TEST_F(NegativeSubgroup, ComputeLocalWorkgroupSize) {
     }
 
     if (subgroup_properties.maxSubgroupSize > 1 && subgroup_properties.minSubgroupSize > 1) {
-        std::stringstream csSource;
+        std::ostringstream csSource;
         csSource << R"glsl(
             #version 450
             layout(local_size_x=
@@ -704,7 +704,7 @@ TEST_F(NegativeSubgroup, MeshLocalWorkgroupSize) {
     uint32_t y = mesh_properties.maxTaskWorkGroupInvocations / x;
     uint32_t z = mesh_properties.maxTaskWorkGroupInvocations / x / y;
 
-    std::stringstream taskSrc;
+    std::ostringstream taskSrc;
     taskSrc << R"(
                 OpCapability MeshShadingEXT
                 OpExtension "SPV_EXT_mesh_shader"

--- a/tests/unit/transform_feedback.cpp
+++ b/tests/unit/transform_feedback.cpp
@@ -649,7 +649,7 @@ TEST_F(NegativeTransformFeedback, RuntimeSpirv) {
     }
 
     {
-        std::stringstream vsSource;
+        std::ostringstream vsSource;
         vsSource << R"asm(
                OpCapability Shader
                OpCapability TransformFeedback
@@ -689,7 +689,7 @@ TEST_F(NegativeTransformFeedback, RuntimeSpirv) {
     }
 
     {
-        std::stringstream gsSource;
+        std::ostringstream gsSource;
         gsSource << R"asm(
                OpCapability Geometry
                OpCapability TransformFeedback
@@ -796,7 +796,7 @@ TEST_F(NegativeTransformFeedback, RuntimeSpirv) {
     }
 
     {
-        std::stringstream gsSource;
+        std::ostringstream gsSource;
         gsSource << R"asm(
                OpCapability Geometry
                OpCapability TransformFeedback
@@ -851,7 +851,7 @@ TEST_F(NegativeTransformFeedback, RuntimeSpirv) {
     }
 
     {
-        std::stringstream gsSource;
+        std::ostringstream gsSource;
         gsSource << R"asm(
                OpCapability Geometry
                OpCapability TransformFeedback
@@ -906,7 +906,7 @@ TEST_F(NegativeTransformFeedback, RuntimeSpirv) {
         uint32_t count = transform_feedback_props.maxTransformFeedbackStreamDataSize / offset + 1;
         // Limit to 25, because we are dynamically adding variables using letters as names
         if (count < 25) {
-            std::stringstream gsSource;
+            std::ostringstream gsSource;
             gsSource << R"asm(
                OpCapability Geometry
                OpCapability TransformFeedback


### PR DESCRIPTION
notices we used both, should just use `ostringstream` as we have no need for input