### PR TITLE
layers: GPL with VkPipelineRenderingCreateInfo madness

### DIFF
--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -3523,6 +3523,7 @@ bool CoreChecks::ValidateDrawPipelineRenderpass(const LastBound &last_bound_stat
     bool skip = false;
     const vvl::CommandBuffer &cb_state = last_bound_state.cb_state;
 
+    // Can use RenderPassState() here even GPL because we only need to check for compatible renderpasses
     const auto &pipeline_rp_state = pipeline.RenderPassState();
     // TODO: AMD extension codes are included here, but actual function entrypoints are not yet intercepted
     if (rp_state.VkHandle() != pipeline_rp_state->VkHandle()) {
@@ -3546,6 +3547,7 @@ bool CoreChecks::ValidateDrawPipelineDynamicRenderpass(const LastBound &last_bou
     bool skip = false;
     const vvl::CommandBuffer &cb_state = last_bound_state.cb_state;
 
+    // Can use RenderPassState() here even GPL because we only need to check for it being null
     const auto pipeline_rp_state = pipeline.RenderPassState();
     ASSERT_AND_RETURN_SKIP(pipeline_rp_state);
     if (pipeline_rp_state->VkHandle() != VK_NULL_HANDLE) {
@@ -3557,7 +3559,7 @@ bool CoreChecks::ValidateDrawPipelineDynamicRenderpass(const LastBound &last_bou
         return skip;
     }
 
-    const VkPipelineRenderingCreateInfo &pipeline_rendering_ci = *(pipeline_rp_state->dynamic_pipeline_rendering_create_info.ptr());
+    const VkPipelineRenderingCreateInfo& pipeline_rendering_ci = pipeline.GetRenderPassPipelineRenderingCreateInfo();
     const auto rendering_view_mask = rp_state.GetDynamicRenderingViewMask();
     // There is currently a 06031 VU that catches the viewMask at vkCmdExecuteCommands time, so seems like this is not suppose to be
     // validated with inherited render passes

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -867,7 +867,7 @@ static void InitDefaultRenderingAttachments(CommandBuffer::RenderingAttachment &
 
 void CommandBuffer::RecordBeginRendering(const VkRenderingInfo &rendering_info, const Location &loc) {
     RecordCommand(loc);
-    active_render_pass = std::make_shared<vvl::RenderPass>(&rendering_info, true);
+    active_render_pass = std::make_shared<vvl::RenderPass>(rendering_info);
     render_area = rendering_info.renderArea;
     render_pass_queries.clear();
 

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -839,6 +839,11 @@ std::vector<std::shared_ptr<const vvl::PipelineLayout>> Pipeline::PipelineLayout
     return {merged_graphics_layout};
 }
 
+// See DeviceState::PreCallValidateCreateGraphicsPipelines() why we need this awful function
+const VkPipelineRenderingCreateInfo& Pipeline::GetRenderPassPipelineRenderingCreateInfo() const {
+    return *(rp_state->dynamic_pipeline_rendering_create_info.ptr());
+}
+
 // Currently will return vvl::ShaderModule with no SPIR-V
 std::shared_ptr<const vvl::ShaderModule> Pipeline::GetGraphicsLibraryStateShader(VkShaderStageFlagBits state) const {
     switch (state) {

--- a/layers/state_tracker/render_pass_state.h
+++ b/layers/state_tracker/render_pass_state.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (C) 2015-2025 Google Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (C) 2015-2026 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -79,9 +79,9 @@ class RenderPass : public StateObject {
 
     const bool use_dynamic_rendering;
     const bool use_dynamic_rendering_inherited;
-    const bool rasterization_enabled;
 
     const vku::safe_VkRenderingInfo dynamic_rendering_begin_rendering_info;
+    // Note, this is not the exact VkPipelineRenderingCreateInfo passed in, instead it will handle fields being ignored
     const vku::safe_VkPipelineRenderingCreateInfo dynamic_pipeline_rendering_create_info;
     // when a secondary command buffer is recorded with VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT
     const vku::safe_VkCommandBufferInheritanceRenderingInfo inheritance_rendering_info;
@@ -112,12 +112,12 @@ class RenderPass : public StateObject {
     RenderPass(VkRenderPass handle, VkRenderPassCreateInfo2 const *pCreateInfo);
 
     // vkCmdBeginRendering
-    RenderPass(VkRenderingInfo const *pRenderingInfo, bool rasterization_enabled);
+    explicit RenderPass(const VkRenderingInfo& rendering_info);
     // vkBeginCommandBuffer (dynamic rendering in secondary commadn buffer)
     explicit RenderPass(VkCommandBufferInheritanceRenderingInfo const *pInheritanceRenderingInfo);
 
     // vkCreateGraphicsPipelines (dynamic rendering state tied to pipeline state)
-    RenderPass(VkPipelineRenderingCreateInfo const *pPipelineRenderingCreateInfo, bool rasterization_enabled);
+    explicit RenderPass(const VkPipelineRenderingCreateInfo& rendering_ci);
 
     VkRenderPass VkHandle() const { return handle_.Cast<VkRenderPass>(); }
 


### PR DESCRIPTION
honestly this is just cleaning up some real :hankey: 

Spec change driving this https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/8031

----

Short-ish summary, when using with GPL you have 

<img width="479" height="242" alt="image" src="https://github.com/user-attachments/assets/f64ffca0-e109-4786-b67f-d87d9d07763e" />

the core issue is for GPL, the `viewMask` is tied to the Pre-Raster/FragmentShader library, but the various formats are tied to the Fragment Output only

there were a lot of assumptions "just working" because we used the renderpass in `FragmentOutput` assuming it had all the values... until Mike found he doesn't set `viewMask` in the `FragmentOutput` and now here we are