### PR TITLE
build: Enable UPDATE_DEPS by default

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ~~~
-# Copyright (c) 2023-2025 LunarG, Inc.
+# Copyright (c) 2023-2026 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ~~~
 
-option(UPDATE_DEPS "Run update_deps.py for user")
+option(UPDATE_DEPS "Run update_deps.py for user" ON)
 if (UPDATE_DEPS)
     find_package(Python3 REQUIRED QUIET)
 


### PR DESCRIPTION
Most developers use UPDATE_DEPS build option to manage build dependencies. Enabling it by default streamlines the process of setting up this repository.

See https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/11647 for documentation update