### PR TITLE
layers: Fix bug

### DIFF
--- a/layers/state_tracker/fence_state.h
+++ b/layers/state_tracker/fence_state.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2024 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
@@ -89,6 +89,7 @@ class Fence : public RefcountedStateObject {
     enum Scope scope_{kInternal};
     std::optional<VkExternalFenceHandleTypeFlagBits> imported_handle_type_;  // has value when scope is not kInternal
     mutable std::shared_mutex lock_;
+    bool completed_already_set_{false};
     std::promise<void> completed_;
     std::shared_future<void> waiter_;
     Logger &logger_;


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11531

Essentially, we need to account for bad fence management. Some app was forgetting to wait and reset a fence before using it again in a submission, leading to a `std::promise` being set twice in a row

I don't fully understand what is happening in this multithreaded context with a number of validation errors detected, so coming up with a test reproducing this exact issue is hard...

Adding @artem-lunarg to the review since this touches sync related stuff!