### PR TITLE
layers: Fix TexelBufferAlignment

### DIFF
--- a/layers/core_checks/cc_buffer.cpp
+++ b/layers/core_checks/cc_buffer.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (C) 2015-2024 Google Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (C) 2015-2026 Google Inc.
  * Modifications Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -320,7 +320,10 @@ bool CoreChecks::PreCallValidateCreateBufferView(VkDevice device, const VkBuffer
             }
         }
     } else if (!IsIntegerMultipleOf(pCreateInfo->offset, phys_dev_props.limits.minTexelBufferOffsetAlignment)) {
-        skip |= LogError("VUID-VkBufferViewCreateInfo-offset-02749", pCreateInfo->buffer, create_info_loc.dot(Field::offset),
+        const char* vuid = (buffer_state.usage & VK_BUFFER_USAGE_2_STORAGE_TEXEL_BUFFER_BIT)
+                               ? " VUID-VkBufferViewCreateInfo-buffer-02750"
+                               : " VUID-VkBufferViewCreateInfo-buffer-02751";
+        skip |= LogError(vuid, pCreateInfo->buffer, create_info_loc.dot(Field::offset),
                          "(%" PRIuLEAST64
                          ") must be a multiple of VkPhysicalDeviceLimits::minTexelBufferOffsetAlignment (%" PRIuLEAST64 ").",
                          pCreateInfo->offset, phys_dev_props.limits.minTexelBufferOffsetAlignment);

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -3165,13 +3165,13 @@ bool CoreChecks::ValidateDescriptorAddressInfoEXT(const VkDescriptorAddressInfoE
     } else if (address_loc.field == Field::pUniformTexelBuffer) {
         buffer_usage = VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT;
         usage_vuid = "VUID-VkDescriptorGetInfoEXT-type-12222";
-        limit_vuid = "VUID-VkDescriptorGetInfoEXT-type-12267";
+        limit_vuid = "VUID-VkDescriptorGetInfoEXT-type-12269";
         limit_field = Field::minTexelBufferOffsetAlignment;
         limit_value = phys_dev_props.limits.minTexelBufferOffsetAlignment;
     } else if (address_loc.field == Field::pStorageTexelBuffer) {
         buffer_usage = VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT;
         usage_vuid = "VUID-VkDescriptorGetInfoEXT-type-12223";
-        limit_vuid = "VUID-VkDescriptorGetInfoEXT-type-12268";
+        limit_vuid = "VUID-VkDescriptorGetInfoEXT-type-12270";
         limit_field = Field::minTexelBufferOffsetAlignment;
         limit_value = phys_dev_props.limits.minTexelBufferOffsetAlignment;
     }

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -927,6 +927,9 @@ class Device : public vvl::base::Device {
                                                               const ErrorObject &error_obj) const override;
 #endif
 
+    bool ValidateHeapTexelBufferAlignment(const VkTexelBufferDescriptorInfoEXT& info, const VkDescriptorType type,
+                                          const Location& loc) const;
+
     bool manual_PreCallValidateWriteResourceDescriptorsEXT(VkDevice device, uint32_t resourceCount,
                                                            const VkResourceDescriptorInfoEXT* pResources,
                                                            const VkHostAddressRangeEXT* pDescriptors, const Context& context) const;

--- a/tests/unit/buffer.cpp
+++ b/tests/unit/buffer.cpp
@@ -147,8 +147,8 @@ TEST_F(NegativeBuffer, BufferViewCreateInfoEntries) {
     TEST_DESCRIPTION("Attempt to create a buffer view with invalid create info.");
     RETURN_IF_SKIP(Init());
     const VkPhysicalDeviceLimits &dev_limits = m_device->Physical().limits_;
-    const VkDeviceSize minTexelBufferOffsetAlignment = dev_limits.minTexelBufferOffsetAlignment;
-    if (minTexelBufferOffsetAlignment == 1) {
+    const VkDeviceSize min_alignment = dev_limits.minTexelBufferOffsetAlignment;
+    if (min_alignment == 1) {
         GTEST_SKIP() << "Test requires minTexelOffsetAlignment to not be equal to 1";
     }
 
@@ -176,11 +176,11 @@ TEST_F(NegativeBuffer, BufferViewCreateInfoEntries) {
     CreateBufferViewTest(buff_view_ci, "VUID-VkBufferViewCreateInfo-offset-00925");
 
     // Offset must be a multiple of VkPhysicalDeviceLimits::minTexelBufferOffsetAlignment so add 1 to ensure it is not
-    buff_view_ci.offset = minTexelBufferOffsetAlignment + 1;
-    CreateBufferViewTest(buff_view_ci, "VUID-VkBufferViewCreateInfo-offset-02749");
+    buff_view_ci.offset = min_alignment + 1;
+    CreateBufferViewTest(buff_view_ci, "VUID-VkBufferViewCreateInfo-buffer-02751");
 
     // Set offset to acceptable value for range tests
-    buff_view_ci.offset = minTexelBufferOffsetAlignment;
+    buff_view_ci.offset = min_alignment;
     // Setting range equal to 0 will cause an error to occur
     buff_view_ci.range = 0;
     CreateBufferViewTest(buff_view_ci, "VUID-VkBufferViewCreateInfo-range-00928");
@@ -195,7 +195,7 @@ TEST_F(NegativeBuffer, BufferViewCreateInfoEntries) {
     buff_view_ci.range = 2 * static_cast<VkDeviceSize>(format_size) * static_cast<VkDeviceSize>(dev_limits.maxTexelBufferElements);
     CreateBufferViewTest(buff_view_ci, "VUID-VkBufferViewCreateInfo-range-00930");
 
-    buff_view_ci.offset = minTexelBufferOffsetAlignment;
+    buff_view_ci.offset = min_alignment;
     buff_view_ci.range = buffer_size;
     CreateBufferViewTest(buff_view_ci, "VUID-VkBufferViewCreateInfo-offset-00931");
 }
@@ -221,8 +221,8 @@ TEST_F(NegativeBuffer, BufferViewCreateInfoFeatures) {
     RETURN_IF_SKIP(Init());
 
     const VkPhysicalDeviceLimits &dev_limits = m_device->Physical().limits_;
-    const VkDeviceSize minTexelBufferOffsetAlignment = dev_limits.minTexelBufferOffsetAlignment;
-    if (minTexelBufferOffsetAlignment == 1) {
+    const VkDeviceSize min_alignment = dev_limits.minTexelBufferOffsetAlignment;
+    if (min_alignment == 1) {
         GTEST_SKIP() << "Test requires minTexelOffsetAlignment to not be equal to 1";
     }
 
@@ -293,8 +293,8 @@ TEST_F(NegativeBuffer, TexelBufferAlignmentIn12) {
         GTEST_SKIP() << "Vulkan version 1.2 or less is required";
     }
 
-    const VkDeviceSize minTexelBufferOffsetAlignment = m_device->Physical().limits_.minTexelBufferOffsetAlignment;
-    if (minTexelBufferOffsetAlignment == 1) {
+    const VkDeviceSize min_alignment = m_device->Physical().limits_.minTexelBufferOffsetAlignment;
+    if (min_alignment == 1) {
         GTEST_SKIP() << "Test requires minTexelOffsetAlignment to not be equal to 1";
     }
     if (!BufferFormatAndFeaturesSupported(Gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT)) {
@@ -307,8 +307,8 @@ TEST_F(NegativeBuffer, TexelBufferAlignmentIn12) {
     buff_view_ci.format = VK_FORMAT_R8G8B8A8_UNORM;
     buff_view_ci.range = VK_WHOLE_SIZE;
     buff_view_ci.buffer = buffer;
-    buff_view_ci.offset = minTexelBufferOffsetAlignment + 1;
-    CreateBufferViewTest(buff_view_ci, "VUID-VkBufferViewCreateInfo-offset-02749");
+    buff_view_ci.offset = min_alignment + 1;
+    CreateBufferViewTest(buff_view_ci, "VUID-VkBufferViewCreateInfo-buffer-02751");
 }
 
 TEST_F(NegativeBuffer, TexelBufferAlignment) {

--- a/tests/unit/descriptor_buffer.cpp
+++ b/tests/unit/descriptor_buffer.cpp
@@ -2158,7 +2158,7 @@ TEST_F(NegativeDescriptorBuffer, GetDescriptorAlignment) {
         vkt::DescriptorGetInfo get_info_u(VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, u_buffer, 4, VK_FORMAT_R32_UINT);
         get_info_u.address_info.address += 1;
 
-        m_errorMonitor->SetDesiredError("VUID-VkDescriptorGetInfoEXT-type-12267");
+        m_errorMonitor->SetDesiredError("VUID-VkDescriptorGetInfoEXT-type-12269");
         vk::GetDescriptorEXT(device(), get_info_u, descriptor_buffer_properties.uniformTexelBufferDescriptorSize, host_descriptor);
         m_errorMonitor->VerifyFound();
 
@@ -2166,7 +2166,7 @@ TEST_F(NegativeDescriptorBuffer, GetDescriptorAlignment) {
         vkt::DescriptorGetInfo get_info_s(VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, s_buffer, 4, VK_FORMAT_R32_UINT);
         get_info_s.address_info.address += 1;
 
-        m_errorMonitor->SetDesiredError("VUID-VkDescriptorGetInfoEXT-type-12268");
+        m_errorMonitor->SetDesiredError("VUID-VkDescriptorGetInfoEXT-type-12270");
         vk::GetDescriptorEXT(device(), get_info_s, descriptor_buffer_properties.storageTexelBufferDescriptorSize, host_descriptor);
         m_errorMonitor->VerifyFound();
     }

--- a/tests/unit/descriptor_heap.cpp
+++ b/tests/unit/descriptor_heap.cpp
@@ -637,24 +637,12 @@ TEST_F(NegativeDescriptorHeap, ResourceParameterUniformAlign) {
     desc_info.data.pAddressRange = &invalid_device_address_range;
     VkHostAddressRangeEXT descriptors = {data.data(), static_cast<size_t>(size)};
 
-    {
-        // Address alignment check
-        invalid_device_address_range.address = buffer.Address() + 1;
-        invalid_device_address_range.size = align;
+    invalid_device_address_range.address = buffer.Address() + 1;
+    invalid_device_address_range.size = align;
 
-        m_errorMonitor->SetDesiredError("VUID-VkResourceDescriptorInfoEXT-type-11452");
-        vk::WriteResourceDescriptorsEXT(device(), 1u, &desc_info, &descriptors);
-        m_errorMonitor->VerifyFound();
-    }
-    {
-        // Size alignment check
-        invalid_device_address_range.address = buffer.Address();
-        invalid_device_address_range.size = align + 1;
-
-        m_errorMonitor->SetDesiredError("VUID-VkResourceDescriptorInfoEXT-type-11452");
-        vk::WriteResourceDescriptorsEXT(device(), 1u, &desc_info, &descriptors);
-        m_errorMonitor->VerifyFound();
-    }
+    m_errorMonitor->SetDesiredError("VUID-VkResourceDescriptorInfoEXT-type-11452");
+    vk::WriteResourceDescriptorsEXT(device(), 1u, &desc_info, &descriptors);
+    m_errorMonitor->VerifyFound();
 }
 
 TEST_F(NegativeDescriptorHeap, ResourceParameterStorageAlign) {
@@ -665,7 +653,6 @@ TEST_F(NegativeDescriptorHeap, ResourceParameterStorageAlign) {
 
     const VkDeviceSize align = m_device->Physical().limits_.minStorageBufferOffsetAlignment;
     const VkDeviceSize bdsize = heap_props.bufferDescriptorSize;
-    const auto type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
 
     EXPECT_GT(align, 0u);
     if (align == 1) {
@@ -674,33 +661,21 @@ TEST_F(NegativeDescriptorHeap, ResourceParameterStorageAlign) {
 
     vkt::Buffer buffer(*m_device, 2 * std::max(align, bdsize), VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
 
-    const VkDeviceSize size = vk::GetPhysicalDeviceDescriptorSizeEXT(Gpu(), type);
+    const VkDeviceSize size = vk::GetPhysicalDeviceDescriptorSizeEXT(Gpu(), VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     std::vector<uint8_t> data(static_cast<size_t>(size));
 
     VkDeviceAddressRangeEXT invalid_device_address_range = {0, 0};
     VkResourceDescriptorInfoEXT desc_info = vku::InitStructHelper();
-    desc_info.type = type;
+    desc_info.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
     desc_info.data.pAddressRange = &invalid_device_address_range;
     VkHostAddressRangeEXT descriptors = {data.data(), static_cast<size_t>(size)};
 
-    {
-        // Address alignment check
-        invalid_device_address_range.address = buffer.Address() + 1;
-        invalid_device_address_range.size = align;
+    invalid_device_address_range.address = buffer.Address() + 1;
+    invalid_device_address_range.size = align;
 
-        m_errorMonitor->SetDesiredError("VUID-VkResourceDescriptorInfoEXT-type-11453");
-        vk::WriteResourceDescriptorsEXT(device(), 1u, &desc_info, &descriptors);
-        m_errorMonitor->VerifyFound();
-    }
-    {
-        // Size alignment check
-        invalid_device_address_range.address = buffer.Address();
-        invalid_device_address_range.size = align + 1;
-
-        m_errorMonitor->SetDesiredError("VUID-VkResourceDescriptorInfoEXT-type-11453");
-        vk::WriteResourceDescriptorsEXT(device(), 1u, &desc_info, &descriptors);
-        m_errorMonitor->VerifyFound();
-    }
+    m_errorMonitor->SetDesiredError("VUID-VkResourceDescriptorInfoEXT-type-11453");
+    vk::WriteResourceDescriptorsEXT(device(), 1u, &desc_info, &descriptors);
+    m_errorMonitor->VerifyFound();
 }
 
 TEST_F(NegativeDescriptorHeap, ResourceParameterAccelerationStructureAlign) {
@@ -713,17 +688,16 @@ TEST_F(NegativeDescriptorHeap, ResourceParameterAccelerationStructureAlign) {
 
     const VkDeviceSize align = 256;
     const VkDeviceSize bdsize = heap_props.bufferDescriptorSize;
-    const auto type = VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR;
 
     vkt::Buffer buffer(*m_device, 2 * std::max(align, bdsize), VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR,
                        vkt::device_address);
 
-    const VkDeviceSize size = vk::GetPhysicalDeviceDescriptorSizeEXT(Gpu(), type);
+    const VkDeviceSize size = vk::GetPhysicalDeviceDescriptorSizeEXT(Gpu(), VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR);
     std::vector<uint8_t> data(static_cast<size_t>(size));
 
     VkDeviceAddressRangeEXT invalid_device_address_range = {0, 0};
     VkResourceDescriptorInfoEXT desc_info = vku::InitStructHelper();
-    desc_info.type = type;
+    desc_info.type = VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR;
     desc_info.data.pAddressRange = &invalid_device_address_range;
     VkHostAddressRangeEXT descriptors = {data.data(), static_cast<size_t>(size)};
 
@@ -780,24 +754,12 @@ TEST_F(NegativeDescriptorHeap, UniformTexelBufferOffsetSingleTexelAlignmentFalse
     auto data = std::vector<uint8_t>(static_cast<size_t>(bdsize));
     VkHostAddressRangeEXT descriptors = {&data[0], data.size()};
 
-    {
-        // Address alignment check
-        texel_buffer_info.addressRange.address = buffer.Address() + 1;
-        texel_buffer_info.addressRange.size = align;
+    texel_buffer_info.addressRange.address = buffer.Address() + 1;
+    texel_buffer_info.addressRange.size = align;
 
-        m_errorMonitor->SetDesiredError("VUID-VkResourceDescriptorInfoEXT-type-11214");
-        vk::WriteResourceDescriptorsEXT(device(), 1u, &desc_info, &descriptors);
-        m_errorMonitor->VerifyFound();
-    }
-    {
-        // Size alignment check
-        texel_buffer_info.addressRange.address = buffer.Address();
-        texel_buffer_info.addressRange.size = align + 1;
-
-        m_errorMonitor->SetDesiredError("VUID-VkResourceDescriptorInfoEXT-type-11214");
-        vk::WriteResourceDescriptorsEXT(device(), 1u, &desc_info, &descriptors);
-        m_errorMonitor->VerifyFound();
-    }
+    m_errorMonitor->SetDesiredError("VUID-VkResourceDescriptorInfoEXT-type-11214");
+    vk::WriteResourceDescriptorsEXT(device(), 1u, &desc_info, &descriptors);
+    m_errorMonitor->VerifyFound();
 }
 
 TEST_F(NegativeDescriptorHeap, UniformTexelBufferOffsetSingleTexelAlignmentTrue) {
@@ -835,24 +797,12 @@ TEST_F(NegativeDescriptorHeap, UniformTexelBufferOffsetSingleTexelAlignmentTrue)
     auto data = std::vector<uint8_t>(static_cast<size_t>(bdsize));
     VkHostAddressRangeEXT descriptors = {&data[0], data.size()};
 
-    {
-        // Address alignment check
-        texel_buffer_info.addressRange.address = buffer.Address() + 1;
-        texel_buffer_info.addressRange.size = align;
+    texel_buffer_info.addressRange.address = buffer.Address() + 1;
+    texel_buffer_info.addressRange.size = align;
 
-        m_errorMonitor->SetDesiredError("VUID-VkResourceDescriptorInfoEXT-type-11216");
-        vk::WriteResourceDescriptorsEXT(device(), 1u, &desc_info, &descriptors);
-        m_errorMonitor->VerifyFound();
-    }
-    {
-        // Size alignment check
-        texel_buffer_info.addressRange.address = buffer.Address();
-        texel_buffer_info.addressRange.size = align + 1;
-
-        m_errorMonitor->SetDesiredError("VUID-VkResourceDescriptorInfoEXT-type-11216");
-        vk::WriteResourceDescriptorsEXT(device(), 1u, &desc_info, &descriptors);
-        m_errorMonitor->VerifyFound();
-    }
+    m_errorMonitor->SetDesiredError("VUID-VkResourceDescriptorInfoEXT-type-11214");
+    vk::WriteResourceDescriptorsEXT(device(), 1u, &desc_info, &descriptors);
+    m_errorMonitor->VerifyFound();
 }
 
 TEST_F(NegativeDescriptorHeap, StorageTexelBufferOffsetSingleTexelAlignmentFalse) {
@@ -868,7 +818,6 @@ TEST_F(NegativeDescriptorHeap, StorageTexelBufferOffsetSingleTexelAlignmentFalse
         GTEST_SKIP() << "storageTexelBufferOffsetSingleTexelAlignment required to be VK_FALSE";
     }
 
-    const VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
     const VkDeviceSize align = align_props.storageTexelBufferOffsetAlignmentBytes;
     const VkDeviceSize bdsize = heap_props.bufferDescriptorSize;
 
@@ -880,7 +829,7 @@ TEST_F(NegativeDescriptorHeap, StorageTexelBufferOffsetSingleTexelAlignmentFalse
     vkt::Buffer buffer(*m_device, 2 * std::max(align, bdsize), VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT, vkt::device_address);
 
     VkTexelBufferDescriptorInfoEXT texel_buffer_info = vku::InitStructHelper();
-    texel_buffer_info.format = format;
+    texel_buffer_info.format = VK_FORMAT_R8G8B8A8_UNORM;
 
     VkResourceDescriptorInfoEXT desc_info = vku::InitStructHelper();
     desc_info.type = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
@@ -889,24 +838,12 @@ TEST_F(NegativeDescriptorHeap, StorageTexelBufferOffsetSingleTexelAlignmentFalse
     auto data = std::vector<uint8_t>(static_cast<size_t>(bdsize));
     VkHostAddressRangeEXT descriptors = {&data[0], data.size()};
 
-    {
-        // Address alignment check
-        texel_buffer_info.addressRange.address = buffer.Address() + 1;
-        texel_buffer_info.addressRange.size = align;
+    texel_buffer_info.addressRange.address = buffer.Address() + 1;
+    texel_buffer_info.addressRange.size = align;
 
-        m_errorMonitor->SetDesiredError("VUID-VkResourceDescriptorInfoEXT-type-11215");
-        vk::WriteResourceDescriptorsEXT(device(), 1u, &desc_info, &descriptors);
-        m_errorMonitor->VerifyFound();
-    }
-    {
-        // Size alignment check
-        texel_buffer_info.addressRange.address = buffer.Address();
-        texel_buffer_info.addressRange.size = align + 1;
-
-        m_errorMonitor->SetDesiredError("VUID-VkResourceDescriptorInfoEXT-type-11215");
-        vk::WriteResourceDescriptorsEXT(device(), 1u, &desc_info, &descriptors);
-        m_errorMonitor->VerifyFound();
-    }
+    m_errorMonitor->SetDesiredError("VUID-VkResourceDescriptorInfoEXT-type-11215");
+    vk::WriteResourceDescriptorsEXT(device(), 1u, &desc_info, &descriptors);
+    m_errorMonitor->VerifyFound();
 }
 
 TEST_F(NegativeDescriptorHeap, StorageTexelBufferOffsetSingleTexelAlignmentTrue) {
@@ -944,24 +881,12 @@ TEST_F(NegativeDescriptorHeap, StorageTexelBufferOffsetSingleTexelAlignmentTrue)
     auto data = std::vector<uint8_t>(static_cast<size_t>(bdsize));
     VkHostAddressRangeEXT descriptors = {&data[0], data.size()};
 
-    {
-        // Address alignment check
-        texel_buffer_info.addressRange.address = buffer.Address() + 1;
-        texel_buffer_info.addressRange.size = align;
+    texel_buffer_info.addressRange.address = buffer.Address() + 1;
+    texel_buffer_info.addressRange.size = align;
 
-        m_errorMonitor->SetDesiredError("VUID-VkResourceDescriptorInfoEXT-type-11217");
-        vk::WriteResourceDescriptorsEXT(device(), 1u, &desc_info, &descriptors);
-        m_errorMonitor->VerifyFound();
-    }
-    {
-        // Size alignment check
-        texel_buffer_info.addressRange.address = buffer.Address();
-        texel_buffer_info.addressRange.size = align + 1;
-
-        m_errorMonitor->SetDesiredError("VUID-VkResourceDescriptorInfoEXT-type-11217");
-        vk::WriteResourceDescriptorsEXT(device(), 1u, &desc_info, &descriptors);
-        m_errorMonitor->VerifyFound();
-    }
+    m_errorMonitor->SetDesiredError("VUID-VkResourceDescriptorInfoEXT-type-11215");
+    vk::WriteResourceDescriptorsEXT(device(), 1u, &desc_info, &descriptors);
+    m_errorMonitor->VerifyFound();
 }
 
 TEST_F(NegativeDescriptorHeap, MinTexelBufferOffsetAlignment) {
@@ -975,7 +900,6 @@ TEST_F(NegativeDescriptorHeap, MinTexelBufferOffsetAlignment) {
 
     GetPhysicalDeviceProperties2(heap_props);
 
-    const VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
     const VkDeviceSize align = m_device->Physical().limits_.minTexelBufferOffsetAlignment;
     const VkDeviceSize bdsize = heap_props.bufferDescriptorSize;
 
@@ -987,7 +911,7 @@ TEST_F(NegativeDescriptorHeap, MinTexelBufferOffsetAlignment) {
     vkt::Buffer buffer(*m_device, 2 * std::max(align, bdsize), VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT, vkt::device_address);
 
     VkTexelBufferDescriptorInfoEXT texel_buffer_info = vku::InitStructHelper();
-    texel_buffer_info.format = format;
+    texel_buffer_info.format = VK_FORMAT_R8G8B8A8_UNORM;
 
     VkResourceDescriptorInfoEXT desc_info = vku::InitStructHelper();
     desc_info.type = VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
@@ -996,24 +920,12 @@ TEST_F(NegativeDescriptorHeap, MinTexelBufferOffsetAlignment) {
     auto data = std::vector<uint8_t>(static_cast<size_t>(bdsize));
     VkHostAddressRangeEXT descriptors = {&data[0], data.size()};
 
-    {
-        // Address alignment check
-        texel_buffer_info.addressRange.address = buffer.Address() + 1;
-        texel_buffer_info.addressRange.size = align;
+    texel_buffer_info.addressRange.address = buffer.Address() + 1;
+    texel_buffer_info.addressRange.size = align;
 
-        m_errorMonitor->SetDesiredError("VUID-VkTexelBufferDescriptorInfoEXT-None-11218");
-        vk::WriteResourceDescriptorsEXT(device(), 1u, &desc_info, &descriptors);
-        m_errorMonitor->VerifyFound();
-    }
-    {
-        // Size alignment check
-        texel_buffer_info.addressRange.address = buffer.Address();
-        texel_buffer_info.addressRange.size = align + 1;
-
-        m_errorMonitor->SetDesiredError("VUID-VkTexelBufferDescriptorInfoEXT-None-11218");
-        vk::WriteResourceDescriptorsEXT(device(), 1u, &desc_info, &descriptors);
-        m_errorMonitor->VerifyFound();
-    }
+    m_errorMonitor->SetDesiredError("VUID-VkTexelBufferDescriptorInfoEXT-None-11218");
+    vk::WriteResourceDescriptorsEXT(device(), 1u, &desc_info, &descriptors);
+    m_errorMonitor->VerifyFound();
 }
 
 TEST_F(NegativeDescriptorHeap, ResourceParameterYCbCr) {
@@ -1338,19 +1250,16 @@ TEST_F(NegativeDescriptorHeap, CmdBindSamplerHeapAlign) {
 
     vkt::Buffer heap(*m_device, heap_size, VK_BUFFER_USAGE_DESCRIPTOR_HEAP_BIT_EXT, vkt::device_address);
 
-    {
-        // Address alignment check
-        VkBindHeapInfoEXT bind_info = vku::InitStructHelper();
-        bind_info.heapRange = {heap.Address() + 1, heap_size - 1};
-        bind_info.reservedRangeOffset = 0;
-        bind_info.reservedRangeSize = heap_props.minSamplerHeapReservedRange;
+    VkBindHeapInfoEXT bind_info = vku::InitStructHelper();
+    bind_info.heapRange = {heap.Address() + 1, heap_size - 1};
+    bind_info.reservedRangeOffset = 0;
+    bind_info.reservedRangeSize = heap_props.minSamplerHeapReservedRange;
 
-        m_command_buffer.Begin();
-        m_errorMonitor->SetDesiredError("VUID-vkCmdBindSamplerHeapEXT-pBindInfo-11226");
-        vk::CmdBindSamplerHeapEXT(m_command_buffer, &bind_info);
-        m_errorMonitor->VerifyFound();
-        m_command_buffer.End();
-    }
+    m_command_buffer.Begin();
+    m_errorMonitor->SetDesiredError("VUID-vkCmdBindSamplerHeapEXT-pBindInfo-11226");
+    vk::CmdBindSamplerHeapEXT(m_command_buffer, &bind_info);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDescriptorHeap, CmdBindSamplerHeapReservedRangeAlign) {
@@ -1588,19 +1497,16 @@ TEST_F(NegativeDescriptorHeap, CmdBindResourceHeapAlign) {
     const VkDeviceSize heap_size = heap_props.minResourceHeapReservedRange * 2;
     vkt::Buffer heap(*m_device, heap_size, VK_BUFFER_USAGE_DESCRIPTOR_HEAP_BIT_EXT, vkt::device_address);
 
-    {
-        // Address alignment check
-        VkBindHeapInfoEXT bind_info = vku::InitStructHelper();
-        bind_info.heapRange = {heap.Address() + 1, heap_size - 1};
-        bind_info.reservedRangeOffset = 0;
-        bind_info.reservedRangeSize = heap_props.minResourceHeapReservedRange;
+    VkBindHeapInfoEXT bind_info = vku::InitStructHelper();
+    bind_info.heapRange = {heap.Address() + 1, heap_size - 1};
+    bind_info.reservedRangeOffset = 0;
+    bind_info.reservedRangeSize = heap_props.minResourceHeapReservedRange;
 
-        m_command_buffer.Begin();
-        m_errorMonitor->SetDesiredError("VUID-vkCmdBindResourceHeapEXT-pBindInfo-11235");
-        vk::CmdBindResourceHeapEXT(m_command_buffer, &bind_info);
-        m_errorMonitor->VerifyFound();
-        m_command_buffer.End();
-    }
+    m_command_buffer.Begin();
+    m_errorMonitor->SetDesiredError("VUID-vkCmdBindResourceHeapEXT-pBindInfo-11235");
+    vk::CmdBindResourceHeapEXT(m_command_buffer, &bind_info);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDescriptorHeap, CmdBindResourceHeapReservedRangeAlign) {


### PR DESCRIPTION
We approved https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/8019 today

1. It reduces the VUs for all descriptor (classic, buffer, heap) texel buffer, so new VUID will come out
2. we were calling `IsIntegerMultipleOf` on the `size` for heaps, which was wrong
3. For Heaps, it fixes what we had,  which was wrong, it now is like buffer/classic