### PR TITLE
gpuav: Fix RT validation

### DIFF
--- a/tests/unit/gpu_av_ray_tracing_positive.cpp
+++ b/tests/unit/gpu_av_ray_tracing_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1050,6 +1050,230 @@ TEST_F(PositiveGpuAVRayTracing, TraceRaysInCubes) {
             payload.hit = barycentric_coords;
         }
     )slang";
+
+    vkt::rt::Pipeline pipeline(*this, m_device);
+    pipeline.AddSlangRayGenShader(slang_shader, "rayGenShader");
+    pipeline.AddSlangMissShader(slang_shader, "missShader");
+    pipeline.AddSlangClosestHitShader(slang_shader, "closestHitShader");
+
+    pipeline.AddBinding(VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, 0);
+    pipeline.AddBinding(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);
+    pipeline.CreateDescriptorSet();
+
+    pipeline.Build();
+
+    pipeline.GetDescriptorSet().WriteDescriptorAccelStruct(0, 1, &tlas_build_info[0].GetDstAS()->handle());
+    pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, debug_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    pipeline.GetDescriptorSet().UpdateDescriptorSets();
+
+    m_command_buffer.Begin();
+
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(), 0, 1,
+                              &pipeline.GetDescriptorSet().set_, 0, nullptr);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline);
+
+    vkt::rt::TraceRaysSbt sbt_ray_gen_1 = pipeline.GetTraceRaysSbt(0);
+    vk::CmdTraceRaysKHR(m_command_buffer, &sbt_ray_gen_1.ray_gen_sbt, &sbt_ray_gen_1.miss_sbt, &sbt_ray_gen_1.hit_sbt,
+                        &sbt_ray_gen_1.callable_sbt, 1, 1, 1);
+
+    m_command_buffer.End();
+
+    m_default_queue->SubmitAndWait(m_command_buffer);
+
+    // Make sure expected ray tracing setup worked, indicating the TLAS was correctly built
+    ASSERT_EQ(debug_buffer_ptr[0], 1);
+    ASSERT_EQ(debug_buffer_ptr[1], 0);
+    ASSERT_EQ(debug_buffer_ptr[2], 1);
+}
+
+TEST_F(PositiveGpuAVRayTracing, TraceRaysInCubes2) {
+    TEST_DESCRIPTION(
+        "Setup a RT pipeline, a TLAS pointing to 2 cubes, and traces rays into it. Have 2 identical BLAS backed by the same "
+        "memory, so that they have the same address, and make sure deleting one when only the other one is used does not lead to "
+        "false positives.");
+
+    RETURN_IF_SKIP(CheckSlangSupport());
+
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_4_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::rayTracingPipeline);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::maintenance4);
+    AddRequiredFeature(vkt::Feature::shaderInt64);
+
+    VkValidationFeaturesEXT validation_features = GetGpuAvValidationFeatures();
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(&validation_features));
+    if (!CanEnableGpuAV(*this)) {
+        GTEST_SKIP() << "Requirements for GPU-AV are not met";
+    }
+    RETURN_IF_SKIP(InitState());
+    InitRenderTarget();
+
+    vkt::as::GeometryKHR cube(vkt::as::blueprint::GeometryCubeOnDeviceInfo(*m_device));
+    vkt::as::BuildGeometryInfoKHR cube_blas = vkt::as::blueprint::BuildGeometryInfoOnDeviceBottomLevel(*m_device, std::move(cube));
+
+    const VkAccelerationStructureBuildSizesInfoKHR size_info = cube_blas.GetSizeInfo();
+    VkBufferCreateInfo blas_buffer_ci = vku::InitStructHelper();
+    blas_buffer_ci.size = size_info.accelerationStructureSize;
+    blas_buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR |
+                           VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
+    vkt::Buffer blas_buffer(*m_device, blas_buffer_ci, vkt::no_mem);
+    VkMemoryRequirements mem_reqs{};
+    vk::GetBufferMemoryRequirements(device(), blas_buffer, &mem_reqs);
+    VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
+    alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
+    VkMemoryAllocateInfo alloc_info = vku::InitStructHelper(&alloc_flags);
+    alloc_info.allocationSize = std::max(size_info.accelerationStructureSize, mem_reqs.size);
+    vkt::DeviceMemory blas_buffer_memory(*m_device, alloc_info);
+    blas_buffer.BindMemory(blas_buffer_memory, 0);
+
+    cube_blas.GetDstAS()->SetDeviceBuffer(std::move(blas_buffer));
+
+    m_command_buffer.Begin();
+    cube_blas.BuildCmdBuffer(m_command_buffer);
+    m_command_buffer.End();
+
+    m_default_queue->Submit(m_command_buffer);
+    m_device->Wait();
+
+    // Create another blas, with a buffer backed by the same memory
+    vkt::as::GeometryKHR cube_2(vkt::as::blueprint::GeometryCubeOnDeviceInfo(*m_device));
+    vkt::as::BuildGeometryInfoKHR cube_2_blas =
+        vkt::as::blueprint::BuildGeometryInfoOnDeviceBottomLevel(*m_device, std::move(cube_2));
+    vkt::Buffer blas_buffer_2(*m_device, blas_buffer_ci, vkt::no_mem);
+    blas_buffer_2.BindMemory(blas_buffer_memory, 0);
+    cube_2_blas.GetDstAS()->SetDeviceBuffer(std::move(blas_buffer_2));
+
+    m_command_buffer.Begin();
+    cube_2_blas.BuildCmdBuffer(m_command_buffer);
+    m_command_buffer.End();
+
+    m_default_queue->Submit(m_command_buffer);
+    m_device->Wait();
+
+    std::vector<vkt::as::GeometryKHR> cube_instances(1);
+    cube_instances[0].SetType(vkt::as::GeometryKHR::Type::Instance);
+
+    VkAccelerationStructureInstanceKHR cube_instance_1{};
+    cube_instance_1.transform.matrix[0][0] = 1.0f;
+    cube_instance_1.transform.matrix[1][1] = 1.0f;
+    cube_instance_1.transform.matrix[2][2] = 1.0f;
+    cube_instance_1.transform.matrix[0][3] = 50.0f;
+    cube_instance_1.transform.matrix[1][3] = 0.0f;
+    cube_instance_1.transform.matrix[2][3] = 0.0f;
+    cube_instance_1.mask = 0xff;
+    cube_instance_1.instanceCustomIndex = 0;
+    // Cube instance 1 will be associated to closest hit shader 1
+    cube_instance_1.instanceShaderBindingTableRecordOffset = 0;
+    cube_instances[0].AddInstanceDeviceAccelStructRef(*m_device, cube_2_blas.GetDstAS()->handle(), cube_instance_1);
+
+    VkAccelerationStructureInstanceKHR cube_instance_2{};
+    cube_instance_2.transform.matrix[0][0] = 1.0f;
+    cube_instance_2.transform.matrix[1][1] = 1.0f;
+    cube_instance_2.transform.matrix[2][2] = 1.0f;
+    cube_instance_2.transform.matrix[0][3] = 0.0f;
+    cube_instance_2.transform.matrix[1][3] = 0.0f;
+    cube_instance_2.transform.matrix[2][3] = 50.0f;
+    cube_instance_2.mask = 0xff;
+    cube_instance_2.instanceCustomIndex = 0;
+    // Cube instance 2 will be associated to closest hit shader 1
+    cube_instance_2.instanceShaderBindingTableRecordOffset = 0;
+
+    cube_instances[0].AddInstanceDeviceAccelStructRef(*m_device, cube_2_blas.GetDstAS()->handle(), cube_instance_2);
+
+    {
+        std::vector<vkt::as::GeometryKHR> cube_instances_foo(1);
+        cube_instances_foo[0].SetType(vkt::as::GeometryKHR::Type::Instance);
+
+        VkAccelerationStructureInstanceKHR cube_instance_1_foo{};
+        cube_instance_1_foo.transform.matrix[0][0] = 1.0f;
+        cube_instance_1_foo.transform.matrix[1][1] = 1.0f;
+        cube_instance_1_foo.transform.matrix[2][2] = 1.0f;
+        cube_instance_1_foo.transform.matrix[0][3] = 50.0f;
+        cube_instance_1_foo.transform.matrix[1][3] = 0.0f;
+        cube_instance_1_foo.transform.matrix[2][3] = 0.0f;
+        cube_instance_1_foo.mask = 0xff;
+        cube_instance_1_foo.instanceCustomIndex = 0;
+        // Cube instance 1 will be associated to closest hit shader 1
+        cube_instance_1_foo.instanceShaderBindingTableRecordOffset = 0;
+        cube_instances_foo[0].AddInstanceDeviceAccelStructRef(*m_device, cube_blas.GetDstAS()->handle(), cube_instance_1_foo);
+
+        VkAccelerationStructureInstanceKHR cube_instance_2_foo{};
+        cube_instance_2_foo.transform.matrix[0][0] = 1.0f;
+        cube_instance_2_foo.transform.matrix[1][1] = 1.0f;
+        cube_instance_2_foo.transform.matrix[2][2] = 1.0f;
+        cube_instance_2_foo.transform.matrix[0][3] = 0.0f;
+        cube_instance_2_foo.transform.matrix[1][3] = 0.0f;
+        cube_instance_2_foo.transform.matrix[2][3] = 50.0f;
+        cube_instance_2_foo.mask = 0xff;
+        cube_instance_2_foo.instanceCustomIndex = 0;
+        // Cube instance 2 will be associated to closest hit shader 1
+        cube_instance_2_foo.instanceShaderBindingTableRecordOffset = 0;
+
+        cube_instances_foo[0].AddInstanceDeviceAccelStructRef(*m_device, cube_blas.GetDstAS()->handle(), cube_instance_2_foo);
+    }
+
+    cube_blas.GetDstAS()->Destroy();
+
+    std::vector<vkt::as::BuildGeometryInfoKHR> tlas_build_info;
+    {
+        vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::CreateTLAS(*m_device, std::move(cube_instances));
+        tlas_build_info.emplace_back(std::move(tlas));
+        m_command_buffer.Begin();
+        vkt::as::BuildAccelerationStructuresKHR(m_command_buffer, tlas_build_info);
+        m_command_buffer.End();
+
+        m_default_queue->Submit(m_command_buffer);
+        m_device->Wait();
+    }
+    // Buffer used to count invocations for the 3 shaders
+    vkt::Buffer debug_buffer(*m_device, 3 * sizeof(uint32_t), VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+                             kHostVisibleMemProps);
+    auto debug_buffer_ptr = static_cast<uint32_t*>(debug_buffer.Memory().Map());
+    std::memset(debug_buffer_ptr, 0, (size_t)debug_buffer.CreateInfo().size);
+
+    const char* slang_shader = R"slang(
+        [[vk::binding(0, 0)]] uniform RaytracingAccelerationStructure tlas;
+        [[vk::binding(1, 0)]] RWStructuredBuffer<uint32_t> debug_buffer;
+
+        struct RayPayload {
+        uint4 payload;
+        float3 hit;
+        };
+
+        [shader("raygeneration")]
+        void rayGenShader()
+        {
+        InterlockedAdd(debug_buffer[0], 1);
+        RayPayload ray_payload = {};
+        RayDesc ray;
+        ray.TMin = 0.01;
+        ray.TMax = 1000.0;
+
+        // Will hit cube 1
+        ray.Origin = float3(0,0,0);
+        ray.Direction = float3(1,0,0);
+        TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+        }
+
+        [shader("miss")]
+        void missShader(inout RayPayload payload)
+        {
+        InterlockedAdd(debug_buffer[1], 1);
+        payload.hit = float3(0.1, 0.2, 0.3);
+        }
+
+        [shader("closesthit")]
+        void closestHitShader(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attr)
+        {
+        InterlockedAdd(debug_buffer[2], 1);
+        const float3 barycentric_coords = float3(1.0f - attr.barycentrics.x - attr.barycentrics.y, attr.barycentrics.x,
+        attr.barycentrics.y);
+        payload.hit = barycentric_coords;
+        }
+        )slang";
 
     vkt::rt::Pipeline pipeline(*this, m_device);
     pipeline.AddSlangRayGenShader(slang_shader, "rayGenShader");


### PR DESCRIPTION
Having a map with AS key as addresses can lead to scenarios where if 2 BLAS happen to have the same address, destroying one will cause its map entry to be destroyed, even though the other BLAS is still alive, leading to VVL believing further reference to this common address are invalid.

- I hope I did not misused WriteLockGuard/ReadLockGuard
- In the updated data structure I only store raw pointers to `vvl::AccelerationStructureKHR`, not shared, for perf reasons. It should be safe in context.
- new test used to fail with current code