### PR TITLE
sync: Clean up AccessContext interface

### DIFF
--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -1181,7 +1181,7 @@ bool SyncOpBeginRenderPass::Validate(const CommandBufferAccessContext &cb_contex
     // by predicating on whether subpass 0 uses the attachment if it is too expensive to create the full list redundantly here.
     // More broadly we could look at thread specific state shared between Validate and Record as is done for other heavyweight
     // operations (though it's currently a messy approach)
-    AttachmentViewGenVector view_gens = RenderPassAccessContext::CreateAttachmentViewGen(render_area, attachments_);
+    const AttachmentViewGenVector view_gens = RenderPassAccessContext::CreateAttachmentViewGen(render_area, attachments_);
     skip |= RenderPassAccessContext::ValidateLayoutTransitions(cb_context, temp_context, rp_state, render_area, subpass, view_gens,
                                                                command_);
 

--- a/layers/sync/sync_renderpass.h
+++ b/layers/sync/sync_renderpass.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2019-2025 The Khronos Group Inc.
- * Copyright (c) 2019-2025 Valve Corporation
- * Copyright (c) 2019-2025 LunarG, Inc.
+/* Copyright (c) 2019-2026 The Khronos Group Inc.
+ * Copyright (c) 2019-2026 Valve Corporation
+ * Copyright (c) 2019-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,6 +79,8 @@ struct BeginRenderingCmdState {
 std::unique_ptr<AccessContext[]> InitSubpassContexts(VkQueueFlags queue_flags, const vvl::RenderPass &rp_state,
                                                      const AccessContext &external_context);
 
+using AttachmentViewGenVector = std::vector<AttachmentViewGen>;
+
 class RenderPassAccessContext {
   public:
     static AttachmentViewGenVector CreateAttachmentViewGen(const VkRect2D &render_area,
@@ -134,9 +136,9 @@ class RenderPassAccessContext {
   private:
     const vvl::RenderPass *rp_state_;
     const VkRect2D render_area_;
+    const AttachmentViewGenVector attachment_views_;
+    const std::unique_ptr<AccessContext[]> subpass_contexts_;
     uint32_t current_subpass_;
-    std::unique_ptr<AccessContext[]> subpass_contexts_;
-    AttachmentViewGenVector attachment_views_;
 };
 
 }  // namespace syncval

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2019-2025 Valve Corporation
- * Copyright (c) 2019-2025 LunarG, Inc.
+ * Copyright (c) 2019-2026 Valve Corporation
+ * Copyright (c) 2019-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -958,8 +958,8 @@ void PresentedImage::SetImage(uint32_t at_index) {
 
 void PresentedImage::UpdateMemoryAccess(SyncAccessIndex usage, ResourceUsageTag tag, AccessContext& access_context,
                                         SyncFlags flags) const {
-    // Intentional copy. The range_gen argument is not copied by the Update... call below
-    access_context.UpdateAccessState(range_gen, usage, SyncOrdering::kNonAttachment, ResourceUsageTagEx{tag}, flags);
+    ImageRangeGen mutable_range_gen = range_gen;
+    access_context.UpdateAccessState(mutable_range_gen, usage, SyncOrdering::kNonAttachment, ResourceUsageTagEx{tag}, flags);
 }
 
 }  // namespace syncval


### PR DESCRIPTION
There are two main `UpdateAccessState` functions (to update buffer and image subresource). All other overloads are the helpers that call the main functions. Move these helpers to functionality to uses them.