### PR TITLE
layers: Cleanup pipeline creation flags

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -335,6 +335,7 @@ vvl_sources = [
   "layers/stateless/sl_buffer.cpp",
   "layers/stateless/sl_cmd_buffer.cpp",
   "layers/stateless/sl_cmd_buffer_dynamic.cpp",
+  "layers/stateless/sl_data_graph.cpp",
   "layers/stateless/sl_descriptor.cpp",
   "layers/stateless/sl_device_generated_commands.cpp",
   "layers/stateless/sl_device_memory.cpp",

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -419,6 +419,7 @@ target_sources(vvl PRIVATE
     stateless/sl_buffer.cpp
     stateless/sl_cmd_buffer_dynamic.cpp
     stateless/sl_cmd_buffer.cpp
+    stateless/sl_data_graph.cpp
     stateless/sl_descriptor.cpp
     stateless/sl_device_generated_commands.cpp
     stateless/sl_device_memory.cpp

--- a/layers/core_checks/cc_pipeline.cpp
+++ b/layers/core_checks/cc_pipeline.cpp
@@ -44,64 +44,6 @@ bool CoreChecks::IsBeforeCtsVersion(uint32_t major, uint32_t minor, uint32_t sub
     return phys_dev_props_core12.conformanceVersion.subminor < subminor;
 }
 
-bool CoreChecks::ValidatePipelineCacheControlFlags(VkPipelineCreateFlags2 flags, const Location &flags_loc,
-                                                   const char *vuid) const {
-    bool skip = false;
-    if (enabled_features.pipelineCreationCacheControl == VK_FALSE) {
-        const VkPipelineCreateFlags invalid_flags =
-            VK_PIPELINE_CREATE_2_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT | VK_PIPELINE_CREATE_2_EARLY_RETURN_ON_FAILURE_BIT;
-        if ((flags & invalid_flags) != 0) {
-            skip |= LogError(vuid, device, flags_loc, "is %s but pipelineCreationCacheControl feature was not enabled.",
-                             string_VkPipelineCreateFlags2(flags).c_str());
-        }
-    }
-    return skip;
-}
-
-bool CoreChecks::ValidatePipelineIndirectBindableFlags(VkPipelineCreateFlags2 flags, const Location &flags_loc,
-                                                       const char *vuid) const {
-    bool skip = false;
-    if (enabled_features.deviceGeneratedComputePipelines == VK_FALSE) {
-        if ((flags & VK_PIPELINE_CREATE_2_INDIRECT_BINDABLE_BIT_NV) != 0) {
-            skip |= LogError(vuid, device, flags_loc, "is %s but deviceGeneratedComputePipelines feature was not enabled.",
-                             string_VkPipelineCreateFlags2(flags).c_str());
-        }
-    }
-    return skip;
-}
-
-bool CoreChecks::ValidatePipelineProtectedAccessFlags(VkPipelineCreateFlags2 flags, const Location &flags_loc) const {
-    bool skip = false;
-    if (enabled_features.pipelineProtectedAccess == VK_FALSE) {
-        const VkPipelineCreateFlags invalid_flags =
-            VK_PIPELINE_CREATE_2_NO_PROTECTED_ACCESS_BIT | VK_PIPELINE_CREATE_2_PROTECTED_ACCESS_ONLY_BIT;
-        if ((flags & invalid_flags) != 0) {
-            skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-pipelineProtectedAccess-07368", device, flags_loc,
-                             "is %s, but pipelineProtectedAccess feature was not enabled.",
-                             string_VkPipelineCreateFlags2(flags).c_str());
-        }
-    }
-    if ((flags & VK_PIPELINE_CREATE_2_NO_PROTECTED_ACCESS_BIT) && (flags & VK_PIPELINE_CREATE_2_PROTECTED_ACCESS_ONLY_BIT)) {
-        skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-flags-07369", device, flags_loc,
-                         "is %s (contains both NO_PROTECTED_ACCESS_BIT and PROTECTED_ACCESS_ONLY_BIT).",
-                         string_VkPipelineCreateFlags2(flags).c_str());
-    }
-    return skip;
-}
-
-bool CoreChecks::ValidatePipeline64BitIndexingFlags(VkPipelineCreateFlags2 flags, const Location &flags_loc,
-                                                    const char *vuid) const {
-    bool skip = false;
-    if (enabled_features.shader64BitIndexing == VK_FALSE) {
-        const VkPipelineCreateFlags2 invalid_flags = VK_PIPELINE_CREATE_2_64_BIT_INDEXING_BIT_EXT;
-        if ((flags & invalid_flags) != 0) {
-            skip |= LogError(vuid, device, flags_loc, "is %s but shader64BitIndexing feature was not enabled.",
-                             string_VkPipelineCreateFlags2(flags).c_str());
-        }
-    }
-    return skip;
-}
-
 // This can be chained in the vkCreate*Pipelines() function or the VkPipelineShaderStageCreateInfo
 bool CoreChecks::ValidatePipelineRobustnessCreateInfo(const vvl::Pipeline &pipeline,
                                                       const VkPipelineRobustnessCreateInfo &pipeline_robustness_info,

--- a/layers/core_checks/cc_pipeline_compute.cpp
+++ b/layers/core_checks/cc_pipeline_compute.cpp
@@ -44,13 +44,6 @@ bool CoreChecks::PreCallValidateCreateComputePipelines(VkDevice device, VkPipeli
         }
 
         skip |= ValidateComputePipelineDerivatives(pipeline_states, i, create_info_loc);
-        const Location flags_loc = pipeline->GetCreateFlagsLoc(create_info_loc);
-        skip |= ValidatePipelineCacheControlFlags(pipeline->create_flags, flags_loc,
-                                                  "VUID-VkComputePipelineCreateInfo-pipelineCreationCacheControl-02875");
-        skip |= ValidatePipelineIndirectBindableFlags(pipeline->create_flags, flags_loc,
-                                                      "VUID-VkComputePipelineCreateInfo-flags-09007");
-        skip |=
-            ValidatePipeline64BitIndexingFlags(pipeline->create_flags, flags_loc, "VUID-VkComputePipelineCreateInfo-flags-11798");
 
         if (const auto *pipeline_robustness_info =
                 vku::FindStructInPNextChain<VkPipelineRobustnessCreateInfo>(pCreateInfos[i].pNext)) {

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -162,12 +162,6 @@ bool CoreChecks::ValidateGraphicsPipeline(const vvl::Pipeline &pipeline, const v
         }
     }
 
-    const Location flags_loc = pipeline.GetCreateFlagsLoc(create_info_loc);
-    skip |= ValidatePipelineCacheControlFlags(pipeline.create_flags, flags_loc,
-                                              "VUID-VkGraphicsPipelineCreateInfo-pipelineCreationCacheControl-02878");
-    skip |= ValidatePipelineProtectedAccessFlags(pipeline.create_flags, flags_loc);
-    skip |= ValidatePipeline64BitIndexingFlags(pipeline.create_flags, flags_loc, "VUID-VkGraphicsPipelineCreateInfo-flags-11798");
-
     const void *pipeline_pnext = pipeline.GetCreateInfoPNext();
     if (const auto *discard_rectangle_state =
             vku::FindStructInPNextChain<VkPipelineDiscardRectangleStateCreateInfoEXT>(pipeline_pnext)) {

--- a/layers/core_checks/cc_pipeline_ray_tracing.cpp
+++ b/layers/core_checks/cc_pipeline_ray_tracing.cpp
@@ -159,11 +159,6 @@ bool CoreChecks::PreCallValidateCreateRayTracingPipelinesNV(VkDevice device, VkP
             skip |= ValidatePipelineShaderStage(*pipeline, stage_ci, pCreateInfos[i].pNext,
                                                 create_info_loc.dot(Field::pStages, stage_index++));
         }
-        const Location flag_loc = pipeline->GetCreateFlagsLoc(create_info_loc);
-        skip |= ValidatePipelineCacheControlFlags(pipeline->create_flags, flag_loc,
-                                                  "VUID-VkRayTracingPipelineCreateInfoNV-pipelineCreationCacheControl-02905");
-        skip |= ValidatePipeline64BitIndexingFlags(pipeline->create_flags, flag_loc,
-                                                   "VUID-VkRayTracingPipelineCreateInfoNV-flags-11798");
 
         if (create_info.maxRecursionDepth > phys_dev_ext_props.ray_tracing_props_nv.maxRecursionDepth) {
             skip |= LogError("VUID-VkRayTracingPipelineCreateInfoNV-maxRecursionDepth-03457", device,
@@ -231,12 +226,6 @@ bool CoreChecks::PreCallValidateCreateRayTracingPipelinesKHR(VkDevice device, Vk
                 ++stateless_data_i;
             }
         }
-
-        const Location flags_loc = pipeline->GetCreateFlagsLoc(create_info_loc);
-        skip |= ValidatePipelineCacheControlFlags(pipeline->create_flags, flags_loc,
-                                                  "VUID-VkRayTracingPipelineCreateInfoKHR-pipelineCreationCacheControl-02905");
-        skip |= ValidatePipeline64BitIndexingFlags(pipeline->create_flags, flags_loc,
-                                                   "VUID-VkRayTracingPipelineCreateInfoKHR-flags-11798");
 
         if (create_info.maxPipelineRayRecursionDepth > phys_dev_ext_props.ray_tracing_props_khr.maxRayRecursionDepth) {
             skip |=

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -329,10 +329,6 @@ class CoreChecks : public vvl::DeviceProxy {
                                            const Location& create_info_loc) const;
 
     bool ValidatePipelineVertexDivisors(const vvl::Pipeline& pipeline, const Location& create_info_loc) const;
-    bool ValidatePipelineCacheControlFlags(VkPipelineCreateFlags2 flags, const Location& flags_loc, const char* vuid) const;
-    bool ValidatePipelineIndirectBindableFlags(VkPipelineCreateFlags2 flags, const Location& flags_loc, const char* vuid) const;
-    bool ValidatePipelineProtectedAccessFlags(VkPipelineCreateFlags2 flags, const Location& flags_loc) const;
-    bool ValidatePipeline64BitIndexingFlags(VkPipelineCreateFlags2 flags, const Location& flags_loc, const char* vuid) const;
     void EnqueueValidateImageBarrierAttachment(const Location& loc, core::CommandBufferSubState& cb_sub_state,
                                                const ImageBarrier& barrier);
     void EnqueueValidateDynamicRenderingImageBarrierLayouts(const Location barrier_loc, vvl::CommandBuffer& cb_state,
@@ -1040,7 +1036,6 @@ class CoreChecks : public vvl::DeviceProxy {
 
     bool ValidateDataGraphPipelineCreateInfo(VkDevice device, const VkDataGraphPipelineCreateInfoARM& create_info,
                                              const Location& create_info_loc, const vvl::Pipeline& pipeline) const;
-    bool ValidateDataGraphPipelineCreateInfoFlags(VkPipelineCreateFlags2 flags, Location flags_loc) const;
     bool ValidateDataGraphPipelineShaderModuleCreateInfo(VkDevice device,
                                                          const VkDataGraphPipelineShaderModuleCreateInfoARM& dg_shader_ci,
                                                          const Location& dg_shader_ci_loc, const vvl::Pipeline& pipeline) const;

--- a/layers/stateless/sl_data_graph.cpp
+++ b/layers/stateless/sl_data_graph.cpp
@@ -1,0 +1,94 @@
+/* Copyright (c) 2025 The Khronos Group Inc.
+ * Copyright (c) 2025 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <vulkan/utility/vk_format_utils.h>
+#include "error_message/error_location.h"
+#include "stateless/stateless_validation.h"
+#include "stateless/sl_vuid_maps.h"
+
+namespace stateless {
+
+bool Device::ValidateCreateDataGraphPipelinesFlags(const VkPipelineCreateFlags2 flags, const Location &flags_loc) const {
+    bool skip = false;
+
+    constexpr VkPipelineCreateFlags2 valid_flag_mask =
+        VK_PIPELINE_CREATE_2_NO_PROTECTED_ACCESS_BIT | VK_PIPELINE_CREATE_2_PROTECTED_ACCESS_ONLY_BIT |
+        VK_PIPELINE_CREATE_2_DISABLE_OPTIMIZATION_BIT | VK_PIPELINE_CREATE_2_DESCRIPTOR_BUFFER_BIT_EXT |
+        VK_PIPELINE_CREATE_2_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT | VK_PIPELINE_CREATE_2_EARLY_RETURN_ON_FAILURE_BIT;
+
+    if ((flags & ~(valid_flag_mask)) != 0) {
+        // TODO - print the flags that violated the list
+        skip |= LogError("VUID-VkDataGraphPipelineCreateInfoARM-flags-09764", device, flags_loc, "(%s) contains invalid values.",
+                         string_VkPipelineCreateFlags2(flags).c_str());
+    }
+
+    if ((flags & VK_PIPELINE_CREATE_2_DESCRIPTOR_BUFFER_BIT_EXT) != 0) {
+        if (!enabled_features.dataGraphDescriptorBuffer) {
+            skip |= LogError("VUID-VkDataGraphPipelineCreateInfoARM-dataGraphDescriptorBuffer-09885", device, flags_loc,
+                             "(%s) includes VK_PIPELINE_CREATE_2_DESCRIPTOR_BUFFER_BIT_EXT but the dataGraphDescriptorBuffer "
+                             "feature is not enabled.",
+                             string_VkPipelineCreateFlags2(flags).c_str());
+        }
+    }
+
+    if ((flags & (VK_PIPELINE_CREATE_2_NO_PROTECTED_ACCESS_BIT | VK_PIPELINE_CREATE_2_PROTECTED_ACCESS_ONLY_BIT)) != 0) {
+        if (!enabled_features.pipelineProtectedAccess) {
+            skip |= LogError("VUID-VkDataGraphPipelineCreateInfoARM-pipelineProtectedAccess-09772", device, flags_loc,
+                             "is %s, but pipelineProtectedAccess feature was not enabled.",
+                             string_VkPipelineCreateFlags2(flags).c_str());
+        }
+        if ((flags & VK_PIPELINE_CREATE_2_NO_PROTECTED_ACCESS_BIT) && (flags & VK_PIPELINE_CREATE_2_PROTECTED_ACCESS_ONLY_BIT)) {
+            skip |= LogError("VUID-VkDataGraphPipelineCreateInfoARM-flags-09773", device, flags_loc,
+                             "is %s (contains both NO_PROTECTED_ACCESS_BIT and PROTECTED_ACCESS_ONLY_BIT).",
+                             string_VkPipelineCreateFlags2(flags).c_str());
+        }
+    }
+
+    return skip;
+}
+
+bool Device::manual_PreCallValidateCreateDataGraphPipelinesARM(VkDevice device, VkDeferredOperationKHR deferredOperation,
+                                                               VkPipelineCache pipelineCache, uint32_t createInfoCount,
+                                                               const VkDataGraphPipelineCreateInfoARM *pCreateInfos,
+                                                               const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
+                                                               const Context &context) const {
+    bool skip = false;
+    const auto &error_obj = context.error_obj;
+
+    if (!enabled_features.dataGraph) {
+        skip |= LogError("VUID-vkCreateDataGraphPipelinesARM-dataGraph-09760", device, error_obj.location,
+                         "dataGraph feature is not enabled");
+    }
+    if (deferredOperation != VK_NULL_HANDLE) {
+        skip |= LogError("VUID-vkCreateDataGraphPipelinesARM-deferredOperation-09761", deferredOperation,
+                         error_obj.location.dot(Field::deferredOperation), "must be VK_NULL_HANDLE");
+    }
+
+    for (uint32_t i = 0; i < createInfoCount; i++) {
+        const Location create_info_loc = error_obj.location.dot(Field::pCreateInfos, i);
+        const VkDataGraphPipelineCreateInfoARM &create_info = pCreateInfos[i];
+
+        skip |= ValidateCreatePipelinesFlagsCommon(create_info.flags, create_info_loc.dot(Field::flags));
+
+        // TODO - Enable and test
+        // skip |= ValidatePipelineShaderStageCreateInfoCommon(context, create_info.stage, create_info_loc.dot(Field::stage));
+        // skip |= ValidatePipelineBinaryInfo(create_info.pNext, create_info.flags, pipelineCache, create_info_loc);
+    }
+
+    return skip;
+}
+
+}  // namespace stateless

--- a/layers/stateless/sl_ray_tracing.cpp
+++ b/layers/stateless/sl_ray_tracing.cpp
@@ -406,7 +406,7 @@ bool Device::manual_PreCallValidateCreateRayTracingPipelinesNV(VkDevice device, 
         } else {
             skip |= ValidateCreatePipelinesFlags2(create_info.flags, flags, flags_loc);
         }
-        skip |= ValidateCreateRayTracingPipelinesFlagsNV(flags, flags_loc);
+        skip |= ValidateCreatePipelinesFlagsCommon(flags, flags_loc);
 
         if (!enabled_features.pipelineCreationCacheControl) {
             if (flags &
@@ -518,7 +518,7 @@ bool Device::manual_PreCallValidateCreateRayTracingPipelinesKHR(VkDevice device,
         } else {
             skip |= ValidateCreatePipelinesFlags2(create_info.flags, flags, flags_loc);
         }
-        skip |= ValidateCreateRayTracingPipelinesFlagsKHR(flags, flags_loc);
+        skip |= ValidateCreatePipelinesFlagsCommon(flags, flags_loc);
 
         for (uint32_t stage_index = 0; stage_index < create_info.stageCount; ++stage_index) {
             const Location stage_loc = create_info_loc.dot(Field::pStages, stage_index);

--- a/layers/stateless/sl_vuid_maps.cpp
+++ b/layers/stateless/sl_vuid_maps.cpp
@@ -1,5 +1,5 @@
-/* Copyright (c) 2024 The Khronos Group Inc.
- * Copyright (c) 2024 LunarG, Inc.
+/* Copyright (c) 2024-2025 The Khronos Group Inc.
+ * Copyright (c) 2024-2025 LunarG, Inc.
  * Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -72,5 +72,29 @@ const std::string &GetPipelineBinaryInfoVUID(const Location &loc, PipelineBinary
     }
     return result;
 }
+
+// clang-format off
+const char *GetPipelineCreateFlagVUID(const Location &loc, PipelineCreateFlagError error) {
+    switch (error) {
+        case PipelineCreateFlagError::CacheControl_02878:
+            return
+                loc.function == Func::vkCreateGraphicsPipelines       ? "VUID-VkGraphicsPipelineCreateInfo-pipelineCreationCacheControl-02878" :
+                loc.function == Func::vkCreateComputePipelines        ? "VUID-VkComputePipelineCreateInfo-pipelineCreationCacheControl-02875" :
+                loc.function == Func::vkCreateRayTracingPipelinesKHR  ? "VUID-VkRayTracingPipelineCreateInfoKHR-pipelineCreationCacheControl-02905" :
+                loc.function == Func::vkCreateRayTracingPipelinesNV   ? "VUID-VkRayTracingPipelineCreateInfoNV-pipelineCreationCacheControl-02905" :
+                loc.function == Func::vkCreateDataGraphPipelinesARM   ? "VUID-VkDataGraphPipelineCreateInfoARM-pipelineCreationCacheControl-09871" :
+                kVUIDUndefined;
+        case PipelineCreateFlagError::Shader64BitIndexing_11798:
+            return
+                loc.function == Func::vkCreateGraphicsPipelines       ? "VUID-VkGraphicsPipelineCreateInfo-flags-11798" :
+                loc.function == Func::vkCreateComputePipelines        ? "VUID-VkComputePipelineCreateInfo-flags-11798" :
+                loc.function == Func::vkCreateRayTracingPipelinesKHR  ? "VUID-VkRayTracingPipelineCreateInfoKHR-flags-11798" :
+                loc.function == Func::vkCreateRayTracingPipelinesNV   ? "VUID-VkRayTracingPipelineCreateInfoNV-flags-11798" :
+                // TOOD - Missing vkCreateDataGraphPipelinesARM
+                kVUIDUndefined;
+    }
+    return "UNASSIGNED-CoreChecks-unhandled-pipeline-create-flage";
+}
+// clang-format on
 
 }  // namespace vvl

--- a/layers/stateless/sl_vuid_maps.h
+++ b/layers/stateless/sl_vuid_maps.h
@@ -1,5 +1,5 @@
-/* Copyright (c) 2024 The Khronos Group Inc.
- * Copyright (c) 2024 LunarG, Inc.
+/* Copyright (c) 2024-2025 The Khronos Group Inc.
+ * Copyright (c) 2024-2025 LunarG, Inc.
  * Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,5 +30,11 @@ enum class PipelineBinaryInfoError {
 };
 
 const std::string &GetPipelineBinaryInfoVUID(const Location &loc, PipelineBinaryInfoError error);
+
+enum class PipelineCreateFlagError {
+    CacheControl_02878,
+    Shader64BitIndexing_11798,
+};
+const char *GetPipelineCreateFlagVUID(const Location &loc, PipelineCreateFlagError error);
 
 }  // namespace vvl

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -572,6 +572,7 @@ class Device : public vvl::base::Device {
     bool ValidatePipelineRenderingCreateInfo(const Context &context, const VkPipelineRenderingCreateInfo &rendering_struct,
                                              const Location &loc) const;
     bool ValidateCreateGraphicsPipelinesFlags(const VkPipelineCreateFlags2 flags, const Location &flags_loc) const;
+    bool ValidateCreatePipelinesFlagsCommon(const VkPipelineCreateFlags2 flags, const Location &flags_loc) const;
     bool manual_PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount,
                                                        const VkGraphicsPipelineCreateInfo *pCreateInfos,
                                                        const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
@@ -583,6 +584,13 @@ class Device : public vvl::base::Device {
                                                       const VkComputePipelineCreateInfo *pCreateInfos,
                                                       const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
                                                       const Context &context) const;
+
+    bool ValidateCreateDataGraphPipelinesFlags(const VkPipelineCreateFlags2 flags, const Location &flags_loc) const;
+    bool manual_PreCallValidateCreateDataGraphPipelinesARM(VkDevice device, VkDeferredOperationKHR deferredOperation,
+                                                           VkPipelineCache pipelineCache, uint32_t createInfoCount,
+                                                           const VkDataGraphPipelineCreateInfoARM *pCreateInfos,
+                                                           const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
+                                                           const Context &context) const;
 
     bool ValidateSamplerFilterMinMax(const VkSamplerCreateInfo &create_info, const Location &create_info_loc) const;
     bool ValidateSamplerCustomBorderColor(const VkSamplerCreateInfo &create_info, const Location &create_info_loc) const;

--- a/layers/vulkan/generated/stateless_validation_helper.cpp
+++ b/layers/vulkan/generated/stateless_validation_helper.cpp
@@ -25981,6 +25981,9 @@ bool Device::PreCallValidateCreateDataGraphPipelinesARM(VkDevice device, VkDefer
     skip |= context.ValidateArray(loc.dot(Field::createInfoCount), loc.dot(Field::pPipelines), createInfoCount, &pPipelines, true,
                                   true, "VUID-vkCreateDataGraphPipelinesARM-createInfoCount-arraylength",
                                   "VUID-vkCreateDataGraphPipelinesARM-pPipelines-parameter");
+    if (!skip)
+        skip |= manual_PreCallValidateCreateDataGraphPipelinesARM(device, deferredOperation, pipelineCache, createInfoCount,
+                                                                  pCreateInfos, pAllocator, pPipelines, context);
     return skip;
 }
 

--- a/scripts/generators/stateless_validation_helper_generator.py
+++ b/scripts/generators/stateless_validation_helper_generator.py
@@ -63,6 +63,7 @@ class StatelessValidationHelperOutputGenerator(BaseGenerator):
             'vkCreateComputePipelines',
             'vkCreateRayTracingPipelinesNV',
             'vkCreateRayTracingPipelinesKHR',
+            'vkCreateDataGraphPipelinesARM',
             'vkCreateSampler',
             'vkCreateDescriptorSetLayout',
             'vkGetDescriptorSetLayoutSupport',

--- a/tests/unit/pipeline.cpp
+++ b/tests/unit/pipeline.cpp
@@ -2469,7 +2469,8 @@ TEST_F(NegativePipeline, CreateFlagsCompute) {
     flags = VK_PIPELINE_CREATE_RAY_TRACING_DISPLACEMENT_MICROMAP_BIT_NV;
     CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkComputePipelineCreateInfo-flags-07996");
     flags = VK_PIPELINE_CREATE_INDIRECT_BINDABLE_BIT_NV;
-    CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkComputePipelineCreateInfo-None-09497");
+    m_errorMonitor->SetDesiredError("VUID-VkComputePipelineCreateInfo-None-09497");
+    CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkComputePipelineCreateInfo-flags-09007");
     flags = 0x80000000;
     CreateComputePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkComputePipelineCreateInfo-None-09497");
 }

--- a/tests/unit/pipeline_binary.cpp
+++ b/tests/unit/pipeline_binary.cpp
@@ -218,6 +218,7 @@ TEST_F(NegativePipelineBinary, ComputePipeline) {
     AddRequiredFeature(vkt::Feature::maintenance5);
     AddRequiredExtensions(VK_KHR_PIPELINE_BINARY_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::pipelineBinaries);
+    AddRequiredFeature(vkt::Feature::pipelineCreationCacheControl);
     RETURN_IF_SKIP(Init());
 
     VkPipelineCache pipeline_cache;
@@ -324,6 +325,7 @@ TEST_F(NegativePipelineBinary, GraphicsPipeline) {
     AddRequiredFeature(vkt::Feature::maintenance5);
     AddRequiredExtensions(VK_KHR_PIPELINE_BINARY_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::pipelineBinaries);
+    AddRequiredFeature(vkt::Feature::pipelineCreationCacheControl);
     RETURN_IF_SKIP(Init());
 
     VkPipelineCache pipeline_cache;


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11015

We had a nice system for flags in stateless, but still had some in core check... now all are in stateless and I feel clean for the 2025 year