### PR TITLE
sync: Cleanup attachment hazard detection

### DIFF
--- a/layers/sync/sync_access_context.cpp
+++ b/layers/sync/sync_access_context.cpp
@@ -456,7 +456,7 @@ AccessMap::iterator AccessContext::ResolveGapRecursePrev(const AccessRange &gap_
 // The passed pos must either be a lower bound (can be the end iterator) or be strictly less than the range.
 // Map entries that intersect range.begin or range.end are split at the intersection point.
 AccessMap::iterator AccessContext::DoUpdateAccessState(AccessMap::iterator pos, const AccessRange &range,
-                                                       SyncAccessIndex access_index, const AttachmentAccessInfo &attachment_access,
+                                                       SyncAccessIndex access_index, const AttachmentAccess &attachment_access,
                                                        ResourceUsageTagEx tag_ex, SyncFlags flags) {
     assert(range.non_empty());
     const SyncAccessInfo &access_info = GetAccessInfo(access_index);
@@ -551,7 +551,7 @@ void AccessContext::UpdateAccessState(const vvl::Buffer &buffer, SyncAccessIndex
     const AccessRange buffer_range = range + base_address;
 
     auto pos = access_state_map_.LowerBound(buffer_range.begin);
-    DoUpdateAccessState(pos, buffer_range, current_usage, AttachmentAccessInfo::NonAttachment(), tag_ex, flags);
+    DoUpdateAccessState(pos, buffer_range, current_usage, AttachmentAccess::NonAttachment(), tag_ex, flags);
 }
 
 void AccessContext::UpdateAccessState(ImageRangeGen &range_gen, SyncAccessIndex current_usage, ResourceUsageTagEx tag_ex,
@@ -562,19 +562,19 @@ void AccessContext::UpdateAccessState(ImageRangeGen &range_gen, SyncAccessIndex 
     }
     auto pos = access_state_map_.LowerBound(range_gen->begin);
     for (; range_gen->non_empty(); ++range_gen) {
-        pos = DoUpdateAccessState(pos, *range_gen, current_usage, AttachmentAccessInfo::NonAttachment(), tag_ex, flags);
+        pos = DoUpdateAccessState(pos, *range_gen, current_usage, AttachmentAccess::NonAttachment(), tag_ex, flags);
     }
 }
 
 void AccessContext::UpdateAccessState(ImageRangeGen &range_gen, SyncAccessIndex current_usage,
-                                      const AttachmentAccessInfo &attachment_access, ResourceUsageTagEx tag_ex, SyncFlags flags) {
+                                      const AttachmentAccess &attachment_access, ResourceUsageTagEx tag_ex) {
     assert(!finalized_);
     if (current_usage == SYNC_ACCESS_INDEX_NONE) {
         return;
     }
     auto pos = access_state_map_.LowerBound(range_gen->begin);
     for (; range_gen->non_empty(); ++range_gen) {
-        pos = DoUpdateAccessState(pos, *range_gen, current_usage, attachment_access, tag_ex, flags);
+        pos = DoUpdateAccessState(pos, *range_gen, current_usage, attachment_access, tag_ex, 0);
     }
 }
 
@@ -680,7 +680,7 @@ AttachmentViewGen::AttachmentViewGen(const vvl::ImageView *image_view, const VkO
     }
 }
 
-const std::optional<ImageRangeGen> &AttachmentViewGen::GetRangeGen(AttachmentViewGen::Gen type) const {
+const ImageRangeGen &AttachmentViewGen::GetRangeGen(AttachmentViewGen::Gen type) const {
     static_assert(Gen::kGenSize == 4, "Function written with this assumption");
     // If the view is a depth only view, then the depth only portion of the render area is simply the render area.
     // If the view is a depth stencil view, then the depth only portion of the render area will be a subset,
@@ -690,7 +690,8 @@ const std::optional<ImageRangeGen> &AttachmentViewGen::GetRangeGen(AttachmentVie
     if (depth_only || stencil_only) {
         type = Gen::kRenderArea;
     }
-    return gen_store_[type];
+    assert(gen_store_[type].has_value());
+    return *gen_store_[type];
 }
 
 AttachmentViewGen::Gen AttachmentViewGen::GetDepthStencilRenderAreaGenType(bool depth_op, bool stencil_op) const {

--- a/layers/sync/sync_access_context.h
+++ b/layers/sync/sync_access_context.h
@@ -200,7 +200,7 @@ class AttachmentViewGen {
     };
     AttachmentViewGen(const vvl::ImageView *image_view, const VkOffset3D &offset, const VkExtent3D &extent);
     const vvl::ImageView *GetViewState() const { return view_; }
-    const std::optional<ImageRangeGen> &GetRangeGen(Gen type) const;
+    const ImageRangeGen &GetRangeGen(Gen type) const;
     Gen GetDepthStencilRenderAreaGenType(bool depth_op, bool stencil_op) const;
 
   private:
@@ -282,8 +282,8 @@ class AccessContext {
     void UpdateAccessState(const vvl::Buffer &buffer, SyncAccessIndex current_usage, const AccessRange &range,
                            ResourceUsageTagEx tag_ex, SyncFlags flags = 0);
     void UpdateAccessState(ImageRangeGen &range_gen, SyncAccessIndex current_usage, ResourceUsageTagEx tag_ex, SyncFlags flags = 0);
-    void UpdateAccessState(ImageRangeGen &range_gen, SyncAccessIndex current_usage, const AttachmentAccessInfo &attachment_access,
-                           ResourceUsageTagEx tag_ex, SyncFlags flags = 0);
+    void UpdateAccessState(ImageRangeGen &range_gen, SyncAccessIndex current_usage, const AttachmentAccess &attachment_access,
+                           ResourceUsageTagEx tag_ex);
 
     void ResolveChildContexts(vvl::span<AccessContext> subpass_contexts);
 
@@ -362,22 +362,24 @@ class AccessContext {
     //
     HazardResult DetectHazard(const vvl::Buffer &buffer, SyncAccessIndex access_index, const AccessRange &range) const;
 
-    HazardResult DetectHazard(const vvl::Image &image, const VkImageSubresourceRange &subresource_range, bool is_depth_sliced,
-                              SyncAccessIndex current_usage, SyncOrdering ordering_rule) const;
+    HazardResult DetectHazard(ImageRangeGen &range_gen, SyncAccessIndex current_usage) const;
+
+    HazardResult DetectHazard(const vvl::Image &image, const VkImageSubresourceRange &subresource_range,
+                              SyncAccessIndex current_usage) const;
     HazardResult DetectHazard(const vvl::Image &image, const VkImageSubresourceRange &subresource_range, const VkOffset3D &offset,
-                              const VkExtent3D &extent, bool is_depth_sliced, SyncAccessIndex current_usage,
-                              SyncOrdering ordering_rule = SyncOrdering::kOrderingNone) const;
+                              const VkExtent3D &extent, SyncAccessIndex current_usage) const;
 
     HazardResult DetectHazard(const vvl::ImageView &image_view, SyncAccessIndex current_usage) const;
     HazardResult DetectHazard(const vvl::ImageView &image_view, const VkOffset3D &offset, const VkExtent3D &extent,
-                              SyncAccessIndex current_usage, SyncOrdering ordering_rule) const;
-
-    HazardResult DetectHazard(const ImageRangeGen &const_range_gen, SyncAccessIndex current_usage,
-                              SyncOrdering ordering_rule = SyncOrdering::kOrderingNone, SyncFlags flags = 0) const;
-    HazardResult DetectHazard(const AttachmentViewGen &view_gen, AttachmentViewGen::Gen gen_type, SyncAccessIndex current_usage,
-                              SyncOrdering ordering_rule, SyncFlags flags = 0) const;
-    HazardResult DetectHazard(const vvl::VideoSession &vs_state, const vvl::VideoPictureResource &resource,
                               SyncAccessIndex current_usage) const;
+
+    HazardResult DetectAttachmentHazard(ImageRangeGen &range_gen, SyncAccessIndex current_usage,
+                                        const AttachmentAccess &attachment_access) const;
+    HazardResult DetectAttachmentHazard(const vvl::Image &image, const VkImageSubresourceRange &subresource_range,
+                                        bool is_depth_sliced, SyncAccessIndex current_usage,
+                                        const AttachmentAccess &attachment_access) const;
+    HazardResult DetectAttachmentHazard(const vvl::ImageView &image_view, const VkOffset3D &offset, const VkExtent3D &extent,
+                                        SyncAccessIndex current_usage, const AttachmentAccess &attachment_access) const;
 
     HazardResult DetectImageBarrierHazard(const vvl::Image &image, const VkImageSubresourceRange &subresource_range,
                                           VkPipelineStageFlags2 src_exec_scope, const SyncAccessFlags &src_access_scope,
@@ -394,6 +396,9 @@ class AccessContext {
 
     HazardResult DetectFirstUseHazard(QueueId queue_id, const ResourceUsageRange &tag_range,
                                       const AccessContext &access_context) const;
+
+    HazardResult DetectVideoHazard(const vvl::VideoSession &vs_state, const vvl::VideoPictureResource &resource,
+                                   SyncAccessIndex current_usage) const;
     HazardResult DetectMarkerHazard(const vvl::Buffer &buffer, const AccessRange &range) const;
 
   private:
@@ -422,8 +427,7 @@ class AccessContext {
     AccessMap::iterator ResolveGapRecursePrev(const AccessRange &gap_range, AccessMap::iterator pos_hint);
 
     AccessMap::iterator DoUpdateAccessState(AccessMap::iterator pos, const AccessRange &range, SyncAccessIndex access_index,
-                                            const AttachmentAccessInfo &attachment_access, ResourceUsageTagEx tag_ex,
-                                            SyncFlags flags);
+                                            const AttachmentAccess &attachment_access, ResourceUsageTagEx tag_ex, SyncFlags flags);
 
     // A recursive range walkers for hazard detection, first for the current context
     // and then walks the DAG of the contexts for subpasses

--- a/layers/sync/sync_access_state.cpp
+++ b/layers/sync/sync_access_state.cpp
@@ -33,6 +33,11 @@ const OrderingBarrier &GetOrderingRules(SyncOrdering ordering_enum) { return kOr
 static ThreadSafeLookupTable<OrderingBarrier> layout_ordering_barrier_lookup;
 ThreadSafeLookupTable<OrderingBarrier> &GetLayoutOrderingBarrierLookup() { return layout_ordering_barrier_lookup; }
 
+bool AttachmentAccess::operator==(const AttachmentAccess &other) const {
+    return type == other.type && ordering == other.ordering && render_pass_instance_id == other.render_pass_instance_id &&
+           subpass == other.subpass;
+}
+
 bool OrderingBarrier::operator==(const OrderingBarrier &rhs) const {
     return exec_scope == rhs.exec_scope && access_scope == rhs.access_scope;
 }
@@ -86,8 +91,9 @@ HazardResult AccessState::DetectMarkerHazard() const {
     return DetectHazard(marker_access_info);
 }
 
-HazardResult AccessState::DetectHazard(const SyncAccessInfo &usage_info, const OrderingBarrier &ordering, SyncFlags flags,
-                                       QueueId queue_id, bool detect_load_op_after_store_op_hazards) const {
+HazardResult AccessState::DetectHazard(const SyncAccessInfo &usage_info, const OrderingBarrier &ordering,
+                                       const AttachmentAccess &attachment_access, SyncFlags flags, QueueId queue_id,
+                                       bool detect_load_op_after_store_op_hazards) const {
     // The ordering guarantees act as barriers to the last accesses, independent of synchronization operations
     const VkPipelineStageFlagBits2 usage_stage = usage_info.stage_mask;
     const SyncAccessIndex access_index = usage_info.access_index;
@@ -111,19 +117,16 @@ HazardResult AccessState::DetectHazard(const SyncAccessInfo &usage_info, const O
 
                 // LoadOp after StoreOp happens only if accesses are from different render pass instances.
                 // Such accesses are not implicitly synchronized.
-                const bool load_op_after_store_op = last_write->IsStoreOp() && (flags & SyncFlag::kLoadOp);
+                const bool load_op_after_store_op =
+                    last_write->IsStoreOp() && attachment_access.type == AttachmentAccessType::LoadOp;
                 const bool validate_load_op_after_store_op = detect_load_op_after_store_op_hazards && load_op_after_store_op;
                 if (validate_load_op_after_store_op) {
                     most_recent_is_ordered = false;
                 }
 
-                // TODO: current implementation does not distiguish separate render pass instances. Some cases can be
-                // handled with SyncFlags, but not all. We need to add some idea of render pass instance id, and
-                // combine that with ordering rules and/or SyncFlags to get unified solution.
-
                 // If most recent write is not ordered then check if subsequent read is ordered
                 if (!most_recent_is_ordered) {
-                    most_recent_is_ordered = (GetOrderedStages(queue_id, ordering, flags) != 0);
+                    most_recent_is_ordered = (GetOrderedStages(queue_id, ordering, attachment_access.type) != 0);
                 }
 
                 is_raw_hazard = !most_recent_is_ordered;
@@ -147,7 +150,7 @@ HazardResult AccessState::DetectHazard(const SyncAccessInfo &usage_info, const O
         VkPipelineStageFlags2 ordered_stages = VK_PIPELINE_STAGE_2_NONE;
         if (usage_write_is_ordered) {
             // If the usage is ordered, we can ignore all ordered read stages w.r.t. WAR)
-            ordered_stages = GetOrderedStages(queue_id, ordering, flags);
+            ordered_stages = GetOrderedStages(queue_id, ordering, attachment_access.type);
         }
         // If we're tracking any reads that aren't ordered against the current write, got to check 'em all.
         if ((ordered_stages & last_read_stages) != last_read_stages) {
@@ -164,7 +167,7 @@ HazardResult AccessState::DetectHazard(const SyncAccessInfo &usage_info, const O
     // Only check for WAW if there are no reads since last_write
     if (last_write.has_value()) {
         // Check if it's two ordered write accesses
-        const bool load_op_after_store_op = last_write->IsStoreOp() && (flags & SyncFlag::kLoadOp);
+        const bool load_op_after_store_op = last_write->IsStoreOp() && attachment_access.type == AttachmentAccessType::LoadOp;
         const bool validate_load_op_after_store_op = detect_load_op_after_store_op_hazards && load_op_after_store_op;
         if (last_write->IsOrdered(ordering, queue_id) && usage_write_is_ordered && !validate_load_op_after_store_op) {
             return {};
@@ -211,8 +214,9 @@ HazardResult AccessState::DetectHazard(const AccessState &recorded_use, QueueId 
                 break;
             }
 
-            const auto &first_ordering = GetOrderingRules(first.ordering_rule);
-            hazard = DetectHazard(*first.usage_info, first_ordering, first.flags, queue_id, detect_load_op_after_store_op_hazards);
+            const auto &first_ordering = GetOrderingRules(first.attachment_access.ordering);
+            hazard = DetectHazard(*first.usage_info, first_ordering, first.attachment_access, first.flags, queue_id,
+                                  detect_load_op_after_store_op_hazards);
             if (hazard.IsHazard()) {
                 hazard.AddRecordedAccess(first);
                 return hazard;
@@ -223,7 +227,7 @@ HazardResult AccessState::DetectHazard(const AccessState &recorded_use, QueueId 
             // Writes are a bit special... both for the "most recent" access logic, and layout transition specific logic
             const auto &last_access = recorded_accesses.back();
             if (tag_range.includes(last_access.tag)) {
-                OrderingBarrier barrier = GetOrderingRules(last_access.ordering_rule);
+                OrderingBarrier barrier = GetOrderingRules(last_access.attachment_access.ordering);
                 if (last_access.usage_info->access_index == SyncAccessIndex::SYNC_IMAGE_LAYOUT_TRANSITION) {
                     // Or in the layout first access scope as a barrier... IFF the usage is an ILT
                     // this was saved off in the "apply barriers" logic to simplify ILT access checks as they straddle
@@ -246,7 +250,7 @@ HazardResult AccessState::DetectHazard(const AccessState &recorded_use, QueueId 
                     // if there are any first use reads, we suppress WAW by injecting the active context write in the ordering rule
                     barrier.access_scope |= last_access.usage_info->access_bit;
                 }
-                hazard = DetectHazard(*last_access.usage_info, barrier, last_access.flags, queue_id,
+                hazard = DetectHazard(*last_access.usage_info, barrier, last_access.attachment_access, last_access.flags, queue_id,
                                       detect_load_op_after_store_op_hazards);
                 if (hazard.IsHazard()) {
                     hazard.AddRecordedAccess(last_access);
@@ -500,18 +504,18 @@ void AccessState::Resolve(const AccessState &other) {
         for (auto &b : other.first_accesses_) {
             // TODO: Determine whether some tag offset will be needed for PHASE II
             while ((a != a_end) && (a->tag < b.tag)) {
-                UpdateFirst(a->TagEx(), *a->usage_info, a->ordering_rule, a->flags);
+                UpdateFirst(a->TagEx(), *a->usage_info, a->attachment_access, a->flags);
                 ++a;
             }
-            UpdateFirst(b.TagEx(), *b.usage_info, b.ordering_rule, b.flags);
+            UpdateFirst(b.TagEx(), *b.usage_info, b.attachment_access, b.flags);
         }
         for (; a != a_end; ++a) {
-            UpdateFirst(a->TagEx(), *a->usage_info, a->ordering_rule, a->flags);
+            UpdateFirst(a->TagEx(), *a->usage_info, a->attachment_access, a->flags);
         }
     }
 }
 
-void AccessState::Update(const SyncAccessInfo &usage_info, const AttachmentAccessInfo &attachment_access, ResourceUsageTagEx tag_ex,
+void AccessState::Update(const SyncAccessInfo &usage_info, const AttachmentAccess &attachment_access, ResourceUsageTagEx tag_ex,
                          SyncFlags flags) {
     const VkPipelineStageFlagBits2 usage_stage = usage_info.stage_mask;
     if (IsRead(usage_info.access_index)) {
@@ -552,7 +556,7 @@ void AccessState::Update(const SyncAccessInfo &usage_info, const AttachmentAcces
     } else {
         SetWrite(usage_info.access_index, attachment_access, tag_ex, flags);
     }
-    UpdateFirst(tag_ex, usage_info, attachment_access.ordering, flags);
+    UpdateFirst(tag_ex, usage_info, attachment_access, flags);
 }
 
 HazardResult HazardResult::HazardVsPriorWrite(const AccessState *access_state, const SyncAccessInfo &usage_info, SyncHazard hazard,
@@ -583,7 +587,7 @@ bool HazardResult::IsWAWHazard() const {
 // Clobber last read and all barriers... because all we have is DANGER, DANGER, WILL ROBINSON!!!
 // if the last_reads/last_write were unsafe, we've reported them, in either case the prior access is irrelevant.
 // We can overwrite them as *this* write is now after them.
-void AccessState::SetWrite(SyncAccessIndex access_index, const AttachmentAccessInfo &attachment_access, ResourceUsageTagEx tag_ex,
+void AccessState::SetWrite(SyncAccessIndex access_index, const AttachmentAccess &attachment_access, ResourceUsageTagEx tag_ex,
                            SyncFlags flags) {
     ClearRead();
     if (!last_write.has_value()) {
@@ -625,8 +629,8 @@ bool AccessState::ApplyBarrier(const BarrierScope &barrier_scope, const SyncBarr
         const OrderingBarrier layout_ordering{barrier.src_exec_scope.exec_scope, barrier.src_access_scope};
 
         // Register write access that models layout transition writes
-        SetWrite(SYNC_IMAGE_LAYOUT_TRANSITION, AttachmentAccessInfo::NonAttachment(), tag_ex);
-        UpdateFirst(tag_ex, layout_transition_access_info, SyncOrdering::kOrderingNone);
+        SetWrite(SYNC_IMAGE_LAYOUT_TRANSITION, AttachmentAccess::NonAttachment(), tag_ex);
+        UpdateFirst(tag_ex, layout_transition_access_info, AttachmentAccess::NonAttachment());
         TouchupFirstForLayoutTransition(layout_transition_tag, layout_ordering);
 
         last_write->barriers |= barrier.dst_access_scope;
@@ -842,8 +846,8 @@ void AccessState::ApplyPendingWriteBarrier(const PendingWriteBarrier &write_barr
 void AccessState::ApplyPendingLayoutTransition(const PendingLayoutTransition &layout_transition, ResourceUsageTag tag) {
     const SyncAccessInfo &layout_usage_info = GetAccessInfo(SYNC_IMAGE_LAYOUT_TRANSITION);
     const ResourceUsageTagEx tag_ex = ResourceUsageTagEx{tag, layout_transition.handle_index};
-    SetWrite(SYNC_IMAGE_LAYOUT_TRANSITION, AttachmentAccessInfo::NonAttachment(), tag_ex);
-    UpdateFirst(tag_ex, layout_usage_info, SyncOrdering::kOrderingNone);
+    SetWrite(SYNC_IMAGE_LAYOUT_TRANSITION, AttachmentAccess::NonAttachment(), tag_ex);
+    UpdateFirst(tag_ex, layout_usage_info, AttachmentAccess::NonAttachment());
     TouchupFirstForLayoutTransition(tag, layout_transition.ordering);
 }
 
@@ -1032,7 +1036,8 @@ bool AccessState::IsRAWHazard(const SyncAccessInfo &usage_info) const {
            last_write->IsWriteHazard(usage_info);
 }
 
-VkPipelineStageFlags2 AccessState::GetOrderedStages(QueueId queue_id, const OrderingBarrier &ordering, SyncFlags flags) const {
+VkPipelineStageFlags2 AccessState::GetOrderedStages(QueueId queue_id, const OrderingBarrier &ordering,
+                                                    AttachmentAccessType attachment_access_type) const {
     // At apply queue submission order limits on the effect of ordering
     VkPipelineStageFlags2 non_qso_stages = VK_PIPELINE_STAGE_2_NONE;
     if (queue_id != kQueueIdInvalid) {
@@ -1047,7 +1052,7 @@ VkPipelineStageFlags2 AccessState::GetOrderedStages(QueueId queue_id, const Orde
     VkPipelineStageFlags2 ordered_stages = read_stages_in_qso & ordering.exec_scope;
     // Special input attachment handling as always (not encoded in exec_scop)
     const bool input_attachment_ordering = ordering.access_scope[SYNC_FRAGMENT_SHADER_INPUT_ATTACHMENT_READ];
-    if (input_attachment_ordering && input_attachment_read && (flags & SyncFlag::kStoreOp) != 0) {
+    if (input_attachment_ordering && input_attachment_read && attachment_access_type == AttachmentAccessType::StoreOp) {
         // If we have an input attachment in last_reads and input attachments are ordered we all that stage
         ordered_stages |= VK_PIPELINE_STAGE_2_FRAGMENT_SHADER_BIT;
     }
@@ -1055,8 +1060,8 @@ VkPipelineStageFlags2 AccessState::GetOrderedStages(QueueId queue_id, const Orde
     return ordered_stages;
 }
 
-void AccessState::UpdateFirst(const ResourceUsageTagEx tag_ex, const SyncAccessInfo &usage_info, SyncOrdering ordering_rule,
-                              SyncFlags flags) {
+void AccessState::UpdateFirst(const ResourceUsageTagEx tag_ex, const SyncAccessInfo &usage_info,
+                              const AttachmentAccess &attachment_access, SyncFlags flags) {
     // Only record until we record a write.
     if (!first_access_closed_) {
         const bool is_read = IsRead(usage_info.access_index);
@@ -1067,7 +1072,7 @@ void AccessState::UpdateFirst(const ResourceUsageTagEx tag_ex, const SyncAccessI
             first_read_stages_ |= usage_stage;
             if (0 == (read_execution_barriers & usage_stage)) {
                 // If this stage isn't masked then we add it (since writes map to usage_stage 0, this also records writes)
-                first_accesses_.emplace_back(usage_info, tag_ex, ordering_rule, flags);
+                first_accesses_.emplace_back(usage_info, tag_ex, attachment_access, flags);
                 first_access_closed_ = !is_read;
             }
         }
@@ -1129,17 +1134,16 @@ bool ReadState::InBarrierSourceScope(const BarrierScope &barrier_scope) const {
     return ReadOrDependencyChainInSourceScope(barrier_scope.scope_queue, barrier_scope.src_exec_scope);
 }
 
-void WriteState::Set(SyncAccessIndex access_index, const AttachmentAccessInfo &attachment_access, ResourceUsageTagEx tag_ex,
+void WriteState::Set(SyncAccessIndex access_index, const AttachmentAccess &attachment_access, ResourceUsageTagEx tag_ex,
                      SyncFlags flags) {
     this->access_index = access_index;
-    this->flags = flags;
+    this->attachment_access = attachment_access;
     barriers.reset();
     dependency_chain = VK_PIPELINE_STAGE_2_NONE;
     tag = tag_ex.tag;
     handle_index = tag_ex.handle_index;
     queue = kQueueIdInvalid;
-    render_pass_instance_id = attachment_access.render_pass_instance_id;
-    subpass = attachment_access.subpass;
+    this->flags = flags;
 }
 
 void WriteState::SetQueueId(QueueId id) {

--- a/layers/sync/sync_access_state.h
+++ b/layers/sync/sync_access_state.h
@@ -72,14 +72,12 @@ enum class SyncOrdering : uint8_t {
 };
 
 struct SyncFlag {
-    enum : uint32_t {
-        kLoadOp = 0x01,
-        kStoreOp = 0x02,
-        kPresent = 0x04,
-        kMarker = 0x08,
+    enum : uint8_t {
+        kPresent = 0x01,
+        kMarker = 0x02,
     };
 };
-using SyncFlags = uint32_t;
+using SyncFlags = uint8_t;
 
 const char *string_SyncHazardVUID(SyncHazard hazard);
 
@@ -144,30 +142,51 @@ class HazardResult {
     std::optional<HazardState> state_;
 };
 
+enum class AttachmentAccessType : uint8_t {
+    Empty,
+    Access,  // Generic access
+    LoadOp,
+    StoreOp,
+    ResolveRead,
+    ResolveWrite,
+};
+
+struct AttachmentAccess {
+    AttachmentAccessType type = AttachmentAccessType::Empty;
+    SyncOrdering ordering = SyncOrdering::kOrderingNone;
+
+    // Identifies a render pass instance (and subpass for legacy render passes).
+    // Used to determine whether two accesses are in the same render pass instance.
+    uint32_t render_pass_instance_id = vvl::kNoIndex32;
+    uint32_t subpass = vvl::kNoIndex32;
+
+    static AttachmentAccess NonAttachment() { return AttachmentAccess{}; }
+    bool operator==(const AttachmentAccess &other) const;
+};
+
 struct FirstAccess {
     const SyncAccessInfo *usage_info;
     ResourceUsageTag tag;
     uint32_t handle_index;
-    SyncOrdering ordering_rule;
+    AttachmentAccess attachment_access;
     SyncFlags flags;
 
-    FirstAccess(const SyncAccessInfo &usage_info, ResourceUsageTagEx tag_ex, SyncOrdering ordering_rule, SyncFlags flags)
-        : usage_info(&usage_info), tag(tag_ex.tag), handle_index(tag_ex.handle_index), ordering_rule(ordering_rule), flags(flags) {}
+    FirstAccess(const SyncAccessInfo &usage_info, ResourceUsageTagEx tag_ex, const AttachmentAccess &attachment_access,
+                SyncFlags flags)
+        : usage_info(&usage_info),
+          tag(tag_ex.tag),
+          handle_index(tag_ex.handle_index),
+          attachment_access(attachment_access),
+          flags(flags) {}
+
     bool operator==(const FirstAccess &rhs) const {
-        return (tag == rhs.tag) && (usage_info == rhs.usage_info) && (ordering_rule == rhs.ordering_rule) && flags == rhs.flags;
+        return tag == rhs.tag && usage_info == rhs.usage_info && attachment_access == rhs.attachment_access && flags == rhs.flags;
     }
+
     ResourceUsageTagEx TagEx() const { return {tag, handle_index}; }
 };
 
 using QueueId = uint32_t;
-
-struct AttachmentAccessInfo {
-    SyncOrdering ordering = SyncOrdering::kOrderingNone;
-    uint32_t render_pass_instance_id = vvl::kNoIndex32;
-    uint32_t subpass = vvl::kNoIndex32;
-
-    static AttachmentAccessInfo NonAttachment() { return AttachmentAccessInfo{}; }
-};
 
 struct OrderingBarrier {
     VkPipelineStageFlags2 exec_scope = VK_PIPELINE_STAGE_2_NONE;
@@ -231,7 +250,7 @@ static_assert(std::is_trivially_copyable_v<ReadState>);
 
 struct WriteState {
     SyncAccessIndex access_index;
-    SyncFlags flags;
+    AttachmentAccess attachment_access;
 
     // Union of applicable barrier masks since last write
     SyncAccessFlags barriers;
@@ -243,13 +262,9 @@ struct WriteState {
     uint32_t handle_index;
     QueueId queue;
 
-    // Identifies a render pass instance (and subpass for legacy render passes).
-    // Used to determine whether two accesses are in the same render pass instance.
-    uint32_t render_pass_instance_id;
-    uint32_t subpass;
+    SyncFlags flags;
 
-    void Set(SyncAccessIndex access_index, const AttachmentAccessInfo &attachment_access, ResourceUsageTagEx tag_ex,
-             SyncFlags flags);
+    void Set(SyncAccessIndex access_index, const AttachmentAccess &attachment_access, ResourceUsageTagEx tag_ex, SyncFlags flags);
     void SetQueueId(QueueId id);
     void MergeBarriers(const WriteState &other);
 
@@ -266,8 +281,8 @@ struct WriteState {
                               const SyncAccessFlags &src_access_scope) const;
 
     bool IsOrdered(const OrderingBarrier &ordering, QueueId queue_id) const;
-    bool IsLoadOp() const { return flags & SyncFlag::kLoadOp; }
-    bool IsStoreOp() const { return flags & SyncFlag::kStoreOp; }
+    bool IsLoadOp() const { return attachment_access.type == AttachmentAccessType::LoadOp; }
+    bool IsStoreOp() const { return attachment_access.type == AttachmentAccessType::StoreOp; }
     bool IsPresent() const { return flags & SyncFlag::kPresent; }
 
     ResourceUsageTagEx TagEx() const { return {tag, handle_index}; }
@@ -338,7 +353,8 @@ class AccessState {
     HazardResult DetectHazard(const SyncAccessInfo &usage_info) const;
     HazardResult DetectMarkerHazard() const;
 
-    HazardResult DetectHazard(const SyncAccessInfo &usage_info, const OrderingBarrier &ordering, SyncFlags flags, QueueId queue_id,
+    HazardResult DetectHazard(const SyncAccessInfo &usage_info, const OrderingBarrier &ordering,
+                              const AttachmentAccess &attachment_access, SyncFlags flags, QueueId queue_id,
                               bool detect_load_op_after_store_op_hazards) const;
     HazardResult DetectHazard(const AccessState &recorded_use, QueueId queue_id, const ResourceUsageRange &tag_range,
                               bool detect_load_op_after_store_op_hazards) const;
@@ -353,9 +369,9 @@ class AccessState {
                                      VkPipelineStageFlags2 source_exec_scope, const SyncAccessFlags &source_access_scope,
                                      QueueId event_queue, ResourceUsageTag event_tag) const;
 
-    void Update(const SyncAccessInfo &usage_info, const AttachmentAccessInfo &attachment_access, ResourceUsageTagEx tag_ex,
+    void Update(const SyncAccessInfo &usage_info, const AttachmentAccess &attachment_access, ResourceUsageTagEx tag_ex,
                 SyncFlags flags = 0);
-    void SetWrite(SyncAccessIndex access_index, const AttachmentAccessInfo &attachment_access, ResourceUsageTagEx tag_ex,
+    void SetWrite(SyncAccessIndex access_index, const AttachmentAccess &attachment_access, ResourceUsageTagEx tag_ex,
                   SyncFlags flags = 0);
     void ClearWrite();
     void ClearRead();
@@ -437,9 +453,11 @@ class AccessState {
     bool IsReadHazard(VkPipelineStageFlags2 stage_mask, const ReadState &read_access) const {
         return stage_mask != (stage_mask & read_access.barriers);
     }
-    VkPipelineStageFlags2 GetOrderedStages(QueueId queue_id, const OrderingBarrier &ordering, SyncFlags flags) const;
+    VkPipelineStageFlags2 GetOrderedStages(QueueId queue_id, const OrderingBarrier &ordering,
+                                           AttachmentAccessType attachment_access_type) const;
 
-    void UpdateFirst(ResourceUsageTagEx tag_ex, const SyncAccessInfo &usage_info, SyncOrdering ordering_rule, SyncFlags flags = 0);
+    void UpdateFirst(ResourceUsageTagEx tag_ex, const SyncAccessInfo &usage_info, const AttachmentAccess &attachment_access,
+                     SyncFlags flags = 0);
     void TouchupFirstForLayoutTransition(ResourceUsageTag tag, const OrderingBarrier &layout_ordering);
 
     bool HasReads() const { return last_read_count != 0; }

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -336,22 +336,22 @@ bool CommandBufferAccessContext::ValidateBeginRendering(const ErrorObject &error
     }
 
     // Need to hazard detect load operations vs. the attachment views
-    const uint32_t attachment_count = static_cast<uint32_t>(info.attachments.size());
-    for (uint32_t i = 0; i < attachment_count; i++) {
+    for (size_t i = 0; i < info.attachments.size(); i++) {
         const auto &attachment = info.attachments[i];
         const SyncAccessIndex load_index = attachment.GetLoadUsage();
         if (load_index == SYNC_ACCESS_INDEX_NONE) {
             continue;
         }
 
-        const HazardResult hazard =
-            GetCurrentAccessContext()->DetectHazard(attachment.view_gen, load_index, attachment.GetOrdering(), SyncFlag::kLoadOp);
+        const AttachmentAccess attachment_access = GetAttachmentAccess(attachment.GetOrdering(), AttachmentAccessType::LoadOp);
+        ImageRangeGen range_gen = attachment.view_gen;
+        const HazardResult hazard = GetCurrentAccessContext()->DetectAttachmentHazard(range_gen, load_index, attachment_access);
         if (hazard.IsHazard()) {
             LogObjectList objlist(cb_state_->Handle(), attachment.view->Handle());
 
             std::ostringstream ss;
             ss << vvl::String(vvl::Field::pRenderingInfo) << ".";
-            ss << attachment.GetLocation(error_obj.location, i).Fields();
+            ss << attachment.GetLocation(error_obj.location, uint32_t(i)).Fields();
             ss << " (" << sync_state_.FormatHandle(attachment.view->Handle());
             ss << ", loadOp " << string_VkAttachmentLoadOp(attachment.info.loadOp) << ")";
             std::string resource_description = ss.str();
@@ -379,9 +379,8 @@ void CommandBufferAccessContext::RecordBeginRendering(BeginRenderingCmdState &cm
                 continue;
             }
             ImageRangeGen range_gen = attachment.view_gen;
-            const AttachmentAccessInfo attachment_access = GetAttachmentAccessInfo(attachment.GetOrdering());
-            GetCurrentAccessContext()->UpdateAccessState(range_gen, load_index, attachment_access, ResourceUsageTagEx{tag},
-                                                         SyncFlag::kLoadOp);
+            const AttachmentAccess attachment_access = GetAttachmentAccess(attachment.GetOrdering(), AttachmentAccessType::LoadOp);
+            GetCurrentAccessContext()->UpdateAccessState(range_gen, load_index, attachment_access, ResourceUsageTagEx{tag});
         }
     }
     dynamic_rendering_info_ = std::move(cmd_state.info);
@@ -409,7 +408,9 @@ bool CommandBufferAccessContext::ValidateEndRendering(const ErrorObject &error_o
             const bool is_color = attachment.type == AttachmentType::kColor;
             const SyncOrdering kResolveOrder = is_color ? kColorResolveOrder : kDepthStencilResolveOrder;
 
-            HazardResult hazard = current_context_->DetectHazard(attachment.view_gen, kResolveRead, kResolveOrder);
+            const AttachmentAccess resolve_read_access = GetAttachmentAccess(kResolveOrder, AttachmentAccessType::ResolveRead);
+            ImageRangeGen view_gen = attachment.view_gen;
+            HazardResult hazard = current_context_->DetectAttachmentHazard(view_gen, kResolveRead, resolve_read_access);
             if (hazard.IsHazard()) {
                 LogObjectList objlist(cb_state_->Handle(), attachment.view->Handle());
 
@@ -426,7 +427,9 @@ bool CommandBufferAccessContext::ValidateEndRendering(const ErrorObject &error_o
                 }
             }
 
-            hazard = current_context_->DetectHazard(*attachment.resolve_gen, kResolveWrite, kResolveOrder);
+            const AttachmentAccess resolve_write_access = GetAttachmentAccess(kResolveOrder, AttachmentAccessType::ResolveWrite);
+            ImageRangeGen resolve_gen = *attachment.resolve_gen;
+            hazard = current_context_->DetectAttachmentHazard(resolve_gen, kResolveWrite, resolve_write_access);
             if (hazard.IsHazard()) {
                 LogObjectList objlist(cb_state_->Handle(), attachment.resolve_view->Handle());
 
@@ -446,8 +449,10 @@ bool CommandBufferAccessContext::ValidateEndRendering(const ErrorObject &error_o
 
         const SyncAccessIndex store_access = attachment.GetStoreUsage();
         if (store_access != SYNC_ACCESS_INDEX_NONE) {
-            HazardResult hazard =
-                current_context_->DetectHazard(attachment.view_gen, store_access, kStoreOrder, SyncFlag::kStoreOp);
+            const AttachmentAccess attachment_access = GetAttachmentAccess(kStoreOrder, AttachmentAccessType::StoreOp);
+            ImageRangeGen view_gen = attachment.view_gen;
+
+            HazardResult hazard = current_context_->DetectAttachmentHazard(view_gen, store_access, attachment_access);
             if (hazard.IsHazard()) {
                 LogObjectList objlist(cb_state_->Handle(), attachment.view->Handle());
 
@@ -484,22 +489,21 @@ void CommandBufferAccessContext::RecordEndRendering(const RecordObject &record_o
         if (attachment.resolve_gen) {
             const bool is_color = attachment.type == AttachmentType::kColor;
             const SyncOrdering kResolveOrder = is_color ? kColorResolveOrder : kDepthStencilResolveOrder;
-            const AttachmentAccessInfo attachment_access = GetAttachmentAccessInfo(kResolveOrder);
 
+            const AttachmentAccess resolve_read_access = GetAttachmentAccess(kResolveOrder, AttachmentAccessType::ResolveRead);
             ImageRangeGen view_gen = attachment.view_gen;
-            access_context.UpdateAccessState(view_gen, kResolveRead, attachment_access, ResourceUsageTagEx{store_tag});
+            access_context.UpdateAccessState(view_gen, kResolveRead, resolve_read_access, ResourceUsageTagEx{store_tag});
 
+            const AttachmentAccess resolve_write_access = GetAttachmentAccess(kResolveOrder, AttachmentAccessType::ResolveWrite);
             ImageRangeGen resolve_gen = *attachment.resolve_gen;
-            access_context.UpdateAccessState(resolve_gen, kResolveWrite, attachment_access, ResourceUsageTagEx{store_tag});
+            access_context.UpdateAccessState(resolve_gen, kResolveWrite, resolve_write_access, ResourceUsageTagEx{store_tag});
         }
 
         const SyncAccessIndex store_index = attachment.GetStoreUsage();
         if (store_index != SYNC_ACCESS_INDEX_NONE) {
-            AttachmentAccessInfo attachment_access = GetAttachmentAccessInfo(kStoreOrder);
-
+            const AttachmentAccess attachment_access = GetAttachmentAccess(kStoreOrder, AttachmentAccessType::StoreOp);
             ImageRangeGen view_gen = attachment.view_gen;
-            access_context.UpdateAccessState(view_gen, store_index, attachment_access, ResourceUsageTagEx{store_tag},
-                                             SyncFlag::kStoreOp);
+            access_context.UpdateAccessState(view_gen, store_index, attachment_access, ResourceUsageTagEx{store_tag});
         }
     }
     current_render_pass_instance_id_++;
@@ -579,9 +583,9 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
                         if (sync_index == SYNC_FRAGMENT_SHADER_INPUT_ATTACHMENT_READ) {
                             const VkExtent3D extent = CastTo3D(cb_state_->render_area.extent);
                             const VkOffset3D offset = CastTo3D(cb_state_->render_area.offset);
-                            // Input attachments are subject to raster ordering rules
-                            hazard =
-                                current_context_->DetectHazard(*img_view_state, offset, extent, sync_index, SyncOrdering::kRaster);
+                            const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kRaster);
+                            hazard = current_context_->DetectAttachmentHazard(*img_view_state, offset, extent, sync_index,
+                                                                              attachment_access);
                         } else {
                             hazard = current_context_->DetectHazard(*img_view_state, sync_index);
                         }
@@ -738,7 +742,7 @@ void CommandBufferAccessContext::RecordDispatchDrawDescriptorSet(VkPipelineBindP
                         if (sync_index == SYNC_FRAGMENT_SHADER_INPUT_ATTACHMENT_READ) {
                             const VkExtent3D extent = CastTo3D(cb_state_->render_area.extent);
                             const VkOffset3D offset = CastTo3D(cb_state_->render_area.offset);
-                            const AttachmentAccessInfo attachment_access = GetAttachmentAccessInfo(SyncOrdering::kRaster);
+                            const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kRaster);
 
                             ImageRangeGen range_gen(MakeImageRangeGen(*img_view_state, offset, extent));
                             current_context_->UpdateAccessState(range_gen, SYNC_FRAGMENT_SHADER_INPUT_ATTACHMENT_READ,
@@ -938,12 +942,18 @@ bool CommandBufferAccessContext::ValidateDrawDynamicRenderingAttachment(const Lo
 
     const DynamicRenderingInfo &info = *dynamic_rendering_info_;
     for (const auto output_location : list) {
-        if (output_location >= info.info.colorAttachmentCount) continue;
+        if (output_location >= info.info.colorAttachmentCount) {
+            continue;
+        }
         const auto &attachment = info.attachments[output_location];
-        if (!attachment.IsWriteable(last_bound_state)) continue;
+        if (!attachment.IsWriteable(last_bound_state)) {
+            continue;
+        }
+        const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kColorAttachment);
+        ImageRangeGen view_gen = attachment.view_gen;
+        HazardResult hazard =
+            access_context.DetectAttachmentHazard(view_gen, SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, attachment_access);
 
-        HazardResult hazard = access_context.DetectHazard(attachment.view_gen, SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE,
-                                                          SyncOrdering::kColorAttachment);
         if (hazard.IsHazard()) {
             LogObjectList obj_list(cb_state_->Handle(), attachment.view->Handle());
             Location loc = attachment.GetLocation(location, output_location);
@@ -964,10 +974,11 @@ bool CommandBufferAccessContext::ValidateDrawDynamicRenderingAttachment(const Lo
         bool writeable = attachment.IsWriteable(last_bound_state);
 
         if (writeable) {
-            HazardResult hazard =
-                access_context.DetectHazard(attachment.view_gen, SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE,
-                                            SyncOrdering::kDepthStencilAttachment);
-            // Depth stencil Hazard check
+            const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kDepthStencilAttachment);
+            ImageRangeGen view_gen = attachment.view_gen;
+            HazardResult hazard = access_context.DetectAttachmentHazard(
+                view_gen, SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, attachment_access);
+
             if (hazard.IsHazard()) {
                 LogObjectList objlist(cb_state_->Handle(), attachment.view->Handle());
                 Location loc = attachment.GetLocation(location);
@@ -1007,8 +1018,7 @@ void CommandBufferAccessContext::RecordDrawDynamicRenderingAttachment(ResourceUs
         if (!attachment.IsWriteable(last_bound_state)) {
             continue;
         }
-        const AttachmentAccessInfo attachment_access = GetAttachmentAccessInfo(SyncOrdering::kColorAttachment);
-
+        const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kColorAttachment);
         ImageRangeGen view_gen = attachment.view_gen;
         access_context.UpdateAccessState(view_gen, SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, attachment_access,
                                          ResourceUsageTagEx{tag});
@@ -1025,7 +1035,7 @@ void CommandBufferAccessContext::RecordDrawDynamicRenderingAttachment(ResourceUs
         bool writeable = attachment.IsWriteable(last_bound_state);
 
         if (writeable) {
-            const AttachmentAccessInfo attachment_access = GetAttachmentAccessInfo(SyncOrdering::kDepthStencilAttachment);
+            const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kDepthStencilAttachment);
             ImageRangeGen view_gen = attachment.view_gen;
             access_context.UpdateAccessState(view_gen, SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, attachment_access,
                                              ResourceUsageTagEx{tag});
@@ -1137,9 +1147,10 @@ bool CommandBufferAccessContext::ValidateClearAttachment(const Location &loc, co
         // and if PLANE aspect is included then only one is allowed.
         assert(GetBitSetCount(aspects_to_clear) == 1);
 
-        HazardResult hazard = current_context_->DetectHazard(
+        const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kColorAttachment);
+        HazardResult hazard = current_context_->DetectAttachmentHazard(
             *info.attachment_view.image_state, subresource_range, info.attachment_view.is_depth_sliced,
-            SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, SyncOrdering::kColorAttachment);
+            SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, attachment_access);
         if (hazard.IsHazard()) {
             std::ostringstream ss;
             ss << string_VkImageAspectFlags(clear_attachment.aspectMask);
@@ -1157,11 +1168,13 @@ bool CommandBufferAccessContext::ValidateClearAttachment(const Location &loc, co
     }
 
     if (aspects_to_clear & kDepthStencilAspects) {
+        const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kDepthStencilAttachment);
+
         // vkCmdClearAttachments depth/stencil writes are executed by the EARLY_FRAGMENT_TESTS_BIT and LATE_FRAGMENT_TESTS_BIT
         // stages. The implementation tracks the most recent access, which happens in the LATE_FRAGMENT_TESTS_BIT stage.
-        HazardResult hazard = current_context_->DetectHazard(
+        HazardResult hazard = current_context_->DetectAttachmentHazard(
             *info.attachment_view.image_state, subresource_range, info.attachment_view.is_depth_sliced,
-            SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, SyncOrdering::kDepthStencilAttachment);
+            SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, attachment_access);
 
         if (hazard.IsHazard()) {
             std::ostringstream ss;
@@ -1196,12 +1209,12 @@ void CommandBufferAccessContext::RecordClearAttachment(ResourceUsageTag tag, con
 
     if (aspects_to_clear & kColorAspects) {
         assert((aspects_to_clear & kDepthStencilAspects) == 0);
-        const AttachmentAccessInfo attachment_access = GetAttachmentAccessInfo(SyncOrdering::kColorAttachment);
+        const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kColorAttachment);
         current_context_->UpdateAccessState(range_gen, SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, attachment_access,
                                             ResourceUsageTagEx{tag});
     } else {
         assert((aspects_to_clear & kColorAspects) == 0);
-        const AttachmentAccessInfo attachment_access = GetAttachmentAccessInfo(SyncOrdering::kDepthStencilAttachment);
+        const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kDepthStencilAttachment);
         current_context_->UpdateAccessState(range_gen, SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, attachment_access,
                                             ResourceUsageTagEx{tag});
     }
@@ -1388,8 +1401,9 @@ void CommandBufferAccessContext::RecordSyncOp(SyncOpPointer &&sync_op) {
     sync_ops_.emplace_back(tag, std::move(sync_op));
 }
 
-AttachmentAccessInfo CommandBufferAccessContext::GetAttachmentAccessInfo(SyncOrdering ordering) {
-    AttachmentAccessInfo attachment_access;
+AttachmentAccess CommandBufferAccessContext::GetAttachmentAccess(SyncOrdering ordering, AttachmentAccessType type) const {
+    AttachmentAccess attachment_access;
+    attachment_access.type = type;
     attachment_access.ordering = ordering;
     attachment_access.render_pass_instance_id = current_render_pass_instance_id_;
     attachment_access.subpass = current_renderpass_context_ ? current_renderpass_context_->GetCurrentSubpass() : vvl::kNoIndex32;

--- a/layers/sync/sync_commandbuffer.h
+++ b/layers/sync/sync_commandbuffer.h
@@ -294,7 +294,7 @@ class CommandBufferAccessContext : public CommandExecutionContext, DebugNameProv
 
     uint32_t AddHandle(const VulkanTypedHandle &typed_handle, uint32_t index);
     void RecordSyncOp(SyncOpPointer &&sync_op);
-    AttachmentAccessInfo GetAttachmentAccessInfo(SyncOrdering ordering);
+    AttachmentAccess GetAttachmentAccess(SyncOrdering ordering, AttachmentAccessType type = AttachmentAccessType::Access) const;
 
     struct ClearAttachmentInfo {
         const vvl::ImageView &attachment_view;

--- a/layers/sync/sync_hazard_detection.cpp
+++ b/layers/sync/sync_hazard_detection.cpp
@@ -113,20 +113,19 @@ class HazardDetector {
     const AccessContext &access_context_;
 };
 
-class HazardDetectorWithOrdering {
+class HazardDetectorAttachment {
   public:
-    HazardDetectorWithOrdering(SyncAccessIndex access_index, SyncOrdering ordering, const AccessContext &access_context,
-                               SyncFlags flags, bool detect_load_op_after_store_op_hazards)
+    HazardDetectorAttachment(SyncAccessIndex access_index, const AttachmentAccess &attachment_access,
+                             const AccessContext &access_context, bool detect_load_op_after_store_op_hazards)
         : access_info_(GetAccessInfo(access_index)),
-          ordering_rule_(ordering),
+          attachment_access_(attachment_access),
           access_context_(access_context),
-          flags_(flags),
           detect_load_op_after_store_op_hazards(detect_load_op_after_store_op_hazards) {}
 
     HazardResult Detect(const AccessMap::const_iterator &pos) const {
-        const OrderingBarrier &ordering = GetOrderingRules(ordering_rule_);
+        const OrderingBarrier &ordering = GetOrderingRules(attachment_access_.ordering);
         return DoDetect(access_context_, pos->second, [this, &ordering](const AccessState &access_state) {
-            return access_state.DetectHazard(access_info_, ordering, flags_, kQueueIdInvalid,
+            return access_state.DetectHazard(access_info_, ordering, attachment_access_, 0, kQueueIdInvalid,
                                              detect_load_op_after_store_op_hazards);
         });
     }
@@ -139,9 +138,8 @@ class HazardDetectorWithOrdering {
 
   private:
     const SyncAccessInfo &access_info_;
-    const SyncOrdering ordering_rule_;
+    const AttachmentAccess attachment_access_;
     const AccessContext &access_context_;
-    const SyncFlags flags_;
     const bool detect_load_op_after_store_op_hazards;
 };
 
@@ -313,79 +311,62 @@ HazardResult AccessContext::DetectHazard(const vvl::Buffer &buffer, SyncAccessIn
     return DetectHazardRange(detector, (range + base_address), DetectOptions::kDetectAll);
 }
 
-HazardResult AccessContext::DetectHazard(const vvl::Image &image, const VkImageSubresourceRange &subresource_range,
-                                         bool is_depth_sliced, SyncAccessIndex current_usage, SyncOrdering ordering_rule) const {
-    ImageRangeGen range_gen = SubState(image).MakeImageRangeGen(subresource_range, is_depth_sliced);
-    if (ordering_rule == SyncOrdering::kOrderingNone) {
-        HazardDetector detector(current_usage, *this);
-        return DetectHazardGeneratedRangeGen(detector, range_gen, DetectOptions::kDetectAll);
-    } else {
-        HazardDetectorWithOrdering detector(current_usage, ordering_rule, *this, 0, false);
-        return DetectHazardGeneratedRangeGen(detector, range_gen, DetectOptions::kDetectAll);
-    }
+HazardResult AccessContext::DetectHazard(ImageRangeGen &range_gen, SyncAccessIndex current_usage) const {
+    HazardDetector detector(current_usage, *this);
+    return DetectHazardGeneratedRangeGen(detector, range_gen, DetectOptions::kDetectAll);
 }
 
 HazardResult AccessContext::DetectHazard(const vvl::Image &image, const VkImageSubresourceRange &subresource_range,
-                                         const VkOffset3D &offset, const VkExtent3D &extent, bool is_depth_sliced,
-                                         SyncAccessIndex current_usage, SyncOrdering ordering_rule) const {
-    ImageRangeGen range_gen = SubState(image).MakeImageRangeGen(subresource_range, offset, extent, is_depth_sliced);
-    if (ordering_rule == SyncOrdering::kOrderingNone) {
-        HazardDetector detector(current_usage, *this);
-        return DetectHazardGeneratedRangeGen(detector, range_gen, DetectOptions::kDetectAll);
-    } else {
-        HazardDetectorWithOrdering detector(current_usage, ordering_rule, *this, 0,
-                                            validator->syncval_settings.load_op_after_store_op_validation);
-        return DetectHazardGeneratedRangeGen(detector, range_gen, DetectOptions::kDetectAll);
-    }
+                                         SyncAccessIndex current_usage) const {
+    const auto &sub_state = SubState(image);
+    HazardDetector detector(current_usage, *this);
+    ImageRangeGen range_gen = sub_state.MakeImageRangeGen(subresource_range, false);
+    return DetectHazardGeneratedRangeGen(detector, range_gen, DetectOptions::kDetectAll);
+}
+
+HazardResult AccessContext::DetectHazard(const vvl::Image &image, const VkImageSubresourceRange &subresource_range,
+                                         const VkOffset3D &offset, const VkExtent3D &extent, SyncAccessIndex current_usage) const {
+    const auto &sub_state = SubState(image);
+    HazardDetector detector(current_usage, *this);
+    ImageRangeGen range_gen = sub_state.MakeImageRangeGen(subresource_range, offset, extent, false);
+    return DetectHazardGeneratedRangeGen(detector, range_gen, DetectOptions::kDetectAll);
 }
 
 HazardResult AccessContext::DetectHazard(const vvl::ImageView &image_view, SyncAccessIndex current_usage) const {
     HazardDetector detector(current_usage, *this);
-    auto range_gen = MakeImageRangeGen(image_view);
+    ImageRangeGen range_gen = MakeImageRangeGen(image_view);
     return DetectHazardGeneratedRangeGen(detector, range_gen, DetectOptions::kDetectAll);
 }
 
 HazardResult AccessContext::DetectHazard(const vvl::ImageView &image_view, const VkOffset3D &offset, const VkExtent3D &extent,
-                                         SyncAccessIndex current_usage, SyncOrdering ordering_rule) const {
-    HazardDetectorWithOrdering detector(current_usage, ordering_rule, *this, 0,
-                                        validator->syncval_settings.load_op_after_store_op_validation);
+                                         SyncAccessIndex current_usage) const {
+    HazardDetector detector(current_usage, *this);
     ImageRangeGen range_gen(MakeImageRangeGen(image_view, offset, extent));
     return DetectHazardGeneratedRangeGen(detector, range_gen, DetectOptions::kDetectAll);
 }
 
-HazardResult AccessContext::DetectHazard(const ImageRangeGen &const_range_gen, SyncAccessIndex current_usage,
-                                         const SyncOrdering ordering_rule, SyncFlags flags) const {
-    ImageRangeGen range_gen(const_range_gen);
-    if (ordering_rule == SyncOrdering::kOrderingNone) {
-        HazardDetector detector(current_usage, *this);
-        return DetectHazardGeneratedRangeGen(detector, range_gen, DetectOptions::kDetectAll);
-    } else {
-        HazardDetectorWithOrdering detector(current_usage, ordering_rule, *this, flags,
-                                            validator->syncval_settings.load_op_after_store_op_validation);
-        return DetectHazardGeneratedRangeGen(detector, range_gen, DetectOptions::kDetectAll);
-    }
-}
-
-HazardResult AccessContext::DetectHazard(const AttachmentViewGen &view_gen, AttachmentViewGen::Gen gen_type,
-                                         SyncAccessIndex current_usage, SyncOrdering ordering_rule, SyncFlags flags) const {
-    HazardDetectorWithOrdering detector(current_usage, ordering_rule, *this, flags,
-                                        validator->syncval_settings.load_op_after_store_op_validation);
-    const std::optional<ImageRangeGen> &attachment_gen = view_gen.GetRangeGen(gen_type);
-    if (!attachment_gen) {
-        return {};
-    }
-    ImageRangeGen range_gen(*attachment_gen);
+HazardResult AccessContext::DetectAttachmentHazard(ImageRangeGen &range_gen, SyncAccessIndex current_usage,
+                                                   const AttachmentAccess &attachment_access) const {
+    HazardDetectorAttachment detector(current_usage, attachment_access, *this,
+                                      validator->syncval_settings.load_op_after_store_op_validation);
     return DetectHazardGeneratedRangeGen(detector, range_gen, DetectOptions::kDetectAll);
 }
 
-HazardResult AccessContext::DetectHazard(const vvl::VideoSession &vs_state, const vvl::VideoPictureResource &resource,
-                                         SyncAccessIndex current_usage) const {
-    const auto image = static_cast<const vvl::Image *>(resource.image_state.get());
-    const auto &sub_state = SubState(*image);
-    const auto offset = resource.GetEffectiveImageOffset(vs_state);
-    const auto extent = resource.GetEffectiveImageExtent(vs_state);
-    ImageRangeGen range_gen(sub_state.MakeImageRangeGen(resource.range, offset, extent, false));
-    HazardDetector detector(current_usage, *this);
+HazardResult AccessContext::DetectAttachmentHazard(const vvl::Image &image, const VkImageSubresourceRange &subresource_range,
+                                                   bool is_depth_sliced, SyncAccessIndex current_usage,
+                                                   const AttachmentAccess &attachment_access) const {
+    const auto &sub_state = SubState(image);
+    HazardDetectorAttachment detector(current_usage, attachment_access, *this, false);
+    ImageRangeGen range_gen = sub_state.MakeImageRangeGen(subresource_range, is_depth_sliced);
+    return DetectHazardGeneratedRangeGen(detector, range_gen, DetectOptions::kDetectAll);
+}
+
+HazardResult AccessContext::DetectAttachmentHazard(const vvl::ImageView &image_view, const VkOffset3D &offset,
+                                                   const VkExtent3D &extent, SyncAccessIndex current_usage,
+                                                   const AttachmentAccess &attachment_access) const {
+    HazardDetectorAttachment detector(current_usage, attachment_access, *this,
+                                      validator->syncval_settings.load_op_after_store_op_validation);
+    ImageRangeGen range_gen(MakeImageRangeGen(image_view, offset, extent));
     return DetectHazardGeneratedRangeGen(detector, range_gen, DetectOptions::kDetectAll);
 }
 
@@ -489,6 +470,17 @@ HazardResult AccessContext::DetectFirstUseHazard(QueueId queue_id, const Resourc
         }
     }
     return {};
+}
+
+HazardResult AccessContext::DetectVideoHazard(const vvl::VideoSession &vs_state, const vvl::VideoPictureResource &resource,
+                                              SyncAccessIndex current_usage) const {
+    const vvl::Image &image = *resource.image_state.get();
+    const auto &sub_state = SubState(image);
+    const auto offset = resource.GetEffectiveImageOffset(vs_state);
+    const auto extent = resource.GetEffectiveImageExtent(vs_state);
+    ImageRangeGen range_gen(sub_state.MakeImageRangeGen(resource.range, offset, extent, false));
+    HazardDetector detector(current_usage, *this);
+    return DetectHazardGeneratedRangeGen(detector, range_gen, DetectOptions::kDetectAll);
 }
 
 HazardResult AccessContext::DetectMarkerHazard(const vvl::Buffer &buffer, const AccessRange &range) const {

--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -1235,21 +1235,21 @@ bool SyncOpBeginRenderPass::Validate(const CommandBufferAccessContext &cb_contex
     // Validate attachment operations
     if (attachments_.empty()) return skip;
     const auto &render_area = renderpass_begin_info_.renderArea;
+    const uint32_t render_pass_instance_id = cb_context.GetCurrentRenderPassInstanceId();
 
     // Since the isn't a valid RenderPassAccessContext until Record, needs to create the view/generator list... we could limit this
     // by predicating on whether subpass 0 uses the attachment if it is too expensive to create the full list redundantly here.
     // More broadly we could look at thread specific state shared between Validate and Record as is done for other heavyweight
     // operations (though it's currently a messy approach)
     const AttachmentViewGenVector view_gens = RenderPassAccessContext::CreateAttachmentViewGen(render_area, attachments_);
-    const uint32_t render_pass_instance_id = cb_context.GetCurrentRenderPassInstanceId();
     skip |= RenderPassAccessContext::ValidateLayoutTransitions(cb_context, temp_context, rp_state, render_area,
                                                                render_pass_instance_id, subpass, view_gens, command_);
 
     // Validate load operations if there were no layout transition hazards
     if (!skip) {
         RenderPassAccessContext::RecordLayoutTransitions(rp_state, subpass, view_gens, kInvalidTag, temp_context);
-        skip |= RenderPassAccessContext::ValidateLoadOperation(cb_context, temp_context, rp_state, render_area, subpass, view_gens,
-                                                               command_);
+        skip |= RenderPassAccessContext::ValidateLoadOperation(cb_context, temp_context, rp_state, render_area,
+                                                               render_pass_instance_id, subpass, view_gens, command_);
     }
 
     return skip;

--- a/layers/sync/sync_renderpass.cpp
+++ b/layers/sync/sync_renderpass.cpp
@@ -27,12 +27,11 @@ namespace syncval {
 
 static void UpdateAttachmentAccessState(AccessContext &access_context, const AttachmentViewGen &view_gen,
                                         AttachmentViewGen::Gen gen_type, SyncAccessIndex current_usage,
-                                        const AttachmentAccessInfo &attachment_access, const ResourceUsageTag tag,
-                                        SyncFlags flags = 0) {
+                                        const AttachmentAccess &attachment_access, const ResourceUsageTag tag) {
     const std::optional<ImageRangeGen> &attachment_gen = view_gen.GetRangeGen(gen_type);
     if (attachment_gen) {
         ImageRangeGen range_gen = *attachment_gen;
-        access_context.UpdateAccessState(range_gen, current_usage, attachment_access, ResourceUsageTagEx{tag}, flags);
+        access_context.UpdateAccessState(range_gen, current_usage, attachment_access, ResourceUsageTagEx{tag});
     }
 }
 
@@ -49,8 +48,9 @@ class ValidateResolveAction {
 
     void operator()(const char *aspect_name, const char *resolve_action_name, uint32_t src_at, uint32_t dst_at,
                     const AttachmentViewGen &view_gen, AttachmentViewGen::Gen gen_type, SyncAccessIndex current_usage,
-                    const AttachmentAccessInfo &attachment_access) {
-        const HazardResult hazard = context_.DetectHazard(view_gen, gen_type, current_usage, attachment_access.ordering);
+                    const AttachmentAccess &attachment_access) {
+        ImageRangeGen attachment_range_gen = view_gen.GetRangeGen(gen_type);
+        const HazardResult hazard = context_.DetectAttachmentHazard(attachment_range_gen, current_usage, attachment_access);
         if (hazard.IsHazard()) {
             const Location loc(command_);
 
@@ -85,7 +85,7 @@ class UpdateStateResolveAction {
   public:
     UpdateStateResolveAction(AccessContext &context, ResourceUsageTag tag) : context_(context), tag_(tag) {}
     void operator()(const char *, const char *, uint32_t, uint32_t, const AttachmentViewGen &view_gen,
-                    AttachmentViewGen::Gen gen_type, SyncAccessIndex current_usage, const AttachmentAccessInfo &attachment_access) {
+                    AttachmentViewGen::Gen gen_type, SyncAccessIndex current_usage, const AttachmentAccess &attachment_access) {
         UpdateAttachmentAccessState(context_, view_gen, gen_type, current_usage, attachment_access, tag_);
     }
 
@@ -217,15 +217,19 @@ bool RenderPassAccessContext::ValidateLayoutTransitions(const CommandBufferAcces
 
 bool RenderPassAccessContext::ValidateLoadOperation(const CommandBufferAccessContext &cb_context,
                                                     const AccessContext &access_context, const vvl::RenderPass &rp_state,
-                                                    const VkRect2D &render_area, uint32_t subpass,
+                                                    const VkRect2D &render_area, uint32_t render_pass_instance_id, uint32_t subpass,
                                                     const AttachmentViewGenVector &attachment_views, vvl::Func command) {
     bool skip = false;
-    const auto *attachment_ci = rp_state.create_info.pAttachments;
+
+    AttachmentAccess attachment_access;
+    attachment_access.type = AttachmentAccessType::LoadOp;
+    attachment_access.render_pass_instance_id = render_pass_instance_id;
+    attachment_access.subpass = subpass;
 
     for (uint32_t i = 0; i < rp_state.create_info.attachmentCount; i++) {
         if (subpass == rp_state.attachment_first_subpass[i]) {
             const auto &view_gen = attachment_views[i];
-            const auto &ci = attachment_ci[i];
+            const auto &ci = rp_state.create_info.pAttachments[i];
 
             // Need check in the following way
             // 1) if the usage bit isn't in the dest_access_scope, and there is layout traniition for initial use, report hazard
@@ -245,19 +249,21 @@ bool RenderPassAccessContext::ValidateLoadOperation(const CommandBufferAccessCon
 
             bool checked_stencil = false;
             if (is_color && (load_index != SYNC_ACCESS_INDEX_NONE)) {
-                hazard = access_context.DetectHazard(view_gen, AttachmentViewGen::Gen::kRenderArea, load_index,
-                                                     SyncOrdering::kColorAttachment, SyncFlag::kLoadOp);
+                ImageRangeGen attachment_range_gen = view_gen.GetRangeGen(AttachmentViewGen::Gen::kRenderArea);
+                attachment_access.ordering = SyncOrdering::kColorAttachment;
+                hazard = access_context.DetectAttachmentHazard(attachment_range_gen, load_index, attachment_access);
                 aspect = "color";
             } else {
                 if (has_depth && (load_index != SYNC_ACCESS_INDEX_NONE)) {
-                    hazard = access_context.DetectHazard(view_gen, AttachmentViewGen::Gen::kDepthOnlyRenderArea, load_index,
-                                                         SyncOrdering::kDepthStencilAttachment, SyncFlag::kLoadOp);
+                    ImageRangeGen attachment_range_gen = view_gen.GetRangeGen(AttachmentViewGen::Gen::kDepthOnlyRenderArea);
+                    attachment_access.ordering = SyncOrdering::kDepthStencilAttachment;
+                    hazard = access_context.DetectAttachmentHazard(attachment_range_gen, load_index, attachment_access);
                     aspect = "depth";
                 }
                 if (!hazard.IsHazard() && has_stencil && (stencil_load_index != SYNC_ACCESS_INDEX_NONE)) {
-                    hazard =
-                        access_context.DetectHazard(view_gen, AttachmentViewGen::Gen::kStencilOnlyRenderArea, stencil_load_index,
-                                                    SyncOrdering::kDepthStencilAttachment, SyncFlag::kLoadOp);
+                    ImageRangeGen attachment_range_gen = view_gen.GetRangeGen(AttachmentViewGen::Gen::kStencilOnlyRenderArea);
+                    attachment_access.ordering = SyncOrdering::kDepthStencilAttachment;
+                    hazard = access_context.DetectAttachmentHazard(attachment_range_gen, stencil_load_index, attachment_access);
                     aspect = "stencil";
                     checked_stencil = true;
                 }
@@ -297,12 +303,13 @@ bool RenderPassAccessContext::ValidateLoadOperation(const CommandBufferAccessCon
 // The latter is handled in layout transistion validation directly
 bool RenderPassAccessContext::ValidateStoreOperation(const CommandBufferAccessContext &cb_context, vvl::Func command) const {
     bool skip = false;
-    const auto *attachment_ci = rp_state_->create_info.pAttachments;
+
+    const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kRaster, AttachmentAccessType::StoreOp);
 
     for (uint32_t i = 0; i < rp_state_->create_info.attachmentCount; i++) {
         if (current_subpass_ == rp_state_->attachment_last_subpass[i]) {
             const AttachmentViewGen &view_gen = attachment_views_[i];
-            const auto &ci = attachment_ci[i];
+            const auto &ci = rp_state_->create_info.pAttachments[i];
 
             // The spec states that "don't care" is an operation with VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
             // so we assume that an implementation is *free* to write in that case, meaning that for correctness
@@ -317,22 +324,22 @@ bool RenderPassAccessContext::ValidateStoreOperation(const CommandBufferAccessCo
             const char *aspect = nullptr;
             bool checked_stencil = false;
             if (is_color) {
-                hazard = CurrentContext().DetectHazard(view_gen, AttachmentViewGen::Gen::kRenderArea,
-                                                       SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, SyncOrdering::kRaster,
-                                                       SyncFlag::kStoreOp);
+                ImageRangeGen attachment_range_gen = view_gen.GetRangeGen(AttachmentViewGen::Gen::kRenderArea);
+                hazard = CurrentContext().DetectAttachmentHazard(
+                    attachment_range_gen, SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, attachment_access);
                 aspect = "color";
             } else {
                 const bool stencil_op_stores = ci.stencilStoreOp != VK_ATTACHMENT_STORE_OP_NONE;
                 if (has_depth && store_op_stores) {
-                    hazard = CurrentContext().DetectHazard(view_gen, AttachmentViewGen::Gen::kDepthOnlyRenderArea,
-                                                           SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE,
-                                                           SyncOrdering::kRaster, SyncFlag::kStoreOp);
+                    ImageRangeGen attachment_range_gen = view_gen.GetRangeGen(AttachmentViewGen::Gen::kDepthOnlyRenderArea);
+                    hazard = CurrentContext().DetectAttachmentHazard(
+                        attachment_range_gen, SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, attachment_access);
                     aspect = "depth";
                 }
                 if (!hazard.IsHazard() && has_stencil && stencil_op_stores) {
-                    hazard = CurrentContext().DetectHazard(view_gen, AttachmentViewGen::Gen::kStencilOnlyRenderArea,
-                                                           SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE,
-                                                           SyncOrdering::kRaster, SyncFlag::kStoreOp);
+                    ImageRangeGen attachment_range_gen = view_gen.GetRangeGen(AttachmentViewGen::Gen::kStencilOnlyRenderArea);
+                    hazard = CurrentContext().DetectAttachmentHazard(
+                        attachment_range_gen, SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, attachment_access);
                     aspect = "stencil";
                     checked_stencil = true;
                 }
@@ -375,18 +382,18 @@ bool IsImageLayoutStencilWritable(VkImageLayout image_layout) {
 }
 
 bool IsDepthAttachmentWriteable(const LastBound &last_bound_state, const VkFormat format, const VkImageLayout layout) {
-    // PHASE1 TODO: These validation should be in core_checks.
-    const bool depth_write_enable = last_bound_state.IsDepthWriteEnable();  // implicitly means DepthTestEnable is set
-    return !vkuFormatIsStencilOnly(format) && depth_write_enable && IsImageLayoutDepthWritable(layout);
+    const bool depth_write_enable = last_bound_state.IsDepthWriteEnable();
+    return (vkuFormatIsDepthAndStencil(format) || vkuFormatIsDepthOnly(format)) && depth_write_enable &&
+           IsImageLayoutDepthWritable(layout);
 }
 
 bool IsStencilAttachmentWriteable(const LastBound &last_bound_state, const VkFormat format, const VkImageLayout layout) {
     // PHASE1 TODO: It needs to check if stencil is writable.
     //              If failOp, passOp, or depthFailOp are not KEEP, and writeMask isn't 0, it's writable.
     //              If depth test is disable, it's considered depth test passes, and then depthFailOp doesn't run.
-    // PHASE1 TODO: These validation should be in core_checks.
     const bool stencil_test_enable = last_bound_state.IsStencilTestEnable();
-    return !vkuFormatIsDepthOnly(format) && stencil_test_enable && IsImageLayoutStencilWritable(layout);
+    return (vkuFormatIsDepthAndStencil(format) || vkuFormatIsStencilOnly(format)) && stencil_test_enable &&
+           IsImageLayoutStencilWritable(layout);
 }
 
 // Traverse the attachment resolves for this a specific subpass, and do action() to them.
@@ -400,21 +407,22 @@ void ResolveOperation(Action &action, const vvl::RenderPass &rp_state, const Att
     const auto *attachment_ci = rp_ci.pAttachments;
     const auto &subpass_ci = rp_ci.pSubpasses[subpass];
 
-    AttachmentAccessInfo attachment_access;
+    AttachmentAccess attachment_access;
     attachment_access.render_pass_instance_id = render_pass_instance_id;
     attachment_access.subpass = subpass;
 
-    // Color resolves -- require an inuse color attachment and a matching inuse resolve attachment
-    const auto *color_attachments = subpass_ci.pColorAttachments;
-    const auto *color_resolve = subpass_ci.pResolveAttachments;
-    if (color_resolve && color_attachments) {
+    // Color resolve requires an inuse color attachment and a matching inuse resolve attachment
+    if (subpass_ci.pResolveAttachments && subpass_ci.pColorAttachments) {
         attachment_access.ordering = SyncOrdering::kColorAttachment;
         for (uint32_t i = 0; i < subpass_ci.colorAttachmentCount; i++) {
-            const auto &color_attach = color_attachments[i].attachment;
-            const auto &resolve_attach = subpass_ci.pResolveAttachments[i].attachment;
-            if ((color_attach != VK_ATTACHMENT_UNUSED) && (resolve_attach != VK_ATTACHMENT_UNUSED)) {
+            const uint32_t color_attach = subpass_ci.pColorAttachments[i].attachment;
+            const uint32_t resolve_attach = subpass_ci.pResolveAttachments[i].attachment;
+            if (color_attach != VK_ATTACHMENT_UNUSED && resolve_attach != VK_ATTACHMENT_UNUSED) {
+                attachment_access.type  = AttachmentAccessType::ResolveRead;
                 action("color", "resolve read", color_attach, resolve_attach, attachment_views[color_attach],
                        AttachmentViewGen::Gen::kRenderArea, SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_READ, attachment_access);
+
+                attachment_access.type = AttachmentAccessType::ResolveWrite;
                 action("color", "resolve write", color_attach, resolve_attach, attachment_views[resolve_attach],
                        AttachmentViewGen::Gen::kRenderArea, SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, attachment_access);
             }
@@ -450,8 +458,12 @@ void ResolveOperation(Action &action, const vvl::RenderPass &rp_state, const Att
 
         if (aspect_string) {
             attachment_access.ordering = SyncOrdering::kRaster;
+
+            attachment_access.type = AttachmentAccessType::ResolveRead;
             action(aspect_string, "resolve read", src_at, dst_at, attachment_views[src_at], gen_type,
                    SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_READ, attachment_access);
+
+            attachment_access.type = AttachmentAccessType::ResolveWrite;
             action(aspect_string, "resolve write", src_at, dst_at, attachment_views[dst_at], gen_type,
                    SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, attachment_access);
         }
@@ -476,7 +488,8 @@ void RenderPassAccessContext::UpdateAttachmentStoreAccess(const vvl::RenderPass 
                                                           const AttachmentViewGenVector &attachment_views,
                                                           uint32_t render_pass_instance_id, uint32_t subpass,
                                                           const ResourceUsageTag tag, AccessContext &access_context) {
-    AttachmentAccessInfo attachment_access;
+    AttachmentAccess attachment_access;
+    attachment_access.type = AttachmentAccessType::StoreOp;
     attachment_access.ordering = SyncOrdering::kRaster;
     attachment_access.render_pass_instance_id = render_pass_instance_id;
     attachment_access.subpass = subpass;
@@ -493,19 +506,16 @@ void RenderPassAccessContext::UpdateAttachmentStoreAccess(const vvl::RenderPass 
 
             if (is_color && store_op_stores) {
                 UpdateAttachmentAccessState(access_context, view_gen, AttachmentViewGen::Gen::kRenderArea,
-                                            SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, attachment_access, tag,
-                                            SyncFlag::kStoreOp);
+                                            SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, attachment_access, tag);
             } else {
                 if (has_depth && store_op_stores) {
                     UpdateAttachmentAccessState(access_context, view_gen, AttachmentViewGen::Gen::kDepthOnlyRenderArea,
-                                                SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, attachment_access, tag,
-                                                SyncFlag::kStoreOp);
+                                                SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, attachment_access, tag);
                 }
                 const bool stencil_op_stores = ci.stencilStoreOp != VK_ATTACHMENT_STORE_OP_NONE;
                 if (has_stencil && stencil_op_stores) {
                     UpdateAttachmentAccessState(access_context, view_gen, AttachmentViewGen::Gen::kStencilOnlyRenderArea,
-                                                SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, attachment_access, tag,
-                                                SyncFlag::kStoreOp);
+                                                SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, attachment_access, tag);
                 }
             }
         }
@@ -573,10 +583,11 @@ bool RenderPassAccessContext::ValidateDrawSubpassAttachment(const CommandBufferA
                 subpass.pColorAttachments[location].attachment == VK_ATTACHMENT_UNUSED) {
                 continue;
             }
+            const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kColorAttachment);
             const AttachmentViewGen &view_gen = attachment_views_[subpass.pColorAttachments[location].attachment];
-            HazardResult hazard =
-                current_context.DetectHazard(view_gen, AttachmentViewGen::Gen::kRenderArea,
-                                             SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, SyncOrdering::kColorAttachment);
+            ImageRangeGen attachment_range_gen = view_gen.GetRangeGen(AttachmentViewGen::Gen::kRenderArea);
+            HazardResult hazard = current_context.DetectAttachmentHazard(
+                attachment_range_gen, SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, attachment_access);
             if (hazard.IsHazard()) {
                 std::ostringstream ss;
                 ss << "color attachment " << location << " in subpass " << cmd_buffer.GetActiveSubpass();
@@ -605,9 +616,10 @@ bool RenderPassAccessContext::ValidateDrawSubpassAttachment(const CommandBufferA
         //              If depth test is disable, it's considered depth test passes, and then depthFailOp doesn't run.
         // const bool early_fragment_test = pipe->fragment_shader_state->early_fragment_test;
         if (depth_write) {
-            HazardResult hazard = current_context.DetectHazard(view_gen, AttachmentViewGen::Gen::kDepthOnlyRenderArea,
-                                                               SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE,
-                                                               SyncOrdering::kDepthStencilAttachment);
+            const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kDepthStencilAttachment);
+            ImageRangeGen attachment_range_gen = view_gen.GetRangeGen(AttachmentViewGen::Gen::kDepthOnlyRenderArea);
+            HazardResult hazard = current_context.DetectAttachmentHazard(
+                attachment_range_gen, SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, attachment_access);
             if (hazard.IsHazard()) {
                 std::ostringstream ss;
                 ss << "depth aspect of depth-stencil attachment  in subpass " << cmd_buffer.GetActiveSubpass();
@@ -616,9 +628,10 @@ bool RenderPassAccessContext::ValidateDrawSubpassAttachment(const CommandBufferA
             }
         }
         if (stencil_write) {
-            HazardResult hazard = current_context.DetectHazard(view_gen, AttachmentViewGen::Gen::kStencilOnlyRenderArea,
-                                                               SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE,
-                                                               SyncOrdering::kDepthStencilAttachment);
+            const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kDepthStencilAttachment);
+            ImageRangeGen attachment_range_gen = view_gen.GetRangeGen(AttachmentViewGen::Gen::kStencilOnlyRenderArea);
+            HazardResult hazard = current_context.DetectAttachmentHazard(
+                attachment_range_gen, SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, attachment_access);
             if (hazard.IsHazard()) {
                 std::ostringstream ss;
                 ss << "stencil aspect of depth-stencil attachment  in subpass " << cmd_buffer.GetActiveSubpass();
@@ -646,8 +659,8 @@ void RenderPassAccessContext::RecordDrawSubpassAttachment(const vvl::CommandBuff
                 subpass.pColorAttachments[location].attachment == VK_ATTACHMENT_UNUSED) {
                 continue;
             }
+            const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kColorAttachment);
             const AttachmentViewGen &view_gen = attachment_views_[subpass.pColorAttachments[location].attachment];
-            const AttachmentAccessInfo attachment_access = GetAttachmentAccessInfo(SyncOrdering::kColorAttachment);
             UpdateAttachmentAccessState(current_context, view_gen, AttachmentViewGen::Gen::kRenderArea,
                                         SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, attachment_access, tag);
         }
@@ -681,7 +694,7 @@ void RenderPassAccessContext::RecordDrawSubpassAttachment(const vvl::CommandBuff
 
         if (depth_write || stencil_write) {
             const auto ds_gentype = view_gen.GetDepthStencilRenderAreaGenType(depth_write, stencil_write);
-            const AttachmentAccessInfo attachment_access = GetAttachmentAccessInfo(SyncOrdering::kDepthStencilAttachment);
+            const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kDepthStencilAttachment);
             // PHASE1 TODO: Add EARLY stage detection based on ExecutionMode.
             UpdateAttachmentAccessState(current_context, view_gen, ds_gentype,
                                         SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, attachment_access, tag);
@@ -728,7 +741,8 @@ bool RenderPassAccessContext::ValidateNextSubpass(const CommandBufferAccessConte
         AccessContext temp_context(cb_context.GetSyncState());
         temp_context.InitFrom(next_context);
         RecordLayoutTransitions(*rp_state_, next_subpass, attachment_views_, kInvalidTag, temp_context);
-        skip |= ValidateLoadOperation(cb_context, temp_context, *rp_state_, render_area_, next_subpass, attachment_views_, command);
+        skip |= ValidateLoadOperation(cb_context, temp_context, *rp_state_, render_area_, render_pass_instance_id_, next_subpass,
+                                      attachment_views_, command);
     }
     return skip;
 }
@@ -825,24 +839,26 @@ void RenderPassAccessContext::RecordLoadOperations(const ResourceUsageTag tag) {
             if (is_color) {
                 const SyncAccessIndex load_op = ColorLoadUsage(ci.loadOp);
                 if (load_op != SYNC_ACCESS_INDEX_NONE) {
-                    const AttachmentAccessInfo attachment_access = GetAttachmentAccessInfo(SyncOrdering::kColorAttachment);
+                    const AttachmentAccess attachment_access =
+                        GetAttachmentAccess(SyncOrdering::kColorAttachment, AttachmentAccessType::LoadOp);
                     UpdateAttachmentAccessState(subpass_context, view_gen, AttachmentViewGen::Gen::kRenderArea, load_op,
-                                                attachment_access, tag, SyncFlag::kLoadOp);
+                                                attachment_access, tag);
                 }
             } else {
-                const AttachmentAccessInfo attachment_access = GetAttachmentAccessInfo(SyncOrdering::kDepthStencilAttachment);
+                const AttachmentAccess attachment_access =
+                    GetAttachmentAccess(SyncOrdering::kDepthStencilAttachment, AttachmentAccessType::LoadOp);
                 if (has_depth) {
                     const SyncAccessIndex load_op = DepthStencilLoadUsage(ci.loadOp);
                     if (load_op != SYNC_ACCESS_INDEX_NONE) {
                         UpdateAttachmentAccessState(subpass_context, view_gen, AttachmentViewGen::Gen::kDepthOnlyRenderArea,
-                                                    load_op, attachment_access, tag, SyncFlag::kLoadOp);
+                                                    load_op, attachment_access, tag);
                     }
                 }
                 if (has_stencil) {
                     const SyncAccessIndex load_op = DepthStencilLoadUsage(ci.stencilLoadOp);
                     if (load_op != SYNC_ACCESS_INDEX_NONE) {
                         UpdateAttachmentAccessState(subpass_context, view_gen, AttachmentViewGen::Gen::kStencilOnlyRenderArea,
-                                                    load_op, attachment_access, tag, SyncFlag::kLoadOp);
+                                                    load_op, attachment_access, tag);
                     }
                 }
             }
@@ -960,8 +976,9 @@ vvl::span<AccessContext> RenderPassAccessContext::GetSubpassContexts() {
     return vvl::make_span<AccessContext>(subpass_contexts_.get(), rp_state_->create_info.subpassCount);
 }
 
-AttachmentAccessInfo RenderPassAccessContext::GetAttachmentAccessInfo(SyncOrdering ordering) const {
-    AttachmentAccessInfo attachment_access;
+AttachmentAccess RenderPassAccessContext::GetAttachmentAccess(SyncOrdering ordering, AttachmentAccessType type) const {
+    AttachmentAccess attachment_access;
+    attachment_access.type = type;
     attachment_access.ordering = ordering;
     attachment_access.render_pass_instance_id = render_pass_instance_id_;
     attachment_access.subpass = current_subpass_;

--- a/layers/sync/sync_renderpass.h
+++ b/layers/sync/sync_renderpass.h
@@ -97,7 +97,8 @@ class RenderPassAccessContext {
                                           const AttachmentViewGenVector &attachment_views, vvl::Func command);
 
     static bool ValidateLoadOperation(const CommandBufferAccessContext &cb_context, const AccessContext &access_context,
-                                      const vvl::RenderPass &rp_state, const VkRect2D &render_area, uint32_t subpass,
+                                      const vvl::RenderPass &rp_state, const VkRect2D &render_area,
+                                      uint32_t render_pass_instance_id, uint32_t subpass,
                                       const AttachmentViewGenVector &attachment_views, vvl::Func command);
 
     bool ValidateStoreOperation(const CommandBufferAccessContext &cb_context, vvl::Func command) const;
@@ -139,7 +140,7 @@ class RenderPassAccessContext {
     AccessContext *CreateStoreResolveProxy() const;
 
 private:
-    AttachmentAccessInfo GetAttachmentAccessInfo(SyncOrdering ordering) const;
+    AttachmentAccess GetAttachmentAccess(SyncOrdering ordering, AttachmentAccessType type = AttachmentAccessType::Access) const;
 
   private:
     const vvl::RenderPass *rp_state_;

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -544,8 +544,8 @@ bool QueueBatchContext::DoQueuePresentValidate(const Location& loc, const Presen
     bool skip = false;
     // Tag the presented images so record doesn't have to know the tagging scheme
     for (const PresentedImage& presented : presented_images) {
-        HazardResult hazard =
-            access_context_.DetectHazard(presented.range_gen, SYNC_PRESENT_ENGINE_SYNCVAL_PRESENT_PRESENTED_SYNCVAL);
+        ImageRangeGen range_gen = presented.range_gen;
+        HazardResult hazard = access_context_.DetectHazard(range_gen, SYNC_PRESENT_ENGINE_SYNCVAL_PRESENT_PRESENTED_SYNCVAL);
         if (hazard.IsHazard()) {
             const VulkanTypedHandle swapchain_handle = vvl::StateObject::Handle(presented.swapchain_state.lock());
             const VulkanTypedHandle image_handle = vvl::StateObject::Handle(presented.image);

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -499,7 +499,7 @@ bool SyncValidator::PreCallValidateCmdCopyImage(VkCommandBuffer commandBuffer, V
     for (const auto [region_index, copy_region] : vvl::enumerate(pRegions, regionCount)) {
         if (src_image) {
             auto hazard = context->DetectHazard(*src_image, RangeFromLayers(copy_region.srcSubresource), copy_region.srcOffset,
-                                                copy_region.extent, false, SYNC_COPY_TRANSFER_READ);
+                                                copy_region.extent, SYNC_COPY_TRANSFER_READ);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, srcImage);
                 const std::string error = error_messages_.ImageCopyResolveBlitError(
@@ -511,7 +511,7 @@ bool SyncValidator::PreCallValidateCmdCopyImage(VkCommandBuffer commandBuffer, V
 
         if (dst_image) {
             auto hazard = context->DetectHazard(*dst_image, RangeFromLayers(copy_region.dstSubresource), copy_region.dstOffset,
-                                                copy_region.extent, false, SYNC_COPY_TRANSFER_WRITE);
+                                                copy_region.extent, SYNC_COPY_TRANSFER_WRITE);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, dstImage);
                 const std::string error = error_messages_.ImageCopyResolveBlitError(
@@ -546,7 +546,7 @@ bool SyncValidator::PreCallValidateCmdCopyImage2(VkCommandBuffer commandBuffer, 
     for (const auto [region_index, copy_region] : vvl::enumerate(pCopyImageInfo->pRegions, pCopyImageInfo->regionCount)) {
         if (src_image) {
             auto hazard = context->DetectHazard(*src_image, RangeFromLayers(copy_region.srcSubresource), copy_region.srcOffset,
-                                                copy_region.extent, false, SYNC_COPY_TRANSFER_READ);
+                                                copy_region.extent, SYNC_COPY_TRANSFER_READ);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, pCopyImageInfo->srcImage);
                 const std::string error = error_messages_.ImageCopyResolveBlitError(
@@ -559,7 +559,7 @@ bool SyncValidator::PreCallValidateCmdCopyImage2(VkCommandBuffer commandBuffer, 
 
         if (dst_image) {
             auto hazard = context->DetectHazard(*dst_image, RangeFromLayers(copy_region.dstSubresource), copy_region.dstOffset,
-                                                copy_region.extent, false, SYNC_COPY_TRANSFER_WRITE);
+                                                copy_region.extent, SYNC_COPY_TRANSFER_WRITE);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, pCopyImageInfo->dstImage);
                 const std::string error = error_messages_.ImageCopyResolveBlitError(
@@ -905,7 +905,7 @@ bool SyncValidator::ValidateCmdCopyBufferToImage(VkCommandBuffer commandBuffer, 
             }
 
             hazard = context->DetectHazard(*dst_image, RangeFromLayers(copy_region.imageSubresource), copy_region.imageOffset,
-                                           copy_region.imageExtent, false, SYNC_COPY_TRANSFER_WRITE);
+                                           copy_region.imageExtent, SYNC_COPY_TRANSFER_WRITE);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, dstImage);
                 const std::string error = error_messages_.ImageCopyResolveBlitError(
@@ -961,7 +961,7 @@ bool SyncValidator::ValidateCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, 
     for (const auto [region_index, copy_region] : vvl::enumerate(pRegions, regionCount)) {
         if (src_image) {
             auto hazard = context->DetectHazard(*src_image, RangeFromLayers(copy_region.imageSubresource), copy_region.imageOffset,
-                                                copy_region.imageExtent, false, SYNC_COPY_TRANSFER_READ);
+                                                copy_region.imageExtent, SYNC_COPY_TRANSFER_READ);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, srcImage);
                 const std::string error = error_messages_.ImageCopyResolveBlitError(
@@ -1031,7 +1031,7 @@ bool SyncValidator::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage 
             VkExtent3D extent = {static_cast<uint32_t>(abs(blit_region.srcOffsets[1].x - blit_region.srcOffsets[0].x)),
                                  static_cast<uint32_t>(abs(blit_region.srcOffsets[1].y - blit_region.srcOffsets[0].y)),
                                  static_cast<uint32_t>(abs(blit_region.srcOffsets[1].z - blit_region.srcOffsets[0].z))};
-            auto hazard = context->DetectHazard(*src_image, RangeFromLayers(blit_region.srcSubresource), offset, extent, false,
+            auto hazard = context->DetectHazard(*src_image, RangeFromLayers(blit_region.srcSubresource), offset, extent,
                                                 SYNC_BLIT_TRANSFER_READ);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, srcImage);
@@ -1049,7 +1049,7 @@ bool SyncValidator::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage 
             VkExtent3D extent = {static_cast<uint32_t>(abs(blit_region.dstOffsets[1].x - blit_region.dstOffsets[0].x)),
                                  static_cast<uint32_t>(abs(blit_region.dstOffsets[1].y - blit_region.dstOffsets[0].y)),
                                  static_cast<uint32_t>(abs(blit_region.dstOffsets[1].z - blit_region.dstOffsets[0].z))};
-            auto hazard = context->DetectHazard(*dst_image, RangeFromLayers(blit_region.dstSubresource), offset, extent, false,
+            auto hazard = context->DetectHazard(*dst_image, RangeFromLayers(blit_region.dstSubresource), offset, extent,
                                                 SYNC_BLIT_TRANSFER_WRITE);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, dstImage);
@@ -1555,7 +1555,7 @@ bool SyncValidator::PreCallValidateCmdClearColorImage(VkCommandBuffer commandBuf
 
     if (auto image_state = Get<vvl::Image>(image)) {
         for (const auto [range_index, range] : vvl::enumerate(pRanges, rangeCount)) {
-            auto hazard = context->DetectHazard(*image_state, range, false, SYNC_CLEAR_TRANSFER_WRITE, SyncOrdering::kOrderingNone);
+            auto hazard = context->DetectHazard(*image_state, range, SYNC_CLEAR_TRANSFER_WRITE);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, image);
                 const auto error = error_messages_.ImageClearError(hazard, *cb_access_context, error_obj.location.function,
@@ -1584,7 +1584,7 @@ bool SyncValidator::PreCallValidateCmdClearDepthStencilImage(VkCommandBuffer com
 
     if (auto image_state = Get<vvl::Image>(image)) {
         for (const auto [range_index, range] : vvl::enumerate(pRanges, rangeCount)) {
-            auto hazard = context->DetectHazard(*image_state, range, false, SYNC_CLEAR_TRANSFER_WRITE, SyncOrdering::kOrderingNone);
+            auto hazard = context->DetectHazard(*image_state, range, SYNC_CLEAR_TRANSFER_WRITE);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, image);
                 const auto error = error_messages_.ImageClearError(hazard, *cb_access_context, error_obj.location.function,
@@ -1692,7 +1692,7 @@ bool SyncValidator::PreCallValidateCmdResolveImage(VkCommandBuffer commandBuffer
     for (const auto [region_index, resolve_region] : vvl::enumerate(pRegions, regionCount)) {
         if (src_image) {
             auto hazard = context->DetectHazard(*src_image, RangeFromLayers(resolve_region.srcSubresource),
-                                                resolve_region.srcOffset, resolve_region.extent, false, SYNC_RESOLVE_TRANSFER_READ);
+                                                resolve_region.srcOffset, resolve_region.extent, SYNC_RESOLVE_TRANSFER_READ);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, srcImage);
                 const std::string error = error_messages_.ImageCopyResolveBlitError(
@@ -1703,9 +1703,8 @@ bool SyncValidator::PreCallValidateCmdResolveImage(VkCommandBuffer commandBuffer
         }
 
         if (dst_image) {
-            auto hazard =
-                context->DetectHazard(*dst_image, RangeFromLayers(resolve_region.dstSubresource), resolve_region.dstOffset,
-                                      resolve_region.extent, false, SYNC_RESOLVE_TRANSFER_WRITE);
+            auto hazard = context->DetectHazard(*dst_image, RangeFromLayers(resolve_region.dstSubresource),
+                                                resolve_region.dstOffset, resolve_region.extent, SYNC_RESOLVE_TRANSFER_WRITE);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, dstImage);
                 const std::string error = error_messages_.ImageCopyResolveBlitError(
@@ -1740,7 +1739,7 @@ bool SyncValidator::PreCallValidateCmdResolveImage2(VkCommandBuffer commandBuffe
         const Location region_loc = image_info_loc.dot(Field::pRegions, region_index);
         if (src_image) {
             auto hazard = context->DetectHazard(*src_image, RangeFromLayers(resolve_region.srcSubresource),
-                                                resolve_region.srcOffset, resolve_region.extent, false, SYNC_RESOLVE_TRANSFER_READ);
+                                                resolve_region.srcOffset, resolve_region.extent, SYNC_RESOLVE_TRANSFER_READ);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, pResolveImageInfo->srcImage);
                 const std::string error = error_messages_.ImageCopyResolveBlitError(
@@ -1752,9 +1751,8 @@ bool SyncValidator::PreCallValidateCmdResolveImage2(VkCommandBuffer commandBuffe
         }
 
         if (dst_image) {
-            auto hazard =
-                context->DetectHazard(*dst_image, RangeFromLayers(resolve_region.dstSubresource), resolve_region.dstOffset,
-                                      resolve_region.extent, false, SYNC_RESOLVE_TRANSFER_WRITE);
+            auto hazard = context->DetectHazard(*dst_image, RangeFromLayers(resolve_region.dstSubresource),
+                                                resolve_region.dstOffset, resolve_region.extent, SYNC_RESOLVE_TRANSFER_WRITE);
             if (hazard.IsHazard()) {
                 const LogObjectList objlist(commandBuffer, pResolveImageInfo->dstImage);
                 const std::string error = error_messages_.ImageCopyResolveBlitError(
@@ -1873,7 +1871,7 @@ bool SyncValidator::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuff
 
     auto dst_resource = vvl::VideoPictureResource(*device_state, pDecodeInfo->dstPictureResource);
     if (dst_resource) {
-        auto hazard = context->DetectHazard(*vs_state, dst_resource, SYNC_VIDEO_DECODE_VIDEO_DECODE_WRITE);
+        auto hazard = context->DetectVideoHazard(*vs_state, dst_resource, SYNC_VIDEO_DECODE_VIDEO_DECODE_WRITE);
         if (hazard.IsHazard()) {
             std::ostringstream ss;
             ss << "decode output picture ";
@@ -1891,7 +1889,7 @@ bool SyncValidator::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuff
         const VkVideoPictureResourceInfoKHR &video_picture = *pDecodeInfo->pSetupReferenceSlot->pPictureResource;
         auto setup_resource = vvl::VideoPictureResource(*device_state, video_picture);
         if (setup_resource && (setup_resource != dst_resource)) {
-            auto hazard = context->DetectHazard(*vs_state, setup_resource, SYNC_VIDEO_DECODE_VIDEO_DECODE_WRITE);
+            auto hazard = context->DetectVideoHazard(*vs_state, setup_resource, SYNC_VIDEO_DECODE_VIDEO_DECODE_WRITE);
             if (hazard.IsHazard()) {
                 std::ostringstream ss;
                 ss << "reconstructed picture ";
@@ -1914,7 +1912,7 @@ bool SyncValidator::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuff
             const VkVideoPictureResourceInfoKHR &video_picture = *pDecodeInfo->pReferenceSlots[i].pPictureResource;
             auto reference_resource = vvl::VideoPictureResource(*device_state, video_picture);
             if (reference_resource) {
-                auto hazard = context->DetectHazard(*vs_state, reference_resource, SYNC_VIDEO_DECODE_VIDEO_DECODE_READ);
+                auto hazard = context->DetectVideoHazard(*vs_state, reference_resource, SYNC_VIDEO_DECODE_VIDEO_DECODE_READ);
                 if (hazard.IsHazard()) {
                     std::ostringstream ss;
                     ss << "reference picture " << i << " ";
@@ -1964,7 +1962,7 @@ bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuff
     }
 
     if (auto src_resource = vvl::VideoPictureResource(*device_state, pEncodeInfo->srcPictureResource)) {
-        auto hazard = context->DetectHazard(*vs_state, src_resource, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_READ);
+        auto hazard = context->DetectVideoHazard(*vs_state, src_resource, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_READ);
         if (hazard.IsHazard()) {
             std::ostringstream ss;
             ss << "encode input picture ";
@@ -1983,7 +1981,7 @@ bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuff
         const VkVideoPictureResourceInfoKHR &video_picture = *pEncodeInfo->pSetupReferenceSlot->pPictureResource;
         auto setup_resource = vvl::VideoPictureResource(*device_state, video_picture);
         if (setup_resource) {
-            auto hazard = context->DetectHazard(*vs_state, setup_resource, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_WRITE);
+            auto hazard = context->DetectVideoHazard(*vs_state, setup_resource, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_WRITE);
             if (hazard.IsHazard()) {
                 std::ostringstream ss;
                 ss << "reconstructed picture ";
@@ -2006,7 +2004,7 @@ bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuff
             const VkVideoPictureResourceInfoKHR &video_picture = *pEncodeInfo->pReferenceSlots[i].pPictureResource;
             auto reference_resource = vvl::VideoPictureResource(*device_state, video_picture);
             if (reference_resource) {
-                auto hazard = context->DetectHazard(*vs_state, reference_resource, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_READ);
+                auto hazard = context->DetectVideoHazard(*vs_state, reference_resource, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_READ);
                 if (hazard.IsHazard()) {
                     std::ostringstream ss;
                     ss << "reference picture " << i << " ";
@@ -2033,8 +2031,7 @@ bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuff
                 VkOffset3D offset = {0, 0, 0};
                 VkExtent3D extent = {quantization_map_info->quantizationMapExtent.width,
                                      quantization_map_info->quantizationMapExtent.height, 1};
-                auto hazard = context->DetectHazard(*image_view_state, offset, extent, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_READ,
-                                                    SyncOrdering::kOrderingNone);
+                auto hazard = context->DetectHazard(*image_view_state, offset, extent, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_READ);
                 if (hazard.IsHazard()) {
                     std::ostringstream ss;
                     ss << "quantization map ";


### PR DESCRIPTION
Follow up to https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/11646.

*  Add more information to `AttachmentAccess` and use it in more attachment-related places
* Previous PR propagated information to Update functions, this PR does the same for Validate (DetectHazard) functions
* Cleanup hazard detection interface and put all attachment-related validation in `DetectAttachmentHazard` functions
