### PR TITLE
tests: Fix NegativePipelineLayout.ExcessPerStageDescriptors

### DIFF
--- a/tests/unit/pipeline_layout.cpp
+++ b/tests/unit/pipeline_layout.cpp
@@ -108,300 +108,220 @@ TEST_F(NegativePipelineLayout, ExcessSubsampledPerStageDescriptors) {
     m_errorMonitor->VerifyFound();
 }
 
+struct ExcessDescriptorData {
+    ExcessDescriptorData(VkShaderStageFlags stages, VkDescriptorType type, uint32_t count)
+        : stages(stages), type(type), count(count) {}
+    VkShaderStageFlags stages;
+    VkDescriptorType type;
+    uint32_t count;
+};
+
+static void test_excess_descriptors(class NegativePipelineLayout* test, const std::vector<ExcessDescriptorData>& data,
+                                    const std::vector<const char*>& vuids, bool update_after_bind = false) {
+    if (test->PhysicalDeviceProps().limits.maxBoundDescriptorSets < data.size()) return;
+
+    VkDevice dev = test->device();
+    VkDescriptorSetLayoutBinding dslb = {};
+    VkDescriptorSetLayoutCreateInfo ds_layout_ci = vku::InitStructHelper();
+    ds_layout_ci.bindingCount = 1;
+    ds_layout_ci.pBindings = &dslb;
+    ds_layout_ci.flags = update_after_bind ? VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT
+                                           : static_cast<VkDescriptorSetLayoutCreateFlagBits>(0u);
+
+    std::vector<VkDescriptorSetLayout> ds_layouts(data.size());
+    for (uint32_t i = 0u; i < data.size(); ++i) {
+        dslb.binding = i;
+        dslb.descriptorType = data[i].type;
+        dslb.descriptorCount = data[i].count;
+        dslb.stageFlags = data[i].stages;
+        dslb.pImmutableSamplers = NULL;
+        VkResult err = vk::CreateDescriptorSetLayout(dev, &ds_layout_ci, NULL, &ds_layouts[i]);
+        ASSERT_EQ(VK_SUCCESS, err);
+    }
+
+    for (const char* vu : vuids) {
+        test->SetDesiredFailureMsg(kErrorBit, vu);
+    }
+
+    VkPipelineLayoutCreateInfo pipeline_layout_ci = vku::InitStructHelper();
+    pipeline_layout_ci.setLayoutCount = ds_layouts.size();
+    pipeline_layout_ci.pSetLayouts = ds_layouts.data();
+    VkPipelineLayout pipeline_layout = VK_NULL_HANDLE;
+    vk::CreatePipelineLayout(dev, &pipeline_layout_ci, NULL, &pipeline_layout);
+    test->VerifyFound();
+
+    for (VkDescriptorSetLayout layout : ds_layouts) {
+        vk::DestroyDescriptorSetLayout(dev, layout, NULL);
+    }
+}
+
 TEST_F(NegativePipelineLayout, ExcessPerStageDescriptors) {
     TEST_DESCRIPTION("Attempt to create a pipeline layout where total descriptors exceed per-stage limits");
 
-    AddOptionalExtensions(VK_KHR_MAINTENANCE_3_EXTENSION_NAME);
-    AddOptionalExtensions(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
-    bool descriptor_indexing =
-        IsExtensionsEnabled(VK_KHR_MAINTENANCE_3_EXTENSION_NAME) && IsExtensionsEnabled(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
 
-    uint32_t max_uniform_buffers = m_device->Physical().limits_.maxPerStageDescriptorUniformBuffers;
-    uint32_t max_storage_buffers = m_device->Physical().limits_.maxPerStageDescriptorStorageBuffers;
-    uint32_t max_sampled_images = m_device->Physical().limits_.maxPerStageDescriptorSampledImages;
-    uint32_t max_storage_images = m_device->Physical().limits_.maxPerStageDescriptorStorageImages;
-    uint32_t max_samplers = m_device->Physical().limits_.maxPerStageDescriptorSamplers;
-    uint32_t max_combined = std::min(max_samplers, max_sampled_images);
-    uint32_t max_input_attachments = m_device->Physical().limits_.maxPerStageDescriptorInputAttachments;
+    const VkPhysicalDeviceLimits& limits = PhysicalDeviceProps().limits;
+    const uint32_t mps_ubos = limits.maxPerStageDescriptorUniformBuffers;
+    const uint32_t mps_ssbos = limits.maxPerStageDescriptorStorageBuffers;
+    const uint32_t mps_sampled_images = limits.maxPerStageDescriptorSampledImages;
+    const uint32_t mps_storage_images = limits.maxPerStageDescriptorStorageImages;
+    const uint32_t mps_samplers = limits.maxPerStageDescriptorSamplers;
+    const uint32_t mps_combined = std::min(mps_samplers, mps_sampled_images);
+    const uint32_t mps_input_attachments = limits.maxPerStageDescriptorInputAttachments;
 
-    uint32_t sum_dyn_uniform_buffers = m_device->Physical().limits_.maxDescriptorSetUniformBuffersDynamic;
-    uint32_t sum_uniform_buffers = m_device->Physical().limits_.maxDescriptorSetUniformBuffers;
-    uint32_t sum_dyn_storage_buffers = m_device->Physical().limits_.maxDescriptorSetStorageBuffersDynamic;
-    uint32_t sum_storage_buffers = m_device->Physical().limits_.maxDescriptorSetStorageBuffers;
-    uint32_t sum_sampled_images = m_device->Physical().limits_.maxDescriptorSetSampledImages;
-    uint32_t sum_storage_images = m_device->Physical().limits_.maxDescriptorSetStorageImages;
-    uint32_t sum_samplers = m_device->Physical().limits_.maxDescriptorSetSamplers;
-    uint32_t sum_input_attachments = m_device->Physical().limits_.maxDescriptorSetInputAttachments;
+    const uint32_t max_dyn_ubos = limits.maxDescriptorSetUniformBuffersDynamic;
+    const uint32_t max_dyn_ssbos = limits.maxDescriptorSetStorageBuffersDynamic;
+    const uint32_t max_sampled_images = limits.maxDescriptorSetSampledImages;
+    const uint32_t max_storage_images = limits.maxDescriptorSetStorageImages;
+    const uint32_t max_samplers = limits.maxDescriptorSetSamplers;
+    const uint32_t max_input_attachments = limits.maxDescriptorSetInputAttachments;
 
-    VkPhysicalDeviceDescriptorIndexingProperties descriptor_indexing_properties =
-        vku::InitStructHelper();
-    if (descriptor_indexing) {
-        GetPhysicalDeviceProperties2(descriptor_indexing_properties);
-    }
+    std::vector<const char*> vuids;
+    std::vector<ExcessDescriptorData> data;
 
-    // Devices that report UINT32_MAX for any of these limits can't run this test
-    if (vvl::kU32Max ==
-        std::max({max_uniform_buffers, max_storage_buffers, max_sampled_images, max_storage_images, max_samplers})) {
-        GTEST_SKIP() << "Physical device limits report as UINT32_MAX";
-    }
+    // Too many sampler type descriptors
+    data.emplace_back(VK_SHADER_STAGE_FRAGMENT_BIT, VK_DESCRIPTOR_TYPE_SAMPLER, mps_samplers);
+    data.emplace_back(VK_SHADER_STAGE_FRAGMENT_BIT, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, mps_combined);
+    vuids.emplace_back("VUID-VkPipelineLayoutCreateInfo-descriptorType-03016");
+    if ((max_samplers - mps_combined) < mps_samplers) vuids.emplace_back("VUID-VkPipelineLayoutCreateInfo-descriptorType-03028");
+    test_excess_descriptors(this, data, vuids);
+    vuids.clear();
+    data.clear();
 
-    VkDescriptorSetLayoutBinding dslb = {};
-    std::vector<VkDescriptorSetLayoutBinding> dslb_vec = {};
-    VkDescriptorSetLayout ds_layout = VK_NULL_HANDLE;
-    VkDescriptorSetLayoutCreateInfo ds_layout_ci = vku::InitStructHelper();
-    VkPipelineLayoutCreateInfo pipeline_layout_ci = vku::InitStructHelper();
-    pipeline_layout_ci.setLayoutCount = 1;
-    pipeline_layout_ci.pSetLayouts = &ds_layout;
-    VkPipelineLayout pipeline_layout = VK_NULL_HANDLE;
+    // Too many uniform buffer type descriptors
+    data.emplace_back(VK_SHADER_STAGE_FRAGMENT_BIT, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, mps_ubos);
+    data.emplace_back(VK_SHADER_STAGE_FRAGMENT_BIT, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, max_dyn_ubos);
+    vuids.emplace_back("VUID-VkPipelineLayoutCreateInfo-descriptorType-03017");
+    test_excess_descriptors(this, data, vuids);
+    vuids.clear();
+    data.clear();
 
-    // VU 0fe0023e - too many sampler type descriptors in fragment stage
-    dslb_vec.clear();
-    dslb.binding = 0;
-    dslb.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
-    dslb.descriptorCount = max_samplers;
-    dslb.stageFlags = VK_SHADER_STAGE_ALL_GRAPHICS;
-    dslb.pImmutableSamplers = NULL;
-    dslb_vec.push_back(dslb);
-    dslb.binding = 1;
-    dslb.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    dslb.descriptorCount = max_combined;
-    dslb.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-    dslb_vec.push_back(dslb);
+    // Too many storage buffer type descriptors
+    data.emplace_back(VK_SHADER_STAGE_FRAGMENT_BIT, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, mps_ssbos);
+    data.emplace_back(VK_SHADER_STAGE_FRAGMENT_BIT, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC, max_dyn_ssbos);
+    vuids.emplace_back("VUID-VkPipelineLayoutCreateInfo-descriptorType-03018");
+    test_excess_descriptors(this, data, vuids);
+    vuids.clear();
+    data.clear();
 
-    ds_layout_ci.bindingCount = dslb_vec.size();
-    ds_layout_ci.pBindings = dslb_vec.data();
-    VkResult err = vk::CreateDescriptorSetLayout(device(), &ds_layout_ci, NULL, &ds_layout);
-    ASSERT_EQ(VK_SUCCESS, err);
+    // Too many sampled image type descriptors
+    data.emplace_back(VK_SHADER_STAGE_FRAGMENT_BIT, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, mps_sampled_images);
+    data.emplace_back(VK_SHADER_STAGE_FRAGMENT_BIT, VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, mps_sampled_images);
+    data.emplace_back(VK_SHADER_STAGE_FRAGMENT_BIT, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, mps_combined);
+    vuids.emplace_back("VUID-VkPipelineLayoutCreateInfo-descriptorType-06939");
+    if ((max_sampled_images - mps_sampled_images < mps_sampled_images) ||
+        (max_sampled_images - mps_sampled_images - mps_sampled_images) < mps_sampled_images)
+        vuids.emplace_back("VUID-VkPipelineLayoutCreateInfo-descriptorType-03033");
+    test_excess_descriptors(this, data, vuids);
+    vuids.clear();
+    data.clear();
 
-    m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-descriptorType-03016");
-    if ((max_samplers + max_combined) > sum_samplers) {
-        m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-descriptorType-03028");  // expect all-stages sum too
-    }
-    if (max_combined > sum_sampled_images) {
-        m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-descriptorType-03033");  // expect all-stages sum too
-    }
-    if (descriptor_indexing) {
-        if ((max_samplers + max_combined) > descriptor_indexing_properties.maxDescriptorSetUpdateAfterBindSamplers) {
-            m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-pSetLayouts-03036");
-        }
-        if ((max_samplers + max_combined) > descriptor_indexing_properties.maxPerStageDescriptorUpdateAfterBindSamplers) {
-            m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-descriptorType-03022");
-        }
-        if (max_combined > descriptor_indexing_properties.maxDescriptorSetUpdateAfterBindSampledImages) {
-            m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-pSetLayouts-03041");
-        }
-        if (max_combined > descriptor_indexing_properties.maxPerStageDescriptorUpdateAfterBindSampledImages) {
-            m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-descriptorType-03025");
-        }
-    }
-    err = vk::CreatePipelineLayout(device(), &pipeline_layout_ci, NULL, &pipeline_layout);
-    m_errorMonitor->VerifyFound();
-    vk::DestroyPipelineLayout(device(), pipeline_layout, NULL);  // Unnecessary but harmless if test passed
-    pipeline_layout = VK_NULL_HANDLE;
-    vk::DestroyDescriptorSetLayout(device(), ds_layout, NULL);
+    // Too many storage image type descriptors
+    data.emplace_back(VK_SHADER_STAGE_FRAGMENT_BIT, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, mps_storage_images);
+    data.emplace_back(VK_SHADER_STAGE_FRAGMENT_BIT, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, mps_storage_images);
+    vuids.emplace_back("VUID-VkPipelineLayoutCreateInfo-descriptorType-03020");
+    if (max_storage_images - mps_storage_images < mps_storage_images)
+        vuids.emplace_back("VUID-VkPipelineLayoutCreateInfo-descriptorType-03034");
+    test_excess_descriptors(this, data, vuids);
+    vuids.clear();
+    data.clear();
 
-    // VU 0fe00240 - too many uniform buffer type descriptors in vertex stage
-    dslb_vec.clear();
-    dslb.binding = 0;
-    dslb.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-    dslb.descriptorCount = max_uniform_buffers + 1;
-    dslb.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
-    dslb_vec.push_back(dslb);
-    dslb.binding = 1;
-    dslb.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
-    dslb.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
-    dslb_vec.push_back(dslb);
+    // Too many input attachment type descriptors
+    data.emplace_back(VK_SHADER_STAGE_FRAGMENT_BIT, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, mps_input_attachments);
+    data.emplace_back(VK_SHADER_STAGE_FRAGMENT_BIT, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, mps_input_attachments);
+    vuids.emplace_back("VUID-VkPipelineLayoutCreateInfo-descriptorType-03021");
+    if ((max_input_attachments - mps_input_attachments) < mps_input_attachments)
+        vuids.emplace_back("VUID-VkPipelineLayoutCreateInfo-descriptorType-03035");
+    test_excess_descriptors(this, data, vuids);
+    vuids.clear();
+    data.clear();
+}
 
-    ds_layout_ci.bindingCount = dslb_vec.size();
-    ds_layout_ci.pBindings = dslb_vec.data();
-    err = vk::CreateDescriptorSetLayout(device(), &ds_layout_ci, NULL, &ds_layout);
-    ASSERT_EQ(VK_SUCCESS, err);
+TEST_F(NegativePipelineLayout, ExcessPerStageDescriptorsIndexing) {
+    TEST_DESCRIPTION(
+        "Attempt to create a pipeline layout where total descriptors exceed per-stage limits with descriptor indexing");
 
-    m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-descriptorType-03017");
-    if (dslb.descriptorCount > sum_uniform_buffers) {
-        m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-descriptorType-03029");  // expect all-stages sum too
-    }
-    if (dslb.descriptorCount > sum_dyn_uniform_buffers) {
-        m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-descriptorType-03030");  // expect all-stages sum too
-    }
-    if (descriptor_indexing) {
-        if (dslb.descriptorCount > descriptor_indexing_properties.maxDescriptorSetUpdateAfterBindUniformBuffersDynamic) {
-            m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-pSetLayouts-03038");
-        }
-        if ((dslb.descriptorCount * 2) > descriptor_indexing_properties.maxPerStageDescriptorUpdateAfterBindUniformBuffers) {
-            m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-descriptorType-03023");
-        }
-        if (dslb.descriptorCount > descriptor_indexing_properties.maxDescriptorSetUpdateAfterBindUniformBuffers) {
-            m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-pSetLayouts-03037");
-        }
-    }
-    err = vk::CreatePipelineLayout(device(), &pipeline_layout_ci, NULL, &pipeline_layout);
-    m_errorMonitor->VerifyFound();
-    vk::DestroyPipelineLayout(device(), pipeline_layout, NULL);  // Unnecessary but harmless if test passed
-    pipeline_layout = VK_NULL_HANDLE;
-    vk::DestroyDescriptorSetLayout(device(), ds_layout, NULL);
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_3_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
 
-    // VU 0fe00242 - too many storage buffer type descriptors in compute stage
-    dslb_vec.clear();
-    dslb.binding = 0;
-    dslb.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    dslb.descriptorCount = max_storage_buffers + 1;
-    dslb.stageFlags = VK_SHADER_STAGE_ALL;
-    dslb_vec.push_back(dslb);
-    dslb.binding = 1;
-    dslb.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC;
-    dslb_vec.push_back(dslb);
-    dslb.binding = 2;
-    dslb.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-    dslb.stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-    dslb_vec.push_back(dslb);
+    VkPhysicalDeviceDescriptorIndexingProperties limits = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(limits);
 
-    ds_layout_ci.bindingCount = dslb_vec.size();
-    ds_layout_ci.pBindings = dslb_vec.data();
-    err = vk::CreateDescriptorSetLayout(device(), &ds_layout_ci, NULL, &ds_layout);
-    ASSERT_EQ(VK_SUCCESS, err);
+    const uint32_t mps_ubos = limits.maxPerStageDescriptorUpdateAfterBindUniformBuffers;
+    const uint32_t mps_ssbos = limits.maxPerStageDescriptorUpdateAfterBindStorageBuffers;
+    const uint32_t mps_sampled_images = limits.maxPerStageDescriptorUpdateAfterBindSampledImages;
+    const uint32_t mps_storage_images = limits.maxPerStageDescriptorUpdateAfterBindStorageImages;
+    const uint32_t mps_samplers = limits.maxPerStageDescriptorUpdateAfterBindSamplers;
+    const uint32_t mps_combined = std::min(mps_samplers, mps_sampled_images);
+    const uint32_t mps_input_attachments = limits.maxPerStageDescriptorUpdateAfterBindInputAttachments;
 
-    m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-descriptorType-03018");
-    if (dslb.descriptorCount > sum_dyn_storage_buffers) {
-        m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-descriptorType-03032");  // expect all-stages sum too
-    }
-    const uint32_t storage_buffer_count = dslb_vec[0].descriptorCount + dslb_vec[2].descriptorCount;
-    if (storage_buffer_count > sum_storage_buffers) {
-        m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-descriptorType-03031");  // expect all-stages sum too
-    }
-    if (descriptor_indexing) {
-        if (storage_buffer_count > descriptor_indexing_properties.maxDescriptorSetUpdateAfterBindStorageBuffers) {
-            m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-pSetLayouts-03039");
-        }
-        if (dslb.descriptorCount > descriptor_indexing_properties.maxDescriptorSetUpdateAfterBindStorageBuffersDynamic) {
-            m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-pSetLayouts-03040");
-        }
-        if ((dslb.descriptorCount * 3) > descriptor_indexing_properties.maxPerStageDescriptorUpdateAfterBindStorageBuffers) {
-            m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-descriptorType-03024");
-        }
-    }
-    err = vk::CreatePipelineLayout(device(), &pipeline_layout_ci, NULL, &pipeline_layout);
-    m_errorMonitor->VerifyFound();
-    vk::DestroyPipelineLayout(device(), pipeline_layout, NULL);  // Unnecessary but harmless if test passed
-    pipeline_layout = VK_NULL_HANDLE;
-    vk::DestroyDescriptorSetLayout(device(), ds_layout, NULL);
+    const uint32_t max_dyn_ubos = limits.maxDescriptorSetUpdateAfterBindUniformBuffersDynamic;
+    const uint32_t max_dyn_ssbos = limits.maxDescriptorSetUpdateAfterBindStorageBuffersDynamic;
+    const uint32_t max_sampled_images = limits.maxDescriptorSetUpdateAfterBindSampledImages;
+    const uint32_t max_storage_images = limits.maxDescriptorSetUpdateAfterBindStorageImages;
+    const uint32_t max_samplers = limits.maxDescriptorSetUpdateAfterBindSamplers;
+    const uint32_t max_input_attachments = limits.maxDescriptorSetUpdateAfterBindInputAttachments;
 
-    // VU 0fe00244 - too many sampled image type descriptors in multiple stages
-    dslb_vec.clear();
-    dslb.binding = 0;
-    dslb.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
-    dslb.descriptorCount = max_sampled_images;
-    dslb.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT;
-    dslb_vec.push_back(dslb);
-    dslb.binding = 1;
-    dslb.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
-    dslb.stageFlags = VK_SHADER_STAGE_ALL_GRAPHICS;
-    dslb_vec.push_back(dslb);
-    dslb.binding = 2;
-    dslb.descriptorCount = max_combined;
-    dslb.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    dslb_vec.push_back(dslb);
+    std::vector<const char*> vuids;
+    std::vector<ExcessDescriptorData> data;
 
-    ds_layout_ci.bindingCount = dslb_vec.size();
-    ds_layout_ci.pBindings = dslb_vec.data();
-    err = vk::CreateDescriptorSetLayout(device(), &ds_layout_ci, NULL, &ds_layout);
-    ASSERT_EQ(VK_SUCCESS, err);
+    // Too many sampler type descriptors
+    data.emplace_back(VK_SHADER_STAGE_FRAGMENT_BIT, VK_DESCRIPTOR_TYPE_SAMPLER, mps_samplers);
+    data.emplace_back(VK_SHADER_STAGE_FRAGMENT_BIT, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, mps_combined);
+    vuids.emplace_back("VUID-VkPipelineLayoutCreateInfo-descriptorType-03022");
+    if ((max_samplers - mps_combined) < mps_samplers) vuids.emplace_back("VUID-VkPipelineLayoutCreateInfo-pSetLayouts-03036");
+    test_excess_descriptors(this, data, vuids, true);
+    vuids.clear();
+    data.clear();
 
-    m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-descriptorType-06939");
-    const uint32_t sampled_image_count = max_combined + 2 * max_sampled_images;
-    if (sampled_image_count > sum_sampled_images) {
-        m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-descriptorType-03033");  // expect all-stages sum too
-    }
-    if (max_combined > sum_samplers) {
-        m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-descriptorType-03028");  // expect all-stages sum too
-    }
-    if (descriptor_indexing) {
-        if (sampled_image_count > descriptor_indexing_properties.maxDescriptorSetUpdateAfterBindSampledImages) {
-            m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-pSetLayouts-03041");
-        }
-        if (sampled_image_count > descriptor_indexing_properties.maxPerStageDescriptorUpdateAfterBindSampledImages) {
-            m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-descriptorType-03025");
-        }
-        if (max_combined > descriptor_indexing_properties.maxDescriptorSetUpdateAfterBindSamplers) {
-            m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-pSetLayouts-03036");
-        }
-        if (max_combined > descriptor_indexing_properties.maxPerStageDescriptorUpdateAfterBindSamplers) {
-            m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-descriptorType-03022");
-        }
-    }
-    err = vk::CreatePipelineLayout(device(), &pipeline_layout_ci, NULL, &pipeline_layout);
-    m_errorMonitor->VerifyFound();
-    vk::DestroyPipelineLayout(device(), pipeline_layout, NULL);  // Unnecessary but harmless if test passed
-    pipeline_layout = VK_NULL_HANDLE;
-    vk::DestroyDescriptorSetLayout(device(), ds_layout, NULL);
+    // Too many uniform buffer type descriptors
+    data.emplace_back(VK_SHADER_STAGE_FRAGMENT_BIT, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, mps_ubos);
+    data.emplace_back(VK_SHADER_STAGE_FRAGMENT_BIT, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, max_dyn_ubos);
+    vuids.emplace_back("VUID-VkPipelineLayoutCreateInfo-descriptorType-03023");
+    test_excess_descriptors(this, data, vuids, true);
+    vuids.clear();
+    data.clear();
 
-    // VU 0fe00246 - too many storage image type descriptors in fragment stage
-    dslb_vec.clear();
-    dslb.binding = 0;
-    dslb.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
-    dslb.descriptorCount = 1 + (max_storage_images / 2);
-    dslb.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-    dslb_vec.push_back(dslb);
-    dslb.binding = 1;
-    dslb.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
-    dslb.stageFlags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT | VK_SHADER_STAGE_COMPUTE_BIT;
-    dslb_vec.push_back(dslb);
+    // Too many storage buffer type descriptors
+    data.emplace_back(VK_SHADER_STAGE_FRAGMENT_BIT, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, mps_ssbos);
+    data.emplace_back(VK_SHADER_STAGE_FRAGMENT_BIT, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC, max_dyn_ssbos);
+    vuids.emplace_back("VUID-VkPipelineLayoutCreateInfo-descriptorType-03024");
+    test_excess_descriptors(this, data, vuids, true);
+    vuids.clear();
+    data.clear();
 
-    ds_layout_ci.bindingCount = dslb_vec.size();
-    ds_layout_ci.pBindings = dslb_vec.data();
-    err = vk::CreateDescriptorSetLayout(device(), &ds_layout_ci, NULL, &ds_layout);
-    ASSERT_EQ(VK_SUCCESS, err);
+    // Too many sampled image type descriptors
+    data.emplace_back(VK_SHADER_STAGE_FRAGMENT_BIT, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, mps_sampled_images);
+    data.emplace_back(VK_SHADER_STAGE_FRAGMENT_BIT, VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, mps_sampled_images);
+    data.emplace_back(VK_SHADER_STAGE_FRAGMENT_BIT, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, mps_combined);
+    vuids.emplace_back("VUID-VkPipelineLayoutCreateInfo-descriptorType-03025");
+    if ((max_sampled_images - mps_sampled_images < mps_sampled_images) ||
+        (max_sampled_images - mps_sampled_images - mps_sampled_images) < mps_sampled_images)
+        vuids.emplace_back("VUID-VkPipelineLayoutCreateInfo-pSetLayouts-03041");
+    test_excess_descriptors(this, data, vuids, true);
+    vuids.clear();
+    data.clear();
 
-    m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-descriptorType-03020");
-    const uint32_t storage_image_count = 2 * dslb.descriptorCount;
-    if (storage_image_count > sum_storage_images) {
-        m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-descriptorType-03034");  // expect all-stages sum too
-    }
-    if (descriptor_indexing) {
-        if (storage_image_count > descriptor_indexing_properties.maxDescriptorSetUpdateAfterBindStorageImages) {
-            m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-pSetLayouts-03042");
-        }
-        if (storage_image_count > descriptor_indexing_properties.maxPerStageDescriptorUpdateAfterBindStorageImages) {
-            m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-descriptorType-03026");
-        }
-    }
-    err = vk::CreatePipelineLayout(device(), &pipeline_layout_ci, NULL, &pipeline_layout);
-    m_errorMonitor->VerifyFound();
-    vk::DestroyPipelineLayout(device(), pipeline_layout, NULL);  // Unnecessary but harmless if test passed
-    pipeline_layout = VK_NULL_HANDLE;
-    vk::DestroyDescriptorSetLayout(device(), ds_layout, NULL);
+    // Too many storage image type descriptors
+    data.emplace_back(VK_SHADER_STAGE_FRAGMENT_BIT, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, mps_storage_images);
+    data.emplace_back(VK_SHADER_STAGE_FRAGMENT_BIT, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, mps_storage_images);
+    vuids.emplace_back("VUID-VkPipelineLayoutCreateInfo-descriptorType-03026");
+    if (max_storage_images - mps_storage_images < mps_storage_images)
+        vuids.emplace_back("VUID-VkPipelineLayoutCreateInfo-pSetLayouts-03042");
+    test_excess_descriptors(this, data, vuids, true);
+    vuids.clear();
+    data.clear();
 
-    // VU 0fe00d18 - too many input attachments in fragment stage
-    dslb_vec.clear();
-    dslb.binding = 0;
-    dslb.descriptorType = VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT;
-    dslb.descriptorCount = 1 + max_input_attachments;
-    dslb.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-    dslb_vec.push_back(dslb);
-
-    ds_layout_ci.bindingCount = dslb_vec.size();
-    ds_layout_ci.pBindings = dslb_vec.data();
-    err = vk::CreateDescriptorSetLayout(device(), &ds_layout_ci, NULL, &ds_layout);
-    ASSERT_EQ(VK_SUCCESS, err);
-
-    m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-descriptorType-03021");
-    if (dslb.descriptorCount > sum_input_attachments) {
-        m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-descriptorType-03035");  // expect all-stages sum too
-    }
-    if (descriptor_indexing) {
-        if (dslb.descriptorCount > descriptor_indexing_properties.maxDescriptorSetUpdateAfterBindInputAttachments) {
-            m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-pSetLayouts-03043");
-        }
-        if (dslb.descriptorCount > descriptor_indexing_properties.maxPerStageDescriptorUpdateAfterBindInputAttachments) {
-            m_errorMonitor->SetDesiredError("VUID-VkPipelineLayoutCreateInfo-descriptorType-03027");
-        }
-    }
-    err = vk::CreatePipelineLayout(device(), &pipeline_layout_ci, NULL, &pipeline_layout);
-    m_errorMonitor->VerifyFound();
-    vk::DestroyPipelineLayout(device(), pipeline_layout, NULL);  // Unnecessary but harmless if test passed
-    pipeline_layout = VK_NULL_HANDLE;
-    vk::DestroyDescriptorSetLayout(device(), ds_layout, NULL);
+    // Too many input attachment type descriptors
+    data.emplace_back(VK_SHADER_STAGE_FRAGMENT_BIT, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, mps_input_attachments);
+    data.emplace_back(VK_SHADER_STAGE_FRAGMENT_BIT, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, mps_input_attachments);
+    vuids.emplace_back("VUID-VkPipelineLayoutCreateInfo-descriptorType-03027");
+    if ((max_input_attachments - mps_input_attachments) < mps_input_attachments)
+        vuids.emplace_back("VUID-VkPipelineLayoutCreateInfo-pSetLayouts-03043");
+    test_excess_descriptors(this, data, vuids, true);
+    vuids.clear();
+    data.clear();
 }
 
 TEST_F(NegativePipelineLayout, ExcessDescriptorsOverall) {


### PR DESCRIPTION
Split descriptor layouts that would allocate more than the maximum allowed by pipeline descriptor layouts. It also splits the tests in two: one that uses descriptor indexing and one that does not. This simplifies the expected VUIDs.

This is the last test that was crashing with KK.

Reworking the other tests in the same file and adding the missing maintenance7 VUIDs are left as an exercise for the reader.