### PR TITLE
layers: Improve vkCmdPushConstant error messages

### DIFF
--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  * Modifications Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -434,6 +434,22 @@ TEST_F(NegativeCommand, PushConstants) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeCommand, PushConstantsCompute) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11404");
+    RETURN_IF_SKIP(Init());
+    InitRenderTarget();
+
+    VkPushConstantRange pc_range = {VK_SHADER_STAGE_COMPUTE_BIT, 0, 4};
+    vkt::PipelineLayout pipeline_layout(*m_device, {}, {pc_range});
+
+    const uint32_t data[4] = {};
+    m_command_buffer.Begin();
+    m_errorMonitor->SetDesiredError("VUID-vkCmdPushConstants-offset-01795");
+    vk::CmdPushConstants(m_command_buffer, pipeline_layout, VK_SHADER_STAGE_COMPUTE_BIT, 0, 8, &data);
+    m_errorMonitor->VerifyFound();
     m_command_buffer.End();
 }
 


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11404

It now will have a good error message like

```
vkCmdPushConstants(): is called with
  stageFlags (VK_SHADER_STAGE_COMPUTE_BIT), offset (0), size (8)
but VkPipelineLayout 0xa000000000a doesn't have any valid VkPushConstantRange:
  stageFlags (VK_SHADER_STAGE_COMPUTE_BIT), offset (0), size (4) [invalid because outside the range]
```

but also still handle the uglier cases when using multiple stages for graphics

```
vkCmdPushConstants(): is called with
  stageFlags (VK_SHADER_STAGE_VERTEX_BIT|VK_SHADER_STAGE_FRAGMENT_BIT), offset (0), size (20)
but VkPipelineLayout 0xa000000000a doesn't have any valid VkPushConstantRange for VK_SHADER_STAGE_VERTEX_BIT:
  stageFlags (VK_SHADER_STAGE_FRAGMENT_BIT), offset (0), size (32)
  stageFlags (VK_SHADER_STAGE_VERTEX_BIT), offset (16), size (64) [invalid because outside the range]

vkCmdPushConstants(): is called with
  stageFlags (VK_SHADER_STAGE_FRAGMENT_BIT), offset (80), size (4)
but VkPipelineLayout 0xa000000000a doesn't have any valid VkPushConstantRange:
  stageFlags (VK_SHADER_STAGE_FRAGMENT_BIT), offset (0), size (32) [invalid because outside the range]
  stageFlags (VK_SHADER_STAGE_VERTEX_BIT), offset (16), size (64) [invalid because stageFlags is not matching]
```