### PR TITLE
sync: Add render pass instance id to access state

### DIFF
--- a/layers/sync/sync_access_context.cpp
+++ b/layers/sync/sync_access_context.cpp
@@ -456,7 +456,7 @@ AccessMap::iterator AccessContext::ResolveGapRecursePrev(const AccessRange &gap_
 // The passed pos must either be a lower bound (can be the end iterator) or be strictly less than the range.
 // Map entries that intersect range.begin or range.end are split at the intersection point.
 AccessMap::iterator AccessContext::DoUpdateAccessState(AccessMap::iterator pos, const AccessRange &range,
-                                                       SyncAccessIndex access_index, SyncOrdering ordering_rule,
+                                                       SyncAccessIndex access_index, const AttachmentAccessInfo &attachment_access,
                                                        ResourceUsageTagEx tag_ex, SyncFlags flags) {
     assert(range.non_empty());
     const SyncAccessInfo &access_info = GetAccessInfo(access_index);
@@ -494,7 +494,7 @@ AccessMap::iterator AccessContext::DoUpdateAccessState(AccessMap::iterator pos, 
             // Update
             AccessState &new_access_state = infilled_it->second;
             ApplyGlobalBarriers(new_access_state);
-            new_access_state.Update(access_info, ordering_rule, tag_ex, flags);
+            new_access_state.Update(access_info, attachment_access, tag_ex, flags);
 
             // Advance current location.
             // Do not advance pos, as it's the next map entry to visit
@@ -511,7 +511,7 @@ AccessMap::iterator AccessContext::DoUpdateAccessState(AccessMap::iterator pos, 
             // Update
             AccessState &access_state = pos->second;
             ApplyGlobalBarriers(access_state);
-            access_state.Update(access_info, ordering_rule, tag_ex, flags);
+            access_state.Update(access_info, attachment_access, tag_ex, flags);
 
             // Advance both current location and map entry
             current_begin = pos->first.end;
@@ -527,7 +527,7 @@ AccessMap::iterator AccessContext::DoUpdateAccessState(AccessMap::iterator pos, 
         // Update
         AccessState &new_access_state = infilled_it->second;
         ApplyGlobalBarriers(new_access_state);
-        new_access_state.Update(access_info, ordering_rule, tag_ex, flags);
+        new_access_state.Update(access_info, attachment_access, tag_ex, flags);
     }
     return pos;
 }
@@ -551,20 +551,30 @@ void AccessContext::UpdateAccessState(const vvl::Buffer &buffer, SyncAccessIndex
     const AccessRange buffer_range = range + base_address;
 
     auto pos = access_state_map_.LowerBound(buffer_range.begin);
-    DoUpdateAccessState(pos, buffer_range, current_usage, SyncOrdering::kOrderingNone, tag_ex, flags);
+    DoUpdateAccessState(pos, buffer_range, current_usage, AttachmentAccessInfo::NonAttachment(), tag_ex, flags);
 }
 
-void AccessContext::UpdateAccessState(ImageRangeGen &range_gen, SyncAccessIndex current_usage, SyncOrdering ordering_rule,
-                                      ResourceUsageTagEx tag_ex, SyncFlags flags) {
+void AccessContext::UpdateAccessState(ImageRangeGen &range_gen, SyncAccessIndex current_usage, ResourceUsageTagEx tag_ex,
+                                      SyncFlags flags) {
     assert(!finalized_);
-
     if (current_usage == SYNC_ACCESS_INDEX_NONE) {
         return;
     }
-
     auto pos = access_state_map_.LowerBound(range_gen->begin);
     for (; range_gen->non_empty(); ++range_gen) {
-        pos = DoUpdateAccessState(pos, *range_gen, current_usage, ordering_rule, tag_ex, flags);
+        pos = DoUpdateAccessState(pos, *range_gen, current_usage, AttachmentAccessInfo::NonAttachment(), tag_ex, flags);
+    }
+}
+
+void AccessContext::UpdateAccessState(ImageRangeGen &range_gen, SyncAccessIndex current_usage,
+                                      const AttachmentAccessInfo &attachment_access, ResourceUsageTagEx tag_ex, SyncFlags flags) {
+    assert(!finalized_);
+    if (current_usage == SYNC_ACCESS_INDEX_NONE) {
+        return;
+    }
+    auto pos = access_state_map_.LowerBound(range_gen->begin);
+    for (; range_gen->non_empty(); ++range_gen) {
+        pos = DoUpdateAccessState(pos, *range_gen, current_usage, attachment_access, tag_ex, flags);
     }
 }
 

--- a/layers/sync/sync_access_context.h
+++ b/layers/sync/sync_access_context.h
@@ -281,7 +281,8 @@ class AccessContext {
 
     void UpdateAccessState(const vvl::Buffer &buffer, SyncAccessIndex current_usage, const AccessRange &range,
                            ResourceUsageTagEx tag_ex, SyncFlags flags = 0);
-    void UpdateAccessState(ImageRangeGen &range_gen, SyncAccessIndex current_usage, SyncOrdering ordering_rule,
+    void UpdateAccessState(ImageRangeGen &range_gen, SyncAccessIndex current_usage, ResourceUsageTagEx tag_ex, SyncFlags flags = 0);
+    void UpdateAccessState(ImageRangeGen &range_gen, SyncAccessIndex current_usage, const AttachmentAccessInfo &attachment_access,
                            ResourceUsageTagEx tag_ex, SyncFlags flags = 0);
 
     void ResolveChildContexts(vvl::span<AccessContext> subpass_contexts);
@@ -421,7 +422,8 @@ class AccessContext {
     AccessMap::iterator ResolveGapRecursePrev(const AccessRange &gap_range, AccessMap::iterator pos_hint);
 
     AccessMap::iterator DoUpdateAccessState(AccessMap::iterator pos, const AccessRange &range, SyncAccessIndex access_index,
-                                            SyncOrdering ordering_rule, ResourceUsageTagEx tag_ex, SyncFlags flags);
+                                            const AttachmentAccessInfo &attachment_access, ResourceUsageTagEx tag_ex,
+                                            SyncFlags flags);
 
     // A recursive range walkers for hazard detection, first for the current context
     // and then walks the DAG of the contexts for subpasses

--- a/layers/sync/sync_access_state.cpp
+++ b/layers/sync/sync_access_state.cpp
@@ -511,7 +511,8 @@ void AccessState::Resolve(const AccessState &other) {
     }
 }
 
-void AccessState::Update(const SyncAccessInfo &usage_info, SyncOrdering ordering_rule, ResourceUsageTagEx tag_ex, SyncFlags flags) {
+void AccessState::Update(const SyncAccessInfo &usage_info, const AttachmentAccessInfo &attachment_access, ResourceUsageTagEx tag_ex,
+                         SyncFlags flags) {
     const VkPipelineStageFlagBits2 usage_stage = usage_info.stage_mask;
     if (IsRead(usage_info.access_index)) {
         // Mulitple outstanding reads may be of interest and do dependency chains independently
@@ -549,9 +550,9 @@ void AccessState::Update(const SyncAccessInfo &usage_info, SyncOrdering ordering
             input_attachment_read = (usage_info.access_index == SYNC_FRAGMENT_SHADER_INPUT_ATTACHMENT_READ);
         }
     } else {
-        SetWrite(usage_info.access_index, tag_ex, flags);
+        SetWrite(usage_info.access_index, attachment_access, tag_ex, flags);
     }
-    UpdateFirst(tag_ex, usage_info, ordering_rule, flags);
+    UpdateFirst(tag_ex, usage_info, attachment_access.ordering, flags);
 }
 
 HazardResult HazardResult::HazardVsPriorWrite(const AccessState *access_state, const SyncAccessInfo &usage_info, SyncHazard hazard,
@@ -582,12 +583,13 @@ bool HazardResult::IsWAWHazard() const {
 // Clobber last read and all barriers... because all we have is DANGER, DANGER, WILL ROBINSON!!!
 // if the last_reads/last_write were unsafe, we've reported them, in either case the prior access is irrelevant.
 // We can overwrite them as *this* write is now after them.
-void AccessState::SetWrite(SyncAccessIndex access_index, ResourceUsageTagEx tag_ex, SyncFlags flags) {
+void AccessState::SetWrite(SyncAccessIndex access_index, const AttachmentAccessInfo &attachment_access, ResourceUsageTagEx tag_ex,
+                           SyncFlags flags) {
     ClearRead();
     if (!last_write.has_value()) {
         last_write.emplace();
     }
-    last_write->Set(access_index, tag_ex, flags);
+    last_write->Set(access_index, attachment_access, tag_ex, flags);
 }
 
 void AccessState::ClearWrite() { last_write.reset(); }
@@ -623,7 +625,7 @@ bool AccessState::ApplyBarrier(const BarrierScope &barrier_scope, const SyncBarr
         const OrderingBarrier layout_ordering{barrier.src_exec_scope.exec_scope, barrier.src_access_scope};
 
         // Register write access that models layout transition writes
-        SetWrite(SYNC_IMAGE_LAYOUT_TRANSITION, tag_ex);
+        SetWrite(SYNC_IMAGE_LAYOUT_TRANSITION, AttachmentAccessInfo::NonAttachment(), tag_ex);
         UpdateFirst(tag_ex, layout_transition_access_info, SyncOrdering::kOrderingNone);
         TouchupFirstForLayoutTransition(layout_transition_tag, layout_ordering);
 
@@ -840,7 +842,7 @@ void AccessState::ApplyPendingWriteBarrier(const PendingWriteBarrier &write_barr
 void AccessState::ApplyPendingLayoutTransition(const PendingLayoutTransition &layout_transition, ResourceUsageTag tag) {
     const SyncAccessInfo &layout_usage_info = GetAccessInfo(SYNC_IMAGE_LAYOUT_TRANSITION);
     const ResourceUsageTagEx tag_ex = ResourceUsageTagEx{tag, layout_transition.handle_index};
-    SetWrite(SYNC_IMAGE_LAYOUT_TRANSITION, tag_ex);
+    SetWrite(SYNC_IMAGE_LAYOUT_TRANSITION, AttachmentAccessInfo::NonAttachment(), tag_ex);
     UpdateFirst(tag_ex, layout_usage_info, SyncOrdering::kOrderingNone);
     TouchupFirstForLayoutTransition(tag, layout_transition.ordering);
 }
@@ -1127,7 +1129,8 @@ bool ReadState::InBarrierSourceScope(const BarrierScope &barrier_scope) const {
     return ReadOrDependencyChainInSourceScope(barrier_scope.scope_queue, barrier_scope.src_exec_scope);
 }
 
-void WriteState::Set(SyncAccessIndex access_index, ResourceUsageTagEx tag_ex, SyncFlags flags) {
+void WriteState::Set(SyncAccessIndex access_index, const AttachmentAccessInfo &attachment_access, ResourceUsageTagEx tag_ex,
+                     SyncFlags flags) {
     this->access_index = access_index;
     this->flags = flags;
     barriers.reset();
@@ -1135,6 +1138,8 @@ void WriteState::Set(SyncAccessIndex access_index, ResourceUsageTagEx tag_ex, Sy
     tag = tag_ex.tag;
     handle_index = tag_ex.handle_index;
     queue = kQueueIdInvalid;
+    render_pass_instance_id = attachment_access.render_pass_instance_id;
+    subpass = attachment_access.subpass;
 }
 
 void WriteState::SetQueueId(QueueId id) {

--- a/layers/sync/sync_access_state.h
+++ b/layers/sync/sync_access_state.h
@@ -161,6 +161,14 @@ struct FirstAccess {
 
 using QueueId = uint32_t;
 
+struct AttachmentAccessInfo {
+    SyncOrdering ordering = SyncOrdering::kOrderingNone;
+    uint32_t render_pass_instance_id = vvl::kNoIndex32;
+    uint32_t subpass = vvl::kNoIndex32;
+
+    static AttachmentAccessInfo NonAttachment() { return AttachmentAccessInfo{}; }
+};
+
 struct OrderingBarrier {
     VkPipelineStageFlags2 exec_scope = VK_PIPELINE_STAGE_2_NONE;
     SyncAccessFlags access_scope;
@@ -235,7 +243,13 @@ struct WriteState {
     uint32_t handle_index;
     QueueId queue;
 
-    void Set(SyncAccessIndex access_index, ResourceUsageTagEx tag_ex, SyncFlags flags);
+    // Identifies a render pass instance (and subpass for legacy render passes).
+    // Used to determine whether two accesses are in the same render pass instance.
+    uint32_t render_pass_instance_id;
+    uint32_t subpass;
+
+    void Set(SyncAccessIndex access_index, const AttachmentAccessInfo &attachment_access, ResourceUsageTagEx tag_ex,
+             SyncFlags flags);
     void SetQueueId(QueueId id);
     void MergeBarriers(const WriteState &other);
 
@@ -339,8 +353,10 @@ class AccessState {
                                      VkPipelineStageFlags2 source_exec_scope, const SyncAccessFlags &source_access_scope,
                                      QueueId event_queue, ResourceUsageTag event_tag) const;
 
-    void Update(const SyncAccessInfo &usage_info, SyncOrdering ordering_rule, ResourceUsageTagEx tag_ex, SyncFlags flags = 0);
-    void SetWrite(SyncAccessIndex access_index, ResourceUsageTagEx tag_ex, SyncFlags flags = 0);
+    void Update(const SyncAccessInfo &usage_info, const AttachmentAccessInfo &attachment_access, ResourceUsageTagEx tag_ex,
+                SyncFlags flags = 0);
+    void SetWrite(SyncAccessIndex access_index, const AttachmentAccessInfo &attachment_access, ResourceUsageTagEx tag_ex,
+                  SyncFlags flags = 0);
     void ClearWrite();
     void ClearRead();
     void ClearFirstUse();

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -223,7 +223,7 @@ static void UpdateImageAccessState(AccessContext &access_context, const vvl::Ima
                                    const VkImageSubresourceRange &subresource_range, const ResourceUsageTag &tag) {
     const auto &sub_state = SubState(image);
     ImageRangeGen range_gen = sub_state.MakeImageRangeGen(subresource_range, false);
-    access_context.UpdateAccessState(range_gen, current_usage, SyncOrdering::kOrderingNone, ResourceUsageTagEx{tag});
+    access_context.UpdateAccessState(range_gen, current_usage, ResourceUsageTagEx{tag});
 }
 
 static void UpdateImageAccessState(AccessContext &access_context, const vvl::Image &image, SyncAccessIndex current_usage,
@@ -231,7 +231,7 @@ static void UpdateImageAccessState(AccessContext &access_context, const vvl::Ima
                                    const VkExtent3D &extent, ResourceUsageTagEx tag_ex) {
     const auto &sub_state = SubState(image);
     ImageRangeGen range_gen = sub_state.MakeImageRangeGen(subresource_range, offset, extent, false);
-    access_context.UpdateAccessState(range_gen, current_usage, SyncOrdering::kOrderingNone, tag_ex);
+    access_context.UpdateAccessState(range_gen, current_usage, tag_ex);
 }
 
 static void UpdateVideoAccessState(AccessContext &access_context, const vvl::VideoSession &vs_state,
@@ -241,7 +241,7 @@ static void UpdateVideoAccessState(AccessContext &access_context, const vvl::Vid
     const auto extent = resource.GetEffectiveImageExtent(vs_state);
     const auto &sub_state = SubState(*image);
     ImageRangeGen range_gen(sub_state.MakeImageRangeGen(resource.range, offset, extent, false));
-    access_context.UpdateAccessState(range_gen, current_usage, SyncOrdering::kOrderingNone, ResourceUsageTagEx{tag});
+    access_context.UpdateAccessState(range_gen, current_usage, ResourceUsageTagEx{tag});
 }
 
 CommandExecutionContext::CommandExecutionContext(const SyncValidator &sync_validator, VkQueueFlags queue_flags)
@@ -368,24 +368,22 @@ bool CommandBufferAccessContext::ValidateBeginRendering(const ErrorObject &error
 }
 
 void CommandBufferAccessContext::RecordBeginRendering(BeginRenderingCmdState &cmd_state, const Location &loc) {
-    using Attachment = DynamicRenderingInfo::Attachment;
-    const DynamicRenderingInfo &info = cmd_state.GetRenderingInfo();
     const auto tag = NextCommandTag(loc.function);
 
-    // Only load if not resuming
-    if (0 == (info.info.flags & VK_RENDERING_RESUMING_BIT)) {
-        const uint32_t attachment_count = static_cast<uint32_t>(info.attachments.size());
-        for (uint32_t i = 0; i < attachment_count; i++) {
-            const Attachment &attachment = info.attachments[i];
+    const DynamicRenderingInfo &info = cmd_state.GetRenderingInfo();
+    if ((info.info.flags & VK_RENDERING_RESUMING_BIT) == 0) {
+        for (size_t i = 0; i < info.attachments.size(); i++) {
+            const DynamicRenderingInfo::Attachment &attachment = info.attachments[i];
             const SyncAccessIndex load_index = attachment.GetLoadUsage();
-            if (load_index == SYNC_ACCESS_INDEX_NONE) continue;
-
+            if (load_index == SYNC_ACCESS_INDEX_NONE) {
+                continue;
+            }
             ImageRangeGen range_gen = attachment.view_gen;
-            GetCurrentAccessContext()->UpdateAccessState(range_gen, load_index, attachment.GetOrdering(), ResourceUsageTagEx{tag},
+            const AttachmentAccessInfo attachment_access = GetAttachmentAccessInfo(attachment.GetOrdering());
+            GetCurrentAccessContext()->UpdateAccessState(range_gen, load_index, attachment_access, ResourceUsageTagEx{tag},
                                                          SyncFlag::kLoadOp);
         }
     }
-
     dynamic_rendering_info_ = std::move(cmd_state.info);
 }
 
@@ -471,32 +469,40 @@ bool CommandBufferAccessContext::ValidateEndRendering(const ErrorObject &error_o
 }
 
 void CommandBufferAccessContext::RecordEndRendering(const RecordObject &record_obj) {
-    if (dynamic_rendering_info_ && (0 == (dynamic_rendering_info_->info.flags & VK_RENDERING_SUSPENDING_BIT))) {
-        auto store_tag = NextCommandTag(record_obj.location.function, ResourceUsageRecord::SubcommandType::kStoreOp);
-
-        const DynamicRenderingInfo &info = *dynamic_rendering_info_;
-        const uint32_t attachment_count = static_cast<uint32_t>(info.attachments.size());
-        AccessContext *access_context = GetCurrentAccessContext();
-        for (uint32_t i = 0; i < attachment_count; i++) {
-            const auto &attachment = info.attachments[i];
-            if (attachment.resolve_gen) {
-                const bool is_color = attachment.type == AttachmentType::kColor;
-                const SyncOrdering kResolveOrder = is_color ? kColorResolveOrder : kDepthStencilResolveOrder;
-
-                ImageRangeGen view_gen = attachment.view_gen;
-                access_context->UpdateAccessState(view_gen, kResolveRead, kResolveOrder, ResourceUsageTagEx{store_tag});
-
-                ImageRangeGen resolve_gen = *attachment.resolve_gen;
-                access_context->UpdateAccessState(resolve_gen, kResolveWrite, kResolveOrder, ResourceUsageTagEx{store_tag});
-            }
-            if (const SyncAccessIndex store_index = attachment.GetStoreUsage(); store_index != SYNC_ACCESS_INDEX_NONE) {
-                ImageRangeGen view_gen = attachment.view_gen;
-                access_context->UpdateAccessState(view_gen, store_index, kStoreOrder, ResourceUsageTagEx{store_tag},
-                                                  SyncFlag::kStoreOp);
-            }
-        }
+    if (!dynamic_rendering_info_) {
+        return;
+    }
+    if ((dynamic_rendering_info_->info.flags & VK_RENDERING_SUSPENDING_BIT) != 0) {
+        dynamic_rendering_info_.reset();
+        return;
     }
 
+    auto store_tag = NextCommandTag(record_obj.location.function, ResourceUsageRecord::SubcommandType::kStoreOp);
+    AccessContext &access_context = *GetCurrentAccessContext();
+
+    for (const auto &attachment : dynamic_rendering_info_->attachments) {
+        if (attachment.resolve_gen) {
+            const bool is_color = attachment.type == AttachmentType::kColor;
+            const SyncOrdering kResolveOrder = is_color ? kColorResolveOrder : kDepthStencilResolveOrder;
+            const AttachmentAccessInfo attachment_access = GetAttachmentAccessInfo(kResolveOrder);
+
+            ImageRangeGen view_gen = attachment.view_gen;
+            access_context.UpdateAccessState(view_gen, kResolveRead, attachment_access, ResourceUsageTagEx{store_tag});
+
+            ImageRangeGen resolve_gen = *attachment.resolve_gen;
+            access_context.UpdateAccessState(resolve_gen, kResolveWrite, attachment_access, ResourceUsageTagEx{store_tag});
+        }
+
+        const SyncAccessIndex store_index = attachment.GetStoreUsage();
+        if (store_index != SYNC_ACCESS_INDEX_NONE) {
+            AttachmentAccessInfo attachment_access = GetAttachmentAccessInfo(kStoreOrder);
+
+            ImageRangeGen view_gen = attachment.view_gen;
+            access_context.UpdateAccessState(view_gen, store_index, attachment_access, ResourceUsageTagEx{store_tag},
+                                             SyncFlag::kStoreOp);
+        }
+    }
+    current_render_pass_instance_id_++;
     dynamic_rendering_info_.reset();
 }
 
@@ -732,12 +738,14 @@ void CommandBufferAccessContext::RecordDispatchDrawDescriptorSet(VkPipelineBindP
                         if (sync_index == SYNC_FRAGMENT_SHADER_INPUT_ATTACHMENT_READ) {
                             const VkExtent3D extent = CastTo3D(cb_state_->render_area.extent);
                             const VkOffset3D offset = CastTo3D(cb_state_->render_area.offset);
+                            const AttachmentAccessInfo attachment_access = GetAttachmentAccessInfo(SyncOrdering::kRaster);
+
                             ImageRangeGen range_gen(MakeImageRangeGen(*img_view_state, offset, extent));
                             current_context_->UpdateAccessState(range_gen, SYNC_FRAGMENT_SHADER_INPUT_ATTACHMENT_READ,
-                                                                SyncOrdering::kRaster, tag_ex);
+                                                                attachment_access, tag_ex);
                         } else {
                             ImageRangeGen range_gen = MakeImageRangeGen(*img_view_state);
-                            current_context_->UpdateAccessState(range_gen, sync_index, SyncOrdering::kOrderingNone, tag_ex);
+                            current_context_->UpdateAccessState(range_gen, sync_index, tag_ex);
                         }
                         break;
                     }
@@ -992,13 +1000,18 @@ void CommandBufferAccessContext::RecordDrawDynamicRenderingAttachment(ResourceUs
 
     const DynamicRenderingInfo &info = *dynamic_rendering_info_;
     for (const auto output_location : list) {
-        if (output_location >= info.info.colorAttachmentCount) continue;
+        if (output_location >= info.info.colorAttachmentCount) {
+            continue;
+        }
         const auto &attachment = info.attachments[output_location];
-        if (!attachment.IsWriteable(last_bound_state)) continue;
+        if (!attachment.IsWriteable(last_bound_state)) {
+            continue;
+        }
+        const AttachmentAccessInfo attachment_access = GetAttachmentAccessInfo(SyncOrdering::kColorAttachment);
 
         ImageRangeGen view_gen = attachment.view_gen;
-        access_context.UpdateAccessState(view_gen, SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE,
-                                         SyncOrdering::kColorAttachment, ResourceUsageTagEx{tag});
+        access_context.UpdateAccessState(view_gen, SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, attachment_access,
+                                         ResourceUsageTagEx{tag});
     }
 
     // TODO -- fixup this and Subpass attachment to correct map the various depth stencil enables/reads vs. writes
@@ -1012,9 +1025,10 @@ void CommandBufferAccessContext::RecordDrawDynamicRenderingAttachment(ResourceUs
         bool writeable = attachment.IsWriteable(last_bound_state);
 
         if (writeable) {
+            const AttachmentAccessInfo attachment_access = GetAttachmentAccessInfo(SyncOrdering::kDepthStencilAttachment);
             ImageRangeGen view_gen = attachment.view_gen;
-            access_context.UpdateAccessState(view_gen, SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE,
-                                             SyncOrdering::kDepthStencilAttachment, ResourceUsageTagEx{tag});
+            access_context.UpdateAccessState(view_gen, SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, attachment_access,
+                                             ResourceUsageTagEx{tag});
         }
     }
 }
@@ -1182,12 +1196,14 @@ void CommandBufferAccessContext::RecordClearAttachment(ResourceUsageTag tag, con
 
     if (aspects_to_clear & kColorAspects) {
         assert((aspects_to_clear & kDepthStencilAspects) == 0);
-        current_context_->UpdateAccessState(range_gen, SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE,
-                                            SyncOrdering::kColorAttachment, ResourceUsageTagEx{tag});
+        const AttachmentAccessInfo attachment_access = GetAttachmentAccessInfo(SyncOrdering::kColorAttachment);
+        current_context_->UpdateAccessState(range_gen, SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, attachment_access,
+                                            ResourceUsageTagEx{tag});
     } else {
         assert((aspects_to_clear & kColorAspects) == 0);
-        current_context_->UpdateAccessState(range_gen, SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE,
-                                            SyncOrdering::kDepthStencilAttachment, ResourceUsageTagEx{tag});
+        const AttachmentAccessInfo attachment_access = GetAttachmentAccessInfo(SyncOrdering::kDepthStencilAttachment);
+        current_context_->UpdateAccessState(range_gen, SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, attachment_access,
+                                            ResourceUsageTagEx{tag});
     }
 }
 
@@ -1200,8 +1216,8 @@ ResourceUsageTag CommandBufferAccessContext::RecordBeginRenderPass(vvl::Func com
     const auto barrier_tag = NextCommandTag(command, ResourceUsageRecord::SubcommandType::kSubpassTransition);
     AddCommandHandle(barrier_tag, rp_state.Handle());
     const auto load_tag = NextSubcommandTag(command, ResourceUsageRecord::SubcommandType::kLoadOp);
-    render_pass_contexts_.emplace_back(
-        std::make_unique<RenderPassAccessContext>(rp_state, render_area, GetQueueFlags(), attachment_views, cb_access_context_));
+    render_pass_contexts_.emplace_back(std::make_unique<RenderPassAccessContext>(
+        rp_state, render_area, GetQueueFlags(), attachment_views, cb_access_context_, current_render_pass_instance_id_));
     current_renderpass_context_ = render_pass_contexts_.back().get();
     current_renderpass_context_->RecordBeginRenderPass(barrier_tag, load_tag);
     current_context_ = &current_renderpass_context_->CurrentContext();
@@ -1235,6 +1251,7 @@ ResourceUsageTag CommandBufferAccessContext::RecordEndRenderPass(vvl::Func comma
     current_renderpass_context_->RecordEndRenderPass(&cb_access_context_, store_tag, barrier_tag);
     current_context_ = &cb_access_context_;
     current_renderpass_context_ = nullptr;
+    current_render_pass_instance_id_++;
     return barrier_tag;
 }
 
@@ -1369,6 +1386,14 @@ void CommandBufferAccessContext::RecordSyncOp(SyncOpPointer &&sync_op) {
     // As renderpass operations can have side effects on the command buffer access context,
     // update the sync operation to record these if any.
     sync_ops_.emplace_back(tag, std::move(sync_op));
+}
+
+AttachmentAccessInfo CommandBufferAccessContext::GetAttachmentAccessInfo(SyncOrdering ordering) {
+    AttachmentAccessInfo attachment_access;
+    attachment_access.ordering = ordering;
+    attachment_access.render_pass_instance_id = current_render_pass_instance_id_;
+    attachment_access.subpass = current_renderpass_context_ ? current_renderpass_context_->GetCurrentSubpass() : vvl::kNoIndex32;
+    return attachment_access;
 }
 
 // NOTE: debug location reporting feature works only for reproducible application sessions
@@ -1824,8 +1849,7 @@ void CommandBufferSubState::RecordEncodeVideo(vvl::VideoSession &vs_state, const
                 VkExtent3D extent = {quantization_map_info->quantizationMapExtent.width,
                                      quantization_map_info->quantizationMapExtent.height, 1};
                 ImageRangeGen range_gen(MakeImageRangeGen(*image_view_state, offset, extent));
-                context->UpdateAccessState(range_gen, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_READ, SyncOrdering::kOrderingNone,
-                                           ResourceUsageTagEx{tag});
+                context->UpdateAccessState(range_gen, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_READ, ResourceUsageTagEx{tag});
             }
         }
     }

--- a/layers/sync/sync_commandbuffer.h
+++ b/layers/sync/sync_commandbuffer.h
@@ -214,6 +214,7 @@ class CommandBufferAccessContext : public CommandExecutionContext, DebugNameProv
 
     RenderPassAccessContext *GetCurrentRenderPassContext() { return current_renderpass_context_; }
     const RenderPassAccessContext *GetCurrentRenderPassContext() const { return current_renderpass_context_; }
+    uint32_t GetCurrentRenderPassInstanceId() const { return current_render_pass_instance_id_; }
     ResourceUsageTag RecordBeginRenderPass(vvl::Func command, const vvl::RenderPass &rp_state, const VkRect2D &render_area,
                                            const std::vector<const vvl::ImageView *> &attachment_views);
 
@@ -292,9 +293,8 @@ class CommandBufferAccessContext : public CommandExecutionContext, DebugNameProv
     CommandBufferAccessContext(const SyncValidator &sync_validator, VkQueueFlags queue_flags);
 
     uint32_t AddHandle(const VulkanTypedHandle &typed_handle, uint32_t index);
-
-    // As this is passing around a shared pointer to record, move to avoid needless atomics.
     void RecordSyncOp(SyncOpPointer &&sync_op);
+    AttachmentAccessInfo GetAttachmentAccessInfo(SyncOrdering ordering);
 
     struct ClearAttachmentInfo {
         const vvl::ImageView &attachment_view;
@@ -339,6 +339,13 @@ class CommandBufferAccessContext : public CommandExecutionContext, DebugNameProv
     // Because in this case PreRecord is not called, the label state is not updated. We make
     // a copy of label state to update it locally together with proxy context.
     std::vector<vvl::LabelCommand> proxy_label_commands_;
+
+    // Zero-based render pass instance id, incremented for each render pass instance.
+    // Used to initialize the corresponding value in the access object during recording.
+    // At submit time, these ids are offset to ensure unique values among all submitted
+    // command buffers.
+    // TODO: add the above mentioned submit time behavior
+    uint32_t current_render_pass_instance_id_ = 0;
 };
 
 class CommandBufferSubState : public vvl::CommandBufferSubState {

--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -1241,8 +1241,9 @@ bool SyncOpBeginRenderPass::Validate(const CommandBufferAccessContext &cb_contex
     // More broadly we could look at thread specific state shared between Validate and Record as is done for other heavyweight
     // operations (though it's currently a messy approach)
     const AttachmentViewGenVector view_gens = RenderPassAccessContext::CreateAttachmentViewGen(render_area, attachments_);
-    skip |= RenderPassAccessContext::ValidateLayoutTransitions(cb_context, temp_context, rp_state, render_area, subpass, view_gens,
-                                                               command_);
+    const uint32_t render_pass_instance_id = cb_context.GetCurrentRenderPassInstanceId();
+    skip |= RenderPassAccessContext::ValidateLayoutTransitions(cb_context, temp_context, rp_state, render_area,
+                                                               render_pass_instance_id, subpass, view_gens, command_);
 
     // Validate load operations if there were no layout transition hazards
     if (!skip) {

--- a/layers/sync/sync_renderpass.cpp
+++ b/layers/sync/sync_renderpass.cpp
@@ -26,12 +26,13 @@
 namespace syncval {
 
 static void UpdateAttachmentAccessState(AccessContext &access_context, const AttachmentViewGen &view_gen,
-                                        AttachmentViewGen::Gen gen_type, SyncAccessIndex current_usage, SyncOrdering ordering_rule,
-                                        const ResourceUsageTag tag, SyncFlags flags = 0) {
+                                        AttachmentViewGen::Gen gen_type, SyncAccessIndex current_usage,
+                                        const AttachmentAccessInfo &attachment_access, const ResourceUsageTag tag,
+                                        SyncFlags flags = 0) {
     const std::optional<ImageRangeGen> &attachment_gen = view_gen.GetRangeGen(gen_type);
     if (attachment_gen) {
         ImageRangeGen range_gen = *attachment_gen;
-        access_context.UpdateAccessState(range_gen, current_usage, ordering_rule, ResourceUsageTagEx{tag}, flags);
+        access_context.UpdateAccessState(range_gen, current_usage, attachment_access, ResourceUsageTagEx{tag}, flags);
     }
 }
 
@@ -48,8 +49,8 @@ class ValidateResolveAction {
 
     void operator()(const char *aspect_name, const char *resolve_action_name, uint32_t src_at, uint32_t dst_at,
                     const AttachmentViewGen &view_gen, AttachmentViewGen::Gen gen_type, SyncAccessIndex current_usage,
-                    SyncOrdering ordering_rule) {
-        const HazardResult hazard = context_.DetectHazard(view_gen, gen_type, current_usage, ordering_rule);
+                    const AttachmentAccessInfo &attachment_access) {
+        const HazardResult hazard = context_.DetectHazard(view_gen, gen_type, current_usage, attachment_access.ordering);
         if (hazard.IsHazard()) {
             const Location loc(command_);
 
@@ -84,8 +85,8 @@ class UpdateStateResolveAction {
   public:
     UpdateStateResolveAction(AccessContext &context, ResourceUsageTag tag) : context_(context), tag_(tag) {}
     void operator()(const char *, const char *, uint32_t, uint32_t, const AttachmentViewGen &view_gen,
-                    AttachmentViewGen::Gen gen_type, SyncAccessIndex current_usage, SyncOrdering ordering_rule) {
-        UpdateAttachmentAccessState(context_, view_gen, gen_type, current_usage, ordering_rule, tag_);
+                    AttachmentViewGen::Gen gen_type, SyncAccessIndex current_usage, const AttachmentAccessInfo &attachment_access) {
+        UpdateAttachmentAccessState(context_, view_gen, gen_type, current_usage, attachment_access, tag_);
     }
 
   private:
@@ -141,19 +142,23 @@ static SyncAccessIndex DepthStencilLoadUsage(VkAttachmentLoadOp load_op) {
 
 // Caller must manage returned pointer
 static AccessContext *CreateStoreResolveProxyContext(const AccessContext &context, const vvl::RenderPass &rp_state,
-                                                     uint32_t subpass, const AttachmentViewGenVector &attachment_views) {
+                                                     uint32_t render_pass_instance_id, uint32_t subpass,
+                                                     const AttachmentViewGenVector &attachment_views) {
     auto *proxy = new AccessContext(*context.validator);
     proxy->InitFrom(context);
-    RenderPassAccessContext::UpdateAttachmentResolveAccess(rp_state, attachment_views, subpass, kInvalidTag, *proxy);
-    RenderPassAccessContext::UpdateAttachmentStoreAccess(rp_state, attachment_views, subpass, kInvalidTag, *proxy);
+    RenderPassAccessContext::UpdateAttachmentResolveAccess(rp_state, attachment_views, render_pass_instance_id, subpass,
+                                                           kInvalidTag, *proxy);
+    RenderPassAccessContext::UpdateAttachmentStoreAccess(rp_state, attachment_views, render_pass_instance_id, subpass, kInvalidTag,
+                                                         *proxy);
     return proxy;
 }
 
 // Layout transitions are handled as if the were occuring in the beginning of the next subpass
 bool RenderPassAccessContext::ValidateLayoutTransitions(const CommandBufferAccessContext &cb_context,
                                                         const AccessContext &access_context, const vvl::RenderPass &rp_state,
-                                                        const VkRect2D &render_area, uint32_t subpass,
-                                                        const AttachmentViewGenVector &attachment_views, vvl::Func command) {
+                                                        const VkRect2D &render_area, uint32_t render_pass_instance_id,
+                                                        uint32_t subpass, const AttachmentViewGenVector &attachment_views,
+                                                        vvl::Func command) {
     bool skip = false;
     // As validation methods are const and precede the record/update phase, for any tranistions from the immediately
     // previous subpass, we have to validate them against a copy of the AccessContext, with resolve operations applied, as
@@ -172,8 +177,8 @@ bool RenderPassAccessContext::ValidateLayoutTransitions(const CommandBufferAcces
         assert(track_back);
         if (prev_needs_proxy) {
             if (!proxy_for_prev) {
-                proxy_for_prev.reset(
-                    CreateStoreResolveProxyContext(*track_back->source_subpass, rp_state, transition.prev_pass, attachment_views));
+                proxy_for_prev.reset(CreateStoreResolveProxyContext(*track_back->source_subpass, rp_state, render_pass_instance_id,
+                                                                    transition.prev_pass, attachment_views));
                 proxy_track_back = *track_back;
                 proxy_track_back.source_subpass = proxy_for_prev.get();
             }
@@ -390,25 +395,28 @@ bool IsStencilAttachmentWriteable(const LastBound &last_bound_state, const VkFor
 // The signature for Action() reflect the needs of both uses.
 template <typename Action>
 void ResolveOperation(Action &action, const vvl::RenderPass &rp_state, const AttachmentViewGenVector &attachment_views,
-                      uint32_t subpass) {
+                      uint32_t render_pass_instance_id, uint32_t subpass) {
     const auto &rp_ci = rp_state.create_info;
     const auto *attachment_ci = rp_ci.pAttachments;
     const auto &subpass_ci = rp_ci.pSubpasses[subpass];
+
+    AttachmentAccessInfo attachment_access;
+    attachment_access.render_pass_instance_id = render_pass_instance_id;
+    attachment_access.subpass = subpass;
 
     // Color resolves -- require an inuse color attachment and a matching inuse resolve attachment
     const auto *color_attachments = subpass_ci.pColorAttachments;
     const auto *color_resolve = subpass_ci.pResolveAttachments;
     if (color_resolve && color_attachments) {
+        attachment_access.ordering = SyncOrdering::kColorAttachment;
         for (uint32_t i = 0; i < subpass_ci.colorAttachmentCount; i++) {
             const auto &color_attach = color_attachments[i].attachment;
             const auto &resolve_attach = subpass_ci.pResolveAttachments[i].attachment;
             if ((color_attach != VK_ATTACHMENT_UNUSED) && (resolve_attach != VK_ATTACHMENT_UNUSED)) {
                 action("color", "resolve read", color_attach, resolve_attach, attachment_views[color_attach],
-                       AttachmentViewGen::Gen::kRenderArea, SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_READ,
-                       SyncOrdering::kColorAttachment);
+                       AttachmentViewGen::Gen::kRenderArea, SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_READ, attachment_access);
                 action("color", "resolve write", color_attach, resolve_attach, attachment_views[resolve_attach],
-                       AttachmentViewGen::Gen::kRenderArea, SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE,
-                       SyncOrdering::kColorAttachment);
+                       AttachmentViewGen::Gen::kRenderArea, SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, attachment_access);
             }
         }
     }
@@ -441,37 +449,43 @@ void ResolveOperation(Action &action, const vvl::RenderPass &rp_state, const Att
         }
 
         if (aspect_string) {
+            attachment_access.ordering = SyncOrdering::kRaster;
             action(aspect_string, "resolve read", src_at, dst_at, attachment_views[src_at], gen_type,
-                   SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_READ, SyncOrdering::kRaster);
+                   SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_READ, attachment_access);
             action(aspect_string, "resolve write", src_at, dst_at, attachment_views[dst_at], gen_type,
-                   SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, SyncOrdering::kRaster);
+                   SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, attachment_access);
         }
     }
 }
 
 bool RenderPassAccessContext::ValidateResolveOperations(const CommandBufferAccessContext &cb_context, vvl::Func command) const {
     ValidateResolveAction validate_action(rp_state_->VkHandle(), current_subpass_, CurrentContext(), cb_context, command);
-    ResolveOperation(validate_action, *rp_state_, attachment_views_, current_subpass_);
+    ResolveOperation(validate_action, *rp_state_, attachment_views_, render_pass_instance_id_, current_subpass_);
     return validate_action.GetSkip();
 }
 
 void RenderPassAccessContext::UpdateAttachmentResolveAccess(const vvl::RenderPass &rp_state,
-                                                            const AttachmentViewGenVector &attachment_views, uint32_t subpass,
+                                                            const AttachmentViewGenVector &attachment_views,
+                                                            uint32_t render_pass_instance_id, uint32_t subpass,
                                                             const ResourceUsageTag tag, AccessContext &access_context) {
     UpdateStateResolveAction update(access_context, tag);
-    ResolveOperation(update, rp_state, attachment_views, subpass);
+    ResolveOperation(update, rp_state, attachment_views, render_pass_instance_id, subpass);
 }
 
 void RenderPassAccessContext::UpdateAttachmentStoreAccess(const vvl::RenderPass &rp_state,
-                                                          const AttachmentViewGenVector &attachment_views, uint32_t subpass,
+                                                          const AttachmentViewGenVector &attachment_views,
+                                                          uint32_t render_pass_instance_id, uint32_t subpass,
                                                           const ResourceUsageTag tag, AccessContext &access_context) {
-    const auto *attachment_ci = rp_state.create_info.pAttachments;
+    AttachmentAccessInfo attachment_access;
+    attachment_access.ordering = SyncOrdering::kRaster;
+    attachment_access.render_pass_instance_id = render_pass_instance_id;
+    attachment_access.subpass = subpass;
 
     for (uint32_t i = 0; i < rp_state.create_info.attachmentCount; i++) {
         if (rp_state.attachment_last_subpass[i] == subpass) {
             const auto &view_gen = attachment_views[i];
 
-            const auto &ci = attachment_ci[i];
+            const auto &ci = rp_state.create_info.pAttachments[i];
             const bool has_depth = vkuFormatHasDepth(ci.format);
             const bool has_stencil = vkuFormatHasStencil(ci.format);
             const bool is_color = !(has_depth || has_stencil);
@@ -479,18 +493,18 @@ void RenderPassAccessContext::UpdateAttachmentStoreAccess(const vvl::RenderPass 
 
             if (is_color && store_op_stores) {
                 UpdateAttachmentAccessState(access_context, view_gen, AttachmentViewGen::Gen::kRenderArea,
-                                            SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, SyncOrdering::kRaster, tag,
+                                            SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, attachment_access, tag,
                                             SyncFlag::kStoreOp);
             } else {
                 if (has_depth && store_op_stores) {
                     UpdateAttachmentAccessState(access_context, view_gen, AttachmentViewGen::Gen::kDepthOnlyRenderArea,
-                                                SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, SyncOrdering::kRaster, tag,
+                                                SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, attachment_access, tag,
                                                 SyncFlag::kStoreOp);
                 }
                 const bool stencil_op_stores = ci.stencilStoreOp != VK_ATTACHMENT_STORE_OP_NONE;
                 if (has_stencil && stencil_op_stores) {
                     UpdateAttachmentAccessState(access_context, view_gen, AttachmentViewGen::Gen::kStencilOnlyRenderArea,
-                                                SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, SyncOrdering::kRaster, tag,
+                                                SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, attachment_access, tag,
                                                 SyncFlag::kStoreOp);
                 }
             }
@@ -633,8 +647,9 @@ void RenderPassAccessContext::RecordDrawSubpassAttachment(const vvl::CommandBuff
                 continue;
             }
             const AttachmentViewGen &view_gen = attachment_views_[subpass.pColorAttachments[location].attachment];
+            const AttachmentAccessInfo attachment_access = GetAttachmentAccessInfo(SyncOrdering::kColorAttachment);
             UpdateAttachmentAccessState(current_context, view_gen, AttachmentViewGen::Gen::kRenderArea,
-                                        SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, SyncOrdering::kColorAttachment, tag);
+                                        SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, attachment_access, tag);
         }
     }
 
@@ -666,10 +681,10 @@ void RenderPassAccessContext::RecordDrawSubpassAttachment(const vvl::CommandBuff
 
         if (depth_write || stencil_write) {
             const auto ds_gentype = view_gen.GetDepthStencilRenderAreaGenType(depth_write, stencil_write);
+            const AttachmentAccessInfo attachment_access = GetAttachmentAccessInfo(SyncOrdering::kDepthStencilAttachment);
             // PHASE1 TODO: Add EARLY stage detection based on ExecutionMode.
             UpdateAttachmentAccessState(current_context, view_gen, ds_gentype,
-                                        SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE,
-                                        SyncOrdering::kDepthStencilAttachment, tag);
+                                        SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, attachment_access, tag);
         }
     }
 }
@@ -704,7 +719,8 @@ bool RenderPassAccessContext::ValidateNextSubpass(const CommandBufferAccessConte
         return skip;
     }
     const auto &next_context = subpass_contexts_[next_subpass];
-    skip |= ValidateLayoutTransitions(cb_context, next_context, *rp_state_, render_area_, next_subpass, attachment_views_, command);
+    skip |= ValidateLayoutTransitions(cb_context, next_context, *rp_state_, render_area_, render_pass_instance_id_, next_subpass,
+                                      attachment_views_, command);
     if (!skip) {
         // To avoid complex (and buggy) duplication of the affect of layout transitions on load operations, we'll record them
         // on a copy of the (empty) next context.
@@ -726,7 +742,8 @@ bool RenderPassAccessContext::ValidateEndRenderPass(const CommandBufferAccessCon
 }
 
 AccessContext *RenderPassAccessContext::CreateStoreResolveProxy() const {
-    return CreateStoreResolveProxyContext(CurrentContext(), *rp_state_, current_subpass_, attachment_views_);
+    return CreateStoreResolveProxyContext(CurrentContext(), *rp_state_, render_pass_instance_id_, current_subpass_,
+                                          attachment_views_);
 }
 
 bool RenderPassAccessContext::ValidateFinalSubpassLayoutTransitions(const CommandBufferAccessContext &cb_context,
@@ -808,22 +825,24 @@ void RenderPassAccessContext::RecordLoadOperations(const ResourceUsageTag tag) {
             if (is_color) {
                 const SyncAccessIndex load_op = ColorLoadUsage(ci.loadOp);
                 if (load_op != SYNC_ACCESS_INDEX_NONE) {
+                    const AttachmentAccessInfo attachment_access = GetAttachmentAccessInfo(SyncOrdering::kColorAttachment);
                     UpdateAttachmentAccessState(subpass_context, view_gen, AttachmentViewGen::Gen::kRenderArea, load_op,
-                                                SyncOrdering::kColorAttachment, tag, SyncFlag::kLoadOp);
+                                                attachment_access, tag, SyncFlag::kLoadOp);
                 }
             } else {
+                const AttachmentAccessInfo attachment_access = GetAttachmentAccessInfo(SyncOrdering::kDepthStencilAttachment);
                 if (has_depth) {
                     const SyncAccessIndex load_op = DepthStencilLoadUsage(ci.loadOp);
                     if (load_op != SYNC_ACCESS_INDEX_NONE) {
                         UpdateAttachmentAccessState(subpass_context, view_gen, AttachmentViewGen::Gen::kDepthOnlyRenderArea,
-                                                    load_op, SyncOrdering::kDepthStencilAttachment, tag, SyncFlag::kLoadOp);
+                                                    load_op, attachment_access, tag, SyncFlag::kLoadOp);
                     }
                 }
                 if (has_stencil) {
                     const SyncAccessIndex load_op = DepthStencilLoadUsage(ci.stencilLoadOp);
                     if (load_op != SYNC_ACCESS_INDEX_NONE) {
                         UpdateAttachmentAccessState(subpass_context, view_gen, AttachmentViewGen::Gen::kStencilOnlyRenderArea,
-                                                    load_op, SyncOrdering::kDepthStencilAttachment, tag, SyncFlag::kLoadOp);
+                                                    load_op, attachment_access, tag, SyncFlag::kLoadOp);
                     }
                 }
             }
@@ -846,11 +865,12 @@ AttachmentViewGenVector RenderPassAccessContext::CreateAttachmentViewGen(
 RenderPassAccessContext::RenderPassAccessContext(const vvl::RenderPass &rp_state, const VkRect2D &render_area,
                                                  VkQueueFlags queue_flags,
                                                  const std::vector<const vvl::ImageView *> &attachment_views,
-                                                 const AccessContext &external_context)
+                                                 const AccessContext &external_context, uint32_t render_pass_instance_id)
     : rp_state_(&rp_state),
       render_area_(render_area),
       attachment_views_(CreateAttachmentViewGen(render_area, attachment_views)),
       subpass_contexts_(InitSubpassContexts(queue_flags, rp_state, external_context)),
+      render_pass_instance_id_(render_pass_instance_id),
       current_subpass_(0) {}
 
 void RenderPassAccessContext::RecordBeginRenderPass(const ResourceUsageTag barrier_tag, const ResourceUsageTag load_tag) {
@@ -865,8 +885,10 @@ void RenderPassAccessContext::RecordBeginRenderPass(const ResourceUsageTag barri
 void RenderPassAccessContext::RecordNextSubpass(const ResourceUsageTag store_tag, const ResourceUsageTag barrier_tag,
                                                 const ResourceUsageTag load_tag) {
     // Resolves are against *prior* subpass context and thus *before* the subpass increment
-    UpdateAttachmentResolveAccess(*rp_state_, attachment_views_, current_subpass_, store_tag, CurrentContext());
-    UpdateAttachmentStoreAccess(*rp_state_, attachment_views_, current_subpass_, store_tag, CurrentContext());
+    UpdateAttachmentResolveAccess(*rp_state_, attachment_views_, render_pass_instance_id_, current_subpass_, store_tag,
+                                  CurrentContext());
+    UpdateAttachmentStoreAccess(*rp_state_, attachment_views_, render_pass_instance_id_, current_subpass_, store_tag,
+                                CurrentContext());
 
     if (current_subpass_ + 1 >= rp_state_->create_info.subpassCount) {
         return;
@@ -884,8 +906,10 @@ void RenderPassAccessContext::RecordNextSubpass(const ResourceUsageTag store_tag
 void RenderPassAccessContext::RecordEndRenderPass(AccessContext *external_context, const ResourceUsageTag store_tag,
                                                   const ResourceUsageTag barrier_tag) {
     // Add the resolve and store accesses
-    UpdateAttachmentResolveAccess(*rp_state_, attachment_views_, current_subpass_, store_tag, CurrentContext());
-    UpdateAttachmentStoreAccess(*rp_state_, attachment_views_, current_subpass_, store_tag, CurrentContext());
+    UpdateAttachmentResolveAccess(*rp_state_, attachment_views_, render_pass_instance_id_, current_subpass_, store_tag,
+                                  CurrentContext());
+    UpdateAttachmentStoreAccess(*rp_state_, attachment_views_, render_pass_instance_id_, current_subpass_, store_tag,
+                                CurrentContext());
 
     // Export the accesses from the renderpass...
     external_context->ResolveChildContexts(GetSubpassContexts());
@@ -934,6 +958,14 @@ vvl::span<const AccessContext> RenderPassAccessContext::GetSubpassContexts() con
 
 vvl::span<AccessContext> RenderPassAccessContext::GetSubpassContexts() {
     return vvl::make_span<AccessContext>(subpass_contexts_.get(), rp_state_->create_info.subpassCount);
+}
+
+AttachmentAccessInfo RenderPassAccessContext::GetAttachmentAccessInfo(SyncOrdering ordering) const {
+    AttachmentAccessInfo attachment_access;
+    attachment_access.ordering = ordering;
+    attachment_access.render_pass_instance_id = render_pass_instance_id_;
+    attachment_access.subpass = current_subpass_;
+    return attachment_access;
 }
 
 void BeginRenderingCmdState::AddRenderingInfo(const SyncValidator &state, const VkRenderingInfo &rendering_info) {

--- a/layers/sync/sync_renderpass.h
+++ b/layers/sync/sync_renderpass.h
@@ -85,12 +85,15 @@ class RenderPassAccessContext {
   public:
     static AttachmentViewGenVector CreateAttachmentViewGen(const VkRect2D &render_area,
                                                            const std::vector<const vvl::ImageView *> &attachment_views);
-    RenderPassAccessContext() : rp_state_(nullptr), render_area_(VkRect2D()), current_subpass_(0) {}
+    RenderPassAccessContext()
+        : rp_state_(nullptr), render_area_(VkRect2D()), render_pass_instance_id_(vvl::kNoIndex32), current_subpass_(0) {}
     RenderPassAccessContext(const vvl::RenderPass &rp_state, const VkRect2D &render_area, VkQueueFlags queue_flags,
-                            const std::vector<const vvl::ImageView *> &attachment_views, const AccessContext &external_context);
+                            const std::vector<const vvl::ImageView *> &attachment_views, const AccessContext &external_context,
+                            uint32_t render_pass_instance_id);
 
     static bool ValidateLayoutTransitions(const CommandBufferAccessContext &cb_context, const AccessContext &access_context,
-                                          const vvl::RenderPass &rp_state, const VkRect2D &render_area, uint32_t subpass,
+                                          const vvl::RenderPass &rp_state, const VkRect2D &render_area,
+                                          uint32_t render_pass_instance_id, uint32_t subpass,
                                           const AttachmentViewGenVector &attachment_views, vvl::Func command);
 
     static bool ValidateLoadOperation(const CommandBufferAccessContext &cb_context, const AccessContext &access_context,
@@ -101,10 +104,12 @@ class RenderPassAccessContext {
     bool ValidateResolveOperations(const CommandBufferAccessContext &cb_context, vvl::Func command) const;
 
     static void UpdateAttachmentResolveAccess(const vvl::RenderPass &rp_state, const AttachmentViewGenVector &attachment_views,
-                                              uint32_t subpass, const ResourceUsageTag tag, AccessContext &access_context);
+                                              uint32_t render_pass_instance_id, uint32_t subpass, const ResourceUsageTag tag,
+                                              AccessContext &access_context);
 
     static void UpdateAttachmentStoreAccess(const vvl::RenderPass &rp_state, const AttachmentViewGenVector &attachment_views,
-                                            uint32_t subpass, const ResourceUsageTag tag, AccessContext &access_context);
+                                            uint32_t render_pass_instance_id, uint32_t subpass, const ResourceUsageTag tag,
+                                            AccessContext &access_context);
 
     static void RecordLayoutTransitions(const vvl::RenderPass &rp_state, uint32_t subpass,
                                         const AttachmentViewGenVector &attachment_views, const ResourceUsageTag tag,
@@ -133,11 +138,15 @@ class RenderPassAccessContext {
     const vvl::RenderPass *GetRenderPassState() const { return rp_state_; }
     AccessContext *CreateStoreResolveProxy() const;
 
+private:
+    AttachmentAccessInfo GetAttachmentAccessInfo(SyncOrdering ordering) const;
+
   private:
     const vvl::RenderPass *rp_state_;
     const VkRect2D render_area_;
     const AttachmentViewGenVector attachment_views_;
     const std::unique_ptr<AccessContext[]> subpass_contexts_;
+    const uint32_t render_pass_instance_id_;
     uint32_t current_subpass_;
 };
 

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -1006,7 +1006,7 @@ void PresentedImage::SetImage(uint32_t at_index) {
 void PresentedImage::UpdateMemoryAccess(SyncAccessIndex usage, ResourceUsageTag tag, AccessContext& access_context,
                                         SyncFlags flags) const {
     ImageRangeGen mutable_range_gen = range_gen;
-    access_context.UpdateAccessState(mutable_range_gen, usage, SyncOrdering::kOrderingNone, ResourceUsageTagEx{tag}, flags);
+    access_context.UpdateAccessState(mutable_range_gen, usage, ResourceUsageTagEx{tag}, flags);
 }
 
 }  // namespace syncval


### PR DESCRIPTION
This helps determine whether two accesses are from different render pass instances (or subpasses for legacy render passes).

The short-term use of this functionality is to fix broken validation of Resolve operation (it exists but never reports errors). This likely will be used in other parts of validation related to rendering.