### PR TITLE
layers: Label missing VkDescriptorUpdateTemplateEntry

### DIFF
--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (C) 2015-2025 Google Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (C) 2015-2026 Google Inc.
  * Copyright (c) 2025 Arm Limited.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -4124,9 +4124,10 @@ bool CoreChecks::PreCallValidateUpdateDescriptorSetWithTemplate(VkDevice device,
     auto template_state = Get<vvl::DescriptorUpdateTemplate>(descriptorUpdateTemplate);
     // Object tracker will report errors for invalid descriptorUpdateTemplate values, avoiding a crash in release builds
     // but retaining the assert as template support is new enough to want to investigate these in debug builds.
-    if (!template_state) return skip;
+    if (!template_state) {
+        return skip;
+    }
 
-    // TODO: Validate template push descriptor updates
     if (template_state->create_info.templateType == VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET) {
         // decode the templatized data and leverage the non-template UpdateDescriptor helper functions.
         // Translate the templated update into a normal update for validation...

--- a/layers/error_message/unimplementable_validation.h
+++ b/layers/error_message/unimplementable_validation.h
@@ -120,6 +120,14 @@ const char* unimplementable_validation[] = {
     "VUID-VkAccelerationStructureGeometryKHR-instances-parameter",
     "VUID-VkAccelerationStructureGeometryKHR-aabbs-parameter",
 
+    // These are being covered by both
+    //   VUID-VkWriteDescriptorSet-dstBinding-00315
+    //   VUID-VkWriteDescriptorSet-dstArrayElement-00321
+    // We would need to really make things complex in order to report these 2 VUs correctly
+    // and on top of that, there are MANY missing similar VUs in VkWriteDescriptorSet the spec would need
+    "VUID-VkDescriptorUpdateTemplateEntry-dstBinding-00354",
+    "VUID-VkDescriptorUpdateTemplateEntry-dstArrayElement-00355",
+
     // If VkDeviceAddress can be zero, we will validate it in cc_buffer_address.h
     // We cover these in VUID-VkDeviceAddress-size-11364
     // https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/7517#note_546958


### PR DESCRIPTION
Wrote tests, confirmed    `VUID-VkDescriptorUpdateTemplateEntry-dstBinding-00354` and `VUID-VkDescriptorUpdateTemplateEntry-dstArrayElement-00355` are being validated

(I added proper template validation logic a while ago)

Unless we want to copy ALL the `VkWriteDescriptorSet` VUs to `VkDescriptorUpdateTemplateEntry` (we dont!!) just put in the `unimplementable_validation.h` file