### PR TITLE
sync: Disable vertex buffer heuristic for indexed draws

### DIFF
--- a/layers/sync/sync_commandbuffer.h
+++ b/layers/sync/sync_commandbuffer.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2019-2025 Valve Corporation
- * Copyright (c) 2019-2025 LunarG, Inc.
+ * Copyright (c) 2019-2026 Valve Corporation
+ * Copyright (c) 2019-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -223,8 +223,8 @@ class CommandBufferAccessContext : public CommandExecutionContext, DebugNameProv
     void RecordEndRendering(const RecordObject &record_obj);
     bool ValidateDispatchDrawDescriptorSet(VkPipelineBindPoint pipelineBindPoint, const Location &loc) const;
     void RecordDispatchDrawDescriptorSet(VkPipelineBindPoint pipelineBindPoint, ResourceUsageTag tag);
-    bool ValidateDrawVertex(std::optional<uint32_t> vertexCount, uint32_t firstVertex, const Location &loc) const;
-    void RecordDrawVertex(std::optional<uint32_t> vertexCount, uint32_t firstVertex, ResourceUsageTag tag);
+    bool ValidateDrawVertex(uint32_t vertexCount, uint32_t firstVertex, const Location &loc) const;
+    void RecordDrawVertex(uint32_t vertexCount, uint32_t firstVertex, ResourceUsageTag tag);
     bool ValidateDrawVertexIndex(uint32_t indexCount, uint32_t firstIndex, const Location &loc) const;
     void RecordDrawVertexIndex(uint32_t indexCount, uint32_t firstIndex, ResourceUsageTag tag);
     bool ValidateDrawAttachment(const Location &loc) const;


### PR DESCRIPTION
This PR disables `vkCmdDrawIndexed` vertex buffer validation, similar to `vkCmdDrawIndirect`, due to missing information about the accessed vertex buffer region. Currently, syncval validates `vkCmdDraw` and also validates index buffers for indexed draws.

For `vkCmdDrawIndexed`, we previously used a heuristic that assumed the entire bound `VkBuffer` is accessed. This assumption does not hold nicely in practice. It is common for games too sub-allocate from larger buffers. This leads to two issues:
a) False positives: the entire buffer is marked as accessed by the draw command, causing conflicts with other buffer usages.
b) Performance issues: large buffer is scanned for each draw call

For example, Doom Eternal allocates ~700 Mb buffers to sub-allocate vertex/index/storage/texel buffers from them. This results in false positives from `vkCmdDrawIndexed`, and validation becomes slow due to traversing entire ~700 Mb region for each draw call.