### PR TITLE
tests: Cleanup syncval render pass test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -227,6 +227,8 @@ target_sources(vk_layer_validation_tests PRIVATE
     unit/sync_val_reporting.cpp
     unit/sync_val_ray_tracing.cpp
     unit/sync_val_ray_tracing_positive.cpp
+    unit/sync_val_render_pass.cpp
+    unit/sync_val_render_pass_positive.cpp
     unit/sync_val_semaphore.cpp
     unit/sync_val_semaphore_positive.cpp
     unit/sync_val_video.cpp

--- a/tests/framework/render_pass_helper.cpp
+++ b/tests/framework/render_pass_helper.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2023-2025 The Khronos Group Inc.
- * Copyright (c) 2023-2025 Valve Corporation
- * Copyright (c) 2023-2025 LunarG, Inc.
+ * Copyright (c) 2023-2026 The Khronos Group Inc.
+ * Copyright (c) 2023-2026 Valve Corporation
+ * Copyright (c) 2023-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,6 +56,10 @@ void RenderPassSingleSubpass::AddAttachmentDescription(VkFormat format, VkSample
     attachment_descriptions_.emplace_back(VkAttachmentDescription{0, format, samples, VK_ATTACHMENT_LOAD_OP_DONT_CARE,
                                                                   VK_ATTACHMENT_STORE_OP_DONT_CARE, VK_ATTACHMENT_LOAD_OP_DONT_CARE,
                                                                   VK_ATTACHMENT_STORE_OP_DONT_CARE, initialLayout, finalLayout});
+}
+
+void RenderPassSingleSubpass::AddAttachmentDescription(const VkAttachmentDescription& attachment_description) {
+    attachment_descriptions_.emplace_back(attachment_description);
 }
 
 void RenderPassSingleSubpass::AddAttachmentReference(VkAttachmentReference reference) {

--- a/tests/framework/render_pass_helper.h
+++ b/tests/framework/render_pass_helper.h
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2023-2025 The Khronos Group Inc.
- * Copyright (c) 2023-2025 Valve Corporation
- * Copyright (c) 2023-2025 LunarG, Inc.
+ * Copyright (c) 2023-2026 The Khronos Group Inc.
+ * Copyright (c) 2023-2026 Valve Corporation
+ * Copyright (c) 2023-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,6 +88,8 @@ class RenderPassSingleSubpass : public InterfaceRenderPassSingleSubpass {
     void AddAttachmentDescription(VkFormat format, VkSampleCountFlagBits samples,
                                   VkImageLayout initialLayout = VK_IMAGE_LAYOUT_GENERAL,
                                   VkImageLayout finalLayout = VK_IMAGE_LAYOUT_GENERAL);
+    // Use already initialized object
+    void AddAttachmentDescription(const VkAttachmentDescription &attachment_description);
 
     void AddAttachmentReference(VkAttachmentReference reference);
 

--- a/tests/framework/sync_val_tests.h
+++ b/tests/framework/sync_val_tests.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2025 The Khronos Group Inc.
- * Copyright (c) 2025 Valve Corporation
- * Copyright (c) 2025 LunarG, Inc.
+/* Copyright (c) 2025-2026 The Khronos Group Inc.
+ * Copyright (c) 2025-2026 Valve Corporation
+ * Copyright (c) 2025-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,4 +44,6 @@ class VkSyncValTest : public VkLayerTest {
     std::unique_ptr<vkt::rt::Pipeline> GetTraceRaysPipeline(VkAccelerationStructureKHR as);
     std::unique_ptr<vkt::as::BuildGeometryInfoKHR> BuildBLAS();
     std::unique_ptr<vkt::as::BuildGeometryInfoKHR> BuildTLAS(const vkt::as::AccelerationStructureKHR &blas);
+
+    VkAttachmentDescription AttachmentWithoutLoadStore(VkFormat format);
 };

--- a/tests/unit/sync_val_render_pass.cpp
+++ b/tests/unit/sync_val_render_pass.cpp
@@ -1,0 +1,252 @@
+/* Copyright (c) 2026 The Khronos Group Inc.
+ * Copyright (c) 2026 Valve Corporation
+ * Copyright (c) 2026 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../framework/sync_val_tests.h"
+#include "../framework/render_pass_helper.h"
+
+struct NegativeSyncValRenderPass : public VkSyncValTest {};
+
+TEST_F(NegativeSyncValRenderPass, ClearColorAttachmentWAW) {
+    TEST_DESCRIPTION("WAW hazard when color attachment is cleared inside render pass");
+    AddRequiredExtensions(VK_KHR_LOAD_STORE_OP_NONE_EXTENSION_NAME);
+    RETURN_IF_SKIP(InitSyncVal());
+
+    const uint32_t width = 256;
+    const uint32_t height = 128;
+    const VkFormat color_format = VK_FORMAT_B8G8R8A8_UNORM;
+
+    vkt::Image src_image(*m_device, width, height, color_format, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
+    vkt::Image image(*m_device, width, height, color_format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::ImageView image_view = image.CreateView();
+
+    RenderPassSingleSubpass render_pass(*this);
+    render_pass.AddAttachmentDescription(AttachmentWithoutLoadStore(color_format));
+    render_pass.AddAttachmentReference({0, VK_IMAGE_LAYOUT_GENERAL});
+    render_pass.AddColorAttachment(0);
+    render_pass.CreateRenderPass();
+
+    vkt::Framebuffer framebuffer(*m_device, render_pass, 1, &image_view.handle(), width, height);
+
+    const VkClearAttachment clear_attachment = {VK_IMAGE_ASPECT_COLOR_BIT, 0};
+
+    VkClearRect clear_rect = {};
+    clear_rect.rect = {{0, 0}, {width / 2, height / 2}};
+    clear_rect.baseArrayLayer = 0;
+    clear_rect.layerCount = 1;
+
+    VkImageCopy copy_region = {};
+    copy_region.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    copy_region.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    copy_region.extent = {width, height, 1};
+
+    m_command_buffer.Begin();
+    vk::CmdCopyImage(m_command_buffer, src_image, VK_IMAGE_LAYOUT_GENERAL, image, VK_IMAGE_LAYOUT_GENERAL, 1, &copy_region);
+    m_command_buffer.BeginRenderPass(render_pass, framebuffer, width, height);
+
+    m_errorMonitor->SetDesiredError("SYNC-HAZARD-WRITE-AFTER-WRITE");
+    vk::CmdClearAttachments(m_command_buffer, 1, &clear_attachment, 1, &clear_rect);
+    m_errorMonitor->VerifyFound();
+
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeSyncValRenderPass, ClearDepthAspectOfAttachmentWAW) {
+    TEST_DESCRIPTION("WAW hazard when depth aspect of attachment is cleared inside render pass");
+    AddRequiredExtensions(VK_KHR_LOAD_STORE_OP_NONE_EXTENSION_NAME);
+    RETURN_IF_SKIP(InitSyncVal());
+
+    const uint32_t width = 256;
+    const uint32_t height = 128;
+    const VkFormat depth_stencil_format = FindSupportedDepthStencilFormat(Gpu());
+
+    vkt::Image src_image(*m_device, width, height, depth_stencil_format, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
+    vkt::Image image(*m_device, width, height, depth_stencil_format,
+                     VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::ImageView image_view = image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
+
+    RenderPassSingleSubpass render_pass(*this);
+    render_pass.AddAttachmentDescription(AttachmentWithoutLoadStore(depth_stencil_format));
+    render_pass.AddAttachmentReference({0, VK_IMAGE_LAYOUT_GENERAL});
+    render_pass.AddDepthStencilAttachment(0);
+    render_pass.CreateRenderPass();
+
+    vkt::Framebuffer framebuffer(*m_device, render_pass, 1, &image_view.handle(), width, height);
+
+    const VkClearAttachment clear_attachment = {VK_IMAGE_ASPECT_DEPTH_BIT};
+
+    VkClearRect clear_rect = {};
+    clear_rect.rect = {{0, 0}, {width / 2, height / 2}};
+    clear_rect.baseArrayLayer = 0;
+    clear_rect.layerCount = 1;
+
+    VkImageCopy copy_region = {};
+    copy_region.srcSubresource = {VK_IMAGE_ASPECT_DEPTH_BIT, 0, 0, 1};
+    copy_region.dstSubresource = {VK_IMAGE_ASPECT_DEPTH_BIT, 0, 0, 1};
+    copy_region.extent = {width, height, 1};
+
+    m_command_buffer.Begin();
+    vk::CmdCopyImage(m_command_buffer, src_image, VK_IMAGE_LAYOUT_GENERAL, image, VK_IMAGE_LAYOUT_GENERAL, 1, &copy_region);
+    m_command_buffer.BeginRenderPass(render_pass, framebuffer, width, height);
+
+    m_errorMonitor->SetDesiredError("SYNC-HAZARD-WRITE-AFTER-WRITE");
+    vk::CmdClearAttachments(m_command_buffer, 1, &clear_attachment, 1, &clear_rect);
+    m_errorMonitor->VerifyFound();
+
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeSyncValRenderPass, ClearStencilAspectOfAttachmentWAW) {
+    TEST_DESCRIPTION("WAW hazard when stencil aspect of attachment is cleared inside render pass");
+    AddRequiredExtensions(VK_KHR_LOAD_STORE_OP_NONE_EXTENSION_NAME);
+    RETURN_IF_SKIP(InitSyncVal());
+
+    const uint32_t width = 256;
+    const uint32_t height = 128;
+    const VkFormat depth_stencil_format = FindSupportedDepthStencilFormat(Gpu());
+
+    vkt::Image src_image(*m_device, width, height, depth_stencil_format, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
+    vkt::Image image(*m_device, width, height, depth_stencil_format,
+                     VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::ImageView image_view = image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
+
+    RenderPassSingleSubpass render_pass(*this);
+    render_pass.AddAttachmentDescription(AttachmentWithoutLoadStore(depth_stencil_format));
+    render_pass.AddAttachmentReference({0, VK_IMAGE_LAYOUT_GENERAL});
+    render_pass.AddDepthStencilAttachment(0);
+    render_pass.CreateRenderPass();
+
+    vkt::Framebuffer framebuffer(*m_device, render_pass, 1, &image_view.handle(), width, height);
+
+    const VkClearAttachment clear_attachment = {VK_IMAGE_ASPECT_STENCIL_BIT};
+
+    VkClearRect clear_rect = {};
+    clear_rect.rect = {{0, 0}, {width / 2, height / 2}};
+    clear_rect.baseArrayLayer = 0;
+    clear_rect.layerCount = 1;
+
+    VkImageCopy copy_region = {};
+    copy_region.srcSubresource = {VK_IMAGE_ASPECT_STENCIL_BIT, 0, 0, 1};
+    copy_region.dstSubresource = {VK_IMAGE_ASPECT_STENCIL_BIT, 0, 0, 1};
+    copy_region.extent = {width, height, 1};
+
+    m_command_buffer.Begin();
+    vk::CmdCopyImage(m_command_buffer, src_image, VK_IMAGE_LAYOUT_GENERAL, image, VK_IMAGE_LAYOUT_GENERAL, 1, &copy_region);
+    m_command_buffer.BeginRenderPass(render_pass, framebuffer, width, height);
+
+    m_errorMonitor->SetDesiredError("SYNC-HAZARD-WRITE-AFTER-WRITE");
+    vk::CmdClearAttachments(m_command_buffer, 1, &clear_attachment, 1, &clear_rect);
+    m_errorMonitor->VerifyFound();
+
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeSyncValRenderPass, ClearAttachmentRAW) {
+    TEST_DESCRIPTION("Tests that vkCmdClearAttachments correctly updates access state, so vkCmdCopyImage can detect hazard.");
+    AddRequiredExtensions(VK_KHR_LOAD_STORE_OP_NONE_EXTENSION_NAME);
+    RETURN_IF_SKIP(InitSyncVal());
+
+    const uint32_t width = 256;
+    const uint32_t height = 128;
+    const VkFormat depth_stencil_format = FindSupportedDepthStencilFormat(Gpu());
+
+    vkt::Image dst_image(*m_device, width, height, depth_stencil_format, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::Image image(*m_device, width, height, depth_stencil_format,
+                     VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
+    vkt::ImageView depth_image_view = image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
+
+    RenderPassSingleSubpass render_pass(*this);
+    render_pass.AddAttachmentDescription(AttachmentWithoutLoadStore(depth_stencil_format));
+    render_pass.AddAttachmentReference({0, VK_IMAGE_LAYOUT_GENERAL});
+    render_pass.AddDepthStencilAttachment(0);
+    render_pass.CreateRenderPass();
+
+    vkt::Framebuffer framebuffer(*m_device, render_pass, 1, &depth_image_view.handle(), width, height);
+
+    const VkClearAttachment clear_attachment = {VK_IMAGE_ASPECT_STENCIL_BIT};
+
+    VkClearRect clear_rect = {};
+    clear_rect.rect = {{0, 0}, {width, height}};
+    clear_rect.baseArrayLayer = 0;
+    clear_rect.layerCount = 1;
+
+    VkImageCopy copy_region = {};
+    copy_region.srcSubresource = {VK_IMAGE_ASPECT_STENCIL_BIT, 0, 0, 1};
+    copy_region.dstSubresource = {VK_IMAGE_ASPECT_STENCIL_BIT, 0, 0, 1};
+    copy_region.extent = {width, height, 1};
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(render_pass, framebuffer, width, height);
+    vk::CmdClearAttachments(m_command_buffer, 1, &clear_attachment, 1, &clear_rect);
+    m_command_buffer.EndRenderPass();
+
+    m_errorMonitor->SetDesiredError("SYNC-HAZARD-READ-AFTER-WRITE");
+    vk::CmdCopyImage(m_command_buffer, image, VK_IMAGE_LAYOUT_GENERAL, dst_image, VK_IMAGE_LAYOUT_GENERAL, 1, &copy_region);
+    m_errorMonitor->VerifyFound();
+
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeSyncValRenderPass, AttachmentClearAndCopyRegionOverlap) {
+    TEST_DESCRIPTION("RAW hazard: two regions with a single pixel overlap");
+    AddRequiredExtensions(VK_KHR_LOAD_STORE_OP_NONE_EXTENSION_NAME);
+    RETURN_IF_SKIP(InitSyncVal());
+
+    const uint32_t width = 256;
+    const uint32_t height = 128;
+    const VkFormat color_format = VK_FORMAT_B8G8R8A8_UNORM;
+
+    vkt::Image src_image(*m_device, width, height, color_format, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
+    vkt::Image image(*m_device, width, height, color_format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::ImageView image_view = image.CreateView();
+
+    RenderPassSingleSubpass render_pass(*this);
+    render_pass.AddAttachmentDescription(AttachmentWithoutLoadStore(color_format));
+    render_pass.AddAttachmentReference({0, VK_IMAGE_LAYOUT_GENERAL});
+    render_pass.AddColorAttachment(0);
+    render_pass.CreateRenderPass();
+
+    vkt::Framebuffer framebuffer(*m_device, render_pass, 1, &image_view.handle(), width, height);
+
+    const VkClearAttachment clear_attachment = {VK_IMAGE_ASPECT_COLOR_BIT, 0};
+
+    VkClearRect clear_rect = {};
+    clear_rect.rect = {{0, 0}, {32, 32}};
+    clear_rect.baseArrayLayer = 0;
+    clear_rect.layerCount = 1;
+
+    VkImageCopy copy_region = {};
+    copy_region.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    copy_region.srcOffset = {31, 31, 0};
+    copy_region.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    copy_region.dstOffset = {31, 31, 0};
+    copy_region.extent = {64, 64, 1};
+
+    m_command_buffer.Begin();
+    vk::CmdCopyImage(m_command_buffer, src_image, VK_IMAGE_LAYOUT_GENERAL, image, VK_IMAGE_LAYOUT_GENERAL, 1, &copy_region);
+    m_command_buffer.BeginRenderPass(render_pass, framebuffer, width, height);
+
+    // Clear and copy regions overlap at a single pixel (x=31, y=31) but that's enough to cause a hazard
+    m_errorMonitor->SetDesiredError("SYNC-HAZARD-WRITE-AFTER-WRITE");
+    vk::CmdClearAttachments(m_command_buffer, 1, &clear_attachment, 1, &clear_rect);
+    m_errorMonitor->VerifyFound();
+
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}

--- a/tests/unit/sync_val_render_pass_positive.cpp
+++ b/tests/unit/sync_val_render_pass_positive.cpp
@@ -1,0 +1,79 @@
+/* Copyright (c) 2026 The Khronos Group Inc.
+ * Copyright (c) 2026 Valve Corporation
+ * Copyright (c) 2026 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../framework/sync_val_tests.h"
+#include "../framework/render_pass_helper.h"
+
+struct PositiveSyncValRenderPass : public VkSyncValTest {};
+
+VkAttachmentDescription VkSyncValTest::AttachmentWithoutLoadStore(VkFormat format) {
+    VkAttachmentDescription attachment = {};
+    attachment.format = format;
+    attachment.samples = VK_SAMPLE_COUNT_1_BIT;
+    attachment.loadOp = VK_ATTACHMENT_LOAD_OP_NONE;
+    attachment.storeOp = VK_ATTACHMENT_STORE_OP_NONE;
+    attachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_NONE;
+    attachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_NONE;
+    attachment.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
+    attachment.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
+    return attachment;
+}
+
+TEST_F(PositiveSyncValRenderPass, AttachmentClearRegionTouchesCopyRegion) {
+    // This test is similar to NegativeSyncValRenderPass.AttachmentClearAndCopyRegionOverlap
+    // but the regions do not overlap but only touch
+    AddRequiredExtensions(VK_KHR_LOAD_STORE_OP_NONE_EXTENSION_NAME);
+    RETURN_IF_SKIP(InitSyncVal());
+
+    const uint32_t width = 256;
+    const uint32_t height = 128;
+    const VkFormat color_format = VK_FORMAT_B8G8R8A8_UNORM;
+
+    vkt::Image src_image(*m_device, width, height, color_format, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
+    vkt::Image image(*m_device, width, height, color_format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::ImageView image_view = image.CreateView();
+
+    RenderPassSingleSubpass render_pass(*this);
+    render_pass.AddAttachmentDescription(AttachmentWithoutLoadStore(color_format));
+    render_pass.AddAttachmentReference({0, VK_IMAGE_LAYOUT_GENERAL});
+    render_pass.AddColorAttachment(0);
+    render_pass.CreateRenderPass();
+
+    vkt::Framebuffer framebuffer(*m_device, render_pass, 1, &image_view.handle(), width, height);
+
+    const VkClearAttachment clear_attachment = {VK_IMAGE_ASPECT_COLOR_BIT, 0};
+
+    VkClearRect clear_rect = {};
+    clear_rect.rect = {{0, 0}, {32, 32}};
+    clear_rect.baseArrayLayer = 0;
+    clear_rect.layerCount = 1;
+
+    VkImageCopy copy_region = {};
+    copy_region.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    copy_region.srcOffset = {32, 32, 0};
+    copy_region.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+    copy_region.dstOffset = {32, 32, 0};
+    copy_region.extent = {64, 64, 1};
+
+    // Clear and copy regions touch at (x=31, y=31) but do not overlap
+    m_command_buffer.Begin();
+    vk::CmdCopyImage(m_command_buffer, src_image, VK_IMAGE_LAYOUT_GENERAL, image, VK_IMAGE_LAYOUT_GENERAL, 1, &copy_region);
+    m_command_buffer.BeginRenderPass(render_pass, framebuffer, width, height);
+    vk::CmdClearAttachments(m_command_buffer, 1, &clear_attachment, 1, &clear_rect);
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}


### PR DESCRIPTION
Rewrite test without using helper and split into separate tests.
Also add `sync_val_render_pass` test files to move there tests for legacy render pass API.

This and the following PRs are the preparations for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/10178 to make syncval work properly with multiview.