### PR TITLE
layers: Fix validation-error for when chain of `OpAccessChain` starting with a `PhysicalStorageBuffer` to an `OpTypeStruct`, ends in a non-composite

### DIFF
--- a/layers/gpuav/spirv/pass.cpp
+++ b/layers/gpuav/spirv/pass.cpp
@@ -682,7 +682,15 @@ uint32_t Pass::FindOffsetInStruct(uint32_t struct_id, const CooperativeMatrixAcc
                 current_type_id = current_type->inst_.Operand(constant_value);  // Get element type for next step
             } break;
             default: {
-                module_.InternalError(Name(), "FindOffsetInStruct has unexpected non-composite type");
+                // A non-composite implies that this must be the end of the access-chain chain
+                auto next_access_chain_iter = (access_chain_iter)+1;
+                if (next_access_chain_iter != access_chain_insts.rend())
+                {
+                    module_.InternalError(Name(), "FindOffsetInStruct has unexpected non-composite type");
+                    break;
+                }
+                const uint32_t type_size = FindTypeByteSize(current_type_id);
+                current_offset = constant_value * type_size;
             } break;
         }
 


### PR DESCRIPTION
Fixes: #11391

Currently the following SPIR-V causes a GPU Assisted Validation error (chain of `OpAccessChain` starting with a `PhysicalStorageBuffer` to an `OpTypeStruct`, ends in a non-composite):
```spirv
         %59 = OpLoad %_ptr_PhysicalStorageBuffer_Data_natural %58
         %60 = OpPtrAccessChain %_ptr_PhysicalStorageBuffer_Data_natural %59 %int_0
         %62 = OpAccessChain %_ptr_PhysicalStorageBuffer_int %60 %int_0
                    OpStore %62 %int_3 Aligned 4
```

The solution is to modify `FindOffsetInStruct` such that we only error if a non-composite appears as the non-final access-chain result-type (in a chain of `OpAccessChain`'s)

Note: the byte-offset calculations don't look like they are correct, although I am not entirely sure on the purpose of this section of the code, so I left the code largely untouched.