### PR TITLE
layers: Remove RT alignment

### DIFF
--- a/layers/stateless/sl_descriptor.cpp
+++ b/layers/stateless/sl_descriptor.cpp
@@ -1662,11 +1662,6 @@ bool Device::manual_PreCallValidateWriteResourceDescriptorsEXT(VkDevice device, 
                                          data_loc.dot(Field::pAddressRange).dot(Field::address),
                                          "(0x%" PRIx64 ") is not aligned to 256", resource.data.pAddressRange->address);
                     }
-                    if (!IsIntegerMultipleOf(resource.data.pAddressRange->size, 256)) {
-                        skip |= LogError("VUID-VkResourceDescriptorInfoEXT-type-11454", device,
-                                         data_loc.dot(Field::pAddressRange).dot(Field::size),
-                                         "(%" PRIu64 ") must be a multiple of 256", resource.data.pAddressRange->size);
-                    }
                 }
             }
         } else {

--- a/tests/unit/descriptor_heap.cpp
+++ b/tests/unit/descriptor_heap.cpp
@@ -727,24 +727,12 @@ TEST_F(NegativeDescriptorHeap, ResourceParameterAccelerationStructureAlign) {
     desc_info.data.pAddressRange = &invalid_device_address_range;
     VkHostAddressRangeEXT descriptors = {data.data(), static_cast<size_t>(size)};
 
-    {
-        // Address alignment check
-        invalid_device_address_range.address = buffer.Address() + 1;
-        invalid_device_address_range.size = align;
+    invalid_device_address_range.address = buffer.Address() + 1;
+    invalid_device_address_range.size = align;
 
-        m_errorMonitor->SetDesiredError("VUID-VkResourceDescriptorInfoEXT-type-11454");
-        vk::WriteResourceDescriptorsEXT(device(), 1u, &desc_info, &descriptors);
-        m_errorMonitor->VerifyFound();
-    }
-    {
-        // Size alignment check
-        invalid_device_address_range.address = buffer.Address();
-        invalid_device_address_range.size = align + 1;
-
-        m_errorMonitor->SetDesiredError("VUID-VkResourceDescriptorInfoEXT-type-11454");
-        vk::WriteResourceDescriptorsEXT(device(), 1u, &desc_info, &descriptors);
-        m_errorMonitor->VerifyFound();
-    }
+    m_errorMonitor->SetDesiredError("VUID-VkResourceDescriptorInfoEXT-type-11454");
+    vk::WriteResourceDescriptorsEXT(device(), 1u, &desc_info, &descriptors);
+    m_errorMonitor->VerifyFound();
 }
 
 TEST_F(NegativeDescriptorHeap, UniformTexelBufferOffsetSingleTexelAlignmentFalse) {


### PR DESCRIPTION
From https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/8024

`VUID-VkResourceDescriptorInfoEXT-type-11454` was too strict