### PR TITLE
layers: Do not remove substates on Destroy

### DIFF
--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (C) 2015-2025 Google Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (C) 2015-2026 Google Inc.
  * Copyright (c) 2025 Arm Limited.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
@@ -344,7 +344,6 @@ void CommandBuffer::Destroy() {
     for (auto &item : sub_states_) {
         item.second->Destroy();
     }
-    sub_states_.clear();
     StateObject::Destroy();
 }
 


### PR DESCRIPTION
Instead, remove substates when the object is actually destructed (in the destructor).

This matches the pre-substate behavior, where a state object could retain some data after Destroy (for example, syncval uses this for error messages).

In the post-substate version, Destroy removes registered substates. In the case of syncval, this results in losing resource handle information during submit time validation. Originally syncval command buffer state object stored the list of handles which was referenced in case of error (even if command buffer was destroyed).

Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11490