### PR TITLE
docs: Update syncval limitations

### DIFF
--- a/docs/syncval_usage.md
+++ b/docs/syncval_usage.md
@@ -1,5 +1,5 @@
 <!-- markdownlint-disable MD041 -->
-<!-- Copyright 2015-2025 LunarG, Inc. -->
+<!-- Copyright 2015-2026 LunarG, Inc. -->
 [![Khronos Vulkan][1]][2]
 
 [1]: https://vulkan.lunarg.com/img/Vulkan_100px_Dec16.png "https://www.khronos.org/vulkan/"
@@ -125,14 +125,13 @@ The pipelined and multi-threaded nature of Vulkan makes it particularly importan
 ### Known Limitations
 - Does not support precise tracking of descriptors accessed by the shader (requires integration with GPU-AV). This includes both classic VkDescriptorSet and VK_EXT_descriptor_buffer APIs
 - Hazards related to memory aliasing are not detected properly
-- Indirectly accessed (indirect/indexed) buffers validated at *binding* granularity. (Every valid location assumed to be accessed.)
-- Queue family ownership transfer not supported
-- Host set event not supported.
-- No dedicated support for sparse resources. Need to investigate which kind of support is needed.
-- Host memory accesses are not tracked. Corresponding race conditions are not reported.
-- Does not include implementation of multi-view renderpass support.
-- Memory access checks not suppressed for VK_CULL_MODE_FRONT_AND_BACK.
-- Does not include component granularity access tracking, or correctly support swizzling.
+- Indirectly accessed buffers (indirect data/indexed vertex data) are not validated
+- Host set event not supported
+- No dedicated support for sparse resources. Need to investigate which kind of support is needed
+- Host memory accesses are not tracked. Corresponding race conditions are not reported
+- Does not include implementation of multi-view renderpass support
+- Memory access checks not suppressed for VK_CULL_MODE_FRONT_AND_BACK
+- Does not include component granularity access tracking, or correctly support swizzling
 
 ## Typical Synchronization Validation Usage
 


### PR DESCRIPTION
Remove QFOT not supported. From now on, any QFOT related issue must be fixed.
Clarified indirect/indexed-vertex-data buffers are not validated.