### PR TITLE
tests: Add Secondary CB with RenderPass

### DIFF
--- a/layers/error_message/unimplementable_validation.h
+++ b/layers/error_message/unimplementable_validation.h
@@ -128,6 +128,10 @@ const char* unimplementable_validation[] = {
     "VUID-VkDescriptorUpdateTemplateEntry-dstBinding-00354",
     "VUID-VkDescriptorUpdateTemplateEntry-dstArrayElement-00355",
 
+    // This is just VUID-vkCmdBeginRendering-renderpass
+    // The logic in CoreChecks::InsideRenderPass() already gives a good error message
+    "VUID-vkCmdBeginRendering-commandBuffer-10914",
+
     // If VkDeviceAddress can be zero, we will validate it in cc_buffer_address.h
     // We cover these in VUID-VkDeviceAddress-size-11364
     // https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/7517#note_546958


### PR DESCRIPTION
we recently added VUID-vkCmdBeginRendering-commandBuffer-10914 but not needed as I already get a really nice error message

```
Validation Error: [ VUID-vkCmdBeginRendering-renderpass ] | MessageID = 0xbc86e7e1
vkCmdBeginRenderingKHR(): It is invalid to issue this call inside this secondary command buffer as it was begun with VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT and viewed as being inside a render pass instance begun with vkCmdBeginRendering.
```