### PR TITLE
tests: Fix test checks for KosmicKrisp

### DIFF
--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -4062,7 +4062,7 @@ TEST_F(NegativeCommand, CommandBufferRecording) {
         m_errorMonitor->VerifyFound();
     }
 
-    {
+    if (m_device->Physical().limits_.timestampComputeAndGraphics) {
         vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_TIMESTAMP, 1);
 
         m_errorMonitor->SetDesiredError("VUID-vkCmdResetQueryPool-commandBuffer-recording");

--- a/tests/unit/image.cpp
+++ b/tests/unit/image.cpp
@@ -2901,6 +2901,10 @@ TEST_F(NegativeImage, ImageFormatListSizeCompatible) {
     image_ci.pNext = &formatList;
     image_ci.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT;
 
+    if (!IsImageFormatSupported(Gpu(), image_ci, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
+        GTEST_SKIP() << "Image create info not supported on device";
+    }
+
     // The first image in the list should be size-compatible (128-bit)
     vkt::Image good_image(*m_device, image_ci);
 
@@ -3124,10 +3128,8 @@ TEST_F(NegativeImage, BlockTexelViewLevelOrLayerCount) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
 
-    VkFormatProperties image_fmt;
-    vk::GetPhysicalDeviceFormatProperties(m_device->Physical(), image_create_info.format, &image_fmt);
-    if (!vkt::Image::IsCompatible(*m_device, image_create_info.usage, image_fmt.optimalTilingFeatures)) {
-        GTEST_SKIP() << "Image usage and format not compatible on device";
+    if (!IsImageFormatSupported(Gpu(), image_create_info, VK_IMAGE_USAGE_SAMPLED_BIT)) {
+        GTEST_SKIP() << "Image create info not compatible on device";
     }
     vkt::Image image(*m_device, image_create_info, vkt::set_layout);
 

--- a/tests/unit/image_positive.cpp
+++ b/tests/unit/image_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -549,6 +549,10 @@ TEST_F(PositiveImage, ImageFormatListSizeCompatibleUncompressed) {
     image_ci.pNext = &format_list;
     image_ci.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT;
 
+    if (!IsImageFormatSupported(Gpu(), image_ci, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
+        GTEST_SKIP() << "Image create info not supported on device";
+    }
+
     vkt::Image image(*m_device, image_ci);
 }
 
@@ -570,6 +574,10 @@ TEST_F(PositiveImage, ImageFormatListSizeCompatibleCompressed) {
     auto image_ci = vkt::Image::ImageCreateInfo2D(128, 128, 1, 1, VK_FORMAT_BC3_UNORM_BLOCK, VK_IMAGE_USAGE_SAMPLED_BIT);
     image_ci.pNext = &format_list;
     image_ci.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT;
+
+    if (!IsImageFormatSupported(Gpu(), image_ci, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
+        GTEST_SKIP() << "Image create info not supported on device";
+    }
 
     vkt::Image image(*m_device, image_ci);
 }
@@ -641,10 +649,8 @@ TEST_F(PositiveImage, RemainingMipLevelsBlockTexelView) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
 
-    VkFormatProperties image_fmt;
-    vk::GetPhysicalDeviceFormatProperties(m_device->Physical(), image_create_info.format, &image_fmt);
-    if (!vkt::Image::IsCompatible(*m_device, image_create_info.usage, image_fmt.optimalTilingFeatures)) {
-        GTEST_SKIP() << "Image usage and format not compatible on device";
+    if (!IsImageFormatSupported(Gpu(), image_create_info, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
+        GTEST_SKIP() << "Image create info not compatible on device";
     }
     vkt::Image image(*m_device, image_create_info, vkt::set_layout);
 
@@ -744,10 +750,8 @@ TEST_F(PositiveImage, BlockTexelViewType) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
 
-    VkFormatProperties image_fmt;
-    vk::GetPhysicalDeviceFormatProperties(m_device->Physical(), image_create_info.format, &image_fmt);
-    if (!vkt::Image::IsCompatible(*m_device, image_create_info.usage, image_fmt.optimalTilingFeatures)) {
-        GTEST_SKIP() << "Image usage and format not compatible on device";
+    if (!IsImageFormatSupported(Gpu(), image_create_info, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
+        GTEST_SKIP() << "Image create info not compatible on device";
     }
     vkt::Image image(*m_device, image_create_info, vkt::set_layout);
 
@@ -922,10 +926,8 @@ TEST_F(PositiveImage, BlockTexelViewLayerCount) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
 
-    VkFormatProperties image_fmt;
-    vk::GetPhysicalDeviceFormatProperties(m_device->Physical(), image_create_info.format, &image_fmt);
-    if (!vkt::Image::IsCompatible(*m_device, image_create_info.usage, image_fmt.optimalTilingFeatures)) {
-        GTEST_SKIP() << "Image usage and format not compatible on device";
+    if (!IsImageFormatSupported(Gpu(), image_create_info, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
+        GTEST_SKIP() << "Image create info not compatible on device";
     }
     vkt::Image image(*m_device, image_create_info);
 

--- a/tests/unit/query.cpp
+++ b/tests/unit/query.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  * Modifications Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -2310,6 +2310,10 @@ TEST_F(NegativeQuery, WriteTimestampInsideRenderPass) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
+    if (!(m_device->Physical().limits_.timestampComputeAndGraphics & VK_QUEUE_GRAPHICS_BIT)) {
+        GTEST_SKIP() << "Timestamps not supported in the graphics queue";
+    }
+
     VkQueryPoolCreateInfo query_pool_create_info = vku::InitStructHelper();
     query_pool_create_info.queryType = VK_QUERY_TYPE_TIMESTAMP;
     query_pool_create_info.queryCount = 2;
@@ -2517,6 +2521,10 @@ TEST_F(NegativeQuery, CopyUnavailableQueries) {
 TEST_F(NegativeQuery, QueryResultCopyBufferInvalidFlags) {
     TEST_DESCRIPTION("Copy query results to a buffer without transfer dst flag");
     RETURN_IF_SKIP(Init());
+
+    if (!m_device->Physical().limits_.timestampComputeAndGraphics) {
+        GTEST_SKIP() << "Timestamps not supported";
+    }
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_TIMESTAMP, 1u);
     vkt::Buffer buffer(*m_device, 16u, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -2868,6 +2868,10 @@ TEST_F(PositiveSyncVal, TwoExternalDependenciesSyncLayoutTransitions) {
 TEST_F(PositiveSyncVal, SingleQueryCopyIgnoresStride) {
     RETURN_IF_SKIP(InitSyncVal());
 
+    if (!m_device->Physical().limits_.timestampComputeAndGraphics) {
+        GTEST_SKIP() << "Timestamps not supported";
+    }
+
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_TIMESTAMP, 1);
     vkt::Buffer buffer8(*m_device, 8, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
     vkt::Buffer buffer16(*m_device, 16, VK_BUFFER_USAGE_TRANSFER_DST_BIT);


### PR DESCRIPTION
With these fixes, we are down to 2 crashes and 13 failures with current KK (need to upstream a few fixes to KK)

Breakdown:

```
[==========] 6231 tests from 244 test suites ran. (57617 ms total)
[  PASSED  ] 2649 tests.
[  SKIPPED ] 3569 tests, listed below:
[  FAILED  ] 13 tests, listed below:
```