### PR TITLE
layers: Add layers and tests for VUs 9916, 9928

### DIFF
--- a/docs/creating_tests.md
+++ b/docs/creating_tests.md
@@ -62,7 +62,7 @@ AddRequiredFeature(vkt::Feature:: samplerYcbcrConversion);
 // Also will check that all extensions and their dependencies were enabled successfully
 RETURN_IF_SKIP(InitFramework());
 
-// Finish initializing state, including creating the VkDevice (whith extensions added) that will be used for the test
+// Finish initializing state, including creating the VkDevice (with extensions added) that will be used for the test
 RETURN_IF_SKIP(InitState());
 ```
 

--- a/layers/error_message/unimplementable_validation.h
+++ b/layers/error_message/unimplementable_validation.h
@@ -542,6 +542,9 @@ const char* unimplementable_validation[] = {
     "VUID-vkDestroyTensorARM-pAllocator-parameter",
     "VUID-vkDestroyTensorViewARM-pAllocator-parameter",
 
+    // about requiring external host access synchronization, can't be verified
+    "VUID-vkCreateDataGraphPipelinesARM-pipelineCache-09762",
+
     // Removed in https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/9302
     // Found these are not invalid actually
     "VUID-VkPhysicalDeviceAccelerationStructurePropertiesKHR-sType-sType",

--- a/layers/stateless/sl_data_graph.cpp
+++ b/layers/stateless/sl_data_graph.cpp
@@ -70,6 +70,22 @@ bool Device::manual_PreCallValidateCreateDataGraphPipelinesARM(VkDevice device, 
 
         skip |= ValidateCreatePipelinesFlagsCommon(create_info.flags, create_info_loc.dot(Field::flags));
 
+        if (deferredOperation != VK_NULL_HANDLE && (create_info.flags & VK_PIPELINE_CREATE_EARLY_RETURN_ON_FAILURE_BIT)) {
+            skip |= LogError(
+                "VUID-vkCreateDataGraphPipelinesARM-deferredOperation-09916", device, create_info_loc.dot(Field::flags),
+                "(%s) includes VK_PIPELINE_CREATE_EARLY_RETURN_ON_FAILURE_BIT but deferredOperation is not VK_NULL_HANDLE.",
+                string_VkPipelineCreateFlags2(create_info.flags).c_str());
+        }
+
+        if (vku::FindStructInPNextChain<VkDataGraphPipelineIdentifierCreateInfoARM>(create_info.pNext)) {
+            if (pipelineCache == VK_NULL_HANDLE) {
+                skip |= LogError("VUID-vkCreateDataGraphPipelinesARM-pNext-09928", device,
+                                 create_info_loc.pNext(Struct::VkDataGraphPipelineIdentifierCreateInfoARM),
+                                 "exists but pipelineCache is VK_NULL_HANDLE.\n%s",
+                                 PrintPNextChain(Struct::VkDataGraphPipelineConstantARM, create_info.pNext).c_str());
+            }
+        }
+
         // TODO - Enable and test
         // skip |= ValidatePipelineShaderStageCreateInfoCommon(context, create_info.stage, create_info_loc.dot(Field::stage));
         // skip |= ValidatePipelineBinaryInfo(create_info.pNext, create_info.flags, pipelineCache, create_info_loc);

--- a/tests/framework/data_graph_objects.cpp
+++ b/tests/framework/data_graph_objects.cpp
@@ -423,8 +423,8 @@ DataGraphPipelineHelper::DataGraphPipelineHelper(VkLayerTest& test, const Helper
     layer_test_.Monitor().Finish();
 }
 
-VkResult DataGraphPipelineHelper::CreateDataGraphPipeline() {
-    return vk::CreateDataGraphPipelinesARM(device_->handle(), VK_NULL_HANDLE, VK_NULL_HANDLE, 1, &pipeline_ci_, nullptr,
+VkResult DataGraphPipelineHelper::CreateDataGraphPipeline(VkPipelineCache pipeline_cache) {
+    return vk::CreateDataGraphPipelinesARM(device_->handle(), VK_NULL_HANDLE, pipeline_cache, 1, &pipeline_ci_, nullptr,
                                            &pipeline_);
 }
 

--- a/tests/framework/data_graph_objects.h
+++ b/tests/framework/data_graph_objects.h
@@ -92,7 +92,7 @@ class DataGraphPipelineHelper {
     void InitTensor(vkt::Tensor &tensor, vkt::TensorView &tensor_view, const VkTensorDescriptionARM &tensor_desc,
                     bool is_protected = false);
     void CreatePipelineLayout(const std::vector<VkPushConstantRange> &push_constant_ranges = {});
-    VkResult CreateDataGraphPipeline();
+    VkResult CreateDataGraphPipeline(VkPipelineCache pipeline_cache = VK_NULL_HANDLE);
     const VkPipeline &Handle() const { return pipeline_; }
     operator VkPipeline() const { return pipeline_; }
 

--- a/tests/unit/data_graph.cpp
+++ b/tests/unit/data_graph.cpp
@@ -56,6 +56,30 @@ TEST_F(NegativeDataGraph, CreateDataGraphPipelinesDeferredOperationNotNull) {
     vk::DestroyDeferredOperationKHR(*m_device, deferred_operation, nullptr);
 }
 
+TEST_F(NegativeDataGraph, CreateDataGraphPipelinesDeferredOperationWrongFlags) {
+    TEST_DESCRIPTION("Try to create a DataGraphPipeline with deferredOperation and invalid pipeline flags");
+    InitBasicDataGraph();
+    AddRequiredExtensions(VK_KHR_DEFERRED_HOST_OPERATIONS_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::pipelineCreationCacheControl);
+    RETURN_IF_SKIP(Init());
+
+    vkt::dg::DataGraphPipelineHelper pipeline_helper(*this);
+    VkDeferredOperationKHR deferred_operation;
+    vk::CreateDeferredOperationKHR(*m_device, nullptr, &deferred_operation);
+    VkPipeline pipeline;
+
+    // set the wrong flags in the pipeline create info
+    pipeline_helper.pipeline_ci_.flags |= VK_PIPELINE_CREATE_EARLY_RETURN_ON_FAILURE_BIT;
+
+    m_errorMonitor->SetDesiredError("VUID-vkCreateDataGraphPipelinesARM-deferredOperation-09916");
+    // this is also triggered because deferredOperations currently MUST be NULL
+    m_errorMonitor->SetDesiredError("VUID-vkCreateDataGraphPipelinesARM-deferredOperation-09761");
+    vk::CreateDataGraphPipelinesARM(*m_device, deferred_operation, VK_NULL_HANDLE, 1, &pipeline_helper.pipeline_ci_, nullptr,
+                                    &pipeline);
+    m_errorMonitor->VerifyFound();
+    vk::DestroyDeferredOperationKHR(*m_device, deferred_operation, nullptr);
+}
+
 TEST_F(NegativeDataGraph, CreateDataGraphPipelinesInvalidFlags) {
     TEST_DESCRIPTION("Try to create a DataGraphPipeline with invalid flags in create_info");
     InitBasicDataGraph();
@@ -1805,7 +1829,8 @@ TEST_F(NegativeDataGraph, DataGraphWrongCreateInfoStructs) {
     // too many of the structs included
     {
         vkt::dg::DataGraphPipelineHelper pipeline(*this);
-        // a VkDataGraphPipelineShaderModuleCreateInfoARM is already included by the helper, add another dummy one
+        // a VkDataGraphPipelineShaderModuleCreateInfoARM is already included by the helper, add also
+        // a VkDataGraphPipelineIdentifierCreateInfoARM (can't have both)
         VkDataGraphPipelineIdentifierCreateInfoARM pipeline_id = vku::InitStructHelper();
         constexpr uint8_t dummy_data = 1;
         pipeline_id.identifierSize = 1;
@@ -1814,11 +1839,17 @@ TEST_F(NegativeDataGraph, DataGraphWrongCreateInfoStructs) {
         pipeline.pipeline_ci_.flags |= VK_PIPELINE_CREATE_2_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
         pipeline.pipeline_ci_.pResourceInfos = nullptr;
         pipeline.pipeline_ci_.resourceInfoCount = 0;
+
+        VkPipelineCache pipeline_cache;
+        VkPipelineCacheCreateInfo cache_create_info = vku::InitStructHelper();
+        cache_create_info.initialDataSize = 0;
+        VkResult err = vk::CreatePipelineCache(device(), &cache_create_info, nullptr, &pipeline_cache);
+        ASSERT_EQ(VK_SUCCESS, err);
+
         m_errorMonitor->SetDesiredError("VUID-VkDataGraphPipelineCreateInfoARM-pNext-09763");
-        // we also get this error because we set resourceInfoCount = 0
-        m_errorMonitor->SetAllowedFailureMsg("VUID-VkDataGraphPipelineCreateInfoARM-resourceInfoCount-arraylength");
-        pipeline.CreateDataGraphPipeline();
+        pipeline.CreateDataGraphPipeline(pipeline_cache);
         m_errorMonitor->VerifyFound();
+        vk::DestroyPipelineCache(device(), pipeline_cache, nullptr);
     }
 }
 
@@ -1947,11 +1978,16 @@ TEST_F(NegativeDataGraph, DataGraphPipelineIdentifierNoFlag) {
     pipeline.pipeline_ci_.pResourceInfos = nullptr;
     pipeline.pipeline_ci_.resourceInfoCount = 0;
 
+    VkPipelineCache pipeline_cache;
+    VkPipelineCacheCreateInfo cache_create_info = vku::InitStructHelper();
+    cache_create_info.initialDataSize = 0;
+    VkResult err = vk::CreatePipelineCache(device(), &cache_create_info, nullptr, &pipeline_cache);
+    ASSERT_EQ(VK_SUCCESS, err);
+
     m_errorMonitor->SetDesiredError("VUID-VkDataGraphPipelineCreateInfoARM-None-11840");
-    // currently we have a conflict with this implicit rule, it will go in a future update
-    m_errorMonitor->SetAllowedFailureMsg("VUID-VkDataGraphPipelineCreateInfoARM-resourceInfoCount-arraylength");
-    pipeline.CreateDataGraphPipeline();
+    pipeline.CreateDataGraphPipeline(pipeline_cache);
     m_errorMonitor->VerifyFound();
+    vk::DestroyPipelineCache(device(), pipeline_cache, nullptr);
 }
 
 TEST_F(NegativeDataGraph, DataGraphPipelineIdentifierHasResources) {
@@ -1970,9 +2006,16 @@ TEST_F(NegativeDataGraph, DataGraphPipelineIdentifierHasResources) {
     // set the correct flags, but leave pResourceInfos
     pipeline.pipeline_ci_.flags |= VK_PIPELINE_CREATE_2_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
 
+    VkPipelineCache pipeline_cache;
+    VkPipelineCacheCreateInfo cache_create_info = vku::InitStructHelper();
+    cache_create_info.initialDataSize = 0;
+    VkResult err = vk::CreatePipelineCache(device(), &cache_create_info, nullptr, &pipeline_cache);
+    ASSERT_EQ(VK_SUCCESS, err);
+
     m_errorMonitor->SetDesiredError("VUID-VkDataGraphPipelineCreateInfoARM-None-12363");
-    pipeline.CreateDataGraphPipeline();
+    pipeline.CreateDataGraphPipeline(pipeline_cache);
     m_errorMonitor->VerifyFound();
+    vk::DestroyPipelineCache(device(), pipeline_cache, nullptr);
 }
 
 TEST_F(NegativeDataGraph, DataGraphCreateInfoResourceCountZero) {
@@ -1992,9 +2035,16 @@ TEST_F(NegativeDataGraph, DataGraphCreateInfoResourceCountZero) {
     pipeline.pipeline_ci_.flags |= VK_PIPELINE_CREATE_2_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
     pipeline.pipeline_ci_.resourceInfoCount = 0;
 
+    VkPipelineCache pipeline_cache;
+    VkPipelineCacheCreateInfo cache_create_info = vku::InitStructHelper();
+    cache_create_info.initialDataSize = 0;
+    VkResult err = vk::CreatePipelineCache(device(), &cache_create_info, nullptr, &pipeline_cache);
+    ASSERT_EQ(VK_SUCCESS, err);
+
     m_errorMonitor->SetDesiredError("VUID-VkDataGraphPipelineCreateInfoARM-resourceInfoCount-12364");
-    pipeline.CreateDataGraphPipeline();
+    pipeline.CreateDataGraphPipeline(pipeline_cache);
     m_errorMonitor->VerifyFound();
+    vk::DestroyPipelineCache(device(), pipeline_cache, nullptr);
 }
 
 TEST_F(NegativeDataGraph, DataGraphCreateInfoNullResources) {
@@ -2011,6 +2061,30 @@ TEST_F(NegativeDataGraph, DataGraphCreateInfoNullResources) {
     m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-pNext-09923");
     m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-pNext-09923");
     pipeline.CreateDataGraphPipeline();
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeDataGraph, DataGraphPipelineIdentifierNoCache) {
+    TEST_DESCRIPTION("Create a datagraph using the cache identifier but without a valid cache object.");
+    InitBasicDataGraph();
+    AddRequiredFeature(vkt::Feature::pipelineCreationCacheControl);
+    RETURN_IF_SKIP(Init());
+
+    vkt::dg::DataGraphPipelineHelper pipeline(*this);
+
+    // add the cache identifier object
+    VkDataGraphPipelineIdentifierCreateInfoARM pipeline_id = vku::InitStructHelper();
+    constexpr uint8_t dummy_data = 1;
+    pipeline_id.identifierSize = 1;
+    pipeline_id.pIdentifier = &dummy_data;
+    vvl::PnextChainAdd(&pipeline.pipeline_ci_, &pipeline_id);
+    pipeline.pipeline_ci_.flags |= VK_PIPELINE_CREATE_2_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
+
+    // ... but pass a NULL handle for the cache object
+    VkPipelineCache pipeline_cache = VK_NULL_HANDLE;
+
+    m_errorMonitor->SetDesiredError("VUID-vkCreateDataGraphPipelinesARM-pNext-09928");
+    pipeline.CreateDataGraphPipeline(pipeline_cache);
     m_errorMonitor->VerifyFound();
 }
 


### PR DESCRIPTION
- a few old tests also touched: the new check caused them to fail because they were not passing a `VkPipelineCache` object.