### PR TITLE
printf: Embed buffer length instead of OpArrayLength

### DIFF
--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
@@ -274,6 +274,7 @@ void GpuShaderInstrumentor::FinishDeviceSetup(const VkDeviceCreateInfo *pCreateI
     instrumentation_device_settings_.max_instrumentations_count = gpuav_settings.debug_max_instrumentations_count;
     instrumentation_device_settings_.support_non_semantic_info =
         IsExtEnabled(extensions.vk_khr_shader_non_semantic_info) && !IsExtEnabled(extensions.vk_khr_portability_subset);
+    instrumentation_device_settings_.debug_printf_buffer_size = gpuav_settings.debug_printf_buffer_size;
 }
 
 void GpuShaderInstrumentor::Cleanup() {

--- a/layers/gpuav/spirv/debug_printf_pass.cpp
+++ b/layers/gpuav/spirv/debug_printf_pass.cpp
@@ -417,8 +417,12 @@ void DebugPrintfPass::CreateBufferWriteFunction(uint32_t argument_count, uint32_
         const uint32_t int_add_id = module_.TakeNextId();
         check_block.CreateInstruction(spv::OpIAdd, {uint32_type_id, int_add_id, atomic_add_id, byte_written_id});
 
-        const uint32_t array_length_id = module_.TakeNextId();
-        check_block.CreateInstruction(spv::OpArrayLength, {uint32_type_id, array_length_id, output_buffer_variable_id, 1});
+        // We hardcode the array length because
+        //   1. We know it and its a bit faster than grabbing the OpArrayLength
+        //   2. It allows us to use VK_DESCRIPTOR_MAPPING_SOURCE_INDIRECT_ADDRESS_EXT
+        // We read the array as a uint[] so need to ceil up to 4 bytes (as OpArrayLength does as well)
+        const uint32_t array_length = (module_.settings_.debug_printf_buffer_size + 3) / 4;
+        const uint32_t array_length_id = type_manager_.GetConstantUInt32(array_length).Id();
 
         const uint32_t less_than_equal_id = module_.TakeNextId();
         const uint32_t bool_type_id = type_manager_.GetTypeBool().Id();

--- a/layers/gpuav/spirv/interface.h
+++ b/layers/gpuav/spirv/interface.h
@@ -99,6 +99,8 @@ struct DeviceSettings {
     // zero is same as "unlimited"
     uint32_t max_instrumentations_count;
     bool support_non_semantic_info;
+    // Lets us embed the size instead of calling OpArrayLength
+    uint32_t debug_printf_buffer_size;
 };
 
 // When running the DebugPrintf pass, if we detect an instrumented shader has a printf call (for debugging) we can hold them until


### PR DESCRIPTION
```glsl
layout(set = 7, binding = 0) buffer OutputBuffer
{
    uint m0;
    uint m1[];
};

void inst_debug_printf_5()
{
    uint x = atomicAdd(m0, 5u);
    if ((x + 5u) <= uint(m1.length()))
    {
        m1[x + 0u] = 12u;
        m1[x + 1u] = 1u;
        m1[x + 2u] = value;
        m1[x + 3u] = value;
        m1[x + 4u] = value;
    }
}
```

is now

```patch
- if ((x + 5u) <= uint(m1.length()))
+ if ((x + 5u) <= 256)
```