### PR TITLE
layers: VUs 9774, 9779 removed; 9850, 9851 modified

### DIFF
--- a/layers/core_checks/cc_data_graph.cpp
+++ b/layers/core_checks/cc_data_graph.cpp
@@ -94,15 +94,6 @@ bool CoreChecks::ValidateDataGraphPipelineCreateInfo(VkDevice device, const VkDa
         }
     }
 
-    for (uint32_t j = 0; j < create_info.resourceInfoCount; j++) {
-        auto resource = create_info.pResourceInfos[j];
-        if (resource.arrayElement != 0) {
-            skip |= LogError("VUID-VkDataGraphPipelineResourceInfoARM-arrayElement-09779", device,
-                             create_info_loc.dot(Field::pResourceInfos, j).dot(Field::arrayElement), "(%" PRIu32 ") is not zero",
-                             resource.arrayElement);
-        }
-    }
-
     return skip;
 }
 


### PR DESCRIPTION
- reflects specs modifications to avoid overlapping rules:
  - 9921 supersedes 9774 and parts of 9850 (constants)
  - 9923 supersedes 9779 and parts of 9851 (resources)

closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11541