### PR TITLE
layers: Unify more RTX checks

### DIFF
--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -25,6 +25,7 @@
 #include <vulkan/utility/vk_format_utils.h>
 #include "containers/limits.h"
 #include "core_validation.h"
+#include "cc_vuid_maps.h"
 #include "core_checks/cc_state_tracker.h"
 #include "cc_buffer_address.h"
 #include "error_message/logging.h"
@@ -466,17 +467,17 @@ bool CoreChecks::ValidateAccelerationVertex(VkFormat vertex_format, VkDeviceOrHo
     return skip;
 }
 
-bool CoreChecks::ValidateAccelerationBuffers(VkCommandBuffer cmd_buffer, uint32_t info_i,
-                                             const VkAccelerationStructureBuildGeometryInfoKHR &info,
-                                             const VkAccelerationStructureBuildRangeInfoKHR *geometry_build_ranges,
-                                             const Location &info_loc) const {
+bool CoreChecks::ValidateAccelerationStructureBuildGeometryInfoDevice(
+    VkCommandBuffer cmd_buffer, uint32_t info_i, const VkAccelerationStructureBuildGeometryInfoKHR& info,
+    const VkAccelerationStructureBuildRangeInfoKHR* geometry_build_ranges, const Location& info_loc) const {
     bool skip = false;
 
     const auto pick_vuid = [&info_loc](const char *direct_build_vu, const char *indirect_build_vu) -> const char * {
         return info_loc.function == Func::vkCmdBuildAccelerationStructuresKHR ? direct_build_vu : indirect_build_vu;
     };
 
-    auto buffer_check = [this, &pick_vuid, cmd_buffer](const VkDeviceOrHostAddressConstKHR address, const Location& loc) -> bool {
+    const LogObjectList cb_objlist(cmd_buffer);
+    auto buffer_check = [this, &pick_vuid, &cb_objlist](const VkDeviceOrHostAddressConstKHR address, const Location& loc) -> bool {
         BufferAddressValidation<1> buffer_address_validator = {
             {{{pick_vuid("VUID-vkCmdBuildAccelerationStructuresKHR-geometry-03673",
                          "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-geometry-03673"),
@@ -489,12 +490,10 @@ bool CoreChecks::ValidateAccelerationBuffers(VkCommandBuffer cmd_buffer, uint32_
                },
                kUsageErrorMsgBuffer}}}};
 
-        return buffer_address_validator.ValidateDeviceAddress(*this, loc.dot(Field::deviceAddress), LogObjectList(cmd_buffer),
+        return buffer_address_validator.ValidateDeviceAddress(*this, loc.dot(Field::deviceAddress), cb_objlist,
                                                               address.deviceAddress);
     };
 
-    const LogObjectList cb_objlist(cmd_buffer);
-    const Location pp_build_range_info_loc(info_loc.function, Field::ppBuildRangeInfos, info_i);
     for (uint32_t geom_i = 0; geom_i < info.geometryCount; ++geom_i) {
         const Location p_geom_loc = info_loc.dot(info.pGeometries ? Field::pGeometries : Field::ppGeometries, geom_i);
         const Location p_geom_geom_loc = p_geom_loc.dot(Field::geometry);
@@ -535,14 +534,14 @@ bool CoreChecks::ValidateAccelerationBuffers(VkCommandBuffer cmd_buffer, uint32_
                         if (geom_i < src_as_state->build_range_infos.size()) {
                             if (const uint32_t recorded_primitive_count = src_as_state->build_range_infos[geom_i].primitiveCount;
                                 recorded_primitive_count != geometry_build_range_primitive_count) {
+                                const Location pp_build_range_info_loc(info_loc.function, Field::ppBuildRangeInfos, info_i);
                                 const LogObjectList objlist(cmd_buffer, info.srcAccelerationStructure);
-                                skip |=
-                                    LogError("VUID-vkCmdBuildAccelerationStructuresKHR-primitiveCount-03769", objlist, p_geom_loc,
-                                             " has corresponding VkAccelerationStructureBuildRangeInfoKHR %s[%" PRIu32
-                                             "], but this build range has its primitiveCount member set to (%" PRIu32
-                                             ") when it was last specified as (%" PRIu32 ").",
-                                             pp_build_range_info_loc.Fields().c_str(), geom_i, geometry_build_range_primitive_count,
-                                             recorded_primitive_count);
+                                skip |= LogError(
+                                    "VUID-vkCmdBuildAccelerationStructuresKHR-primitiveCount-03769", objlist, p_geom_loc,
+                                    " has corresponding VkAccelerationStructureBuildRangeInfoKHR %s, but this build range has its "
+                                    "primitiveCount member set to (%" PRIu32 ") when it was last specified as (%" PRIu32 ").",
+                                    pp_build_range_info_loc.brackets(geom_i).Fields().c_str(), geometry_build_range_primitive_count,
+                                    recorded_primitive_count);
                             }
                         }
                     }
@@ -751,283 +750,222 @@ bool CoreChecks::ValidateAccelerationBuffers(VkCommandBuffer cmd_buffer, uint32_
         }
     }
 
-    if (info_loc.function == Func::vkCmdBuildAccelerationStructuresKHR &&
-        !(info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR &&
-          (info.flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR))) {
-        if (const auto dst_as_state = Get<vvl::AccelerationStructureKHR>(info.dstAccelerationStructure)) {
-            const VkDeviceSize as_minimum_size =
-                rt::ComputeAccelerationStructureSize(rt::BuildType::Device, device, info, geometry_build_ranges);
-            if (dst_as_state->GetSize() < as_minimum_size) {
-                const LogObjectList objlist(cmd_buffer, info.dstAccelerationStructure);
-                skip |= LogError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-10126", objlist,
-                                 info_loc.dot(Field::dstAccelerationStructure),
-                                 " was created with size (%" PRIu64
-                                 "), but an acceleration structure build with corresponding ppBuildRangeInfos[%" PRIu32
-                                 "] requires a minimum size of (%" PRIu64 ").",
-                                 dst_as_state->GetSize(), info_i, as_minimum_size);
-            }
-        }
-    }
+    return skip;
+}
+
+bool CoreChecks::ValidateAccelerationStructureBuildScratch(VkCommandBuffer cmd_buffer,
+                                                           const VkAccelerationStructureBuildGeometryInfoKHR& info,
+                                                           const VkAccelerationStructureBuildRangeInfoKHR* geometry_build_ranges,
+                                                           const Location& info_loc) const {
+    bool skip = false;
+
     const VkDeviceSize scratch_size = info_loc.function == Func::vkCmdBuildAccelerationStructuresKHR
                                           ? rt::ComputeScratchSize(rt::BuildType::Device, device, info, geometry_build_ranges)
                                           : 1;
-    if (scratch_size > 0) {
-        if (info.scratchData.deviceAddress == 0) {
-            const char *scratch_address_range_vuid =
-                info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR
-                    ? pick_vuid("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-12261",
-                                "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-12261")
-                    : pick_vuid("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-12260",
-                                "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-12260");
-            skip |=
-                LogError(scratch_address_range_vuid, device, info_loc.dot(Field::scratchData).dot(Field::deviceAddress), "is zero");
-        } else {
-            // Hardcoded value of 1 for indirect calls because scratch size cannot be computed on the CPU in this case
-            // (need to access build ranges). Easier to hardcode than to add the logic to not perform scratch buffer size
-            // validation for indirect calls.
+    if (scratch_size == 0) {
+        return skip;
+    }
 
-            const vvl::range<VkDeviceSize> scratch_address_range(info.scratchData.deviceAddress,
-                                                                 info.scratchData.deviceAddress + scratch_size);
-            const char *scratch_address_range_vuid =
-                info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR
-                    ? pick_vuid("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-12258",
-                                "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-12258")
-                    : pick_vuid("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-12259",
-                                "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-12259");
+    const auto pick_vuid = [&info_loc](const char* direct_build_vu, const char* indirect_build_vu) -> const char* {
+        return info_loc.function == Func::vkCmdBuildAccelerationStructuresKHR ? direct_build_vu : indirect_build_vu;
+    };
 
-            const char *scratch_buffer_has_storage_flag_vuid =
-                info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR
-                    ? pick_vuid("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-12260",
-                                "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-12260")
-                    : pick_vuid("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-12261",
-                                "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-12261");
+    if (info.scratchData.deviceAddress == 0) {
+        const char* scratch_address_range_vuid = info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR
+                                                     ? pick_vuid("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-12261",
+                                                                 "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-12261")
+                                                     : pick_vuid("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-12260",
+                                                                 "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-12260");
+        skip |= LogError(scratch_address_range_vuid, device, info_loc.dot(Field::scratchData).dot(Field::deviceAddress), "is zero");
+    } else {
+        // Hardcoded value of 1 for indirect calls because scratch size cannot be computed on the CPU in this case
+        // (need to access build ranges). Easier to hardcode than to add the logic to not perform scratch buffer size
+        // validation for indirect calls.
 
-            BufferAddressValidation<2> buffer_address_validator = {
-                {{{scratch_buffer_has_storage_flag_vuid,
-                   [](const vvl::Buffer &buffer_state) { return (buffer_state.usage & VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT) == 0; },
-                   []() { return "The following buffers are missing VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT"; }, kUsageErrorMsgBuffer},
+        const vvl::range<VkDeviceSize> scratch_address_range(info.scratchData.deviceAddress,
+                                                             info.scratchData.deviceAddress + scratch_size);
+        const char* scratch_address_range_vuid = info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR
+                                                     ? pick_vuid("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-12258",
+                                                                 "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-12258")
+                                                     : pick_vuid("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-12259",
+                                                                 "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-12259");
 
-                  {scratch_address_range_vuid,
-                   [scratch_address_range](const vvl::Buffer &buffer_state) {
-                       const vvl::range<VkDeviceSize> buffer_address_range = buffer_state.DeviceAddressRange();
-                       return !buffer_address_range.includes(scratch_address_range);
-                   },
-                   [scratch_size]() {
-                       return "The scratch size (" + std::to_string(scratch_size) + ") does not fit in any buffer";
-                   },
-                   kEmptyErrorMsgBuffer}}}};
+        const char* scratch_buffer_has_storage_flag_vuid =
+            info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR
+                ? pick_vuid("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-12261",
+                            "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-12261")
+                : pick_vuid("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-12260",
+                            "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-12260");
 
-            skip |=
-                buffer_address_validator.ValidateDeviceAddress(*this, info_loc.dot(Field::scratchData).dot(Field::deviceAddress),
-                                                               cb_objlist, info.scratchData.deviceAddress, scratch_size);
+        BufferAddressValidation<2> buffer_address_validator = {
+            {{{scratch_buffer_has_storage_flag_vuid,
+               [](const vvl::Buffer& buffer_state) { return (buffer_state.usage & VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT) == 0; },
+               []() { return "The following buffers are missing VK_BUFFER_USAGE_2_STORAGE_BUFFER_BIT"; }, kUsageErrorMsgBuffer},
+
+              {scratch_address_range_vuid,
+               [scratch_address_range](const vvl::Buffer& buffer_state) {
+                   const vvl::range<VkDeviceSize> buffer_address_range = buffer_state.DeviceAddressRange();
+                   return !buffer_address_range.includes(scratch_address_range);
+               },
+               [scratch_size]() { return "The scratch size (" + std::to_string(scratch_size) + ") does not fit in any buffer"; },
+               kEmptyErrorMsgBuffer}}}};
+
+        skip |=
+            buffer_address_validator.ValidateDeviceAddress(*this, info_loc.dot(Field::scratchData).dot(Field::deviceAddress),
+                                                           LogObjectList(cmd_buffer), info.scratchData.deviceAddress, scratch_size);
+    }
+
+    return skip;
+}
+
+bool CoreChecks::ValidateAccelerationStructureBuildGeometryInfoUpdate(const vvl::AccelerationStructureKHR& src_as_state,
+                                                                      const VkAccelerationStructureBuildGeometryInfoKHR& info,
+                                                                      const Location& info_loc,
+                                                                      const VulkanTypedHandle& handle) const {
+    bool skip = false;
+
+    if (!src_as_state.is_built) {
+        const LogObjectList objlist(handle, info.srcAccelerationStructure);
+        skip |= LogError(
+            GetBuildASVUID(info_loc, vvl::BuildASError::IsBuilt_03667), objlist, info_loc.dot(Field::mode),
+            "is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR, but srcAccelerationStructure must have been previously built");
+        return skip;
+    }
+    if (!src_as_state.build_info_khr.has_value()) {
+        return skip;
+    }
+    if (!(src_as_state.build_info_khr->flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR)) {
+        const LogObjectList objlist(handle, info.srcAccelerationStructure);
+        skip |= LogError(GetBuildASVUID(info_loc, vvl::BuildASError::IsBuilt_03667), objlist, info_loc.dot(Field::mode),
+                         "is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR, but srcAccelerationStructure has been previously "
+                         "constructed with flags %s.",
+                         string_VkBuildAccelerationStructureFlagsKHR(src_as_state.build_info_khr->flags).c_str());
+    }
+
+    if (info.flags != src_as_state.build_info_khr->flags) {
+        const LogObjectList objlist(handle, info.srcAccelerationStructure);
+        skip |=
+            LogError(GetBuildASVUID(info_loc, vvl::BuildASError::SameFlags_03759), objlist, info_loc.dot(Field::mode),
+                     "is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR, but %s (%s) must have the same value as "
+                     "specified when srcAccelerationStructure was last built (%s).",
+                     info_loc.dot(Field::flags).Fields().c_str(), string_VkBuildAccelerationStructureFlagsKHR(info.flags).c_str(),
+                     string_VkBuildAccelerationStructureFlagsKHR(src_as_state.build_info_khr->flags).c_str());
+    }
+
+    if (info.type != src_as_state.build_info_khr->type) {
+        const LogObjectList objlist(handle, info.srcAccelerationStructure);
+        skip |= LogError(GetBuildASVUID(info_loc, vvl::BuildASError::SameType_03760), objlist, info_loc.dot(Field::mode),
+                         "is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR, but type (%s) must have the same value as "
+                         "specified when srcAccelerationStructure was last built (%s).",
+                         string_VkAccelerationStructureTypeKHR(info.type),
+                         string_VkAccelerationStructureTypeKHR(src_as_state.build_info_khr->type));
+    }
+
+    if (info.geometryCount != src_as_state.build_info_khr->geometryCount) {
+        const LogObjectList objlist(handle, info.srcAccelerationStructure);
+        skip |= LogError(GetBuildASVUID(info_loc, vvl::BuildASError::SameCount_03758), objlist, info_loc.dot(Field::mode),
+                         "is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR,"
+                         " but geometryCount (%" PRIu32
+                         ") must have the same value as specified when "
+                         "srcAccelerationStructure was last built (%" PRIu32 ").",
+                         info.geometryCount, src_as_state.build_info_khr->geometryCount);
+    } else if (info.pGeometries || info.ppGeometries) {
+        for (uint32_t geom_i = 0; geom_i < info.geometryCount; ++geom_i) {
+            const VkAccelerationStructureGeometryKHR& updated_geometry = rt::GetGeometry(info, geom_i);
+            const VkAccelerationStructureGeometryKHR& last_geometry =
+                rt::GetGeometry(*src_as_state.build_info_khr.value().ptr(), geom_i);
+
+            const Location geometry_ptr_loc = info_loc.dot(info.pGeometries ? Field::pGeometries : Field::ppGeometries, geom_i);
+
+            if (updated_geometry.geometryType != last_geometry.geometryType) {
+                const LogObjectList objlist(handle, info.srcAccelerationStructure);
+                skip |= LogError(GetBuildASVUID(info_loc, vvl::BuildASError::SameType_03761), objlist,
+                                 geometry_ptr_loc.dot(Field::geometryType), "is %s but was last specified as %s.",
+                                 string_VkGeometryTypeKHR(updated_geometry.geometryType),
+                                 string_VkGeometryTypeKHR(last_geometry.geometryType));
+            }
+
+            if (updated_geometry.flags != last_geometry.flags) {
+                const LogObjectList objlist(handle, info.srcAccelerationStructure);
+                skip |= LogError(GetBuildASVUID(info_loc, vvl::BuildASError::SameFlags_03762), objlist,
+                                 geometry_ptr_loc.dot(Field::flags), "is %s but was last specified as %s.",
+                                 string_VkGeometryFlagsKHR(updated_geometry.flags).c_str(),
+                                 string_VkGeometryFlagsKHR(last_geometry.flags).c_str());
+            }
+
+            if (updated_geometry.geometryType == VK_GEOMETRY_TYPE_TRIANGLES_KHR) {
+                if (updated_geometry.geometry.triangles.vertexFormat != last_geometry.geometry.triangles.vertexFormat) {
+                    const LogObjectList objlist(handle, info.srcAccelerationStructure);
+                    skip |= LogError(GetBuildASVUID(info_loc, vvl::BuildASError::TriangleVertexFormat_03763), objlist,
+                                     geometry_ptr_loc.dot(Field::geometry).dot(Field::triangles).dot(Field::vertexFormat),
+                                     "is %s but was last specified as %s.",
+                                     string_VkFormat(updated_geometry.geometry.triangles.vertexFormat),
+                                     string_VkFormat(last_geometry.geometry.triangles.vertexFormat));
+                }
+
+                if (updated_geometry.geometry.triangles.maxVertex != last_geometry.geometry.triangles.maxVertex) {
+                    const LogObjectList objlist(handle, info.srcAccelerationStructure);
+                    skip |= LogError(GetBuildASVUID(info_loc, vvl::BuildASError::TriangleMaxVertex_03764), objlist,
+                                     geometry_ptr_loc.dot(Field::geometry).dot(Field::triangles).dot(Field::maxVertex),
+                                     "is %" PRIu32 " but was last specified as %" PRIu32 ".",
+                                     updated_geometry.geometry.triangles.maxVertex, last_geometry.geometry.triangles.maxVertex);
+                }
+
+                if (updated_geometry.geometry.triangles.indexType != last_geometry.geometry.triangles.indexType) {
+                    const LogObjectList objlist(handle, info.srcAccelerationStructure);
+                    skip |= LogError(GetBuildASVUID(info_loc, vvl::BuildASError::TriangleIndexType_03765), objlist,
+                                     geometry_ptr_loc.dot(Field::geometry).dot(Field::triangles).dot(Field::indexType),
+                                     "is %s but was last specified as %s.",
+                                     string_VkIndexType(updated_geometry.geometry.triangles.indexType),
+                                     string_VkIndexType(last_geometry.geometry.triangles.indexType));
+                }
+
+                if (last_geometry.geometry.triangles.transformData.deviceAddress == 0 &&
+                    updated_geometry.geometry.triangles.transformData.deviceAddress != 0) {
+                    const LogObjectList objlist(handle, info.srcAccelerationStructure);
+                    skip |= LogError(GetBuildASVUID(info_loc, vvl::BuildASError::TriangleTransformData_03766), objlist,
+                                     geometry_ptr_loc.dot(Field::geometry).dot(Field::triangles).dot(Field::transformData),
+                                     "is 0x%" PRIx64 " but was last specified as NULL.",
+                                     updated_geometry.geometry.triangles.transformData.deviceAddress);
+                }
+
+                if (last_geometry.geometry.triangles.transformData.deviceAddress != 0 &&
+                    updated_geometry.geometry.triangles.transformData.deviceAddress == 0) {
+                    const LogObjectList objlist(handle, info.srcAccelerationStructure);
+                    skip |= LogError(GetBuildASVUID(info_loc, vvl::BuildASError::TriangleTransformData_03767), objlist,
+                                     geometry_ptr_loc.dot(Field::geometry).dot(Field::triangles).dot(Field::transformData),
+                                     "is NULL but was last specified as 0x%" PRIx64 ".",
+                                     last_geometry.geometry.triangles.transformData.deviceAddress);
+                }
+            }
         }
     }
 
     return skip;
 }
 
-bool CoreChecks::CommonBuildAccelerationStructureValidation(const VkAccelerationStructureBuildGeometryInfoKHR &info,
-                                                            const Location &info_loc, LogObjectList object_list) const {
+bool CoreChecks::ValidateAccelerationStructureBuildDst(const vvl::AccelerationStructureKHR& dst_as_state,
+                                                       const VkAccelerationStructureBuildGeometryInfoKHR& info,
+                                                       const Location& info_loc, const VulkanTypedHandle& handle) const {
     bool skip = false;
 
-    const auto src_as_state = Get<vvl::AccelerationStructureKHR>(info.srcAccelerationStructure);
-    if (!src_as_state) return skip;
-
-    if (info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR) {
-        if (!src_as_state->is_built) {
-            const char *vuid = info_loc.function == Func::vkCmdBuildAccelerationStructuresKHR
-                                   ? "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03667"
-                               : info_loc.function == Func::vkCmdBuildAccelerationStructuresIndirectKHR
-                                   ? "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03667"
-                                   : "VUID-vkBuildAccelerationStructuresKHR-pInfos-03667";
-            LogObjectList objlist = object_list;
-            objlist.add(info.srcAccelerationStructure);
+    const VkAccelerationStructureTypeKHR dst_as_type = dst_as_state.GetType();
+    if (info.type == VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR) {
+        if (dst_as_type != VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR &&
+            dst_as_type != VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR) {
             skip |= LogError(
-                vuid, objlist, info_loc.dot(Field::mode),
-                "is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR, srcAccelerationStructure must have been previously built");
-        } else if (src_as_state->build_info_khr.has_value()) {
-            if (!(src_as_state->build_info_khr->flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR)) {
-                const char *vuid = info_loc.function == Func::vkCmdBuildAccelerationStructuresKHR
-                                       ? "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03667"
-                                   : info_loc.function == Func::vkCmdBuildAccelerationStructuresIndirectKHR
-                                       ? "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03667"
-                                       : "VUID-vkBuildAccelerationStructuresKHR-pInfos-03667";
-                LogObjectList objlist = object_list;
-                objlist.add(info.srcAccelerationStructure);
-                skip |= LogError(vuid, objlist, info_loc.dot(Field::mode),
-                                 "is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR, srcAccelerationStructure has been previously "
-                                 "constructed with flags %s.",
-                                 string_VkBuildAccelerationStructureFlagsKHR(src_as_state->build_info_khr->flags).c_str());
-            }
-
-            if (info.flags != src_as_state->build_info_khr->flags) {
-                const char *vuid = info_loc.function == Func::vkCmdBuildAccelerationStructuresKHR
-                                       ? "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03759"
-                                   : info_loc.function == Func::vkCmdBuildAccelerationStructuresIndirectKHR
-                                       ? "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03759"
-                                       : "VUID-vkBuildAccelerationStructuresKHR-pInfos-03759";
-                LogObjectList objlist = object_list;
-                objlist.add(info.srcAccelerationStructure);
-                skip |= LogError(vuid, objlist, info_loc.dot(Field::mode),
-                                 "is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR, but %s (%s) must have the same value as "
-                                 "specified when srcAccelerationStructure was last built (%s).",
-                                 info_loc.dot(Field::flags).Fields().c_str(),
-                                 string_VkBuildAccelerationStructureFlagsKHR(info.flags).c_str(),
-                                 string_VkBuildAccelerationStructureFlagsKHR(src_as_state->build_info_khr->flags).c_str());
-            }
-
-            if (info.type != src_as_state->build_info_khr->type) {
-                const char *vuid = info_loc.function == Func::vkCmdBuildAccelerationStructuresKHR
-                                       ? "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03760"
-                                   : info_loc.function == Func::vkCmdBuildAccelerationStructuresIndirectKHR
-                                       ? "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03760"
-                                       : "VUID-vkBuildAccelerationStructuresKHR-pInfos-03760";
-
-                LogObjectList objlist = object_list;
-                objlist.add(info.srcAccelerationStructure);
-                skip |= LogError(vuid, objlist, info_loc.dot(Field::mode),
-                                 "is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR, but type (%s) must have the same value as "
-                                 "specified when srcAccelerationStructure was last built (%s).",
-                                 string_VkAccelerationStructureTypeKHR(info.type),
-                                 string_VkAccelerationStructureTypeKHR(src_as_state->build_info_khr->type));
-            }
-
-            if (info.geometryCount != src_as_state->build_info_khr->geometryCount) {
-                const char *vuid = info_loc.function == Func::vkCmdBuildAccelerationStructuresKHR
-                                       ? "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03758"
-                                   : info_loc.function == Func::vkCmdBuildAccelerationStructuresIndirectKHR
-                                       ? "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03758"
-                                       : "VUID-vkBuildAccelerationStructuresKHR-pInfos-03758";
-
-                LogObjectList objlist = object_list;
-                objlist.add(info.srcAccelerationStructure);
-                skip |= LogError(vuid, objlist, info_loc.dot(Field::mode),
-                                 "is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR,"
-                                 " but geometryCount (%" PRIu32
-                                 ") must have the same value as specified when "
-                                 "srcAccelerationStructure was last built (%" PRIu32 ").",
-                                 info.geometryCount, src_as_state->build_info_khr->geometryCount);
-            } else if (info.pGeometries || info.ppGeometries) {
-                for (uint32_t geom_i = 0; geom_i < info.geometryCount; ++geom_i) {
-                    const VkAccelerationStructureGeometryKHR &updated_geometry =
-                        info.pGeometries ? info.pGeometries[geom_i] : *info.ppGeometries[geom_i];
-
-                    const vku::safe_VkAccelerationStructureGeometryKHR &last_geometry =
-                        src_as_state->build_info_khr->pGeometries ? src_as_state->build_info_khr->pGeometries[geom_i]
-                                                                  : *src_as_state->build_info_khr->ppGeometries[geom_i];
-
-                    const Location geom_loc = info_loc.dot(info.pGeometries ? Field::pGeometries : Field::ppGeometries, geom_i);
-
-                    if (updated_geometry.geometryType != last_geometry.geometryType) {
-                        const char *vuid = info_loc.function == Func::vkCmdBuildAccelerationStructuresKHR
-                                               ? "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03761"
-                                           : info_loc.function == Func::vkCmdBuildAccelerationStructuresIndirectKHR
-                                               ? "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03761"
-                                               : "VUID-vkBuildAccelerationStructuresKHR-pInfos-03761";
-
-                        LogObjectList objlist = object_list;
-                        objlist.add(info.srcAccelerationStructure);
-                        skip |= LogError(vuid, objlist, geom_loc.dot(Field::geometryType), "is %s but was last specified as %s.",
-                                         string_VkGeometryTypeKHR(updated_geometry.geometryType),
-                                         string_VkGeometryTypeKHR(last_geometry.geometryType));
-                    }
-
-                    if (updated_geometry.flags != last_geometry.flags) {
-                        const char *vuid = info_loc.function == Func::vkCmdBuildAccelerationStructuresKHR
-                                               ? "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03762"
-                                           : info_loc.function == Func::vkCmdBuildAccelerationStructuresIndirectKHR
-                                               ? "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03762"
-                                               : "VUID-vkBuildAccelerationStructuresKHR-pInfos-03762";
-
-                        LogObjectList objlist = object_list;
-                        objlist.add(info.srcAccelerationStructure);
-                        skip |= LogError(vuid, objlist, geom_loc.dot(Field::flags), "is %s but was last specified as %s.",
-                                         string_VkGeometryFlagsKHR(updated_geometry.flags).c_str(),
-                                         string_VkGeometryFlagsKHR(last_geometry.flags).c_str());
-                    }
-
-                    if (updated_geometry.geometryType == VK_GEOMETRY_TYPE_TRIANGLES_KHR) {
-                        if (updated_geometry.geometry.triangles.vertexFormat != last_geometry.geometry.triangles.vertexFormat) {
-                            const char *vuid = info_loc.function == Func::vkCmdBuildAccelerationStructuresKHR
-                                                   ? "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03763"
-                                               : info_loc.function == Func::vkCmdBuildAccelerationStructuresIndirectKHR
-                                                   ? "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03763"
-                                                   : "VUID-vkBuildAccelerationStructuresKHR-pInfos-03763";
-
-                            LogObjectList objlist = object_list;
-                            objlist.add(info.srcAccelerationStructure);
-                            skip |= LogError(vuid, objlist,
-                                             geom_loc.dot(Field::geometry).dot(Field::triangles).dot(Field::vertexFormat),
-                                             "is %s but was last specified as %s.",
-                                             string_VkFormat(updated_geometry.geometry.triangles.vertexFormat),
-                                             string_VkFormat(last_geometry.geometry.triangles.vertexFormat));
-                        }
-
-                        if (updated_geometry.geometry.triangles.maxVertex != last_geometry.geometry.triangles.maxVertex) {
-                            const char *vuid = info_loc.function == Func::vkCmdBuildAccelerationStructuresKHR
-                                                   ? "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03764"
-                                               : info_loc.function == Func::vkCmdBuildAccelerationStructuresIndirectKHR
-                                                   ? "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03764"
-                                                   : "VUID-vkBuildAccelerationStructuresKHR-pInfos-03764";
-
-                            LogObjectList objlist = object_list;
-                            objlist.add(info.srcAccelerationStructure);
-                            skip |=
-                                LogError(vuid, objlist, geom_loc.dot(Field::geometry).dot(Field::triangles).dot(Field::maxVertex),
-                                         "is %" PRIu32 " but was last specified as %" PRIu32 ".",
-                                         updated_geometry.geometry.triangles.maxVertex, last_geometry.geometry.triangles.maxVertex);
-                        }
-
-                        if (updated_geometry.geometry.triangles.indexType != last_geometry.geometry.triangles.indexType) {
-                            const char *vuid = info_loc.function == Func::vkCmdBuildAccelerationStructuresKHR
-                                                   ? "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03765"
-                                               : info_loc.function == Func::vkCmdBuildAccelerationStructuresIndirectKHR
-                                                   ? "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03765"
-                                                   : "VUID-vkBuildAccelerationStructuresKHR-pInfos-03765";
-
-                            LogObjectList objlist = object_list;
-                            objlist.add(info.srcAccelerationStructure);
-                            skip |=
-                                LogError(vuid, objlist, geom_loc.dot(Field::geometry).dot(Field::triangles).dot(Field::indexType),
-                                         "is %s but was last specified as %s.",
-                                         string_VkIndexType(updated_geometry.geometry.triangles.indexType),
-                                         string_VkIndexType(last_geometry.geometry.triangles.indexType));
-                        }
-
-                        if (last_geometry.geometry.triangles.transformData.deviceAddress == 0 &&
-                            updated_geometry.geometry.triangles.transformData.deviceAddress != 0) {
-                            const char *vuid = info_loc.function == Func::vkCmdBuildAccelerationStructuresKHR
-                                                   ? "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03766"
-                                               : info_loc.function == Func::vkCmdBuildAccelerationStructuresIndirectKHR
-                                                   ? "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03766"
-                                                   : "VUID-vkBuildAccelerationStructuresKHR-pInfos-03766";
-
-                            LogObjectList objlist = object_list;
-                            objlist.add(info.srcAccelerationStructure);
-                            skip |= LogError(vuid, objlist,
-                                             geom_loc.dot(Field::geometry).dot(Field::triangles).dot(Field::transformData),
-                                             "is 0x%" PRIx64 " but was last specified as NULL.",
-                                             updated_geometry.geometry.triangles.transformData.deviceAddress);
-                        }
-
-                        if (last_geometry.geometry.triangles.transformData.deviceAddress != 0 &&
-                            updated_geometry.geometry.triangles.transformData.deviceAddress == 0) {
-                            const char *vuid = info_loc.function == Func::vkCmdBuildAccelerationStructuresKHR
-                                                   ? "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03767"
-                                               : info_loc.function == Func::vkCmdBuildAccelerationStructuresIndirectKHR
-                                                   ? "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03767"
-                                                   : "VUID-vkBuildAccelerationStructuresKHR-pInfos-03767";
-
-                            LogObjectList objlist = object_list;
-                            objlist.add(info.srcAccelerationStructure);
-                            skip |= LogError(vuid, objlist,
-                                             geom_loc.dot(Field::geometry).dot(Field::triangles).dot(Field::transformData),
-                                             "is NULL but was last specified as 0x%" PRIx64 ".",
-                                             last_geometry.geometry.triangles.transformData.deviceAddress);
-                        }
-                    }
-                }
-            }
+                GetBuildASVUID(info_loc, vvl::BuildASError::DstBottom_03700), handle, info_loc.dot(Field::type),
+                "is VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR, but its dstAccelerationStructure was created with %s.",
+                string_VkAccelerationStructureTypeKHR(dst_as_type));
+        }
+    }
+    if (info.type == VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR) {
+        if (dst_as_type != VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR &&
+            dst_as_type != VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR) {
+            skip |=
+                LogError(GetBuildASVUID(info_loc, vvl::BuildASError::DstTop_03699), handle, info_loc.dot(Field::type),
+                         "is VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR, but its dstAccelerationStructure was created with %s.",
+                         string_VkAccelerationStructureTypeKHR(dst_as_type));
         }
     }
 
@@ -1057,7 +995,7 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresKHR(
         if (const auto src_as_state = Get<vvl::AccelerationStructureKHR>(info.srcAccelerationStructure)) {
             if (info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR) {
                 if (!src_as_state->buffer_state) {
-                    const LogObjectList objlist(device, commandBuffer, info.srcAccelerationStructure);
+                    const LogObjectList objlist(commandBuffer, info.srcAccelerationStructure);
                     skip |= LogError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03708", objlist, info_loc.dot(Field::mode),
                                      "is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR but the buffer associated with "
                                      "srcAccelerationStructure is not valid.");
@@ -1066,6 +1004,8 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresKHR(
                                                           info_loc.dot(Field::srcAccelerationStructure),
                                                           "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03708");
                 }
+
+                skip |= ValidateAccelerationStructureBuildGeometryInfoUpdate(*src_as_state, info, info_loc, error_obj.handle);
             }
         }
 
@@ -1073,32 +1013,28 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresKHR(
             skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *dst_as_state->buffer_state,
                                                   info_loc.dot(Field::dstAccelerationStructure),
                                                   "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03707");
-            const auto dst_as_type = dst_as_state->GetType();
-            if (info.type == VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR) {
-                if (dst_as_type != VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR &&
-                    dst_as_type != VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR) {
-                    const LogObjectList objlist(device, commandBuffer);
-                    skip |= LogError(
-                        "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03700", objlist, info_loc.dot(Field::type),
-                        "is VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR, but its dstAccelerationStructure was created with %s.",
-                        string_VkAccelerationStructureTypeKHR(dst_as_type));
-                }
-            }
-            if (info.type == VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR) {
-                if (dst_as_type != VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR &&
-                    dst_as_type != VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR) {
-                    const LogObjectList objlist(device, commandBuffer);
-                    skip |= LogError(
-                        "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03699", objlist, info_loc.dot(Field::type),
-                        "is VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR, but its dstAccelerationStructure was created with %s.",
-                        string_VkAccelerationStructureTypeKHR(dst_as_type));
+
+            skip |= ValidateAccelerationStructureBuildDst(*dst_as_state, info, info_loc, error_obj.handle);
+
+            if (!(info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR &&
+                  (info.flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR))) {
+                const VkDeviceSize as_minimum_size =
+                    rt::ComputeAccelerationStructureSize(rt::BuildType::Device, device, info, ppBuildRangeInfos[info_i]);
+                if (dst_as_state->GetSize() < as_minimum_size) {
+                    const LogObjectList objlist(commandBuffer, info.dstAccelerationStructure);
+                    skip |= LogError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-10126", objlist,
+                                     info_loc.dot(Field::dstAccelerationStructure),
+                                     " was created with size (%" PRIu64
+                                     "), but an acceleration structure build with corresponding ppBuildRangeInfos[%" PRIu32
+                                     "] requires a minimum size of (%" PRIu64 ").",
+                                     dst_as_state->GetSize(), info_i, as_minimum_size);
                 }
             }
         }
 
-        skip |= CommonBuildAccelerationStructureValidation(info, info_loc, commandBuffer);
-
-        skip |= ValidateAccelerationBuffers(commandBuffer, info_i, info, ppBuildRangeInfos[info_i], info_loc);
+        skip |=
+            ValidateAccelerationStructureBuildGeometryInfoDevice(commandBuffer, info_i, info, ppBuildRangeInfos[info_i], info_loc);
+        skip |= ValidateAccelerationStructureBuildScratch(commandBuffer, info, ppBuildRangeInfos[info_i], info_loc);
     }
 
     skip |= ValidateAccelerationStructuresDeviceScratchBufferMemoryAliasing(commandBuffer, infoCount, pInfos, ppBuildRangeInfos,
@@ -1127,6 +1063,7 @@ bool CoreChecks::PreCallValidateBuildAccelerationStructuresKHR(
                 skip |=
                     ValidateAccelStructBufferMemoryIsNotMultiInstance(*src_as_state, info_loc.dot(Field::srcAccelerationStructure),
                                                                       "VUID-vkBuildAccelerationStructuresKHR-pInfos-03776");
+                skip |= ValidateAccelerationStructureBuildGeometryInfoUpdate(*src_as_state, info, info_loc, error_obj.handle);
             }
         }
 
@@ -1136,6 +1073,8 @@ bool CoreChecks::PreCallValidateBuildAccelerationStructuresKHR(
 
             skip |= ValidateAccelStructBufferMemoryIsNotMultiInstance(*dst_as_state, info_loc.dot(Field::dstAccelerationStructure),
                                                                       "VUID-vkBuildAccelerationStructuresKHR-pInfos-03775");
+
+            skip |= ValidateAccelerationStructureBuildDst(*dst_as_state, info, info_loc, error_obj.handle);
 
             if (!(info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR &&
                   (info.flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR))) {
@@ -1149,29 +1088,6 @@ bool CoreChecks::PreCallValidateBuildAccelerationStructuresKHR(
                                      "), but an acceleration structure build with corresponding ppBuildRangeInfos[%" PRIu32
                                      "] requires a minimum size of (%" PRIu64 ").",
                                      dst_as_state->GetSize(), info_i, as_minimum_size);
-                }
-            }
-
-            const auto dst_as_type = dst_as_state->GetType();
-            if (info.type == VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR) {
-                if (dst_as_type != VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR &&
-                    dst_as_type != VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR) {
-                    skip |= LogError("VUID-vkBuildAccelerationStructuresKHR-pInfos-03700", info.dstAccelerationStructure,
-                                     info_loc.dot(Field::type),
-                                     "is VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR, but its dstAccelerationStructure was "
-                                     "built with type %s.",
-                                     string_VkAccelerationStructureTypeKHR(dst_as_type));
-                }
-            }
-
-            if (info.type == VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR) {
-                if (dst_as_type != VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR &&
-                    dst_as_type != VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR) {
-                    skip |= LogError(
-                        "VUID-vkBuildAccelerationStructuresKHR-pInfos-03699", info.dstAccelerationStructure,
-                        info_loc.dot(Field::type),
-                        "is VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR, but its dstAccelerationStructure was built with type %s.",
-                        string_VkAccelerationStructureTypeKHR(dst_as_type));
                 }
             }
         }
@@ -1205,8 +1121,6 @@ bool CoreChecks::PreCallValidateBuildAccelerationStructuresKHR(
             }
         }
 
-        skip |= CommonBuildAccelerationStructureValidation(info, info_loc, LogObjectList());
-
         for (uint32_t geom_i = 0; geom_i < info.geometryCount; ++geom_i) {
             const VkAccelerationStructureGeometryKHR &geom = rt::GetGeometry(info, geom_i);
 
@@ -1216,68 +1130,71 @@ bool CoreChecks::PreCallValidateBuildAccelerationStructuresKHR(
 
             const Location geometry_loc = info_loc.dot(info.pGeometries ? Field::pGeometries : Field::ppGeometries, geom_i);
 
+            const VkAccelerationStructureBuildRangeInfoKHR& build_range = ppBuildRangeInfos[info_i][geom_i];
+
             if (info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR && src_as_state &&
                 src_as_state->build_info_khr.has_value()) {
                 if (geom_i < src_as_state->build_range_infos.size()) {
                     if (const uint32_t recorded_primitive_count = src_as_state->build_range_infos[geom_i].primitiveCount;
-                        recorded_primitive_count != ppBuildRangeInfos[info_i][geom_i].primitiveCount) {
+                        recorded_primitive_count != build_range.primitiveCount) {
                         const LogObjectList objlist(info.srcAccelerationStructure);
-                        skip |= LogError("VUID-vkCmdBuildAccelerationStructuresKHR-primitiveCount-03769", objlist, geometry_loc,
-                                         " has corresponding VkAccelerationStructureBuildRangeInfoKHR %s[%" PRIu32
-                                         "], but this build range has its primitiveCount member set to (%" PRIu32
-                                         ") when it was last specified as (%" PRIu32 ").",
-                                         error_obj.location.dot(Field::ppBuildRangeInfos, info_i).Fields().c_str(), geom_i,
-                                         ppBuildRangeInfos[info_i][geom_i].primitiveCount, recorded_primitive_count);
+                        skip |=
+                            LogError("VUID-vkCmdBuildAccelerationStructuresKHR-primitiveCount-03769", objlist, geometry_loc,
+                                     " has corresponding VkAccelerationStructureBuildRangeInfoKHR %s, but this build range has its "
+                                     "primitiveCount member set to (%" PRIu32 ") when it was last specified as (%" PRIu32 ").",
+                                     error_obj.location.dot(Field::ppBuildRangeInfos, info_i).brackets(geom_i).Fields().c_str(),
+                                     build_range.primitiveCount, recorded_primitive_count);
                     }
                 }
             }
 
-            for (uint32_t instance_i = 0; instance_i < ppBuildRangeInfos[info_i][geom_i].primitiveCount; ++instance_i) {
+            for (uint32_t instance_i = 0; instance_i < build_range.primitiveCount; ++instance_i) {
+                if (!geom.geometry.instances.data.hostAddress) {
+                    continue;
+                }
                 const VkAccelerationStructureInstanceKHR *instance = nullptr;
-                if (geom.geometry.instances.data.hostAddress) {
-                    if (geom.geometry.instances.arrayOfPointers) {
-                        auto instance_pointers_array = reinterpret_cast<VkAccelerationStructureInstanceKHR const *const *>(
-                            geom.geometry.instances.data.hostAddress);
-                        instance = instance_pointers_array[instance_i];
-                    } else {
-                        auto instances_array =
-                            reinterpret_cast<VkAccelerationStructureInstanceKHR const *>(geom.geometry.instances.data.hostAddress);
-                        instance = instances_array + instance_i;
-                    }
+                if (geom.geometry.instances.arrayOfPointers) {
+                    auto instance_pointers_array = reinterpret_cast<VkAccelerationStructureInstanceKHR const* const*>(
+                        geom.geometry.instances.data.hostAddress);
+                    instance = instance_pointers_array[instance_i];
+                } else {
+                    auto instances_array =
+                        reinterpret_cast<VkAccelerationStructureInstanceKHR const*>(geom.geometry.instances.data.hostAddress);
+                    instance = instances_array + instance_i;
+                }
 
-                    // Can only get here if geom.geometry.instances.arrayOfPointers is true
-                    if (!instance) {
-                        skip |= LogError(
-                            "VUID-vkBuildAccelerationStructuresKHR-pInfos-03779", device,
-                            geometry_loc.dot(Field::geometry)
-                                .dot(Field::instances)
-                                .dot(Field::data)
-                                .dot(Field::hostAddress, instance_i),
-                            "(0x%p) does not reference a valid VkAccelerationStructureKHR object. %s is %s.", instance,
-                            geometry_loc.dot(Field::geometry).dot(Field::instances).dot(Field::arrayOfPointers).Fields().c_str(),
-                            string_VkBool32(geom.geometry.instances.arrayOfPointers).c_str());
+                // Can only get here if geom.geometry.instances.arrayOfPointers is true
+                if (!instance) {
+                    skip |= LogError(
+                        "VUID-vkBuildAccelerationStructuresKHR-pInfos-03779", device,
+                        geometry_loc.dot(Field::geometry)
+                            .dot(Field::instances)
+                            .dot(Field::data)
+                            .dot(Field::hostAddress, instance_i),
+                        "(0x%p) does not reference a valid VkAccelerationStructureKHR object. %s is %s.", instance,
+                        geometry_loc.dot(Field::geometry).dot(Field::instances).dot(Field::arrayOfPointers).Fields().c_str(),
+                        string_VkBool32(geom.geometry.instances.arrayOfPointers).c_str());
 
-                        // Following checks rely on instance not being null
-                        continue;
-                    }
+                    // Following checks rely on instance not being null
+                    continue;
+                }
 
-                    const VkAccelerationStructureKHR accel_struct =
-                        CastFromUint64<VkAccelerationStructureKHR>(instance->accelerationStructureReference);
-                    auto accel_struct_state = Get<vvl::AccelerationStructureKHR>(accel_struct);
+                const VkAccelerationStructureKHR accel_struct =
+                    CastFromUint64<VkAccelerationStructureKHR>(instance->accelerationStructureReference);
+                auto accel_struct_state = Get<vvl::AccelerationStructureKHR>(accel_struct);
 
-                    if (!accel_struct_state) {
-                        skip |= LogError(
-                            "VUID-vkBuildAccelerationStructuresKHR-pInfos-03779", device,
-                            geometry_loc.dot(Field::geometry)
-                                .dot(Field::instances)
-                                .dot(Field::data)
-                                .dot(Field::hostAddress, instance_i)
-                                .dot(Field::accelerationStructureReference),
-                            "(%" PRIu64 ") does not reference a valid VkAccelerationStructureKHR object. %s is %s.",
-                            instance->accelerationStructureReference,
-                            geometry_loc.dot(Field::geometry).dot(Field::instances).dot(Field::arrayOfPointers).Fields().c_str(),
-                            string_VkBool32(geom.geometry.instances.arrayOfPointers).c_str());
-                    }
+                if (!accel_struct_state) {
+                    skip |= LogError(
+                        "VUID-vkBuildAccelerationStructuresKHR-pInfos-03779", device,
+                        geometry_loc.dot(Field::geometry)
+                            .dot(Field::instances)
+                            .dot(Field::data)
+                            .dot(Field::hostAddress, instance_i)
+                            .dot(Field::accelerationStructureReference),
+                        "(%" PRIu64 ") does not reference a valid VkAccelerationStructureKHR object. %s is %s.",
+                        instance->accelerationStructureReference,
+                        geometry_loc.dot(Field::geometry).dot(Field::instances).dot(Field::arrayOfPointers).Fields().c_str(),
+                        string_VkBool32(geom.geometry.instances.arrayOfPointers).c_str());
                 }
             }
         }
@@ -1304,9 +1221,19 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresIndirectKHR(VkComm
 
         if (auto src_as_state = Get<vvl::AccelerationStructureKHR>(info.srcAccelerationStructure)) {
             if (info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR) {
-                skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *src_as_state->buffer_state,
-                                                      info_loc.dot(Field::srcAccelerationStructure),
-                                                      "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03708");
+                if (!src_as_state->buffer_state) {
+                    const LogObjectList objlist(commandBuffer, info.srcAccelerationStructure);
+                    skip |= LogError("VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03708", objlist,
+                                     info_loc.dot(Field::mode),
+                                     "is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR but the buffer associated with "
+                                     "srcAccelerationStructure is not valid.");
+                } else {
+                    skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *src_as_state->buffer_state,
+                                                          info_loc.dot(Field::srcAccelerationStructure),
+                                                          "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03708");
+                }
+
+                skip |= ValidateAccelerationStructureBuildGeometryInfoUpdate(*src_as_state, info, info_loc, error_obj.handle);
             }
         }
 
@@ -1314,35 +1241,14 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresIndirectKHR(VkComm
             skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *dst_as_state->buffer_state,
                                                   info_loc.dot(Field::dstAccelerationStructure),
                                                   "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03707");
-            const auto dst_as_type = dst_as_state->GetType();
-            if (info.type == VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR) {
-                if (dst_as_type != VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR &&
-                    dst_as_type != VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR) {
-                    skip |= LogError("VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03700", info.dstAccelerationStructure,
-                                     info_loc.dot(Field::type),
-                                     "is VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR, but its dstAccelerationStructure was "
-                                     "built with type %s.",
-                                     string_VkAccelerationStructureTypeKHR(dst_as_type));
-                }
-            }
 
-            if (info.type == VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR) {
-                if (dst_as_type != VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR &&
-                    dst_as_type != VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR) {
-                    skip |= LogError(
-                        "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03699", info.dstAccelerationStructure,
-                        info_loc.dot(Field::type),
-                        "is VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR, but its dstAccelerationStructure was built with type %s.",
-                        string_VkAccelerationStructureTypeKHR(dst_as_type));
-                }
-            }
+            skip |= ValidateAccelerationStructureBuildDst(*dst_as_state, info, info_loc, error_obj.handle);
         }
 
         skip |= ValidateAccelerationStructuresMemoryAlisasing(commandBuffer, infoCount, pInfos, info_i, error_obj);
 
-        skip |= CommonBuildAccelerationStructureValidation(info, info_loc, commandBuffer);
-
-        skip |= ValidateAccelerationBuffers(commandBuffer, info_i, info, nullptr, info_loc);
+        skip |= ValidateAccelerationStructureBuildGeometryInfoDevice(commandBuffer, info_i, info, nullptr, info_loc);
+        skip |= ValidateAccelerationStructureBuildScratch(commandBuffer, info, nullptr, info_loc);
     }
     return skip;
 }

--- a/layers/core_checks/cc_vuid_maps.cpp
+++ b/layers/core_checks/cc_vuid_maps.cpp
@@ -598,6 +598,92 @@ const std::string &GetImageImageLayoutVUID(const Location &loc) {
     return result;
 }
 
+const char* GetBuildASVUID(const Location& loc, BuildASError error) {
+    // clang-format off
+    switch (error) {
+        case BuildASError::IsBuilt_03667:
+            return
+                loc.function == Func::vkBuildAccelerationStructuresKHR  ? "VUID-vkBuildAccelerationStructuresKHR-pInfos-03667" :
+                loc.function == Func::vkCmdBuildAccelerationStructuresKHR  ? "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03667" :
+                loc.function == Func::vkCmdBuildAccelerationStructuresIndirectKHR  ? "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03667" :
+                kVUIDUndefined;
+        case BuildASError::SameCount_03758:
+            return
+                loc.function == Func::vkBuildAccelerationStructuresKHR  ? "VUID-vkBuildAccelerationStructuresKHR-pInfos-03758" :
+                loc.function == Func::vkCmdBuildAccelerationStructuresKHR  ? "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03758" :
+                loc.function == Func::vkCmdBuildAccelerationStructuresIndirectKHR  ? "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03758" :
+                kVUIDUndefined;
+        case BuildASError::SameFlags_03759:
+            return
+                loc.function == Func::vkBuildAccelerationStructuresKHR  ? "VUID-vkBuildAccelerationStructuresKHR-pInfos-03759" :
+                loc.function == Func::vkCmdBuildAccelerationStructuresKHR  ? "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03759" :
+                loc.function == Func::vkCmdBuildAccelerationStructuresIndirectKHR  ? "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03759" :
+                kVUIDUndefined;
+        case BuildASError::SameType_03760:
+            return
+                loc.function == Func::vkBuildAccelerationStructuresKHR  ? "VUID-vkBuildAccelerationStructuresKHR-pInfos-03760" :
+                loc.function == Func::vkCmdBuildAccelerationStructuresKHR  ? "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03760" :
+                loc.function == Func::vkCmdBuildAccelerationStructuresIndirectKHR  ? "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03760" :
+                kVUIDUndefined;
+        case BuildASError::SameType_03761:
+            return
+                loc.function == Func::vkBuildAccelerationStructuresKHR  ? "VUID-vkBuildAccelerationStructuresKHR-pInfos-03761" :
+                loc.function == Func::vkCmdBuildAccelerationStructuresKHR  ? "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03761" :
+                loc.function == Func::vkCmdBuildAccelerationStructuresIndirectKHR  ? "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03761" :
+                kVUIDUndefined;
+        case BuildASError::SameFlags_03762:
+            return
+                loc.function == Func::vkBuildAccelerationStructuresKHR  ? "VUID-vkBuildAccelerationStructuresKHR-pInfos-03762" :
+                loc.function == Func::vkCmdBuildAccelerationStructuresKHR  ? "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03762" :
+                loc.function == Func::vkCmdBuildAccelerationStructuresIndirectKHR  ? "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03762" :
+                kVUIDUndefined;
+        case BuildASError::TriangleVertexFormat_03763:
+            return
+                loc.function == Func::vkBuildAccelerationStructuresKHR  ? "VUID-vkBuildAccelerationStructuresKHR-pInfos-03763" :
+                loc.function == Func::vkCmdBuildAccelerationStructuresKHR  ? "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03763" :
+                loc.function == Func::vkCmdBuildAccelerationStructuresIndirectKHR  ? "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03763" :
+                kVUIDUndefined;
+        case BuildASError::TriangleMaxVertex_03764:
+            return
+                loc.function == Func::vkBuildAccelerationStructuresKHR  ? "VUID-vkBuildAccelerationStructuresKHR-pInfos-03764" :
+                loc.function == Func::vkCmdBuildAccelerationStructuresKHR  ? "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03764" :
+                loc.function == Func::vkCmdBuildAccelerationStructuresIndirectKHR  ? "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03764" :
+                kVUIDUndefined;
+        case BuildASError::TriangleIndexType_03765:
+            return
+                loc.function == Func::vkBuildAccelerationStructuresKHR  ? "VUID-vkBuildAccelerationStructuresKHR-pInfos-03765" :
+                loc.function == Func::vkCmdBuildAccelerationStructuresKHR  ? "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03765" :
+                loc.function == Func::vkCmdBuildAccelerationStructuresIndirectKHR  ? "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03765" :
+                kVUIDUndefined;
+        case BuildASError::TriangleTransformData_03766:
+            return
+                loc.function == Func::vkBuildAccelerationStructuresKHR  ? "VUID-vkBuildAccelerationStructuresKHR-pInfos-03766" :
+                loc.function == Func::vkCmdBuildAccelerationStructuresKHR  ? "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03766" :
+                loc.function == Func::vkCmdBuildAccelerationStructuresIndirectKHR  ? "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03766" :
+                kVUIDUndefined;
+        case BuildASError::TriangleTransformData_03767:
+            return
+                loc.function == Func::vkBuildAccelerationStructuresKHR  ? "VUID-vkBuildAccelerationStructuresKHR-pInfos-03767" :
+                loc.function == Func::vkCmdBuildAccelerationStructuresKHR  ? "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03767" :
+                loc.function == Func::vkCmdBuildAccelerationStructuresIndirectKHR  ? "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03767" :
+                kVUIDUndefined;
+        case BuildASError::DstTop_03699:
+            return
+                loc.function == Func::vkBuildAccelerationStructuresKHR  ? "VUID-vkBuildAccelerationStructuresKHR-pInfos-03699" :
+                loc.function == Func::vkCmdBuildAccelerationStructuresKHR  ? "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03699" :
+                loc.function == Func::vkCmdBuildAccelerationStructuresIndirectKHR  ? "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03699" :
+                kVUIDUndefined;
+        case BuildASError::DstBottom_03700:
+            return
+                loc.function == Func::vkBuildAccelerationStructuresKHR  ? "VUID-vkBuildAccelerationStructuresKHR-pInfos-03700" :
+                loc.function == Func::vkCmdBuildAccelerationStructuresKHR  ? "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03700" :
+                loc.function == Func::vkCmdBuildAccelerationStructuresIndirectKHR  ? "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03700" :
+                kVUIDUndefined;
+    }
+    return "UNASSIGNED-CoreChecks-unhandled-build-as";
+    // clang-format on
+}
+
 const std::string &GetSubresourceRangeVUID(const Location &loc, SubresourceRangeError error) {
     static const std::map<SubresourceRangeError, std::array<Entry, 6>> errors{
         {SubresourceRangeError::BaseMip_01486,

--- a/layers/core_checks/cc_vuid_maps.h
+++ b/layers/core_checks/cc_vuid_maps.h
@@ -99,6 +99,23 @@ const std::string &GetImageMipLevelVUID(const Location &loc);
 const std::string &GetImageArrayLayerRangeVUID(const Location &loc);
 const std::string &GetImageImageLayoutVUID(const Location &loc);
 
+enum class BuildASError {
+    IsBuilt_03667,
+    SameCount_03758,
+    SameFlags_03759,
+    SameType_03760,
+    SameType_03761,
+    SameFlags_03762,
+    TriangleVertexFormat_03763,
+    TriangleMaxVertex_03764,
+    TriangleIndexType_03765,
+    TriangleTransformData_03766,
+    TriangleTransformData_03767,
+    DstTop_03699,
+    DstBottom_03700,
+};
+const char* GetBuildASVUID(const Location& loc, BuildASError error);
+
 enum class SubresourceRangeError {
     BaseMip_01486,
     MipCount_01724,

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1811,13 +1811,20 @@ class CoreChecks : public vvl::DeviceProxy {
                                                                  const ErrorObject& error_obj) const override;
     bool ValidateAccelerationVertex(VkFormat vertex_format, VkDeviceOrHostAddressConstKHR vertex_data, VkDeviceSize vertex_stride,
                                     const LogObjectList& objlist, const Location& loc) const;
-    // Validate buffers accessed using a device address
-    bool ValidateAccelerationBuffers(VkCommandBuffer cmd_buffer, uint32_t info_i,
-                                     const VkAccelerationStructureBuildGeometryInfoKHR& info,
-                                     const VkAccelerationStructureBuildRangeInfoKHR* geometry_build_ranges,
-                                     const Location& info_loc) const;
-    bool CommonBuildAccelerationStructureValidation(const VkAccelerationStructureBuildGeometryInfoKHR& info,
-                                                    const Location& info_loc, LogObjectList object_list) const;
+    bool ValidateAccelerationStructureBuildGeometryInfoDevice(VkCommandBuffer cmd_buffer, uint32_t info_i,
+                                                              const VkAccelerationStructureBuildGeometryInfoKHR& info,
+                                                              const VkAccelerationStructureBuildRangeInfoKHR* geometry_build_ranges,
+                                                              const Location& info_loc) const;
+    bool ValidateAccelerationStructureBuildScratch(VkCommandBuffer cmd_buffer,
+                                                   const VkAccelerationStructureBuildGeometryInfoKHR& info,
+                                                   const VkAccelerationStructureBuildRangeInfoKHR* geometry_build_ranges,
+                                                   const Location& info_loc) const;
+    bool ValidateAccelerationStructureBuildGeometryInfoUpdate(const vvl::AccelerationStructureKHR& src_as_state,
+                                                              const VkAccelerationStructureBuildGeometryInfoKHR& info,
+                                                              const Location& info_loc, const VulkanTypedHandle& handle) const;
+    bool ValidateAccelerationStructureBuildDst(const vvl::AccelerationStructureKHR& dst_as_state,
+                                               const VkAccelerationStructureBuildGeometryInfoKHR& info, const Location& info_loc,
+                                               const VulkanTypedHandle& handle) const;
     bool ValidateAccelerationStructuresMemoryAlisasing(const LogObjectList& objlist, uint32_t infoCount,
                                                        const VkAccelerationStructureBuildGeometryInfoKHR* pInfos, uint32_t info_i,
                                                        const ErrorObject& error_obj) const;

--- a/layers/state_tracker/ray_tracing_state.h
+++ b/layers/state_tracker/ray_tracing_state.h
@@ -112,7 +112,7 @@ class AccelerationStructureKHR : public StateObject, public SubStateManager<Acce
         : StateObject(handle, kVulkanObjectTypeAccelerationStructureKHR),
           buffer_state(buf_state),
           buffer_device_address(buffer_device_address),
-          createFlags(pCreateInfo->createFlags),
+          create_flags(pCreateInfo->createFlags),
           offset(pCreateInfo->offset),
           size(pCreateInfo->size),
           type(pCreateInfo->type),
@@ -151,7 +151,7 @@ class AccelerationStructureKHR : public StateObject, public SubStateManager<Acce
         }
     }
 
-    VkAccelerationStructureCreateFlagsKHR GetCreateFlags() const { return createFlags; }
+    VkAccelerationStructureCreateFlagsKHR GetCreateFlags() const { return create_flags; }
     VkBuffer GetBuffer() const { return buffer_state->VkHandle(); }
     VkDeviceSize GetOffset() const { return offset; }
     VkDeviceSize GetSize() const { return size; }
@@ -169,7 +169,7 @@ class AccelerationStructureKHR : public StateObject, public SubStateManager<Acce
     bool is_built = false;
 
   private:
-    const VkAccelerationStructureCreateFlagsKHR createFlags = 0;
+    const VkAccelerationStructureCreateFlagsKHR create_flags = 0;
     const VkDeviceSize offset = 0;
     const VkDeviceSize size = 0;
     const VkAccelerationStructureTypeKHR type = VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR;

--- a/layers/stateless/sl_ray_tracing.cpp
+++ b/layers/stateless/sl_ray_tracing.cpp
@@ -43,19 +43,18 @@ bool Device::manual_PreCallValidateCreateAccelerationStructureKHR(VkDevice devic
                          "accelerationStructure feature was not enabled.");
     }
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
-    if (pCreateInfo->createFlags & VK_ACCELERATION_STRUCTURE_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT_KHR &&
-        !enabled_features.accelerationStructureCaptureReplay) {
-        skip |=
-            LogError("VUID-VkAccelerationStructureCreateInfoKHR-createFlags-03613", device, create_info_loc.dot(Field::createFlags),
-                     "includes "
-                     "VK_ACCELERATION_STRUCTURE_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT_KHR, "
-                     "but accelerationStructureCaptureReplay feature is not enabled.");
-    }
-    if (pCreateInfo->deviceAddress &&
-        !(pCreateInfo->createFlags & VK_ACCELERATION_STRUCTURE_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT_KHR)) {
+    if ((pCreateInfo->createFlags & VK_ACCELERATION_STRUCTURE_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT_KHR) != 0) {
+        if (!enabled_features.accelerationStructureCaptureReplay) {
+            skip |= LogError("VUID-VkAccelerationStructureCreateInfoKHR-createFlags-03613", device,
+                             create_info_loc.dot(Field::createFlags),
+                             "includes "
+                             "VK_ACCELERATION_STRUCTURE_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT_KHR, "
+                             "but accelerationStructureCaptureReplay feature is not enabled.");
+        }
+    } else if (pCreateInfo->deviceAddress) {
         skip |= LogError(
             "VUID-VkAccelerationStructureCreateInfoKHR-deviceAddress-03612", device, create_info_loc.dot(Field::createFlags),
-            "(%s) does not include VK_ACCELERATION_STRUCTURE_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT_KHR and the deviceAddress "
+            "(%s) does not include VK_ACCELERATION_STRUCTURE_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT_KHR but the deviceAddress "
             "(%" PRIu64 ") is not zero.",
             string_VkAccelerationStructureCreateFlagsKHR(pCreateInfo->createFlags).c_str(), pCreateInfo->deviceAddress);
     }
@@ -69,20 +68,16 @@ bool Device::manual_PreCallValidateCreateAccelerationStructureKHR(VkDevice devic
                          "(%" PRIu64 ") must be a multiple of 256 bytes", pCreateInfo->offset);
     }
 
-    if ((pCreateInfo->createFlags & VK_ACCELERATION_STRUCTURE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT) &&
-        !enabled_features.descriptorBufferCaptureReplay) {
-        skip |=
-            LogError("VUID-VkAccelerationStructureCreateInfoKHR-createFlags-08108", device, create_info_loc.dot(Field::createFlags),
-                     "includes VK_ACCELERATION_STRUCTURE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT, but the "
-                     "descriptorBufferCaptureReplay feature was not enabled.");
-    }
-
-    const auto *opaque_capture_descriptor_buffer =
-        vku::FindStructInPNextChain<VkOpaqueCaptureDescriptorDataCreateInfoEXT>(pCreateInfo->pNext);
-    if (opaque_capture_descriptor_buffer &&
-        !(pCreateInfo->createFlags & VK_ACCELERATION_STRUCTURE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT)) {
+    if ((pCreateInfo->createFlags & VK_ACCELERATION_STRUCTURE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT) != 0) {
+        if (!enabled_features.descriptorBufferCaptureReplay) {
+            skip |= LogError("VUID-VkAccelerationStructureCreateInfoKHR-createFlags-08108", device,
+                             create_info_loc.dot(Field::createFlags),
+                             "includes VK_ACCELERATION_STRUCTURE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT, but the "
+                             "descriptorBufferCaptureReplay feature was not enabled.");
+        }
+    } else if (vku::FindStructInPNextChain<VkOpaqueCaptureDescriptorDataCreateInfoEXT>(pCreateInfo->pNext)) {
         skip |= LogError("VUID-VkAccelerationStructureCreateInfoKHR-pNext-08109", device, create_info_loc.dot(Field::createFlags),
-                         "includes VK_ACCELERATION_STRUCTURE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT, but "
+                         "is missing VK_ACCELERATION_STRUCTURE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT, but "
                          "VkOpaqueCaptureDescriptorDataCreateInfoEXT is in pNext chain.\n%s",
                          PrintPNextChain(Struct::VkAccelerationStructureCreateInfoKHR, pCreateInfo->pNext).c_str());
     }
@@ -176,46 +171,47 @@ bool Device::manual_PreCallValidateCreateRayTracingPipelinesKHR(VkDevice device,
 
         for (uint32_t stage_index = 0; stage_index < create_info.stageCount; ++stage_index) {
             const Location stage_loc = create_info_loc.dot(Field::pStages, stage_index);
-            skip |= ValidatePipelineShaderStageCreateInfoCommon(context, create_info.pStages[stage_index], stage_loc);
+            const VkPipelineShaderStageCreateInfo& stage_ci = create_info.pStages[stage_index];
+            skip |= ValidatePipelineShaderStageCreateInfoCommon(context, stage_ci, stage_loc);
 
-            const auto stage = create_info.pStages[stage_index].stage;
-            if ((stage & kShaderStageAllRayTracing) == 0) {
+            if ((stage_ci.stage & kShaderStageAllRayTracing) == 0) {
                 skip |= LogError("VUID-VkRayTracingPipelineCreateInfoKHR-stage-06899", device, stage_loc.dot(Field::stage),
-                                 "is %s.", string_VkShaderStageFlagBits(stage));
+                                 "is %s.", string_VkShaderStageFlagBits(stage_ci.stage));
             }
         }
 
-        auto feedback_struct = vku::FindStructInPNextChain<VkPipelineCreationFeedbackCreateInfo>(create_info.pNext);
-        if ((feedback_struct != nullptr) && (feedback_struct->pipelineStageCreationFeedbackCount != 0) &&
-            (feedback_struct->pipelineStageCreationFeedbackCount != create_info.stageCount)) {
-            skip |= LogError(
-                "VUID-VkRayTracingPipelineCreateInfoKHR-pipelineStageCreationFeedbackCount-06652", device,
-                create_info_loc.pNext(Struct::VkPipelineCreationFeedbackCreateInfo, Field::pipelineStageCreationFeedbackCount),
-                "(%" PRIu32 ") is not equal to %s (%" PRIu32 ").", feedback_struct->pipelineStageCreationFeedbackCount,
-                create_info_loc.Fields().c_str(), create_info.stageCount);
+        if (auto feedback_struct = vku::FindStructInPNextChain<VkPipelineCreationFeedbackCreateInfo>(create_info.pNext)) {
+            if (feedback_struct->pipelineStageCreationFeedbackCount != 0 &&
+                feedback_struct->pipelineStageCreationFeedbackCount != create_info.stageCount) {
+                skip |= LogError(
+                    "VUID-VkRayTracingPipelineCreateInfoKHR-pipelineStageCreationFeedbackCount-06652", device,
+                    create_info_loc.pNext(Struct::VkPipelineCreationFeedbackCreateInfo, Field::pipelineStageCreationFeedbackCount),
+                    "(%" PRIu32 ") is not equal to %s (%" PRIu32 ").", feedback_struct->pipelineStageCreationFeedbackCount,
+                    create_info_loc.Fields().c_str(), create_info.stageCount);
+            }
         }
 
         for (uint32_t group_index = 0; group_index < create_info.groupCount; ++group_index) {
             const Location group_loc = create_info_loc.dot(Field::pGroups, group_index);
-            if ((create_info.pGroups[group_index].type == VK_RAY_TRACING_SHADER_GROUP_TYPE_TRIANGLES_HIT_GROUP_KHR) ||
-                (create_info.pGroups[group_index].type == VK_RAY_TRACING_SHADER_GROUP_TYPE_PROCEDURAL_HIT_GROUP_KHR)) {
+            const VkRayTracingShaderGroupCreateInfoKHR& group_ci = create_info.pGroups[group_index];
+            if ((group_ci.type == VK_RAY_TRACING_SHADER_GROUP_TYPE_TRIANGLES_HIT_GROUP_KHR) ||
+                (group_ci.type == VK_RAY_TRACING_SHADER_GROUP_TYPE_PROCEDURAL_HIT_GROUP_KHR)) {
                 if ((flags & VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_ANY_HIT_SHADERS_BIT_KHR) &&
-                    (create_info.pGroups[group_index].anyHitShader == VK_SHADER_UNUSED_KHR)) {
+                    (group_ci.anyHitShader == VK_SHADER_UNUSED_KHR)) {
                     skip |= LogError(
                         "VUID-VkRayTracingPipelineCreateInfoKHR-flags-03470", device, flags_loc,
                         "includes VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_ANY_HIT_SHADERS_BIT_KHR but %s is VK_SHADER_UNUSED_KHR.",
                         group_loc.dot(Field::anyHitShader).Fields().c_str());
                 }
                 if ((flags & VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_CLOSEST_HIT_SHADERS_BIT_KHR) &&
-                    (create_info.pGroups[group_index].closestHitShader == VK_SHADER_UNUSED_KHR)) {
+                    (group_ci.closestHitShader == VK_SHADER_UNUSED_KHR)) {
                     skip |= LogError("VUID-VkRayTracingPipelineCreateInfoKHR-flags-03471", device, flags_loc,
                                      "includes VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_CLOSEST_HIT_SHADERS_BIT_KHR but %s is "
                                      "VK_SHADER_UNUSED_KHR.",
                                      group_loc.dot(Field::closestHitShader).Fields().c_str());
                 }
             }
-            if (enabled_features.rayTracingPipelineShaderGroupHandleCaptureReplay &&
-                create_info.pGroups[group_index].pShaderGroupCaptureReplayHandle) {
+            if (enabled_features.rayTracingPipelineShaderGroupHandleCaptureReplay && group_ci.pShaderGroupCaptureReplayHandle) {
                 if (!(flags & VK_PIPELINE_CREATE_RAY_TRACING_SHADER_GROUP_HANDLE_CAPTURE_REPLAY_BIT_KHR)) {
                     skip |=
                         LogError("VUID-VkRayTracingPipelineCreateInfoKHR-rayTracingPipelineShaderGroupHandleCaptureReplay-03599",
@@ -254,8 +250,7 @@ bool Device::manual_PreCallValidateCreateRayTracingPipelinesKHR(VkDevice device,
             }
         }
 
-        const bool library_enabled = IsExtEnabled(extensions.vk_khr_pipeline_library);
-        if (!library_enabled) {
+        if (!IsExtEnabled(extensions.vk_khr_pipeline_library)) {
             if (create_info.pLibraryInfo) {
                 skip |= LogError("VUID-VkRayTracingPipelineCreateInfoKHR-pLibraryInfo-03595", device,
                                  create_info_loc.dot(Field::pLibraryInfo), "is not NULL.");
@@ -624,9 +619,9 @@ bool Device::ValidateTotalPrimitivesCount(uint64_t total_triangles_count, uint64
     return skip;
 }
 
-bool Device::ValidateAccelerationStructureBuildGeometryInfoKHR(const Context &context,
-                                                               const VkAccelerationStructureBuildGeometryInfoKHR &info,
-                                                               const VulkanTypedHandle &handle, const Location &info_loc) const {
+bool Device::ValidateAccelerationStructureBuildGeometryInfo(const VulkanTypedHandle& handle,
+                                                            const VkAccelerationStructureBuildGeometryInfoKHR& info,
+                                                            const Location& info_loc) const {
     bool skip = false;
 
     if (info.type == VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR) {
@@ -659,122 +654,373 @@ bool Device::ValidateAccelerationStructureBuildGeometryInfoKHR(const Context &co
         skip |= LogError("VUID-VkAccelerationStructureBuildGeometryInfoKHR-pGeometries-03788", handle,
                          info_loc.dot(Field::geometryCount),
                          "is (%" PRIu32 ") but both pGeometries and ppGeometries are both NULL.", info.geometryCount);
-        return skip;
     }
 
-    for (uint32_t geom_i = 0; geom_i < info.geometryCount; ++geom_i) {
-        const VkAccelerationStructureGeometryKHR &geom = rt::GetGeometry(info, geom_i);
+    return skip;
+}
 
-        const Location geometry_ptr_loc = info_loc.dot(info.pGeometries ? Field::pGeometries : Field::ppGeometries, geom_i);
-        const Location geometry_loc = geometry_ptr_loc.dot(Field::geometry);
+bool Device::ValidateAccelerationStructureGeometry(const Context& context, const VkAccelerationStructureBuildGeometryInfoKHR& info,
+                                                   const VkAccelerationStructureGeometryKHR& geom,
+                                                   const Location& geometry_ptr_loc) const {
+    bool skip = false;
 
-        skip |= context.ValidateRangedEnum(geometry_ptr_loc.dot(Field::geometryType), vvl::Enum::VkGeometryTypeKHR,
-                                           geom.geometryType, "VUID-VkAccelerationStructureGeometryKHR-geometryType-parameter");
-        if (geom.geometryType == VK_GEOMETRY_TYPE_TRIANGLES_KHR) {
-            const Location triangles_loc = geometry_loc.dot(Field::triangles);
-            const auto &triangles = geom.geometry.triangles;
-            skip |= ValidateAccelerationStructureGeometryTrianglesDataKHR(context, triangles, triangles_loc);
+    const Location geometry_loc = geometry_ptr_loc.dot(Field::geometry);
 
-            if (triangles.vertexStride > vvl::kU32Max) {
-                skip |= LogError("VUID-VkAccelerationStructureGeometryTrianglesDataKHR-vertexStride-03819", handle,
-                                 triangles_loc.dot(Field::vertexStride), "(%" PRIu64 ") must be less than or equal to 2^32-1.",
-                                 triangles.vertexStride);
-            }
-            if (!IsValueIn(triangles.indexType, {VK_INDEX_TYPE_UINT16, VK_INDEX_TYPE_UINT32, VK_INDEX_TYPE_NONE_KHR})) {
-                skip |= LogError("VUID-VkAccelerationStructureGeometryTrianglesDataKHR-indexType-03798", handle,
-                                 triangles_loc.dot(Field::indexType), "is %s.", string_VkIndexType(triangles.indexType));
-            }
-        } else if (geom.geometryType == VK_GEOMETRY_TYPE_INSTANCES_KHR) {
-            const Location instances_loc = geometry_loc.dot(Field::instances);
+    skip |= context.ValidateRangedEnum(geometry_ptr_loc.dot(Field::geometryType), vvl::Enum::VkGeometryTypeKHR, geom.geometryType,
+                                       "VUID-VkAccelerationStructureGeometryKHR-geometryType-parameter");
+    if (geom.geometryType == VK_GEOMETRY_TYPE_TRIANGLES_KHR) {
+        const Location triangles_loc = geometry_loc.dot(Field::triangles);
+        const VkAccelerationStructureGeometryTrianglesDataKHR& triangles = geom.geometry.triangles;
+        skip |= ValidateAccelerationStructureGeometryTrianglesDataKHR(context, triangles, triangles_loc);
 
-            skip |= ValidateAccelerationStructureGeometryInstancesDataKHR(context, geom.geometry.instances, instances_loc);
-        } else if (geom.geometryType == VK_GEOMETRY_TYPE_AABBS_KHR) {
-            const Location aabbs_loc = geometry_loc.dot(Field::aabbs);
-            const auto &aabbs = geom.geometry.aabbs;
-
-            skip |= ValidateAccelerationStructureGeometryAabbsDataKHR(context, aabbs, aabbs_loc);
-
-            if (!IsIntegerMultipleOf(aabbs.stride, 8)) {
-                skip |= LogError("VUID-VkAccelerationStructureGeometryAabbsDataKHR-stride-03545", handle,
-                                 aabbs_loc.dot(Field::stride), "(%" PRIu64 ") is not a multiple of 8.", aabbs.stride);
-            }
-            if (aabbs.stride > vvl::kU32Max) {
-                skip |= LogError("VUID-VkAccelerationStructureGeometryAabbsDataKHR-stride-03820", handle,
-                                 aabbs_loc.dot(Field::stride), "(%" PRIu64 ") must be less than or equal to 2^32-1.", aabbs.stride);
-            }
+        if (triangles.vertexStride > vvl::kU32Max) {
+            skip |= LogError("VUID-VkAccelerationStructureGeometryTrianglesDataKHR-vertexStride-03819", context.error_obj.handle,
+                             triangles_loc.dot(Field::vertexStride), "(%" PRIu64 ") must be less than or equal to 2^32-1.",
+                             triangles.vertexStride);
         }
-        if (geom.geometryType == VK_GEOMETRY_TYPE_SPHERES_NV) {
-            auto sphere_struct = reinterpret_cast<VkAccelerationStructureGeometrySpheresDataNV const *>(geom.pNext);
-            if (!enabled_features.spheres) {
-                skip |= LogError("VUID-VkAccelerationStructureGeometrySpheresDataNV-None-10429", device,
-                                 geometry_loc.pNext(Struct::VkAccelerationStructureGeometrySpheresDataNV),
-                                 "The spheres feature must be enabled");
-            }
-            if (sphere_struct->vertexStride > vvl::kU32Max) {
-                skip |= LogError("VUID-VkAccelerationStructureGeometrySpheresDataNV-vertexStride-10432", handle,
-                                 geometry_loc.pNext(Struct::VkAccelerationStructureGeometrySpheresDataNV).dot(Field::vertexStride),
-                                 "(%" PRIu64 ") must be less than or equal to 2^32-1.", sphere_struct->vertexStride);
-            }
-            if (sphere_struct->radiusStride > vvl::kU32Max) {
-                skip |= LogError("VUID-VkAccelerationStructureGeometrySpheresDataNV-vertexStride-10432", handle,
-                                 geometry_loc.pNext(Struct::VkAccelerationStructureGeometrySpheresDataNV).dot(Field::radiusStride),
-                                 "(%" PRIu64 ") must be less than or equal to 2^32-1.", sphere_struct->radiusStride);
-            }
-            if (sphere_struct->indexType != VK_INDEX_TYPE_UINT16 && sphere_struct->indexType != VK_INDEX_TYPE_UINT32 &&
-                sphere_struct->indexType != VK_INDEX_TYPE_NONE_KHR) {
-                skip |= LogError("VUID-VkAccelerationStructureGeometrySpheresDataNV-indexData-10437", handle,
-                                 geometry_loc.pNext(Struct::VkAccelerationStructureGeometrySpheresDataNV).dot(Field::indexType),
-                                 "is %s.", string_VkIndexType(sphere_struct->indexType));
-            }
+        if (!IsValueIn(triangles.indexType, {VK_INDEX_TYPE_UINT16, VK_INDEX_TYPE_UINT32, VK_INDEX_TYPE_NONE_KHR})) {
+            skip |= LogError("VUID-VkAccelerationStructureGeometryTrianglesDataKHR-indexType-03798", context.error_obj.handle,
+                             triangles_loc.dot(Field::indexType), "is %s.", string_VkIndexType(triangles.indexType));
         }
-        if (geom.geometryType == VK_GEOMETRY_TYPE_LINEAR_SWEPT_SPHERES_NV) {
-            auto sphere_linear_struct =
-                reinterpret_cast<VkAccelerationStructureGeometryLinearSweptSpheresDataNV const *>(geom.pNext);
-            if (!enabled_features.linearSweptSpheres) {
-                skip |= LogError("VUID-VkAccelerationStructureGeometryLinearSweptSpheresDataNV-None-10419", device,
-                                 geometry_loc.pNext(Struct::VkAccelerationStructureGeometryLinearSweptSpheresDataNV),
-                                 "The linearSweptSpheres feature must be enabled");
-            }
-            if (sphere_linear_struct->vertexStride > vvl::kU32Max) {
-                skip |= LogError(
-                    "VUID-VkAccelerationStructureGeometryLinearSweptSpheresDataNV-vertexStride-10422", handle,
-                    geometry_loc.pNext(Struct::VkAccelerationStructureGeometryLinearSweptSpheresDataNV).dot(Field::vertexStride),
-                    "(%" PRIu64 ") must be less than or equal to 2^32-1.", sphere_linear_struct->vertexStride);
-            }
-            if (sphere_linear_struct->radiusStride > vvl::kU32Max) {
-                skip |= LogError(
-                    "VUID-VkAccelerationStructureGeometryLinearSweptSpheresDataNV-vertexStride-10422", handle,
-                    geometry_loc.pNext(Struct::VkAccelerationStructureGeometryLinearSweptSpheresDataNV).dot(Field::radiusStride),
-                    "(%" PRIu64 ") must be less than or equal to 2^32-1.", sphere_linear_struct->radiusStride);
-            }
-            if (sphere_linear_struct->indexType != VK_INDEX_TYPE_UINT16 &&
-                sphere_linear_struct->indexType != VK_INDEX_TYPE_UINT32 &&
-                sphere_linear_struct->indexType != VK_INDEX_TYPE_NONE_KHR) {
-                skip |= LogError(
-                    "VUID-VkAccelerationStructureGeometryLinearSweptSpheresDataNV-indexData-10428", handle,
-                    geometry_loc.pNext(Struct::VkAccelerationStructureGeometryLinearSweptSpheresDataNV).dot(Field::indexType),
-                    "is %s.", string_VkIndexType(sphere_linear_struct->indexType));
-            }
+    } else if (geom.geometryType == VK_GEOMETRY_TYPE_INSTANCES_KHR) {
+        const Location instances_loc = geometry_loc.dot(Field::instances);
+
+        skip |= ValidateAccelerationStructureGeometryInstancesDataKHR(context, geom.geometry.instances, instances_loc);
+    } else if (geom.geometryType == VK_GEOMETRY_TYPE_AABBS_KHR) {
+        const Location aabbs_loc = geometry_loc.dot(Field::aabbs);
+        const VkAccelerationStructureGeometryAabbsDataKHR& aabbs = geom.geometry.aabbs;
+
+        skip |= ValidateAccelerationStructureGeometryAabbsDataKHR(context, aabbs, aabbs_loc);
+
+        if (!IsIntegerMultipleOf(aabbs.stride, 8)) {
+            skip |= LogError("VUID-VkAccelerationStructureGeometryAabbsDataKHR-stride-03545", context.error_obj.handle,
+                             aabbs_loc.dot(Field::stride), "(%" PRIu64 ") is not a multiple of 8.", aabbs.stride);
         }
-        if (info.type == VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR && geom.geometryType != VK_GEOMETRY_TYPE_INSTANCES_KHR) {
+        if (aabbs.stride > vvl::kU32Max) {
+            skip |= LogError("VUID-VkAccelerationStructureGeometryAabbsDataKHR-stride-03820", context.error_obj.handle,
+                             aabbs_loc.dot(Field::stride), "(%" PRIu64 ") must be less than or equal to 2^32-1.", aabbs.stride);
+        }
+    } else if (geom.geometryType == VK_GEOMETRY_TYPE_SPHERES_NV) {
+        auto sphere_struct = reinterpret_cast<VkAccelerationStructureGeometrySpheresDataNV const*>(geom.pNext);
+        if (!enabled_features.spheres) {
+            skip |= LogError("VUID-VkAccelerationStructureGeometrySpheresDataNV-None-10429", device,
+                             geometry_loc.pNext(Struct::VkAccelerationStructureGeometrySpheresDataNV),
+                             "The spheres feature must be enabled");
+        }
+        if (sphere_struct->vertexStride > vvl::kU32Max) {
+            skip |= LogError("VUID-VkAccelerationStructureGeometrySpheresDataNV-vertexStride-10432", context.error_obj.handle,
+                             geometry_loc.pNext(Struct::VkAccelerationStructureGeometrySpheresDataNV).dot(Field::vertexStride),
+                             "(%" PRIu64 ") must be less than or equal to 2^32-1.", sphere_struct->vertexStride);
+        }
+        if (sphere_struct->radiusStride > vvl::kU32Max) {
+            skip |= LogError("VUID-VkAccelerationStructureGeometrySpheresDataNV-vertexStride-10432", context.error_obj.handle,
+                             geometry_loc.pNext(Struct::VkAccelerationStructureGeometrySpheresDataNV).dot(Field::radiusStride),
+                             "(%" PRIu64 ") must be less than or equal to 2^32-1.", sphere_struct->radiusStride);
+        }
+        if (!IsValueIn(sphere_struct->indexType, {VK_INDEX_TYPE_UINT16, VK_INDEX_TYPE_UINT32, VK_INDEX_TYPE_NONE_KHR})) {
+            skip |= LogError("VUID-VkAccelerationStructureGeometrySpheresDataNV-indexData-10437", context.error_obj.handle,
+                             geometry_loc.pNext(Struct::VkAccelerationStructureGeometrySpheresDataNV).dot(Field::indexType),
+                             "is %s.", string_VkIndexType(sphere_struct->indexType));
+        }
+    } else if (geom.geometryType == VK_GEOMETRY_TYPE_LINEAR_SWEPT_SPHERES_NV) {
+        auto sphere_linear_struct = reinterpret_cast<VkAccelerationStructureGeometryLinearSweptSpheresDataNV const*>(geom.pNext);
+        if (!enabled_features.linearSweptSpheres) {
+            skip |= LogError("VUID-VkAccelerationStructureGeometryLinearSweptSpheresDataNV-None-10419", device,
+                             geometry_loc.pNext(Struct::VkAccelerationStructureGeometryLinearSweptSpheresDataNV),
+                             "The linearSweptSpheres feature must be enabled");
+        }
+        if (sphere_linear_struct->vertexStride > vvl::kU32Max) {
+            skip |= LogError(
+                "VUID-VkAccelerationStructureGeometryLinearSweptSpheresDataNV-vertexStride-10422", context.error_obj.handle,
+                geometry_loc.pNext(Struct::VkAccelerationStructureGeometryLinearSweptSpheresDataNV).dot(Field::vertexStride),
+                "(%" PRIu64 ") must be less than or equal to 2^32-1.", sphere_linear_struct->vertexStride);
+        }
+        if (sphere_linear_struct->radiusStride > vvl::kU32Max) {
+            skip |= LogError(
+                "VUID-VkAccelerationStructureGeometryLinearSweptSpheresDataNV-vertexStride-10422", context.error_obj.handle,
+                geometry_loc.pNext(Struct::VkAccelerationStructureGeometryLinearSweptSpheresDataNV).dot(Field::radiusStride),
+                "(%" PRIu64 ") must be less than or equal to 2^32-1.", sphere_linear_struct->radiusStride);
+        }
+        if (!IsValueIn(sphere_linear_struct->indexType, {VK_INDEX_TYPE_UINT16, VK_INDEX_TYPE_UINT32, VK_INDEX_TYPE_NONE_KHR})) {
             skip |=
-                LogError("VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-03789", handle,
-                         geometry_ptr_loc.dot(Field::geometryType), "is %s but %s is VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR.",
-                         string_VkGeometryTypeKHR(geom.geometryType), info_loc.dot(Field::type).Fields().c_str());
+                LogError("VUID-VkAccelerationStructureGeometryLinearSweptSpheresDataNV-indexData-10428", context.error_obj.handle,
+                         geometry_loc.pNext(Struct::VkAccelerationStructureGeometryLinearSweptSpheresDataNV).dot(Field::indexType),
+                         "is %s.", string_VkIndexType(sphere_linear_struct->indexType));
         }
-        if (info.type == VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR) {
-            if (geom.geometryType == VK_GEOMETRY_TYPE_INSTANCES_KHR) {
-                skip |= LogError("VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-03791", handle,
-                                 geometry_ptr_loc.dot(Field::geometryType),
-                                 "is %s but %s is VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR.",
-                                 string_VkGeometryTypeKHR(geom.geometryType), info_loc.dot(Field::type).Fields().c_str());
+    }
+
+    if (info.type == VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR && geom.geometryType != VK_GEOMETRY_TYPE_INSTANCES_KHR) {
+        skip |=
+            LogError("VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-03789", context.error_obj.handle,
+                     geometry_ptr_loc.dot(Field::geometryType),
+                     "is %s but VkAccelerationStructureBuildGeometryInfoKHR::type is VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR.",
+                     string_VkGeometryTypeKHR(geom.geometryType));
+    }
+    if (info.type == VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR) {
+        if (geom.geometryType == VK_GEOMETRY_TYPE_INSTANCES_KHR) {
+            skip |= LogError(
+                "VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-03791", context.error_obj.handle,
+                geometry_ptr_loc.dot(Field::geometryType),
+                "is %s but VkAccelerationStructureBuildGeometryInfoKHR::type is VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR.",
+                string_VkGeometryTypeKHR(geom.geometryType));
+        }
+        if (geom.geometryType != rt::GetGeometry(info, 0).geometryType) {
+            skip |= LogError("VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-03792", context.error_obj.handle,
+                             geometry_ptr_loc.dot(Field::geometryType), "(%s) is different than pGeometries[0].geometryType (%s)",
+                             string_VkGeometryTypeKHR(geom.geometryType),
+                             string_VkGeometryTypeKHR(rt::GetGeometry(info, 0).geometryType));
+        }
+    }
+
+    return skip;
+}
+
+bool Device::ValidateAccelerationStructureGeometryHost(const Context& context,
+                                                       const VkAccelerationStructureBuildGeometryInfoKHR& info,
+                                                       const VkAccelerationStructureGeometryKHR& geom,
+                                                       const Location& geometry_ptr_loc) const {
+    bool skip = false;
+    const Location geometry_loc = geometry_ptr_loc.dot(Field::geometry);
+
+    if (geom.geometryType == VK_GEOMETRY_TYPE_TRIANGLES_KHR) {
+        const VkAccelerationStructureGeometryTrianglesDataKHR& triangles = geom.geometry.triangles;
+        if (!triangles.vertexData.hostAddress) {
+            skip |= LogError("VUID-vkBuildAccelerationStructuresKHR-pInfos-03771", device,
+                             geometry_loc.dot(Field::triangles).dot(Field::vertexData).dot(Field::hostAddress), "is NULL.");
+        }
+        if (triangles.indexType != VK_INDEX_TYPE_NONE_KHR && !triangles.indexData.hostAddress) {
+            skip |= LogError("VUID-vkBuildAccelerationStructuresKHR-pInfos-03772", device,
+                             geometry_loc.dot(Field::triangles).dot(Field::indexData).dot(Field::hostAddress), "is NULL.");
+        }
+
+        if (const auto* micromap =
+                vku::FindStructInPNextChain<VkAccelerationStructureTrianglesOpacityMicromapEXT>(triangles.pNext)) {
+            if (micromap->indexType != VK_INDEX_TYPE_NONE_KHR && !micromap->indexBuffer.hostAddress) {
+                skip |= LogError("VUID-vkBuildAccelerationStructuresKHR-pInfos-10892", device,
+                                 geometry_loc.dot(Field::triangles)
+                                     .pNext(Struct::VkAccelerationStructureTrianglesOpacityMicromapEXT, Field::indexBuffer)
+                                     .dot(Field::hostAddress),
+                                 "is NULL.");
             }
-            if (geom.geometryType != rt::GetGeometry(info, 0).geometryType) {
+        }
+    } else if (geom.geometryType == VK_GEOMETRY_TYPE_AABBS_KHR) {
+        if (!geom.geometry.aabbs.data.hostAddress) {
+            skip |= LogError("VUID-vkBuildAccelerationStructuresKHR-pInfos-03774", device,
+                             geometry_loc.dot(Field::aabbs).dot(Field::data).dot(Field::hostAddress), "is NULL.");
+        }
+    } else if (geom.geometryType == VK_GEOMETRY_TYPE_INSTANCES_KHR) {
+        if (!geom.geometry.instances.data.hostAddress) {
+            skip |= LogError("VUID-vkBuildAccelerationStructuresKHR-pInfos-03778", device,
+                             geometry_loc.dot(Field::instances).dot(Field::data).dot(Field::hostAddress), "is NULL.");
+        }
+    } else if (geom.geometryType == VK_GEOMETRY_TYPE_SPHERES_NV) {
+        auto sphere_struct = reinterpret_cast<VkAccelerationStructureGeometrySpheresDataNV const*>(geom.pNext);
+        if (sphere_struct) {
+            if (sphere_struct->indexType == VK_INDEX_TYPE_NONE_KHR) {
+                if (sphere_struct->indexData.hostAddress != 0) {
+                    skip |=
+                        LogError("VUID-vkBuildAccelerationStructuresKHR-pInfos-11822", device,
+                                 geometry_ptr_loc.pNext(Struct::VkAccelerationStructureGeometrySpheresDataNV, Field::indexData)
+                                     .dot(Field::hostAddress),
+                                 "(%p) is not 0 when indexType is VK_INDEX_TYPE_NONE_KHR.", sphere_struct->indexData.hostAddress);
+                }
+            } else {
+                if (sphere_struct->indexData.hostAddress == 0) {
+                    skip |= LogError("VUID-vkBuildAccelerationStructuresKHR-pInfos-11823", device,
+                                     geometry_ptr_loc.pNext(Struct::VkAccelerationStructureGeometrySpheresDataNV, Field::indexData)
+                                         .dot(Field::hostAddress),
+                                     "is 0");
+                }
+            }
+            if (sphere_struct->vertexData.hostAddress == 0) {
+                skip |= LogError("VUID-vkBuildAccelerationStructuresKHR-pInfos-11824", device,
+                                 geometry_ptr_loc.pNext(Struct::VkAccelerationStructureGeometrySpheresDataNV, Field::vertexData)
+                                     .dot(Field::hostAddress),
+                                 "is 0");
+            }
+            if (sphere_struct->radiusData.hostAddress == 0) {
+                skip |= LogError("VUID-vkBuildAccelerationStructuresKHR-pInfos-11825", device,
+                                 geometry_ptr_loc.pNext(Struct::VkAccelerationStructureGeometrySpheresDataNV, Field::radiusData)
+                                     .dot(Field::hostAddress),
+                                 "is 0");
+            }
+        }
+    } else if (geom.geometryType == VK_GEOMETRY_TYPE_LINEAR_SWEPT_SPHERES_NV) {
+        auto sphere_linear_struct = reinterpret_cast<VkAccelerationStructureGeometryLinearSweptSpheresDataNV const*>(geom.pNext);
+        if (sphere_linear_struct) {
+            if (sphere_linear_struct->indexType == VK_INDEX_TYPE_NONE_KHR) {
+                if (sphere_linear_struct->indexData.hostAddress != 0) {
+                    skip |= LogError(
+                        "VUID-vkBuildAccelerationStructuresKHR-pInfos-11826", device,
+                        geometry_ptr_loc.pNext(Struct::VkAccelerationStructureGeometryLinearSweptSpheresDataNV, Field::indexData)
+                            .dot(Field::hostAddress),
+                        "(%p) is not 0 when indexType is VK_INDEX_TYPE_NONE_KHR.", sphere_linear_struct->indexData.hostAddress);
+                }
+            } else {
+                if (sphere_linear_struct->indexData.hostAddress == 0) {
+                    skip |= LogError(
+                        "VUID-vkBuildAccelerationStructuresKHR-pInfos-11827", device,
+                        geometry_ptr_loc.pNext(Struct::VkAccelerationStructureGeometryLinearSweptSpheresDataNV, Field::indexData)
+                            .dot(Field::hostAddress),
+                        "is 0");
+                }
+            }
+            if (sphere_linear_struct->vertexData.hostAddress == 0) {
                 skip |= LogError(
-                    "VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-03792", handle,
-                    geometry_ptr_loc.dot(Field::geometryType), "(%s) is different than pGeometries[0].geometryType (%s)",
-                    string_VkGeometryTypeKHR(geom.geometryType), string_VkGeometryTypeKHR(rt::GetGeometry(info, 0).geometryType));
+                    "VUID-vkBuildAccelerationStructuresKHR-pInfos-11828", device,
+                    geometry_ptr_loc.pNext(Struct::VkAccelerationStructureGeometryLinearSweptSpheresDataNV, Field::vertexData)
+                        .dot(Field::hostAddress),
+                    "is 0");
             }
+            if (sphere_linear_struct->radiusData.hostAddress == 0) {
+                skip |= LogError(
+                    "VUID-vkBuildAccelerationStructuresKHR-pInfos-11829", device,
+                    geometry_ptr_loc.pNext(Struct::VkAccelerationStructureGeometryLinearSweptSpheresDataNV, Field::radiusData)
+                        .dot(Field::hostAddress),
+                    "is 0");
+            }
+        }
+    }
+
+    return skip;
+}
+
+bool Device::ValidateAccelerationStructureGeometryDevice(const Context& context, const VkAccelerationStructureGeometryKHR& geom,
+                                                         const Location& geometry_ptr_loc) const {
+    bool skip = false;
+    const Location geometry_loc = geometry_ptr_loc.dot(Field::geometry);
+
+    const auto pick_vuid = [&geometry_ptr_loc](const char* direct_build_vu, const char* indirect_build_vu) -> const char* {
+        return geometry_ptr_loc.function == Func::vkCmdBuildAccelerationStructuresKHR ? direct_build_vu : indirect_build_vu;
+    };
+
+    if (geom.geometryType == VK_GEOMETRY_TYPE_TRIANGLES_KHR) {
+        const VkAccelerationStructureGeometryTrianglesDataKHR& triangles = geom.geometry.triangles;
+        const uint32_t index_type_size = IndexTypeSize(triangles.indexType);
+        if (triangles.indexType != VK_INDEX_TYPE_NONE_KHR) {
+            if (!IsPointerAligned(triangles.indexData.deviceAddress, index_type_size)) {
+                skip |= LogError(pick_vuid("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03712",
+                                           "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03712"),
+                                 context.error_obj.handle,
+                                 geometry_loc.dot(Field::triangles).dot(Field::indexData).dot(Field::deviceAddress),
+                                 "(0x%" PRIx64 ") is not aligned to %" PRIu32 " (the corresponding geometry's VkIndexType of %s).",
+                                 triangles.indexData.deviceAddress, index_type_size, string_VkIndexType(triangles.indexType));
+            }
+
+            if (!IsPointerAligned(triangles.transformData.deviceAddress, 16)) {
+                skip |= LogError(pick_vuid("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03810",
+                                           "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03810"),
+                                 context.error_obj.handle,
+                                 geometry_loc.dot(Field::triangles).dot(Field::transformData).dot(Field::deviceAddress),
+                                 "(0x%" PRIx64 ") must be aligned to 16 bytes when geometryType is VK_GEOMETRY_TYPE_TRIANGLES_KHR.",
+                                 triangles.transformData.deviceAddress);
+            }
+        }
+    } else if (geom.geometryType == VK_GEOMETRY_TYPE_AABBS_KHR) {
+        const VkAccelerationStructureGeometryAabbsDataKHR& aabbs = geom.geometry.aabbs;
+        if (!IsPointerAligned(aabbs.data.deviceAddress, 8)) {
+            skip |= LogError(pick_vuid("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03714",
+                                       "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03714"),
+                             context.error_obj.handle, geometry_loc.dot(Field::aabbs).dot(Field::data).dot(Field::deviceAddress),
+                             "(0x%" PRIx64 ") must be aligned to 8 bytes when geometryType is VK_GEOMETRY_TYPE_AABBS_KHR.",
+                             aabbs.data.deviceAddress);
+        }
+    } else if (geom.geometryType == VK_GEOMETRY_TYPE_INSTANCES_KHR) {
+        const VkAccelerationStructureGeometryInstancesDataKHR& instances = geom.geometry.instances;
+        if (instances.arrayOfPointers == VK_TRUE) {
+            if (!IsPointerAligned(instances.data.deviceAddress, 8)) {
+                skip |= LogError(pick_vuid("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03716",
+                                           "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03716"),
+                                 context.error_obj.handle,
+                                 geometry_loc.dot(Field::instances).dot(Field::data).dot(Field::deviceAddress),
+                                 "(0x%" PRIx64
+                                 ") must be aligned to 8 bytes when geometryType is VK_GEOMETRY_TYPE_INSTANCES_KHR and "
+                                 "geometry.instances.arrayOfPointers is "
+                                 "VK_TRUE.",
+                                 instances.data.deviceAddress);
+            }
+        } else {
+            if (!IsPointerAligned(instances.data.deviceAddress, 16)) {
+                skip |= LogError(pick_vuid("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03715",
+                                           "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03715"),
+                                 context.error_obj.handle,
+                                 geometry_loc.dot(Field::instances).dot(Field::data).dot(Field::deviceAddress),
+                                 "(0x%" PRIx64
+                                 ") must be aligned to 16 bytes when geometryType is VK_GEOMETRY_TYPE_INSTANCES_KHR and "
+                                 "geometry.instances.arrayOfPointers is VK_FALSE.",
+                                 instances.data.deviceAddress);
+            }
+        }
+    }
+
+    return skip;
+}
+
+bool Device::ValidateAccelerationStructureBuildRangeInfo(const Context& context, const VkAccelerationStructureGeometryKHR& geom,
+                                                         const VkAccelerationStructureBuildRangeInfoKHR& build_range,
+                                                         const Location& geometry_ptr_loc, const Location& build_range_loc) const {
+    bool skip = false;
+
+    if (geom.geometryType == VK_GEOMETRY_TYPE_TRIANGLES_KHR) {
+        const VkAccelerationStructureGeometryTrianglesDataKHR& triangles = geom.geometry.triangles;
+        const uint32_t index_type_size = IndexTypeSize(triangles.indexType);
+        if (triangles.indexType != VK_INDEX_TYPE_NONE_KHR) {
+            if (!IsIntegerMultipleOf(build_range.primitiveOffset, index_type_size)) {
+                skip |= LogError("VUID-VkAccelerationStructureBuildRangeInfoKHR-primitiveOffset-03656", context.error_obj.handle,
+                                 build_range_loc.dot(Field::primitiveOffset),
+                                 "(%" PRIu32 ") is not a multiple of %" PRIu32 " (the corresponding geometry's VkIndexType of %s).",
+                                 build_range.primitiveOffset, index_type_size, string_VkIndexType(triangles.indexType));
+            }
+        } else {
+            if (build_range.primitiveCount > 0) {
+                const uint64_t build_range_max_vertex =
+                    uint64_t(build_range.firstVertex) + 3 * uint64_t(build_range.primitiveCount) - 1;
+                if (uint64_t(triangles.maxVertex) < build_range_max_vertex) {
+                    skip |= LogError("VUID-VkAccelerationStructureBuildRangeInfoKHR-None-10775", context.error_obj.handle,
+                                     geometry_ptr_loc.dot(Field::geometry).dot(Field::triangles).dot(Field::maxVertex),
+                                     "is %" PRIu32 " but for %s, firstVertex ( %" PRIu32 " ) + primitiveCount ( %" PRIu32
+                                     " ) x 3 - 1 = %" PRIu64 ".",
+                                     triangles.maxVertex, build_range_loc.Fields().c_str(), build_range.firstVertex,
+                                     build_range.primitiveCount, build_range_max_vertex);
+                }
+            }
+
+            const uint32_t vertex_format_size = vkuFormatTexelBlockSize(triangles.vertexFormat);
+            if (!IsIntegerMultipleOf(build_range.primitiveOffset, vertex_format_size)) {
+                skip |= LogError("VUID-VkAccelerationStructureBuildRangeInfoKHR-primitiveOffset-03657", context.error_obj.handle,
+                                 build_range_loc.dot(Field::primitiveOffset),
+                                 "(%" PRIu32 ") is not a multiple of %" PRIu32
+                                 " (the corresponding geometry's triangles vertexFormat %s).",
+                                 build_range.primitiveOffset, vertex_format_size, string_VkFormat(triangles.vertexFormat));
+            }
+        }
+
+        if (!IsIntegerMultipleOf(build_range.transformOffset, 16u)) {
+            skip |= LogError("VUID-VkAccelerationStructureBuildRangeInfoKHR-transformOffset-03658", context.error_obj.handle,
+                             build_range_loc.dot(Field::transformOffset), "(%" PRIu32 ") is not a multiple of 16.",
+                             build_range.transformOffset);
+        }
+
+    } else if (geom.geometryType == VK_GEOMETRY_TYPE_AABBS_KHR) {
+        if (!IsIntegerMultipleOf(build_range.primitiveOffset, 8u)) {
+            skip |= LogError("VUID-VkAccelerationStructureBuildRangeInfoKHR-primitiveOffset-03659", context.error_obj.handle,
+                             build_range_loc.dot(Field::primitiveOffset), "(%" PRIu32 ") is not a multiple of 8.",
+                             build_range.primitiveOffset);
+        }
+    } else if (geom.geometryType == VK_GEOMETRY_TYPE_INSTANCES_KHR) {
+        if (build_range.primitiveCount > phys_dev_ext_props.acc_structure_props.maxInstanceCount) {
+            skip |= LogError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03801", context.error_obj.handle,
+                             build_range_loc.dot(Field::primitiveCount),
+                             "(%" PRIu32
+                             ") is greater than to VkPhysicalDeviceAccelerationStructurePropertiesKHR::maxInstanceCount "
+                             "(%" PRIu64 ").",
+                             build_range.primitiveCount, phys_dev_ext_props.acc_structure_props.maxInstanceCount);
+        }
+
+        if (!IsIntegerMultipleOf(build_range.primitiveOffset, 16u)) {
+            skip |= LogError("VUID-VkAccelerationStructureBuildRangeInfoKHR-primitiveOffset-03660", context.error_obj.handle,
+                             build_range_loc.dot(Field::primitiveOffset), "(%" PRIu32 ") is not a multiple of 16.",
+                             build_range.primitiveOffset);
         }
     }
 
@@ -853,7 +1099,7 @@ bool Device::manual_PreCallValidateCmdBuildAccelerationStructuresKHR(
     for (const auto [info_i, info] : vvl::enumerate(pInfos, infoCount)) {
         const Location info_loc = error_obj.location.dot(Field::pInfos, info_i);
 
-        skip |= ValidateAccelerationStructureBuildGeometryInfoKHR(context, info, error_obj.handle, info_loc);
+        skip |= ValidateAccelerationStructureBuildGeometryInfo(error_obj.handle, info, info_loc);
 
         if (!IsPointerAligned(info.scratchData.deviceAddress,
                               phys_dev_ext_props.acc_structure_props.minAccelerationStructureScratchOffsetAlignment)) {
@@ -863,15 +1109,22 @@ bool Device::manual_PreCallValidateCmdBuildAccelerationStructuresKHR(
                              info.scratchData.deviceAddress,
                              phys_dev_ext_props.acc_structure_props.minAccelerationStructureScratchOffsetAlignment);
         }
+
         skip |= context.ValidateRangedEnum(info_loc.dot(Field::mode), vvl::Enum::VkBuildAccelerationStructureModeKHR, info.mode,
                                            "VUID-vkCmdBuildAccelerationStructuresKHR-mode-04628");
+        skip |= context.ValidateArray(info_loc.dot(Field::geometryCount), error_obj.location.dot(Field::ppBuildRangeInfos, info_i),
+                                      info.geometryCount, &ppBuildRangeInfos[info_i], false, true, kVUIDUndefined,
+                                      "VUID-vkCmdBuildAccelerationStructuresKHR-ppBuildRangeInfos-03676");
+
         if (info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR && info.srcAccelerationStructure == VK_NULL_HANDLE) {
             skip |= LogError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-04630", commandBuffer, info_loc.dot(Field::mode),
                              "is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR, but srcAccelerationStructure is VK_NULL_HANDLE.");
         }
 
         for (const auto [other_info_j, other_info] : vvl::enumerate(pInfos, infoCount)) {
-            if (info_i == other_info_j) continue;
+            if (info_i == other_info_j) {
+                continue;
+            }
             if (info.dstAccelerationStructure == other_info.dstAccelerationStructure) {
                 const LogObjectList objlist(commandBuffer, info.dstAccelerationStructure);
                 skip |= LogError("VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03698", objlist,
@@ -891,127 +1144,16 @@ bool Device::manual_PreCallValidateCmdBuildAccelerationStructuresKHR(
         }
 
         for (uint32_t geom_i = 0; geom_i < info.geometryCount; ++geom_i) {
-            const VkAccelerationStructureGeometryKHR &as_geometry = rt::GetGeometry(info, geom_i);
-            const Location p_geom_loc = info_loc.dot(info.pGeometries ? Field::pGeometries : Field::ppGeometries, geom_i);
-            const Location p_geom_geom_loc = p_geom_loc.dot(Field::geometry);
-            const VkAccelerationStructureBuildRangeInfoKHR &build_range = ppBuildRangeInfos[info_i][geom_i];
-            if (as_geometry.geometryType == VK_GEOMETRY_TYPE_TRIANGLES_KHR) {
-                const auto &triangles = as_geometry.geometry.triangles;
-                const uint32_t index_type_size = IndexTypeSize(triangles.indexType);
-                if (triangles.indexType != VK_INDEX_TYPE_NONE_KHR) {
-                    if (!IsPointerAligned(triangles.indexData.deviceAddress, index_type_size)) {
-                        skip |= LogError(
-                            "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03712", commandBuffer,
-                            p_geom_geom_loc.dot(Field::triangles).dot(Field::indexData).dot(Field::deviceAddress),
-                            "(0x%" PRIx64 ") is not aligned to %" PRIu32 " (the corresponding geometry's VkIndexType of %s).",
-                            triangles.indexData.deviceAddress, index_type_size, string_VkIndexType(triangles.indexType));
-                    }
+            const VkAccelerationStructureGeometryKHR& geometry = rt::GetGeometry(info, geom_i);
+            const Location geometry_ptr_loc = info_loc.dot(info.pGeometries ? Field::pGeometries : Field::ppGeometries, geom_i);
+            skip |= ValidateAccelerationStructureGeometry(context, info, geometry, geometry_ptr_loc);
+            skip |= ValidateAccelerationStructureGeometryDevice(context, geometry, geometry_ptr_loc);
 
-                    if (!IsPointerAligned(triangles.transformData.deviceAddress, 16)) {
-                        skip |= LogError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03810", commandBuffer,
-                                         p_geom_geom_loc.dot(Field::triangles).dot(Field::transformData).dot(Field::deviceAddress),
-                                         "(0x%" PRIx64
-                                         ") must be aligned to 16 bytes when geometryType is VK_GEOMETRY_TYPE_TRIANGLES_KHR.",
-                                         triangles.transformData.deviceAddress);
-                    }
-
-                    if (!IsIntegerMultipleOf(build_range.primitiveOffset, index_type_size)) {
-                        skip |= LogError(
-                            "VUID-VkAccelerationStructureBuildRangeInfoKHR-primitiveOffset-03656", commandBuffer,
-                            error_obj.location.dot(Field::ppBuildRangeInfos, info_i).brackets(geom_i).dot(Field::primitiveOffset),
-                            "(%" PRIu32 ") is not a multiple of %" PRIu32 " (the corresponding geometry's VkIndexType of %s).",
-                            build_range.primitiveOffset, index_type_size, string_VkIndexType(triangles.indexType));
-                    }
-                } else {
-                    if (build_range.primitiveCount > 0) {
-                        const uint64_t build_range_max_vertex =
-                            uint64_t(build_range.firstVertex) + 3 * uint64_t(build_range.primitiveCount) - 1;
-                        if (uint64_t(triangles.maxVertex) < build_range_max_vertex) {
-                            const Location p_build_range_loc = error_obj.location.dot(Field::ppBuildRangeInfos, info_i);
-                            skip |= LogError("VUID-VkAccelerationStructureBuildRangeInfoKHR-None-10775", commandBuffer,
-                                             p_geom_geom_loc.dot(Field::triangles).dot(Field::maxVertex),
-                                             "is %" PRIu32 " but for %s[%" PRIu32 "], firstVertex ( %" PRIu32
-                                             " ) + primitiveCount ( %" PRIu32 " ) x 3 - 1 = %" PRIu64 ".",
-                                             triangles.maxVertex, p_build_range_loc.Fields().c_str(), geom_i,
-                                             build_range.firstVertex, build_range.primitiveCount, build_range_max_vertex);
-                        }
-                    }
-
-                    const uint32_t vertex_format_size = vkuFormatTexelBlockSize(triangles.vertexFormat);
-                    if (!IsIntegerMultipleOf(build_range.primitiveOffset, vertex_format_size)) {
-                        skip |= LogError(
-                            "VUID-VkAccelerationStructureBuildRangeInfoKHR-primitiveOffset-03657", commandBuffer,
-                            error_obj.location.dot(Field::ppBuildRangeInfos, info_i).brackets(geom_i).dot(Field::primitiveOffset),
-                            "(%" PRIu32 ") is not a multiple of %" PRIu32
-                            " (the corresponding geometry's triangles vertexFormat %s).",
-                            build_range.primitiveOffset, vertex_format_size, string_VkFormat(triangles.vertexFormat));
-                    }
-                }
-
-                if (!IsIntegerMultipleOf(build_range.transformOffset, 16u)) {
-                    skip |= LogError(
-                        "VUID-VkAccelerationStructureBuildRangeInfoKHR-transformOffset-03658", commandBuffer,
-                        error_obj.location.dot(Field::ppBuildRangeInfos, info_i).brackets(geom_i).dot(Field::transformOffset),
-                        "(%" PRIu32 ") is not a multiple of 16.", build_range.transformOffset);
-                }
-
-            } else if (as_geometry.geometryType == VK_GEOMETRY_TYPE_AABBS_KHR) {
-                const auto &aabbs = as_geometry.geometry.aabbs;
-                if (!IsPointerAligned(aabbs.data.deviceAddress, 8)) {
-                    skip |= LogError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03714", commandBuffer,
-                                     p_geom_geom_loc.dot(Field::aabbs).dot(Field::data).dot(Field::deviceAddress),
-                                     "(0x%" PRIx64 ") must be aligned to 8 bytes when geometryType is VK_GEOMETRY_TYPE_AABBS_KHR.",
-                                     aabbs.data.deviceAddress);
-                }
-
-                if (!IsIntegerMultipleOf(build_range.primitiveOffset, 8u)) {
-                    skip |= LogError(
-                        "VUID-VkAccelerationStructureBuildRangeInfoKHR-primitiveOffset-03659", commandBuffer,
-                        error_obj.location.dot(Field::ppBuildRangeInfos, info_i).brackets(geom_i).dot(Field::primitiveOffset),
-                        "(%" PRIu32 ") is not a multiple of 8.", build_range.primitiveOffset);
-                }
-            } else if (as_geometry.geometryType == VK_GEOMETRY_TYPE_INSTANCES_KHR) {
-                const auto &instances = as_geometry.geometry.instances;
-                if (instances.arrayOfPointers == VK_TRUE) {
-                    if (!IsPointerAligned(instances.data.deviceAddress, 8)) {
-                        skip |= LogError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03716", commandBuffer,
-                                         p_geom_geom_loc.dot(Field::instances).dot(Field::data).dot(Field::deviceAddress),
-                                         "(0x%" PRIx64
-                                         ") must be aligned to 8 bytes when geometryType is VK_GEOMETRY_TYPE_INSTANCES_KHR and "
-                                         "geometry.instances.arrayOfPointers is "
-                                         "VK_TRUE.",
-                                         instances.data.deviceAddress);
-                    }
-                } else {
-                    if (!IsPointerAligned(instances.data.deviceAddress, 16)) {
-                        skip |= LogError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03715", commandBuffer,
-                                         p_geom_geom_loc.dot(Field::instances).dot(Field::data).dot(Field::deviceAddress),
-                                         "(0x%" PRIx64
-                                         ") must be aligned to 16 bytes when geometryType is VK_GEOMETRY_TYPE_INSTANCES_KHR and "
-                                         "geometry.instances.arrayOfPointers is VK_FALSE.",
-                                         instances.data.deviceAddress);
-                    }
-                }
-                const Location p_build_range_loc = error_obj.location.dot(Field::ppBuildRangeInfos, info_i);
-                if (build_range.primitiveCount > phys_dev_ext_props.acc_structure_props.maxInstanceCount) {
-                    skip |= LogError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03801", commandBuffer, p_build_range_loc,
-                                     "[%" PRIu32 "].primitiveCount (%" PRIu32
-                                     ") is superior to VkPhysicalDeviceAccelerationStructurePropertiesKHR::maxInstanceCount "
-                                     "(%" PRIu64 ").",
-                                     geom_i, build_range.primitiveCount, phys_dev_ext_props.acc_structure_props.maxInstanceCount);
-                }
-
-                if (!IsIntegerMultipleOf(build_range.primitiveOffset, 16u)) {
-                    skip |= LogError(
-                        "VUID-VkAccelerationStructureBuildRangeInfoKHR-primitiveOffset-03660", commandBuffer,
-                        error_obj.location.dot(Field::ppBuildRangeInfos, info_i).brackets(geom_i).dot(Field::primitiveOffset),
-                        "(%" PRIu32 ") is not a multiple of 16.", build_range.primitiveOffset);
-                }
-            }
+            const VkAccelerationStructureBuildRangeInfoKHR& build_range = ppBuildRangeInfos[info_i][geom_i];
+            skip |= ValidateAccelerationStructureBuildRangeInfo(
+                context, geometry, build_range, geometry_ptr_loc,
+                error_obj.location.dot(Field::ppBuildRangeInfos, info_i).brackets(geom_i));
         }
-        skip |= context.ValidateArray(info_loc.dot(Field::geometryCount), error_obj.location.dot(Field::ppBuildRangeInfos, info_i),
-                                      info.geometryCount, &ppBuildRangeInfos[info_i], false, true, kVUIDUndefined,
-                                      "VUID-vkCmdBuildAccelerationStructuresKHR-ppBuildRangeInfos-03676");
     }
 
     return skip;
@@ -1038,7 +1180,7 @@ bool Device::manual_PreCallValidateCmdBuildAccelerationStructuresIndirectKHR(
     for (const auto [info_i, info] : vvl::enumerate(pInfos, infoCount)) {
         const Location info_loc = error_obj.location.dot(Field::pInfos, info_i);
 
-        skip |= ValidateAccelerationStructureBuildGeometryInfoKHR(context, pInfos[info_i], error_obj.handle, info_loc);
+        skip |= ValidateAccelerationStructureBuildGeometryInfo(error_obj.handle, pInfos[info_i], info_loc);
 
         if (!IsPointerAligned(info.scratchData.deviceAddress,
                               phys_dev_ext_props.acc_structure_props.minAccelerationStructureScratchOffsetAlignment)) {
@@ -1047,145 +1189,6 @@ bool Device::manual_PreCallValidateCmdBuildAccelerationStructuresIndirectKHR(
                              "(0x%" PRIx64 ") must be aligned to minAccelerationStructureScratchOffsetAlignment (%" PRIu32 ").",
                              info.scratchData.deviceAddress,
                              phys_dev_ext_props.acc_structure_props.minAccelerationStructureScratchOffsetAlignment);
-        }
-        skip |= context.ValidateRangedEnum(info_loc.dot(Field::mode), vvl::Enum::VkBuildAccelerationStructureModeKHR, info.mode,
-                                           "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-mode-04628");
-
-        if (info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR && info.srcAccelerationStructure == VK_NULL_HANDLE) {
-            skip |=
-                LogError("VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-04630", commandBuffer, info_loc.dot(Field::mode),
-                         "is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR, but srcAccelerationStructure is VK_NULL_HANDLE.");
-        }
-
-        for (uint32_t info_k = 0; info_k < infoCount; ++info_k) {
-            if (info_i == info_k) continue;
-            if (info.dstAccelerationStructure == pInfos[info_k].dstAccelerationStructure) {
-                const LogObjectList objlist(commandBuffer, info.dstAccelerationStructure);
-                skip |= LogError("VUID-vkCmdBuildAccelerationStructuresIndirectKHR-dstAccelerationStructure-03698", objlist,
-                                 info_loc.dot(Field::dstAccelerationStructure),
-                                 "and pInfos[%" PRIu32 "].dstAccelerationStructure are both %s.", info_k,
-                                 FormatHandle(info.dstAccelerationStructure).c_str());
-                break;
-            }
-            if (info.srcAccelerationStructure == pInfos[info_k].dstAccelerationStructure) {
-                const LogObjectList objlist(commandBuffer, info.srcAccelerationStructure);
-                skip |= LogError("VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03403", objlist,
-                                 info_loc.dot(Field::srcAccelerationStructure),
-                                 "and pInfos[%" PRIu32 "].dstAccelerationStructure are both %s.", info_k,
-                                 FormatHandle(info.srcAccelerationStructure).c_str());
-                break;
-            }
-        }
-        for (uint32_t j = 0; j < info.geometryCount; ++j) {
-            if (info.pGeometries) {
-                const VkAccelerationStructureGeometryKHR &as_geometry = info.pGeometries[j];
-                const Location geometry_loc = error_obj.location.dot(Field::pGeometries, j);
-                if (as_geometry.geometryType == VK_GEOMETRY_TYPE_INSTANCES_KHR) {
-                    const auto &instances = as_geometry.geometry.instances;
-                    if (instances.arrayOfPointers == VK_TRUE) {
-                        if (!IsPointerAligned(instances.data.deviceAddress, 8)) {
-                            skip |= LogError(
-                                "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03716", commandBuffer,
-                                geometry_loc.dot(Field::geometry).dot(Field::instances).dot(Field::data).dot(Field::deviceAddress),
-                                "(0x%" PRIx64
-                                ") must be aligned to 8 bytes when geometryType is VK_GEOMETRY_TYPE_INSTANCES_KHR and "
-                                "geometry.instances.arrayOfPointers is "
-                                "VK_TRUE.",
-                                instances.data.deviceAddress);
-                        }
-                    } else {
-                        if (!IsPointerAligned(instances.data.deviceAddress, 16)) {
-                            skip |= LogError(
-                                "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03715", commandBuffer,
-                                geometry_loc.dot(Field::geometry).dot(Field::instances).dot(Field::data).dot(Field::deviceAddress),
-                                "(0x%" PRIx64
-                                ") must be aligned to 16 bytes when geometryType is VK_GEOMETRY_TYPE_INSTANCES_KHR and "
-                                "geometry.instances.arrayOfPointers is VK_FALSE.",
-                                instances.data.deviceAddress);
-                        }
-                    }
-                } else if (as_geometry.geometryType == VK_GEOMETRY_TYPE_AABBS_KHR) {
-                    const auto &aabbs = as_geometry.geometry.aabbs;
-                    if (!IsPointerAligned(aabbs.data.deviceAddress, 8)) {
-                        skip |= LogError(
-                            "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03714", commandBuffer,
-                            geometry_loc.dot(Field::geometry).dot(Field::instances).dot(Field::data).dot(Field::deviceAddress),
-                            "(0x%" PRIx64 ") must be aligned to 8 bytes when geometryType is VK_GEOMETRY_TYPE_AABBS_KHR.",
-                            aabbs.data.deviceAddress);
-                    }
-                } else if (as_geometry.geometryType == VK_GEOMETRY_TYPE_TRIANGLES_KHR) {
-                    const auto &triangles = as_geometry.geometry.triangles;
-                    const uint32_t index_type_size = IndexTypeSize(triangles.indexType);
-                    if (triangles.indexType != VK_INDEX_TYPE_NONE_KHR &&
-                        !IsPointerAligned(triangles.indexData.deviceAddress, index_type_size)) {
-                        skip |= LogError(
-                            "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03712", commandBuffer,
-                            geometry_loc.dot(Field::geometry).dot(Field::triangles).dot(Field::indexData).dot(Field::deviceAddress),
-                            "(0x%" PRIx64 ") is not aligned to %" PRIu32 " (the alignment for %s).",
-                            triangles.indexData.deviceAddress, index_type_size, string_VkIndexType(triangles.indexType));
-                    }
-
-                    if (!IsPointerAligned(triangles.transformData.deviceAddress, 16)) {
-                        skip |= LogError("VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03810", commandBuffer,
-                                         geometry_loc.dot(Field::geometry)
-                                             .dot(Field::triangles)
-                                             .dot(Field::transformData)
-                                             .dot(Field::deviceAddress),
-                                         "(0x%" PRIx64
-                                         ") must be aligned to 16 bytes when geometryType is VK_GEOMETRY_TYPE_TRIANGLES_KHR.",
-                                         triangles.transformData.deviceAddress);
-                    }
-                }
-            } else if (info.ppGeometries) {
-                const VkAccelerationStructureGeometryKHR &as_geometry = *info.ppGeometries[j];
-                const Location geometry_loc = error_obj.location.dot(Field::ppGeometries, j);
-                if (as_geometry.geometryType == VK_GEOMETRY_TYPE_INSTANCES_KHR) {
-                    const auto &instances = as_geometry.geometry.instances;
-                    if (instances.arrayOfPointers == VK_TRUE) {
-                        if (!IsPointerAligned(instances.data.deviceAddress, 8)) {
-                            skip |= LogError(
-                                "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03716", commandBuffer,
-                                geometry_loc.dot(Field::geometry).dot(Field::instances).dot(Field::data).dot(Field::deviceAddress),
-                                "(0x%" PRIx64
-                                ") must be aligned to 8 bytes when geometryType is VK_GEOMETRY_TYPE_INSTANCES_KHR and "
-                                "geometry.instances.arrayOfPointers is "
-                                "VK_TRUE.",
-                                instances.data.deviceAddress);
-                        }
-                    } else {
-                        if (!IsPointerAligned(instances.data.deviceAddress, 16)) {
-                            skip |= LogError(
-                                "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03715", commandBuffer,
-                                geometry_loc.dot(Field::geometry).dot(Field::instances).dot(Field::data).dot(Field::deviceAddress),
-                                "(0x%" PRIx64
-                                ") must be aligned to 16 bytes when geometryType is VK_GEOMETRY_TYPE_INSTANCES_KHR and "
-                                "geometry.instances.arrayOfPointers is VK_FALSE.",
-                                instances.data.deviceAddress);
-                        }
-                    }
-                } else if (as_geometry.geometryType == VK_GEOMETRY_TYPE_AABBS_KHR) {
-                    const auto &aabbs = as_geometry.geometry.aabbs;
-                    if (!IsPointerAligned(aabbs.data.deviceAddress, 8)) {
-                        skip |=
-                            LogError("VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03714", commandBuffer,
-                                     geometry_loc.dot(Field::geometry).dot(Field::aabbs).dot(Field::data).dot(Field::deviceAddress),
-                                     "(0x%" PRIx64 ") must be aligned to 8 bytes when geometryType is VK_GEOMETRY_TYPE_AABBS_KHR.",
-                                     aabbs.data.deviceAddress);
-                    }
-                } else if (as_geometry.geometryType == VK_GEOMETRY_TYPE_TRIANGLES_KHR) {
-                    const auto &triangles = as_geometry.geometry.triangles;
-                    if (!IsPointerAligned(triangles.transformData.deviceAddress, 16)) {
-                        skip |= LogError("VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03810", commandBuffer,
-                                         geometry_loc.dot(Field::geometry)
-                                             .dot(Field::triangles)
-                                             .dot(Field::transformData)
-                                             .dot(Field::deviceAddress),
-                                         "(0x%" PRIx64
-                                         ") must be aligned to 16 bytes when geometryType is VK_GEOMETRY_TYPE_TRIANGLES_KHR.",
-                                         triangles.transformData.deviceAddress);
-                    }
-                }
-            }
         }
 
         if (!IsPointerAligned(pIndirectDeviceAddresses[info_i], 4)) {
@@ -1198,6 +1201,43 @@ bool Device::manual_PreCallValidateCmdBuildAccelerationStructuresIndirectKHR(
             skip |= LogError("VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pIndirectStrides-03787", commandBuffer,
                              error_obj.location.dot(Field::pIndirectStrides, info_i), "(%" PRIu32 ") is not a multiple of 4.",
                              pIndirectStrides[info_i]);
+        }
+
+        skip |= context.ValidateRangedEnum(info_loc.dot(Field::mode), vvl::Enum::VkBuildAccelerationStructureModeKHR, info.mode,
+                                           "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-mode-04628");
+
+        if (info.mode == VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR && info.srcAccelerationStructure == VK_NULL_HANDLE) {
+            skip |=
+                LogError("VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-04630", commandBuffer, info_loc.dot(Field::mode),
+                         "is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR, but srcAccelerationStructure is VK_NULL_HANDLE.");
+        }
+
+        for (const auto [other_info_j, other_info] : vvl::enumerate(pInfos, infoCount)) {
+            if (info_i == other_info_j) {
+                continue;
+            }
+            if (info.dstAccelerationStructure == other_info.dstAccelerationStructure) {
+                const LogObjectList objlist(commandBuffer, info.dstAccelerationStructure);
+                skip |= LogError("VUID-vkCmdBuildAccelerationStructuresIndirectKHR-dstAccelerationStructure-03698", objlist,
+                                 info_loc.dot(Field::dstAccelerationStructure),
+                                 "and pInfos[%" PRIu32 "].dstAccelerationStructure are both %s.", other_info_j,
+                                 FormatHandle(info.dstAccelerationStructure).c_str());
+                break;
+            }
+            if (info.srcAccelerationStructure == other_info.dstAccelerationStructure) {
+                const LogObjectList objlist(commandBuffer, info.srcAccelerationStructure);
+                skip |= LogError("VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-03403", objlist,
+                                 info_loc.dot(Field::srcAccelerationStructure),
+                                 "and pInfos[%" PRIu32 "].dstAccelerationStructure are both %s.", other_info_j,
+                                 FormatHandle(info.srcAccelerationStructure).c_str());
+                break;
+            }
+        }
+
+        for (uint32_t geom_i = 0; geom_i < info.geometryCount; ++geom_i) {
+            const VkAccelerationStructureGeometryKHR& geometry = rt::GetGeometry(info, geom_i);
+            const Location geometry_ptr_loc = info_loc.dot(info.pGeometries ? Field::pGeometries : Field::ppGeometries, geom_i);
+            skip |= ValidateAccelerationStructureGeometry(context, info, geometry, geometry_ptr_loc);
         }
     }
     return skip;
@@ -1223,7 +1263,7 @@ bool Device::manual_PreCallValidateBuildAccelerationStructuresKHR(
     for (const auto [info_i, info] : vvl::enumerate(pInfos, infoCount)) {
         const Location info_loc = error_obj.location.dot(Field::pInfos, info_i);
 
-        skip |= ValidateAccelerationStructureBuildGeometryInfoKHR(context, info, error_obj.handle, error_obj.location);
+        skip |= ValidateAccelerationStructureBuildGeometryInfo(error_obj.handle, info, info_loc);
 
         skip |= context.ValidateRangedEnum(info_loc.dot(Field::mode), vvl::Enum::VkBuildAccelerationStructureModeKHR, info.mode,
                                            "VUID-vkBuildAccelerationStructuresKHR-mode-04628");
@@ -1251,114 +1291,31 @@ bool Device::manual_PreCallValidateBuildAccelerationStructuresKHR(
             }
         }
 
-        for (uint32_t geom_i = 0; geom_i < info.geometryCount; ++geom_i) {
-            const VkAccelerationStructureGeometryKHR &geom = rt::GetGeometry(info, geom_i);
-            if (geom.geometryType == VK_GEOMETRY_TYPE_TRIANGLES_KHR) {
-                const auto &triangles = geom.geometry.triangles;
-                if (!triangles.vertexData.hostAddress) {
-                    skip |= LogError("VUID-vkBuildAccelerationStructuresKHR-pInfos-03771", device,
-                                     info_loc.dot(Field::triangles).dot(Field::vertexData).dot(Field::hostAddress), "is NULL.");
-                }
-                if (triangles.indexType != VK_INDEX_TYPE_NONE_KHR && !triangles.indexData.hostAddress) {
-                    skip |= LogError("VUID-vkBuildAccelerationStructuresKHR-pInfos-03772", device,
-                                     info_loc.dot(Field::triangles).dot(Field::indexData).dot(Field::hostAddress), "is NULL.");
-                }
-
-                if (const auto *micromap =
-                        vku::FindStructInPNextChain<VkAccelerationStructureTrianglesOpacityMicromapEXT>(triangles.pNext)) {
-                    if (micromap->indexType != VK_INDEX_TYPE_NONE_KHR && !micromap->indexBuffer.hostAddress) {
-                        skip |= LogError("VUID-vkBuildAccelerationStructuresKHR-pInfos-10892", device,
-                                         info_loc.dot(Field::triangles)
-                                             .pNext(Struct::VkAccelerationStructureTrianglesOpacityMicromapEXT, Field::indexBuffer)
-                                             .dot(Field::hostAddress),
-                                         "is NULL.");
-                    }
-                }
-            } else if (geom.geometryType == VK_GEOMETRY_TYPE_AABBS_KHR) {
-                if (!geom.geometry.aabbs.data.hostAddress) {
-                    skip |= LogError("VUID-vkBuildAccelerationStructuresKHR-pInfos-03774", device,
-                                     info_loc.dot(Field::aabbs).dot(Field::data).dot(Field::hostAddress), "is NULL.");
-                }
-            } else if (geom.geometryType == VK_GEOMETRY_TYPE_INSTANCES_KHR) {
-                if (!geom.geometry.instances.data.hostAddress) {
-                    skip |= LogError("VUID-vkBuildAccelerationStructuresKHR-pInfos-03778", device,
-                                     info_loc.dot(Field::instances).dot(Field::data).dot(Field::hostAddress), "is NULL.");
-                }
-            } else if (geom.geometryType == VK_GEOMETRY_TYPE_SPHERES_NV) {
-                auto sphere_struct = reinterpret_cast<VkAccelerationStructureGeometrySpheresDataNV const *>(geom.pNext);
-                if (sphere_struct) {
-                    if (sphere_struct->indexType == VK_INDEX_TYPE_NONE_KHR) {
-                        if (sphere_struct->indexData.hostAddress != 0) {
-                            skip |= LogError("VUID-vkBuildAccelerationStructuresKHR-pInfos-11822", device,
-                                             info_loc.dot(Field::spheres).dot(Field::indexData).dot(Field::hostAddress),
-                                             "(%p) is not 0 when indexType is VK_INDEX_TYPE_NONE_KHR.",
-                                             sphere_struct->indexData.hostAddress);
-                        }
-                    } else {
-                        if (sphere_struct->indexData.hostAddress == 0) {
-                            skip |= LogError("VUID-vkBuildAccelerationStructuresKHR-pInfos-11823", device,
-                                             info_loc.dot(Field::spheres).dot(Field::indexData).dot(Field::hostAddress), "is 0");
-                        }
-                    }
-                    if (sphere_struct->vertexData.hostAddress == 0) {
-                        skip |= LogError("VUID-vkBuildAccelerationStructuresKHR-pInfos-11824", device,
-                                         info_loc.dot(Field::spheres).dot(Field::vertexData).dot(Field::hostAddress), "is 0");
-                    }
-                    if (sphere_struct->radiusData.hostAddress == 0) {
-                        skip |= LogError("VUID-vkBuildAccelerationStructuresKHR-pInfos-11825", device,
-                                         info_loc.dot(Field::spheres).dot(Field::radiusData).dot(Field::hostAddress), "is 0");
-                    }
-                }
-            } else if (geom.geometryType == VK_GEOMETRY_TYPE_LINEAR_SWEPT_SPHERES_NV) {
-                auto sphere_linear_struct =
-                    reinterpret_cast<VkAccelerationStructureGeometryLinearSweptSpheresDataNV const *>(geom.pNext);
-                if (sphere_linear_struct) {
-                    if (sphere_linear_struct->indexType == VK_INDEX_TYPE_NONE_KHR) {
-                        if (sphere_linear_struct->indexData.hostAddress != 0) {
-                            skip |= LogError("VUID-vkBuildAccelerationStructuresKHR-pInfos-11826", device,
-                                             info_loc.dot(Field::linearSweptSpheres).dot(Field::indexData).dot(Field::hostAddress),
-                                             "(%p) is not 0 when indexType is VK_INDEX_TYPE_NONE_KHR.",
-                                             sphere_linear_struct->indexData.hostAddress);
-                        }
-                    } else {
-                        if (sphere_linear_struct->indexData.hostAddress == 0) {
-                            skip |= LogError("VUID-vkBuildAccelerationStructuresKHR-pInfos-11827", device,
-                                             info_loc.dot(Field::linearSweptSpheres).dot(Field::indexData).dot(Field::hostAddress),
-                                             "is 0");
-                        }
-                    }
-                    if (sphere_linear_struct->vertexData.hostAddress == 0) {
-                        skip |= LogError("VUID-vkBuildAccelerationStructuresKHR-pInfos-11828", device,
-                                         info_loc.dot(Field::linearSweptSpheres).dot(Field::vertexData).dot(Field::hostAddress),
-                                         "is 0");
-                    }
-                    if (sphere_linear_struct->radiusData.hostAddress == 0) {
-                        skip |= LogError("VUID-vkBuildAccelerationStructuresKHR-pInfos-11829", device,
-                                         info_loc.dot(Field::linearSweptSpheres).dot(Field::radiusData).dot(Field::hostAddress),
-                                         "is 0");
-                    }
-                }
-            }
-        }
-
-        for (uint32_t info_k = 0; info_k < infoCount; ++info_k) {
-            if (info_i == info_k) {
+        for (const auto [other_info_j, other_info] : vvl::enumerate(pInfos, infoCount)) {
+            if (info_i == other_info_j) {
                 continue;
             }
-            if (info.dstAccelerationStructure == pInfos[info_k].dstAccelerationStructure) {
+            if (info.dstAccelerationStructure == other_info.dstAccelerationStructure) {
                 skip |= LogError("VUID-vkBuildAccelerationStructuresKHR-dstAccelerationStructure-03698", device,
                                  info_loc.dot(Field::dstAccelerationStructure),
-                                 "and pInfos[%" PRIu32 "].dstAccelerationStructure are both %s.", info_k,
+                                 "and pInfos[%" PRIu32 "].dstAccelerationStructure are both %s.", other_info_j,
                                  FormatHandle(info.dstAccelerationStructure).c_str());
                 break;
             }
-            if (info.srcAccelerationStructure == pInfos[info_k].dstAccelerationStructure) {
+            if (info.srcAccelerationStructure == other_info.dstAccelerationStructure) {
                 skip |= LogError("VUID-vkBuildAccelerationStructuresKHR-pInfos-03403", device,
                                  info_loc.dot(Field::srcAccelerationStructure),
-                                 "and pInfos[%" PRIu32 "].dstAccelerationStructure are both %s.", info_k,
+                                 "and pInfos[%" PRIu32 "].dstAccelerationStructure are both %s.", other_info_j,
                                  FormatHandle(info.srcAccelerationStructure).c_str());
                 break;
             }
+        }
+
+        for (uint32_t geom_i = 0; geom_i < info.geometryCount; ++geom_i) {
+            const VkAccelerationStructureGeometryKHR& geometry = rt::GetGeometry(info, geom_i);
+            const Location geometry_ptr_loc = info_loc.dot(info.pGeometries ? Field::pGeometries : Field::ppGeometries, geom_i);
+            skip |= ValidateAccelerationStructureGeometry(context, info, geometry, geometry_ptr_loc);
+            skip |= ValidateAccelerationStructureGeometryHost(context, info, geometry, geometry_ptr_loc);
         }
     }
     return skip;
@@ -1376,28 +1333,13 @@ bool Device::manual_PreCallValidateGetAccelerationStructureBuildSizesKHR(
                          "accelerationStructure feature was not enabled.");
     }
     if (pBuildInfo) {
-        if (pBuildInfo->geometryCount != 0 && !pMaxPrimitiveCounts) {
-            skip |= LogError("VUID-vkGetAccelerationStructureBuildSizesKHR-pBuildInfo-03619", device,
-                             error_obj.location.dot(Field::pBuildInfo).dot(Field::geometryCount),
-                             "is %" PRIu32 ", but pMaxPrimitiveCounts is NULL.", pBuildInfo->geometryCount);
-        }
+        const Location build_info_loc = error_obj.location.dot(Field::pBuildInfo);
+        const VkAccelerationStructureBuildGeometryInfoKHR& build_info = *pBuildInfo;
 
-        if (pMaxPrimitiveCounts && (pBuildInfo->pGeometries || pBuildInfo->ppGeometries)) {
-            for (uint32_t geom_i = 0; geom_i < pBuildInfo->geometryCount; ++geom_i) {
-                const VkAccelerationStructureGeometryKHR &geom = rt::GetGeometry(*pBuildInfo, geom_i);
-                if (geom.geometryType == VK_GEOMETRY_TYPE_INSTANCES_KHR) {
-                    if (pMaxPrimitiveCounts[geom_i] > phys_dev_ext_props.acc_structure_props.maxInstanceCount) {
-                        const Field p_geom = pBuildInfo->pGeometries ? Field::pGeometries : Field::ppGeometries;
-                        skip |= LogError(
-                            "VUID-vkGetAccelerationStructureBuildSizesKHR-pBuildInfo-03785", device,
-                            error_obj.location.dot(Field::pBuildInfo).dot(p_geom, geom_i).dot(Field::geometryType),
-                            "is %s, but pMaxPrimitiveCount[%" PRIu32 "] (%" PRIu32
-                            ") is larger than VkPhysicalDeviceAccelerationStructurePropertiesKHR::maxInstanceCount (%" PRIu64 ").",
-                            string_VkGeometryTypeKHR(geom.geometryType), geom_i, pMaxPrimitiveCounts[geom_i],
-                            phys_dev_ext_props.acc_structure_props.maxInstanceCount);
-                    }
-                }
-            }
+        if (build_info.geometryCount != 0 && !pMaxPrimitiveCounts) {
+            skip |= LogError("VUID-vkGetAccelerationStructureBuildSizesKHR-pBuildInfo-03619", device,
+                             build_info_loc.dot(Field::geometryCount), "is %" PRIu32 ", but pMaxPrimitiveCounts is NULL.",
+                             build_info.geometryCount);
         }
 
         if (pMaxPrimitiveCounts) {
@@ -1408,8 +1350,29 @@ bool Device::manual_PreCallValidateGetAccelerationStructureBuildSizesKHR(
             skip |= ValidateTotalPrimitivesCount(total_triangles_count, total_aabbs_count, error_obj.handle, error_obj.location);
         }
 
-        skip |= ValidateAccelerationStructureBuildGeometryInfoKHR(context, *pBuildInfo, error_obj.handle,
-                                                                  error_obj.location.dot(Field::pBuildInfo, 0));
+        skip |=
+            ValidateAccelerationStructureBuildGeometryInfo(error_obj.handle, build_info, error_obj.location.dot(Field::pBuildInfo));
+
+        if (pBuildInfo->pGeometries || pBuildInfo->ppGeometries) {
+            for (uint32_t geom_i = 0; geom_i < build_info.geometryCount; ++geom_i) {
+                const VkAccelerationStructureGeometryKHR& geometry = rt::GetGeometry(build_info, geom_i);
+                const Location geometry_ptr_loc =
+                    build_info_loc.dot(build_info.pGeometries ? Field::pGeometries : Field::ppGeometries, geom_i);
+                skip |= ValidateAccelerationStructureGeometry(context, build_info, geometry, geometry_ptr_loc);
+
+                if (pMaxPrimitiveCounts && geometry.geometryType == VK_GEOMETRY_TYPE_INSTANCES_KHR) {
+                    if (pMaxPrimitiveCounts[geom_i] > phys_dev_ext_props.acc_structure_props.maxInstanceCount) {
+                        skip |= LogError(
+                            "VUID-vkGetAccelerationStructureBuildSizesKHR-pBuildInfo-03785", device,
+                            geometry_ptr_loc.dot(Field::geometryType),
+                            "is %s, but pMaxPrimitiveCount[%" PRIu32 "] (%" PRIu32
+                            ") is larger than VkPhysicalDeviceAccelerationStructurePropertiesKHR::maxInstanceCount (%" PRIu64 ").",
+                            string_VkGeometryTypeKHR(geometry.geometryType), geom_i, pMaxPrimitiveCounts[geom_i],
+                            phys_dev_ext_props.acc_structure_props.maxInstanceCount);
+                    }
+                }
+            }
+        }
     }
 
     return skip;

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -997,12 +997,22 @@ class Device : public vvl::base::Device {
                                                      const VkDeviceSize *pSizes, const VkDeviceSize *pStrides,
                                                      const Context &context) const;
 
-    [[nodiscard]] bool ValidateTotalPrimitivesCount(uint64_t total_triangles_count, uint64_t total_aabbs_count,
-                                                    const VulkanTypedHandle &handle, const Location &loc) const;
-    [[nodiscard]] bool ValidateAccelerationStructureBuildGeometryInfoKHR(const Context &context,
-                                                                         const VkAccelerationStructureBuildGeometryInfoKHR &info,
-                                                                         const VulkanTypedHandle &handle,
-                                                                         const Location &info_loc) const;
+    bool ValidateTotalPrimitivesCount(uint64_t total_triangles_count, uint64_t total_aabbs_count, const VulkanTypedHandle& handle,
+                                      const Location& loc) const;
+    bool ValidateAccelerationStructureBuildGeometryInfo(const VulkanTypedHandle& handle,
+                                                        const VkAccelerationStructureBuildGeometryInfoKHR& info,
+                                                        const Location& info_loc) const;
+    bool ValidateAccelerationStructureGeometry(const Context& context, const VkAccelerationStructureBuildGeometryInfoKHR& info,
+                                               const VkAccelerationStructureGeometryKHR& geom,
+                                               const Location& geometry_ptr_loc) const;
+    bool ValidateAccelerationStructureGeometryHost(const Context& context, const VkAccelerationStructureBuildGeometryInfoKHR& info,
+                                                   const VkAccelerationStructureGeometryKHR& geom,
+                                                   const Location& geometry_ptr_loc) const;
+    bool ValidateAccelerationStructureGeometryDevice(const Context& context, const VkAccelerationStructureGeometryKHR& geom,
+                                                     const Location& geometry_ptr_loc) const;
+    bool ValidateAccelerationStructureBuildRangeInfo(const Context& context, const VkAccelerationStructureGeometryKHR& geom,
+                                                     const VkAccelerationStructureBuildRangeInfoKHR& build_range,
+                                                     const Location& geometry_ptr_loc, const Location& build_range_loc) const;
     bool manual_PreCallValidateCmdBuildAccelerationStructuresKHR(
         VkCommandBuffer commandBuffer, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR *pInfos,
         const VkAccelerationStructureBuildRangeInfoKHR *const *ppBuildRangeInfos, const Context &context) const;

--- a/tests/unit/descriptor_buffer.cpp
+++ b/tests/unit/descriptor_buffer.cpp
@@ -494,7 +494,7 @@ TEST_F(NegativeDescriptorBuffer, NotEnabledDescriptorBufferCaptureReplayAS) {
     m_errorMonitor->VerifyFound();
 
     asci.pNext = &ocddci;
-    asci.createFlags &= ~VK_ACCELERATION_STRUCTURE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
+    asci.createFlags = 0;
     m_errorMonitor->SetDesiredError("VUID-VkAccelerationStructureCreateInfoKHR-pNext-08109");
     vk::CreateAccelerationStructureKHR(device(), &asci, NULL, &as);
     m_errorMonitor->VerifyFound();

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -1847,7 +1847,7 @@ TEST_F(NegativeRayTracing, CmdBuildAccelerationStructuresKHR) {
         auto bad_scratch = std::make_shared<vkt::Buffer>(*m_device, scratch_size, VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
                                                          VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &alloc_flags);
         blas.SetScratchBuffer(std::move(bad_scratch));
-        m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-12260");
+        m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-12261");
         blas.BuildCmdBuffer(m_command_buffer);
         m_errorMonitor->VerifyFound();
     }


### PR DESCRIPTION
Found many small bugs printing the wrong location and just forgetting some `vkCmdBuildAccelerationStructuresIndirectKHR` checks

This just re-groups things to be more organized