### PR TITLE
scripts: Check type for VkDescriptorImageInfo handlewrapping

### DIFF
--- a/layers/state_tracker/descriptor_sets.cpp
+++ b/layers/state_tracker/descriptor_sets.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (C) 2015-2025 Google Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (C) 2015-2026 Google Inc.
  * Copyright (c) 2025 Arm Limited.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1286,7 +1286,7 @@ void vvl::MutableDescriptor::WriteUpdate(DescriptorSet &set_state, const vvl::De
             break;
         case DescriptorClass::ImageSampler: {
             if (update.pImageInfo) {
-                const auto &image_info = update.pImageInfo[index];
+                const VkDescriptorImageInfo &image_info = update.pImageInfo[index];
                 if (!immutable_) {
                     ReplaceStatePtr(set_state, sampler_state_, dev_data.GetConstCastShared<vvl::Sampler>(image_info.sampler),
                                     is_bindless);
@@ -1299,7 +1299,8 @@ void vvl::MutableDescriptor::WriteUpdate(DescriptorSet &set_state, const vvl::De
         }
         case DescriptorClass::Image: {
             if (update.pImageInfo) {
-                const auto &image_info = update.pImageInfo[index];
+                // The VkSampler is ignored and may be garbage
+                const VkDescriptorImageInfo &image_info = update.pImageInfo[index];
                 image_layout_ = image_info.imageLayout;
                 ReplaceStatePtr(set_state, image_view_state_, dev_data.GetConstCastShared<vvl::ImageView>(image_info.imageView),
                                 is_bindless);
@@ -1308,7 +1309,7 @@ void vvl::MutableDescriptor::WriteUpdate(DescriptorSet &set_state, const vvl::De
         }
         case DescriptorClass::GeneralBuffer: {
             if (update.pBufferInfo) {
-                const auto &buffer_info = update.pBufferInfo[index];
+                const VkDescriptorBufferInfo &buffer_info = update.pBufferInfo[index];
                 offset_ = buffer_info.offset;
                 range_ = buffer_info.range;
                 // can be null if using nullDescriptors

--- a/layers/stateless/sl_descriptor.cpp
+++ b/layers/stateless/sl_descriptor.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (C) 2015-2025 Google Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (C) 2015-2026 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -762,9 +762,9 @@ bool Device::ValidateWriteDescriptorSet(const Context &context, const Location &
         }
 
         const VkDescriptorType descriptor_type = descriptor_writes.descriptorType;
-        if ((descriptor_type == VK_DESCRIPTOR_TYPE_SAMPLER) || (descriptor_type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER) ||
-            (descriptor_type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE) || (descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_IMAGE) ||
-            (descriptor_type == VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT)) {
+        if (IsValueIn(descriptor_type,
+                      {VK_DESCRIPTOR_TYPE_SAMPLER, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
+                       VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT})) {
             if (descriptor_writes.pImageInfo != nullptr &&  descriptor_type != VK_DESCRIPTOR_TYPE_SAMPLER) {
                 for (uint32_t descriptor_index = 0; descriptor_index < descriptor_writes.descriptorCount; ++descriptor_index) {
                     skip |= context.ValidateRangedEnum(writes_loc.dot(Field::pImageInfo, descriptor_index).dot(Field::imageLayout),

--- a/layers/vulkan/generated/dispatch_functions.h
+++ b/layers/vulkan/generated/dispatch_functions.h
@@ -3,9 +3,9 @@
 
 /***************************************************************************
  *
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/layers/vulkan/generated/dispatch_object.cpp
+++ b/layers/vulkan/generated/dispatch_object.cpp
@@ -3,9 +3,9 @@
 
 /***************************************************************************
  *
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1593,12 +1593,18 @@ void Device::UpdateDescriptorSets(VkDevice device, uint32_t descriptorWriteCount
                     local_pDescriptorWrites[index0].dstSet = Unwrap(pDescriptorWrites[index0].dstSet);
                 }
                 if (local_pDescriptorWrites[index0].pImageInfo) {
+                    // need for when updating VkDescriptorImageInfo
+                    bool has_sampler =
+                        local_pDescriptorWrites[index0].descriptorType == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER ||
+                        local_pDescriptorWrites[index0].descriptorType == VK_DESCRIPTOR_TYPE_SAMPLER;
+                    bool has_image_view = local_pDescriptorWrites[index0].descriptorType != VK_DESCRIPTOR_TYPE_SAMPLER;
+
                     for (uint32_t index1 = 0; index1 < local_pDescriptorWrites[index0].descriptorCount; ++index1) {
-                        if (pDescriptorWrites[index0].pImageInfo[index1].sampler) {
+                        if (pDescriptorWrites[index0].pImageInfo[index1].sampler && has_sampler) {
                             local_pDescriptorWrites[index0].pImageInfo[index1].sampler =
                                 Unwrap(pDescriptorWrites[index0].pImageInfo[index1].sampler);
                         }
-                        if (pDescriptorWrites[index0].pImageInfo[index1].imageView) {
+                        if (pDescriptorWrites[index0].pImageInfo[index1].imageView && has_image_view) {
                             local_pDescriptorWrites[index0].pImageInfo[index1].imageView =
                                 Unwrap(pDescriptorWrites[index0].pImageInfo[index1].imageView);
                         }
@@ -2931,12 +2937,18 @@ void Device::CmdPushDescriptorSet(VkCommandBuffer commandBuffer, VkPipelineBindP
                     local_pDescriptorWrites[index0].dstSet = Unwrap(pDescriptorWrites[index0].dstSet);
                 }
                 if (local_pDescriptorWrites[index0].pImageInfo) {
+                    // need for when updating VkDescriptorImageInfo
+                    bool has_sampler =
+                        local_pDescriptorWrites[index0].descriptorType == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER ||
+                        local_pDescriptorWrites[index0].descriptorType == VK_DESCRIPTOR_TYPE_SAMPLER;
+                    bool has_image_view = local_pDescriptorWrites[index0].descriptorType != VK_DESCRIPTOR_TYPE_SAMPLER;
+
                     for (uint32_t index1 = 0; index1 < local_pDescriptorWrites[index0].descriptorCount; ++index1) {
-                        if (pDescriptorWrites[index0].pImageInfo[index1].sampler) {
+                        if (pDescriptorWrites[index0].pImageInfo[index1].sampler && has_sampler) {
                             local_pDescriptorWrites[index0].pImageInfo[index1].sampler =
                                 Unwrap(pDescriptorWrites[index0].pImageInfo[index1].sampler);
                         }
-                        if (pDescriptorWrites[index0].pImageInfo[index1].imageView) {
+                        if (pDescriptorWrites[index0].pImageInfo[index1].imageView && has_image_view) {
                             local_pDescriptorWrites[index0].pImageInfo[index1].imageView =
                                 Unwrap(pDescriptorWrites[index0].pImageInfo[index1].imageView);
                         }
@@ -3026,13 +3038,21 @@ void Device::CmdPushDescriptorSet2(VkCommandBuffer commandBuffer, const VkPushDe
                             Unwrap(pPushDescriptorSetInfo->pDescriptorWrites[index1].dstSet);
                     }
                     if (local_pPushDescriptorSetInfo->pDescriptorWrites[index1].pImageInfo) {
+                        // need for when updating VkDescriptorImageInfo
+                        bool has_sampler =
+                            local_pPushDescriptorSetInfo->pDescriptorWrites[index1].descriptorType ==
+                                VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER ||
+                            local_pPushDescriptorSetInfo->pDescriptorWrites[index1].descriptorType == VK_DESCRIPTOR_TYPE_SAMPLER;
+                        bool has_image_view =
+                            local_pPushDescriptorSetInfo->pDescriptorWrites[index1].descriptorType != VK_DESCRIPTOR_TYPE_SAMPLER;
+
                         for (uint32_t index2 = 0; index2 < local_pPushDescriptorSetInfo->pDescriptorWrites[index1].descriptorCount;
                              ++index2) {
-                            if (pPushDescriptorSetInfo->pDescriptorWrites[index1].pImageInfo[index2].sampler) {
+                            if (pPushDescriptorSetInfo->pDescriptorWrites[index1].pImageInfo[index2].sampler && has_sampler) {
                                 local_pPushDescriptorSetInfo->pDescriptorWrites[index1].pImageInfo[index2].sampler =
                                     Unwrap(pPushDescriptorSetInfo->pDescriptorWrites[index1].pImageInfo[index2].sampler);
                             }
-                            if (pPushDescriptorSetInfo->pDescriptorWrites[index1].pImageInfo[index2].imageView) {
+                            if (pPushDescriptorSetInfo->pDescriptorWrites[index1].pImageInfo[index2].imageView && has_image_view) {
                                 local_pPushDescriptorSetInfo->pDescriptorWrites[index1].pImageInfo[index2].imageView =
                                     Unwrap(pPushDescriptorSetInfo->pDescriptorWrites[index1].pImageInfo[index2].imageView);
                             }
@@ -3889,12 +3909,18 @@ void Device::CmdPushDescriptorSetKHR(VkCommandBuffer commandBuffer, VkPipelineBi
                     local_pDescriptorWrites[index0].dstSet = Unwrap(pDescriptorWrites[index0].dstSet);
                 }
                 if (local_pDescriptorWrites[index0].pImageInfo) {
+                    // need for when updating VkDescriptorImageInfo
+                    bool has_sampler =
+                        local_pDescriptorWrites[index0].descriptorType == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER ||
+                        local_pDescriptorWrites[index0].descriptorType == VK_DESCRIPTOR_TYPE_SAMPLER;
+                    bool has_image_view = local_pDescriptorWrites[index0].descriptorType != VK_DESCRIPTOR_TYPE_SAMPLER;
+
                     for (uint32_t index1 = 0; index1 < local_pDescriptorWrites[index0].descriptorCount; ++index1) {
-                        if (pDescriptorWrites[index0].pImageInfo[index1].sampler) {
+                        if (pDescriptorWrites[index0].pImageInfo[index1].sampler && has_sampler) {
                             local_pDescriptorWrites[index0].pImageInfo[index1].sampler =
                                 Unwrap(pDescriptorWrites[index0].pImageInfo[index1].sampler);
                         }
-                        if (pDescriptorWrites[index0].pImageInfo[index1].imageView) {
+                        if (pDescriptorWrites[index0].pImageInfo[index1].imageView && has_image_view) {
                             local_pDescriptorWrites[index0].pImageInfo[index1].imageView =
                                 Unwrap(pDescriptorWrites[index0].pImageInfo[index1].imageView);
                         }
@@ -5126,13 +5152,21 @@ void Device::CmdPushDescriptorSet2KHR(VkCommandBuffer commandBuffer, const VkPus
                             Unwrap(pPushDescriptorSetInfo->pDescriptorWrites[index1].dstSet);
                     }
                     if (local_pPushDescriptorSetInfo->pDescriptorWrites[index1].pImageInfo) {
+                        // need for when updating VkDescriptorImageInfo
+                        bool has_sampler =
+                            local_pPushDescriptorSetInfo->pDescriptorWrites[index1].descriptorType ==
+                                VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER ||
+                            local_pPushDescriptorSetInfo->pDescriptorWrites[index1].descriptorType == VK_DESCRIPTOR_TYPE_SAMPLER;
+                        bool has_image_view =
+                            local_pPushDescriptorSetInfo->pDescriptorWrites[index1].descriptorType != VK_DESCRIPTOR_TYPE_SAMPLER;
+
                         for (uint32_t index2 = 0; index2 < local_pPushDescriptorSetInfo->pDescriptorWrites[index1].descriptorCount;
                              ++index2) {
-                            if (pPushDescriptorSetInfo->pDescriptorWrites[index1].pImageInfo[index2].sampler) {
+                            if (pPushDescriptorSetInfo->pDescriptorWrites[index1].pImageInfo[index2].sampler && has_sampler) {
                                 local_pPushDescriptorSetInfo->pDescriptorWrites[index1].pImageInfo[index2].sampler =
                                     Unwrap(pPushDescriptorSetInfo->pDescriptorWrites[index1].pImageInfo[index2].sampler);
                             }
-                            if (pPushDescriptorSetInfo->pDescriptorWrites[index1].pImageInfo[index2].imageView) {
+                            if (pPushDescriptorSetInfo->pDescriptorWrites[index1].pImageInfo[index2].imageView && has_image_view) {
                                 local_pPushDescriptorSetInfo->pDescriptorWrites[index1].pImageInfo[index2].imageView =
                                     Unwrap(pPushDescriptorSetInfo->pDescriptorWrites[index1].pImageInfo[index2].imageView);
                             }

--- a/layers/vulkan/generated/dispatch_object_device_methods.h
+++ b/layers/vulkan/generated/dispatch_object_device_methods.h
@@ -3,9 +3,9 @@
 
 /***************************************************************************
  *
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/layers/vulkan/generated/dispatch_object_instance_methods.h
+++ b/layers/vulkan/generated/dispatch_object_instance_methods.h
@@ -3,9 +3,9 @@
 
 /***************************************************************************
  *
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/unit/descriptors_positive.cpp
+++ b/tests/unit/descriptors_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -2414,4 +2414,20 @@ TEST_F(PositiveDescriptors, WriteDescriptorTensorAliasingLayout) {
     descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
     descriptor_write.pImageInfo = &image_info;
     vk::UpdateDescriptorSets(device(), 1, &descriptor_write, 0, nullptr);
+}
+
+TEST_F(PositiveDescriptors, InputAttachmentDescriptorUpdateGarbageSampler) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11356");
+    RETURN_IF_SKIP(Init());
+    OneOffDescriptorSet descriptor_set(m_device,
+                                       {
+                                           {0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
+                                       });
+
+    VkSampler sampler = CastToHandle<VkSampler, uintptr_t>(0xbaadbeef);  // Sampler with invalid handle
+    vkt::Image image(*m_device, 32, 32, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
+    vkt::ImageView image_view = image.CreateView();
+
+    descriptor_set.WriteDescriptorImageInfo(0, image_view, sampler, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, VK_IMAGE_LAYOUT_GENERAL);
+    descriptor_set.UpdateDescriptorSets();
 }


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11356

Adds check for `VkDescriptorImageInfo` before handle wrapping if we can