### PR TITLE
layers: Force HasTileMemoryType to require a valid index

### DIFF
--- a/layers/core_checks/cc_device_memory.cpp
+++ b/layers/core_checks/cc_device_memory.cpp
@@ -385,7 +385,9 @@ bool CoreChecks::PreCallValidateAllocateMemory(VkDevice device, const VkMemoryAl
                  pAllocateInfo->allocationSize, phys_dev_props_core11.maxMemoryAllocationSize);
     }
 
-    if (!enabled_features.tileMemoryHeap && HasTileMemoryType(pAllocateInfo->memoryTypeIndex)) {
+    /* HasTileMemoryType requires that the index be valid */
+    if (!enabled_features.tileMemoryHeap && pAllocateInfo->memoryTypeIndex < phys_dev_mem_props.memoryTypeCount &&
+        HasTileMemoryType(pAllocateInfo->memoryTypeIndex)) {
         skip |= LogError("VUID-vkAllocateMemory-tileMemoryHeap-10976", device, allocate_info_loc.dot(Field::memoryTypeIndex),
                          "(%" PRIu32
                          ") identifies a memory type that corresponds to a VkMemoryHeap with the"
@@ -848,6 +850,7 @@ bool CoreChecks::ValidateMemoryTypes(const vvl::DeviceMemory &mem_info, const ui
 }
 
 bool CoreChecks::HasTileMemoryType(uint32_t memory_type_index) const {
+    assert(memory_type_index < phys_dev_mem_props.memoryTypeCount);
     const uint32_t memory_heap_index = phys_dev_mem_props.memoryTypes[memory_type_index].heapIndex;
     return (phys_dev_mem_props.memoryHeaps[memory_heap_index].flags & VK_MEMORY_HEAP_TILE_MEMORY_BIT_QCOM);
 }


### PR DESCRIPTION
NegativeMemory.MemoryType tries to allocate memory from a memory type with an index greater than the device has. This leads the layer to try and get the heap index from memory that contains garbage data. The index is later used to access the heap's flags leading to an out of bounds access.

Fixes the crash observed in NegativeMemory.MemoryType with KK. Although I am not sure how we don't hit this on other platforms