### PR TITLE
layers: Add missing CPU side RT VUs

### DIFF
--- a/layers/error_message/error_location.cpp
+++ b/layers/error_message/error_location.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2021-2025 The Khronos Group Inc.
- * Copyright (c) 2021-2025 Valve Corporation
- * Copyright (c) 2021-2025 LunarG, Inc.
+/* Copyright (c) 2021-2026 The Khronos Group Inc.
+ * Copyright (c) 2021-2026 Valve Corporation
+ * Copyright (c) 2021-2026 LunarG, Inc.
  * Copyright (C) 2021-2022 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,22 +24,25 @@ void Location::AppendFields(std::ostream& out) const {
         // Instead of dealing with partial non-const Location, just do the check here
         const Location& prev_loc = (prev->field == field && prev->index == vvl::kNoIndex32 && prev->prev) ? *prev->prev : *prev;
 
-        // Work back and print for Locaiton first
+        // Work back and print for Location first
         prev_loc.AppendFields(out);
 
         // check if need connector from last item
-        if (prev_loc.structure != vvl::Struct::Empty || prev_loc.field != vvl::Field::Empty) {
+        const bool prev_loc_struct_not_empty = prev_loc.structure != vvl::Struct::Empty;
+        const bool prev_loc_has_unindexed_field = prev_loc.field != vvl::Field::Empty && prev_loc.index == vvl::kNoIndex32;
+        const bool loc_is_array_element_field =
+            prev_loc.index != vvl::kNoIndex32 && field != vvl::Field::Empty;  // eg: this->Fields() would yield "pInfos[42].mode"
+        if (prev_loc_struct_not_empty || prev_loc_has_unindexed_field || loc_is_array_element_field) {
             out << ((prev_loc.index == vvl::kNoIndex32 && IsFieldPointer(prev_loc.field)) ? "->" : ".");
         }
     }
     if (isPNext && structure != vvl::Struct::Empty) {
         out << "pNext<" << vvl::String(structure) << (field != vvl::Field::Empty ? ">." : ">");
     }
-    if (field != vvl::Field::Empty) {
-        out << vvl::String(field);
-        if (index != vvl::kNoIndex32) {
-            out << "[" << index << "]";
-        }
+
+    out << vvl::String(field);
+    if (index != vvl::kNoIndex32) {
+        out << "[" << index << "]";
     }
 }
 

--- a/layers/error_message/error_location.h
+++ b/layers/error_message/error_location.h
@@ -77,6 +77,11 @@ struct Location {
         Location result(*this, this->structure, this->field, sub_index, false);
         return result;
     }
+    // Use this for 2D arrays, to obtain a Location string that looks like "ppBuildRangeInfos[42][14]"
+    Location brackets(uint32_t sub_index) const {
+        Location result(*this, vvl::Struct::Empty, vvl::Field::Empty, sub_index, false);
+        return result;
+    }
 
     // same as dot() but will mark these were part of a pNext struct
     Location pNext(vvl::Struct s, vvl::Field sub_field = vvl::Field::Empty, uint32_t sub_index = vvl::kNoIndex32) const {

--- a/layers/vulkan/generated/error_location_helper.cpp
+++ b/layers/vulkan/generated/error_location_helper.cpp
@@ -2183,7 +2183,7 @@ const char* String(Struct structure) {
 
 const char* String(Field field) {
     static const std::string_view table[] = {
-    {"INVALID_EMPTY", 15}, // Field::Empty
+    {"", 1}, // Field::Empty
     {"AType", 6},
     {"BType", 6},
     {"CType", 6},

--- a/layers/vulkan/generated/error_location_helper.h
+++ b/layers/vulkan/generated/error_location_helper.h
@@ -2174,7 +2174,7 @@ enum class Struct {
 };
 
 enum class Field {
-    Empty = 0,
+    Empty = 0,  // Field::Empty (if something tries to print it, it will be empty)
     AType,
     BType,
     CType,

--- a/layers/vulkan/generated/feature_requirements_helper.cpp
+++ b/layers/vulkan/generated/feature_requirements_helper.cpp
@@ -4795,21 +4795,21 @@ FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **i
             }
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 
-                case Feature::constantAlphaColorBlendFactors : {
-                auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
-                    vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
-                if (!vk_struct) {
-                    vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
-                    *vk_struct = vku::InitStructHelper();
-                    if (*inout_pnext_chain) {
-                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
-                    } else {
-                        *inout_pnext_chain = vk_struct;
-                    }
+        case Feature::constantAlphaColorBlendFactors: {
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
                 }
-                return {&vk_struct->constantAlphaColorBlendFactors,
-                        "VkPhysicalDevicePortabilitySubsetFeaturesKHR::constantAlphaColorBlendFactors"};
             }
+            return {&vk_struct->constantAlphaColorBlendFactors,
+                    "VkPhysicalDevicePortabilitySubsetFeaturesKHR::constantAlphaColorBlendFactors"};
+        }
 #endif  // VK_ENABLE_BETA_EXTENSIONS
 #ifdef VK_ENABLE_BETA_EXTENSIONS
 

--- a/scripts/generators/error_location_helper_generator.py
+++ b/scripts/generators/error_location_helper_generator.py
@@ -114,7 +114,7 @@ class ErrorLocationHelperOutputGenerator(BaseGenerator):
 
         out.append('\n')
         out.append('enum class Field {\n')
-        out.append('    Empty = 0,\n')
+        out.append('    Empty = 0,  // Field::Empty (if something tries to print it, it will be empty)\n')
         # Already alpha-sorted
         for field in self.fields:
             out.append(f'    {field},\n')
@@ -221,7 +221,7 @@ const char* String(Struct structure) {
 
 const char* String(Field field) {
     static const std::string_view table[] = {
-    {"INVALID_EMPTY", 15}, // Field::Empty
+    {"", 1}, // Field::Empty
 ''')
         for field in self.fields:
             out.append(f'    {{"{field}", {len(field) + 1}}},\n')

--- a/tests/unit/gpu_av_ray_tracing_positive.cpp
+++ b/tests/unit/gpu_av_ray_tracing_positive.cpp
@@ -1421,8 +1421,6 @@ TEST_F(PositiveGpuAVRayTracing, OutOfBoundsIndex2) {
 
     vkt::as::BuildGeometryInfoKHR cube_blas = vkt::as::blueprint::BuildGeometryInfoOnDeviceBottomLevel(*m_device, std::move(cube));
 
-    cube_blas.GetBuildRanges()[0].primitiveOffset = 35 * sizeof(uint32_t);
-
     m_command_buffer.Begin();
     cube_blas.BuildCmdBuffer(m_command_buffer);
     m_command_buffer.End();


### PR DESCRIPTION
Last time I looked at them I thought I needed GPU-AV for that, but actually not at all

part of https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/9448

Made some changes to `Location` so that it can correctly output indices in a 2D array, like so:

```
ppBuildRangeInfos[0][0].primitiveOffset
```