### PR TITLE
sync: Apply single barrier immediately

### DIFF
--- a/layers/sync/sync_access_map.cpp
+++ b/layers/sync/sync_access_map.cpp
@@ -48,6 +48,7 @@ void AccessMap::Erase(iterator first, iterator last) {
 }
 
 AccessMap::iterator AccessMap::Insert(const_iterator hint, const AccessRange &range, const AccessState &access_state) {
+    assert(range.non_empty());
     bool hint_open;
     const_iterator impl_next = hint;
     if (impl_map_.empty()) {
@@ -75,9 +76,8 @@ AccessMap::iterator AccessMap::Insert(const_iterator hint, const AccessRange &ra
 }
 
 std::pair<AccessMap::iterator, bool> AccessMap::Insert(const AccessRange &range, const AccessState &access_state) {
-    if (!range.non_empty()) {
-        return std::make_pair(end(), false);
-    }
+    assert(range.non_empty());
+
     // Look for range conflicts (and an insertion point, which makes the lower_bound *not* wasted work)
     // we don't have to check upper if just check that lower doesn't intersect (which it would if lower != upper)
     auto lower = LowerBound(range.begin);

--- a/layers/sync/sync_op.h
+++ b/layers/sync/sync_op.h
@@ -208,11 +208,18 @@ class SyncOpPipelineBarrier : public SyncOpBase {
     uint32_t GetExecutionDependencyBarrierCount() const { return barrier_set_.execution_dependency_barrier_count; }
 
   private:
-    // Single barrier can be applied more efficently since there is no need to support independent
-    // barrier application and collect pending state.
-    void ApplySingleBarrier(CommandExecutionContext &exec_context) const;
+    // A single barrier can be applied more efficently (immidiately) compared to multiple barrier.
+    // The latter are applied in two steps (collect and then apply)
+    void ApplySingleBufferBarrier(CommandExecutionContext &exec_context, const SyncBufferBarrier &buffer_barrier,
+                                  const SyncBarrier &exec_dep_barrier) const;
+    void ApplySingleImageBarrier(CommandExecutionContext &exec_context, const SyncImageBarrier &image_barrier,
+                                 const SyncBarrier &exec_dep_barrier, ResourceUsageTag exec_tag) const;
+    void ApplySingleMemoryBarrier(CommandExecutionContext &exec_context, const SyncBarrier &memory_barrier) const;
 
-    void ApplyMultipleBarriers(CommandExecutionContext &exec_context, const ResourceUsageTag exec_tag) const;
+    // This handles all configurations where barriers cannot be applied immidiately and need to use
+    // the PendingBarriers helper to ensure independent barrier application. All such configurations
+    // use more than one barrier.
+    void ApplyMultipleBarriers(CommandExecutionContext &exec_context, ResourceUsageTag exec_tag) const;
 
   private:
     BarrierSet barrier_set_;


### PR DESCRIPTION
Apply global barrier functionality from https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/11405 to simplify the case where only a single image or buffer barrier is specified by a barrier command.

Multiple barriers are applied in two steps (collect and apply) to ensure independent barrier application. This path was also used for a single image or buffer barrier, but in that case the barrier can be applied immediately (followed by global barrier for execution dependency).