### PR TITLE
sync: Introduce global barriers

### DIFF
--- a/layers/sync/sync_access_context.cpp
+++ b/layers/sync/sync_access_context.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2019-2025 Valve Corporation
- * Copyright (c) 2019-2025 LunarG, Inc.
+ * Copyright (c) 2019-2026 Valve Corporation
+ * Copyright (c) 2019-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,69 +28,144 @@ namespace syncval {
 bool SimpleBinding(const vvl::Bindable &bindable) { return !bindable.sparse && bindable.Binding(); }
 VkDeviceSize ResourceBaseAddress(const vvl::Buffer &buffer) { return buffer.GetFakeBaseAddress(); }
 
-class HazardDetector {
-    const SyncAccessInfo &access_info_;
-
-  public:
-    HazardResult Detect(const AccessMap::const_iterator &pos) const { return pos->second.DetectHazard(access_info_); }
-    HazardResult DetectAsync(const AccessMap::const_iterator &pos, ResourceUsageTag start_tag, QueueId queue_id) const {
-        return pos->second.DetectAsyncHazard(access_info_, start_tag, queue_id);
+template <typename DetectorRunner>
+HazardResult DoDetect(const AccessContext &access_context, const AccessState &access_state, DetectorRunner detector_runner) {
+    if (access_state.next_global_barrier_index < access_context.GetGlobalBarrierCount()) {
+        AccessState new_access_state = AccessState::DefaultAccessState();
+        new_access_state.Assign(access_state);
+        access_context.ApplyGlobalBarriers(new_access_state);
+        return detector_runner(new_access_state);
+    } else {
+        return detector_runner(access_state);
     }
-    explicit HazardDetector(SyncAccessIndex access_index) : access_info_(GetAccessInfo(access_index)) {}
+}
+
+class HazardDetector {
+  public:
+    HazardDetector(SyncAccessIndex access_index, const AccessContext &access_context)
+        : access_info_(GetAccessInfo(access_index)), access_context_(access_context) {}
+
+    HazardResult Detect(const AccessMap::const_iterator &pos) const {
+        return DoDetect(access_context_, pos->second,
+                        [this](const AccessState &access_state) { return access_state.DetectHazard(access_info_); });
+    }
+
+    HazardResult DetectAsync(const AccessMap::const_iterator &pos, ResourceUsageTag start_tag, QueueId queue_id) const {
+        return DoDetect(access_context_, pos->second, [this, start_tag, queue_id](const AccessState &access_state) {
+            return access_state.DetectAsyncHazard(access_info_, start_tag, queue_id);
+        });
+    }
+
+  private:
+    const SyncAccessInfo &access_info_;
+    const AccessContext &access_context_;
 };
 
 class HazardDetectorWithOrdering {
-    const SyncAccessInfo &access_info_;
-    const SyncOrdering ordering_rule_;
-    const SyncFlags flags_;
-    const bool detect_load_op_after_store_op_hazards;
-
   public:
-    HazardDetectorWithOrdering(SyncAccessIndex access_index, SyncOrdering ordering, SyncFlags flags,
-                               bool detect_load_op_after_store_op_hazards)
+    HazardDetectorWithOrdering(SyncAccessIndex access_index, SyncOrdering ordering, const AccessContext &access_context,
+                               SyncFlags flags, bool detect_load_op_after_store_op_hazards)
         : access_info_(GetAccessInfo(access_index)),
           ordering_rule_(ordering),
+          access_context_(access_context),
           flags_(flags),
           detect_load_op_after_store_op_hazards(detect_load_op_after_store_op_hazards) {}
 
     HazardResult Detect(const AccessMap::const_iterator &pos) const {
         const OrderingBarrier &ordering = GetOrderingRules(ordering_rule_);
-        return pos->second.DetectHazard(access_info_, ordering, flags_, kQueueIdInvalid, detect_load_op_after_store_op_hazards);
+        return DoDetect(access_context_, pos->second, [this, &ordering](const AccessState &access_state) {
+            return access_state.DetectHazard(access_info_, ordering, flags_, kQueueIdInvalid,
+                                             detect_load_op_after_store_op_hazards);
+        });
     }
+
     HazardResult DetectAsync(const AccessMap::const_iterator &pos, ResourceUsageTag start_tag, QueueId queue_id) const {
-        return pos->second.DetectAsyncHazard(access_info_, start_tag, queue_id);
+        return DoDetect(access_context_, pos->second, [this, start_tag, queue_id](const AccessState &access_state) {
+            return access_state.DetectAsyncHazard(access_info_, start_tag, queue_id);
+        });
     }
+
+  private:
+    const SyncAccessInfo &access_info_;
+    const SyncOrdering ordering_rule_;
+    const AccessContext &access_context_;
+    const SyncFlags flags_;
+    const bool detect_load_op_after_store_op_hazards;
 };
 
 class HazardDetectFirstUse {
   public:
     HazardDetectFirstUse(const AccessState &recorded_use, QueueId queue_id, const ResourceUsageRange &tag_range,
-                         bool detect_load_op_after_store_op_hazards)
+                         const AccessContext &access_context, bool detect_load_op_after_store_op_hazards)
         : recorded_use_(recorded_use),
           queue_id_(queue_id),
           tag_range_(tag_range),
+          access_context_(access_context),
           detect_load_op_after_store_op_hazards(detect_load_op_after_store_op_hazards) {}
 
     HazardResult Detect(const AccessMap::const_iterator &pos) const {
-        return pos->second.DetectHazard(recorded_use_, queue_id_, tag_range_, detect_load_op_after_store_op_hazards);
+        return DoDetect(access_context_, pos->second, [this](const AccessState &access_state) {
+            return access_state.DetectHazard(recorded_use_, queue_id_, tag_range_, detect_load_op_after_store_op_hazards);
+        });
     }
+
     HazardResult DetectAsync(const AccessMap::const_iterator &pos, ResourceUsageTag start_tag, QueueId queue_id) const {
-        return pos->second.DetectAsyncHazard(recorded_use_, tag_range_, start_tag, queue_id);
+        return DoDetect(access_context_, pos->second, [this, start_tag, queue_id](const AccessState &access_state) {
+            return access_state.DetectAsyncHazard(recorded_use_, tag_range_, start_tag, queue_id);
+        });
     }
 
   private:
     const AccessState &recorded_use_;
     const QueueId queue_id_;
     const ResourceUsageRange &tag_range_;
+    const AccessContext &access_context_;
     const bool detect_load_op_after_store_op_hazards;
 };
 
 struct HazardDetectorMarker {
-    HazardResult Detect(const AccessMap::const_iterator &pos) const { return pos->second.DetectMarkerHazard(); }
-    HazardResult DetectAsync(const AccessMap::const_iterator &pos, ResourceUsageTag start_tag,
-                             QueueId queue_id) const {
-        return pos->second.DetectAsyncHazard(GetAccessInfo(SYNC_COPY_TRANSFER_WRITE), start_tag, queue_id);
+    HazardDetectorMarker(const AccessContext &access_context) : access_context(access_context) {}
+
+    HazardResult Detect(const AccessMap::const_iterator &pos) const {
+        return DoDetect(access_context, pos->second,
+                        [](const AccessState &access_state) { return access_state.DetectMarkerHazard(); });
     }
+
+    HazardResult DetectAsync(const AccessMap::const_iterator &pos, ResourceUsageTag start_tag, QueueId queue_id) const {
+        return DoDetect(access_context, pos->second, [start_tag, queue_id](const AccessState &access_state) {
+            return access_state.DetectAsyncHazard(GetAccessInfo(SYNC_COPY_TRANSFER_WRITE), start_tag, queue_id);
+        });
+    }
+
+    const AccessContext &access_context;
+};
+
+class BarrierHazardDetector {
+  public:
+    BarrierHazardDetector(const AccessContext &access_context, SyncAccessIndex access_index, VkPipelineStageFlags2 src_exec_scope,
+                          SyncAccessFlags src_access_scope)
+        : access_context_(access_context),
+          access_info_(GetAccessInfo(access_index)),
+          src_exec_scope_(src_exec_scope),
+          src_access_scope_(src_access_scope) {}
+
+    HazardResult Detect(const AccessMap::const_iterator &pos) const {
+        return DoDetect(access_context_, pos->second, [this](const AccessState &access_state) {
+            return access_state.DetectBarrierHazard(access_info_, kQueueIdInvalid, src_exec_scope_, src_access_scope_);
+        });
+    }
+
+    HazardResult DetectAsync(const AccessMap::const_iterator &pos, ResourceUsageTag start_tag, QueueId queue_id) const {
+        return DoDetect(access_context_, pos->second, [this, start_tag, queue_id](const AccessState &access_state) {
+            return access_state.DetectAsyncHazard(access_info_, start_tag, queue_id);
+        });
+    }
+
+  private:
+    const AccessContext &access_context_;
+    const SyncAccessInfo &access_info_;
+    VkPipelineStageFlags2 src_exec_scope_;
+    SyncAccessFlags src_access_scope_;
 };
 
 void AccessContext::InitFrom(uint32_t subpass, VkQueueFlags queue_flags,
@@ -124,6 +199,13 @@ void AccessContext::InitFrom(uint32_t subpass, VkQueueFlags queue_flags,
     }
 }
 
+void CollectBarriersFunctor::operator()(const Iterator &pos) const {
+    AccessState &access_state = pos->second;
+    access_context.ApplyGlobalBarriers(access_state);
+    access_state.CollectPendingBarriers(barrier_scope, barrier, layout_transition, layout_transition_handle_index,
+                                        pending_barriers);
+}
+
 void AccessContext::InitFrom(const AccessContext &other) {
     access_state_map_.Assign(other.access_state_map_);
     prev_ = other.prev_;
@@ -132,6 +214,13 @@ void AccessContext::InitFrom(const AccessContext &other) {
     src_external_ = other.src_external_;
     dst_external_ = other.dst_external_;
     start_tag_ = other.start_tag_;
+
+    global_barriers_queue_ = other.global_barriers_queue_;
+    for (uint32_t i = 0; i < other.global_barrier_def_count_; i++) {
+        global_barrier_defs_[i] = other.global_barrier_defs_[i];
+    }
+    global_barrier_def_count_ = other.global_barrier_def_count_;
+    global_barriers_ = other.global_barriers_;
 
     // Even though the "other" context may be finalized, we might still need to update "this" copy.
     // Therefore, the copied context cannot be marked as finalized yet.
@@ -148,6 +237,7 @@ void AccessContext::Reset() {
     src_external_ = nullptr;
     dst_external_ = {};
     start_tag_ = {};
+    ResetGlobalBarriers();
     finalized_ = false;
     sorted_first_accesses_.Clear();
 }
@@ -156,6 +246,101 @@ void AccessContext::Finalize() {
     assert(!finalized_);  // no need to finalize finalized
     sorted_first_accesses_.Init(access_state_map_);
     finalized_ = true;
+}
+
+void AccessContext::RegisterGlobalBarrier(const SyncBarrier &barrier, QueueId queue_id) {
+    assert(global_barriers_.empty() || global_barriers_queue_ == queue_id);
+    global_barriers_queue_ = queue_id;
+
+    // Search for existing def
+    uint32_t def_index = 0;
+    for (; def_index < global_barrier_def_count_; def_index++) {
+        if (global_barrier_defs_[def_index].barrier == barrier) {
+            break;
+        }
+    }
+    // Register a new def if this barrier is encountered for the first time
+    if (def_index == global_barrier_def_count_) {
+        // Flush global barriers if all def slots are in use
+        if (global_barrier_def_count_ == kMaxGlobaBarrierDefCount) {
+            for (auto &[_, access] : access_state_map_) {
+                ApplyGlobalBarriers(access);
+                access.next_global_barrier_index = 0;  // to match state after reset
+            }
+            ResetGlobalBarriers();
+            def_index = 0;
+        }
+
+        GlobalBarrierDef &new_def = global_barrier_defs_[global_barrier_def_count_++];
+        new_def.barrier = barrier;
+        new_def.chain_mask = 0;
+
+        // Update chain masks
+        for (uint32_t i = 0; i < global_barrier_def_count_ - 1; i++) {
+            GlobalBarrierDef &def = global_barrier_defs_[i];
+            if ((new_def.barrier.src_exec_scope.exec_scope & def.barrier.dst_exec_scope.exec_scope) != 0) {
+                new_def.chain_mask |= 1u << i;
+            }
+            if ((def.barrier.src_exec_scope.exec_scope & new_def.barrier.dst_exec_scope.exec_scope) != 0) {
+                def.chain_mask |= 1u << (global_barrier_def_count_ - 1);
+            }
+        }
+    }
+    // A global barrier is just a reference to its def
+    global_barriers_.push_back(def_index);
+}
+
+void AccessContext::ApplyGlobalBarriers(AccessState &access_state) const {
+    const uint32_t global_barrier_count = GetGlobalBarrierCount();
+    assert(access_state.next_global_barrier_index <= global_barrier_count);
+    if (access_state.next_global_barrier_index == global_barrier_count) {
+        return;  // access state is up-to-date
+    }
+    uint32_t applied_barrier_mask = 0;  // used to skip already applied barriers
+    uint32_t applied_count = 0;         // used for early exit when all unique barriers are applied
+    uint32_t failed_mask = 0;           // used to quickly test barriers that failed the first application attempt
+
+    for (size_t i = access_state.next_global_barrier_index; i < global_barrier_count; i++) {
+        const uint32_t def_index = global_barriers_[i];
+        const uint32_t def_mask = 1u << def_index;
+        assert(def_index < global_barrier_def_count_);
+
+        const GlobalBarrierDef &def = global_barrier_defs_[def_index];
+
+        // Skip barriers that were already applied
+        if ((def_mask & applied_barrier_mask) != 0) {
+            continue;
+        }
+
+        // If this barrier failed to apply initially, it can only be applied
+        // again if it can chain with one of the newly applied barriers
+        if ((def_mask & failed_mask) != 0) {
+            if ((def.chain_mask & applied_barrier_mask) == 0) {
+                continue;
+            }
+        }
+
+        // TODO: for requests with multiple barriers we need to register them in groups
+        // and use PendingBarriers helper here.
+        const BarrierScope barrier_scope(def.barrier, global_barriers_queue_);
+        const bool is_barrier_applied = access_state.ApplyBarrier(barrier_scope, def.barrier);
+        if (is_barrier_applied) {
+            applied_barrier_mask |= def_mask;
+            applied_count++;
+            if (applied_count == global_barrier_def_count_) {
+                break;  // no barriers left that can add new information
+            }
+        } else {
+            failed_mask |= def_mask;
+        }
+    }
+    access_state.next_global_barrier_index = global_barrier_count;
+}
+
+void AccessContext::ResetGlobalBarriers() {
+    global_barriers_queue_ = kQueueIdInvalid;
+    global_barrier_def_count_ = 0;
+    global_barriers_.clear();
 }
 
 void AccessContext::TrimAndClearFirstAccess() {
@@ -176,7 +361,7 @@ void AccessContext::AddReferencedTags(ResourceUsageTagSet &used) const {
 void AccessContext::ResolveFromContext(const AccessContext &from) {
     assert(!finalized_);
     auto noop_action = [](AccessState *access) {};
-    from.ResolveAccessRangeRecursePrev(kFullRange, noop_action, &access_state_map_, false);
+    from.ResolveAccessRangeRecursePrev(kFullRange, noop_action, *this, false);
 }
 
 void AccessContext::ResolvePreviousAccesses() {
@@ -184,7 +369,7 @@ void AccessContext::ResolvePreviousAccesses() {
     if (!prev_.empty()) {
         for (const auto &prev_dep : prev_) {
             const ApplyTrackbackStackAction barrier_action(prev_dep.barriers, nullptr);
-            prev_dep.source_subpass->ResolveAccessRangeRecursePrev(kFullRange, barrier_action, &access_state_map_, true);
+            prev_dep.source_subpass->ResolveAccessRangeRecursePrev(kFullRange, barrier_action, *this, true);
         }
     }
 }
@@ -194,59 +379,67 @@ void AccessContext::ResolveFromSubpassContext(const ApplySubpassTransitionBarrie
                                               subresource_adapter::ImageRangeGenerator attachment_range_gen) {
     assert(!finalized_);
     for (; attachment_range_gen->non_empty(); ++attachment_range_gen) {
-        from_context.ResolveAccessRangeRecursePrev(*attachment_range_gen, subpass_transition_action, &access_state_map_, true);
+        from_context.ResolveAccessRangeRecursePrev(*attachment_range_gen, subpass_transition_action, *this, true);
     }
 }
 
-void AccessContext::ResolvePreviousAccess(const AccessRange &range, AccessMap *descent_map) const {
-    assert(range.non_empty());
-    if (prev_.empty()) {
-        // Fill the empty poritions of descent_map with the default state
-        UpdateRangeValue(*descent_map, range, AccessState::DefaultAccessState());
-    } else {
-        for (const auto &prev_dep : prev_) {
-            const ApplyTrackbackStackAction barrier_action(prev_dep.barriers, nullptr);
-            prev_dep.source_subpass->ResolveAccessRangeRecursePrev(range, barrier_action, descent_map, true);
-        }
-    }
-}
-
-void AccessContext::ResolvePreviousAccess(const AccessRange &range, AccessMap *descent_map, bool infill,
+void AccessContext::ResolvePreviousAccess(const AccessRange &range, AccessContext &descent_context, bool infill,
                                           const AccessStateFunction &previous_barrier_action) const {
     assert(range.non_empty());
+    AccessMap &descent_map = descent_context.access_state_map_;
     if (prev_.empty()) {
         if (infill) {
-            // Fill the empty poritions of descent_map with the default state with the barrier function applied
             AccessState access_state = AccessState::DefaultAccessState();
+
+            // The following is not needed for correctness but is rather an optimization. We are going to fill
+            // the gaps and the application of the global barriers to an empty state is noop (nothing is in the
+            // barrier's source scope). Update the index to skip application of the registered global barriers.
+            access_state.next_global_barrier_index = descent_context.GetGlobalBarrierCount();
+
             previous_barrier_action(&access_state);
-            UpdateRangeValue(*descent_map, range, access_state);
+
+            // Fill the empty ranges of descent_map
+            UpdateRangeValue(descent_map, range, access_state);
         }
     } else {
         for (const auto &prev_dep : prev_) {
             const ApplyTrackbackStackAction barrier_action(prev_dep.barriers, &previous_barrier_action);
-            prev_dep.source_subpass->ResolveAccessRangeRecursePrev(range, barrier_action, descent_map, infill);
+            prev_dep.source_subpass->ResolveAccessRangeRecursePrev(range, barrier_action, descent_context, infill);
         }
     }
 }
 
 void AccessContext::ResolveAccessRange(const AccessRange &range, const AccessStateFunction &barrier_action,
-                                       AccessMap *resolve_map) const {
+                                       AccessContext &resolve_context) const {
     if (!range.non_empty()) {
         return;
     }
-    ParallelIterator current(*resolve_map, access_state_map_, range.begin);
+    AccessMap &resolve_map = resolve_context.access_state_map_;
+
+    ParallelIterator current(resolve_map, access_state_map_, range.begin);
     while (current.range.non_empty() && range.includes(current.range.begin)) {
         const auto current_range = current.range & range;
         if (current.pos_B.inside_lower_bound_range) {
             const auto &src_pos = current.pos_B.lower_bound;
-            AccessState access(src_pos->second);  // intentional copy
-            barrier_action(&access);
+
+            // Create a copy of the source access state (source is this context, destination is the resolve context).
+            // Then do the following steps:
+            //  a) apply not yet applied global barriers
+            //  b) update global barrier index to ensure global barriers from the resolve context are not applied
+            //  c) apply barrier action
+            AccessState src_access = src_pos->second;
+            ApplyGlobalBarriers(src_access);                                                 // a
+            src_access.next_global_barrier_index = resolve_context.GetGlobalBarrierCount();  // b
+            barrier_action(&src_access);                                                     // c
+
             if (current.pos_A.inside_lower_bound_range) {
-                const auto trimmed = Split(current.pos_A.lower_bound, *resolve_map, current_range);
-                trimmed->second.Resolve(access);
+                const auto trimmed = Split(current.pos_A.lower_bound, resolve_map, current_range);
+                AccessState &dst_state = trimmed->second;
+                resolve_context.ApplyGlobalBarriers(dst_state);
+                dst_state.Resolve(src_access);
                 current.OnCurrentRangeModified(trimmed);
             } else {
-                auto inserted = resolve_map->Insert(current.pos_A.lower_bound, current_range, access);
+                auto inserted = resolve_map.Insert(current.pos_A.lower_bound, current_range, src_access);
                 current.OnCurrentRangeModified(inserted);
             }
         }
@@ -257,23 +450,36 @@ void AccessContext::ResolveAccessRange(const AccessRange &range, const AccessSta
 }
 
 void AccessContext::ResolveAccessRangeRecursePrev(const AccessRange &range, const AccessStateFunction &barrier_action,
-                                                  AccessMap *resolve_map, bool infill) const {
+                                                  AccessContext &resolve_context, bool infill) const {
     if (!range.non_empty()) {
         return;
     }
-    ParallelIterator current(*resolve_map, access_state_map_, range.begin);
+    AccessMap &resolve_map = resolve_context.access_state_map_;
+
+    ParallelIterator current(resolve_map, access_state_map_, range.begin);
     while (current.range.non_empty() && range.includes(current.range.begin)) {
         const auto current_range = current.range & range;
         if (current.pos_B.inside_lower_bound_range) {
             const auto &src_pos = current.pos_B.lower_bound;
-            AccessState access(src_pos->second);  // intentional copy
-            barrier_action(&access);
+
+            // Create a copy of the source access state (source is this context, destination is the resolve context).
+            // Then do the following steps:
+            //  a) apply not yet applied global barriers
+            //  b) update global barrier index to ensure global barriers from the resolve context are not applied
+            //  c) apply barrier action
+            AccessState src_access = src_pos->second;
+            ApplyGlobalBarriers(src_access);                                                 // a
+            src_access.next_global_barrier_index = resolve_context.GetGlobalBarrierCount();  // b
+            barrier_action(&src_access);                                                     // c
+
             if (current.pos_A.inside_lower_bound_range) {
-                const auto trimmed = Split(current.pos_A.lower_bound, *resolve_map, current_range);
-                trimmed->second.Resolve(access);
+                const auto trimmed = Split(current.pos_A.lower_bound, resolve_map, current_range);
+                AccessState &dst_state = trimmed->second;
+                resolve_context.ApplyGlobalBarriers(dst_state);
+                dst_state.Resolve(src_access);
                 current.OnCurrentRangeModified(trimmed);
             } else {
-                auto inserted = resolve_map->Insert(current.pos_A.lower_bound, current_range, access);
+                auto inserted = resolve_map.Insert(current.pos_A.lower_bound, current_range, src_access);
                 current.OnCurrentRangeModified(inserted);
             }
         } else {  // Descend to fill this gap
@@ -288,7 +494,7 @@ void AccessContext::ResolveAccessRangeRecursePrev(const AccessRange &range, cons
                 // Recur only over the range until B becomes valid (within the limits of range).
                 recurrence_range.end = std::min(range.end, current.pos_B.lower_bound->first.begin);
             }
-            ResolvePreviousAccess(range, resolve_map, infill, barrier_action);
+            ResolvePreviousAccess(recurrence_range, resolve_context, infill, barrier_action);
 
             // recurrence_range is already processed and it can be larger than the current_range.
             // The NextRange might move to the range that is still inside recurrence_range, but we
@@ -307,21 +513,152 @@ void AccessContext::ResolveAccessRangeRecursePrev(const AccessRange &range, cons
     // Infill if range goes passed both the current and resolve map prior contents
     if (current.range.end < range.end) {
         AccessRange trailing_fill_range = {current.range.end, range.end};
-        ResolvePreviousAccess(trailing_fill_range, resolve_map, infill, barrier_action);
+        ResolvePreviousAccess(trailing_fill_range, resolve_context, infill, barrier_action);
     }
+}
+
+AccessMap::iterator AccessContext::InfillGapRecursePrev(const AccessRange &range, AccessMap::iterator pos_hint) {
+    assert(range.non_empty());
+    if (prev_.empty()) {
+        AccessState access_state = AccessState::DefaultAccessState();
+
+        // The following is not needed for correctness but is rather an optimization. We are going to fill
+        // the gaps and the application of the global barriers to an empty state is noop (nothing is in the
+        // barrier's source scope). Update the index to skip application of the registered global barriers.
+        access_state.next_global_barrier_index = GetGlobalBarrierCount();
+
+        return access_state_map_.InfillGap(pos_hint, range, access_state);
+    } else {
+        for (const auto &prev_dep : prev_) {
+            const ApplyTrackbackStackAction barrier_action(prev_dep.barriers, nullptr);
+            prev_dep.source_subpass->ResolveAccessRangeRecursePrev(range, barrier_action, *this, true);
+        }
+        return access_state_map_.LowerBound(range.begin);
+    }
+}
+
+// Update memory state over the given range. Inserts new accesses for empty regions and
+// updates existing accesses. The passed pos must either LowerBound (which may be the end
+// iterator) or be strictly less than range. Trims to range boundaries. The iterators
+// used for update is already trimmed to fit within the range.
+AccessMap::iterator AccessContext::DoUpdateAccessState(AccessMap::iterator pos, const AccessRange &range,
+                                                       SyncAccessIndex access_index, SyncOrdering ordering_rule,
+                                                       ResourceUsageTagEx tag_ex, SyncFlags flags) {
+    assert(range.non_empty());
+    const SyncAccessInfo &access_info = GetAccessInfo(access_index);
+
+    const auto end = access_state_map_.end();
+    assert(pos == access_state_map_.LowerBound(range.begin) || pos->first.strictly_less(range));
+    if (pos != end && pos->first.strictly_less(range)) {
+        // pos isn't lower_bound for range (it's less than range), however, if range is monotonically increasing
+        // it's likely the next entry in the map will be the lower bound.
+        ++pos;
+
+        // If the new (pos + 1) *isn't* stricly_less and pos is, (pos + 1) must be the lower_bound,
+        // otherwise we have to run the full search.
+        if (pos != end && pos->first.strictly_less(range)) {
+            pos = access_state_map_.LowerBound(range.begin);
+        }
+    }
+    assert(pos == access_state_map_.LowerBound(range.begin));
+
+    if ((pos != end) && (range.begin > pos->first.begin)) {
+        // lower bound starts before the range, trim and advance
+        pos = access_state_map_.Split(pos, range.begin);
+        ++pos;
+    }
+
+    AccessMap::index_type current_begin = range.begin;
+    while (pos != end && current_begin < range.end) {
+        if (current_begin < pos->first.begin) {
+            // The current_begin is pointing to the beginning of a gap to infill (we supply pos for "insert in front of" calls)
+            const AccessRange gap_range(current_begin, std::min(range.end, pos->first.begin));
+
+            // The range corresponds to a gap that will be infilled with specific access state.
+            // If there are previous contexts (subpass case) the infill state will be derived
+            // from them, otherwise the gap will be filled with an empty access state.
+            AccessMap::iterator it_gap_range = InfillGapRecursePrev(gap_range, pos);
+
+            // Update
+            AccessState &new_access_state = it_gap_range->second;
+            ApplyGlobalBarriers(new_access_state);
+            new_access_state.Update(access_info, ordering_rule, tag_ex, flags);
+
+            // Advance current begin, but *not* pos as it's the next valid value. (infill shall not invalidate pos)
+            current_begin = pos->first.begin;
+        } else {
+            // The current_begin is pointing to the next existing value to update
+            assert(current_begin == pos->first.begin);
+
+            // We need to run the update operation on the valid portion of the current value.
+            // If this entry overlaps end-of-range we need to trim it to the range
+            if (pos->first.end > range.end) {
+                pos = access_state_map_.Split(pos, range.end);
+            }
+
+            // We have a valid fully contained range, apply update op
+            AccessState &access_state = pos->second;
+            ApplyGlobalBarriers(access_state);
+            access_state.Update(access_info, ordering_rule, tag_ex, flags);
+
+            // Advance the current location and map entry
+            current_begin = pos->first.end;
+            ++pos;
+        }
+    }
+
+    // Fill to the end as needed
+    if (current_begin < range.end) {
+        const AccessRange gap_range(current_begin, range.end);
+
+        // The range corresponds to a gap that will be infilled with specific access state.
+        // If there are previous contexts (subpass case) the infill state will be derived
+        // from them, otherwise the gap will be filled with an empty access state.
+        AccessMap::iterator it_gap_range = InfillGapRecursePrev(gap_range, pos);
+
+        // Update
+        AccessState &new_access_state = it_gap_range->second;
+        ApplyGlobalBarriers(new_access_state);
+        new_access_state.Update(access_info, ordering_rule, tag_ex, flags);
+    }
+
+    return pos;
 }
 
 void AccessContext::UpdateAccessState(const vvl::Buffer &buffer, SyncAccessIndex current_usage, SyncOrdering ordering_rule,
                                       const AccessRange &range, ResourceUsageTagEx tag_ex, SyncFlags flags) {
+    assert(range.valid());
+    assert(!finalized_);
+
     if (current_usage == SYNC_ACCESS_INDEX_NONE) {
         return;
     }
     if (!SimpleBinding(buffer)) {
         return;
     }
-    const auto base_address = ResourceBaseAddress(buffer);
-    UpdateMemoryAccessStateFunctor action(*this, current_usage, ordering_rule, tag_ex, flags);
-    UpdateMemoryAccessRangeState(action, range + base_address);
+    if (range.empty()) {
+        return;
+    }
+
+    const VkDeviceSize base_address = ResourceBaseAddress(buffer);
+    const AccessRange buffer_range = range + base_address;
+
+    auto pos = access_state_map_.LowerBound(buffer_range.begin);
+    DoUpdateAccessState(pos, buffer_range, current_usage, ordering_rule, tag_ex, flags);
+}
+
+void AccessContext::UpdateAccessState(ImageRangeGen &range_gen, SyncAccessIndex current_usage, SyncOrdering ordering_rule,
+                                      ResourceUsageTagEx tag_ex, SyncFlags flags) {
+    assert(!finalized_);
+
+    if (current_usage == SYNC_ACCESS_INDEX_NONE) {
+        return;
+    }
+
+    auto pos = access_state_map_.LowerBound(range_gen->begin);
+    for (; range_gen->non_empty(); ++range_gen) {
+        pos = DoUpdateAccessState(pos, *range_gen, current_usage, ordering_rule, tag_ex, flags);
+    }
 }
 
 void AccessContext::UpdateAccessState(const vvl::Image &image, SyncAccessIndex current_usage, SyncOrdering ordering_rule,
@@ -373,15 +710,6 @@ void AccessContext::UpdateAccessState(const vvl::VideoSession &vs_state, const v
     UpdateAccessState(range_gen, current_usage, SyncOrdering::kNonAttachment, ResourceUsageTagEx{tag});
 }
 
-void AccessContext::UpdateAccessState(ImageRangeGen &range_gen, SyncAccessIndex current_usage, SyncOrdering ordering_rule,
-                                      ResourceUsageTagEx tag_ex, SyncFlags flags) {
-    if (current_usage == SYNC_ACCESS_INDEX_NONE) {
-        return;
-    }
-    UpdateMemoryAccessStateFunctor action(*this, current_usage, ordering_rule, tag_ex, flags);
-    UpdateMemoryAccessState(action, range_gen);
-}
-
 void AccessContext::UpdateAccessState(const ImageRangeGen &range_gen, SyncAccessIndex current_usage, SyncOrdering ordering_rule,
                                       ResourceUsageTagEx tag_ex, SyncFlags flags) {
     // range_gen is non-temporary to avoid infinite call recursion
@@ -391,9 +719,10 @@ void AccessContext::UpdateAccessState(const ImageRangeGen &range_gen, SyncAccess
 
 void AccessContext::ResolveChildContexts(vvl::span<AccessContext> subpass_contexts) {
     assert(!finalized_);
+
     for (AccessContext &context : subpass_contexts) {
         ApplyTrackbackStackAction barrier_action(context.GetDstExternalTrackBack().barriers);
-        context.ResolveAccessRange(kFullRange, barrier_action, &access_state_map_);
+        context.ResolveAccessRange(kFullRange, barrier_action, *this);
     }
 }
 
@@ -432,7 +761,7 @@ void AccessContext::AddAsyncContext(const AccessContext *context, ResourceUsageT
 HazardResult AccessContext::DetectHazard(const vvl::Buffer &buffer, SyncAccessIndex access_index, const AccessRange &range) const {
     if (!SimpleBinding(buffer)) return HazardResult();
     const auto base_address = ResourceBaseAddress(buffer);
-    HazardDetector detector(access_index);
+    HazardDetector detector(access_index, *this);
     return DetectHazardRange(detector, (range + base_address), DetectOptions::kDetectAll);
 }
 
@@ -468,13 +797,13 @@ HazardResult AccessContext::DetectHazard(Detector &detector, const vvl::Image &i
 
 HazardResult AccessContext::DetectHazard(const vvl::Image &image, SyncAccessIndex current_usage,
                                          const VkImageSubresourceRange &subresource_range, bool is_depth_sliced) const {
-    HazardDetector detector(current_usage);
+    HazardDetector detector(current_usage, *this);
     return DetectHazard(detector, image, subresource_range, is_depth_sliced, DetectOptions::kDetectAll);
 }
 
 HazardResult AccessContext::DetectHazard(const vvl::ImageView &image_view, SyncAccessIndex current_usage) const {
     // Get is const, but callee will copy
-    HazardDetector detector(current_usage);
+    HazardDetector detector(current_usage, *this);
     auto range_gen = MakeImageRangeGen(image_view);
     return DetectHazardGeneratedRanges(detector, range_gen, DetectOptions::kDetectAll);
 }
@@ -482,11 +811,11 @@ HazardResult AccessContext::DetectHazard(const vvl::ImageView &image_view, SyncA
 HazardResult AccessContext::DetectHazard(const ImageRangeGen &ref_range_gen, SyncAccessIndex current_usage,
                                          const SyncOrdering ordering_rule, SyncFlags flags) const {
     if (ordering_rule == SyncOrdering::kOrderingNone) {
-        HazardDetector detector(current_usage);
+        HazardDetector detector(current_usage, *this);
         return DetectHazardGeneratedRanges(detector, ref_range_gen, DetectOptions::kDetectAll);
     }
 
-    HazardDetectorWithOrdering detector(current_usage, ordering_rule, flags,
+    HazardDetectorWithOrdering detector(current_usage, ordering_rule, *this, flags,
                                         validator->syncval_settings.load_op_after_store_op_validation);
     return DetectHazardGeneratedRanges(detector, ref_range_gen, DetectOptions::kDetectAll);
 }
@@ -495,14 +824,14 @@ HazardResult AccessContext::DetectHazard(const vvl::ImageView &image_view, const
                                          SyncAccessIndex current_usage, SyncOrdering ordering_rule) const {
     // range_gen is non-temporary to avoid an additional copy
     ImageRangeGen range_gen(MakeImageRangeGen(image_view, offset, extent));
-    HazardDetectorWithOrdering detector(current_usage, ordering_rule, 0,
+    HazardDetectorWithOrdering detector(current_usage, ordering_rule, *this, 0,
                                         validator->syncval_settings.load_op_after_store_op_validation);
     return DetectHazardGeneratedRanges(detector, range_gen, DetectOptions::kDetectAll);
 }
 
 HazardResult AccessContext::DetectHazard(const AttachmentViewGen &view_gen, AttachmentViewGen::Gen gen_type,
                                          SyncAccessIndex current_usage, SyncOrdering ordering_rule, SyncFlags flags) const {
-    HazardDetectorWithOrdering detector(current_usage, ordering_rule, flags,
+    HazardDetectorWithOrdering detector(current_usage, ordering_rule, *this, flags,
                                         validator->syncval_settings.load_op_after_store_op_validation);
     return DetectHazard(detector, view_gen, gen_type, DetectOptions::kDetectAll);
 }
@@ -514,7 +843,7 @@ HazardResult AccessContext::DetectHazard(const vvl::VideoSession &vs_state, cons
     const auto offset = resource.GetEffectiveImageOffset(vs_state);
     const auto extent = resource.GetEffectiveImageExtent(vs_state);
     ImageRangeGen range_gen(sub_state.MakeImageRangeGen(resource.range, offset, extent, false));
-    HazardDetector detector(current_usage);
+    HazardDetector detector(current_usage, *this);
     return DetectHazardGeneratedRanges(detector, range_gen, DetectOptions::kDetectAll);
 }
 
@@ -522,32 +851,13 @@ HazardResult AccessContext::DetectHazard(const vvl::Image &image, const VkImageS
                                          const VkOffset3D &offset, const VkExtent3D &extent, bool is_depth_sliced,
                                          SyncAccessIndex current_usage, SyncOrdering ordering_rule) const {
     if (ordering_rule == SyncOrdering::kOrderingNone) {
-        HazardDetector detector(current_usage);
+        HazardDetector detector(current_usage, *this);
         return DetectHazard(detector, image, subresource_range, offset, extent, is_depth_sliced, DetectOptions::kDetectAll);
     }
-    HazardDetectorWithOrdering detector(current_usage, ordering_rule, 0,
+    HazardDetectorWithOrdering detector(current_usage, ordering_rule, *this, 0,
                                         validator->syncval_settings.load_op_after_store_op_validation);
     return DetectHazard(detector, image, subresource_range, offset, extent, is_depth_sliced, DetectOptions::kDetectAll);
 }
-
-class BarrierHazardDetector {
-  public:
-    BarrierHazardDetector(SyncAccessIndex access_index, VkPipelineStageFlags2 src_exec_scope, SyncAccessFlags src_access_scope)
-        : access_info_(GetAccessInfo(access_index)), src_exec_scope_(src_exec_scope), src_access_scope_(src_access_scope) {}
-
-    HazardResult Detect(const AccessMap::const_iterator &pos) const {
-        return pos->second.DetectBarrierHazard(access_info_, kQueueIdInvalid, src_exec_scope_, src_access_scope_);
-    }
-    HazardResult DetectAsync(const AccessMap::const_iterator &pos, ResourceUsageTag start_tag, QueueId queue_id) const {
-        // Async barrier hazard detection can use the same path as the usage index is not IsRead, but is IsWrite
-        return pos->second.DetectAsyncHazard(access_info_, start_tag, queue_id);
-    }
-
-  private:
-    const SyncAccessInfo &access_info_;
-    VkPipelineStageFlags2 src_exec_scope_;
-    SyncAccessFlags src_access_scope_;
-};
 
 class EventBarrierHazardDetector {
   public:
@@ -644,7 +954,7 @@ HazardResult AccessContext::DetectImageBarrierHazard(const vvl::Image &image, co
 
 HazardResult AccessContext::DetectImageBarrierHazard(const AttachmentViewGen &view_gen, const SyncBarrier &barrier,
                                                      DetectOptions options) const {
-    BarrierHazardDetector detector(SyncAccessIndex::SYNC_IMAGE_LAYOUT_TRANSITION, barrier.src_exec_scope.exec_scope,
+    BarrierHazardDetector detector(*this, SyncAccessIndex::SYNC_IMAGE_LAYOUT_TRANSITION, barrier.src_exec_scope.exec_scope,
                                    barrier.src_access_scope);
     return DetectHazard(detector, view_gen, AttachmentViewGen::Gen::kViewSubresource, options);
 }
@@ -653,25 +963,8 @@ HazardResult AccessContext::DetectImageBarrierHazard(const vvl::Image &image, Vk
                                                      const SyncAccessFlags &src_access_scope,
                                                      const VkImageSubresourceRange &subresource_range, bool is_depth_sliced,
                                                      const DetectOptions options) const {
-    BarrierHazardDetector detector(SyncAccessIndex::SYNC_IMAGE_LAYOUT_TRANSITION, src_exec_scope, src_access_scope);
+    BarrierHazardDetector detector(*this, SyncAccessIndex::SYNC_IMAGE_LAYOUT_TRANSITION, src_exec_scope, src_access_scope);
     return DetectHazard(detector, image, subresource_range, is_depth_sliced, options);
-}
-
-AccessMap::iterator AccessContext::UpdateMemoryAccessStateFunctor::Infill(AccessMap *accesses, const Iterator &pos_hint,
-                                                                          const AccessRange &range) const {
-    // InfillUpdateRange calls infill operation with not empty ranges
-    assert(range.non_empty());
-
-    // The range corresponds to a gap and resolve will replace it with a valid range
-    context.ResolvePreviousAccess(range, accesses);
-
-    // This returns a valid range
-    return accesses->LowerBound(range.begin);
-}
-
-void AccessContext::UpdateMemoryAccessStateFunctor::operator()(const AccessMap::iterator &pos) const {
-    auto &access_state = pos->second;
-    access_state.Update(usage_info, ordering_rule, tag_ex, flags);
 }
 
 // This is called with the *recorded* command buffers access context, with the *active* access context pass in, againsts which
@@ -687,7 +980,7 @@ HazardResult AccessContext::DetectFirstUseHazard(QueueId queue_id, const Resourc
             // For single tag first accesses we have exact search and can assert the find
             assert(access.FirstAccessInTagRange(tag_range));
 
-            HazardDetectFirstUse detector(access, queue_id, tag_range,
+            HazardDetectFirstUse detector(access, queue_id, tag_range, access_context,
                                           validator->syncval_settings.load_op_after_store_op_validation);
             HazardResult hazard = access_context.DetectHazardRange(detector, access_range, DetectOptions::kDetectAll);
             if (hazard.IsHazard()) {
@@ -704,7 +997,7 @@ HazardResult AccessContext::DetectFirstUseHazard(QueueId queue_id, const Resourc
                 continue;
             }
 
-            HazardDetectFirstUse detector(access, queue_id, tag_range,
+            HazardDetectFirstUse detector(access, queue_id, tag_range, access_context,
                                           validator->syncval_settings.load_op_after_store_op_validation);
             HazardResult hazard = access_context.DetectHazardRange(detector, access_range, DetectOptions::kDetectAll);
             if (hazard.IsHazard()) {
@@ -719,7 +1012,7 @@ HazardResult AccessContext::DetectFirstUseHazard(QueueId queue_id, const Resourc
             if (!recorded_access.second.FirstAccessInTagRange(tag_range)) {
                 continue;
             }
-            HazardDetectFirstUse detector(recorded_access.second, queue_id, tag_range,
+            HazardDetectFirstUse detector(recorded_access.second, queue_id, tag_range, access_context,
                                           validator->syncval_settings.load_op_after_store_op_validation);
             HazardResult hazard = access_context.DetectHazardRange(detector, recorded_access.first, DetectOptions::kDetectAll);
             if (hazard.IsHazard()) {
@@ -735,7 +1028,7 @@ HazardResult AccessContext::DetectMarkerHazard(const vvl::Buffer &buffer, const 
         return HazardResult();
     }
     const VkDeviceSize base_address = ResourceBaseAddress(buffer);
-    HazardDetectorMarker detector;
+    HazardDetectorMarker detector(*this);
     return DetectHazardRange(detector, (range + base_address), DetectOptions::kDetectAll);
 }
 

--- a/layers/sync/sync_access_map.cpp
+++ b/layers/sync/sync_access_map.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2025 The Khronos Group Inc.
- * Copyright (c) 2025 Valve Corporation
- * Copyright (c) 2025 LunarG, Inc.
+/* Copyright (c) 2026 The Khronos Group Inc.
+ * Copyright (c) 2026 Valve Corporation
+ * Copyright (c) 2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,6 +87,13 @@ std::pair<AccessMap::iterator, bool> AccessMap::Insert(const AccessRange &range,
     }
     // We don't replace
     return {lower, false};
+}
+
+AccessMap::iterator AccessMap::InfillGap(const_iterator range_lower_bound, const AccessRange &range,
+                                         const AccessState &access_state) {
+    assert(LowerBound(range.begin) == range_lower_bound);
+    assert(range_lower_bound == end() || range.strictly_less(range_lower_bound->first));
+    return impl_map_.insert(range_lower_bound, {range, access_state});
 }
 
 AccessMap::iterator AccessMap::Split(const iterator split_it, const index_type &index) {

--- a/layers/sync/sync_access_map.h
+++ b/layers/sync/sync_access_map.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2019-2025 The Khronos Group Inc.
- * Copyright (c) 2019-2025 Valve Corporation
- * Copyright (c) 2019-2025 LunarG, Inc.
- * Copyright (C) 2019-2025 Google Inc.
+/* Copyright (c) 2019-2026 The Khronos Group Inc.
+ * Copyright (c) 2019-2026 Valve Corporation
+ * Copyright (c) 2019-2026 LunarG, Inc.
+ * Copyright (C) 2019-2026 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,6 +77,7 @@ class AccessMap {
     iterator Erase(const iterator &pos);
     void Erase(iterator first, iterator last);
     iterator Insert(const_iterator hint, const AccessRange &range, const AccessState &access_state);
+    iterator InfillGap(const_iterator range_lower_bound, const AccessRange &range, const AccessState &access_state);
     iterator Split(const iterator split_it, const index_type &index);
 
     AccessMap() : impl_map_(AccessMapCompare()) {}

--- a/layers/sync/sync_access_state.h
+++ b/layers/sync/sync_access_state.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2019-2025 The Khronos Group Inc.
- * Copyright (c) 2019-2025 Valve Corporation
- * Copyright (c) 2019-2025 LunarG, Inc.
+/* Copyright (c) 2019-2026 The Khronos Group Inc.
+ * Copyright (c) 2019-2026 Valve Corporation
+ * Copyright (c) 2019-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -348,7 +348,7 @@ class AccessState {
     void Resolve(const AccessState &other);
 
     // Apply a single barrier to the access state
-    void ApplyBarrier(const BarrierScope &barrier_scope, const SyncBarrier &barrier, bool layout_transition = false,
+    bool ApplyBarrier(const BarrierScope &barrier_scope, const SyncBarrier &barrier, bool layout_transition = false,
                       uint32_t layout_transition_handle_index = vvl::kNoIndex32,
                       ResourceUsageTag layout_transition_tag = kInvalidTag);
 
@@ -456,6 +456,13 @@ class AccessState {
     void AddRead(const ReadState &read);
     void MergeReads(const AccessState &other);
     void ClearReadStates();
+
+public:
+    // Index of the next global barrier to apply.
+    // Global barriers are stored in the AccessContext associated with this access state.
+    // If 0, no global barriers have been applied yet.
+    // If greater than 0, then all global barriers with smaller indices are already applied.
+    uint32_t next_global_barrier_index = 0;
 
   private:
     // The most recent write.

--- a/layers/sync/sync_renderpass.cpp
+++ b/layers/sync/sync_renderpass.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2019-2025 The Khronos Group Inc.
- * Copyright (c) 2019-2025 Valve Corporation
- * Copyright (c) 2019-2025 LunarG, Inc.
+/* Copyright (c) 2019-2026 The Khronos Group Inc.
+ * Copyright (c) 2019-2026 Valve Corporation
+ * Copyright (c) 2019-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -908,7 +908,8 @@ void RenderPassAccessContext::RecordEndRenderPass(AccessContext *external_contex
             PendingBarriers pending_barriers;
             for (const auto &barrier : last_trackback.barriers) {
                 const BarrierScope barrier_scope(barrier);
-                CollectBarriersFunctor collect_barriers(barrier_scope, barrier, true, vvl::kNoIndex32, pending_barriers);
+                CollectBarriersFunctor collect_barriers(*external_context, barrier_scope, barrier, true, vvl::kNoIndex32,
+                                                        pending_barriers);
                 external_context->UpdateMemoryAccessState(collect_barriers, range_gen);
             }
             pending_barriers.Apply(barrier_tag);

--- a/tests/stress/sync_val_stress.cpp
+++ b/tests/stress/sync_val_stress.cpp
@@ -58,7 +58,7 @@ TEST_F(StressSyncVal, CopyPagesInSmallChunks) {
     AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(InitSyncVal());
 
-    const uint32_t page_count = 2;
+    const uint32_t page_count = 16;
     const uint32_t page_size = 65536;
     const uint32_t copies_per_page = page_size / 16;  // 4K
 
@@ -105,7 +105,7 @@ TEST_F(StressSyncVal, CopyPagesInSmallChunksNoQueueSync) {
     AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(InitSyncVal());
 
-    const uint32_t page_count = 2;
+    const uint32_t page_count = 16;
     const uint32_t page_size = 65536;
     const uint32_t copies_per_page = page_size / 16;  // 4K
 


### PR DESCRIPTION
This implements infrastructure to lazily apply global barriers only to the ranges that are actually accessed. The previous implementation applied global barriers immediately to **all** memory ranges. This removes `O(n)` complexity with some constant bookkeeping overhead (~1-2% overhead).

Currently the feature is enabled for a single use case to remove hotspot https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10376.

The plan for the next PRs is to enable this for more scenarios (execution dependencies created by image/buffer barriers) where we also have `O(n)`.

The improvement for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10376 when running actual CTS test:

before:
no validation: 5 seconds
core 8 seconds
sync 207 seconds (not great)

now:
sync 33 seconds (6x faster)

The internal vvl tests that reproduce this scenario run 20x faster. 

It is still significantly slower than core but that's due to other reasons.

