### PR TITLE
tests: Remove enabling portability

### DIFF
--- a/tests/framework/render.cpp
+++ b/tests/framework/render.cpp
@@ -153,9 +153,6 @@ bool VkRenderFramework::DeviceExtensionSupported(const char *extension_name, con
 VkInstanceCreateInfo VkRenderFramework::GetInstanceCreateInfo() const {
     VkInstanceCreateInfo info = vku::InitStructHelper();
     info.pNext = m_errorMonitor->GetDebugCreateInfo();
-#if defined(VK_USE_PLATFORM_METAL_EXT)
-    info.flags = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
-#endif
     info.pApplicationInfo = &app_info_;
     info.enabledLayerCount = size32(instance_layers_);
     info.ppEnabledLayerNames = instance_layers_.data();
@@ -193,16 +190,11 @@ void VkRenderFramework::InitFramework(void *instance_pnext) {
     };
 
     // Beginning with the 1.3.216 Vulkan SDK, the VK_KHR_PORTABILITY_subset extension is mandatory.
-#ifdef VK_USE_PLATFORM_METAL_EXT
-    AddRequiredExtensions(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
-    AddRequiredExtensions(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
-#else
     // Note by default VK_KHRONOS_PROFILES_EMULATE_PORTABILITY is true.
     if (auto str = GetEnvironment("VK_KHRONOS_PROFILES_EMULATE_PORTABILITY"); !str.empty() && str != "false") {
         AddRequiredExtensions(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
         AddRequiredExtensions(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
     }
-#endif
 
     vk::ResetAllExtensions();
 


### PR DESCRIPTION
Once https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/39858 goes in, we have a clean run of the VVL tests. I'll remove it from draft once the change goes in.

This change removes the portability extension at instance creation. If preferred, we could add some checks and try to enable based on the available driver.