### PR TITLE
gpuav: Use underscore in long GLSL names

### DIFF
--- a/layers/gpuav/debug_printf/debug_printf.cpp
+++ b/layers/gpuav/debug_printf/debug_printf.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2020-2025 The Khronos Group Inc.
- * Copyright (c) 2020-2025 Valve Corporation
- * Copyright (c) 2020-2025 LunarG, Inc.
+/* Copyright (c) 2020-2026 The Khronos Group Inc.
+ * Copyright (c) 2020-2026 Valve Corporation
+ * Copyright (c) 2020-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -206,10 +206,10 @@ struct DebugPrintfCbState {
 
 void AnalyzeAndGenerateMessage(Validator &gpuav, VkCommandBuffer command_buffer, DebugPrintfBufferInfo &buffer_info,
                                uint32_t *const debug_output_buffer, const Location &loc) {
-    uint32_t output_buffer_dwords_counts = debug_output_buffer[gpuav::kDebugPrintfOutputBufferDWordsCount];
+    uint32_t output_buffer_dwords_counts = debug_output_buffer[gpuav::kDebugPrintf_OutputBuffer_DWordsCount];
     if (!output_buffer_dwords_counts) return;
 
-    uint32_t output_record_i = gpuav::kDebugPrintfOutputBufferData;  // get first OutputRecord index
+    uint32_t output_record_i = gpuav::kDebugPrintf_OutputBuffer_Data;  // get first OutputRecord index
     while (debug_output_buffer[output_record_i]) {
         std::ostringstream shader_message;
 
@@ -380,7 +380,7 @@ void AnalyzeAndGenerateMessage(Validator &gpuav, VkCommandBuffer command_buffer,
         }
         output_record_i += debug_record->size;
     }
-    if ((output_record_i - gpuav::kDebugPrintfOutputBufferData) < output_buffer_dwords_counts) {
+    if ((output_record_i - gpuav::kDebugPrintf_OutputBuffer_Data) < output_buffer_dwords_counts) {
         // Originally we had this to log a warning, but if using the default settings, warnings are hidden.
         // We report this information the same we report the "real" debug printf message so we know it is seen
         std::ostringstream message;
@@ -398,8 +398,8 @@ void AnalyzeAndGenerateMessage(Validator &gpuav, VkCommandBuffer command_buffer,
 
     // Only memset what is needed, in case we are only using a small portion of a large buffer_size.
     // At the same time we want to make sure we don't memset past the actual VkBuffer allocation
-    uint32_t clear_size =
-        sizeof(uint32_t) * (debug_output_buffer[gpuav::kDebugPrintfOutputBufferDWordsCount] + gpuav::kDebugPrintfOutputBufferData);
+    uint32_t clear_size = sizeof(uint32_t) * (debug_output_buffer[gpuav::kDebugPrintf_OutputBuffer_DWordsCount] +
+                                              gpuav::kDebugPrintf_OutputBuffer_Data);
     clear_size = std::min(gpuav.gpuav_settings.debug_printf_buffer_size, clear_size);
     memset(debug_output_buffer, 0, clear_size);
 }

--- a/layers/gpuav/instrumentation/buffer_device_address.cpp
+++ b/layers/gpuav/instrumentation/buffer_device_address.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2024-2025 LunarG, Inc.
+/* Copyright (c) 2024-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,24 +43,24 @@ void RegisterBufferDeviceAddressValidation(Validator& gpuav, CommandBufferSubSta
                                                                                  std::string& out_vuid_msg) {
             using namespace glsl;
             bool error_found = false;
-            if (GetErrorGroup(error_record) != kErrorGroupInstBufferDeviceAddress) {
+            if (GetErrorGroup(error_record) != kErrorGroup_InstBufferDeviceAddress) {
                 return error_found;
             }
             error_found = true;
 
             std::ostringstream strm;
 
-            const uint32_t payload = error_record[kInstLogErrorParameterOffset_2];
-            const bool is_write = ((payload >> kInstBuffAddrAccessPayloadShiftIsWrite) & 1) != 0;
-            const bool is_struct = ((payload >> kInstBuffAddrAccessPayloadShiftIsStruct) & 1) != 0;
+            const uint32_t payload = error_record[kInst_LogError_ParameterOffset_2];
+            const bool is_write = ((payload >> kInst_BuffAddrAccess_PayloadShiftIsWrite) & 1) != 0;
+            const bool is_struct = ((payload >> kInst_BuffAddrAccess_PayloadShiftIsStruct) & 1) != 0;
 
-            const uint64_t address = *reinterpret_cast<const uint64_t*>(error_record + kInstLogErrorParameterOffset_0);
+            const uint64_t address = *reinterpret_cast<const uint64_t*>(error_record + kInst_LogError_ParameterOffset_0);
 
             const uint32_t error_sub_code = GetSubError(error_record);
             switch (error_sub_code) {
-                case kErrorSubCodeBufferDeviceAddressUnallocRef: {
+                case kErrorSubCode_BufferDeviceAddress_UnallocRef: {
                     const char* access_type = is_write ? "written" : "read";
-                    const uint32_t byte_size = payload & kInstBuffAddrAccessPayloadMaskAccessInfo;
+                    const uint32_t byte_size = payload & kInst_BuffAddrAccess_PayloadMaskAccessInfo;
                     strm << "Out of bounds access: " << byte_size << " bytes " << access_type << " at buffer device address 0x"
                          << std::hex << address << '.';
                     if (is_struct) {
@@ -73,9 +73,9 @@ void RegisterBufferDeviceAddressValidation(Validator& gpuav, CommandBufferSubSta
                     out_vuid_msg = "VUID-RuntimeSpirv-PhysicalStorageBuffer64-11819";
 
                 } break;
-                case kErrorSubCodeBufferDeviceAddressAlignment: {
+                case kErrorSubCode_BufferDeviceAddress_Alignment: {
                     const char* access_type = is_write ? "OpStore" : "OpLoad";
-                    const uint32_t alignment = (payload & kInstBuffAddrAccessPayloadMaskAccessInfo);
+                    const uint32_t alignment = (payload & kInst_BuffAddrAccess_PayloadMaskAccessInfo);
                     strm << "Unaligned pointer access: The " << access_type << " at buffer device address 0x" << std::hex << address
                          << " is not aligned to the instruction Aligned operand of " << std::dec << alignment << '.';
                     out_vuid_msg = "VUID-RuntimeSpirv-PhysicalStorageBuffer64-06315";

--- a/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2020-2025 The Khronos Group Inc.
- * Copyright (c) 2020-2025 Valve Corporation
- * Copyright (c) 2020-2025 LunarG, Inc.
+/* Copyright (c) 2020-2026 The Khronos Group Inc.
+ * Copyright (c) 2020-2026 Valve Corporation
+ * Copyright (c) 2020-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -348,18 +348,19 @@ bool LogInstrumentationError(Validator &gpuav, const CommandBufferSubState &cb_s
         // Lookup the VkShaderModule handle and SPIR-V code used to create the shader, using the unique shader ID value returned
         // by the instrumented shader.
         const InstrumentedShader *instrumented_shader = nullptr;
-        const uint32_t shader_id = error_record[glsl::kHeaderShaderIdErrorOffset] & glsl::kShaderIdMask;
+        const uint32_t shader_id = error_record[glsl::kHeader_ShaderIdErrorOffset] & glsl::kShaderIdMask;
         auto it = gpuav.instrumented_shaders_map_.find(shader_id);
         if (it != gpuav.instrumented_shaders_map_.end()) {
             instrumented_shader = &it->second;
         }
 
-        const uint32_t stage_id = error_record[glsl::kHeaderStageInstructionIdOffset] >> glsl::kStageIdShift;
-        const uint32_t instruction_position_offset = error_record[glsl::kHeaderStageInstructionIdOffset] & glsl::kInstructionIdMask;
+        const uint32_t stage_id = error_record[glsl::kHeader_StageInstructionIdOffset] >> glsl::kStageId_Shift;
+        const uint32_t instruction_position_offset =
+            error_record[glsl::kHeader_StageInstructionIdOffset] & glsl::kInstructionId_Mask;
         GpuShaderInstrumentor::ShaderMessageInfo shader_info{stage_id,
-                                                             error_record[glsl::kHeaderStageInfoOffset_0],
-                                                             error_record[glsl::kHeaderStageInfoOffset_1],
-                                                             error_record[glsl::kHeaderStageInfoOffset_2],
+                                                             error_record[glsl::kHeader_StageInfoOffset_0],
+                                                             error_record[glsl::kHeader_StageInfoOffset_1],
+                                                             error_record[glsl::kHeader_StageInfoOffset_2],
                                                              instruction_position_offset,
                                                              shader_id};
         std::string debug_info_message = gpuav.GenerateDebugInfoMessage(

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2020-2025 The Khronos Group Inc.
- * Copyright (c) 2020-2025 Valve Corporation
- * Copyright (c) 2020-2025 LunarG, Inc.
+/* Copyright (c) 2020-2026 The Khronos Group Inc.
+ * Copyright (c) 2020-2026 Valve Corporation
+ * Copyright (c) 2020-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1491,7 +1491,7 @@ bool GpuShaderInstrumentor::InstrumentShader(const vvl::span<const uint32_t> &in
     if (unique_shader_id >= glsl::kMaxInstrumentedShaders) {
         InternalWarning(device, loc, "kMaxInstrumentedShaders limit has been hit, no shaders can be instrumented.");
         return false;
-    } else if ((input_spirv.size() * sizeof(uint32_t)) > (1 << glsl::kStageIdShift)) {
+    } else if ((input_spirv.size() * sizeof(uint32_t)) > (1 << glsl::kStageId_Shift)) {
         // If we are hitting this, will need to rethink limit (if someone hits this, please raise an issue!)
         InternalWarning(
             device, loc,
@@ -1700,28 +1700,28 @@ static std::string LookupDebugUtilsNameNoLock(const DebugReport *debug_report, c
 static void GenerateStageMessage(std::ostringstream &ss, const GpuShaderInstrumentor::ShaderMessageInfo &shader_info,
                                  const std::vector<uint32_t> &instructions) {
     switch (shader_info.stage_id) {
-        case glsl::kExecutionModelMultiEntryPoint: {
+        case glsl::kExecutionModel_MultiEntryPoint: {
             ss << "Stage has multiple OpEntryPoint (";
             ::spirv::GetExecutionModelNames(instructions, ss);
             ss << ") and could not detect stage. ";
         } break;
-        case glsl::kExecutionModelVertex: {
+        case glsl::kExecutionModel_Vertex: {
             ss << "Stage = Vertex. Vertex Index = " << shader_info.stage_info_0 << " Instance Index = " << shader_info.stage_info_1
                << ". ";
         } break;
-        case glsl::kExecutionModelTessellationControl: {
+        case glsl::kExecutionModel_TessellationControl: {
             ss << "Stage = Tessellation Control.  Invocation ID = " << shader_info.stage_info_0
                << ", Primitive ID = " << shader_info.stage_info_1;
         } break;
-        case glsl::kExecutionModelTessellationEvaluation: {
+        case glsl::kExecutionModel_TessellationEvaluation: {
             ss << "Stage = Tessellation Eval.  Primitive ID = " << shader_info.stage_info_0 << ", TessCoord (u, v) = ("
                << shader_info.stage_info_1 << ", " << shader_info.stage_info_2 << "). ";
         } break;
-        case glsl::kExecutionModelGeometry: {
+        case glsl::kExecutionModel_Geometry: {
             ss << "Stage = Geometry.  Primitive ID = " << shader_info.stage_info_0
                << " Invocation ID = " << shader_info.stage_info_1 << ". ";
         } break;
-        case glsl::kExecutionModelFragment: {
+        case glsl::kExecutionModel_Fragment: {
             // Should use std::bit_cast but requires c++20
             float x_coord;
             float y_coord;
@@ -1729,47 +1729,47 @@ static void GenerateStageMessage(std::ostringstream &ss, const GpuShaderInstrume
             std::memcpy(&y_coord, &shader_info.stage_info_1, sizeof(float));
             ss << "Stage = Fragment.  Fragment coord (x,y) = (" << x_coord << ", " << y_coord << "). ";
         } break;
-        case glsl::kExecutionModelGLCompute: {
+        case glsl::kExecutionModel_GLCompute: {
             ss << "Stage = Compute.  Global invocation ID (x, y, z) = (" << shader_info.stage_info_0 << ", "
                << shader_info.stage_info_1 << ", " << shader_info.stage_info_2 << ")";
         } break;
-        case glsl::kExecutionModelRayGenerationKHR: {
+        case glsl::kExecutionModel_RayGenerationKHR: {
             ss << "Stage = Ray Generation.  Global Launch ID (x,y,z) = (" << shader_info.stage_info_0 << ", "
                << shader_info.stage_info_1 << ", " << shader_info.stage_info_2 << "). ";
         } break;
-        case glsl::kExecutionModelIntersectionKHR: {
+        case glsl::kExecutionModel_IntersectionKHR: {
             ss << "Stage = Intersection.  Global Launch ID (x,y,z) = (" << shader_info.stage_info_0 << ", "
                << shader_info.stage_info_1 << ", " << shader_info.stage_info_2 << "). ";
         } break;
-        case glsl::kExecutionModelAnyHitKHR: {
+        case glsl::kExecutionModel_AnyHitKHR: {
             ss << "Stage = Any Hit.  Global Launch ID (x,y,z) = (" << shader_info.stage_info_0 << ", " << shader_info.stage_info_1
                << ", " << shader_info.stage_info_2 << "). ";
         } break;
-        case glsl::kExecutionModelClosestHitKHR: {
+        case glsl::kExecutionModel_ClosestHitKHR: {
             ss << "Stage = Closest Hit.  Global Launch ID (x,y,z) = (" << shader_info.stage_info_0 << ", "
                << shader_info.stage_info_1 << ", " << shader_info.stage_info_2 << "). ";
         } break;
-        case glsl::kExecutionModelMissKHR: {
+        case glsl::kExecutionModel_MissKHR: {
             ss << "Stage = Miss.  Global Launch ID (x,y,z) = (" << shader_info.stage_info_0 << ", " << shader_info.stage_info_1
                << ", " << shader_info.stage_info_2 << "). ";
         } break;
-        case glsl::kExecutionModelCallableKHR: {
+        case glsl::kExecutionModel_CallableKHR: {
             ss << "Stage = Callable.  Global Launch ID (x,y,z) = (" << shader_info.stage_info_0 << ", " << shader_info.stage_info_1
                << ", " << shader_info.stage_info_2 << "). ";
         } break;
-        case glsl::kExecutionModelTaskEXT: {
+        case glsl::kExecutionModel_TaskEXT: {
             ss << "Stage = TaskEXT. Global invocation ID (x, y, z) = (" << shader_info.stage_info_0 << ", "
                << shader_info.stage_info_1 << ", " << shader_info.stage_info_2 << ")";
         } break;
-        case glsl::kExecutionModelMeshEXT: {
+        case glsl::kExecutionModel_MeshEXT: {
             ss << "Stage = MeshEXT. Global invocation ID (x, y, z) = (" << shader_info.stage_info_0 << ", "
                << shader_info.stage_info_1 << ", " << shader_info.stage_info_2 << ")";
         } break;
-        case glsl::kExecutionModelTaskNV: {
+        case glsl::kExecutionModel_TaskNV: {
             ss << "Stage = TaskNV. Global invocation ID (x, y, z) = (" << shader_info.stage_info_0 << ", "
                << shader_info.stage_info_1 << ", " << shader_info.stage_info_2 << ")";
         } break;
-        case glsl::kExecutionModelMeshNV: {
+        case glsl::kExecutionModel_MeshNV: {
             ss << "Stage = MeshNV. Global invocation ID (x, y, z) = (" << shader_info.stage_info_0 << ", "
                << shader_info.stage_info_1 << ", " << shader_info.stage_info_2 << ")";
         } break;

--- a/layers/gpuav/instrumentation/mesh_shading.cpp
+++ b/layers/gpuav/instrumentation/mesh_shading.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2025 LunarG, Inc.
+/* Copyright (c) 2025-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ void RegisterMeshShadingValidation(Validator &gpuav, CommandBufferSubState &cb) 
                    std::string &out_vuid_msg) {
                     using namespace glsl;
                     bool error_found = false;
-                    if (GetErrorGroup(error_record) != kErrorGroupInstMeshShading) {
+                    if (GetErrorGroup(error_record) != kErrorGroup_InstMeshShading) {
                         return error_found;
                     }
                     error_found = true;
@@ -42,11 +42,11 @@ void RegisterMeshShadingValidation(Validator &gpuav, CommandBufferSubState &cb) 
                     const uint32_t error_sub_code = GetSubError(error_record);
                     switch (error_sub_code) {
                         case kErrorSubCode_MeshShading_SetMeshOutputs: {
-                            const uint32_t vertex_count = error_record[kInstLogErrorParameterOffset_0];
-                            const uint32_t primitive_count = error_record[kInstLogErrorParameterOffset_1];
-                            const uint32_t encoded_output = error_record[kInstLogErrorParameterOffset_2];
-                            const uint32_t output_vertices = encoded_output >> kMeshShadingOutputVerticesShift;
-                            const uint32_t output_primitive = encoded_output & kMeshShadingOutputPrimitivesMask;
+                            const uint32_t vertex_count = error_record[kInst_LogError_ParameterOffset_0];
+                            const uint32_t primitive_count = error_record[kInst_LogError_ParameterOffset_1];
+                            const uint32_t encoded_output = error_record[kInst_LogError_ParameterOffset_2];
+                            const uint32_t output_vertices = encoded_output >> kInst_MeshShading_OutputVerticesShift;
+                            const uint32_t output_primitive = encoded_output & kInst_MeshShading_OutputPrimitivesMask;
 
                             // We normally don't do "logic" to determine the VU, but in this case, its valuable to print both value,
                             // so we already have all the information and easier to select the VUID here than via the shader

--- a/layers/gpuav/instrumentation/ray_hit_object.cpp
+++ b/layers/gpuav/instrumentation/ray_hit_object.cpp
@@ -34,7 +34,7 @@ void RegisterRayHitObjectValidation(Validator &gpuav, CommandBufferSubState &cb)
                                                                                  std::string &out_vuid_msg) {
             using namespace glsl;
             bool error_found = false;
-            if (GetErrorGroup(error_record) != kErrorGroupInstRayHitObject) {
+            if (GetErrorGroup(error_record) != kErrorGroup_InstRayHitObject) {
                 return error_found;
             }
             error_found = true;
@@ -42,83 +42,83 @@ void RegisterRayHitObjectValidation(Validator &gpuav, CommandBufferSubState &cb)
             std::ostringstream strm;
 
             const uint32_t error_sub_code = GetSubError(error_record);
-            const uint32_t opcode = error_record[kInstLogErrorParameterOffset_1];
+            const uint32_t opcode = error_record[kInst_LogError_ParameterOffset_1];
 
             switch (error_sub_code) {
-                case kErrorSubCodeRayHitObjectNegativeMin: {
+                case kErrorSubCode_RayHitObject_NegativeMin: {
                     // TODO - Figure a way to properly use GLSL floatBitsToUint and print the float values
                     strm << string_SpvOpcode(opcode) << " operand Ray Tmin value is negative. ";
                     out_vuid_msg = "VUID-RuntimeSpirv-OpHitObjectTraceRayEXT-11879";
                 } break;
-                case kErrorSubCodeRayHitObjectNegativeMax: {
+                case kErrorSubCode_RayHitObject_NegativeMax: {
                     strm << string_SpvOpcode(opcode) << " operand Ray Tmax value is negative. ";
                     out_vuid_msg = "VUID-RuntimeSpirv-OpHitObjectTraceRayEXT-11879";
                 } break;
-                case kErrorSubCodeRayHitObjectMinMax: {
+                case kErrorSubCode_RayHitObject_MinMax: {
                     strm << string_SpvOpcode(opcode) << " operand Ray Tmax is less than RayTmin. ";
                     out_vuid_msg = "VUID-RuntimeSpirv-OpHitObjectTraceRayEXT-11880";
                 } break;
-                case kErrorSubCodeRayHitObjectMinNaN: {
+                case kErrorSubCode_RayHitObject_MinNaN: {
                     strm << string_SpvOpcode(opcode) << " operand Ray Tmin is NaN. ";
                     out_vuid_msg = "VUID-RuntimeSpirv-OpHitObjectTraceRayEXT-11881";
                 } break;
-                case kErrorSubCodeRayHitObjectMaxNaN: {
+                case kErrorSubCode_RayHitObject_MaxNaN: {
                     strm << string_SpvOpcode(opcode) << " operand Ray Tmax is NaN. ";
                     out_vuid_msg = "VUID-RuntimeSpirv-OpHitObjectTraceRayEXT-11881";
                 } break;
-                case kErrorSubCodeRayHitObjectOriginNaN: {
+                case kErrorSubCode_RayHitObject_OriginNaN: {
                     strm << string_SpvOpcode(opcode) << " operand Ray Origin contains a NaN. ";
                     out_vuid_msg = "VUID-RuntimeSpirv-OpHitObjectTraceRayEXT-11881";
                 } break;
-                case kErrorSubCodeRayHitObjectDirectionNaN: {
+                case kErrorSubCode_RayHitObject_DirectionNaN: {
                     strm << string_SpvOpcode(opcode) << " operand Ray Direction contains a NaN. ";
                     out_vuid_msg = "VUID-RuntimeSpirv-OpHitObjectTraceRayEXT-11881";
                 } break;
-                case kErrorSubCodeRayHitObjectOriginFinite: {
+                case kErrorSubCode_RayHitObject_OriginFinite: {
                     strm << string_SpvOpcode(opcode) << " operand Ray Origin contains a non-finite value. ";
                     out_vuid_msg = "VUID-RuntimeSpirv-OpHitObjectTraceRayEXT-11878";
                 } break;
-                case kErrorSubCodeRayHitObjectDirectionFinite: {
+                case kErrorSubCode_RayHitObject_DirectionFinite: {
                     strm << string_SpvOpcode(opcode) << " operand Ray Direction contains a non-finite value. ";
                     out_vuid_msg = "VUID-RuntimeSpirv-OpHitObjectTraceRayEXT-11878";
                 } break;
-                case kErrorSubCodeRayHitObjectBothSkip: {
-                    const uint32_t value = error_record[kInstLogErrorParameterOffset_0];
+                case kErrorSubCode_RayHitObject_BothSkip: {
+                    const uint32_t value = error_record[kInst_LogError_ParameterOffset_0];
                     strm << string_SpvOpcode(opcode) << " operand Ray Flags is 0x" << std::hex << value << ". ";
                     out_vuid_msg = "VUID-RuntimeSpirv-OpHitObjectTraceRayEXT-11883";
                 } break;
-                case kErrorSubCodeRayHitObjectSkipCull: {
-                    const uint32_t value = error_record[kInstLogErrorParameterOffset_0];
+                case kErrorSubCode_RayHitObject_SkipCull: {
+                    const uint32_t value = error_record[kInst_LogError_ParameterOffset_0];
                     strm << string_SpvOpcode(opcode) << " operand Ray Flags is 0x" << std::hex << value << ". ";
                     out_vuid_msg = "VUID-RuntimeSpirv-OpHitObjectTraceRayEXT-11884";
                 } break;
-                case kErrorSubCodeRayHitObjectOpaque: {
-                    const uint32_t value = error_record[kInstLogErrorParameterOffset_0];
+                case kErrorSubCode_RayHitObject_Opaque: {
+                    const uint32_t value = error_record[kInst_LogError_ParameterOffset_0];
                     strm << string_SpvOpcode(opcode) << " operand Ray Flags is 0x" << std::hex << value << ". ";
                     out_vuid_msg = "VUID-RuntimeSpirv-OpHitObjectTraceRayEXT-11885";
                 } break;
-                case kErrorSubCodeRayHitObjectSkipTrianglesWithPipelineSkipAABBs: {
-                    const uint32_t value = error_record[kInstLogErrorParameterOffset_0];
+                case kErrorSubCode_RayHitObject_SkipTrianglesWithPipelineSkipAABBs: {
+                    const uint32_t value = error_record[kInst_LogError_ParameterOffset_0];
                     strm << string_SpvOpcode(opcode) << " operand Ray Flags (0x" << std::hex << value
                          << ") contains SkipTrianglesKHR, but pipeline was created with "
                             "VK_PIPELINE_CREATE_RAY_TRACING_SKIP_AABBS_BIT_KHR. ";
                     out_vuid_msg = "VUID-RuntimeSpirv-OpHitObjectTraceRayEXT-11886";
                 } break;
-                case kErrorSubCodeRayHitObjectSkipAABBsWithPipelineSkipTriangles: {
-                    const uint32_t value = error_record[kInstLogErrorParameterOffset_0];
+                case kErrorSubCode_RayHitObject_SkipAABBsWithPipelineSkipTriangles: {
+                    const uint32_t value = error_record[kInst_LogError_ParameterOffset_0];
                     strm << string_SpvOpcode(opcode) << " operand Ray Flags (0x" << std::hex << value
                          << ") contains SkipAABBsKHR, but pipeline was created with "
                             "VK_PIPELINE_CREATE_RAY_TRACING_SKIP_TRIANGLES_BIT_KHR. ";
                     out_vuid_msg = "VUID-RuntimeSpirv-OpHitObjectTraceRayEXT-11887";
                 } break;
-                case kErrorSubCodeRayHitObjectTimeOutOfRange: {
+                case kErrorSubCode_RayHitObject_TimeOutOfRange: {
                     strm << string_SpvOpcode(opcode) << " operand time is not between 0.0 and 1.0. ";
                     out_vuid_msg = "VUID-RuntimeSpirv-OpHitObjectTraceRayEXT-11882";
                 } break;
-                case kErrorSubCodeRayHitObjectSBTIndexExceedsLimit: {
+                case kErrorSubCode_RayHitObject_SBTIndexExceedsLimit: {
                     // For this case, param_0 contains the SBT index and opcode_type slot contains the max SBT index
-                    const uint32_t sbt_index = error_record[kInstLogErrorParameterOffset_0];
-                    const uint32_t max_sbt_index = error_record[kInstLogErrorParameterOffset_1];
+                    const uint32_t sbt_index = error_record[kInst_LogError_ParameterOffset_0];
+                    const uint32_t max_sbt_index = error_record[kInst_LogError_ParameterOffset_1];
                     strm << "OpHitObjectSetShaderBindingTableRecordIndexEXT SBT index (" << std::dec << sbt_index
                          << ") exceeds VkPhysicalDeviceRayTracingInvocationReorderPropertiesEXT::maxShaderBindingTableRecordIndex (" << max_sbt_index << "). ";
                     out_vuid_msg = "VUID-RuntimeSpirv-maxShaderBindingTableRecordIndex-11888";

--- a/layers/gpuav/instrumentation/ray_query.cpp
+++ b/layers/gpuav/instrumentation/ray_query.cpp
@@ -33,7 +33,7 @@ void RegisterRayQueryValidation(Validator &gpuav, CommandBufferSubState &cb) {
                                                                                  std::string &out_vuid_msg) {
             using namespace glsl;
             bool error_found = false;
-            if (GetErrorGroup(error_record) != kErrorGroupInstRayQuery) {
+            if (GetErrorGroup(error_record) != kErrorGroup_InstRayQuery) {
                 return error_found;
             }
             error_found = true;
@@ -43,55 +43,55 @@ void RegisterRayQueryValidation(Validator &gpuav, CommandBufferSubState &cb) {
             const uint32_t error_sub_code = GetSubError(error_record);
 
             switch (error_sub_code) {
-                case kErrorSubCodeRayQueryNegativeMin: {
+                case kErrorSubCode_RayQuery_NegativeMin: {
                     // TODO - Figure a way to properly use GLSL floatBitsToUint and print the float values
                     strm << "OpRayQueryInitializeKHR operand Ray Tmin value is negative. ";
                     out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06349";
                 } break;
-                case kErrorSubCodeRayQueryNegativeMax: {
+                case kErrorSubCode_RayQuery_NegativeMax: {
                     strm << "OpRayQueryInitializeKHR operand Ray Tmax value is negative. ";
                     out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06349";
                 } break;
-                case kErrorSubCodeRayQueryMinMax: {
+                case kErrorSubCode_RayQuery_MinMax: {
                     strm << "OpRayQueryInitializeKHR operand Ray Tmax is less than RayTmin. ";
                     out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06350";
                 } break;
-                case kErrorSubCodeRayQueryMinNaN: {
+                case kErrorSubCode_RayQuery_MinNaN: {
                     strm << "OpRayQueryInitializeKHR operand Ray Tmin is NaN. ";
                     out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06351";
                 } break;
-                case kErrorSubCodeRayQueryMaxNaN: {
+                case kErrorSubCode_RayQuery_MaxNaN: {
                     strm << "OpRayQueryInitializeKHR operand Ray Tmax is NaN. ";
                     out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06351";
                 } break;
-                case kErrorSubCodeRayQueryOriginNaN: {
+                case kErrorSubCode_RayQuery_OriginNaN: {
                     strm << "OpRayQueryInitializeKHR operand Ray Origin contains a NaN. ";
                     out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06351";
                 } break;
-                case kErrorSubCodeRayQueryDirectionNaN: {
+                case kErrorSubCode_RayQuery_DirectionNaN: {
                     strm << "OpRayQueryInitializeKHR operand Ray Direction contains a NaN. ";
                     out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06351";
                 } break;
-                case kErrorSubCodeRayQueryOriginFinite: {
+                case kErrorSubCode_RayQuery_OriginFinite: {
                     strm << "OpRayQueryInitializeKHR operand Ray Origin contains a non-finite value. ";
                     out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06348";
                 } break;
-                case kErrorSubCodeRayQueryDirectionFinite: {
+                case kErrorSubCode_RayQuery_DirectionFinite: {
                     strm << "OpRayQueryInitializeKHR operand Ray Direction contains a non-finite value. ";
                     out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06348";
                 } break;
-                case kErrorSubCodeRayQueryBothSkip: {
-                    const uint32_t value = error_record[kInstLogErrorParameterOffset_0];
+                case kErrorSubCode_RayQuery_BothSkip: {
+                    const uint32_t value = error_record[kInst_LogError_ParameterOffset_0];
                     strm << "OpRayQueryInitializeKHR operand Ray Flags is 0x" << std::hex << value << ". ";
                     out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06889";
                 } break;
-                case kErrorSubCodeRayQuerySkipCull: {
-                    const uint32_t value = error_record[kInstLogErrorParameterOffset_0];
+                case kErrorSubCode_RayQuery_SkipCull: {
+                    const uint32_t value = error_record[kInst_LogError_ParameterOffset_0];
                     strm << "OpRayQueryInitializeKHR operand Ray Flags is 0x" << std::hex << value << ". ";
                     out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06890";
                 } break;
-                case kErrorSubCodeRayQueryOpaque: {
-                    const uint32_t value = error_record[kInstLogErrorParameterOffset_0];
+                case kErrorSubCode_RayQuery_Opaque: {
+                    const uint32_t value = error_record[kInst_LogError_ParameterOffset_0];
                     strm << "OpRayQueryInitializeKHR operand Ray Flags is 0x" << std::hex << value << ". ";
                     out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06891";
                 } break;

--- a/layers/gpuav/instrumentation/vertex_attribute_fetch_oob.cpp
+++ b/layers/gpuav/instrumentation/vertex_attribute_fetch_oob.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2024-2025 LunarG, Inc.
+/* Copyright (c) 2024-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -165,11 +165,11 @@ void RegisterVertexAttributeFetchOobValidation(Validator &gpuav, CommandBufferSu
         auto local_error_info = std::make_shared<ErrorInfo>();
         *local_error_info = *error_info;
         CommandBufferSubState::InstrumentationErrorLogger inst_error_logger = [local_error_info = std::move(local_error_info)](
-                                                                                  Validator &gpuav, const Location &loc,
-                                                                                  const uint32_t *error_record,
-                                                                                  std::string &out_error_msg,
-                                                                                  std::string &out_vuid_msg) {
-            if (GetErrorGroup(error_record) != glsl::kErrorGroupInstIndexedDraw) {
+                                                                                  Validator& gpuav, const Location& loc,
+                                                                                  const uint32_t* error_record,
+                                                                                  std::string& out_error_msg,
+                                                                                  std::string& out_vuid_msg) {
+            if (GetErrorGroup(error_record) != glsl::kErrorGroup_InstIndexedDraw) {
                 return false;
             }
 
@@ -248,11 +248,11 @@ void RegisterVertexAttributeFetchOobValidation(Validator &gpuav, CommandBufferSu
 
             if (error_sub_code == glsl::kErrorSubCode_IndexedDraw_OOBVertexIndex) {
                 out_error_msg += "Vertex index ";
-                const uint32_t oob_vertex_index = error_record[glsl::kHeaderStageInfoOffset_0];
+                const uint32_t oob_vertex_index = error_record[glsl::kHeader_StageInfoOffset_0];
                 out_error_msg += std::to_string(oob_vertex_index);
             } else if (error_sub_code == glsl::kErrorSubCode_IndexedDraw_OOBInstanceIndex) {
                 out_error_msg += "Instance index ";
-                const uint32_t oob_instance_index = error_record[glsl::kHeaderStageInfoOffset_1];
+                const uint32_t oob_instance_index = error_record[glsl::kHeader_StageInfoOffset_1];
                 out_error_msg += std::to_string(oob_instance_index);
                 const uint32_t instance_rate_divisor =
                     local_error_info->vertex_attribute_fetch_limit_instance_input_rate->instance_rate_divisor;

--- a/layers/gpuav/resources/gpuav_state_trackers.cpp
+++ b/layers/gpuav/resources/gpuav_state_trackers.cpp
@@ -344,12 +344,12 @@ void CommandBufferSubState::OnCompletion(VkQueue queue, const std::vector<std::s
                 error_output_buffer_ptr + (glsl::kErrorBufferByteSize - cst::stream_output_data_offset);
 
             uint32_t *error_record_ptr = error_records_start;
-            uint32_t record_size = error_record_ptr[glsl::kHeaderErrorRecordSizeOffset];
+            uint32_t record_size = error_record_ptr[glsl::kHeader_ErrorRecordSizeOffset];
             assert(record_size == glsl::kErrorRecordSize);
 
             while (record_size > 0 && (error_record_ptr + record_size) <= error_records_end) {
                 const uint32_t error_logger_i =
-                    error_record_ptr[glsl::kHeaderActionIdErrorLoggerIdOffset] & glsl::kErrorLoggerIdMask;
+                    error_record_ptr[glsl::kHeader_ActionIdErrorLoggerIdOffset] & glsl::kErrorLoggerId_Mask;
 
                 assert(error_logger_i < cst::indices_count);
                 if (error_logger_i == cst::invalid_index_command) {
@@ -371,7 +371,7 @@ void CommandBufferSubState::OnCompletion(VkQueue queue, const std::vector<std::s
 
                 // Next record
                 error_record_ptr += record_size;
-                record_size = error_record_ptr[glsl::kHeaderErrorRecordSizeOffset];
+                record_size = error_record_ptr[glsl::kHeader_ErrorRecordSizeOffset];
             }
 
             VVL_TracyPlot("GPU-AV errors count", int64_t(total_words / glsl::kErrorRecordSize));

--- a/layers/gpuav/shaders/gpuav_error_codes.h
+++ b/layers/gpuav/shaders/gpuav_error_codes.h
@@ -27,98 +27,98 @@ namespace glsl {
 // Error Groups
 //
 // These will match one-for-one with the file found in gpu_shader folder
-// Note - We currently have a max of 256 slots for error groups (see kHeaderShaderIdErrorOffset)
-const int kErrorGroupInstDescriptorIndexingOOB = 1;
-const int kErrorGroupInstBufferDeviceAddress = 2;
-const int kErrorGroupInstRayQuery = 3;
-const int kErrorGroupGpuPreDraw = 4;
-const int kErrorGroupGpuPreDispatch = 5;
-const int kErrorGroupGpuPreTraceRays = 6;
-const int kErrorGroupGpuCopyBufferToImage = 7;
-const int kErrorGroupInstDescriptorClass = 8;
-const int kErrorGroupInstIndexedDraw = 9;
-const int kErrorGroupGpuCopyMemoryIndirect = 10;
-const int kErrorGroupInstSanitizer = 11;
-const int kErrorGroupGpuPreBuildAccelerationStructures = 12;
-const int kErrorGroupInstMeshShading = 13;
-const int kErrorGroupInstRayHitObject = 14;
+// Note - We currently have a max of 256 slots for error groups (see kHeader_ShaderIdErrorOffset)
+const int kErrorGroup_InstDescriptorIndexingOOB = 1;
+const int kErrorGroup_InstBufferDeviceAddress = 2;
+const int kErrorGroup_InstRayQuery = 3;
+const int kErrorGroup_GpuPreDraw = 4;
+const int kErrorGroup_GpuPreDispatch = 5;
+const int kErrorGroup_GpuPreTraceRays = 6;
+const int kErrorGroup_GpuCopyBufferToImage = 7;
+const int kErrorGroup_InstDescriptorClass = 8;
+const int kErrorGroup_InstIndexedDraw = 9;
+const int kErrorGroup_GpuCopyMemoryIndirect = 10;
+const int kErrorGroup_InstSanitizer = 11;
+const int kErrorGroup_GpuPreBuildAccelerationStructures = 12;
+const int kErrorGroup_InstMeshShading = 13;
+const int kErrorGroup_InstRayHitObject = 14;
 
 // We just take ExecutionModel and normalize it so we only use 5 bits to store it
-const int kExecutionModelVertex = 0;
-const int kExecutionModelTessellationControl = 1;
-const int kExecutionModelTessellationEvaluation = 2;
-const int kExecutionModelGeometry = 3;
-const int kExecutionModelFragment = 4;
-const int kExecutionModelGLCompute = 5;
-const int kExecutionModelKernel = 6;
-const int kExecutionModelTaskNV = 7;
-const int kExecutionModelMeshNV = 8;
-const int kExecutionModelRayGenerationKHR = 9;
-const int kExecutionModelIntersectionKHR = 10;
-const int kExecutionModelAnyHitKHR = 11;
-const int kExecutionModelClosestHitKHR = 12;
-const int kExecutionModelMissKHR = 13;
-const int kExecutionModelCallableKHR = 14;
-const int kExecutionModelTaskEXT = 15;
-const int kExecutionModelMeshEXT = 16;
+const int kExecutionModel_Vertex = 0;
+const int kExecutionModel_TessellationControl = 1;
+const int kExecutionModel_TessellationEvaluation = 2;
+const int kExecutionModel_Geometry = 3;
+const int kExecutionModel_Fragment = 4;
+const int kExecutionModel_GLCompute = 5;
+const int kExecutionModel_Kernel = 6;
+const int kExecutionModel_TaskNV = 7;
+const int kExecutionModel_MeshNV = 8;
+const int kExecutionModel_RayGenerationKHR = 9;
+const int kExecutionModel_IntersectionKHR = 10;
+const int kExecutionModel_AnyHitKHR = 11;
+const int kExecutionModel_ClosestHitKHR = 12;
+const int kExecutionModel_MissKHR = 13;
+const int kExecutionModel_CallableKHR = 14;
+const int kExecutionModel_TaskEXT = 15;
+const int kExecutionModel_MeshEXT = 16;
 // Used for MultiEntry and there is no single stage set
-const int kExecutionModelMultiEntryPoint = 31;
+const int kExecutionModel_MultiEntryPoint = 31;
 
 // Descriptor Indexing
 //
-const int kErrorSubCodeDescriptorIndexingBounds = 1;
-const int kErrorSubCodeDescriptorIndexingUninitialized = 2;
-const int kErrorSubCodeDescriptorIndexingDestroyed = 3;
+const int kErrorSubCode_DescriptorIndexing_Bounds = 1;
+const int kErrorSubCode_DescriptorIndexing_Uninitialized = 2;
+const int kErrorSubCode_DescriptorIndexing_Destroyed = 3;
 
 // Descriptor Class specific errors
 //
 // Buffers
-const int kErrorSubCodeDescriptorClassGeneralBufferBounds = 1;
+const int kErrorSubCode_DescriptorClass_GeneralBufferBounds = 1;
 // Texel Buffers
-const int kErrorSubCodeDescriptorClassTexelBufferBounds = 2;
+const int kErrorSubCode_DescriptorClass_TexelBufferBounds = 2;
 // Buffers, but with Cooperative Matrix
-const int kErrorSubCodeDescriptorClassGeneralBufferCoopMatBounds = 3;
+const int kErrorSubCode_DescriptorClass_GeneralBufferCoopMatBounds = 3;
 
 // Buffer Device Address
 //
-const int kErrorSubCodeBufferDeviceAddressUnallocRef = 1;
-const int kErrorSubCodeBufferDeviceAddressAlignment = 2;
+const int kErrorSubCode_BufferDeviceAddress_UnallocRef = 1;
+const int kErrorSubCode_BufferDeviceAddress_Alignment = 2;
 
 // Ray Query
 //
-const int kErrorSubCodeRayQueryNegativeMin = 1;
-const int kErrorSubCodeRayQueryNegativeMax = 2;
-const int kErrorSubCodeRayQueryBothSkip = 3;
-const int kErrorSubCodeRayQuerySkipCull = 4;
-const int kErrorSubCodeRayQueryOpaque = 5;
-const int kErrorSubCodeRayQueryMinMax = 6;
-const int kErrorSubCodeRayQueryMinNaN = 7;
-const int kErrorSubCodeRayQueryMaxNaN = 8;
-const int kErrorSubCodeRayQueryOriginNaN = 9;
-const int kErrorSubCodeRayQueryDirectionNaN = 10;
-const int kErrorSubCodeRayQueryOriginFinite = 11;
-const int kErrorSubCodeRayQueryDirectionFinite = 12;
+const int kErrorSubCode_RayQuery_NegativeMin = 1;
+const int kErrorSubCode_RayQuery_NegativeMax = 2;
+const int kErrorSubCode_RayQuery_BothSkip = 3;
+const int kErrorSubCode_RayQuery_SkipCull = 4;
+const int kErrorSubCode_RayQuery_Opaque = 5;
+const int kErrorSubCode_RayQuery_MinMax = 6;
+const int kErrorSubCode_RayQuery_MinNaN = 7;
+const int kErrorSubCode_RayQuery_MaxNaN = 8;
+const int kErrorSubCode_RayQuery_OriginNaN = 9;
+const int kErrorSubCode_RayQuery_DirectionNaN = 10;
+const int kErrorSubCode_RayQuery_OriginFinite = 11;
+const int kErrorSubCode_RayQuery_DirectionFinite = 12;
 
 // Ray Hit Object (VK_EXT_ray_tracing_invocation_reorder)
 // OpHitObjectTraceRayEXT, OpHitObjectTraceReorderExecuteEXT, OpHitObjectTraceRayMotionEXT,
 // OpHitObjectTraceMotionReorderExecuteEXT, OpHitObjectSetShaderBindingTableRecordIndexEXT
 //
-const int kErrorSubCodeRayHitObjectNegativeMin = 1;
-const int kErrorSubCodeRayHitObjectNegativeMax = 2;
-const int kErrorSubCodeRayHitObjectBothSkip = 3;
-const int kErrorSubCodeRayHitObjectSkipCull = 4;
-const int kErrorSubCodeRayHitObjectOpaque = 5;
-const int kErrorSubCodeRayHitObjectMinMax = 6;
-const int kErrorSubCodeRayHitObjectMinNaN = 7;
-const int kErrorSubCodeRayHitObjectMaxNaN = 8;
-const int kErrorSubCodeRayHitObjectOriginNaN = 9;
-const int kErrorSubCodeRayHitObjectDirectionNaN = 10;
-const int kErrorSubCodeRayHitObjectOriginFinite = 11;
-const int kErrorSubCodeRayHitObjectDirectionFinite = 12;
-const int kErrorSubCodeRayHitObjectSkipTrianglesWithPipelineSkipAABBs = 13;
-const int kErrorSubCodeRayHitObjectSkipAABBsWithPipelineSkipTriangles = 14;
-const int kErrorSubCodeRayHitObjectTimeOutOfRange = 15;
-const int kErrorSubCodeRayHitObjectSBTIndexExceedsLimit = 16;
+const int kErrorSubCode_RayHitObject_NegativeMin = 1;
+const int kErrorSubCode_RayHitObject_NegativeMax = 2;
+const int kErrorSubCode_RayHitObject_BothSkip = 3;
+const int kErrorSubCode_RayHitObject_SkipCull = 4;
+const int kErrorSubCode_RayHitObject_Opaque = 5;
+const int kErrorSubCode_RayHitObject_MinMax = 6;
+const int kErrorSubCode_RayHitObject_MinNaN = 7;
+const int kErrorSubCode_RayHitObject_MaxNaN = 8;
+const int kErrorSubCode_RayHitObject_OriginNaN = 9;
+const int kErrorSubCode_RayHitObject_DirectionNaN = 10;
+const int kErrorSubCode_RayHitObject_OriginFinite = 11;
+const int kErrorSubCode_RayHitObject_DirectionFinite = 12;
+const int kErrorSubCode_RayHitObject_SkipTrianglesWithPipelineSkipAABBs = 13;
+const int kErrorSubCode_RayHitObject_SkipAABBsWithPipelineSkipTriangles = 14;
+const int kErrorSubCode_RayHitObject_TimeOutOfRange = 15;
+const int kErrorSubCode_RayHitObject_SBTIndexExceedsLimit = 16;
 
 // MeshShading
 //
@@ -131,27 +131,27 @@ const int kErrorSubCode_IndexedDraw_OOBInstanceIndex = 2;
 
 // Sanitizer
 //
-const int kErrorSubCodeSanitizerEmpty = 0;  // reserved to mean no error was set
-const int kErrorSubCodeSanitizerDivideZero = 1;
-const int kErrorSubCodeSanitizerImageGather = 2;
-const int kErrorSubCodeSanitizerPow = 3;
-const int kErrorSubCodeSanitizerAtan2 = 4;
-const int kErrorSubCodeSanitizerFminmax = 5;
-const int kErrorSubCodeSanitizerCount = 6;  // update when adding new item
+const int kErrorSubCode_Sanitizer_Empty = 0;  // reserved to mean no error was set
+const int kErrorSubCode_Sanitizer_DivideZero = 1;
+const int kErrorSubCode_Sanitizer_ImageGather = 2;
+const int kErrorSubCode_Sanitizer_Pow = 3;
+const int kErrorSubCode_Sanitizer_Atan2 = 4;
+const int kErrorSubCode_Sanitizer_Fminmax = 5;
+const int kErrorSubCode_Sanitizer_Count = 6;  // update when adding new item
 
 // Pre Draw
 //
 // The draw count exceeded the draw buffer size
-const int kErrorSubCodePreDraw_DrawBufferSize = 1;
+const int kErrorSubCode_PreDraw_DrawBufferSize = 1;
 // The draw count exceeded the maxDrawCount parameter to the command
-const int kErrorSubCodePreDraw_DrawCountLimit = 2;
+const int kErrorSubCode_PreDraw_DrawCountLimit = 2;
 // A firstInstance field was non-zero
-const int kErrorSubCodePreDrawFirstInstance = 3;
+const int kErrorSubCode_PreDraw_FirstInstance = 3;
 // Mesh limit checks
-const int kErrorSubCodePreDrawGroupCountX = 4;
-const int kErrorSubCodePreDrawGroupCountY = 5;
-const int kErrorSubCodePreDrawGroupCountZ = 6;
-const int kErrorSubCodePreDrawGroupCountTotal = 7;
+const int kErrorSubCode_PreDraw_GroupCountX = 4;
+const int kErrorSubCode_PreDraw_GroupCountY = 5;
+const int kErrorSubCode_PreDraw_GroupCountZ = 6;
+const int kErrorSubCode_PreDraw_GroupCountTotal = 7;
 // The index count exceeded the index buffer size
 const int kErrorSubCode_OobIndexBuffer = 8;
 // An index in the index buffer exceeded the vertex buffer size
@@ -159,31 +159,31 @@ const int kErrorSubCode_OobVertexBuffer = 9;
 
 // Pre Dispatch
 //
-const int kErrorSubCodePreDispatchCountLimitX = 1;
-const int kErrorSubCodePreDispatchCountLimitY = 2;
-const int kErrorSubCodePreDispatchCountLimitZ = 3;
+const int kErrorSubCode_PreDispatch_CountLimitX = 1;
+const int kErrorSubCode_PreDispatch_CountLimitY = 2;
+const int kErrorSubCode_PreDispatch_CountLimitZ = 3;
 
 // Pre Trace Rays
 //
-const int kErrorSubCodePreTraceRaysLimitWidth = 1;
-const int kErrorSubCodePreTraceRaysLimitHeight = 2;
-const int kErrorSubCodePreTraceRaysLimitDepth = 3;
-const int kErrorSubCodePreTraceRaysLimitVolume = 4;
+const int kErrorSubCode_PreTraceRays_LimitWidth = 1;
+const int kErrorSubCode_PreTraceRays_LimitHeight = 2;
+const int kErrorSubCode_PreTraceRays_LimitDepth = 3;
+const int kErrorSubCode_PreTraceRays_LimitVolume = 4;
 // Pre Copy Buffer To Image
 //
 const int kErrorSubCodePreCopyBufferToImageBufferTexel = 1;
 
 // Pre Copy Memory Indirect
 //
-const int kErrorSubCodePreCopyMemoryIndirectSrcAddressAligned = 1;
-const int kErrorSubCodePreCopyMemoryIndirectDstAddressAligned = 2;
-const int kErrorSubCodePreCopyMemoryIndirectSizeAligned = 3;
-const int kErrorSubCodePreCopyMemoryToImageIndirectSrcAddressAligned = 4;
-const int kErrorSubCodePreCopyMemoryToImageIndirectBufferRowLength = 5;
-const int kErrorSubCodePreCopyMemoryToImageIndirectBufferImageHeight = 6;
-const int kErrorSubCodePreCopyMemoryIndirectSrcAddressInvalid = 7;
-const int kErrorSubCodePreCopyMemoryIndirectDstAddressInvalid = 8;
-const int kErrorSubCodePreCopyMemoryToImageIndirectSrcAddressInvalid = 9;
+const int kErrorSubCode_PreCopyMemoryIndirect_SrcAddressAligned = 1;
+const int kErrorSubCode_PreCopyMemoryIndirect_DstAddressAligned = 2;
+const int kErrorSubCode_PreCopyMemoryIndirect_SizeAligned = 3;
+const int kErrorSubCode_PreCopyMemoryToImageIndirect_SrcAddressAligned = 4;
+const int kErrorSubCode_PreCopyMemoryToImageIndirect_BufferRowLength = 5;
+const int kErrorSubCode_PreCopyMemoryToImageIndirect_BufferImageHeight = 6;
+const int kErrorSubCode_PreCopyMemoryIndirect_SrcAddressInvalid = 7;
+const int kErrorSubCode_PreCopyMemoryIndirect_DstAddressInvalid = 8;
+const int kErrorSubCode_PreCopyMemoryToImageIndirect_SrcAddressInvalid = 9;
 
 // Pre Build Acceleration Structures
 //

--- a/layers/gpuav/shaders/gpuav_error_header.h
+++ b/layers/gpuav/shaders/gpuav_error_header.h
@@ -52,37 +52,37 @@ using uint = unsigned int;
 
 // Each record first contains the size of the record in 32-bit words, including
 // the size word.
-const int kHeaderErrorRecordSizeOffset = 0;
+const int kHeader_ErrorRecordSizeOffset = 0;
 
 // We compress the |shader id|, |error group| and |error sub code| in a single dword
 // |shader id| is used to map back the VkShaderMoudle/Pipeline/ShaderObject
 // |error group| maps to which instrumentation pass is from
 // |error sub code| is how we can map things to a single VUID
-const int kHeaderShaderIdErrorOffset = 1;
+const int kHeader_ShaderIdErrorOffset = 1;
 
 // This is the ordinal position of the instruction within the SPIR-V shader
 // which generated the validation error.
 //
 // This also is the stage which generated the validation error.
-const int kHeaderStageInstructionIdOffset = 2;
+const int kHeader_StageInstructionIdOffset = 2;
 
 // Each stage will contain different values in the next set of words of the
 // record used to identify which instantiation of the shader generated the
 // validation error.
-const int kHeaderStageInfoOffset_0 = 3;
-const int kHeaderStageInfoOffset_1 = 4;
-const int kHeaderStageInfoOffset_2 = 5;
+const int kHeader_StageInfoOffset_0 = 3;
+const int kHeader_StageInfoOffset_1 = 4;
+const int kHeader_StageInfoOffset_2 = 5;
 
 // Compressed dword to know where the error came from in the API
-const int kHeaderActionIdErrorLoggerIdOffset = 6;
+const int kHeader_ActionIdErrorLoggerIdOffset = 6;
 
 const int kHeaderSize = 7;
 
-const int kInstLogErrorParameterOffset_0 = kHeaderSize;
-const int kInstLogErrorParameterOffset_1 = kHeaderSize + 1;
-const int kInstLogErrorParameterOffset_2 = kHeaderSize + 2;
+const int kInst_LogError_ParameterOffset_0 = kHeaderSize;
+const int kInst_LogError_ParameterOffset_1 = kHeaderSize + 1;
+const int kInst_LogError_ParameterOffset_2 = kHeaderSize + 2;
 
-// kHeaderShaderIdErrorOffset
+// kHeader_ShaderIdErrorOffset
 // ---
 // This dword is split up as
 // | 31 ..... 24 | 23 ......... 18 | 17 ................. 0 |
@@ -90,51 +90,45 @@ const int kInstLogErrorParameterOffset_2 = kHeaderSize + 2;
 //
 // These limits are reasonable and will be awhile until we go past them
 // When moved to slang from GLSL, can add staic asserts
-const int kErrorSubCodeShift = 18;
-const int kErrorSubCodeMask = 0x3F << kErrorSubCodeShift;  // 32 slot
-const int kErrorGroupShift = 24;
-const int kErrorGroupMask = 0xFF << kErrorGroupShift;  // 256 slots
+const int kErrorSubCode_Shift = 18;
+const int kErrorSubCode_Mask = 0x3F << kErrorSubCode_Shift;  // 32 slot
+const int kErrorGroup_Shift = 24;
+const int kErrorGroup_Mask = 0xFF << kErrorGroup_Shift;  // 256 slots
 
-// kHeaderStageInstructionIdOffset
+// kHeader_StageInstructionIdOffset
 // ---
 // This dword is split up as
 // | 31 .. 27 | 26 ...... 0 |
 // | Stage Id | Instruction Id |
 // We control and know there are under 32 shader stages
 // We can assume shader are under 128MB
-const int kStageIdShift = 27;
-const int kStageIdMask = 0x1F << kStageIdShift;  // 32 slot
-const int kInstructionIdMask = 0x7FFFFFF;
+const int kStageId_Shift = 27;
+const int kStageId_Mask = 0x1F << kStageId_Shift;  // 32 slot
+const int kInstructionId_Mask = 0x7FFFFFF;
 
-// kHeaderActionIdErrorLoggerIdOffset
+// kHeader_ActionIdErrorLoggerIdOffset
 // ---
 // This dword is split up as
 // | 31 ..... 16 | 15 ................. 0 |
 // | Error Group | Instrumented Shader Id |
 // Note we have a limit (cst::indices_count) but for simplicity, divide in half until find need to adjust.
-const int kActionIdShift = 16;
-const int kActionIdMask = 0xFFFF << kActionIdShift;  // 64k slot
-const int kErrorLoggerIdMask = 0xFFFF;
+const int kActionId_Shift = 16;
+const int kActionId_Mask = 0xFFFF << kActionId_Shift;  // 64k slot
+const int kErrorLoggerId_Mask = 0xFFFF;
 
 // Error specific parameters offsets:
 // ----------------------------------
 
 // Descriptor Indexing
 // ---
-const int kInstDescriptorIndexingSetAndIndexOffset = kHeaderSize;
-const int kInstDescriptorIndexingParamOffset_0 = kHeaderSize + 1;
-const int kInstDescriptorIndexingParamOffset_1 = kHeaderSize + 2;
-
-// kInstDescriptorIndexingSetAndIndexOffset
-// ---
 // This dword is split up as
 // | 31 ........ 27 | 26 ............................................ 0 |
 // | Descriptor Set | Global Descriptor index (with binding LUT offset) |
 // We only allow for 32 sets (see kDebugInputBindlessMaxDescSets)
 // We use a LUT per set that knows which binding the "global" Descriptor Index value lives
-const int kInstDescriptorIndexingSetShift = 27;
-const int kInstDescriptorIndexingSetMask = 0x1F << kInstDescriptorIndexingSetShift;  // 32 slot
-const int kInstDescriptorIndexingIndexMask = 0x7FFFFFF;
+const int kInst_DescriptorIndexing_SetShift = 27;
+const int kInst_DescriptorIndexing_SetMask = 0x1F << kInst_DescriptorIndexing_SetShift;  // 32 slot
+const int kInst_DescriptorIndexing_IndexMask = 0x7FFFFFF;
 
 // Buffer device addresses
 // ---
@@ -143,26 +137,26 @@ const int kInstDescriptorIndexingIndexMask = 0x7FFFFFF;
 // Note - if needed, we could use log2(alignment) as it must be a Power-of-Two
 // |    31    |     30    | 29 ........................ 0 |
 // | is write | is struct | Alignment OR Access Byte Size |
-const uint kInstBuffAddrAccessPayloadShiftIsWrite = 31;
-const uint kInstBuffAddrAccessPayloadShiftIsStruct = 30;
-const uint kInstBuffAddrAccessPayloadMaskAccessInfo = 0x3FFFFFFF;
+const uint kInst_BuffAddrAccess_PayloadShiftIsWrite = 31;
+const uint kInst_BuffAddrAccess_PayloadShiftIsStruct = 30;
+const uint kInst_BuffAddrAccess_PayloadMaskAccessInfo = 0x3FFFFFFF;
 
-// kErrorGroupInstMeshShading
+// kErrorGroup_InstMeshShading
 // ---
 // This dword is split up as
 // | 31 ........ 16 | 15 .............. 0 |
 // | OutputVertices | OutputPrimitivesEXT |
 // This is because the limits for both of these on all known devices is 1024
-const int kMeshShadingOutputVerticesShift = 16;
-const int kMeshShadingOutputPrimitivesMask = 0xFFFF;
+const int kInst_MeshShading_OutputVerticesShift = 16;
+const int kInst_MeshShading_OutputPrimitivesMask = 0xFFFF;
 
 // Validation commands shaders
 // ---
-const int kValCmdErrorPayloadDword_0 = kHeaderSize;
-const int kValCmdErrorPayloadDword_1 = kHeaderSize + 1;
-const int kValCmdErrorPayloadDword_2 = kHeaderSize + 2;
-const int kValCmdErrorPayloadDword_3 = kHeaderSize + 3;
-const int kValCmdErrorPayloadDword_4 = kHeaderSize + 4;
+const int kValCmd_ErrorPayloadDword_0 = kHeaderSize;
+const int kValCmd_ErrorPayloadDword_1 = kHeaderSize + 1;
+const int kValCmd_ErrorPayloadDword_2 = kHeaderSize + 2;
+const int kValCmd_ErrorPayloadDword_3 = kHeaderSize + 3;
+const int kValCmd_ErrorPayloadDword_4 = kHeaderSize + 4;
 
 // Sizes/Counts
 // -------------------
@@ -176,17 +170,17 @@ const int kErrorBufferByteSize = 4 * kErrorRecordSize * kErrorRecordCounts + 2 *
 
 // DebugPrintf
 // ---
-const int kDebugPrintfOutputBufferDWordsCount = 0;
-const int kDebugPrintfOutputBufferData = 1;
+const int kDebugPrintf_OutputBuffer_DWordsCount = 0;
+const int kDebugPrintf_OutputBuffer_Data = 1;
 
 #ifdef __cplusplus
 
 [[maybe_unused]] static inline uint32_t GetErrorGroup(const uint32_t* error_record) {
-    return error_record[glsl::kHeaderShaderIdErrorOffset] >> glsl::kErrorGroupShift;
+    return error_record[glsl::kHeader_ShaderIdErrorOffset] >> glsl::kErrorGroup_Shift;
 }
 
 [[maybe_unused]] static inline uint32_t GetSubError(const uint32_t* error_record) {
-    return (error_record[glsl::kHeaderShaderIdErrorOffset] & glsl::kErrorSubCodeMask) >> glsl::kErrorSubCodeShift;
+    return (error_record[glsl::kHeader_ShaderIdErrorOffset] & glsl::kErrorSubCode_Mask) >> glsl::kErrorSubCode_Shift;
 }
 
 }  // namespace gpuav

--- a/layers/gpuav/shaders/instrumentation/buffer_device_address.comp
+++ b/layers/gpuav/shaders/instrumentation/buffer_device_address.comp
@@ -1,6 +1,6 @@
-// Copyright (c) 2024-2025 The Khronos Group Inc.
-// Copyright (c) 2024-2025 Valve Corporation
-// Copyright (c) 2024-2025 LunarG, Inc.
+// Copyright (c) 2024-2026 The Khronos Group Inc.
+// Copyright (c) 2024-2026 Valve Corporation
+// Copyright (c) 2024-2026 LunarG, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -91,7 +91,7 @@ bool inst_buffer_device_address_range(
 
     error_payload = ErrorPayload(
                         inst_offset,
-                        SpecConstantLinkShaderId | (kErrorGroupInstBufferDeviceAddress << kErrorGroupShift) | (kErrorSubCodeBufferDeviceAddressUnallocRef << kErrorSubCodeShift),
+                        SpecConstantLinkShaderId | (kErrorGroup_InstBufferDeviceAddress << kErrorGroup_Shift) | (kErrorSubCode_BufferDeviceAddress_UnallocRef << kErrorSubCode_Shift),
                         uint(addr),
                         uint(addr >> 32u),
                         access_type | access_byte_size
@@ -110,7 +110,7 @@ bool inst_buffer_device_address_align(
     if ((addr & (alignment - 1)) != 0) {
         error_payload = ErrorPayload(
                             inst_offset,
-                            SpecConstantLinkShaderId | (kErrorGroupInstBufferDeviceAddress << kErrorGroupShift) | (kErrorSubCodeBufferDeviceAddressAlignment << kErrorSubCodeShift),
+                            SpecConstantLinkShaderId | (kErrorGroup_InstBufferDeviceAddress << kErrorGroup_Shift) | (kErrorSubCode_BufferDeviceAddress_Alignment << kErrorSubCode_Shift),
                             uint(addr),
                             uint(addr >> 32u),
                             access_type | alignment

--- a/layers/gpuav/shaders/instrumentation/descriptor_class_general_buffer.comp
+++ b/layers/gpuav/shaders/instrumentation/descriptor_class_general_buffer.comp
@@ -1,6 +1,6 @@
-// Copyright (c) 2024-2025 The Khronos Group Inc.
-// Copyright (c) 2024-2025 Valve Corporation
-// Copyright (c) 2024-2025 LunarG, Inc.
+// Copyright (c) 2024-2026 The Khronos Group Inc.
+// Copyright (c) 2024-2026 Valve Corporation
+// Copyright (c) 2024-2026 LunarG, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -60,8 +60,8 @@ void inst_descriptor_class_general_buffer(const uint inst_offset, const uint des
     if (byte_offset >= resource_size) {
         error_payload = ErrorPayload(
                             inst_offset,
-                            SpecConstantLinkShaderId | (kErrorGroupInstDescriptorClass << kErrorGroupShift) | (kErrorSubCodeDescriptorClassGeneralBufferBounds << kErrorSubCodeShift),
-                            (desc_set << kInstDescriptorIndexingSetShift) | global_descriptor_index,
+                            SpecConstantLinkShaderId | (kErrorGroup_InstDescriptorClass << kErrorGroup_Shift) | (kErrorSubCode_DescriptorClass_GeneralBufferBounds << kErrorSubCode_Shift),
+                            (desc_set << kInst_DescriptorIndexing_SetShift) | global_descriptor_index,
                             byte_offset,
                             resource_size
                         );
@@ -80,8 +80,8 @@ void inst_descriptor_class_general_buffer_coop_mat(const uint inst_offset, const
         if (byte_offset >= resource_size) {
             error_payload = ErrorPayload(
                                 inst_offset,
-                                SpecConstantLinkShaderId | (kErrorGroupInstDescriptorClass << kErrorGroupShift) | (kErrorSubCodeDescriptorClassGeneralBufferCoopMatBounds << kErrorSubCodeShift),
-                                (desc_set << kInstDescriptorIndexingSetShift) | global_descriptor_index,
+                                SpecConstantLinkShaderId | (kErrorGroup_InstDescriptorClass << kErrorGroup_Shift) | (kErrorSubCode_DescriptorClass_GeneralBufferCoopMatBounds << kErrorSubCode_Shift),
+                                (desc_set << kInst_DescriptorIndexing_SetShift) | global_descriptor_index,
                                 byte_offset,
                                 resource_size
                             );

--- a/layers/gpuav/shaders/instrumentation/descriptor_class_texel_buffer.comp
+++ b/layers/gpuav/shaders/instrumentation/descriptor_class_texel_buffer.comp
@@ -1,6 +1,6 @@
-// Copyright (c) 2024-2025 The Khronos Group Inc.
-// Copyright (c) 2024-2025 Valve Corporation
-// Copyright (c) 2024-2025 LunarG, Inc.
+// Copyright (c) 2024-2026 The Khronos Group Inc.
+// Copyright (c) 2024-2026 Valve Corporation
+// Copyright (c) 2024-2026 LunarG, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,8 +45,8 @@ void inst_descriptor_class_texel_buffer(const uint inst_offset, const uint desc_
     if (byte_offset >= resource_size) {
         error_payload = ErrorPayload(
                             inst_offset,
-                            SpecConstantLinkShaderId | (kErrorGroupInstDescriptorClass << kErrorGroupShift) | (kErrorSubCodeDescriptorClassTexelBufferBounds << kErrorSubCodeShift),
-                            (desc_set << kInstDescriptorIndexingSetShift) | global_descriptor_index,
+                            SpecConstantLinkShaderId | (kErrorGroup_InstDescriptorClass << kErrorGroup_Shift) | (kErrorSubCode_DescriptorClass_TexelBufferBounds << kErrorSubCode_Shift),
+                            (desc_set << kInst_DescriptorIndexing_SetShift) | global_descriptor_index,
                             byte_offset,
                             resource_size
                         );

--- a/layers/gpuav/shaders/instrumentation/descriptor_indexing_oob.comp
+++ b/layers/gpuav/shaders/instrumentation/descriptor_indexing_oob.comp
@@ -1,6 +1,6 @@
-// Copyright (c) 2024-2025 The Khronos Group Inc.
-// Copyright (c) 2024-2025 Valve Corporation
-// Copyright (c) 2024-2025 LunarG, Inc.
+// Copyright (c) 2024-2026 The Khronos Group Inc.
+// Copyright (c) 2024-2026 Valve Corporation
+// Copyright (c) 2024-2026 LunarG, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -48,8 +48,8 @@ bool inst_descriptor_indexing_oob_non_bindless(const uint inst_offset, const uin
     if (desc_index >= binding_layout_size) {
         error_payload = ErrorPayload(
                             inst_offset,
-                            SpecConstantLinkShaderId | (kErrorGroupInstDescriptorIndexingOOB << kErrorGroupShift) | (kErrorSubCodeDescriptorIndexingBounds << kErrorSubCodeShift),
-                            (desc_set << kInstDescriptorIndexingSetShift) | desc_index,
+                            SpecConstantLinkShaderId | (kErrorGroup_InstDescriptorIndexingOOB << kErrorGroup_Shift) | (kErrorSubCode_DescriptorIndexing_Bounds << kErrorSubCode_Shift),
+                            (desc_set << kInst_DescriptorIndexing_SetShift) | desc_index,
                             binding_layout_size,
                             binding
                         );
@@ -66,7 +66,7 @@ bool inst_descriptor_indexing_oob_bindless(const uint inst_offset, const uint de
 
     // First make sure the index is not OOB
     if (desc_index >= binding_layout_size) {
-        error = kErrorSubCodeDescriptorIndexingBounds;
+        error = kErrorSubCode_DescriptorIndexing_Bounds;
     } else {
         DescriptorSetType descriptor_set_type = gpuav.descriptor_set_types[desc_set];
 
@@ -74,13 +74,13 @@ bool inst_descriptor_indexing_oob_bindless(const uint inst_offset, const uint de
         const uint global_descriptor_index = binding_layout_offset + desc_index;
         uint desc_id = descriptor_set_type.data[global_descriptor_index].x & kNullDescriptor;
         if (desc_id == 0u) {
-            error = kErrorSubCodeDescriptorIndexingUninitialized;
+            error = kErrorSubCode_DescriptorIndexing_Uninitialized;
         } else if (desc_id != kNullDescriptor) {
             // check that the resource is still valid (and not using nullDescriptor)
             uint desc_index = desc_id / 32;
             uint desc_bit = 1 << (desc_id & 31);
             if ((gpuav.descriptor_init_status.data[desc_index] & desc_bit) == 0) {
-                error = kErrorSubCodeDescriptorIndexingDestroyed;
+                error = kErrorSubCode_DescriptorIndexing_Destroyed;
             }
         }
     }
@@ -88,8 +88,8 @@ bool inst_descriptor_indexing_oob_bindless(const uint inst_offset, const uint de
     if (0u != error) {
         error_payload = ErrorPayload(
                         inst_offset,
-                        SpecConstantLinkShaderId | (kErrorGroupInstDescriptorIndexingOOB << kErrorGroupShift) | (error << kErrorSubCodeShift),
-                        (desc_set << kInstDescriptorIndexingSetShift) | desc_index,
+                        SpecConstantLinkShaderId | (kErrorGroup_InstDescriptorIndexingOOB << kErrorGroup_Shift) | (error << kErrorSubCode_Shift),
+                        (desc_set << kInst_DescriptorIndexing_SetShift) | desc_index,
                         binding_layout_size,
                         binding
                     );
@@ -105,7 +105,7 @@ bool inst_descriptor_indexing_oob_bindless_combined_image_sampler(const uint ins
 
     // First make sure the index is not OOB
     if (desc_index >= binding_layout_size) {
-        error = kErrorSubCodeDescriptorIndexingBounds;
+        error = kErrorSubCode_DescriptorIndexing_Bounds;
     } else {
         DescriptorSetType descriptor_set_type = gpuav.descriptor_set_types[desc_set];
 
@@ -114,13 +114,13 @@ bool inst_descriptor_indexing_oob_bindless_combined_image_sampler(const uint ins
         uvec2 descriptor_state = descriptor_set_type.data[global_descriptor_index];
         uint desc_id = descriptor_state.x & kNullDescriptor;
         if (desc_id == 0u) {
-            error = kErrorSubCodeDescriptorIndexingUninitialized;
+            error = kErrorSubCode_DescriptorIndexing_Uninitialized;
         } else if (desc_id != kNullDescriptor) {
             // check that the resource is still valid (and not using nullDescriptor)
             uint desc_index = desc_id / 32;
             uint desc_bit = 1 << (desc_id & 31);
             if ((gpuav.descriptor_init_status.data[desc_index] & desc_bit) == 0) {
-                error = kErrorSubCodeDescriptorIndexingDestroyed;
+                error = kErrorSubCode_DescriptorIndexing_Destroyed;
             }
         }
 
@@ -130,13 +130,13 @@ bool inst_descriptor_indexing_oob_bindless_combined_image_sampler(const uint ins
             // check sampler
             desc_id = descriptor_state.y;
             if (desc_id == 0u) {
-                error = kErrorSubCodeDescriptorIndexingUninitialized;
+                error = kErrorSubCode_DescriptorIndexing_Uninitialized;
             } else if (desc_id != kNullDescriptor) {
                 // check that the resource is still valid
                 uint desc_index = desc_id / 32;
                 uint desc_bit = 1 << (desc_id & 31);
                 if ((gpuav.descriptor_init_status.data[desc_index] & desc_bit) == 0) {
-                    error = kErrorSubCodeDescriptorIndexingDestroyed;
+                    error = kErrorSubCode_DescriptorIndexing_Destroyed;
                 }
             }
         }
@@ -145,8 +145,8 @@ bool inst_descriptor_indexing_oob_bindless_combined_image_sampler(const uint ins
     if (0u != error) {
         error_payload = ErrorPayload(
                         inst_offset,
-                        SpecConstantLinkShaderId | (kErrorGroupInstDescriptorIndexingOOB << kErrorGroupShift) | (error << kErrorSubCodeShift),
-                        (desc_set << kInstDescriptorIndexingSetShift) | desc_index,
+                        SpecConstantLinkShaderId | (kErrorGroup_InstDescriptorIndexingOOB << kErrorGroup_Shift) | (error << kErrorSubCode_Shift),
+                        (desc_set << kInst_DescriptorIndexing_SetShift) | desc_index,
                         binding_layout_size,
                         binding
                     );

--- a/layers/gpuav/shaders/instrumentation/error_payload.h
+++ b/layers/gpuav/shaders/instrumentation/error_payload.h
@@ -1,6 +1,6 @@
-// Copyright (c) 2025 The Khronos Group Inc.
-// Copyright (c) 2025 Valve Corporation
-// Copyright (c) 2025 LunarG, Inc.
+// Copyright (c) 2025-2026 The Khronos Group Inc.
+// Copyright (c) 2025-2026 Valve Corporation
+// Copyright (c) 2025-2026 LunarG, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,9 +19,9 @@
 
 // TODO - Would be nice to get this down to a only 16 bytes as per-thread memory is VERY precious for runtime perf
 struct ErrorPayload {
-    uint inst_offset;
-    uint shader_error_encoding;
-    uint parameter_0;
-    uint parameter_1;
-    uint parameter_2;
+    uint inst_offset;            // kHeader_StageInstructionIdOffset
+    uint shader_error_encoding;  // kHeader_ShaderIdErrorOffset
+    uint parameter_0;            // kInst_LogError_ParameterOffset_0
+    uint parameter_1;            // kInst_LogError_ParameterOffset_1
+    uint parameter_2;            // kInst_LogError_ParameterOffset_2
 } error_payload;

--- a/layers/gpuav/shaders/instrumentation/log_error.comp
+++ b/layers/gpuav/shaders/instrumentation/log_error.comp
@@ -1,6 +1,6 @@
-// Copyright (c) 2024-2025 The Khronos Group Inc.
-// Copyright (c) 2024-2025 Valve Corporation
-// Copyright (c) 2024-2025 LunarG, Inc.
+// Copyright (c) 2024-2026 The Khronos Group Inc.
+// Copyright (c) 2024-2026 Valve Corporation
+// Copyright (c) 2024-2026 LunarG, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,18 +32,18 @@ void inst_log_error(const uvec4 stage_info) {
             const bool errors_buffer_not_filled = (write_pos + kErrorRecordSize) <= uint(inst_errors_buffer.data.length());
 
             if (errors_buffer_not_filled) {
-                inst_errors_buffer.data[write_pos + kHeaderErrorRecordSizeOffset] = kErrorRecordSize;
-                inst_errors_buffer.data[write_pos + kHeaderShaderIdErrorOffset] = error_payload.shader_error_encoding;
-                inst_errors_buffer.data[write_pos + kHeaderStageInstructionIdOffset] = error_payload.inst_offset | (stage_info.x << kStageIdShift);
-                inst_errors_buffer.data[write_pos + kHeaderStageInfoOffset_0] = stage_info.y;
-                inst_errors_buffer.data[write_pos + kHeaderStageInfoOffset_1] = stage_info.z;
-                inst_errors_buffer.data[write_pos + kHeaderStageInfoOffset_2] = stage_info.w;
+                inst_errors_buffer.data[write_pos + kHeader_ErrorRecordSizeOffset] = kErrorRecordSize;
+                inst_errors_buffer.data[write_pos + kHeader_ShaderIdErrorOffset] = error_payload.shader_error_encoding;
+                inst_errors_buffer.data[write_pos + kHeader_StageInstructionIdOffset] = error_payload.inst_offset | (stage_info.x << kStageId_Shift);
+                inst_errors_buffer.data[write_pos + kHeader_StageInfoOffset_0] = stage_info.y;
+                inst_errors_buffer.data[write_pos + kHeader_StageInfoOffset_1] = stage_info.z;
+                inst_errors_buffer.data[write_pos + kHeader_StageInfoOffset_2] = stage_info.w;
 
-                inst_errors_buffer.data[write_pos + kHeaderActionIdErrorLoggerIdOffset] = (inst_action_index_buffer.index[0] << kActionIdShift) | inst_error_logger_index_buffer.index[0];
+                inst_errors_buffer.data[write_pos + kHeader_ActionIdErrorLoggerIdOffset] = (inst_action_index_buffer.index[0] << kActionId_Shift) | inst_error_logger_index_buffer.index[0];
 
-                inst_errors_buffer.data[write_pos + kInstLogErrorParameterOffset_0] = error_payload.parameter_0;
-                inst_errors_buffer.data[write_pos + kInstLogErrorParameterOffset_1] = error_payload.parameter_1;
-                inst_errors_buffer.data[write_pos + kInstLogErrorParameterOffset_2] = error_payload.parameter_2;
+                inst_errors_buffer.data[write_pos + kInst_LogError_ParameterOffset_0] = error_payload.parameter_0;
+                inst_errors_buffer.data[write_pos + kInst_LogError_ParameterOffset_1] = error_payload.parameter_1;
+                inst_errors_buffer.data[write_pos + kInst_LogError_ParameterOffset_2] = error_payload.parameter_2;
             }
         }
     }

--- a/layers/gpuav/shaders/instrumentation/mesh_shading.comp
+++ b/layers/gpuav/shaders/instrumentation/mesh_shading.comp
@@ -1,6 +1,6 @@
-// Copyright (c) 2025 The Khronos Group Inc.
-// Copyright (c) 2025 Valve Corporation
-// Copyright (c) 2025 LunarG, Inc.
+// Copyright (c) 2025-2026 The Khronos Group Inc.
+// Copyright (c) 2025-2026 Valve Corporation
+// Copyright (c) 2025-2026 LunarG, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,10 +26,10 @@ bool inst_set_mesh_output(const uint inst_offset, const uint vertex_count, const
     if ((vertex_count > output_vertices) || (primitive_count > output_primitive)) {
         error_payload = ErrorPayload(
                         inst_offset,
-                        SpecConstantLinkShaderId | (kErrorGroupInstMeshShading << kErrorGroupShift) | (kErrorSubCode_MeshShading_SetMeshOutputs << kErrorSubCodeShift),
+                        SpecConstantLinkShaderId | (kErrorGroup_InstMeshShading << kErrorGroup_Shift) | (kErrorSubCode_MeshShading_SetMeshOutputs << kErrorSubCode_Shift),
                         vertex_count,
                         primitive_count,
-                        (output_vertices << kMeshShadingOutputVerticesShift) | output_primitive);
+                        (output_vertices << kInst_MeshShading_OutputVerticesShift) | output_primitive);
         return false;
     }
     return true;

--- a/layers/gpuav/shaders/instrumentation/ray_hit_object.comp
+++ b/layers/gpuav/shaders/instrumentation/ray_hit_object.comp
@@ -42,25 +42,25 @@ bool inst_ray_hit_object(const uint inst_offset, const uint opcode_type, const u
     const bool is_motion_opcode = (opcode_type == OpHitObjectTraceRayMotionEXT || opcode_type == OpHitObjectTraceMotionReorderExecuteEXT);
 
     if (is_motion_opcode && (time < 0.0f || time > 1.0f)) {
-        error = kErrorSubCodeRayHitObjectTimeOutOfRange;
+        error = kErrorSubCode_RayHitObject_TimeOutOfRange;
     } else if (isnan(ray_tmin)) {
-        error = kErrorSubCodeRayHitObjectMinNaN;
+        error = kErrorSubCode_RayHitObject_MinNaN;
     } else if (isnan(ray_tmax)) {
-        error = kErrorSubCodeRayHitObjectMaxNaN;
+        error = kErrorSubCode_RayHitObject_MaxNaN;
     } else if (isnan(ray_origin.x) || isnan(ray_origin.y) || isnan(ray_origin.z)) {
-        error = kErrorSubCodeRayHitObjectOriginNaN;
+        error = kErrorSubCode_RayHitObject_OriginNaN;
     } else if (isnan(ray_direction.x) || isnan(ray_direction.y) || isnan(ray_direction.z)) {
-        error = kErrorSubCodeRayHitObjectDirectionNaN;
+        error = kErrorSubCode_RayHitObject_DirectionNaN;
     } else if (isinf(ray_origin.x) || isinf(ray_origin.y) || isinf(ray_origin.z)) {
-        error = kErrorSubCodeRayHitObjectOriginFinite;
+        error = kErrorSubCode_RayHitObject_OriginFinite;
     } else if (isinf(ray_direction.x) || isinf(ray_direction.y) || isinf(ray_direction.z)) {
-        error = kErrorSubCodeRayHitObjectDirectionFinite;
+        error = kErrorSubCode_RayHitObject_DirectionFinite;
     } else if (ray_tmin < 0.0f) {
-        error = kErrorSubCodeRayHitObjectNegativeMin;
+        error = kErrorSubCode_RayHitObject_NegativeMin;
     } else if (ray_tmax < 0.0f) {
-        error = kErrorSubCodeRayHitObjectNegativeMax;
+        error = kErrorSubCode_RayHitObject_NegativeMax;
     } else if (ray_tmax < ray_tmin) {
-        error = kErrorSubCodeRayHitObjectMinMax;
+        error = kErrorSubCode_RayHitObject_MinMax;
     } else {
         // From SPIRV-Headers
         const uint OpaqueKHR = 0x00000001;
@@ -81,21 +81,21 @@ bool inst_ray_hit_object(const uint inst_offset, const uint opcode_type, const u
         uint opaque_mask = ray_flags &(OpaqueKHR | NoOpaqueKHR | CullOpaqueKHR | CullNoOpaqueKHR);
 
         if ((ray_flags & both_skip) == both_skip) {
-            error = kErrorSubCodeRayHitObjectBothSkip;
+            error = kErrorSubCode_RayHitObject_BothSkip;
             param_0 = ray_flags;
         } else if (skip_cull_mask != 0 && ((skip_cull_mask & (skip_cull_mask - 1)) != 0)) {
-            error = kErrorSubCodeRayHitObjectSkipCull;
+            error = kErrorSubCode_RayHitObject_SkipCull;
             param_0 = ray_flags;
         } else if (opaque_mask != 0 && ((opaque_mask & (opaque_mask - 1)) != 0)) {
-            error = kErrorSubCodeRayHitObjectOpaque;
+            error = kErrorSubCode_RayHitObject_Opaque;
             param_0 = ray_flags;
         } else if ((ray_flags & SkipTrianglesKHR) != 0 && (pipeline_flags & kPipelineHasSkipAABBs) != 0) {
             // SkipTriangles ray flag with pipeline SKIP_AABBS flag
-            error = kErrorSubCodeRayHitObjectSkipTrianglesWithPipelineSkipAABBs;
+            error = kErrorSubCode_RayHitObject_SkipTrianglesWithPipelineSkipAABBs;
             param_0 = ray_flags;
         } else if ((ray_flags & SkipAABBsKHR) != 0 && (pipeline_flags & kPipelineHasSkipTriangles) != 0) {
             // SkipAABBs ray flag with pipeline SKIP_TRIANGLES flag
-            error = kErrorSubCodeRayHitObjectSkipAABBsWithPipelineSkipTriangles;
+            error = kErrorSubCode_RayHitObject_SkipAABBsWithPipelineSkipTriangles;
             param_0 = ray_flags;
         }
     }
@@ -103,7 +103,7 @@ bool inst_ray_hit_object(const uint inst_offset, const uint opcode_type, const u
     if (0u != error) {
          error_payload = ErrorPayload(
                             inst_offset,
-                            SpecConstantLinkShaderId | (kErrorGroupInstRayHitObject << kErrorGroupShift) | (error << kErrorSubCodeShift),
+                            SpecConstantLinkShaderId | (kErrorGroup_InstRayHitObject << kErrorGroup_Shift) | (error << kErrorSubCode_Shift),
                             param_0,
                             opcode_type,
                             0
@@ -119,7 +119,7 @@ bool inst_ray_hit_object_sbt_index_check(const uint inst_offset, const uint sbt_
     if (sbt_index > max_sbt_index) {
         error_payload = ErrorPayload(
             inst_offset,
-            SpecConstantLinkShaderId | (kErrorGroupInstRayHitObject << kErrorGroupShift) | (kErrorSubCodeRayHitObjectSBTIndexExceedsLimit << kErrorSubCodeShift),
+            SpecConstantLinkShaderId | (kErrorGroup_InstRayHitObject << kErrorGroup_Shift) | (kErrorSubCode_RayHitObject_SBTIndexExceedsLimit << kErrorSubCode_Shift),
             sbt_index,
             max_sbt_index,
             0

--- a/layers/gpuav/shaders/instrumentation/ray_query.comp
+++ b/layers/gpuav/shaders/instrumentation/ray_query.comp
@@ -1,6 +1,6 @@
-// Copyright (c) 2024-2025 The Khronos Group Inc.
-// Copyright (c) 2024-2025 Valve Corporation
-// Copyright (c) 2024-2025 LunarG, Inc.
+// Copyright (c) 2024-2026 The Khronos Group Inc.
+// Copyright (c) 2024-2026 Valve Corporation
+// Copyright (c) 2024-2026 LunarG, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,23 +27,23 @@ bool inst_ray_query_comp(const uint inst_offset, const uint ray_flags, const vec
     uint param_0 = 0u;
 
     if (isnan(ray_tmin)) {
-        error = kErrorSubCodeRayQueryMinNaN;
+        error = kErrorSubCode_RayQuery_MinNaN;
     } else if (isnan(ray_tmax)) {
-        error = kErrorSubCodeRayQueryMaxNaN;
+        error = kErrorSubCode_RayQuery_MaxNaN;
     } else if (isnan(ray_origin.x) || isnan(ray_origin.y) || isnan(ray_origin.z)) {
-        error = kErrorSubCodeRayQueryOriginNaN;
+        error = kErrorSubCode_RayQuery_OriginNaN;
     } else if (isnan(ray_direction.x) || isnan(ray_direction.y) || isnan(ray_direction.z)) {
-        error = kErrorSubCodeRayQueryDirectionNaN;
+        error = kErrorSubCode_RayQuery_DirectionNaN;
     } else if (isinf(ray_origin.x) || isinf(ray_origin.y) || isinf(ray_origin.z)) {
-        error = kErrorSubCodeRayQueryOriginFinite;
+        error = kErrorSubCode_RayQuery_OriginFinite;
     } else if (isinf(ray_direction.x) || isinf(ray_direction.y) || isinf(ray_direction.z)) {
-        error = kErrorSubCodeRayQueryDirectionFinite;
+        error = kErrorSubCode_RayQuery_DirectionFinite;
     } else if (ray_tmin < 0.0f) {
-        error = kErrorSubCodeRayQueryNegativeMin;
+        error = kErrorSubCode_RayQuery_NegativeMin;
     } else if (ray_tmax < 0.0f) {
-        error = kErrorSubCodeRayQueryNegativeMax;
+        error = kErrorSubCode_RayQuery_NegativeMax;
     } else if (ray_tmax < ray_tmin) {
-        error = kErrorSubCodeRayQueryMinMax;
+        error = kErrorSubCode_RayQuery_MinMax;
     } else {
         // From SPIRV-Headers
         const uint OpaqueKHR = 0x00000001;
@@ -60,13 +60,13 @@ bool inst_ray_query_comp(const uint inst_offset, const uint ray_flags, const vec
         uint opaque_mask = ray_flags &(OpaqueKHR | NoOpaqueKHR | CullOpaqueKHR | CullNoOpaqueKHR);
 
         if ((ray_flags & both_skip) == both_skip) {
-            error = kErrorSubCodeRayQueryBothSkip;
+            error = kErrorSubCode_RayQuery_BothSkip;
             param_0 = ray_flags;
         } else if (skip_cull_mask != 0 && ((skip_cull_mask & (skip_cull_mask - 1)) != 0)) {
-            error = kErrorSubCodeRayQuerySkipCull;
+            error = kErrorSubCode_RayQuery_SkipCull;
             param_0 = ray_flags;
         } else if (opaque_mask != 0 && ((opaque_mask & (opaque_mask - 1)) != 0)) {
-            error = kErrorSubCodeRayQueryOpaque;
+            error = kErrorSubCode_RayQuery_Opaque;
             param_0 = ray_flags;
         }
     }
@@ -74,7 +74,7 @@ bool inst_ray_query_comp(const uint inst_offset, const uint ray_flags, const vec
     if (0u != error) {
          error_payload = ErrorPayload(
                             inst_offset,
-                            SpecConstantLinkShaderId | (kErrorGroupInstRayQuery << kErrorGroupShift) | (error << kErrorSubCodeShift),
+                            SpecConstantLinkShaderId | (kErrorGroup_InstRayQuery << kErrorGroup_Shift) | (error << kErrorSubCode_Shift),
                             param_0,
                             0,
                             0

--- a/layers/gpuav/shaders/instrumentation/sanitizer.comp
+++ b/layers/gpuav/shaders/instrumentation/sanitizer.comp
@@ -29,7 +29,7 @@ bool inst_sanitizer_divide_by_zero(const bool is_invalid, const uint inst_offset
     if (is_invalid) {
         error_payload = ErrorPayload(
                         inst_offset,
-                        SpecConstantLinkShaderId | (kErrorGroupInstSanitizer << kErrorGroupShift) | (kErrorSubCodeSanitizerDivideZero << kErrorSubCodeShift),
+                        SpecConstantLinkShaderId | (kErrorGroup_InstSanitizer << kErrorGroup_Shift) | (kErrorSubCode_Sanitizer_DivideZero << kErrorSubCode_Shift),
                         opcode,
                         vector_size,
                         0);
@@ -43,7 +43,7 @@ void inst_sanitizer_image_gather(const uint inst_offset, const uint component)
 {
     error_payload = ErrorPayload(
                     inst_offset,
-                    SpecConstantLinkShaderId | (kErrorGroupInstSanitizer << kErrorGroupShift) | (kErrorSubCodeSanitizerImageGather << kErrorSubCodeShift),
+                    SpecConstantLinkShaderId | (kErrorGroup_InstSanitizer << kErrorGroup_Shift) | (kErrorSubCode_Sanitizer_ImageGather << kErrorSubCode_Shift),
                     component,
                     0,
                     0);
@@ -56,7 +56,7 @@ bool inst_sanitizer_pow(const bool is_invalid, const uint inst_offset, const uin
     if (is_invalid) {
         error_payload = ErrorPayload(
                         inst_offset,
-                        SpecConstantLinkShaderId | (kErrorGroupInstSanitizer << kErrorGroupShift) | (kErrorSubCodeSanitizerPow << kErrorSubCodeShift),
+                        SpecConstantLinkShaderId | (kErrorGroup_InstSanitizer << kErrorGroup_Shift) | (kErrorSubCode_Sanitizer_Pow << kErrorSubCode_Shift),
                         vector_size,
                         x,
                         y);
@@ -70,7 +70,7 @@ bool inst_sanitizer_atan2(const bool is_invalid, const uint inst_offset)
     if (is_invalid) {
         error_payload = ErrorPayload(
                         inst_offset,
-                        SpecConstantLinkShaderId | (kErrorGroupInstSanitizer << kErrorGroupShift) | (kErrorSubCodeSanitizerAtan2 << kErrorSubCodeShift),
+                        SpecConstantLinkShaderId | (kErrorGroup_InstSanitizer << kErrorGroup_Shift) | (kErrorSubCode_Sanitizer_Atan2 << kErrorSubCode_Shift),
                         0,
                         0,
                         0);
@@ -84,7 +84,7 @@ bool inst_sanitizer_fminman(const bool is_x_invalid, const bool is_y_invalid, co
     if (is_x_invalid || is_y_invalid) {
         error_payload = ErrorPayload(
                         inst_offset,
-                        SpecConstantLinkShaderId | (kErrorGroupInstSanitizer << kErrorGroupShift) | (kErrorSubCodeSanitizerFminmax << kErrorSubCodeShift),
+                        SpecConstantLinkShaderId | (kErrorGroup_InstSanitizer << kErrorGroup_Shift) | (kErrorSubCode_Sanitizer_Fminmax << kErrorSubCode_Shift),
                         uint(is_x_invalid) | (uint(is_y_invalid) << 1),
                         vector_size,
                         glsl_opcode);

--- a/layers/gpuav/shaders/instrumentation/vertex_attribute_fetch_oob.vert
+++ b/layers/gpuav/shaders/instrumentation/vertex_attribute_fetch_oob.vert
@@ -1,6 +1,6 @@
-// Copyright (c) 2024-2025 The Khronos Group Inc.
-// Copyright (c) 2024-2025 Valve Corporation
-// Copyright (c) 2024-2025 LunarG, Inc.
+// Copyright (c) 2024-2026 The Khronos Group Inc.
+// Copyright (c) 2024-2026 Valve Corporation
+// Copyright (c) 2024-2026 LunarG, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -57,15 +57,15 @@ void inst_vertex_attribute_fetch_oob(const uvec4 stage_info)
         if (errors_buffer_not_filled) {
             const uint error = valid_vertex_attribute_fetch_vertex_input_rate ? kErrorSubCode_IndexedDraw_OOBInstanceIndex : kErrorSubCode_IndexedDraw_OOBVertexIndex;
 
-            inst_errors_buffer.data[write_pos + kHeaderErrorRecordSizeOffset] = kErrorRecordSize;
-            inst_errors_buffer.data[write_pos + kHeaderShaderIdErrorOffset] = SpecConstantLinkShaderId | (kErrorGroupInstIndexedDraw << kErrorGroupShift) | (error << kErrorSubCodeShift);
+            inst_errors_buffer.data[write_pos + kHeader_ErrorRecordSizeOffset] = kErrorRecordSize;
+            inst_errors_buffer.data[write_pos + kHeader_ShaderIdErrorOffset] = SpecConstantLinkShaderId | (kErrorGroup_InstIndexedDraw << kErrorGroup_Shift) | (error << kErrorSubCode_Shift);
             // The shader stage is irrelevant because we know it is a vertex shader
-            inst_errors_buffer.data[write_pos + kHeaderStageInstructionIdOffset] = stage_info[0] << kStageIdShift;
-            inst_errors_buffer.data[write_pos + kHeaderStageInfoOffset_0] = stage_info[1];
-            inst_errors_buffer.data[write_pos + kHeaderStageInfoOffset_1] = stage_info[2];
-            inst_errors_buffer.data[write_pos + kHeaderStageInfoOffset_2] = stage_info[3];
+            inst_errors_buffer.data[write_pos + kHeader_StageInstructionIdOffset] = stage_info[0] << kStageId_Shift;
+            inst_errors_buffer.data[write_pos + kHeader_StageInfoOffset_0] = stage_info[1];
+            inst_errors_buffer.data[write_pos + kHeader_StageInfoOffset_1] = stage_info[2];
+            inst_errors_buffer.data[write_pos + kHeader_StageInfoOffset_2] = stage_info[3];
 
-            inst_errors_buffer.data[write_pos + kHeaderActionIdErrorLoggerIdOffset] = (inst_action_index_buffer.index[0] << kActionIdShift) | inst_error_logger_index_buffer.index[0];
+            inst_errors_buffer.data[write_pos + kHeader_ActionIdErrorLoggerIdOffset] = (inst_action_index_buffer.index[0] << kActionId_Shift) | inst_error_logger_index_buffer.index[0];
         }
     }
 }

--- a/layers/gpuav/shaders/validation_cmd/build_acceleration_structures.comp
+++ b/layers/gpuav/shaders/validation_cmd/build_acceleration_structures.comp
@@ -122,6 +122,6 @@ void main() {
         const uint error_dword_2 = as_instance_i;
         const uint error_dword_3 = pc.blas_array_i;// #ARNO_TODO swap dwords 2 and 3
         const uint error_dword_4 = blas_built_in_cmd_i;
-        GpuavLogError5(kErrorGroupGpuPreBuildAccelerationStructures, error_subcode, error_dword_0, error_dword_1, error_dword_2, error_dword_3, error_dword_4);
+        GpuavLogError5(kErrorGroup_GpuPreBuildAccelerationStructures, error_subcode, error_dword_0, error_dword_1, error_dword_2, error_dword_3, error_dword_4);
     }
 }

--- a/layers/gpuav/shaders/validation_cmd/common.h
+++ b/layers/gpuav/shaders/validation_cmd/common.h
@@ -1,6 +1,6 @@
-// Copyright (c) 2023-2025 The Khronos Group Inc.
-// Copyright (c) 2023-2025 Valve Corporation
-// Copyright (c) 2023-2025 LunarG, Inc.
+// Copyright (c) 2023-2026 The Khronos Group Inc.
+// Copyright (c) 2023-2026 Valve Corporation
+// Copyright (c) 2023-2026 LunarG, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -50,15 +50,16 @@ void GpuavLogError5(uint error_group, uint error_sub_code, uint dword_0, uint dw
     const bool errors_buffer_filled = (vo_idx + kErrorRecordSize) > errors_buffer.length();
     if (errors_buffer_filled) return;
 
-    errors_buffer[vo_idx + kHeaderShaderIdErrorOffset] = (error_group << kErrorGroupShift) | (error_sub_code << kErrorSubCodeShift);
-    errors_buffer[vo_idx + kHeaderErrorRecordSizeOffset] = kErrorRecordSize;
-    errors_buffer[vo_idx + kHeaderActionIdErrorLoggerIdOffset] = (action_index[0] << kActionIdShift) | resource_index[0];
+    errors_buffer[vo_idx + kHeader_ShaderIdErrorOffset] =
+        (error_group << kErrorGroup_Shift) | (error_sub_code << kErrorSubCode_Shift);
+    errors_buffer[vo_idx + kHeader_ErrorRecordSizeOffset] = kErrorRecordSize;
+    errors_buffer[vo_idx + kHeader_ActionIdErrorLoggerIdOffset] = (action_index[0] << kActionId_Shift) | resource_index[0];
 
-    errors_buffer[vo_idx + kValCmdErrorPayloadDword_0] = dword_0;
-    errors_buffer[vo_idx + kValCmdErrorPayloadDword_1] = dword_1;
-    errors_buffer[vo_idx + kValCmdErrorPayloadDword_2] = dword_2;
-    errors_buffer[vo_idx + kValCmdErrorPayloadDword_3] = dword_3;
-    errors_buffer[vo_idx + kValCmdErrorPayloadDword_4] = dword_4;
+    errors_buffer[vo_idx + kValCmd_ErrorPayloadDword_0] = dword_0;
+    errors_buffer[vo_idx + kValCmd_ErrorPayloadDword_1] = dword_1;
+    errors_buffer[vo_idx + kValCmd_ErrorPayloadDword_2] = dword_2;
+    errors_buffer[vo_idx + kValCmd_ErrorPayloadDword_3] = dword_3;
+    errors_buffer[vo_idx + kValCmd_ErrorPayloadDword_4] = dword_4;
 }
 
 void GpuavLogError2(uint error_group, uint error_sub_code, uint dword_0, uint dword_1) {

--- a/layers/gpuav/shaders/validation_cmd/copy_buffer_to_image.comp
+++ b/layers/gpuav/shaders/validation_cmd/copy_buffer_to_image.comp
@@ -1,6 +1,6 @@
-// Copyright (c) 2022-2025 The Khronos Group Inc.
-// Copyright (c) 2022-2025 Valve Corporation
-// Copyright (c) 2022-2025 LunarG, Inc.
+// Copyright (c) 2022-2026 The Khronos Group Inc.
+// Copyright (c) 2022-2026 Valve Corporation
+// Copyright (c) 2022-2026 LunarG, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -110,7 +110,7 @@ void main() {
 
         Texel texel = SearchOobDepthValue(tid, region_i);
         if (texel.value < 0 || texel.value > 1) {
-            GpuavLogError2(kErrorGroupGpuCopyBufferToImage, kErrorSubCodePreCopyBufferToImageBufferTexel, texel.byte_offset, 0);
+            GpuavLogError2(kErrorGroup_GpuCopyBufferToImage, kErrorSubCodePreCopyBufferToImageBufferTexel, texel.byte_offset, 0);
         }
     }
 }

--- a/layers/gpuav/shaders/validation_cmd/copy_memory_indirect.comp
+++ b/layers/gpuav/shaders/validation_cmd/copy_memory_indirect.comp
@@ -1,6 +1,6 @@
-// Copyright (c) 2022-2025 The Khronos Group Inc.
-// Copyright (c) 2022-2025 Valve Corporation
-// Copyright (c) 2022-2025 LunarG, Inc.
+// Copyright (c) 2022-2026 The Khronos Group Inc.
+// Copyright (c) 2022-2026 Valve Corporation
+// Copyright (c) 2022-2026 LunarG, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -110,42 +110,42 @@ void main() {
     if (api.is_image_copy != 0) {
         CopyMemoryToImageIndirectCommand command = CopyMemoryToImageIndirectCommand(command_address);
         if (!ValidDeviceAddress(command.srcAddress)) {
-            GpuavLogError4(kErrorGroupGpuCopyMemoryIndirect, kErrorSubCodePreCopyMemoryToImageIndirectSrcAddressInvalid,
+            GpuavLogError4(kErrorGroup_GpuCopyMemoryIndirect, kErrorSubCode_PreCopyMemoryToImageIndirect_SrcAddressInvalid,
                             uint(command.srcAddress), uint(command.srcAddress >> 32), tid, 0);
             MakeSafeImage(command_address);
         } else if ((command.srcAddress & 3ul) != 0) {
-            GpuavLogError4(kErrorGroupGpuCopyMemoryIndirect, kErrorSubCodePreCopyMemoryToImageIndirectSrcAddressAligned,
+            GpuavLogError4(kErrorGroup_GpuCopyMemoryIndirect, kErrorSubCode_PreCopyMemoryToImageIndirect_SrcAddressAligned,
                             uint(command.srcAddress), uint(command.srcAddress >> 32), tid, 0);
             MakeSafeImage(command_address);
         } else if (command.bufferRowLength != 0 && command.bufferRowLength < command.imageExtent_width) {
-            GpuavLogError4(kErrorGroupGpuCopyMemoryIndirect, kErrorSubCodePreCopyMemoryToImageIndirectBufferRowLength,
+            GpuavLogError4(kErrorGroup_GpuCopyMemoryIndirect, kErrorSubCode_PreCopyMemoryToImageIndirect_BufferRowLength,
                             command.bufferRowLength, command.imageExtent_width, tid, 0);
             MakeSafeImage(command_address);
         } else if (command.bufferImageHeight != 0 && command.bufferImageHeight < command.imageExtent_height) {
-            GpuavLogError4(kErrorGroupGpuCopyMemoryIndirect, kErrorSubCodePreCopyMemoryToImageIndirectBufferImageHeight,
+            GpuavLogError4(kErrorGroup_GpuCopyMemoryIndirect, kErrorSubCode_PreCopyMemoryToImageIndirect_BufferImageHeight,
                             command.bufferImageHeight, command.imageExtent_height, tid, 0);
             MakeSafeImage(command_address);
         }
     } else {
         CopyMemoryIndirectCommand command = CopyMemoryIndirectCommand(command_address);
         if (!ValidDeviceAddress(command.srcAddress)) {
-            GpuavLogError4(kErrorGroupGpuCopyMemoryIndirect, kErrorSubCodePreCopyMemoryIndirectSrcAddressInvalid,
+            GpuavLogError4(kErrorGroup_GpuCopyMemoryIndirect, kErrorSubCode_PreCopyMemoryIndirect_SrcAddressInvalid,
                             uint(command.srcAddress), uint(command.srcAddress >> 32), tid, 0);
             MakeSafeBuffer(command_address);
         } else if (!ValidDeviceAddress(command.dstAddress)) {
-            GpuavLogError4(kErrorGroupGpuCopyMemoryIndirect, kErrorSubCodePreCopyMemoryIndirectDstAddressInvalid,
+            GpuavLogError4(kErrorGroup_GpuCopyMemoryIndirect, kErrorSubCode_PreCopyMemoryIndirect_DstAddressInvalid,
                             uint(command.dstAddress), uint(command.dstAddress >> 32), tid, 0);
             MakeSafeBuffer(command_address);
         } else if ((command.srcAddress & 3ul) != 0) {
-            GpuavLogError4(kErrorGroupGpuCopyMemoryIndirect, kErrorSubCodePreCopyMemoryIndirectSrcAddressAligned,
+            GpuavLogError4(kErrorGroup_GpuCopyMemoryIndirect, kErrorSubCode_PreCopyMemoryIndirect_SrcAddressAligned,
                             uint(command.srcAddress), uint(command.srcAddress >> 32), tid, 0);
             MakeSafeBuffer(command_address);
         } else if ((command.dstAddress & 3ul) != 0) {
-            GpuavLogError4(kErrorGroupGpuCopyMemoryIndirect, kErrorSubCodePreCopyMemoryIndirectDstAddressAligned,
+            GpuavLogError4(kErrorGroup_GpuCopyMemoryIndirect, kErrorSubCode_PreCopyMemoryIndirect_DstAddressAligned,
                             uint(command.dstAddress), uint(command.dstAddress >> 32), tid, 0);
             MakeSafeBuffer(command_address);
         } else if ((command.size & 3ul) != 0) {
-            GpuavLogError4(kErrorGroupGpuCopyMemoryIndirect, kErrorSubCodePreCopyMemoryIndirectSizeAligned,
+            GpuavLogError4(kErrorGroup_GpuCopyMemoryIndirect, kErrorSubCode_PreCopyMemoryIndirect_SizeAligned,
                             uint(command.size), uint(command.size >> 32), tid, 0);
             MakeSafeBuffer(command_address);
         }

--- a/layers/gpuav/shaders/validation_cmd/count_buffer.comp
+++ b/layers/gpuav/shaders/validation_cmd/count_buffer.comp
@@ -1,6 +1,6 @@
-// Copyright (c) 2021-2025 The Khronos Group Inc.
-// Copyright (c) 2021-2025 Valve Corporation
-// Copyright (c) 2021-2025 LunarG, Inc.
+// Copyright (c) 2021-2026 The Khronos Group Inc.
+// Copyright (c) 2021-2026 Valve Corporation
+// Copyright (c) 2021-2026 LunarG, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,8 +36,8 @@ void main() {
 
     const uint64_t draw_buffer_max_read_offset = pc.api_stride * (draw_count - 1) + pc.api_offset + pc.api_struct_size_byte;
     if (draw_buffer_max_read_offset > pc.draw_buffer_size) {
-        GpuavLogError2(kErrorGroupGpuPreDraw, kErrorSubCodePreDraw_DrawBufferSize, draw_count, 0);
+        GpuavLogError2(kErrorGroup_GpuPreDraw, kErrorSubCode_PreDraw_DrawBufferSize, draw_count, 0);
     } else if (draw_count > pc.device_limit_max_draw_indirect_count) {
-        GpuavLogError2(kErrorGroupGpuPreDraw, kErrorSubCodePreDraw_DrawCountLimit, draw_count, 0);
+        GpuavLogError2(kErrorGroup_GpuPreDraw, kErrorSubCode_PreDraw_DrawCountLimit, draw_count, 0);
     }
 }

--- a/layers/gpuav/shaders/validation_cmd/dispatch.comp
+++ b/layers/gpuav/shaders/validation_cmd/dispatch.comp
@@ -1,6 +1,6 @@
-// Copyright (c) 2022-2025 The Khronos Group Inc.
-// Copyright (c) 2022-2025 Valve Corporation
-// Copyright (c) 2022-2025 LunarG, Inc.
+// Copyright (c) 2022-2026 The Khronos Group Inc.
+// Copyright (c) 2022-2026 Valve Corporation
+// Copyright (c) 2022-2026 LunarG, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,10 +36,10 @@ void main() {
     const uint indirect_z = indirect_buffer[ pc.indirect_x_offset + 2 ];
 
     if (indirect_x > pc.limit_x) {
-        GpuavLogError2(kErrorGroupGpuPreDispatch, kErrorSubCodePreDispatchCountLimitX, indirect_x, 0);
+        GpuavLogError2(kErrorGroup_GpuPreDispatch, kErrorSubCode_PreDispatch_CountLimitX, indirect_x, 0);
     } else if (indirect_y > pc.limit_y) {
-        GpuavLogError2(kErrorGroupGpuPreDispatch, kErrorSubCodePreDispatchCountLimitY, indirect_y, 0);
+        GpuavLogError2(kErrorGroup_GpuPreDispatch, kErrorSubCode_PreDispatch_CountLimitY, indirect_y, 0);
     } else if (indirect_z > pc.limit_z) {
-        GpuavLogError2(kErrorGroupGpuPreDispatch, kErrorSubCodePreDispatchCountLimitZ, indirect_z, 0);
+        GpuavLogError2(kErrorGroup_GpuPreDispatch, kErrorSubCode_PreDispatch_CountLimitZ, indirect_z, 0);
     }
 }

--- a/layers/gpuav/shaders/validation_cmd/draw_indexed_indirect_index_buffer.comp
+++ b/layers/gpuav/shaders/validation_cmd/draw_indexed_indirect_index_buffer.comp
@@ -1,6 +1,6 @@
-// Copyright (c) 2021-2025 The Khronos Group Inc.
-// Copyright (c) 2021-2025 Valve Corporation
-// Copyright (c) 2021-2025 LunarG, Inc.
+// Copyright (c) 2021-2026 The Khronos Group Inc.
+// Copyright (c) 2021-2026 Valve Corporation
+// Copyright (c) 2021-2026 LunarG, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -74,6 +74,6 @@ void main() {
     const uint draw_i_first_index = draw_indexed_indirect_cmds[ draw_indexed_indirect_cmd_i + kFirstIndex ];
 
     if ((draw_i_first_index + draw_i_index_count) > pc.bound_index_buffer_indices_count) {
-        GpuavLogError4(kErrorGroupGpuPreDraw, kErrorSubCode_OobIndexBuffer, draw_i, draw_i_first_index, draw_i_index_count, 0);
+        GpuavLogError4(kErrorGroup_GpuPreDraw, kErrorSubCode_OobIndexBuffer, draw_i, draw_i_first_index, draw_i_index_count, 0);
     }
 }

--- a/layers/gpuav/shaders/validation_cmd/draw_mesh_indirect.comp
+++ b/layers/gpuav/shaders/validation_cmd/draw_mesh_indirect.comp
@@ -1,6 +1,6 @@
-// Copyright (c) 2021-2025 The Khronos Group Inc.
-// Copyright (c) 2021-2025 Valve Corporation
-// Copyright (c) 2021-2025 LunarG, Inc.
+// Copyright (c) 2021-2026 The Khronos Group Inc.
+// Copyright (c) 2021-2026 Valve Corporation
+// Copyright (c) 2021-2026 LunarG, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -63,17 +63,17 @@ void main() {
     const uint y = draw_buffer[ draw_mesh_task_indirect_cmd_i + kGroupCountY ];
     const uint z = draw_buffer[ draw_mesh_task_indirect_cmd_i + kGroupCountZ ];
     if (x > pc.max_workgroup_count_x) {
-        GpuavLogError2(kErrorGroupGpuPreDraw, kErrorSubCodePreDrawGroupCountX, x, draw_i);
+        GpuavLogError2(kErrorGroup_GpuPreDraw, kErrorSubCode_PreDraw_GroupCountX, x, draw_i);
     }
     if (y > pc.max_workgroup_count_y) {
-        GpuavLogError2(kErrorGroupGpuPreDraw, kErrorSubCodePreDrawGroupCountY, y, draw_i);
+        GpuavLogError2(kErrorGroup_GpuPreDraw, kErrorSubCode_PreDraw_GroupCountY, y, draw_i);
     }
     if (z > pc.max_workgroup_count_z) {
-        GpuavLogError2(kErrorGroupGpuPreDraw, kErrorSubCodePreDrawGroupCountZ, z, draw_i);
+        GpuavLogError2(kErrorGroup_GpuPreDraw, kErrorSubCode_PreDraw_GroupCountZ, z, draw_i);
     }
 
     const uint total = x * y * z;
     if (total > pc.max_workgroup_total_count) {
-        GpuavLogError2(kErrorGroupGpuPreDraw, kErrorSubCodePreDrawGroupCountTotal, total, draw_i);
+        GpuavLogError2(kErrorGroup_GpuPreDraw, kErrorSubCode_PreDraw_GroupCountTotal, total, draw_i);
     }
 }

--- a/layers/gpuav/shaders/validation_cmd/first_instance.comp
+++ b/layers/gpuav/shaders/validation_cmd/first_instance.comp
@@ -1,6 +1,6 @@
-// Copyright (c) 2021-2025 The Khronos Group Inc.
-// Copyright (c) 2021-2025 Valve Corporation
-// Copyright (c) 2021-2025 LunarG, Inc.
+// Copyright (c) 2021-2026 The Khronos Group Inc.
+// Copyright (c) 2021-2026 Valve Corporation
+// Copyright (c) 2021-2026 LunarG, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -51,6 +51,6 @@ void main() {
     const uint draw_indexed_indirect_cmd_i = draw_i * pc.api_stride_dwords + pc.first_instance_member_pos + pc.api_offset_dwords;
     const uint first_instance = draw_indexed_indirect_cmds[ draw_indexed_indirect_cmd_i ];
     if (first_instance != 0) {
-        GpuavLogError2(kErrorGroupGpuPreDraw, kErrorSubCodePreDrawFirstInstance, draw_i, first_instance);
+        GpuavLogError2(kErrorGroup_GpuPreDraw, kErrorSubCode_PreDraw_FirstInstance, draw_i, first_instance);
     }
 }

--- a/layers/gpuav/shaders/validation_cmd/setup_draw_indexed_indirect_index_buffer.comp
+++ b/layers/gpuav/shaders/validation_cmd/setup_draw_indexed_indirect_index_buffer.comp
@@ -1,6 +1,6 @@
-// Copyright (c) 2021-2025 The Khronos Group Inc.
-// Copyright (c) 2021-2025 Valve Corporation
-// Copyright (c) 2021-2025 LunarG, Inc.
+// Copyright (c) 2021-2026 The Khronos Group Inc.
+// Copyright (c) 2021-2026 Valve Corporation
+// Copyright (c) 2021-2026 LunarG, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/layers/gpuav/shaders/validation_cmd/trace_rays.comp
+++ b/layers/gpuav/shaders/validation_cmd/trace_rays.comp
@@ -1,6 +1,6 @@
-// Copyright (c) 2022-2025 The Khronos Group Inc.
-// Copyright (c) 2022-2025 Valve Corporation
-// Copyright (c) 2022-2025 LunarG, Inc.
+// Copyright (c) 2022-2026 The Khronos Group Inc.
+// Copyright (c) 2022-2026 Valve Corporation
+// Copyright (c) 2022-2026 LunarG, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,13 +27,13 @@ layout(push_constant, scalar) uniform PushConstants {
 
 void main() {
     if (pc.indirect_data.trace_rays_dimensions.width > pc.trace_rays_width_limit) {
-        GpuavLogError2(kErrorGroupGpuPreTraceRays, kErrorSubCodePreTraceRaysLimitWidth, pc.indirect_data.trace_rays_dimensions.width, 0);
+        GpuavLogError2(kErrorGroup_GpuPreTraceRays, kErrorSubCode_PreTraceRays_LimitWidth, pc.indirect_data.trace_rays_dimensions.width, 0);
     }
     if (pc.indirect_data.trace_rays_dimensions.height > pc.trace_rays_height_limit) {
-        GpuavLogError2(kErrorGroupGpuPreTraceRays, kErrorSubCodePreTraceRaysLimitHeight, pc.indirect_data.trace_rays_dimensions.height, 0);
+        GpuavLogError2(kErrorGroup_GpuPreTraceRays, kErrorSubCode_PreTraceRays_LimitHeight, pc.indirect_data.trace_rays_dimensions.height, 0);
     }
     if (pc.indirect_data.trace_rays_dimensions.depth > pc.trace_rays_depth_limit) {
-        GpuavLogError2(kErrorGroupGpuPreTraceRays, kErrorSubCodePreTraceRaysLimitDepth, pc.indirect_data.trace_rays_dimensions.depth, 0);
+        GpuavLogError2(kErrorGroup_GpuPreTraceRays, kErrorSubCode_PreTraceRays_LimitDepth, pc.indirect_data.trace_rays_dimensions.depth, 0);
     }
 
     const uint64_t trace_rays_volume =
@@ -43,8 +43,8 @@ void main() {
 
     if (trace_rays_volume > pc.max_ray_dispatch_invocation_count) {
         GpuavLogError4(
-            kErrorGroupGpuPreTraceRays,
-            kErrorSubCodePreTraceRaysLimitVolume,
+            kErrorGroup_GpuPreTraceRays,
+            kErrorSubCode_PreTraceRays_LimitVolume,
             pc.indirect_data.trace_rays_dimensions.width,
             pc.indirect_data.trace_rays_dimensions.height,
             pc.indirect_data.trace_rays_dimensions.depth,

--- a/layers/gpuav/spirv/buffer_device_address_pass.cpp
+++ b/layers/gpuav/spirv/buffer_device_address_pass.cpp
@@ -53,10 +53,10 @@ uint32_t BufferDeviceAddressPass::CreateFunctionCall(BasicBlock& block, Instruct
 
     uint32_t access_type_value = 0;
     if (opcode == spv::OpStore) {
-        access_type_value |= 1 << glsl::kInstBuffAddrAccessPayloadShiftIsWrite;
+        access_type_value |= 1 << glsl::kInst_BuffAddrAccess_PayloadShiftIsWrite;
     }
     if (meta.type_is_struct) {
-        access_type_value |= 1 << glsl::kInstBuffAddrAccessPayloadShiftIsStruct;
+        access_type_value |= 1 << glsl::kInst_BuffAddrAccess_PayloadShiftIsStruct;
     }
     const Constant& access_type = type_manager_.GetConstantUInt32(access_type_value);
     const uint32_t bool_type = type_manager_.GetTypeBool().Id();

--- a/layers/gpuav/spirv/debug_printf_pass.cpp
+++ b/layers/gpuav/spirv/debug_printf_pass.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2024-2025 LunarG, Inc.
+/* Copyright (c) 2024-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -320,8 +320,8 @@ uint32_t DebugPrintfPass::CreateDescriptorSet() {
     new_struct_inst->Fill({struct_type_id, uint32_type.Id(), runtime_array_type_id});
     const Type& struct_type = type_manager_.AddType(std::move(new_struct_inst), SpvType::kStruct);
     module_.AddDecoration(struct_type_id, spv::DecorationBlock, {});
-    module_.AddMemberDecoration(struct_type_id, gpuav::kDebugPrintfOutputBufferDWordsCount, spv::DecorationOffset, {0});
-    module_.AddMemberDecoration(struct_type_id, gpuav::kDebugPrintfOutputBufferData, spv::DecorationOffset, {4});
+    module_.AddMemberDecoration(struct_type_id, gpuav::kDebugPrintf_OutputBuffer_DWordsCount, spv::DecorationOffset, {0});
+    module_.AddMemberDecoration(struct_type_id, gpuav::kDebugPrintf_OutputBuffer_Data, spv::DecorationOffset, {4});
 
     // create a storage buffer interface variable
     const Type& pointer_type = type_manager_.GetTypePointer(spv::StorageClassStorageBuffer, struct_type);

--- a/layers/gpuav/spirv/pass.cpp
+++ b/layers/gpuav/spirv/pass.cpp
@@ -98,34 +98,34 @@ uint32_t Pass::GetStageInfo(Function& function, const BasicBlock& target_block_i
     if (module_.entry_points_.size() > 1) {
         // For Multi Entry Points it currently a lot of work to scan every function to see where it will be called from
         // For now we will just report it is "unknown" and skip printing that part of the error message
-        stage_info[0] = type_manager_.GetConstantUInt32(glsl::kExecutionModelMultiEntryPoint).Id();
+        stage_info[0] = type_manager_.GetConstantUInt32(glsl::kExecutionModel_MultiEntryPoint).Id();
     } else {
         spv::ExecutionModel execution_model = spv::ExecutionModel(module_.entry_points_.begin()->get()->Operand(0));
 
         // Need to map how GenerateStageMessage() will consume it
         uint32_t normalized_execution_model = execution_model;
         if (execution_model == spv::ExecutionModelTaskNV) {
-            normalized_execution_model = glsl::kExecutionModelTaskNV;
+            normalized_execution_model = glsl::kExecutionModel_TaskNV;
         } else if (execution_model == spv::ExecutionModelMeshNV) {
-            normalized_execution_model = glsl::kExecutionModelMeshNV;
+            normalized_execution_model = glsl::kExecutionModel_MeshNV;
         } else if (execution_model == spv::ExecutionModelRayGenerationKHR) {
-            normalized_execution_model = glsl::kExecutionModelRayGenerationKHR;
+            normalized_execution_model = glsl::kExecutionModel_RayGenerationKHR;
         } else if (execution_model == spv::ExecutionModelIntersectionKHR) {
-            normalized_execution_model = glsl::kExecutionModelIntersectionKHR;
+            normalized_execution_model = glsl::kExecutionModel_IntersectionKHR;
         } else if (execution_model == spv::ExecutionModelAnyHitKHR) {
-            normalized_execution_model = glsl::kExecutionModelAnyHitKHR;
+            normalized_execution_model = glsl::kExecutionModel_AnyHitKHR;
         } else if (execution_model == spv::ExecutionModelClosestHitKHR) {
-            normalized_execution_model = glsl::kExecutionModelClosestHitKHR;
+            normalized_execution_model = glsl::kExecutionModel_ClosestHitKHR;
         } else if (execution_model == spv::ExecutionModelMissKHR) {
-            normalized_execution_model = glsl::kExecutionModelMissKHR;
+            normalized_execution_model = glsl::kExecutionModel_MissKHR;
         } else if (execution_model == spv::ExecutionModelCallableKHR) {
-            normalized_execution_model = glsl::kExecutionModelCallableKHR;
+            normalized_execution_model = glsl::kExecutionModel_CallableKHR;
         } else if (execution_model == spv::ExecutionModelCallableKHR) {
-            normalized_execution_model = glsl::kExecutionModelCallableKHR;
+            normalized_execution_model = glsl::kExecutionModel_CallableKHR;
         } else if (execution_model == spv::ExecutionModelTaskEXT) {
-            normalized_execution_model = glsl::kExecutionModelTaskEXT;
+            normalized_execution_model = glsl::kExecutionModel_TaskEXT;
         } else if (execution_model == spv::ExecutionModelMeshEXT) {
-            normalized_execution_model = glsl::kExecutionModelMeshEXT;
+            normalized_execution_model = glsl::kExecutionModel_MeshEXT;
         }
         stage_info[0] = type_manager_.GetConstantUInt32(normalized_execution_model).Id();
 

--- a/layers/gpuav/spirv/sanitizer_pass.h
+++ b/layers/gpuav/spirv/sanitizer_pass.h
@@ -48,7 +48,7 @@ class SanitizerPass : public Pass {
         const Type* result_type = nullptr;
         const Instruction* target_instruction = nullptr;
 
-        uint32_t sub_code = glsl::kErrorSubCodeSanitizerEmpty;
+        uint32_t sub_code = glsl::kErrorSubCode_Sanitizer_Empty;
         uint32_t glsl_opcode = 0;
 
         // There are cases where it is easier to just adjust the bad code than if/else wrap it
@@ -71,7 +71,7 @@ class SanitizerPass : public Pass {
     bool IsConstantZero(const Constant& constant) const;
 
     // Function IDs to link in
-    uint32_t link_function_ids_[glsl::kErrorSubCodeSanitizerCount];
+    uint32_t link_function_ids_[glsl::kErrorSubCode_Sanitizer_Count];
 
     uint32_t glsl_std450_id_ = 0;  // GLSL.std.450
 };

--- a/layers/gpuav/validation_cmd/gpuav_copy_buffer_to_image.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_copy_buffer_to_image.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2018-2025 The Khronos Group Inc.
- * Copyright (c) 2018-2025 Valve Corporation
- * Copyright (c) 2018-2025 LunarG, Inc.
+/* Copyright (c) 2018-2026 The Khronos Group Inc.
+ * Copyright (c) 2018-2026 Valve Corporation
+ * Copyright (c) 2018-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -219,14 +219,14 @@ void CopyBufferToImage(Validator &gpuav, const Location &loc, CommandBufferSubSt
         bool skip = false;
         using namespace glsl;
 
-        if (GetErrorGroup(error_record) != kErrorGroupGpuCopyBufferToImage) {
+        if (GetErrorGroup(error_record) != kErrorGroup_GpuCopyBufferToImage) {
             return skip;
         }
 
         const uint32_t error_sub_code = GetSubError(error_record);
         switch (error_sub_code) {
             case kErrorSubCodePreCopyBufferToImageBufferTexel: {
-                const uint32_t texel_offset = error_record[kValCmdErrorPayloadDword_0];
+                const uint32_t texel_offset = error_record[kValCmd_ErrorPayloadDword_0];
                 LogObjectList objlist_and_src_buffer = objlist;
                 objlist_and_src_buffer.add(src_buffer);
                 const char *vuid = loc_with_debug_region.function == vvl::Func::vkCmdCopyBufferToImage

--- a/layers/gpuav/validation_cmd/gpuav_copy_memory_indirect.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_copy_memory_indirect.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2025 The Khronos Group Inc.
- * Copyright (c) 2025 Valve Corporation
- * Copyright (c) 2025 LunarG, Inc.
+/* Copyright (c) 2025-2026 The Khronos Group Inc.
+ * Copyright (c) 2025-2026 Valve Corporation
+ * Copyright (c) 2025-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -160,16 +160,16 @@ void CopyMemoryIndirect(Validator &gpuav, const Location &loc, CommandBufferSubS
         bool skip = false;
         using namespace glsl;
 
-        if (GetErrorGroup(error_record) != kErrorGroupGpuCopyMemoryIndirect) {
+        if (GetErrorGroup(error_record) != kErrorGroup_GpuCopyMemoryIndirect) {
             return skip;
         }
 
         const uint32_t error_sub_code = GetSubError(error_record);
-        const uint64_t payload_start = GetUint64(&error_record[kValCmdErrorPayloadDword_0]);
-        const uint32_t copy_index = error_record[kValCmdErrorPayloadDword_2];
+        const uint64_t payload_start = GetUint64(&error_record[kValCmd_ErrorPayloadDword_0]);
+        const uint32_t copy_index = error_record[kValCmd_ErrorPayloadDword_2];
         const VkDeviceSize offset = api_copy_info.address_range.stride * copy_index;
         switch (error_sub_code) {
-            case kErrorSubCodePreCopyMemoryIndirectSrcAddressInvalid: {
+            case kErrorSubCode_PreCopyMemoryIndirect_SrcAddressInvalid: {
                 const uint64_t src_address = payload_start;
                 skip |= gpuav.LogError("VUID-VkCopyMemoryIndirectCommandKHR-srcAddress-parameter", objlist, loc_with_debug_region,
                                        "VkCopyMemoryIndirectInfoKHR::copyAddressRange.address (0x%" PRIx64 ") + (stride [%" PRIu64
@@ -182,7 +182,7 @@ void CopyMemoryIndirect(Validator &gpuav, const Location &loc, CommandBufferSubS
 
                 break;
             }
-            case kErrorSubCodePreCopyMemoryIndirectSrcAddressAligned: {
+            case kErrorSubCode_PreCopyMemoryIndirect_SrcAddressAligned: {
                 const uint64_t src_address = payload_start;
                 skip |= gpuav.LogError("VUID-VkCopyMemoryIndirectCommandKHR-srcAddress-10958", objlist, loc_with_debug_region,
                                        "VkCopyMemoryIndirectInfoKHR::copyAddressRange.address (0x%" PRIx64 ") + (stride [%" PRIu64
@@ -195,7 +195,7 @@ void CopyMemoryIndirect(Validator &gpuav, const Location &loc, CommandBufferSubS
 
                 break;
             }
-            case kErrorSubCodePreCopyMemoryIndirectDstAddressInvalid: {
+            case kErrorSubCode_PreCopyMemoryIndirect_DstAddressInvalid: {
                 const uint64_t dst_address = payload_start;
                 skip |= gpuav.LogError("VUID-VkCopyMemoryIndirectCommandKHR-dstAddress-parameter", objlist, loc_with_debug_region,
                                        "VkCopyMemoryIndirectInfoKHR::copyAddressRange.address (0x%" PRIx64 ") + (stride [%" PRIu64
@@ -208,7 +208,7 @@ void CopyMemoryIndirect(Validator &gpuav, const Location &loc, CommandBufferSubS
 
                 break;
             }
-            case kErrorSubCodePreCopyMemoryIndirectDstAddressAligned: {
+            case kErrorSubCode_PreCopyMemoryIndirect_DstAddressAligned: {
                 const uint64_t dst_address = payload_start;
                 skip |= gpuav.LogError("VUID-VkCopyMemoryIndirectCommandKHR-dstAddress-10959", objlist, loc_with_debug_region,
                                        "VkCopyMemoryIndirectInfoKHR::copyAddressRange.address (0x%" PRIx64 ") + (stride [%" PRIu64
@@ -221,7 +221,7 @@ void CopyMemoryIndirect(Validator &gpuav, const Location &loc, CommandBufferSubS
 
                 break;
             }
-            case kErrorSubCodePreCopyMemoryIndirectSizeAligned: {
+            case kErrorSubCode_PreCopyMemoryIndirect_SizeAligned: {
                 const uint64_t command_size = payload_start;
                 skip |= gpuav.LogError("VUID-VkCopyMemoryIndirectCommandKHR-size-10960", objlist, loc_with_debug_region,
                                        "VkCopyMemoryIndirectInfoKHR::copyAddressRange.address (0x%" PRIx64 ") + (stride [%" PRIu64
@@ -234,7 +234,7 @@ void CopyMemoryIndirect(Validator &gpuav, const Location &loc, CommandBufferSubS
 
                 break;
             }
-            case kErrorSubCodePreCopyMemoryToImageIndirectSrcAddressAligned: {
+            case kErrorSubCode_PreCopyMemoryToImageIndirect_SrcAddressAligned: {
                 const uint64_t src_address = payload_start;
                 skip |=
                     gpuav.LogError("VUID-VkCopyMemoryToImageIndirectCommandKHR-srcAddress-10963", objlist, loc_with_debug_region,
@@ -248,7 +248,7 @@ void CopyMemoryIndirect(Validator &gpuav, const Location &loc, CommandBufferSubS
 
                 break;
             }
-            case kErrorSubCodePreCopyMemoryToImageIndirectSrcAddressInvalid: {
+            case kErrorSubCode_PreCopyMemoryToImageIndirect_SrcAddressInvalid: {
                 const uint64_t src_address = payload_start;
                 skip |= gpuav.LogError("VUID-VkCopyMemoryToImageIndirectCommandKHR-srcAddress-parameter", objlist,
                                        loc_with_debug_region,
@@ -262,9 +262,9 @@ void CopyMemoryIndirect(Validator &gpuav, const Location &loc, CommandBufferSubS
 
                 break;
             }
-            case kErrorSubCodePreCopyMemoryToImageIndirectBufferRowLength: {
-                const uint32_t buffer_row_length = error_record[kValCmdErrorPayloadDword_0];
-                const uint32_t image_extent_width = error_record[kValCmdErrorPayloadDword_1];
+            case kErrorSubCode_PreCopyMemoryToImageIndirect_BufferRowLength: {
+                const uint32_t buffer_row_length = error_record[kValCmd_ErrorPayloadDword_0];
+                const uint32_t image_extent_width = error_record[kValCmd_ErrorPayloadDword_1];
                 skip |= gpuav.LogError("VUID-VkCopyMemoryToImageIndirectCommandKHR-bufferRowLength-10964", objlist,
                                        loc_with_debug_region,
                                        "VkCopyMemoryToImageIndirectInfoKHR::copyAddressRange.address (0x%" PRIx64
@@ -277,9 +277,9 @@ void CopyMemoryIndirect(Validator &gpuav, const Location &loc, CommandBufferSubS
 
                 break;
             }
-            case kErrorSubCodePreCopyMemoryToImageIndirectBufferImageHeight: {
-                const uint32_t buffer_image_height = error_record[kValCmdErrorPayloadDword_0];
-                const uint32_t image_extent_height = error_record[kValCmdErrorPayloadDword_1];
+            case kErrorSubCode_PreCopyMemoryToImageIndirect_BufferImageHeight: {
+                const uint32_t buffer_image_height = error_record[kValCmd_ErrorPayloadDword_0];
+                const uint32_t image_extent_height = error_record[kValCmd_ErrorPayloadDword_1];
                 skip |= gpuav.LogError("VUID-VkCopyMemoryToImageIndirectCommandKHR-bufferImageHeight-10965", objlist,
                                        loc_with_debug_region,
                                        "VkCopyMemoryToImageIndirectInfoKHR::copyAddressRange.address (0x%" PRIx64

--- a/layers/gpuav/validation_cmd/gpuav_dispatch.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_dispatch.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2018-2025 The Khronos Group Inc.
- * Copyright (c) 2018-2025 Valve Corporation
- * Copyright (c) 2018-2025 LunarG, Inc.
+/* Copyright (c) 2018-2026 The Khronos Group Inc.
+ * Copyright (c) 2018-2026 Valve Corporation
+ * Copyright (c) 2018-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,30 +102,30 @@ void DispatchIndirect(Validator &gpuav, const Location &loc, CommandBufferSubSta
             bool skip = false;
             using namespace glsl;
 
-            if (GetErrorGroup(error_record) != kErrorGroupGpuPreDispatch) {
+            if (GetErrorGroup(error_record) != kErrorGroup_GpuPreDispatch) {
                 return skip;
             }
 
             const uint32_t error_sub_code = GetSubError(error_record);
             switch (error_sub_code) {
-                case kErrorSubCodePreDispatchCountLimitX: {
-                    uint32_t count = error_record[kValCmdErrorPayloadDword_0];
+                case kErrorSubCode_PreDispatch_CountLimitX: {
+                    uint32_t count = error_record[kValCmd_ErrorPayloadDword_0];
                     skip |= gpuav.LogError("VUID-VkDispatchIndirectCommand-x-00417", objlist, loc_with_debug_region,
                                            "Indirect dispatch VkDispatchIndirectCommand::x of %" PRIu32
                                            " would exceed maxComputeWorkGroupCount[0] limit of %" PRIu32 ".",
                                            count, gpuav.phys_dev_props.limits.maxComputeWorkGroupCount[0]);
                     break;
                 }
-                case kErrorSubCodePreDispatchCountLimitY: {
-                    uint32_t count = error_record[kValCmdErrorPayloadDword_0];
+                case kErrorSubCode_PreDispatch_CountLimitY: {
+                    uint32_t count = error_record[kValCmd_ErrorPayloadDword_0];
                     skip |= gpuav.LogError("VUID-VkDispatchIndirectCommand-y-00418", objlist, loc_with_debug_region,
                                            "Indirect dispatch VkDispatchIndirectCommand::y of %" PRIu32
                                            " would exceed maxComputeWorkGroupCount[1] limit of %" PRIu32 ".",
                                            count, gpuav.phys_dev_props.limits.maxComputeWorkGroupCount[1]);
                     break;
                 }
-                case kErrorSubCodePreDispatchCountLimitZ: {
-                    uint32_t count = error_record[kValCmdErrorPayloadDword_0];
+                case kErrorSubCode_PreDispatch_CountLimitZ: {
+                    uint32_t count = error_record[kValCmd_ErrorPayloadDword_0];
                     skip |= gpuav.LogError("VUID-VkDispatchIndirectCommand-z-00419", objlist, loc_with_debug_region,
                                            "Indirect dispatch VkDispatchIndirectCommand::z of %" PRIu32
                                            " would exceed maxComputeWorkGroupCount[2] limit of %" PRIu32 ".",

--- a/layers/gpuav/validation_cmd/gpuav_draw.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_draw.cpp
@@ -240,14 +240,14 @@ void FirstInstance(Validator &gpuav, CommandBufferSubState &cb_state, const Loca
         bool skip = false;
         using namespace glsl;
 
-        if (GetErrorGroup(error_record) != kErrorGroupGpuPreDraw) {
+        if (GetErrorGroup(error_record) != kErrorGroup_GpuPreDraw) {
             return skip;
         }
 
-        assert(GetSubError(error_record) == kErrorSubCodePreDrawFirstInstance);
+        assert(GetSubError(error_record) == kErrorSubCode_PreDraw_FirstInstance);
 
-        const uint32_t index = error_record[kValCmdErrorPayloadDword_0];
-        const uint32_t invalid_first_instance = error_record[kValCmdErrorPayloadDword_1];
+        const uint32_t index = error_record[kValCmd_ErrorPayloadDword_0];
+        const uint32_t invalid_first_instance = error_record[kValCmd_ErrorPayloadDword_1];
 
         skip |= gpuav.LogError(vuid, objlist, loc_with_debug_region,
                                "The firstInstance member of the %s structure at "
@@ -437,8 +437,8 @@ void CountBuffer(Validator &gpuav, CommandBufferSubState &cb_state, const Locati
 
         const uint32_t error_sub_code = GetSubError(error_record);
         switch (error_sub_code) {
-            case kErrorSubCodePreDraw_DrawBufferSize: {
-                const uint32_t count = error_record[kValCmdErrorPayloadDword_0];
+            case kErrorSubCode_PreDraw_DrawBufferSize: {
+                const uint32_t count = error_record[kValCmd_ErrorPayloadDword_0];
 
                 const VkDeviceSize draw_size = (api_stride * (count - 1) + api_offset + api_struct_size_byte);
 
@@ -454,8 +454,8 @@ void CountBuffer(Validator &gpuav, CommandBufferSubState &cb_state, const Locati
                                          vvl::String(api_struct_name), draw_size);
                 break;
             }
-            case kErrorSubCodePreDraw_DrawCountLimit: {
-                const uint32_t count = error_record[kValCmdErrorPayloadDword_0];
+            case kErrorSubCode_PreDraw_DrawCountLimit: {
+                const uint32_t count = error_record[kValCmd_ErrorPayloadDword_0];
                 skip |= gpuav.LogError(vuid, objlist, loc_with_debug_region,
                                        "Indirect draw count of %" PRIu32 " would exceed maxDrawIndirectCount limit of %" PRIu32 ".",
                                        count, gpuav.phys_dev_props.limits.maxDrawIndirectCount);
@@ -640,16 +640,16 @@ void DrawMeshIndirect(Validator &gpuav, CommandBufferSubState &cb_state, const L
         const char *vuid_mesh_group_count_exceeds_max_z = "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07328";
         const char *vuid_mesh_group_count_exceeds_max_total = "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07329";
 
-        const uint32_t draw_i = error_record[kValCmdErrorPayloadDword_1];
+        const uint32_t draw_i = error_record[kValCmd_ErrorPayloadDword_1];
         const char *group_count_name = is_task_shader ? "maxTaskWorkGroupCount" : "maxMeshWorkGroupCount";
         const char *group_count_total_name = is_task_shader ? "maxTaskWorkGroupTotalCount" : "maxMeshWorkGroupTotalCount";
 
         const uint32_t error_sub_code = GetSubError(error_record);
         switch (error_sub_code) {
-            case kErrorSubCodePreDrawGroupCountX: {
+            case kErrorSubCode_PreDraw_GroupCountX: {
                 const char *vuid_group_count_exceeds_max =
                     is_task_shader ? vuid_task_group_count_exceeds_max_x : vuid_mesh_group_count_exceeds_max_x;
-                const uint32_t group_count_x = error_record[kValCmdErrorPayloadDword_0];
+                const uint32_t group_count_x = error_record[kValCmd_ErrorPayloadDword_0];
                 const uint32_t limit = is_task_shader ? gpuav.phys_dev_ext_props.mesh_shader_props_ext.maxTaskWorkGroupCount[0]
                                                       : gpuav.phys_dev_ext_props.mesh_shader_props_ext.maxMeshWorkGroupCount[0];
                 skip |= gpuav.LogError(vuid_group_count_exceeds_max, objlist, loc_with_debug_region,
@@ -660,10 +660,10 @@ void DrawMeshIndirect(Validator &gpuav, CommandBufferSubState &cb_state, const L
                 break;
             }
 
-            case kErrorSubCodePreDrawGroupCountY: {
+            case kErrorSubCode_PreDraw_GroupCountY: {
                 const char *vuid_group_count_exceeds_max =
                     is_task_shader ? vuid_task_group_count_exceeds_max_y : vuid_mesh_group_count_exceeds_max_y;
-                const uint32_t group_count_y = error_record[kValCmdErrorPayloadDword_0];
+                const uint32_t group_count_y = error_record[kValCmd_ErrorPayloadDword_0];
                 const uint32_t limit = is_task_shader ? gpuav.phys_dev_ext_props.mesh_shader_props_ext.maxTaskWorkGroupCount[1]
                                                       : gpuav.phys_dev_ext_props.mesh_shader_props_ext.maxMeshWorkGroupCount[1];
                 skip |= gpuav.LogError(vuid_group_count_exceeds_max, objlist, loc_with_debug_region,
@@ -674,10 +674,10 @@ void DrawMeshIndirect(Validator &gpuav, CommandBufferSubState &cb_state, const L
                 break;
             }
 
-            case kErrorSubCodePreDrawGroupCountZ: {
+            case kErrorSubCode_PreDraw_GroupCountZ: {
                 const char *vuid_group_count_exceeds_max =
                     is_task_shader ? vuid_task_group_count_exceeds_max_z : vuid_mesh_group_count_exceeds_max_z;
-                const uint32_t group_count_z = error_record[kValCmdErrorPayloadDword_0];
+                const uint32_t group_count_z = error_record[kValCmd_ErrorPayloadDword_0];
                 const uint32_t limit = is_task_shader ? gpuav.phys_dev_ext_props.mesh_shader_props_ext.maxTaskWorkGroupCount[2]
                                                       : gpuav.phys_dev_ext_props.mesh_shader_props_ext.maxMeshWorkGroupCount[2];
                 skip |= gpuav.LogError(vuid_group_count_exceeds_max, objlist, loc_with_debug_region,
@@ -688,10 +688,10 @@ void DrawMeshIndirect(Validator &gpuav, CommandBufferSubState &cb_state, const L
                 break;
             }
 
-            case kErrorSubCodePreDrawGroupCountTotal: {
+            case kErrorSubCode_PreDraw_GroupCountTotal: {
                 const char *vuid_group_count_exceeds_max =
                     is_task_shader ? vuid_task_group_count_exceeds_max_total : vuid_mesh_group_count_exceeds_max_total;
-                const uint32_t group_count_total = error_record[kValCmdErrorPayloadDword_0];
+                const uint32_t group_count_total = error_record[kValCmd_ErrorPayloadDword_0];
                 const uint32_t limit = is_task_shader ? gpuav.phys_dev_ext_props.mesh_shader_props_ext.maxTaskWorkGroupTotalCount
                                                       : gpuav.phys_dev_ext_props.mesh_shader_props_ext.maxMeshWorkGroupTotalCount;
                 skip |= gpuav.LogError(vuid_group_count_exceeds_max, objlist, loc_with_debug_region,
@@ -977,9 +977,9 @@ void DrawIndexedIndirectIndexBuffer(Validator &gpuav, CommandBufferSubState &cb_
         const uint32_t error_sub_code = GetSubError(error_record);
         switch (error_sub_code) {
             case kErrorSubCode_OobIndexBuffer: {
-                const uint32_t draw_i = error_record[kValCmdErrorPayloadDword_0];
-                const uint32_t first_index = error_record[kValCmdErrorPayloadDword_1];
-                const uint32_t index_count = error_record[kValCmdErrorPayloadDword_2];
+                const uint32_t draw_i = error_record[kValCmd_ErrorPayloadDword_0];
+                const uint32_t first_index = error_record[kValCmd_ErrorPayloadDword_1];
+                const uint32_t index_count = error_record[kValCmd_ErrorPayloadDword_2];
                 const uint32_t highest_accessed_index = first_index + index_count;
                 const uint32_t index_bits_size = GetIndexBitsSize(index_buffer_binding.index_type);
                 const uint32_t max_indices_in_buffer = static_cast<uint32_t>(index_buffer_binding.size / (index_bits_size / 8u));

--- a/layers/gpuav/validation_cmd/gpuav_ray_tracing.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_ray_tracing.cpp
@@ -109,14 +109,14 @@ void TraceRaysIndirect(Validator& gpuav, const Location& loc, CommandBufferSubSt
         bool skip = false;
         using namespace glsl;
 
-        if (GetErrorGroup(error_record) != kErrorGroupGpuPreTraceRays) {
+        if (GetErrorGroup(error_record) != kErrorGroup_GpuPreTraceRays) {
             return skip;
         }
 
         const uint32_t error_sub_code = GetSubError(error_record);
         switch (error_sub_code) {
-            case kErrorSubCodePreTraceRaysLimitWidth: {
-                const uint32_t width = error_record[kValCmdErrorPayloadDword_0];
+            case kErrorSubCode_PreTraceRays_LimitWidth: {
+                const uint32_t width = error_record[kValCmd_ErrorPayloadDword_0];
                 skip |= gpuav.LogError("VUID-VkTraceRaysIndirectCommandKHR-width-03638", objlist, loc_with_debug_region,
                                        "Indirect trace rays of VkTraceRaysIndirectCommandKHR::width of %" PRIu32
                                        " would exceed VkPhysicalDeviceLimits::maxComputeWorkGroupCount[0] * "
@@ -126,8 +126,8 @@ void TraceRaysIndirect(Validator& gpuav, const Location& loc, CommandBufferSubSt
                                            static_cast<uint64_t>(gpuav.phys_dev_props.limits.maxComputeWorkGroupSize[0]));
                 break;
             }
-            case kErrorSubCodePreTraceRaysLimitHeight: {
-                const uint32_t height = error_record[kValCmdErrorPayloadDword_0];
+            case kErrorSubCode_PreTraceRays_LimitHeight: {
+                const uint32_t height = error_record[kValCmd_ErrorPayloadDword_0];
                 skip |= gpuav.LogError("VUID-VkTraceRaysIndirectCommandKHR-height-03639", objlist, loc_with_debug_region,
                                        "Indirect trace rays of VkTraceRaysIndirectCommandKHR::height of %" PRIu32
                                        " would exceed VkPhysicalDeviceLimits::maxComputeWorkGroupCount[1] * "
@@ -137,8 +137,8 @@ void TraceRaysIndirect(Validator& gpuav, const Location& loc, CommandBufferSubSt
                                            static_cast<uint64_t>(gpuav.phys_dev_props.limits.maxComputeWorkGroupSize[1]));
                 break;
             }
-            case kErrorSubCodePreTraceRaysLimitDepth: {
-                const uint32_t depth = error_record[kValCmdErrorPayloadDword_0];
+            case kErrorSubCode_PreTraceRays_LimitDepth: {
+                const uint32_t depth = error_record[kValCmd_ErrorPayloadDword_0];
                 skip |= gpuav.LogError("VUID-VkTraceRaysIndirectCommandKHR-depth-03640", objlist, loc_with_debug_region,
                                        "Indirect trace rays of VkTraceRaysIndirectCommandKHR::height of %" PRIu32
                                        " would exceed VkPhysicalDeviceLimits::maxComputeWorkGroupCount[2] * "
@@ -148,10 +148,10 @@ void TraceRaysIndirect(Validator& gpuav, const Location& loc, CommandBufferSubSt
                                            static_cast<uint64_t>(gpuav.phys_dev_props.limits.maxComputeWorkGroupSize[2]));
                 break;
             }
-            case kErrorSubCodePreTraceRaysLimitVolume: {
-                const VkExtent3D trace_rays_extent = {error_record[kValCmdErrorPayloadDword_0],
-                                                      error_record[kValCmdErrorPayloadDword_1],
-                                                      error_record[kValCmdErrorPayloadDword_2]};
+            case kErrorSubCode_PreTraceRays_LimitVolume: {
+                const VkExtent3D trace_rays_extent = {error_record[kValCmd_ErrorPayloadDword_0],
+                                                      error_record[kValCmd_ErrorPayloadDword_1],
+                                                      error_record[kValCmd_ErrorPayloadDword_2]};
                 const uint64_t rays_volume = trace_rays_extent.width * trace_rays_extent.height * trace_rays_extent.depth;
                 skip |= gpuav.LogError(
                     "VUID-VkTraceRaysIndirectCommandKHR-width-03641", objlist, loc_with_debug_region,
@@ -586,13 +586,13 @@ void BuildAccelerationStructures(Validator& gpuav, const Location& loc, CommandB
         bool skip = false;
         using namespace glsl;
 
-        if (GetErrorGroup(error_record) != kErrorGroupGpuPreBuildAccelerationStructures) {
+        if (GetErrorGroup(error_record) != kErrorGroup_GpuPreBuildAccelerationStructures) {
             return skip;
         }
 
-        const uint64_t blas_in_tlas_addr = glsl::GetUint64(error_record + kValCmdErrorPayloadDword_0);
-        const uint32_t as_instance_i = error_record[kValCmdErrorPayloadDword_2];
-        const uint32_t blas_array_i = error_record[kValCmdErrorPayloadDword_3];
+        const uint64_t blas_in_tlas_addr = glsl::GetUint64(error_record + kValCmd_ErrorPayloadDword_0);
+        const uint32_t as_instance_i = error_record[kValCmd_ErrorPayloadDword_2];
+        const uint32_t blas_array_i = error_record[kValCmd_ErrorPayloadDword_3];
 
         // Gather error info
         // ---
@@ -665,7 +665,7 @@ void BuildAccelerationStructures(Validator& gpuav, const Location& loc, CommandB
                 break;
             }
             case kErrorSubCode_PreBuildAccelerationStructures_BlasMemoryOverlap: {
-                const uint32_t blas_built_in_cmd_i = error_record[kValCmdErrorPayloadDword_4];
+                const uint32_t blas_built_in_cmd_i = error_record[kValCmd_ErrorPayloadDword_4];
                 const BlasBuiltInCmd& blas_built_in_cmd = blas_built_in_cmd_array[blas_built_in_cmd_i];
                 std::stringstream error_ss;
                 if (as_found_it != gpuav.device_state->as_with_addresses.array.end()) {


### PR DESCRIPTION
@arno-lunarg started this, I like the idea... lets just fix it now once and for all

Feel free to leave feedback, this should be a simple find-and-replace if you have suggestions

My advice, just look at `gpuav_error_header.h` and `gpuav_error_codes.h` to see what actually changed