### PR TITLE
layers: Add layers and tests for VU 09935

### DIFF
--- a/layers/drawdispatch/drawdispatch_vuids.cpp
+++ b/layers/drawdispatch/drawdispatch_vuids.cpp
@@ -4681,6 +4681,7 @@ struct DispatchVuidsCmdDispatchDataGraphARM : DrawDispatchVuid {
         compatible_pipeline_08600                = "VUID-vkCmdDispatchDataGraphARM-None-09797";
         unprotected_command_buffer_02707         = "VUID-vkCmdDispatchDataGraphARM-commandBuffer-09800";
         protected_command_buffer_02712           = "VUID-vkCmdDispatchDataGraphARM-commandBuffer-09801";
+        descriptor_buffer_bit_set_08114          = "VUID-vkCmdDispatchDataGraphARM-None-09935";
     }
 };
 

--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -534,13 +534,12 @@ class TensorDescriptor : public Descriptor {
     uint32_t GetTensorViewCount() const { return tensor_view_count_; }
     const VkTensorViewARM *GetTensorViews() const { return tensor_views_; }
     const vvl::TensorView *GetTensorViewState() const { return tensor_view_state_.get(); }
-    const vvl::Tensor *GetTensorState() const { return tensor_state_.get(); }
+    const vvl::Tensor *GetTensorState() const;
 
   private:
     uint32_t tensor_view_count_{0};
     const VkTensorViewARM *tensor_views_{VK_NULL_HANDLE};
-    std::shared_ptr<vvl::Tensor> tensor_state_;
-    std::shared_ptr<vvl::TensorView> tensor_view_state_;
+    std::shared_ptr<vvl::TensorView> tensor_view_state_{nullptr};
 };
 
 class ImageSamplerDescriptor : public ImageDescriptor {
@@ -673,8 +672,8 @@ class MutableDescriptor : public Descriptor {
     VkDeviceSize GetOffset() const { return offset_; }
     VkDeviceSize GetRange() const { return range_; }
     VkDeviceSize GetEffectiveRange() const;
+    std::shared_ptr<vvl::Tensor> GetSharedTensor() const;
     std::shared_ptr<vvl::BufferView> GetSharedBufferViewState() const { return buffer_view_state_; }
-    std::shared_ptr<vvl::Tensor> GetSharedTensor() const { return tensor_state_; }
     std::shared_ptr<vvl::TensorView> GetSharedTensorView() const { return tensor_view_state_; }
     VkAccelerationStructureKHR GetAccelerationStructureKHR() const { return acc_; }
     const vvl::AccelerationStructureKHR *GetAccelerationStructureStateKHR() const { return acc_state_.get(); }
@@ -729,7 +728,6 @@ class MutableDescriptor : public Descriptor {
     uint32_t tensor_view_count_{0};
     const VkTensorViewARM *tensor_views_{VK_NULL_HANDLE};
     std::shared_ptr<vvl::TensorView> tensor_view_state_;
-    std::shared_ptr<vvl::Tensor> tensor_state_;
 };
 
 // We will want to build this map and list of layouts once in order to record in the state tracker at PostCallRecord time.

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -504,6 +504,11 @@ void DeviceState::PostCallRecordCreateTensorARM(VkDevice device, const VkTensorC
     Add(std::move(tensor_state));
 }
 
+void DeviceState::PreCallRecordDestroyTensorARM(VkDevice device, VkTensorARM tensor, const VkAllocationCallbacks *pAllocator,
+                                                const RecordObject &record_obj) {
+    Destroy<Tensor>(tensor);
+}
+
 void DeviceState::PostCallRecordBindTensorMemoryARM(VkDevice device, uint32_t bindInfoCount,
                                                     const VkBindTensorMemoryInfoARM *pBindInfos, const RecordObject &record_obj) {
     if (VK_SUCCESS != record_obj.result) return;
@@ -688,6 +693,11 @@ void DeviceState::PostCallRecordCreateTensorViewARM(VkDevice device, const VkTen
     auto tensor_state = Get<vvl::Tensor>(pCreateInfo->tensor);
     ASSERT_AND_RETURN(tensor_state);
     Add(CreateTensorViewState(tensor_state, *pView, pCreateInfo));
+}
+
+void DeviceState::PreCallRecordDestroyTensorViewARM(VkDevice device, VkTensorViewARM tensorView,
+                                                    const VkAllocationCallbacks *pAllocator, const RecordObject &record_obj) {
+    Destroy<TensorView>(tensorView);
 }
 
 void DeviceState::PostCallRecordCmdCopyBuffer2KHR(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2KHR *pCopyBufferInfo,

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -883,6 +883,8 @@ class DeviceState : public vvl::base::Device {
     void PostCallRecordCreateTensorARM(VkDevice device, const VkTensorCreateInfoARM* pCreateInfo,
                                        const VkAllocationCallbacks* pAllocator, VkTensorARM* pTensor,
                                        const RecordObject& record_obj) override;
+    void PreCallRecordDestroyTensorARM(VkDevice device, VkTensorARM tensor, const VkAllocationCallbacks* pAllocator,
+                                       const RecordObject& record_obj) override;
     void PostCallRecordBindTensorMemoryARM(VkDevice device, uint32_t bindInfoCount, const VkBindTensorMemoryInfoARM* pBindInfos,
                                            const RecordObject& record_obj) override;
     virtual std::shared_ptr<vvl::TensorView> CreateTensorViewState(const std::shared_ptr<vvl::Tensor>& tensor,
@@ -890,6 +892,8 @@ class DeviceState : public vvl::base::Device {
                                                                    const VkTensorViewCreateInfoARM* pCreateInfo);
     void PostCallRecordCreateTensorViewARM(VkDevice device, const VkTensorViewCreateInfoARM* pCreateInfo,
                                            const VkAllocationCallbacks* pAllocator, VkTensorViewARM* pView,
+                                           const RecordObject& record_obj) override;
+    void PreCallRecordDestroyTensorViewARM(VkDevice device, VkTensorViewARM tensorView, const VkAllocationCallbacks* pAllocator,
                                            const RecordObject& record_obj) override;
     virtual std::shared_ptr<vvl::Buffer> CreateBufferState(VkBuffer handle, const VkBufferCreateInfo* create_info);
     void PostCallRecordCreateBuffer(VkDevice device, const VkBufferCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,

--- a/layers/utils/action_command_utils.h
+++ b/layers/utils/action_command_utils.h
@@ -64,7 +64,8 @@ static inline bool IsCommandDispatch(Func command) {
         command == Func::vkCmdDispatchGraphAMDX ||
         command == Func::vkCmdDispatchGraphIndirectAMDX ||
         command == Func::vkCmdDispatchGraphIndirectCountAMDX ||
-        command == Func::vkCmdDispatchTileQCOM;
+        command == Func::vkCmdDispatchTileQCOM ||
+        command == Func::vkCmdDispatchDataGraphARM;
 }
 
 static inline bool IsCommandTraceRays(Func command) {

--- a/tests/framework/data_graph_objects.h
+++ b/tests/framework/data_graph_objects.h
@@ -116,7 +116,8 @@ class DataGraphPipelineHelper {
 
   private:
     void CreateShaderModule(const char *spirv_source, const char *entrypoint = "main");
-    void InitTensor(vkt::Tensor &tensor, vkt::TensorView &tensor_view, const std::vector<int64_t> &tensor_dims, bool is_protected);
+    void InitTensor(vkt::Tensor &tensor, vkt::TensorView &tensor_view, const VkTensorDescriptionARM &tensor_desc,
+                    bool is_protected);
 
     VkPipeline pipeline_ = VK_NULL_HANDLE;
     HelperParameters params_ = HelperParameters();


### PR DESCRIPTION
Also:
- removed Mutable::tensor_state_, use tensor_view_state_.tensor_state instead. Duplicate/redundant definition, wasn't updated correctly.
- fixed sync issues between vvl::Tensor(View) and vkt::Tensor(View)
- TensorView correctly intialized for GetSpirvTensorArrayDataGraph
- various comments and descriptions