### PR TITLE
layers: Batch leaking object message

### DIFF
--- a/layers/object_tracker/object_lifetime_validation.cpp
+++ b/layers/object_tracker/object_lifetime_validation.cpp
@@ -612,10 +612,7 @@ void Device::CreateSwapchainImageObject(VkImage swapchain_image, VkSwapchainKHR 
     tracker.CreateObject(swapchain_image, kVulkanObjectTypeImage, nullptr, loc, swapchain);
 }
 
-bool Instance::ReportLeakedObjects(VulkanObjectType object_type, const std::string &error_code,
-                                           const Location &loc) const {
-    bool skip = false;
-
+void Instance::FindLeakedObjects(VulkanObjectType object_type, std::vector<VulkanTypedHandle>& leaked_list) const {
     // The state tracker also tracks implicit images created for swapchains and reports them as leak.
     // This is entirely incorrect and unfortunately the machinery does not allow distinguishing between
     // implicitly and explicitly created swapchain images, so the best we can do is to ignore any leaked
@@ -632,25 +629,54 @@ bool Instance::ReportLeakedObjects(VulkanObjectType object_type, const std::stri
             : tracker.object_map[object_type].snapshot();
     for (const auto &item : snapshot) {
         const auto object_info = item.second;
-        const LogObjectList objlist(instance, ObjTrackStateTypedHandle(*object_info));
-        skip |= LogError(error_code, objlist, loc, "Object Tracking - For %s, %s has not been destroyed.",
-                         FormatHandle(instance).c_str(), FormatHandle(ObjTrackStateTypedHandle(*object_info)).c_str());
+        leaked_list.emplace_back(ObjTrackStateTypedHandle(*object_info));
     }
-    return skip;
 }
 
-bool Device::ReportLeakedObjects(VulkanObjectType object_type, const std::string &error_code,
-                                       const Location &loc) const {
-    bool skip = false;
+bool Instance::ReportLeakedObjects(std::vector<VulkanTypedHandle>& leaked_list, const Location& loc) const {
+    std::stringstream ss;
+    ss << FormatHandle(instance) << " has " << leaked_list.size() << " leaked objects that have not been destroyed.\n";
+    uint32_t count = 0;
+    for (const auto& object : leaked_list) {
+        if (count >= 64) {
+            // Feels like spam after this, user should have zero anyway
+            ss << "\n(Only printing the first 64 objects)";
+            break;
+        }
+        if (count != 0) {
+            ss << ", ";
+        }
+        ss << FormatHandle(object);
+        count++;
+    }
+    return LogError("VUID-vkDestroyInstance-instance-00629", instance, loc, "%s", ss.str().c_str());
+}
 
+void Device::FindLeakedObjects(VulkanObjectType object_type, std::vector<VulkanTypedHandle>& leaked_list) const {
     auto snapshot = tracker.object_map[object_type].snapshot();
     for (const auto &item : snapshot) {
         const auto object_info = item.second;
-        const LogObjectList objlist(device, ObjTrackStateTypedHandle(*object_info));
-        skip |= LogError(error_code, objlist, loc, "Object Tracking - For %s, %s has not been destroyed.",
-                         FormatHandle(device).c_str(), FormatHandle(ObjTrackStateTypedHandle(*object_info)).c_str());
+        leaked_list.emplace_back(ObjTrackStateTypedHandle(*object_info));
     }
-    return skip;
+}
+
+bool Device::ReportLeakedObjects(std::vector<VulkanTypedHandle>& leaked_list, const Location& loc) const {
+    std::stringstream ss;
+    ss << FormatHandle(device) << " has " << leaked_list.size() << " leaked objects that have not been destroyed.\n";
+    uint32_t count = 0;
+    for (const auto& object : leaked_list) {
+        if (count >= 64) {
+            // Feels like spam after this, user should have zero anyway
+            ss << "\n(Only printing the first 64 objects)";
+            break;
+        }
+        if (count != 0) {
+            ss << ", ";
+        }
+        ss << FormatHandle(object);
+        count++;
+    }
+    return LogError("VUID-vkDestroyDevice-device-05137", device, loc, "%s", ss.str().c_str());
 }
 
 bool Instance::PreCallValidateDestroyInstance(VkInstance instance, const VkAllocationCallbacks *pAllocator,

--- a/layers/object_tracker/object_lifetime_validation.h
+++ b/layers/object_tracker/object_lifetime_validation.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (C) 2015-2025 Google Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (C) 2015-2026 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -163,8 +163,9 @@ class Instance : public vvl::base::Instance {
 
     void DestroyLeakedObjects();
     bool ReportUndestroyedObjects(const Location &loc) const;
-    bool ReportLeakedObjects(VulkanObjectType object_type, const std::string &error_code,
-                                     const Location &loc) const;
+    void FindLeakedObjects(VulkanObjectType object_type, std::vector<VulkanTypedHandle>& leaked_list) const;
+    bool ReportLeakedObjects(std::vector<VulkanTypedHandle>& leaked_list, const Location& loc) const;
+
     void AllocateDisplayKHR(VkPhysicalDevice physical_device, VkDisplayKHR display, const Location &loc);
 
     // helper methods for tracker
@@ -218,8 +219,8 @@ class Device : public vvl::base::Device {
 
     void DestroyLeakedObjects();
     bool ReportUndestroyedObjects(const Location &loc) const;
-    bool ReportLeakedObjects(VulkanObjectType object_type, const std::string &error_code,
-                                     const Location &loc) const;
+    void FindLeakedObjects(VulkanObjectType object_type, std::vector<VulkanTypedHandle>& leaked_list) const;
+    bool ReportLeakedObjects(std::vector<VulkanTypedHandle>& leaked_list, const Location& loc) const;
 
     void CreateQueue(VkQueue vkObj, const Location &loc);
     void AllocateCommandBuffer(const VkCommandPool command_pool, const VkCommandBuffer command_buffer, VkCommandBufferLevel level,

--- a/layers/vulkan/generated/object_tracker.cpp
+++ b/layers/vulkan/generated/object_tracker.cpp
@@ -33,66 +33,72 @@ WriteLockGuard Device::WriteLock() { return WriteLockGuard(validation_object_mut
 // ObjectTracker undestroyed objects validation function
 bool Instance::ReportUndestroyedObjects(const Location& loc) const {
     bool skip = false;
-    const std::string error_code = "VUID-vkDestroyInstance-instance-00629";
-    skip |= ReportLeakedObjects(kVulkanObjectTypeSurfaceKHR, error_code, loc);
-    // No destroy API or implicitly freed/destroyed -- do not report: skip |= ReportLeakedObjects(kVulkanObjectTypeDisplayKHR,
-    // error_code, loc); No destroy API or implicitly freed/destroyed -- do not report: skip |=
-    // ReportLeakedObjects(kVulkanObjectTypeDisplayModeKHR, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeDebugReportCallbackEXT, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeDebugUtilsMessengerEXT, error_code, loc);
+    std::vector<VulkanTypedHandle> leaked_list;
+    FindLeakedObjects(kVulkanObjectTypeSurfaceKHR, leaked_list);
+    // No destroy API or implicitly freed/destroyed -- do not report: FindLeakedObjects(kVulkanObjectTypeDisplayKHR, leaked_list);
+    // No destroy API or implicitly freed/destroyed -- do not report: FindLeakedObjects(kVulkanObjectTypeDisplayModeKHR,
+    // leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeDebugReportCallbackEXT, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeDebugUtilsMessengerEXT, leaked_list);
+    if (!leaked_list.empty()) {
+        skip |= ReportLeakedObjects(leaked_list, loc);
+    }
     return skip;
 }
 
 bool Device::ReportUndestroyedObjects(const Location& loc) const {
     bool skip = false;
-    const std::string error_code = "VUID-vkDestroyDevice-device-05137";
-    skip |= ReportLeakedObjects(kVulkanObjectTypeCommandBuffer, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeBuffer, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeImage, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeSemaphore, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeFence, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeDeviceMemory, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeQueryPool, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeImageView, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeCommandPool, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeRenderPass, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeFramebuffer, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeEvent, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeBufferView, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeShaderModule, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypePipelineCache, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypePipelineLayout, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypePipeline, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeDescriptorSetLayout, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeSampler, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeDescriptorSet, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeDescriptorPool, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeDescriptorUpdateTemplate, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeSamplerYcbcrConversion, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypePrivateDataSlot, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeSwapchainKHR, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeVideoSessionKHR, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeVideoSessionParametersKHR, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeDeferredOperationKHR, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypePipelineBinaryKHR, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeCuModuleNVX, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeCuFunctionNVX, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeTensorARM, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeValidationCacheEXT, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeAccelerationStructureNV, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypePerformanceConfigurationINTEL, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeIndirectCommandsLayoutNV, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeCudaModuleNV, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeCudaFunctionNV, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeAccelerationStructureKHR, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeBufferCollectionFUCHSIA, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeMicromapEXT, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeTensorViewARM, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeOpticalFlowSessionNV, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeShaderEXT, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeDataGraphPipelineSessionARM, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeIndirectExecutionSetEXT, error_code, loc);
-    skip |= ReportLeakedObjects(kVulkanObjectTypeIndirectCommandsLayoutEXT, error_code, loc);
+    std::vector<VulkanTypedHandle> leaked_list;
+    FindLeakedObjects(kVulkanObjectTypeCommandBuffer, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeBuffer, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeImage, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeSemaphore, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeFence, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeDeviceMemory, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeQueryPool, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeImageView, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeCommandPool, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeRenderPass, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeFramebuffer, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeEvent, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeBufferView, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeShaderModule, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypePipelineCache, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypePipelineLayout, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypePipeline, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeDescriptorSetLayout, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeSampler, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeDescriptorSet, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeDescriptorPool, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeDescriptorUpdateTemplate, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeSamplerYcbcrConversion, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypePrivateDataSlot, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeSwapchainKHR, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeVideoSessionKHR, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeVideoSessionParametersKHR, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeDeferredOperationKHR, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypePipelineBinaryKHR, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeCuModuleNVX, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeCuFunctionNVX, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeTensorARM, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeValidationCacheEXT, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeAccelerationStructureNV, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypePerformanceConfigurationINTEL, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeIndirectCommandsLayoutNV, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeCudaModuleNV, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeCudaFunctionNV, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeAccelerationStructureKHR, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeBufferCollectionFUCHSIA, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeMicromapEXT, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeTensorViewARM, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeOpticalFlowSessionNV, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeShaderEXT, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeDataGraphPipelineSessionARM, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeIndirectExecutionSetEXT, leaked_list);
+    FindLeakedObjects(kVulkanObjectTypeIndirectCommandsLayoutEXT, leaked_list);
+    if (!leaked_list.empty()) {
+        skip |= ReportLeakedObjects(leaked_list, loc);
+    }
     return skip;
 }
 

--- a/scripts/generators/object_tracker_generator.py
+++ b/scripts/generators/object_tracker_generator.py
@@ -398,33 +398,39 @@ WriteLockGuard Device::WriteLock() { return WriteLockGuard(validation_object_mut
 // ObjectTracker undestroyed objects validation function
 bool Instance::ReportUndestroyedObjects(const Location& loc) const {
     bool skip = false;
-    const std::string error_code = "VUID-vkDestroyInstance-instance-00629";
+    std::vector<VulkanTypedHandle> leaked_list;
 ''')
         for handle in [x for x in self.vk.handles.values() if not x.dispatchable and not self.isParentDevice(x)]:
             comment_prefix = ''
             if APISpecific.IsImplicitlyDestroyed(self.targetApiName, handle.name):
                 comment_prefix = '// No destroy API or implicitly freed/destroyed -- do not report: '
-            out.append(f'    {comment_prefix}skip |= ReportLeakedObjects(kVulkanObjectType{handle.name[2:]}, error_code, loc);\n')
+            out.append(f'    {comment_prefix}FindLeakedObjects(kVulkanObjectType{handle.name[2:]}, leaked_list);\n')
+        out.append('    if (!leaked_list.empty()) {')
+        out.append('        skip |= ReportLeakedObjects(leaked_list, loc);')
+        out.append('    }')
         out.append('    return skip;\n')
         out.append('}\n')
 
         out.append('''
 bool Device::ReportUndestroyedObjects(const Location& loc) const {
     bool skip = false;
-    const std::string error_code = "VUID-vkDestroyDevice-device-05137";
+    std::vector<VulkanTypedHandle> leaked_list;
 ''')
 
         comment_prefix = ''
         if APISpecific.IsImplicitlyDestroyed(self.targetApiName, 'VkCommandBuffer'):
             comment_prefix = '// No destroy API or implicitly freed/destroyed -- do not report: '
-        out.append(f'    {comment_prefix}skip |= ReportLeakedObjects(kVulkanObjectTypeCommandBuffer, error_code, loc);\n')
+        out.append(f'    {comment_prefix}FindLeakedObjects(kVulkanObjectTypeCommandBuffer, leaked_list);\n')
 
         for handle in [x for x in self.vk.handles.values() if not x.dispatchable and self.isParentDevice(x)]:
             comment_prefix = ''
             if APISpecific.IsImplicitlyDestroyed(self.targetApiName, handle.name):
                 comment_prefix = '// No destroy API or implicitly freed/destroyed -- do not report: '
-            out.append(f'    {comment_prefix}skip |= ReportLeakedObjects(kVulkanObjectType{handle.name[2:]}, error_code, loc);\n')
-        out.append('    return skip;\n')
+            out.append(f'    {comment_prefix}FindLeakedObjects(kVulkanObjectType{handle.name[2:]}, leaked_list);\n')
+        out.append('    if (!leaked_list.empty()) {')
+        out.append('        skip |= ReportLeakedObjects(leaked_list, loc);')
+        out.append('    }')
+        out.append('    return skip;')
         out.append('}\n')
 
         out.append('\nvoid Instance::DestroyLeakedObjects() {\n')

--- a/tests/unit/best_practices.cpp
+++ b/tests/unit/best_practices.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
- * Copyright (c) 2015-2025 Google, Inc.
+ * Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
+ * Copyright (c) 2015-2026 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -2095,16 +2095,13 @@ TEST_F(VkBestPracticesLayerTest, BadDestroy) {
     vk::AllocateCommandBuffers(leaky_device, &command_buffer_allocate_info, &command_buffer);
 
     m_errorMonitor->SetDesiredError("VUID-vkDestroyDevice-device-05137");
-    m_errorMonitor->SetDesiredError("VUID-vkDestroyDevice-device-05137");
     // Those 2 will come from self validation if it is enabled
-    m_errorMonitor->SetAllowedFailureMsg("VUID-vkDestroyDevice-device-05137");
     m_errorMonitor->SetAllowedFailureMsg("VUID-vkDestroyDevice-device-05137");
     vk::DestroyDevice(leaky_device, nullptr);
     m_errorMonitor->VerifyFound();
 
     // There's no way we can destroy the command pool at this point. Even though DestroyDevice failed, the loader has already
     // removed references to the device
-    m_errorMonitor->SetAllowedFailureMsg("VUID-vkDestroyDevice-device-05137");
     m_errorMonitor->SetAllowedFailureMsg("VUID-vkDestroyDevice-device-05137");
     m_errorMonitor->SetAllowedFailureMsg("VUID-vkDestroyInstance-instance-00629");
 }

--- a/tests/unit/gpu_av.cpp
+++ b/tests/unit/gpu_av.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2020-2025 The Khronos Group Inc.
- * Copyright (c) 2020-2025 Valve Corporation
- * Copyright (c) 2020-2025 LunarG, Inc.
- * Copyright (c) 2020-2025 Google, Inc.
+ * Copyright (c) 2020-2026 The Khronos Group Inc.
+ * Copyright (c) 2020-2026 Valve Corporation
+ * Copyright (c) 2020-2026 LunarG, Inc.
+ * Copyright (c) 2020-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -629,16 +629,13 @@ TEST_F(NegativeGpuAV, BadDestroy) {
     vk::AllocateCommandBuffers(leaky_device, &command_buffer_allocate_info, &command_buffer);
 
     m_errorMonitor->SetDesiredError("VUID-vkDestroyDevice-device-05137");
-    m_errorMonitor->SetDesiredError("VUID-vkDestroyDevice-device-05137");
     // Those 2 will come from self validation if it is enabled
-    m_errorMonitor->SetAllowedFailureMsg("VUID-vkDestroyDevice-device-05137");
     m_errorMonitor->SetAllowedFailureMsg("VUID-vkDestroyDevice-device-05137");
     vk::DestroyDevice(leaky_device, nullptr);
     m_errorMonitor->VerifyFound();
 
     // There's no way we can destroy the command pool at this point. Even though DestroyDevice failed, the loader has already
     // removed references to the device
-    m_errorMonitor->SetAllowedFailureMsg("VUID-vkDestroyDevice-device-05137");
     m_errorMonitor->SetAllowedFailureMsg("VUID-vkDestroyDevice-device-05137");
     m_errorMonitor->SetAllowedFailureMsg("VUID-vkDestroyInstance-instance-00629");
 }


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11675

now prints a single error message printing all the objects together (stopped at 64, the app I tested with leaked 14,000 objects and its just too much text IMO after about 50-ish)