### PR TITLE
layers: Fix Matrix using wrong Location/Component

### DIFF
--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (C) 2015-2025 Google Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (C) 2015-2026 Google Inc.
  * Modifications Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -914,9 +914,10 @@ bool CoreChecks::ValidateDrawDynamicStateVertex(const LastBound& last_bound_stat
                 const uint32_t var_base_type_id = variable_ptr->base_type.ResultId();
                 const uint32_t attribute_type = spirv::GetFormatType(attrib->desc.format);
                 const uint32_t var_numeric_type = vert_spirv_state->GetNumericType(var_base_type_id);
+                const spirv::Instruction* var_base_type = vert_spirv_state->FindDef(var_base_type_id);
 
                 const bool attribute64 = vkuFormatIs64bit(attrib->desc.format);
-                const bool shader64 = vert_spirv_state->GetBaseTypeInstruction(var_base_type_id)->GetBitWidth() == 64;
+                const bool shader64 = vert_spirv_state->GetBaseTypeInstruction(var_base_type)->GetBitWidth() == 64;
 
                 // first type check before doing 64-bit matching
                 if ((attribute_type & var_numeric_type) == 0) {

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2021-2025 The Khronos Group Inc.
+/* Copyright (c) 2021-2026 The Khronos Group Inc.
  * Copyright (c) 2025 Arm Limited.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -791,8 +791,8 @@ struct Module {
     bool GetBoolIfConstant(const spirv::Instruction &insn, bool *value) const;
     bool GetInt32IfConstant(const spirv::Instruction &insn, uint32_t *value) const;
 
-    uint32_t GetLocationsConsumedByType(uint32_t type) const;
-    uint32_t GetComponentsConsumedByType(uint32_t type) const;
+    uint32_t GetLocationsConsumedByType(const Instruction* insn) const;
+    uint32_t GetComponentsConsumedByType(const Instruction* insn) const;
     NumericType GetNumericType(uint32_t type) const;
 
     bool HasRuntimeArray(uint32_t type_id) const;
@@ -802,7 +802,7 @@ struct Module {
     uint32_t GetTypeBitsSize(const Instruction *insn) const;
     uint32_t GetTypeBytesSize(const Instruction *insn) const;
     uint32_t GetBaseType(const Instruction *insn) const;
-    const Instruction *GetBaseTypeInstruction(uint32_t type) const;
+    const Instruction* GetBaseTypeInstruction(const Instruction* insn) const;
     const Instruction *GetVariablePointerType(const spirv::Instruction &var_insn) const;
     const Instruction *GetVariableDataType(const spirv::Instruction &var_insn) const;
     uint32_t GetTypeId(uint32_t id) const;


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11355

Core issue was `mat4x3` should look like

```
Location 0 : [0, 1, 2]
Location 1 : [3, 4, 5]
Location 2 : [6, 7, 8]
Location 3:  [9, 10, 11]
```

but was looking like

```
Location 0 : [0, 1, 2, 3]
Location 1 : [4, 5, 6, 7]
Location 2 : [8, 9, 10, 11]
```