### PR TITLE
layers: Cleanup of push constants

### DIFF
--- a/layers/core_checks/cc_vuid_maps.cpp
+++ b/layers/core_checks/cc_vuid_maps.cpp
@@ -719,6 +719,22 @@ const char *GetSpirvInterfaceVariableVUID(const Location &loc, SpirvInterfaceVar
                 loc.function == Func::vkCreateRayTracingPipelinesNV  ? "VUID-VkRayTracingPipelineCreateInfoNV-flags-11312" :
                 loc.function == Func::vkCreateShadersEXT ? "VUID-VkShaderCreateInfoEXT-flags-11292" :
                 kVUIDUndefined;
+        case SpirvInterfaceVariableError::PushConstantStage_07987:
+            return
+                loc.function == Func::vkCreateGraphicsPipelines ? "VUID-VkGraphicsPipelineCreateInfo-layout-07987" :
+                loc.function == Func::vkCreateComputePipelines  ? "VUID-VkComputePipelineCreateInfo-layout-07987" :
+                loc.function == Func::vkCreateRayTracingPipelinesKHR ? "VUID-VkRayTracingPipelineCreateInfoKHR-layout-07987" :
+                loc.function == Func::vkCreateRayTracingPipelinesNV  ? "VUID-VkRayTracingPipelineCreateInfoNV-layout-07987" :
+                loc.function == Func::vkCreateShadersEXT ? "VUID-VkShaderCreateInfoEXT-codeType-10064" :
+                kVUIDUndefined;
+        case SpirvInterfaceVariableError::PushConstantRange_10069:
+            return
+                loc.function == Func::vkCreateGraphicsPipelines ? "VUID-VkGraphicsPipelineCreateInfo-layout-10069" :
+                loc.function == Func::vkCreateComputePipelines  ? "VUID-VkComputePipelineCreateInfo-layout-10069" :
+                loc.function == Func::vkCreateRayTracingPipelinesKHR ? "VUID-VkRayTracingPipelineCreateInfoKHR-layout-10069" :
+                loc.function == Func::vkCreateRayTracingPipelinesNV  ? "VUID-VkRayTracingPipelineCreateInfoNV-layout-10069" :
+                loc.function == Func::vkCreateShadersEXT ? "VUID-VkShaderCreateInfoEXT-codeType-10065" :
+                kVUIDUndefined;
     }
     return "UNASSIGNED-CoreChecks-unhandled-pipeline-interface-variable";
     // clang-format on

--- a/layers/core_checks/cc_vuid_maps.h
+++ b/layers/core_checks/cc_vuid_maps.h
@@ -116,6 +116,8 @@ enum class SpirvInterfaceVariableError {
     DescriptorCount_07991,
     Inline_10391,
     DescriptorHeapMapping_11312,
+    PushConstantStage_07987,
+    PushConstantRange_10069,
 };
 const char *GetSpirvInterfaceVariableVUID(const Location &loc, SpirvInterfaceVariableError error);
 

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -563,6 +563,7 @@ struct EntryPoint {
     const vvl::unordered_set<uint32_t> accessible_ids;
 
     // only one Push Constant block is allowed per entry point
+    // (This assumption is broken with VK_NV_push_constant_bank, but not fully supported)
     std::shared_ptr<const PushConstantVariable> push_constant_variable;
     // For both Task and Mesh entry point, there can be one TaskPayloadWorkgroupEXT variable
     std::shared_ptr<const TaskPayloadVariable> task_payload_variable;

--- a/tests/unit/shader_object.cpp
+++ b/tests/unit/shader_object.cpp
@@ -5570,10 +5570,6 @@ TEST_F(NegativeShaderObject, CooperativeMatrix) {
         GTEST_SKIP() << "local_size_x (32) is not a multiple of subgroupSize";
     }
 
-    std::vector<VkDescriptorSetLayoutBinding> bindings(0);
-    const vkt::DescriptorSetLayout dsl(*m_device, bindings);
-    const vkt::PipelineLayout pl(*m_device, {&dsl});
-
     // Tests are assume that Float16 3*5 is not available
     const char* comp_src = R"glsl(
         #version 450

--- a/tests/unit/subgroups.cpp
+++ b/tests/unit/subgroups.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -275,10 +275,6 @@ TEST_F(NegativeSubgroup, ExtendedTypesDisabled) {
         !(subgroup_prop.supportedStages & VK_SHADER_STAGE_COMPUTE_BIT)) {
         GTEST_SKIP() << "Required features not supported";
     }
-
-    std::vector<VkDescriptorSetLayoutBinding> bindings(0);
-    const vkt::DescriptorSetLayout dsl(*m_device, bindings);
-    const vkt::PipelineLayout pl(*m_device, {&dsl});
 
     const char *csSource = R"glsl(
         #version 450


### PR DESCRIPTION
1. Confirms `VK_EXT_shader_subgroup_partitioned` and `VK_NV_push_constant_bank` "just work" currently
2. The Push Constant error message were a bit non-nice, but was waiting for the Descriptor Heap logic to get merged in first