### PR TITLE
layers: Ensure promise is not set for enqueued fence

### DIFF
--- a/layers/state_tracker/fence_state.cpp
+++ b/layers/state_tracker/fence_state.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2024 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
@@ -58,6 +58,13 @@ bool vvl::Fence::EnqueueSignal(vvl::Queue *queue_state, uint64_t next_seq) {
     if (scope_ != kInternal) {
         return true;
     }
+
+    // Ensure that the fence's std::promise is not set when the fence is submitted to the queue.
+    // This guarantees that we can always call set_value() on the promise during Retire.
+    // (For ill-formed applications that forgot to call vkResetFences, the fence may be in the
+    // signaled state and its promise set - this would cause a crash during Retire)
+    ResetPromise();
+
     // Mark fence in use
     state_ = kInflight;
     queue_ = queue_state;
@@ -137,13 +144,13 @@ void vvl::Fence::Reset() {
         imported_handle_type_.reset();
     }
     state_ = kUnsignaled;
-    completed_ = std::promise<void>();
-    waiter_ = std::shared_future<void>(completed_.get_future());
     present_submission_ref_.reset();
 
     // Do not reset swapchain-in-use state of each semaphore here, only stop the tracking.
     // In order to reset swapchain-in-use state we need to wait on the fence.
     present_wait_semaphores_.clear();
+
+    ResetPromise();
 }
 
 void vvl::Fence::Import(VkExternalFenceHandleTypeFlagBits handle_type, VkFenceImportFlags flags) {
@@ -170,8 +177,7 @@ void vvl::Fence::Export(VkExternalFenceHandleTypeFlagBits handle_type) {
             imported_handle_type_.reset();
         }
         state_ = kUnsignaled;
-        completed_ = std::promise<void>();
-        waiter_ = std::shared_future<void>(completed_.get_future());
+        ResetPromise();
     }
 }
 
@@ -213,4 +219,9 @@ void vvl::Fence::SetPresentWaitSemaphores(vvl::span<std::shared_ptr<vvl::Semapho
     for (const auto &semaphore : present_wait_semaphores) {
         present_wait_semaphores_.emplace_back(semaphore);
     }
+}
+
+void vvl::Fence::ResetPromise() {
+    completed_ = std::promise<void>();
+    waiter_ = std::shared_future<void>(completed_.get_future());
 }

--- a/layers/state_tracker/fence_state.h
+++ b/layers/state_tracker/fence_state.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (C) 2015-2024 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
@@ -82,6 +82,9 @@ class Fence : public RefcountedStateObject {
   private:
     ReadLockGuard ReadLock() const { return ReadLockGuard(lock_); }
     WriteLockGuard WriteLock() { return WriteLockGuard(lock_); }
+
+private:
+    void ResetPromise();
 
     Queue *queue_{nullptr};
     uint64_t seq_{0};

--- a/tests/undefined/core_undefined.cpp
+++ b/tests/undefined/core_undefined.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2025 The Khronos Group Inc.
- * Copyright (c) 2025 LunarG, Inc.
+ * Copyright (c) 2025-2026 The Khronos Group Inc.
+ * Copyright (c) 2025-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,4 +62,22 @@ TEST_F(UndefinedCore, BindInvalidPipelineLayout) {
 
     m_command_buffer.EndRenderPass();
     m_command_buffer.End();
+}
+
+TEST_F(UndefinedCore, RetireSignaledFence) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11531");
+    RETURN_IF_SKIP(Init());
+
+    vkt::Fence fence(*m_device);
+    m_default_queue->Submit(vkt::no_cmd, fence);
+    m_default_queue->Wait();
+
+    // This allows to run PreRecord during Submit for already signaled fence
+    m_errorMonitor->SetAllowedFailureMsg("VUID-vkQueueSubmit-fence-00063");
+    m_default_queue->Submit(vkt::no_cmd, fence);
+
+    // In the original issue this called Fence::Retire for the fence that was not reset (by vkResetFences)
+    // so it had its std::promise set, which led to crash during retire (promise was double set).
+    // The fix ensures that std::promise is always re-initialized when the fence is enqueued.
+    m_default_queue->Wait();
 }


### PR DESCRIPTION
For valid applications, the promise object is in the default state when the fence is enqueued (it is reset during `vkResetFences`). However, for applications that forgot to reset the fence, we must still ensure that the promise object is in the default (not set) state so it can be safely set by `Fence::Retire`.

Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11531
(tested on: 0bb8249 - fix incorrect return value check for semaphore creation)

Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8267
(I did not test, but  because it is also a crash in Video when promise is double set I assume it is the same)