### PR TITLE
layers: Clarify supported accesses for ALL_COMMANDS stage

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -378,7 +378,7 @@ class CoreChecks : public vvl::DeviceProxy {
                                                             const VkImageMemoryBarrier& image_barrier,
                                                             const Location& image_loc) const;
     bool ValidateAccessMask(const LogObjectList& objlist, const Location& access_mask_loc, const Location& stage_mask_loc,
-                            VkQueueFlags queue_flags, VkAccessFlags2KHR access_mask, VkPipelineStageFlags2KHR stage_mask) const;
+                            VkQueueFlags queue_flags, VkAccessFlags2 access_mask, VkPipelineStageFlags2 stage_mask) const;
     bool ValidateMemoryBarrier(const LogObjectList& objlist, const Location& barrier_loc, const vvl::CommandBuffer& cb_state,
                                const SyncMemoryBarrier& barrier,
                                OwnershipTransferOp ownership_transfer_op = OwnershipTransferOp::none,

--- a/layers/utils/sync_utils.cpp
+++ b/layers/utils/sync_utils.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2019-2025 The Khronos Group Inc.
- * Copyright (c) 2019-2025 Valve Corporation
- * Copyright (c) 2019-2025 LunarG, Inc.
+/* Copyright (c) 2019-2026 The Khronos Group Inc.
+ * Copyright (c) 2019-2026 Valve Corporation
+ * Copyright (c) 2019-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -107,15 +107,10 @@ VkAccessFlags2 DisabledAccesses(const DeviceExtensions &device_extensions) {
 // print the old strings. There are common code paths where we need
 // to print masks as strings and this makes the output less confusing
 // for people not using synchronization2.
-//
-// TODO 2025: It is also confusing for people using sync2 that some masks
-// printed as STAGE_and some as STAGE_2_ for the same app. The suggestion
-// to rework this so the function itself prefers a single style - sync2, so
-// it covers all cases, but maybe introduce overload or additional parameter
-// so the caller can specify which version to use (if we really need this).
-std::string StringPipelineStageFlags(VkPipelineStageFlags2 mask) {
-    VkPipelineStageFlags sync1_mask = static_cast<VkPipelineStageFlags>(mask & AllVkPipelineStageFlagBits);
-    if (sync1_mask) {
+std::string StringPipelineStageFlags(VkPipelineStageFlags2 mask, bool sync1) {
+    if (sync1) {
+        VkPipelineStageFlags sync1_mask = static_cast<VkPipelineStageFlags>(mask & AllVkPipelineStageFlagBits);
+        assert(sync1_mask == mask);
         return string_VkPipelineStageFlags(sync1_mask);
     }
     return string_VkPipelineStageFlags2(mask);
@@ -181,9 +176,10 @@ VkAccessFlags2 CompatibleAccessMask(VkPipelineStageFlags2 stage_mask) {
     return result;
 }
 
-std::string StringAccessFlags(VkAccessFlags2 mask) {
-    VkAccessFlags sync1_mask = static_cast<VkAccessFlags>(mask & AllVkAccessFlagBits);
-    if (sync1_mask) {
+std::string StringAccessFlags(VkAccessFlags2 mask, bool sync1) {
+    if (sync1) {
+        VkAccessFlags sync1_mask = static_cast<VkAccessFlags>(mask & AllVkAccessFlagBits);
+        assert(sync1_mask == mask);
         return string_VkAccessFlags(sync1_mask);
     }
     return string_VkAccessFlags2(mask);

--- a/layers/utils/sync_utils.h
+++ b/layers/utils/sync_utils.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2019-2025 The Khronos Group Inc.
- * Copyright (c) 2019-2025 Valve Corporation
- * Copyright (c) 2019-2025 LunarG, Inc.
+/* Copyright (c) 2019-2026 The Khronos Group Inc.
+ * Copyright (c) 2019-2026 Valve Corporation
+ * Copyright (c) 2019-2026 LunarG, Inc.
  * Copyright (C) 2025 Arm Limited.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -271,7 +271,7 @@ namespace sync_utils {
 VkPipelineStageFlags2 DisabledPipelineStages(const DeviceFeatures& features, const DeviceExtensions& device_extensions);
 VkAccessFlags2 DisabledAccesses(const DeviceExtensions& device_extensions);
 
-std::string StringPipelineStageFlags(VkPipelineStageFlags2 mask);
+std::string StringPipelineStageFlags(VkPipelineStageFlags2 mask, bool sync1 = false);
 
 // Expand all pipeline stage bits. If queue_flags and disabled_feature_mask is provided, the expansion of ALL_COMMANDS_BIT
 // and ALL_GRAPHICS_BIT will be limited to what is supported.
@@ -280,7 +280,7 @@ VkPipelineStageFlags2 ExpandPipelineStages(VkPipelineStageFlags2 stage_mask, VkQ
 
 VkAccessFlags2 CompatibleAccessMask(VkPipelineStageFlags2 stage_mask);
 
-std::string StringAccessFlags(VkAccessFlags2 mask);
+std::string StringAccessFlags(VkAccessFlags2 mask, bool sync1 = false);
 
 ExecScopes GetExecScopes(const VkDependencyInfo& dep_info);
 }  // namespace sync_utils


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11358

> vkCmdPipelineBarrier2(): pDependencyInfo->pImageMemoryBarriers[0].dstAccessMask (VK_ACCESS_2_SHADER_READ_BIT) is not supported by stage mask (VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT). The expansion of VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT for VK_QUEUE_TRANSFER_BIT|VK_QUEUE_SPARSE_BINDING_BIT does not include any stages that support VK_ACCESS_2_SHADER_READ_BIT.

> The expanded stages are: VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT|VK_PIPELINE_STAGE_2_BOTTOM_OF_PIPE_BIT|VK_PIPELINE_STAGE_2_ACCELERATION_STRUCTURE_COPY_BIT_KHR|VK_PIPELINE_STAGE_2_COPY_BIT|VK_PIPELINE_STAGE_2_RESOLVE_BIT|VK_PIPELINE_STAGE_2_BLIT_BIT|VK_PIPELINE_STAGE_2_CLEAR_BIT|VK_PIPELINE_STAGE_2_CONVERT_COOPERATIVE_VECTOR_MATRIX_BIT_NV|VK_PIPELINE_STAGE_2_COPY_INDIRECT_BIT_KHR.
