### PR TITLE
layers: Improve AS Buffer error message

### DIFF
--- a/layers/core_checks/cc_buffer_address.h
+++ b/layers/core_checks/cc_buffer_address.h
@@ -109,15 +109,13 @@ class BufferAddressValidation {
                 ss << "\nAbove at range " << string_range_hex(nearest.above_range) << " has buffers:";
                 for (const auto buffer : nearest.above_buffers) {
                     // use std::to_string() to print as simple way to print size as decimal, not hex, like everything else
-                    ss << "\n  " << validator.FormatHandle(buffer->Handle()) << ", size " << std::to_string(buffer->create_info.size) << ", range "
-                       << string_range_hex(buffer->DeviceAddressRange());
+                    ss << "\n  " << buffer->Describe(validator);
                 }
             }
             if (!nearest.below_buffers.empty()) {
                 ss << "\nBelow at range " << string_range_hex(nearest.below_range) << " has buffers:";
                 for (const auto buffer : nearest.below_buffers) {
-                    ss << "\n  " << validator.FormatHandle(buffer->Handle()) << ", size " << std::to_string(buffer->create_info.size) << ", range "
-                       << string_range_hex(buffer->DeviceAddressRange());
+                    ss << "\n  " << buffer->Describe(validator);
                 }
             }
             skip |= validator.LogError("VUID-VkDeviceAddress-size-11364", objlist, device_address_loc, "%s", ss.str().c_str());
@@ -246,11 +244,7 @@ bool BufferAddressValidation<ChecksCount>::LogInvalidBuffers(const vvl::DevicePr
 
             // Always print the buffer range/size
             error_msg += "  ";  // small indent help to visualize
-            error_msg += validator.FormatHandle(buffer->Handle());
-            error_msg += ", size ";
-            error_msg += std::to_string(buffer->create_info.size);
-            error_msg += ", range ";
-            error_msg += string_range_hex(buffer->DeviceAddressRange());
+            error_msg += buffer->Describe(validator);
             error_msg += " ";
             error_msg += error_msg_buffer_func(*buffer);
             error_msg += "\n";
@@ -277,8 +271,7 @@ bool BufferAddressValidation<ChecksCount>::LogInvalidBuffers(const vvl::DevicePr
 [[maybe_unused]] static std::string PrintBufferRanges(const CoreChecks& validator, vvl::span<vvl::Buffer* const> buffers) {
     std::ostringstream ss;
     for (const auto& buffer : buffers) {
-        ss << "  " << validator.FormatHandle(buffer->Handle()) << " : size " << buffer->create_info.size << " : range "
-           << string_range_hex(buffer->DeviceAddressRange()) << '\n';
+        ss << "  " << buffer->Describe(validator) << '\n';
     }
     return ss.str();
 }

--- a/layers/state_tracker/buffer_state.cpp
+++ b/layers/state_tracker/buffer_state.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (C) 2015-2024 Google Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (C) 2015-2026 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -122,6 +122,13 @@ bool Buffer::CompareCreateInfo(const Buffer &other) const {
     return (create_info.flags == other.create_info.flags) && (create_info.size == other.create_info.size) &&
            (usage == other.usage) && (create_info.sharingMode == other.create_info.sharingMode) && valid_external &&
            valid_queue_family;
+}
+
+std::string Buffer::Describe(const Logger& dev_data) const {
+    std::stringstream ss;
+    ss << dev_data.FormatHandle(Handle()) << ", size " << std::to_string(create_info.size) << ", range "
+       << string_range_hex(DeviceAddressRange());
+    return ss.str();
 }
 
 BufferView::BufferView(const std::shared_ptr<vvl::Buffer> &bf, VkBufferView handle, const VkBufferViewCreateInfo *pCreateInfo,

--- a/layers/state_tracker/buffer_state.h
+++ b/layers/state_tracker/buffer_state.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (C) 2015-2024 Google Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (C) 2015-2026 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -77,6 +77,9 @@ class Buffer : public Bindable, public SubStateManager<BufferSubState> {
 
     // This function is only used for comparing Imported External Dedicated Memory
     bool CompareCreateInfo(const Buffer &other) const;
+
+    // Used to help unify the way we print the BDA info
+    std::string Describe(const Logger& dev_data) const;
 
   private:
     std::variant<std::monostate, BindableLinearMemoryTracker, BindableSparseMemoryTracker> tracker_;


### PR DESCRIPTION
follow on for https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/11509 I have for the new extension as well

Adds a `Buffer::Describe()` to unify how we print out buffers