### PR TITLE
tests: Add UntypedPointer 64bit indexing

### DIFF
--- a/tests/unit/shader_64bit_indexing.cpp
+++ b/tests/unit/shader_64bit_indexing.cpp
@@ -36,7 +36,7 @@ TEST_F(NegativeShader64BitIndexing, Length64) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeShader64BitIndexing, ShaderLength64) {
+TEST_F(NegativeShader64BitIndexing, ShaderObjectLength64) {
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredFeature(vkt::Feature::shader64BitIndexing);
     AddRequiredFeature(vkt::Feature::shaderInt64);
@@ -65,6 +65,55 @@ TEST_F(NegativeShader64BitIndexing, ShaderLength64) {
 
     m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-OpArrayLength-11807");
     const vkt::Shader shader(*m_device, create_info);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeShader64BitIndexing, UntypedPointerLength64) {
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_KHR_SHADER_UNTYPED_POINTERS_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_SHADER_64BIT_INDEXING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::shader64BitIndexing);
+    AddRequiredFeature(vkt::Feature::shaderInt64);
+    AddRequiredFeature(vkt::Feature::shaderUntypedPointers);
+    RETURN_IF_SKIP(Init());
+
+    const char *cs_source = R"(
+               OpCapability Shader
+               OpCapability UntypedPointersKHR
+               OpCapability Int64
+               OpExtension "SPV_KHR_untyped_pointers"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %b
+               OpExecutionMode %main LocalSize 1 1 1
+               OpDecorate %_runtimearr_float ArrayStride 4
+               OpDecorate %B Block
+               OpMemberDecorate %B 0 NonWritable
+               OpMemberDecorate %B 0 Offset 0
+               OpDecorate %b NonWritable
+               OpDecorate %b Binding 0
+               OpDecorate %b DescriptorSet 0
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+%_runtimearr_float = OpTypeRuntimeArray %float
+          %B = OpTypeStruct %_runtimearr_float
+        %ptr = OpTypeUntypedPointerKHR StorageBuffer
+          %b = OpUntypedVariableKHR %ptr StorageBuffer %B
+      %ulong = OpTypeInt 64 0
+       %long = OpTypeInt 64 1
+       %main = OpFunction %void None %4
+          %6 = OpLabel
+         %13 = OpUntypedArrayLengthKHR %ulong %B %b 0
+         %15 = OpBitcast %long %13
+               OpReturn
+               OpFunctionEnd
+    )";
+
+    CreateComputePipelineHelper pipe(*this);
+    pipe.cs_ = VkShaderObj(*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3, SPV_SOURCE_ASM);
+    pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}};
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-OpArrayLength-11807");
+    pipe.CreateComputePipeline();
     m_errorMonitor->VerifyFound();
 }
 


### PR DESCRIPTION
@ziga-lunarg was about to add the new VU for https://gitlab.khronos.org/vulkan/vulkan/-/commit/d638c4a7 but wanted to first make sure the related 64-bit indexing version for `VUID-RuntimeSpirv-OpArrayLength-11807` worked

(Pinging to let you know I am adding `11475`, but also so you can review this quickly :smile: )