### PR TITLE
layers: Fix IndexTypeSize

### DIFF
--- a/layers/best_practices/bp_drawdispatch.cpp
+++ b/layers/best_practices/bp_drawdispatch.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -193,7 +193,7 @@ bool BestPractices::ValidateIndexBufferArm(const bp_state::CommandBufferSubState
 
     // no point checking index buffer if the memory is nonexistant/unmapped, or if there is no graphics pipeline bound to this CB
     if (ib_mem) {
-        const uint32_t scan_stride = GetIndexAlignment(ib_type);
+        const uint32_t scan_stride = IndexTypeSize(ib_type);
         // Check if all indices are within the memory allocation size, if robustness is enabled they might not be
         if ((firstIndex + indexCount) * scan_stride > ib_memory_state->allocate_info.allocationSize) {
             return skip;

--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -528,11 +528,11 @@ bool CoreChecks::ValidateCmdBindIndexBuffer(const vvl::CommandBuffer &cb_state, 
     vuid = is_2 ? "VUID-vkCmdBindIndexBuffer2-buffer-08785" : "VUID-vkCmdBindIndexBuffer-buffer-08785";
     skip |= ValidateMemoryIsBoundToBuffer(cb_state.Handle(), *buffer_state, loc.dot(Field::buffer), vuid);
 
-    const VkDeviceSize offset_align = static_cast<VkDeviceSize>(GetIndexAlignment(indexType));
-    if (!IsIntegerMultipleOf(offset, offset_align)) {
+    const uint32_t index_type_size = IndexTypeSize(indexType);
+    if (!IsIntegerMultipleOf(offset, index_type_size)) {
         vuid = is_2 ? "VUID-vkCmdBindIndexBuffer2-offset-08783" : "VUID-vkCmdBindIndexBuffer-offset-08783";
         skip |= LogError(vuid, objlist, loc.dot(Field::offset),
-                         "(%" PRIu64 ") is not a multiple of %" PRIu64 " (the alignment for %s).", offset, offset_align,
+                         "(%" PRIu64 ") is not a multiple of %" PRIu32 " (the alignment for %s).", offset, index_type_size,
                          string_VkIndexType(indexType));
     }
     if (offset >= buffer_state->create_info.size) {
@@ -564,11 +564,12 @@ bool CoreChecks::PreCallValidateCmdBindIndexBuffer2(VkCommandBuffer commandBuffe
         auto buffer_state = Get<vvl::Buffer>(buffer);
         if (!buffer_state) return skip;  // if using nullDescriptors
 
-        const VkDeviceSize offset_align = static_cast<VkDeviceSize>(GetIndexAlignment(indexType));
-        if (!IsIntegerMultipleOf(size, offset_align)) {
+        const uint32_t index_type_size = IndexTypeSize(indexType);
+        if (!IsIntegerMultipleOf(size, index_type_size)) {
             const LogObjectList objlist(commandBuffer, buffer);
             skip |= LogError("VUID-vkCmdBindIndexBuffer2-size-08767", objlist, error_obj.location.dot(Field::size),
-                             "(%" PRIu64 ") does not fall on alignment (%s) boundary.", size, string_VkIndexType(indexType));
+                             "(%" PRIu64 ") is not a multiple of %" PRIu32 " (the alignment for %s).", size, index_type_size,
+                             string_VkIndexType(indexType));
         }
         if ((offset + size) > buffer_state->create_info.size) {
             const LogObjectList objlist(commandBuffer, buffer);

--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -236,7 +236,7 @@ bool CoreChecks::ValidateCmdDrawIndexedBufferSize(const vvl::CommandBuffer &cb_s
         return skip;
     }
 
-    const uint32_t index_size = GetIndexAlignment(cb_state.index_buffer_binding.index_type);
+    const uint32_t index_size = IndexTypeSize(cb_state.index_buffer_binding.index_type);
     // This doesn't exactly match the pseudocode of the VUID, but the binding size is the *bound* size, such that the offset
     // has already been accounted for (subtracted from the buffer size), and is consistent with the use of
     // BufferBinding::size for vertex buffer bindings (which record the *bound* size, not the size of the bound buffer)

--- a/layers/gpuav/instrumentation/vertex_attribute_fetch_oob.cpp
+++ b/layers/gpuav/instrumentation/vertex_attribute_fetch_oob.cpp
@@ -282,9 +282,10 @@ void RegisterVertexAttributeFetchOobValidation(Validator &gpuav, CommandBufferSu
             }
 
             if (error_sub_code == glsl::kErrorSubCode_IndexedDraw_OOBVertexIndex) {
-                const uint32_t index_bits_size = GetIndexBitsSize(local_error_info->index_buffer_binding->index_type);
+                const uint32_t index_byte_size = IndexTypeSize(local_error_info->index_buffer_binding->index_type);
+                assert(index_byte_size != 0);  // Should never be VK_INDEX_TYPE_NONE_KHR
                 const uint32_t max_indices_in_buffer =
-                    static_cast<uint32_t>(local_error_info->index_buffer_binding->size / (index_bits_size / 8u));
+                    static_cast<uint32_t>(local_error_info->index_buffer_binding->size / index_byte_size);
                 out_error_msg += "Index Buffer (";
                 out_error_msg += gpuav.FormatHandle(local_error_info->index_buffer_binding->buffer);
                 out_error_msg += ") binding info:\n";

--- a/layers/gpuav/validation_cmd/gpuav_draw.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_draw.cpp
@@ -845,8 +845,8 @@ void DrawIndexedIndirectIndexBuffer(Validator &gpuav, CommandBufferSubState &cb_
             return;
         }
 
-        const uint32_t index_bits_size = GetIndexBitsSize(index_buffer_binding.index_type);
-        const uint32_t max_indices_in_buffer = static_cast<uint32_t>(index_buffer_binding.size / (index_bits_size / 8u));
+        const uint32_t index_byte_size = IndexTypeSize(index_buffer_binding.index_type);
+        const uint32_t max_indices_in_buffer = static_cast<uint32_t>(index_buffer_binding.size / index_byte_size);
 
         vko::BufferRange validation_dispatch_params_buffer_range =
             cb_state.gpu_resources_manager.GetDeviceLocalIndirectBufferRange(3 * sizeof(uint32_t));
@@ -981,8 +981,9 @@ void DrawIndexedIndirectIndexBuffer(Validator &gpuav, CommandBufferSubState &cb_
                 const uint32_t first_index = error_record[kValCmd_ErrorPayloadDword_1];
                 const uint32_t index_count = error_record[kValCmd_ErrorPayloadDword_2];
                 const uint32_t highest_accessed_index = first_index + index_count;
-                const uint32_t index_bits_size = GetIndexBitsSize(index_buffer_binding.index_type);
-                const uint32_t max_indices_in_buffer = static_cast<uint32_t>(index_buffer_binding.size / (index_bits_size / 8u));
+                const uint32_t index_byte_size = IndexTypeSize(index_buffer_binding.index_type);
+                assert(index_byte_size != 0);  // Should never be VK_INDEX_TYPE_NONE_KHR
+                const uint32_t max_indices_in_buffer = static_cast<uint32_t>(index_buffer_binding.size / index_byte_size);
 
                 skip |= gpuav.LogError(
                     vuid, objlist, loc_with_debug_region,

--- a/layers/gpuav/validation_cmd/gpuav_ray_tracing.cpp
+++ b/layers/gpuav/validation_cmd/gpuav_ray_tracing.cpp
@@ -847,7 +847,7 @@ void BLAS(Validator& gpuav, const Location& loc, CommandBufferSubState& cb_state
         switch (error_sub_code) {
             case kErrorSubCode_PreBuildAccelerationStructures_MaxFetchedIndex: {
                 const uint32_t index = error_record[kValCmd_ErrorPayloadDword_2];
-                const uint32_t index_type_byte_size = GetIndexBitsSize(error_info.geom.triangles.indexType) / 8u;
+                const uint32_t index_type_byte_size = IndexTypeSize(error_info.geom.triangles.indexType);
 
                 skip |= gpuav.LogError(
                     "VUID-VkAccelerationStructureBuildRangeInfoKHR-maxVertex-10774", objlist, loc_with_debug_region,

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -880,7 +880,7 @@ bool CommandBufferAccessContext::ValidateDrawVertexIndex(uint32_t index_count, u
     const auto index_buf_state = sync_state_.Get<vvl::Buffer>(index_binding.buffer);
     if (!index_buf_state) return skip;
 
-    const auto index_size = GetIndexAlignment(index_binding.index_type);
+    const uint32_t index_size = IndexTypeSize(index_binding.index_type);
     const AccessRange range = MakeRangeForIndexData(index_binding.offset, firstIndex, index_count, index_size);
 
     auto hazard = current_context_->DetectHazard(*index_buf_state, SYNC_INDEX_INPUT_INDEX_READ, range);
@@ -909,7 +909,7 @@ void CommandBufferAccessContext::RecordDrawVertexIndex(uint32_t indexCount, uint
     const auto index_buf_state = sync_state_.Get<vvl::Buffer>(index_binding.buffer);
     if (!index_buf_state) return;
 
-    const auto index_size = GetIndexAlignment(index_binding.index_type);
+    const uint32_t index_size = IndexTypeSize(index_binding.index_type);
     const AccessRange range = MakeRangeForIndexData(index_binding.offset, firstIndex, indexCount, index_size);
     const ResourceUsageTagEx tag_ex = AddCommandHandle(tag, index_buf_state->Handle());
     current_context_->UpdateAccessState(*index_buf_state, SYNC_INDEX_INPUT_INDEX_READ, SyncOrdering::kNonAttachment, range, tag_ex);

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -3022,9 +3022,9 @@ static std::optional<AccelerationStructureGeometryInfo> GetValidGeometryInfo(
             if (p_index_data) {
                 geometry_info.index_data = p_index_data;
                 const VkDeviceSize base_index_offset = triangles.indexData.deviceAddress - p_index_data->deviceAddress;
-                const uint32_t index_size = GetIndexBitsSize(triangles.indexType) / 8;
+                const uint32_t index_byte_size = IndexTypeSize(triangles.indexType);
                 const VkDeviceSize offset = base_index_offset + range_info.primitiveOffset;
-                const uint32_t index_data_size = 3 * range_info.primitiveCount * index_size;
+                const uint32_t index_data_size = 3 * range_info.primitiveCount * index_byte_size;
                 geometry_info.index_range = MakeRange(*p_index_data, offset, index_data_size);
             }
         }

--- a/layers/utils/vk_api_utils.h
+++ b/layers/utils/vk_api_utils.h
@@ -33,8 +33,8 @@ static const VkShaderStageFlags kShaderStageAllRayTracing =
     VK_SHADER_STAGE_ANY_HIT_BIT_KHR | VK_SHADER_STAGE_CALLABLE_BIT_KHR | VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR |
     VK_SHADER_STAGE_INTERSECTION_BIT_KHR | VK_SHADER_STAGE_MISS_BIT_KHR | VK_SHADER_STAGE_RAYGEN_BIT_KHR;
 
-static inline uint32_t GetIndexAlignment(VkIndexType indexType) {
-    switch (indexType) {
+static inline uint32_t IndexTypeSize(VkIndexType index_type) {
+    switch (index_type) {
         case VK_INDEX_TYPE_UINT16:
             return 2;
         case VK_INDEX_TYPE_UINT32:
@@ -43,27 +43,12 @@ static inline uint32_t GetIndexAlignment(VkIndexType indexType) {
             return 1;
         case VK_INDEX_TYPE_NONE_KHR:  // alias VK_INDEX_TYPE_NONE_NV
             return 0;
-        default:
-            // Not a real index type. Express no alignment requirement here; we expect upper layer
-            // to have already picked up on the enum being nonsense.
-            return 1;
-    }
-}
-
-inline constexpr uint32_t GetIndexBitsSize(VkIndexType indexType) {
-    switch (indexType) {
-        case VK_INDEX_TYPE_UINT16:
-            return 16;
-        case VK_INDEX_TYPE_UINT32:
-            return 32;
-        case VK_INDEX_TYPE_NONE_KHR:
-            return 0;
-        case VK_INDEX_TYPE_UINT8_KHR:
-            return 8;
         case VK_INDEX_TYPE_MAX_ENUM:
-            return 0;
+            break;
+            // Not a real index type. Express no alignment requirement here
+            // Assume caller is handling this already
     }
-    return 0;
+    return 1;  // so compilers don't complain nothing is returned in all cases
 }
 
 static bool inline IsStageInPipelineBindPoint(VkShaderStageFlags stages, VkPipelineBindPoint bind_point) {


### PR DESCRIPTION
we had `GetIndexBitsSize`, which is really just `GetIndexAlignment`

renamed it to `IndexTypeSize` and cleaned up the various spots using it