### PR TITLE
layers: Fix AS VertexFormat for packed format

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1813,6 +1813,8 @@ class CoreChecks : public vvl::DeviceProxy {
     bool PreCallValidateGetAccelerationStructureDeviceAddressKHR(VkDevice device,
                                                                  const VkAccelerationStructureDeviceAddressInfoKHR* pInfo,
                                                                  const ErrorObject& error_obj) const override;
+    bool ValidateAccelerationVertex(VkFormat vertex_format, VkDeviceOrHostAddressConstKHR vertex_data, VkDeviceSize vertex_stride,
+                                    const LogObjectList& objlist, const Location& loc) const;
     // Validate buffers accessed using a device address
     bool ValidateAccelerationBuffers(VkCommandBuffer cmd_buffer, uint32_t info_i,
                                      const VkAccelerationStructureBuildGeometryInfoKHR& info,

--- a/tests/unit/ray_tracing_spheres.cpp
+++ b/tests/unit/ray_tracing_spheres.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -99,7 +99,6 @@ TEST_F(NegativeRayTracingSpheres, SpheresInvalidVertexFormat) {
     auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device, vkt::as::GeometryKHR::Type::Spheres);
     blas.GetGeometries()[0].SetSpheresVertexFormat(spheres_vertex_format);
 
-    m_errorMonitor->SetDesiredError("VUID-VkAccelerationStructureGeometrySpheresDataNV-vertexFormat-10434");
     m_errorMonitor->SetDesiredError("VUID-VkAccelerationStructureGeometrySpheresDataNV-vertexFormat-10434");
     blas.BuildCmdBuffer(m_command_buffer);
     m_errorMonitor->VerifyFound();


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11533

Spheres had this correct, the spec was wrong from KHR, getting fixed, this unifies the check as well