### PR TITLE
layers: Better 2D arrayLayers copy messages

### DIFF
--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (C) 2015-2024 Google Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (C) 2015-2026 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -363,9 +363,16 @@ VkExtent3D Image::GetEffectiveSubresourceExtent(const VkImageSubresourceRange &r
 std::string Image::DescribeSubresourceLayers(const VkImageSubresourceLayers &subresource) const {
     std::ostringstream ss;
     VkExtent3D subresource_extent = GetEffectiveSubresourceExtent(subresource);
+
     const VkFormat format = create_info.format;
     ss << "The " << string_VkImageType(create_info.imageType) << " VkImage was created with format " << string_VkFormat(format)
-       << " and an extent of [" << string_VkExtent3D(create_info.extent) << "]\n";
+       << " and an extent of [" << string_VkExtent3D(create_info.extent) << "]";
+    if (VK_IMAGE_TYPE_3D != create_info.imageType && create_info.arrayLayers > 1) {
+        ss << " (arrayLayers is " << create_info.arrayLayers << " which provides an effective [depth = " << subresource_extent.depth
+           << "] for the non-3D image)";
+    }
+    ss << '\n';
+
     if (subresource.mipLevel != 0) {
         ss << "\tmipLevel " << subresource.mipLevel << " is [" << string_VkExtent3D(subresource_extent) << "]\n";
     }


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11627

new message

```
vkCopyMemoryToImageEXT(): pCopyMemoryToImageInfo->pRegions[0].imageExtent (width = 32, height = 32, depth = 1) must match the imageSubresource extents (width = 32, height = 32, depth = 2) because pCopyMemoryToImageInfo->flags contains VK_HOST_IMAGE_COPY_MEMCPY
The VK_IMAGE_TYPE_2D VkImage was created with format VK_FORMAT_R8G8B8A8_UNORM and an extent of [width = 32, height = 32, depth = 1] (arrayLayers is 2 which provides an effective [depth = 2] for the non-3D image)
```
