### PR TITLE
gpuav: New and clean instrumentation interface

### DIFF
--- a/layers/gpuav/spirv/debug_printf_pass.cpp
+++ b/layers/gpuav/spirv/debug_printf_pass.cpp
@@ -451,7 +451,7 @@ void DebugPrintfPass::CreateBufferWriteFunction(uint32_t argument_count, uint32_
         store_block.CreateInstruction(spv::OpAccessChain,
                                       {pointer_type_id, access_chain_id, output_buffer_variable_id, one_id, int_add_id});
 
-        const uint32_t shader_id = type_manager_.GetConstantUInt32(module_.settings_.shader_id).Id();
+        const uint32_t shader_id = type_manager_.GetConstantUInt32(module_.interface_.unique_shader_id).Id();
         store_block.CreateInstruction(spv::OpStore, {access_chain_id, shader_id});
     }
 
@@ -513,8 +513,8 @@ bool DebugPrintfPass::Instrument() {
                     for (const auto& debug_inst : module_.debug_source_) {
                         const uint32_t string_id = (*inst_it)->Word(5);
                         if (debug_inst->Opcode() == spv::OpString && debug_inst->ResultId() == string_id) {
-                            internal_only_debug_printf_.emplace_back(
-                                InternalOnlyDebugPrintf{module_.settings_.shader_id, string_id, debug_inst->GetAsString(2)});
+                            internal_only_debug_printf_.emplace_back(InternalOnlyDebugPrintf{
+                                module_.interface_.unique_shader_id, string_id, debug_inst->GetAsString(2)});
                         }
                     }
                 }

--- a/layers/gpuav/spirv/descriptor_class_general_buffer_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_class_general_buffer_pass.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2024-2025 LunarG, Inc.
+/* Copyright (c) 2024-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,7 +60,8 @@ void DescriptorClassGeneralBufferPass::CreateFunctionCall(BasicBlock& block, Ins
     const uint32_t descriptor_offset_id =
         GetLastByte(*meta.descriptor_type, meta.access_chain_insts, meta.coop_mat_access, block, inst_it);
 
-    BindingLayout binding_layout = module_.set_index_to_bindings_layout_lut_[meta.descriptor_set][meta.descriptor_binding];
+    const auto& layout_lut = module_.interface_.instrumentation_dsl.set_index_to_bindings_layout_lut;
+    BindingLayout binding_layout = layout_lut[meta.descriptor_set][meta.descriptor_binding];
     const Constant& binding_layout_offset = type_manager_.GetConstantUInt32(binding_layout.start);
 
     const uint32_t inst_position = meta.target_instruction->GetPositionOffset();
@@ -188,7 +189,7 @@ void DescriptorClassGeneralBufferPass::PrintDebugInfo() const {
 
 // Created own Instrument() because need to control finding the largest offset in a given block
 bool DescriptorClassGeneralBufferPass::Instrument() {
-    if (module_.set_index_to_bindings_layout_lut_.empty()) {
+    if (module_.interface_.instrumentation_dsl.set_index_to_bindings_layout_lut.empty()) {
         return false;  // If there is no bindings, nothing to instrument
     }
 

--- a/layers/gpuav/spirv/descriptor_class_texel_buffer_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_class_texel_buffer_pass.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2024-2025 LunarG, Inc.
+/* Copyright (c) 2024-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,8 @@ void DescriptorClassTexelBufferPass::CreateFunctionCall(BasicBlock& block, Instr
     // TODO - This assumes no depth/arrayed/ms from RequiresInstrumentation
     const uint32_t descriptor_offset_id = CastToUint32(meta.target_instruction->Operand(1), block, inst_it);
 
-    BindingLayout binding_layout = module_.set_index_to_bindings_layout_lut_[meta.descriptor_set][meta.descriptor_binding];
+    const auto& layout_lut = module_.interface_.instrumentation_dsl.set_index_to_bindings_layout_lut;
+    BindingLayout binding_layout = layout_lut[meta.descriptor_set][meta.descriptor_binding];
     const Constant& binding_layout_offset = type_manager_.GetConstantUInt32(binding_layout.start);
 
     const uint32_t inst_position = meta.target_instruction->GetPositionOffset();
@@ -169,7 +170,7 @@ void DescriptorClassTexelBufferPass::PrintDebugInfo() const {
 
 // Created own Instrument() because need to control finding the largest offset in a given block
 bool DescriptorClassTexelBufferPass::Instrument() {
-    if (module_.set_index_to_bindings_layout_lut_.empty()) {
+    if (module_.interface_.instrumentation_dsl.set_index_to_bindings_layout_lut.empty()) {
         return false;  // If there is no bindings, nothing to instrument
     }
 

--- a/layers/gpuav/spirv/descriptor_indexing_oob_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_indexing_oob_pass.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2024-2025 LunarG, Inc.
+/* Copyright (c) 2024-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,7 +84,8 @@ uint32_t DescriptorIndexingOOBPass::CreateFunctionCall(BasicBlock& block, Instru
         }
     }
 
-    BindingLayout binding_layout = module_.set_index_to_bindings_layout_lut_[meta.descriptor_set][meta.descriptor_binding];
+    const auto& layout_lut = module_.interface_.instrumentation_dsl.set_index_to_bindings_layout_lut;
+    BindingLayout binding_layout = layout_lut[meta.descriptor_set][meta.descriptor_binding];
     const Constant& binding_layout_size = type_manager_.GetConstantUInt32(binding_layout.count);
     const Constant& binding_layout_offset = type_manager_.GetConstantUInt32(binding_layout.start);
 
@@ -115,8 +116,7 @@ uint32_t DescriptorIndexingOOBPass::CreateFunctionCall(BasicBlock& block, Instru
         const uint32_t sampler_descriptor_index_id =
             CastToUint32(meta.sampler_descriptor_index_id, block, inst_it);  // might be int32
 
-        BindingLayout sampler_binding_layout =
-            module_.set_index_to_bindings_layout_lut_[meta.sampler_descriptor_set][meta.sampler_descriptor_binding];
+        BindingLayout sampler_binding_layout = layout_lut[meta.sampler_descriptor_set][meta.sampler_descriptor_binding];
         const Constant& sampler_binding_layout_size = type_manager_.GetConstantUInt32(sampler_binding_layout.count);
         const Constant& sampler_binding_layout_offset = type_manager_.GetConstantUInt32(sampler_binding_layout.start);
 
@@ -378,7 +378,7 @@ bool DescriptorIndexingOOBPass::RequiresInstrumentation(const Function& function
     return true;
 }
 bool DescriptorIndexingOOBPass::Instrument() {
-    if (module_.set_index_to_bindings_layout_lut_.empty()) {
+    if (module_.interface_.instrumentation_dsl.set_index_to_bindings_layout_lut.empty()) {
         return false;  // If there is no bindings, nothing to instrument
     }
 

--- a/layers/gpuav/spirv/post_process_descriptor_indexing_pass.cpp
+++ b/layers/gpuav/spirv/post_process_descriptor_indexing_pass.cpp
@@ -1,4 +1,4 @@
-/* Copyright (c) 2024-2025 LunarG, Inc.
+/* Copyright (c) 2024-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,8 @@ void PostProcessDescriptorIndexingPass::CreateFunctionCall(BasicBlock& block, In
     const Constant& binding_constant = type_manager_.GetConstantUInt32(meta.descriptor_binding);
     const uint32_t descriptor_index_id = CastToUint32(meta.descriptor_index_id, block, inst_it);  // might be int32
 
-    BindingLayout binding_layout = module_.set_index_to_bindings_layout_lut_[meta.descriptor_set][meta.descriptor_binding];
+    const auto& layout_lut = module_.interface_.instrumentation_dsl.set_index_to_bindings_layout_lut;
+    BindingLayout binding_layout = layout_lut[meta.descriptor_set][meta.descriptor_binding];
     const Constant& binding_layout_offset = type_manager_.GetConstantUInt32(binding_layout.start);
     const Constant& variable_id_constant = type_manager_.GetConstantUInt32(meta.variable_id);
 
@@ -167,7 +168,7 @@ bool PostProcessDescriptorIndexingPass::RequiresInstrumentation(const Function& 
 }
 
 bool PostProcessDescriptorIndexingPass::Instrument() {
-    if (module_.set_index_to_bindings_layout_lut_.empty()) {
+    if (module_.interface_.instrumentation_dsl.set_index_to_bindings_layout_lut.empty()) {
         return false;  // If there is no bindings, nothing to instrument
     }
 

--- a/layers/gpuav/spirv/ray_hit_object_pass.cpp
+++ b/layers/gpuav/spirv/ray_hit_object_pass.cpp
@@ -64,9 +64,8 @@ uint32_t RayHitObjectPass::CreateFunctionCall(BasicBlock& block, InstructionIt* 
 
     const uint32_t opcode_type_id = type_manager_.CreateConstantUInt32(opcode).Id();
 
-    const uint32_t pipeline_flags =
-        (module_.settings_.pipeline_has_skip_aabbs_flag ? 1u : 0u) |
-        (module_.settings_.pipeline_has_skip_triangles_flag ? 2u : 0u);
+    const uint32_t pipeline_flags = (module_.interface_.instrumentation_dsl.pipeline_has_skip_aabbs_flag ? 1u : 0u) |
+                                    (module_.interface_.instrumentation_dsl.pipeline_has_skip_triangles_flag ? 2u : 0u);
     const uint32_t pipeline_flags_id = type_manager_.CreateConstantUInt32(pipeline_flags).Id();
 
     // For non-motion opcodes, pass 0.0 as time (valid value, won't trigger error)
@@ -93,7 +92,9 @@ uint32_t RayHitObjectPass::CreateSBTIndexCheckFunctionCall(BasicBlock& block, In
     const uint32_t inst_position = meta.target_instruction->GetPositionOffset();
     const uint32_t inst_position_id = type_manager_.CreateConstantUInt32(inst_position).Id();
 
-    const uint32_t max_sbt_index_id = type_manager_.CreateConstantUInt32(module_.settings_.max_shader_binding_table_record_index).Id();
+    // maxShaderBindingTableRecordIndex
+    const uint32_t max_sbt_index = module_.interface_.instrumentation_dsl.max_shader_binding_table_record_index;
+    const uint32_t max_sbt_index_id = type_manager_.CreateConstantUInt32(max_sbt_index).Id();
 
     block.CreateInstruction(spv::OpFunctionCall,
                             {bool_type, function_result, function_def, inst_position_id, sbt_index_id, max_sbt_index_id},

--- a/layers/gpuav/spirv/sanitizer_pass.cpp
+++ b/layers/gpuav/spirv/sanitizer_pass.cpp
@@ -22,6 +22,7 @@
 #include <cstdint>
 #include <spirv/unified1/spirv.hpp>
 #include <iostream>
+#include <cstring>
 
 #include "generated/gpuav_offline_spirv.h"
 


### PR DESCRIPTION
This cleans up the `InstrumentShader` function way of creating a `spirv::Module` 

comments inlined