### PR TITLE
sync: Fix resolve read validation

### DIFF
--- a/layers/sync/sync_access_state.cpp
+++ b/layers/sync/sync_access_state.cpp
@@ -94,34 +94,40 @@ HazardResult AccessState::DetectMarkerHazard() const {
 HazardResult AccessState::DetectHazard(const SyncAccessInfo &usage_info, const OrderingBarrier &ordering,
                                        const AttachmentAccess &attachment_access, SyncFlags flags, QueueId queue_id,
                                        bool detect_load_op_after_store_op_hazards) const {
-    // The ordering guarantees act as barriers to the last accesses, independent of synchronization operations
-    const VkPipelineStageFlagBits2 usage_stage = usage_info.stage_mask;
+    const VkPipelineStageFlagBits2 access_stage = usage_info.stage_mask;
     const SyncAccessIndex access_index = usage_info.access_index;
-    const bool input_attachment_ordering = ordering.access_scope[SYNC_FRAGMENT_SHADER_INPUT_ATTACHMENT_READ];
 
     if (IsRead(usage_info.access_index)) {
-        // Exclude RAW if no write, or write not most "most recent" operation w.r.t. usage;
         bool is_raw_hazard = IsRAWHazard(usage_info);
         if (is_raw_hazard) {
-            // NOTE: we know last_write is non-zero
-            // See if the ordering rules save us from the simple RAW check above
-            // First check to see if the current usage is covered by the ordering rules
-            const bool usage_is_input_attachment = (access_index == SYNC_FRAGMENT_SHADER_INPUT_ATTACHMENT_READ);
-            const bool usage_is_ordered =
-                (input_attachment_ordering && usage_is_input_attachment) || (0 != (usage_stage & ordering.exec_scope));
-            if (usage_is_ordered) {
+            const bool access_is_input_attachment = (access_index == SYNC_FRAGMENT_SHADER_INPUT_ATTACHMENT_READ);
+            const bool input_attachment_ordering = ordering.access_scope[SYNC_FRAGMENT_SHADER_INPUT_ATTACHMENT_READ];
+
+            // Check if the ordering rules make a RAW sequence not a hazard.
+            // The ordering act as barriers to the last accesses.
+            // At first check if the current access is covered by the ordering rules
+            const bool access_is_ordered =
+                (access_stage & ordering.exec_scope) != 0 || (access_is_input_attachment && input_attachment_ordering);
+
+            if (access_is_ordered) {
                 // Check if the most recent write is ordered.
                 // Input attachment is ordered against load op but not against regular draws (requires subpass barrier).
                 bool most_recent_is_ordered =
-                    last_write->IsOrdered(ordering, queue_id) && (!usage_is_input_attachment || last_write->IsLoadOp());
+                    last_write->IsOrdered(ordering, queue_id) && (!access_is_input_attachment || last_write->IsLoadOp());
 
                 // LoadOp after StoreOp happens only if accesses are from different render pass instances.
                 // Such accesses are not implicitly synchronized.
-                const bool load_op_after_store_op =
-                    last_write->IsStoreOp() && attachment_access.type == AttachmentAccessType::LoadOp;
-                const bool validate_load_op_after_store_op = detect_load_op_after_store_op_hazards && load_op_after_store_op;
-                if (validate_load_op_after_store_op) {
-                    most_recent_is_ordered = false;
+                if (detect_load_op_after_store_op_hazards) {
+                    if (last_write->IsStoreOp() && attachment_access.type == AttachmentAccessType::LoadOp) {
+                        most_recent_is_ordered = false;
+                    }
+                }
+
+                // Resolve read is not ordered against accesses from other subpasses
+                if (attachment_access.type == AttachmentAccessType::ResolveRead) {
+                    if (attachment_access.subpass != last_write->attachment_access.subpass) {
+                        most_recent_is_ordered = false;
+                    }
                 }
 
                 // If most recent write is not ordered then check if subsequent read is ordered
@@ -156,7 +162,7 @@ HazardResult AccessState::DetectHazard(const SyncAccessInfo &usage_info, const O
         if ((ordered_stages & last_read_stages) != last_read_stages) {
             for (const auto &read_access : GetReads()) {
                 if (read_access.stage & ordered_stages) continue;  // but we can skip the ordered ones
-                if (IsReadHazard(usage_stage, read_access)) {
+                if (IsReadHazard(access_stage, read_access)) {
                     return HazardResult::HazardVsPriorRead(this, usage_info, WRITE_AFTER_READ, read_access);
                 }
             }

--- a/layers/sync/sync_error_messages.cpp
+++ b/layers/sync/sync_error_messages.cpp
@@ -236,7 +236,6 @@ std::string ErrorMessages::ClearAttachmentError(const HazardResult& hazard, cons
 
 std::string ErrorMessages::RenderPassAttachmentError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
                                                      vvl::Func command, const std::string& resource_description) const {
-    // TODO: revisit error message when this function is covered by the tests.
     return Error(hazard, cb_context, command, resource_description, "RenderPassAttachmentError");
 }
 
@@ -321,7 +320,6 @@ std::string ErrorMessages::RenderPassLoadOpVsLayoutTransitionError(const HazardR
 
 std::string ErrorMessages::RenderPassResolveError(const HazardResult& hazard, const CommandBufferAccessContext& cb_context,
                                                   vvl::Func command, const std::string& resource_description) const {
-    // TODO: rework error message and maybe refactor ValidateResolveAction helper when this function is covered by the tests.
     return Error(hazard, cb_context, command, resource_description, "RenderPassResolveError");
 }
 

--- a/layers/sync/sync_renderpass.cpp
+++ b/layers/sync/sync_renderpass.cpp
@@ -56,13 +56,10 @@ class ValidateResolveAction {
 
             const SyncValidator &validator = cb_context_.GetSyncState();
 
-            // TODO: this error message is not triggered by the tests
             std::ostringstream ss;
             ss << validator.FormatHandle(view_gen.GetViewState()->Handle());
-            ss << " (" << aspect_name << " " << resolve_action_name;
-            ss << ", attachment " << src_at;
-            ss << ", resolve attachment " << dst_at;
-            ss << ", subpass " << subpass_ << " of " << validator.FormatHandle(render_pass_) << ")";
+            ss << " (" << resolve_action_name << " of " << aspect_name << " multisample attachment " << src_at;
+            ss << " in subpass " << subpass_ << " of " << validator.FormatHandle(render_pass_) << ")";
             const std::string resource_description = ss.str();
             const auto error =
                 validator.error_messages_.RenderPassResolveError(hazard, cb_context_, command_, resource_description);

--- a/tests/unit/sync_val_render_pass.cpp
+++ b/tests/unit/sync_val_render_pass.cpp
@@ -370,3 +370,92 @@ TEST_F(NegativeSyncValRenderPass, StoreOpWAR) {
     m_command_buffer.EndRenderPass();
     m_errorMonitor->VerifyFound();
 }
+
+TEST_F(NegativeSyncValRenderPass, MultisampleAttachmentRAW) {
+    TEST_DESCRIPTION("Insufficient synchronization between multisample resolve read and previous attachment clear");
+    RETURN_IF_SKIP(InitSyncVal());
+
+    VkImageCreateInfo multi_sample_image_ci =
+        vkt::Image::ImageCreateInfo2D(32, 32, 1, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    multi_sample_image_ci.samples = VK_SAMPLE_COUNT_4_BIT;
+    vkt::Image multi_sample_image(*m_device, multi_sample_image_ci);
+    vkt::ImageView multi_sample_image_view = multi_sample_image.CreateView();
+
+    VkImageCreateInfo single_sample_image_ci = vkt::Image::ImageCreateInfo2D(
+        32, 32, 1, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
+    vkt::Image single_sample_image(*m_device, single_sample_image_ci);
+    vkt::ImageView single_sample_image_view = single_sample_image.CreateView();
+
+    VkAttachmentDescription multi_sample_attachment = {};
+    multi_sample_attachment.format = VK_FORMAT_R8G8B8A8_UNORM;
+    multi_sample_attachment.samples = VK_SAMPLE_COUNT_4_BIT;
+    multi_sample_attachment.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    multi_sample_attachment.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    multi_sample_attachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    multi_sample_attachment.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+    VkAttachmentDescription single_sample_attachment = {};
+    single_sample_attachment.format = VK_FORMAT_R8G8B8A8_UNORM;
+    single_sample_attachment.samples = VK_SAMPLE_COUNT_1_BIT;
+    single_sample_attachment.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    single_sample_attachment.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    single_sample_attachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    single_sample_attachment.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+    const VkAttachmentReference multi_sample_attachment_ref = {0, VK_IMAGE_LAYOUT_GENERAL};
+    const VkAttachmentReference single_sample_attachment_ref = {1, VK_IMAGE_LAYOUT_GENERAL};
+
+    VkSubpassDescription subpass0{};
+    subpass0.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    subpass0.colorAttachmentCount = 1;
+    subpass0.pColorAttachments = &multi_sample_attachment_ref;
+
+    VkSubpassDescription subpass1{};
+    subpass1.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    subpass1.colorAttachmentCount = 1;
+    subpass1.pColorAttachments = &multi_sample_attachment_ref;
+    subpass1.pResolveAttachments = &single_sample_attachment_ref;
+
+    VkSubpassDependency subpass_dependency{};
+    subpass_dependency.srcSubpass = 0;
+    subpass_dependency.dstSubpass = 1;
+    subpass_dependency.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    subpass_dependency.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    subpass_dependency.srcAccessMask = 0;  // Hazard: do not make clear writes available
+    subpass_dependency.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;
+
+    const VkSubpassDescription subpasses[2] = {subpass0, subpass1};
+    const VkAttachmentDescription attachments[2] = {multi_sample_attachment, single_sample_attachment};
+    const VkImageView image_views[2] = {multi_sample_image_view, single_sample_image_view};
+
+    VkRenderPassCreateInfo renderpass_ci = vku::InitStructHelper();
+    renderpass_ci.attachmentCount = 2;
+    renderpass_ci.pAttachments = attachments;
+    renderpass_ci.subpassCount = 2;
+    renderpass_ci.pSubpasses = subpasses;
+    renderpass_ci.dependencyCount = 1;
+    renderpass_ci.pDependencies = &subpass_dependency;
+
+    const vkt::RenderPass render_pass(*m_device, renderpass_ci);
+    const vkt::Framebuffer framebuffer(*m_device, render_pass, 2, image_views, 32, 32);
+
+    VkClearAttachment clear_attachment{};
+    clear_attachment.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    clear_attachment.colorAttachment = 0;
+
+    VkClearRect clear_rect{};
+    clear_rect.rect = {{0, 0}, {32, 32}};
+    clear_rect.baseArrayLayer = 0;
+    clear_rect.layerCount = 1;
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(render_pass, framebuffer, 32, 32);
+    vk::CmdClearAttachments(m_command_buffer, 1, &clear_attachment, 1, &clear_rect);
+
+    m_command_buffer.NextSubpass();
+
+    // Hazard when reading multi sample attachment due to incomplete sync with clear
+    m_errorMonitor->SetDesiredError("SYNC-HAZARD-READ-AFTER-WRITE");
+    m_command_buffer.EndRenderPass();
+    m_errorMonitor->VerifyFound();
+}

--- a/tests/unit/sync_val_render_pass_positive.cpp
+++ b/tests/unit/sync_val_render_pass_positive.cpp
@@ -21,7 +21,7 @@
 struct PositiveSyncValRenderPass : public VkSyncValTest {};
 
 TEST_F(PositiveSyncValRenderPass, SyncInputAttachmentReadWithResolveWrite) {
-    TEST_DESCRIPTION("Synchronize input attachment read with multisample resolve write");
+    TEST_DESCRIPTION("Synchronize input attachment reads with previous multisample resolve writes");
     RETURN_IF_SKIP(InitSyncVal());
 
     VkImageCreateInfo multi_sample_image_ci =
@@ -164,4 +164,96 @@ TEST_F(PositiveSyncValRenderPass, SyncStoreOpWriteWithPreviousRead) {
     m_command_buffer.BeginRenderPass(render_pass, framebuffer, 64, 64);
 
     m_command_buffer.EndRenderPass();
+}
+
+TEST_F(PositiveSyncValRenderPass, SyncMultisampleReadWithPreviousWrite) {
+    TEST_DESCRIPTION("Synchronize multisample attachment resolve reads with previous writes");
+    RETURN_IF_SKIP(InitSyncVal());
+
+    VkImageCreateInfo multi_sample_image_ci =
+        vkt::Image::ImageCreateInfo2D(32, 32, 1, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    multi_sample_image_ci.samples = VK_SAMPLE_COUNT_4_BIT;
+    vkt::Image multi_sample_image(*m_device, multi_sample_image_ci);
+    vkt::ImageView multi_sample_image_view = multi_sample_image.CreateView();
+
+    VkImageCreateInfo single_sample_image_ci = vkt::Image::ImageCreateInfo2D(
+        32, 32, 1, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
+    vkt::Image single_sample_image(*m_device, single_sample_image_ci);
+    vkt::ImageView single_sample_image_view = single_sample_image.CreateView();
+
+    VkAttachmentDescription multi_sample_attachment = {};
+    multi_sample_attachment.format = VK_FORMAT_R8G8B8A8_UNORM;
+    multi_sample_attachment.samples = VK_SAMPLE_COUNT_4_BIT;
+    multi_sample_attachment.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    multi_sample_attachment.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    multi_sample_attachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    multi_sample_attachment.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+    VkAttachmentDescription single_sample_attachment = {};
+    single_sample_attachment.format = VK_FORMAT_R8G8B8A8_UNORM;
+    single_sample_attachment.samples = VK_SAMPLE_COUNT_1_BIT;
+    single_sample_attachment.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    single_sample_attachment.storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    single_sample_attachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    single_sample_attachment.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+    const VkAttachmentReference multi_sample_attachment_ref = {0, VK_IMAGE_LAYOUT_GENERAL};
+    const VkAttachmentReference single_sample_attachment_ref = {1, VK_IMAGE_LAYOUT_GENERAL};
+
+    VkSubpassDescription subpass0{};
+    subpass0.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    subpass0.colorAttachmentCount = 1;
+    subpass0.pColorAttachments = &multi_sample_attachment_ref;
+
+    VkSubpassDescription subpass1{};
+    subpass1.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    subpass1.colorAttachmentCount = 1;
+    subpass1.pColorAttachments = &multi_sample_attachment_ref;
+    subpass1.pResolveAttachments = &single_sample_attachment_ref;
+
+    VkSubpassDependency subpass_dependency{};
+    subpass_dependency.srcSubpass = 0;
+    subpass_dependency.dstSubpass = 1;
+    subpass_dependency.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    subpass_dependency.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    // clear multisample attachment in the first subpass
+    subpass_dependency.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    // read multisample attachment in the second subpass during resolve
+    subpass_dependency.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;
+
+    const VkSubpassDescription subpasses[2] = {subpass0, subpass1};
+    const VkAttachmentDescription attachments[2] = {multi_sample_attachment, single_sample_attachment};
+    const VkImageView image_views[2] = {multi_sample_image_view, single_sample_image_view};
+
+    VkRenderPassCreateInfo renderpass_ci = vku::InitStructHelper();
+    renderpass_ci.attachmentCount = 2;
+    renderpass_ci.pAttachments = attachments;
+    renderpass_ci.subpassCount = 2;
+    renderpass_ci.pSubpasses = subpasses;
+    renderpass_ci.dependencyCount = 1;
+    renderpass_ci.pDependencies = &subpass_dependency;
+
+    const vkt::RenderPass render_pass(*m_device, renderpass_ci);
+    const vkt::Framebuffer framebuffer(*m_device, render_pass, 2, image_views, 32, 32);
+
+    VkClearAttachment clear_attachment{};
+    clear_attachment.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    clear_attachment.colorAttachment = 0;
+
+    VkClearRect clear_rect{};
+    clear_rect.rect = {{0, 0}, {32, 32}};
+    clear_rect.baseArrayLayer = 0;
+    clear_rect.layerCount = 1;
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(render_pass, framebuffer, 32, 32);
+
+    // Write to multisample attachment
+    vk::CmdClearAttachments(m_command_buffer, 1, &clear_attachment, 1, &clear_rect);
+
+    m_command_buffer.NextSubpass();
+
+    // The multisample read happens at the end of this subpass (part of resolve)
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
 }


### PR DESCRIPTION
We have validation code for resolve accesses but it was incorrectly suppressed by the implicit ordering rules for render passes and could not report an error. This also explains the missing tests for resolve functionality.

Here is a confirmation that this validation makes sense: https://gitlab.khronos.org/vulkan/vulkan/-/issues/4686