### PR TITLE
layers: Fix 10894 message

### DIFF
--- a/layers/core_checks/cc_buffer_address.h
+++ b/layers/core_checks/cc_buffer_address.h
@@ -128,7 +128,7 @@ class BufferAddressValidation {
         vuid_and_validations[ChecksCount] = {
             "VUID-VkDeviceAddress-None-10894",
             [](const vvl::Buffer& buffer_state) { return !buffer_state.sparse && !buffer_state.IsMemoryBound(); },
-            []() { return "The following buffers are not bound to memory or it has been freed:"; },
+            []() { return "The following buffers are not bound to memory or it has been freed"; },
             [&validator](const vvl::Buffer& buffer_state) {
                 const auto memory_state = buffer_state.MemoryState();
                 if (memory_state && memory_state->Destroyed()) {


### PR DESCRIPTION
Before the message was:

```
Validation Error: [ VUID-VkDeviceAddress-None-10894 ] | MessageID = 0x2f6379df
vkCmdCopyMemoryIndirectKHR(): pCopyMemoryIndirectInfo->copyAddressRange.address [0x1972c000, 0x1972c018) (24 bytes) has no buffer(s) associated that are valid.
The following buffers are not bound to memory or it has been freed::
```