### PR TITLE
layers: Remove attachment references from rp2 helper

### DIFF
--- a/tests/framework/render_pass_helper.cpp
+++ b/tests/framework/render_pass_helper.cpp
@@ -162,47 +162,73 @@ void RenderPass2SingleSubpass::SetAttachmentDescriptionPNext(uint32_t index, voi
     attachment_descriptions_[index].pNext = pNext;
 }
 
-void RenderPass2SingleSubpass::AddAttachmentReference(uint32_t attachment, VkImageLayout layout, VkImageAspectFlags aspect_mask,
-                                                      void* pNext) {
-    attachments_references_.push_back(vku::InitStruct<VkAttachmentReference2>(pNext, attachment, layout, aspect_mask));
-}
+void RenderPass2SingleSubpass::AddInputAttachment(uint32_t attachment_index, VkImageLayout layout, VkImageAspectFlags aspect_mask,
+                                                  void* pNext) {
+    VkAttachmentReference2 attachment_ref = vku::InitStructHelper(pNext);
+    attachment_ref.attachment = attachment_index;
+    attachment_ref.layout = layout;
+    attachment_ref.aspectMask = aspect_mask;
 
-void RenderPass2SingleSubpass::AddInputAttachment(uint32_t index) {
-    input_attachments_.push_back(attachments_references_[index]);
+    input_attachments_.push_back(attachment_ref);
     subpass_description_.inputAttachmentCount = input_attachments_.size();
     subpass_description_.pInputAttachments = input_attachments_.data();
 }
 
-void RenderPass2SingleSubpass::AddColorAttachment(uint32_t index) {
-    color_attachments_.push_back(attachments_references_[index]);
+void RenderPass2SingleSubpass::AddColorAttachment(uint32_t attachment_index, VkImageLayout layout, VkImageAspectFlags aspect_mask,
+                                                  void* pNext) {
+    VkAttachmentReference2 attachment_ref = vku::InitStructHelper(pNext);
+    attachment_ref.attachment = attachment_index;
+    attachment_ref.layout = layout;
+    attachment_ref.aspectMask = aspect_mask;
+
+    color_attachments_.push_back(attachment_ref);
     subpass_description_.colorAttachmentCount = color_attachments_.size();
     subpass_description_.pColorAttachments = color_attachments_.data();
 }
 
-void RenderPass2SingleSubpass::AddResolveAttachment(uint32_t index) {
-    resolve_attachment_ = attachments_references_[index];
+void RenderPass2SingleSubpass::AddResolveAttachment(uint32_t attachment_index, VkImageLayout layout, VkImageAspectFlags aspect_mask,
+                                                    void* pNext) {
+    resolve_attachment_ = vku::InitStructHelper(pNext);
+    resolve_attachment_.attachment = attachment_index;
+    resolve_attachment_.layout = layout;
+    resolve_attachment_.aspectMask = aspect_mask;
     subpass_description_.pResolveAttachments = &resolve_attachment_;
 }
 
-void RenderPass2SingleSubpass::AddDepthStencilAttachment(uint32_t index) {
-    ds_attachment_ = attachments_references_[index];
+void RenderPass2SingleSubpass::AddDepthStencilAttachment(uint32_t attachment_index, VkImageLayout layout,
+                                                         VkImageAspectFlags aspect_mask, void* pNext) {
+    ds_attachment_ = vku::InitStructHelper(pNext);
+    ds_attachment_.attachment = attachment_index;
+    ds_attachment_.layout = layout;
+    ds_attachment_.aspectMask = aspect_mask;
     subpass_description_.pDepthStencilAttachment = &ds_attachment_;
 }
 
-void RenderPass2SingleSubpass::AddDepthStencilResolveAttachment(uint32_t index, VkResolveModeFlagBits depth_resolve_mode,
+void RenderPass2SingleSubpass::AddDepthStencilResolveAttachment(uint32_t attachment_index, VkImageLayout layout,
+                                                                VkResolveModeFlagBits depth_resolve_mode,
                                                                 VkResolveModeFlagBits stencil_resolve_mode) {
-    ds_attachment_resolve_ = vku::InitStructHelper();
-    ds_attachment_resolve_.pDepthStencilResolveAttachment = &attachments_references_[index];
-    ds_attachment_resolve_.depthResolveMode = depth_resolve_mode;
-    ds_attachment_resolve_.stencilResolveMode = stencil_resolve_mode;
-    subpass_description_.pNext = &ds_attachment_resolve_;
+    ds_resolve_attachment_ = vku::InitStructHelper();
+    ds_resolve_attachment_.attachment = attachment_index;
+    ds_resolve_attachment_.layout = layout;
+
+    ds_resolve_ = vku::InitStructHelper();
+    ds_resolve_.pDepthStencilResolveAttachment = &ds_resolve_attachment_;
+    ds_resolve_.depthResolveMode = depth_resolve_mode;
+    ds_resolve_.stencilResolveMode = stencil_resolve_mode;
+
+    subpass_description_.pNext = &ds_resolve_;
 }
 
-void RenderPass2SingleSubpass::AddFragmentShadingRateAttachment(uint32_t index, VkExtent2D texel_size) {
+void RenderPass2SingleSubpass::AddFragmentShadingRateAttachment(uint32_t attachment_index, VkImageLayout layout,
+                                                                VkExtent2D texel_size) {
     fsr_attachment_ = vku::InitStructHelper();
-    fsr_attachment_.pFragmentShadingRateAttachment = &attachments_references_[index];
-    fsr_attachment_.shadingRateAttachmentTexelSize = texel_size;
-    subpass_description_.pNext = &fsr_attachment_;
+    fsr_attachment_.attachment = attachment_index;
+    fsr_attachment_.layout = layout;
+
+    fsr_attachment_info_ = vku::InitStructHelper();
+    fsr_attachment_info_.pFragmentShadingRateAttachment = &fsr_attachment_;
+    fsr_attachment_info_.shadingRateAttachmentTexelSize = texel_size;
+    subpass_description_.pNext = &fsr_attachment_info_;
 }
 
 void RenderPass2SingleSubpass::AddSubpassDependency(VkSubpassDependency2 dependency) {

--- a/tests/framework/render_pass_helper.h
+++ b/tests/framework/render_pass_helper.h
@@ -49,12 +49,6 @@ class InterfaceRenderPassSingleSubpass {
                                           VkImageLayout initialLayout = VK_IMAGE_LAYOUT_GENERAL,
                                           VkImageLayout finalLayout = VK_IMAGE_LAYOUT_GENERAL) = 0;
 
-    // Pass in index to VkAttachmentReference
-    virtual void AddInputAttachment(uint32_t index) = 0;
-    virtual void AddColorAttachment(uint32_t index) = 0;
-    virtual void AddResolveAttachment(uint32_t index) = 0;
-    virtual void AddDepthStencilAttachment(uint32_t index) = 0;
-
     virtual void AddSubpassDependency(VkPipelineStageFlags srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
                                       VkPipelineStageFlags dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
                                       VkAccessFlags srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
@@ -142,19 +136,20 @@ class RenderPass2SingleSubpass : public InterfaceRenderPassSingleSubpass {
     // Have a seperate set function to keep AddAttachmentDescription simple (very few things extend the AttachmentDescription)
     void SetAttachmentDescriptionPNext(uint32_t index, void *pNext);
 
-    void AddAttachmentReference(uint32_t attachment, VkImageLayout layout, VkImageAspectFlags aspect_mask = 0,
-                                void *pNext = nullptr);
-
-    // Pass in index to VkAttachmentReference
-    void AddInputAttachment(uint32_t index);
-    void AddColorAttachment(uint32_t index);
-    void AddResolveAttachment(uint32_t index);
-    void AddDepthStencilAttachment(uint32_t index);
+    // Pass in index to attachment description
+    void AddInputAttachment(uint32_t attachment_index, VkImageLayout layout, VkImageAspectFlags aspect_mask = 0,
+                            void *pNext = nullptr);
+    void AddColorAttachment(uint32_t attachment_index, VkImageLayout layout, VkImageAspectFlags aspect_mask = 0,
+                            void *pNext = nullptr);
+    void AddResolveAttachment(uint32_t attachment_index, VkImageLayout layout, VkImageAspectFlags aspect_mask = 0,
+                              void *pNext = nullptr);
+    void AddDepthStencilAttachment(uint32_t attachment_index, VkImageLayout layout, VkImageAspectFlags aspect_mask = 0,
+                                   void *pNext = nullptr);
     // VK_KHR_depth_stencil_resolve
-    void AddDepthStencilResolveAttachment(uint32_t index, VkResolveModeFlagBits depth_resolve_mode,
+    void AddDepthStencilResolveAttachment(uint32_t attachment_index, VkImageLayout layout, VkResolveModeFlagBits depth_resolve_mode,
                                           VkResolveModeFlagBits stencil_resolve_mode);
     // VK_KHR_fragment_shading_rate
-    void AddFragmentShadingRateAttachment(uint32_t index, VkExtent2D texel_size);
+    void AddFragmentShadingRateAttachment(uint32_t attachment_index, VkImageLayout layout, VkExtent2D texel_size);
 
     void SetViewMask(uint32_t view_mask) { subpass_description_.viewMask = view_mask; }
 
@@ -171,15 +166,16 @@ class RenderPass2SingleSubpass : public InterfaceRenderPassSingleSubpass {
     VkRenderPassCreateInfo2 rp_create_info_;
 
     std::vector<VkAttachmentDescription2> attachment_descriptions_;
-
-    std::vector<VkAttachmentReference2> attachments_references_;  // global pool
     std::vector<VkAttachmentReference2> input_attachments_;
     std::vector<VkAttachmentReference2> color_attachments_;
     VkAttachmentReference2 resolve_attachment_;
     VkAttachmentReference2 ds_attachment_;
 
-    VkSubpassDescriptionDepthStencilResolve ds_attachment_resolve_;
-    VkFragmentShadingRateAttachmentInfoKHR fsr_attachment_;
+    VkSubpassDescriptionDepthStencilResolve ds_resolve_;
+    VkAttachmentReference2 ds_resolve_attachment_;
+
+    VkFragmentShadingRateAttachmentInfoKHR fsr_attachment_info_;
+    VkAttachmentReference2 fsr_attachment_;
 
     VkSubpassDescription2 subpass_description_;
     std::vector<VkSubpassDependency2> subpass_dependencies_;

--- a/tests/unit/android_external_resolve.cpp
+++ b/tests/unit/android_external_resolve.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2023-2025 The Khronos Group Inc.
- * Copyright (c) 2023-2025 Valve Corporation
- * Copyright (c) 2023-2025 LunarG, Inc.
+ * Copyright (c) 2023-2026 The Khronos Group Inc.
+ * Copyright (c) 2023-2026 Valve Corporation
+ * Copyright (c) 2023-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,10 +41,8 @@ TEST_F(NegativeAndroidExternalResolve, SubpassDescriptionSample) {
     rp.AddAttachmentDescription(VK_FORMAT_UNDEFINED);
     rp.SetAttachmentDescriptionPNext(0, &external_format);
     rp.SetAttachmentDescriptionPNext(1, &external_format);
-    rp.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_PLANE_0_BIT);
-    rp.AddAttachmentReference(1, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
-    rp.AddColorAttachment(0);
-    rp.AddResolveAttachment(1);
+    rp.AddColorAttachment(0, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_PLANE_0_BIT);
+    rp.AddResolveAttachment(1, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
 
     m_errorMonitor->SetDesiredError("VUID-VkSubpassDescription2-externalFormatResolve-09345");
     rp.CreateRenderPass();
@@ -76,10 +74,8 @@ TEST_F(NegativeAndroidExternalResolve, AttachmentDescriptionZeroExternalFormat) 
     rp.AddAttachmentDescription(VK_FORMAT_UNDEFINED);
     rp.SetAttachmentDescriptionPNext(0, &external_format);
     rp.SetAttachmentDescriptionPNext(1, &external_format);
-    rp.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_PLANE_0_BIT);
-    rp.AddAttachmentReference(1, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
-    rp.AddColorAttachment(0);
-    rp.AddResolveAttachment(1);
+    rp.AddColorAttachment(0, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_PLANE_0_BIT);
+    rp.AddResolveAttachment(1, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
 
     m_errorMonitor->SetDesiredError("VUID-VkAttachmentDescription2-format-09334");
     rp.CreateRenderPass();
@@ -108,10 +104,8 @@ TEST_F(NegativeAndroidExternalResolve, SubpassDescriptionViewMask) {
     rp.AddAttachmentDescription(VK_FORMAT_UNDEFINED);
     rp.SetAttachmentDescriptionPNext(0, &external_format);
     rp.SetAttachmentDescriptionPNext(1, &external_format);
-    rp.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
-    rp.AddAttachmentReference(1, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
-    rp.AddColorAttachment(0);
-    rp.AddResolveAttachment(1);
+    rp.AddColorAttachment(0, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
+    rp.AddResolveAttachment(1, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
     rp.SetViewMask(1);  // bad
 
     m_errorMonitor->SetDesiredError("VUID-VkSubpassDescription2-externalFormatResolve-09346");
@@ -201,11 +195,9 @@ TEST_F(NegativeAndroidExternalResolve, SubpassDescriptionMultiPlaneInput) {
     rp.AddAttachmentDescription(VK_FORMAT_UNDEFINED);
     rp.SetAttachmentDescriptionPNext(0, &external_format);
     rp.SetAttachmentDescriptionPNext(1, &external_format);
-    rp.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_PLANE_0_BIT);
-    rp.AddAttachmentReference(1, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
-    rp.AddColorAttachment(0);
-    rp.AddResolveAttachment(1);
-    rp.AddInputAttachment(0);
+    rp.AddColorAttachment(0, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_PLANE_0_BIT);
+    rp.AddResolveAttachment(1, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
+    rp.AddInputAttachment(0, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_PLANE_0_BIT);
 
     m_errorMonitor->SetDesiredError("VUID-VkSubpassDescription2-externalFormatResolve-09348");
     rp.CreateRenderPass();
@@ -294,10 +286,8 @@ TEST_F(NegativeAndroidExternalResolve, Framebuffer) {
     rp.AddAttachmentDescription(VK_FORMAT_UNDEFINED);
     rp.SetAttachmentDescriptionPNext(0, &external_format);
     rp.SetAttachmentDescriptionPNext(1, &external_format);
-    rp.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
-    rp.AddAttachmentReference(1, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
-    rp.AddColorAttachment(0);
-    rp.AddResolveAttachment(1);
+    rp.AddColorAttachment(0, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
+    rp.AddResolveAttachment(1, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
     rp.CreateRenderPass();
 
     VkImageCreateInfo image_ci = vku::InitStructHelper();
@@ -369,10 +359,8 @@ TEST_F(NegativeAndroidExternalResolve, ImagelessFramebuffer) {
     rp.AddAttachmentDescription(VK_FORMAT_UNDEFINED);
     rp.SetAttachmentDescriptionPNext(0, &external_format);
     rp.SetAttachmentDescriptionPNext(1, &external_format);
-    rp.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_PLANE_0_BIT);
-    rp.AddAttachmentReference(1, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
-    rp.AddColorAttachment(0);
-    rp.AddResolveAttachment(1);
+    rp.AddColorAttachment(0, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_PLANE_0_BIT);
+    rp.AddResolveAttachment(1, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
     rp.CreateRenderPass();
 
     VkImageCreateInfo image_ci = vku::InitStructHelper();
@@ -491,10 +479,8 @@ TEST_F(NegativeAndroidExternalResolve, ImagelessFramebufferFormat) {
     rp.AddAttachmentDescription(VK_FORMAT_UNDEFINED);
     rp.SetAttachmentDescriptionPNext(0, &external_format);
     rp.SetAttachmentDescriptionPNext(1, &external_format);
-    rp.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_PLANE_0_BIT);
-    rp.AddAttachmentReference(1, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
-    rp.AddColorAttachment(0);
-    rp.AddResolveAttachment(1);
+    rp.AddColorAttachment(0, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_PLANE_0_BIT);
+    rp.AddResolveAttachment(1, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
     rp.CreateRenderPass();
 
     VkImageCreateInfo image_ci = vku::InitStructHelper();
@@ -787,10 +773,8 @@ TEST_F(NegativeAndroidExternalResolve, PipelineRasterizationSamples) {
     rp.AddAttachmentDescription(VK_FORMAT_UNDEFINED);
     rp.SetAttachmentDescriptionPNext(0, &external_format);
     rp.SetAttachmentDescriptionPNext(1, &external_format);
-    rp.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_PLANE_0_BIT);
-    rp.AddAttachmentReference(1, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
-    rp.AddColorAttachment(0);
-    rp.AddResolveAttachment(1);
+    rp.AddColorAttachment(0, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_PLANE_0_BIT);
+    rp.AddResolveAttachment(1, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
     rp.CreateRenderPass();
 
     CreatePipelineHelper pipe(*this, &external_format);
@@ -1117,10 +1101,8 @@ TEST_F(NegativeAndroidExternalResolve, PipelineBarrier) {
     rp.AddAttachmentDescription(format_resolve_prop.colorAttachmentFormat);
     rp.SetAttachmentDescriptionPNext(0, &external_format);
     rp.SetAttachmentDescriptionPNext(1, &external_format);
-    rp.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_PLANE_0_BIT);
-    rp.AddAttachmentReference(1, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
-    rp.AddColorAttachment(0);
-    rp.AddResolveAttachment(1);
+    rp.AddColorAttachment(0, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_PLANE_0_BIT);
+    rp.AddResolveAttachment(1, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
     rp.AddSubpassDependency();
     rp.CreateRenderPass();
 
@@ -1210,10 +1192,8 @@ TEST_F(NegativeAndroidExternalResolve, PipelineBarrierUnused) {
     rp.AddAttachmentDescription(VK_FORMAT_UNDEFINED);
     rp.SetAttachmentDescriptionPNext(0, &external_format);
     rp.SetAttachmentDescriptionPNext(1, &external_format);
-    rp.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_PLANE_0_BIT);
-    rp.AddAttachmentReference(1, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
-    rp.AddColorAttachment(0);
-    rp.AddResolveAttachment(1);
+    rp.AddColorAttachment(0, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_PLANE_0_BIT);
+    rp.AddResolveAttachment(1, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
     rp.AddSubpassDependency();
     rp.CreateRenderPass();
 
@@ -1309,10 +1289,8 @@ TEST_F(NegativeAndroidExternalResolve, RenderPassAndFramebuffer) {
     rp.AddAttachmentDescription(VK_FORMAT_UNDEFINED);
     rp.SetAttachmentDescriptionPNext(0, &external_format);
     rp.SetAttachmentDescriptionPNext(1, &external_format);
-    rp.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_PLANE_0_BIT);
-    rp.AddAttachmentReference(1, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
-    rp.AddColorAttachment(0);
-    rp.AddResolveAttachment(1);
+    rp.AddColorAttachment(0, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_PLANE_0_BIT);
+    rp.AddResolveAttachment(1, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
     rp.CreateRenderPass();
 
     VkImageCreateInfo image_ci = vku::InitStructHelper();

--- a/tests/unit/android_external_resolve_positive.cpp
+++ b/tests/unit/android_external_resolve_positive.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2023-2025 The Khronos Group Inc.
- * Copyright (c) 2023-2025 Valve Corporation
- * Copyright (c) 2023-2025 LunarG, Inc.
+ * Copyright (c) 2023-2026 The Khronos Group Inc.
+ * Copyright (c) 2023-2026 Valve Corporation
+ * Copyright (c) 2023-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,10 +63,8 @@ TEST_F(PositiveAndroidExternalResolve, RenderPassAndFramebuffer) {
     rp.AddAttachmentDescription(VK_FORMAT_UNDEFINED);
     rp.SetAttachmentDescriptionPNext(0, &external_format);
     rp.SetAttachmentDescriptionPNext(1, &external_format);
-    rp.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_PLANE_0_BIT);
-    rp.AddAttachmentReference(1, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
-    rp.AddColorAttachment(0);
-    rp.AddResolveAttachment(1);
+    rp.AddColorAttachment(0, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_PLANE_0_BIT);
+    rp.AddResolveAttachment(1, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
     rp.CreateRenderPass();
 
     VkImageCreateInfo image_ci = vku::InitStructHelper();
@@ -139,10 +137,8 @@ TEST_F(PositiveAndroidExternalResolve, ImagelessFramebuffer) {
     rp.AddAttachmentDescription(VK_FORMAT_UNDEFINED);
     rp.SetAttachmentDescriptionPNext(0, &external_format);
     rp.SetAttachmentDescriptionPNext(1, &external_format);
-    rp.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_PLANE_0_BIT);
-    rp.AddAttachmentReference(1, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
-    rp.AddColorAttachment(0);
-    rp.AddResolveAttachment(1);
+    rp.AddColorAttachment(0, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_PLANE_0_BIT);
+    rp.AddResolveAttachment(1, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
     rp.CreateRenderPass();
 
     VkImageCreateInfo image_ci = vku::InitStructHelper();
@@ -329,10 +325,8 @@ TEST_F(PositiveAndroidExternalResolve, PipelineBarrier) {
     rp.AddAttachmentDescription(VK_FORMAT_UNDEFINED);
     rp.SetAttachmentDescriptionPNext(0, &external_format);
     rp.SetAttachmentDescriptionPNext(1, &external_format);
-    rp.AddAttachmentReference(VK_ATTACHMENT_UNUSED, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_PLANE_0_BIT);
-    rp.AddAttachmentReference(1, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
-    rp.AddColorAttachment(0);
-    rp.AddResolveAttachment(1);
+    rp.AddColorAttachment(VK_ATTACHMENT_UNUSED, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_PLANE_0_BIT);
+    rp.AddResolveAttachment(1, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_COLOR_BIT);
     rp.AddSubpassDependency();
     rp.CreateRenderPass();
 

--- a/tests/unit/fragment_shading_rate.cpp
+++ b/tests/unit/fragment_shading_rate.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (c) 2015-2025 Google, Inc.
  * Modifications Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
  *
@@ -768,8 +768,7 @@ TEST_F(NegativeFragmentShadingRate, FramebufferUsage) {
 
     RenderPass2SingleSubpass rp(*this);
     rp.AddAttachmentDescription(VK_FORMAT_R8_UINT);
-    rp.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL);
-    rp.AddFragmentShadingRateAttachment(0, fsr_properties.minFragmentShadingRateAttachmentTexelSize);
+    rp.AddFragmentShadingRateAttachment(0, VK_IMAGE_LAYOUT_GENERAL, fsr_properties.minFragmentShadingRateAttachmentTexelSize);
     rp.CreateRenderPass();
 
     vkt::Image image(*m_device, 1, 1, VK_FORMAT_R8_UINT, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
@@ -797,8 +796,7 @@ TEST_F(NegativeFragmentShadingRate, FramebufferDimensions) {
 
     RenderPass2SingleSubpass rp(*this);
     rp.AddAttachmentDescription(VK_FORMAT_R8_UINT);
-    rp.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL);
-    rp.AddFragmentShadingRateAttachment(0, fsr_properties.minFragmentShadingRateAttachmentTexelSize);
+    rp.AddFragmentShadingRateAttachment(0, VK_IMAGE_LAYOUT_GENERAL, fsr_properties.minFragmentShadingRateAttachmentTexelSize);
     rp.CreateRenderPass();
 
     VkImageCreateInfo ici =
@@ -852,8 +850,7 @@ TEST_F(NegativeFragmentShadingRate, FramebufferDimensionsMultiview) {
 
     RenderPass2SingleSubpass rp(*this);
     rp.AddAttachmentDescription(VK_FORMAT_R8_UINT);
-    rp.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL);
-    rp.AddFragmentShadingRateAttachment(0, fsr_properties.minFragmentShadingRateAttachmentTexelSize);
+    rp.AddFragmentShadingRateAttachment(0, VK_IMAGE_LAYOUT_GENERAL, fsr_properties.minFragmentShadingRateAttachmentTexelSize);
     rp.SetViewMask(0x4);
     rp.CreateRenderPass();
 
@@ -1051,14 +1048,12 @@ TEST_F(NegativeFragmentShadingRate, IncompatibleFragmentRateShadingAttachmentInE
 
     RenderPass2SingleSubpass rp_fsr_1(*this);
     rp_fsr_1.AddAttachmentDescription(VK_FORMAT_R8G8B8A8_UNORM);
-    rp_fsr_1.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL);
-    rp_fsr_1.AddFragmentShadingRateAttachment(0, texel_size_1);
+    rp_fsr_1.AddFragmentShadingRateAttachment(0, VK_IMAGE_LAYOUT_GENERAL, texel_size_1);
     rp_fsr_1.CreateRenderPass();
 
     RenderPass2SingleSubpass rp_fsr_2(*this);
     rp_fsr_2.AddAttachmentDescription(VK_FORMAT_R8G8B8A8_UNORM);
-    rp_fsr_2.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL);
-    rp_fsr_2.AddFragmentShadingRateAttachment(0, texel_size_2);
+    rp_fsr_2.AddFragmentShadingRateAttachment(0, VK_IMAGE_LAYOUT_GENERAL, texel_size_2);
     rp_fsr_2.CreateRenderPass();
 
     vkt::Image image(*m_device, 32, 32, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);

--- a/tests/unit/fragment_shading_rate_positive.cpp
+++ b/tests/unit/fragment_shading_rate_positive.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2025 Valve Corporation
- * Copyright (c) 2023-2025 LunarG, Inc.
+ * Copyright (c) 2023-2026 Valve Corporation
+ * Copyright (c) 2023-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,8 +80,7 @@ TEST_F(PositiveFragmentShadingRate, Attachments) {
 
     RenderPass2SingleSubpass rp(*this);
     rp.AddAttachmentDescription(VK_FORMAT_R8_UINT);
-    rp.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL);
-    rp.AddFragmentShadingRateAttachment(0, fsr_properties.minFragmentShadingRateAttachmentTexelSize);
+    rp.AddFragmentShadingRateAttachment(0, VK_IMAGE_LAYOUT_GENERAL, fsr_properties.minFragmentShadingRateAttachmentTexelSize);
     rp.SetViewMask(0x2);
     rp.CreateRenderPass();
     vkt::Image image(*m_device, 1, 1, VK_FORMAT_R8_UINT, VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR);

--- a/tests/unit/imageless_framebuffer.cpp
+++ b/tests/unit/imageless_framebuffer.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (c) 2015-2025 Google, Inc.
  * Modifications Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
  *
@@ -680,10 +680,8 @@ TEST_F(NegativeImagelessFramebuffer, DepthStencilResolveAttachment) {
     RenderPass2SingleSubpass rp(*this);
     rp.AddAttachmentDescription(attachment_format, VK_SAMPLE_COUNT_4_BIT);  // Depth/stencil
     rp.AddAttachmentDescription(attachment_format, VK_SAMPLE_COUNT_1_BIT);  // Depth/stencil resolve
-    rp.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL);
-    rp.AddAttachmentReference(1, VK_IMAGE_LAYOUT_GENERAL);
-    rp.AddDepthStencilAttachment(0);
-    rp.AddDepthStencilResolveAttachment(1, depth_resolve_mode, stencil_resolve_mode);
+    rp.AddDepthStencilAttachment(0, VK_IMAGE_LAYOUT_GENERAL);
+    rp.AddDepthStencilResolveAttachment(1, VK_IMAGE_LAYOUT_GENERAL, depth_resolve_mode, stencil_resolve_mode);
     rp.SetViewMask(0x3u);
     rp.CreateRenderPass();
 
@@ -752,8 +750,7 @@ TEST_F(NegativeImagelessFramebuffer, FragmentShadingRateUsage) {
 
     RenderPass2SingleSubpass rp(*this);
     rp.AddAttachmentDescription(VK_FORMAT_R8_UINT);
-    rp.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL);
-    rp.AddFragmentShadingRateAttachment(0, fsr_properties.minFragmentShadingRateAttachmentTexelSize);
+    rp.AddFragmentShadingRateAttachment(0, VK_IMAGE_LAYOUT_GENERAL, fsr_properties.minFragmentShadingRateAttachmentTexelSize);
     rp.CreateRenderPass();
 
     VkFormat view_format = VK_FORMAT_R8_UINT;
@@ -798,8 +795,7 @@ TEST_F(NegativeImagelessFramebuffer, FragmentShadingRateDimensions) {
 
     RenderPass2SingleSubpass rp(*this);
     rp.AddAttachmentDescription(VK_FORMAT_R8_UINT);
-    rp.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL);
-    rp.AddFragmentShadingRateAttachment(0, fsr_properties.minFragmentShadingRateAttachmentTexelSize);
+    rp.AddFragmentShadingRateAttachment(0, VK_IMAGE_LAYOUT_GENERAL, fsr_properties.minFragmentShadingRateAttachmentTexelSize);
     rp.CreateRenderPass();
 
     VkFormat view_format = VK_FORMAT_R8_UINT;
@@ -865,8 +861,7 @@ TEST_F(NegativeImagelessFramebuffer, FragmentShadingRateDimensionsMultiview) {
 
     RenderPass2SingleSubpass rp(*this);
     rp.AddAttachmentDescription(VK_FORMAT_R8_UINT);
-    rp.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL);
-    rp.AddFragmentShadingRateAttachment(0, fsr_properties.minFragmentShadingRateAttachmentTexelSize);
+    rp.AddFragmentShadingRateAttachment(0, VK_IMAGE_LAYOUT_GENERAL, fsr_properties.minFragmentShadingRateAttachmentTexelSize);
     rp.SetViewMask(0x4);
     rp.CreateRenderPass();
 

--- a/tests/unit/imageless_framebuffer_positive.cpp
+++ b/tests/unit/imageless_framebuffer_positive.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023-2025 Valve Corporation
- * Copyright (c) 2023-2025 LunarG, Inc.
+ * Copyright (c) 2023-2026 Valve Corporation
+ * Copyright (c) 2023-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -224,16 +224,16 @@ TEST_F(PositiveImagelessFramebuffer, FragmentShadingRateDimensionsMultiview) {
     // Render Pass with view mask (0x4)
     RenderPass2SingleSubpass rp_view_mask(*this);
     rp_view_mask.AddAttachmentDescription(VK_FORMAT_R8_UINT);
-    rp_view_mask.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL);
-    rp_view_mask.AddFragmentShadingRateAttachment(0, fsr_properties.minFragmentShadingRateAttachmentTexelSize);
+    rp_view_mask.AddFragmentShadingRateAttachment(0, VK_IMAGE_LAYOUT_GENERAL,
+                                                  fsr_properties.minFragmentShadingRateAttachmentTexelSize);
     rp_view_mask.SetViewMask(0x4);
     rp_view_mask.CreateRenderPass();
 
     // Render Pass without view mask
     RenderPass2SingleSubpass rp_no_view_mask(*this);
     rp_no_view_mask.AddAttachmentDescription(VK_FORMAT_R8_UINT);
-    rp_no_view_mask.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL);
-    rp_no_view_mask.AddFragmentShadingRateAttachment(0, fsr_properties.minFragmentShadingRateAttachmentTexelSize);
+    rp_no_view_mask.AddFragmentShadingRateAttachment(0, VK_IMAGE_LAYOUT_GENERAL,
+                                                     fsr_properties.minFragmentShadingRateAttachmentTexelSize);
     rp_no_view_mask.SetViewMask(0);
     rp_no_view_mask.CreateRenderPass();
 

--- a/tests/unit/multiview.cpp
+++ b/tests/unit/multiview.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (c) 2015-2025 Google, Inc.
  * Modifications Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2021 ARM, Inc. All rights reserved.
@@ -1063,8 +1063,7 @@ TEST_F(NegativeMultiview, FeaturesDisabled) {
 
     RenderPass2SingleSubpass rp(*this);
     rp.AddAttachmentDescription(VK_FORMAT_B8G8R8A8_UNORM);
-    rp.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL);
-    rp.AddColorAttachment(0);
+    rp.AddColorAttachment(0, VK_IMAGE_LAYOUT_GENERAL);
     rp.SetViewMask(0x3u);
     rp.CreateRenderPass();
 

--- a/tests/unit/render_pass.cpp
+++ b/tests/unit/render_pass.cpp
@@ -1427,9 +1427,7 @@ TEST_F(NegativeRenderPass, BeginLayoutsStencilBufferImageUsageMismatches) {
         RenderPass2SingleSubpass rp(*this);
         rp.AddAttachmentDescription(depth_stencil_format, depth_initial_layout, VK_IMAGE_LAYOUT_GENERAL);
         rp.SetAttachmentDescriptionPNext(0, &stencil_layout);
-        rp.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT,
-                                  &stencil_ref);
-        rp.AddInputAttachment(0);
+        rp.AddInputAttachment(0, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT, &stencil_ref);
         rp.CreateRenderPass();
 
         const uint32_t fb_width = input_image.Width();
@@ -1662,10 +1660,8 @@ TEST_F(NegativeRenderPass, FramebufferDepthStencilResolveAttachment) {
     RenderPass2SingleSubpass rp(*this);
     rp.AddAttachmentDescription(attachment_format, VK_SAMPLE_COUNT_4_BIT);  // Depth/stencil
     rp.AddAttachmentDescription(attachment_format, VK_SAMPLE_COUNT_1_BIT);  // Depth/stencil resolve
-    rp.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL);
-    rp.AddAttachmentReference(1, VK_IMAGE_LAYOUT_GENERAL);
-    rp.AddDepthStencilAttachment(0);
-    rp.AddDepthStencilResolveAttachment(1, depth_resolve_mode, stencil_resolve_mode);
+    rp.AddDepthStencilAttachment(0, VK_IMAGE_LAYOUT_GENERAL);
+    rp.AddDepthStencilResolveAttachment(1, VK_IMAGE_LAYOUT_GENERAL, depth_resolve_mode, stencil_resolve_mode);
     rp.CreateRenderPass();
 
     // Depth resolve attachment, mismatched image usage
@@ -2431,10 +2427,9 @@ TEST_F(NegativeRenderPass, DepthStencilResolveAttachmentFormat) {
     RenderPass2SingleSubpass rp(*this);
     rp.AddAttachmentDescription(VK_FORMAT_R8_UNORM, VK_SAMPLE_COUNT_1_BIT);  // Depth/stencil
     rp.AddAttachmentDescription(ds_format, VK_SAMPLE_COUNT_4_BIT);           // Depth/stencil resolve
-    rp.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL);
-    rp.AddAttachmentReference(1, VK_IMAGE_LAYOUT_GENERAL);
-    rp.AddDepthStencilAttachment(1);
-    rp.AddDepthStencilResolveAttachment(0, VK_RESOLVE_MODE_SAMPLE_ZERO_BIT, VK_RESOLVE_MODE_SAMPLE_ZERO_BIT);
+    rp.AddDepthStencilAttachment(1, VK_IMAGE_LAYOUT_GENERAL);
+    rp.AddDepthStencilResolveAttachment(0, VK_IMAGE_LAYOUT_GENERAL, VK_RESOLVE_MODE_SAMPLE_ZERO_BIT,
+                                        VK_RESOLVE_MODE_SAMPLE_ZERO_BIT);
 
     m_errorMonitor->SetDesiredError("VUID-VkSubpassDescriptionDepthStencilResolve-pDepthStencilResolveAttachment-02651");
     rp.CreateRenderPass();

--- a/tests/unit/render_pass_positive.cpp
+++ b/tests/unit/render_pass_positive.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  * Copyright (c) 2015-2025 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -565,8 +565,7 @@ TEST_F(PositiveRenderPass, BeginDedicatedStencilLayout) {
     RenderPass2SingleSubpass rp(*this);
     rp.AddAttachmentDescription(ds_format, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL);
     rp.SetAttachmentDescriptionPNext(0, &attachment_desc_stencil_layout);
-    rp.AddAttachmentReference(0, VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL, 0, &attachment_ref_stencil_layout);
-    rp.AddDepthStencilAttachment(0);
+    rp.AddDepthStencilAttachment(0, VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL, 0, &attachment_ref_stencil_layout);
     rp.CreateRenderPass();
 
     vkt::Framebuffer fb(*m_device, rp, 1, &ds_view.handle(), ds_image.Width(), ds_image.Height());

--- a/tests/unit/tile_memory_heap.cpp
+++ b/tests/unit/tile_memory_heap.cpp
@@ -550,7 +550,6 @@ TEST_F(NegativeTileMemoryHeap, TileProperties) {
 
     RenderPass2SingleSubpass rp2(*this);
     rp2.AddAttachmentDescription(VK_FORMAT_R8_UINT);
-    rp2.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL);
 
     m_errorMonitor->SetDesiredError("VUID-VkTileMemorySizeInfoQCOM-size-10729");
     rp2.CreateRenderPass(&tile_memory_size_info);
@@ -558,7 +557,6 @@ TEST_F(NegativeTileMemoryHeap, TileProperties) {
 
     RenderPassSingleSubpass rp(*this);
     rp.AddAttachmentDescription(VK_FORMAT_R8_UINT);
-    rp.AddAttachmentReference({0, VK_IMAGE_LAYOUT_GENERAL});
 
     m_errorMonitor->SetDesiredError("VUID-VkTileMemorySizeInfoQCOM-size-10729");
     rp.CreateRenderPass(&tile_memory_size_info);


### PR DESCRIPTION
Removes indirection where we introduce attachment references and then specify their indices. Instead specify attachment reference information directly.