### PR TITLE
Update heaps to use indirect address

### DIFF
--- a/layers/gpuav/core/gpuav.h
+++ b/layers/gpuav/core/gpuav.h
@@ -116,10 +116,6 @@ class Validator : public GpuShaderInstrumentor {
                                                   const VkDescriptorBufferBindingInfoEXT* pBindingInfos,
                                                   const RecordObject& record_obj,
                                                   chassis::CmdBindDescriptorBuffers& chassis_state) final;
-    void PreCallRecordCmdBindResourceHeapEXT(VkCommandBuffer commandBuffer, const VkBindHeapInfoEXT* pBindInfo,
-                                             const RecordObject& record_obj) final;
-    void PostCallRecordCmdBindResourceHeapEXT(VkCommandBuffer commandBuffer, const VkBindHeapInfoEXT* pBindInfo,
-                                              const RecordObject& record_obj) override;
 
     void PreCallActionCommand(Validator& gpuav, CommandBufferSubState& cb_state, const LastBound& last_bound, const Location& loc);
 

--- a/layers/gpuav/core/gpuav_record.cpp
+++ b/layers/gpuav/core/gpuav_record.cpp
@@ -144,34 +144,6 @@ void Validator::PreCallRecordCmdBindDescriptorBuffersEXT(VkCommandBuffer command
     chassis_state.pBindInfos = reinterpret_cast<VkDescriptorBufferBindingInfoEXT *>(chassis_state.modified_binding_infos.data());
 }
 
-
-void Validator::PreCallRecordCmdBindResourceHeapEXT(VkCommandBuffer commandBuffer, const VkBindHeapInfoEXT *pBindInfo,
-                                                    const RecordObject &record_obj) {
-    const auto buffer_states = GetBuffersByAddress(pBindInfo->heapRange.address);
-    if (buffer_states.empty()) {
-        InternalError(commandBuffer, record_obj.location.dot(Field::pBindInfo), "address points to no VkBuffer");
-    } else {
-        if (buffer_states.size() > 1) {
-            InternalWarning(commandBuffer, record_obj.location.dot(Field::pBindInfo),
-                            "address points to multiple VkBuffer, taking first one");
-        }
-        resource_heap.buffer_state_ = buffer_states[0];
-    }
-    resource_heap.reserved_offset_ = pBindInfo->reservedRangeOffset;
-
-    auto modified_bind_heap_info = const_cast<VkBindHeapInfoEXT *>(pBindInfo);
-    modified_bind_heap_info->reservedRangeOffset += resource_heap_reserved_bytes_;
-    modified_bind_heap_info->reservedRangeSize -= resource_heap_reserved_bytes_;
-}
-
-void Validator::PostCallRecordCmdBindResourceHeapEXT(VkCommandBuffer commandBuffer, const VkBindHeapInfoEXT *pBindInfo,
-                                                     const RecordObject &record_obj) {
-    // Revert adjustment so the user doesn't see it
-    auto modified_bind_heap_info = const_cast<VkBindHeapInfoEXT *>(pBindInfo);
-    modified_bind_heap_info->reservedRangeOffset -= resource_heap_reserved_bytes_;
-    modified_bind_heap_info->reservedRangeSize += resource_heap_reserved_bytes_;
-}
-
 void Validator::PreCallRecordBeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo *pBeginInfo,
                                                 const RecordObject &record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
@@ -808,7 +780,7 @@ bool Validator::PreCallValidateCmdPushDataEXT(VkCommandBuffer commandBuffer, con
                      "VkPhysicalDeviceDescriptorHeapPropertiesEXT::maxPushDataSize is %" PRIu32
                      ", however GPU-AV reserved 8 bytes at the end of the push data range for internal use. Therefore only %" PRIu32
                      " bytes are available to the application.",
-                     static_cast<uint32_t>(push_data_offset_ + 8u), push_data_offset_);
+                     static_cast<uint32_t>(push_data_offset_ + sizeof(VkDeviceAddress)), push_data_offset_);
     }
     return skip;
 }

--- a/layers/gpuav/core/gpuav_setup.cpp
+++ b/layers/gpuav/core/gpuav_setup.cpp
@@ -324,8 +324,7 @@ vko::Buffer& Validator::GetGlobalDescriptorHeap() {
     if (global_resource_descriptor_heap_.IsDestroyed()) {
         VkBufferCreateInfo buffer_info = vku::InitStructHelper();
         buffer_info.size = resource_heap_reserved_bytes_ + phys_dev_ext_props.descriptor_heap_props.minResourceHeapReservedRange;
-        buffer_info.usage =
-            VK_BUFFER_USAGE_DESCRIPTOR_HEAP_BIT_EXT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+        buffer_info.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
         VmaAllocationCreateInfo alloc_info = {};
         alloc_info.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
         alloc_info.preferredFlags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;

--- a/layers/gpuav/debug_printf/debug_printf.cpp
+++ b/layers/gpuav/debug_printf/debug_printf.cpp
@@ -452,13 +452,12 @@ void RegisterDebugPrintf(Validator &gpuav, CommandBufferSubState &cb_state) {
 
     cb_state.on_instrumentation_desc_heap_update_functions.emplace_back(
         [debug_printf_buffer_size = gpuav.gpuav_settings.debug_printf_buffer_size](
-            CommandBufferSubState &cb, VkPipelineBindPoint bind_point, VkDeviceAddressRangeEXT &out_address_range) {
+            CommandBufferSubState &cb, VkPipelineBindPoint bind_point, VkDeviceAddress &out_address) {
             vko::BufferRange debug_printf_output_buffer =
                 cb.gpu_resources_manager.GetHostCoherentBufferRange(debug_printf_buffer_size);
             std::memset(debug_printf_output_buffer.offset_mapped_ptr, 0, (size_t)debug_printf_buffer_size);
 
-            out_address_range.address = debug_printf_output_buffer.offset_address;
-            out_address_range.size = debug_printf_output_buffer.size;
+            out_address = debug_printf_output_buffer.offset_address;
 
             DebugPrintfCbState &debug_printf_cb_state = cb.shared_resources_cache.GetOrCreate<DebugPrintfCbState>();
             debug_printf_cb_state.buffer_infos.emplace_back(

--- a/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
@@ -490,106 +490,21 @@ void PreCallSetupShaderInstrumentationResourcesDescriptorHeap(Validator &gpuav, 
     if (!gpuav.gpuav_settings.debug_printf_enabled) {
         return;  // currently only thing enabled
     }
-    void *resource_heap_memory = nullptr;
-    VkDeviceSize write_offset = gpuav.resource_heap.reserved_offset_;
-    bool need_to_unmap_resource = false;
-    bool host_visible_heap = true;
-    bool host_coherent_heap = true;
-    if (gpuav.resource_heap.buffer_state_) {
-        const auto memory_state = gpuav.resource_heap.buffer_state_->MemoryState();
-        const VkMemoryType memory_type = gpuav.phys_dev_mem_props.memoryTypes[memory_state->allocate_info.memoryTypeIndex];
-        if (memory_state->p_driver_data) {
-            resource_heap_memory = memory_state->p_driver_data;
-            if ((memory_type.propertyFlags & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT) == 0) {
-                host_coherent_heap = false;
-            }
-        } else if ((memory_type.propertyFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) != 0) {
-            need_to_unmap_resource = true;
-            DispatchMapMemory(gpuav.device, memory_state->VkHandle(), 0, VK_WHOLE_SIZE, 0, &resource_heap_memory);
-            if ((memory_type.propertyFlags & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT) == 0) {
-                host_coherent_heap = false;
-            }
-        } else {
-            write_offset = 0;
-            host_visible_heap = false;
-        }
-    }
-
-    if (!resource_heap_memory) {
-        vko::Buffer& global_heap = gpuav.GetGlobalDescriptorHeap();
-        resource_heap_memory = global_heap.GetMappedPtr();
-
-        if (host_visible_heap) {
-            VkBindHeapInfoEXT bind_resource_info = vku::InitStructHelper();
-            bind_resource_info.heapRange.address = global_heap.Address();
-            bind_resource_info.heapRange.size = global_heap.Size();
-            bind_resource_info.reservedRangeOffset = gpuav.resource_heap_reserved_bytes_;
-            bind_resource_info.reservedRangeSize = global_heap.Size() - gpuav.resource_heap_reserved_bytes_;
-            DispatchCmdBindResourceHeapEXT(cb_state.VkHandle(), &bind_resource_info);
-        }
-    }
+    const auto &heap_buffer = gpuav.GetGlobalDescriptorHeap();
+    VkDeviceAddress *resource_heap_memory = static_cast<VkDeviceAddress *>(heap_buffer.GetMappedPtr());
 
     for (size_t func_i = 0; func_i < cb_state.on_instrumentation_desc_heap_update_functions.size(); ++func_i) {
-        VkDeviceAddressRangeEXT device_range;
-        cb_state.on_instrumentation_desc_heap_update_functions[func_i](cb_state, last_bound.bind_point, device_range);
-
-        VkResourceDescriptorInfoEXT resource = vku::InitStructHelper();
-        resource.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-        resource.data.pAddressRange = &device_range;
-
-        VkHostAddressRangeEXT descriptor;
-        descriptor.address = static_cast<uint8_t *>(resource_heap_memory) + write_offset;
-        descriptor.size = static_cast<size_t>(gpuav.buffer_descriptor_size_);
-        DispatchWriteResourceDescriptorsEXT(gpuav.device, 1u, &resource, &descriptor);
+        VkDeviceAddress device_address;
+        cb_state.on_instrumentation_desc_heap_update_functions[func_i](cb_state, last_bound.bind_point, device_address);
+        resource_heap_memory[0] = device_address;
     }
 
-    if (!host_coherent_heap) {
-        VkMappedMemoryRange memory_range = vku::InitStructHelper();
-        memory_range.memory = gpuav.resource_heap.buffer_state_->MemoryState()->VkHandle();
-        memory_range.offset = write_offset;
-        memory_range.size = gpuav.buffer_descriptor_size_;
-        DispatchFlushMappedMemoryRanges(gpuav.device, 1u, &memory_range);
-    }
-
-    const uint32_t push_offset = static_cast<uint32_t>(gpuav.resource_heap.reserved_offset_);
+    VkDeviceAddress gpuav_data_address = heap_buffer.Address();
     VkPushDataInfoEXT push_data_info = vku::InitStructHelper();
     push_data_info.offset = gpuav.push_data_offset_;
-    push_data_info.data.address = &push_offset;
-    push_data_info.data.size = sizeof(uint32_t);
+    push_data_info.data.address = &gpuav_data_address;
+    push_data_info.data.size = sizeof(VkDeviceAddress);
     DispatchCmdPushDataEXT(cb_state.VkHandle(), &push_data_info);
-
-    if (!host_visible_heap) {
-        VkBufferCopy region;
-        region.srcOffset = 0u;
-        region.dstOffset = gpuav.resource_heap.reserved_offset_;
-        region.size = gpuav.resource_heap_reserved_bytes_;
-        DispatchCmdCopyBuffer(cb_state.VkHandle(), gpuav.GetGlobalDescriptorHeap().VkHandle(),
-                              gpuav.resource_heap.buffer_state_->VkHandle(), 1u, &region);
-        if (gpuav.enabled_features.synchronization2) {
-            VkBufferMemoryBarrier2 buffer_barrier = vku::InitStructHelper();
-            buffer_barrier.srcStageMask = VK_PIPELINE_STAGE_2_TRANSFER_BIT;
-            buffer_barrier.srcAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
-            buffer_barrier.dstStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
-            buffer_barrier.dstAccessMask = VK_ACCESS_2_RESOURCE_HEAP_READ_BIT_EXT;
-            buffer_barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-            buffer_barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-            buffer_barrier.buffer = gpuav.resource_heap.buffer_state_->VkHandle();
-            buffer_barrier.offset = gpuav.resource_heap.reserved_offset_;
-            buffer_barrier.size = gpuav.resource_heap_reserved_bytes_;
-            VkDependencyInfo dep_info = vku::InitStructHelper();
-            dep_info.bufferMemoryBarrierCount = 1;
-            dep_info.pBufferMemoryBarriers = &buffer_barrier;
-            DispatchCmdPipelineBarrier2(cb_state.VkHandle(), &dep_info);
-        } else {
-            VkMemoryBarrier memory_barrier = vku::InitStructHelper();
-            memory_barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-            memory_barrier.dstAccessMask = VK_ACCESS_NONE;
-            DispatchCmdPipelineBarrier(cb_state.VkHandle(), VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0,
-                                       1, &memory_barrier, 0, nullptr, 0, nullptr);
-        }
-    } else if (need_to_unmap_resource) {
-        DispatchUnmapMemory(gpuav.device, gpuav.resource_heap.buffer_state_->MemoryState()->VkHandle());
-    }
 }
 
 void PreCallSetupShaderInstrumentationResourcesDescriptorBuffer(Validator &gpuav, CommandBufferSubState &cb_state,

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
@@ -1171,11 +1171,10 @@ void GpuShaderInstrumentor::AddDescriptorHeapMappings(VkBaseOutStructure *create
     debug_printf_mapping.descriptorSet = instrumentation_desc_set_bind_index_;
     debug_printf_mapping.firstBinding = 0;
     debug_printf_mapping.bindingCount = 1;
-    debug_printf_mapping.resourceMask = VK_SPIRV_RESOURCE_TYPE_ALL_EXT;
-    debug_printf_mapping.source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_PUSH_INDEX_EXT;
-    debug_printf_mapping.sourceData.pushIndex.heapOffset = 0;
-    debug_printf_mapping.sourceData.pushIndex.pushOffset = push_data_offset_;
-    debug_printf_mapping.sourceData.pushIndex.heapIndexStride = 1;
+    debug_printf_mapping.resourceMask = VK_SPIRV_RESOURCE_TYPE_READ_WRITE_STORAGE_BUFFER_BIT_EXT;
+    debug_printf_mapping.source = VK_DESCRIPTOR_MAPPING_SOURCE_INDIRECT_ADDRESS_EXT;
+    debug_printf_mapping.sourceData.indirectAddress.addressOffset = 0;
+    debug_printf_mapping.sourceData.indirectAddress.pushOffset = push_data_offset_;
 
     new_mappings[mapping_count - 1] = debug_printf_mapping;
 

--- a/layers/gpuav/resources/gpuav_state_trackers.h
+++ b/layers/gpuav/resources/gpuav_state_trackers.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2018-2025 The Khronos Group Inc.
- * Copyright (c) 2018-2025 Valve Corporation
- * Copyright (c) 2018-2025 LunarG, Inc.
+/* Copyright (c) 2018-2026 The Khronos Group Inc.
+ * Copyright (c) 2018-2026 Valve Corporation
+ * Copyright (c) 2018-2026 LunarG, Inc.
  * Copyright (c) 2025 Arm Limited.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -63,8 +63,8 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
         stdext::inplace_function<void(CommandBufferSubState &cb, VkPipelineBindPoint bind_point,
                                       VkDescriptorAddressInfoEXT &out_address_info, uint32_t &out_dst_binding),
                                  48>;
-    using OnInstrumentationDescHeapUpdate = stdext::inplace_function<
-        void(CommandBufferSubState &cb, VkPipelineBindPoint bind_point, VkDeviceAddressRangeEXT &out_address_range), 48>;
+    using OnInstrumentationDescHeapUpdate =
+        stdext::inplace_function<void(CommandBufferSubState &cb, VkPipelineBindPoint bind_point, VkDeviceAddress &out_address), 48>;
     using OnCommandBufferSubmission =
         stdext::inplace_function<void(Validator &gpuav, CommandBufferSubState &cb, VkCommandBuffer per_submission_cb)>;
     using OnCommandBufferCompletion =

--- a/tests/unit/debug_printf.cpp
+++ b/tests/unit/debug_printf.cpp
@@ -6427,3 +6427,134 @@ TEST_F(NegativeDebugPrintf, DeviceLocalHeap) {
     m_default_queue->SubmitAndWait(m_command_buffer);
     m_errorMonitor->VerifyFound();
 }
+
+TEST_F(NegativeDebugPrintf, DeviceLocalHeapGraphics) {
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_EXT_DESCRIPTOR_HEAP_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::descriptorHeap);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::vertexPipelineStoresAndAtomics);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(InitDebugPrintfFramework());
+    RETURN_IF_SKIP(InitState());
+    InitRenderTarget();
+
+    VkPhysicalDeviceDescriptorHeapPropertiesEXT heap_props = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(heap_props);
+
+    vkt::Buffer buffer_data(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
+    uint32_t *data = (uint32_t *)buffer_data.Memory().Map();
+    data[0] = 8;
+    data[1] = 12;
+    data[2] = 1;
+
+    VkDeviceSize resource_heap_size_app = Align(heap_props.bufferDescriptorSize, heap_props.bufferDescriptorAlignment);
+    resource_heap_size_app = Align(resource_heap_size_app, heap_props.imageDescriptorAlignment);
+    const VkDeviceSize resource_heap_size_driver = resource_heap_size_app + heap_props.minResourceHeapReservedRange;
+
+    VkMemoryAllocateFlagsInfo allocate_flag_info = vku::InitStructHelper();
+    allocate_flag_info.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
+    vkt::Buffer descriptor_heap(
+        *m_device, resource_heap_size_driver,
+        VK_BUFFER_USAGE_DESCRIPTOR_HEAP_BIT_EXT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+        VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &allocate_flag_info);
+
+    vkt::Buffer copy_src(*m_device, resource_heap_size_app, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, kHostVisibleMemProps);
+    const auto descriptor_heap_ptr = static_cast<char *>(copy_src.Memory().Map());
+
+    VkHostAddressRangeEXT descriptor_host;
+    descriptor_host.address = descriptor_heap_ptr;
+    descriptor_host.size = static_cast<size_t>(heap_props.bufferDescriptorSize);
+
+    VkDeviceAddressRangeEXT device_range;
+    device_range.address = buffer_data.Address();
+    device_range.size = 16;
+
+    VkResourceDescriptorInfoEXT descriptor_info = vku::InitStructHelper();
+    descriptor_info.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+    descriptor_info.data.pAddressRange = &device_range;
+
+    vk::WriteResourceDescriptorsEXT(*m_device, 1u, &descriptor_info, &descriptor_host);
+
+    const char *vs_source = R"glsl(
+        #version 450
+        #extension GL_EXT_debug_printf : enable
+        layout (set = 0, binding = 0) buffer SSBO_0 {
+            uint a;
+            uint b;
+            uint c;
+        };
+
+        void main() {
+            if (gl_VertexIndex == 0) {
+                c = a + b;
+                debugPrintfEXT("c == %u\n", c);
+            }
+            gl_Position = vec4(1.0f);
+        }
+    )glsl";
+
+    VkDescriptorSetAndBindingMappingEXT mapping = vku::InitStructHelper();
+    mapping.descriptorSet = 0;
+    mapping.firstBinding = 0;
+    mapping.bindingCount = 1;
+    mapping.resourceMask = VK_SPIRV_RESOURCE_TYPE_ALL_EXT;
+    mapping.source = VK_DESCRIPTOR_MAPPING_SOURCE_HEAP_WITH_CONSTANT_OFFSET_EXT;
+    mapping.sourceData.constantOffset.heapOffset = 0;
+    mapping.sourceData.constantOffset.heapArrayStride = 0;
+
+    VkShaderDescriptorSetAndBindingMappingInfoEXT mapping_info = vku::InitStructHelper();
+    mapping_info.mappingCount = 1u;
+    mapping_info.pMappings = &mapping;
+
+    VkShaderObj vs_module = VkShaderObj(*m_device, vs_source, VK_SHADER_STAGE_VERTEX_BIT);
+    VkShaderObj fs_module = VkShaderObj(*m_device, kFragmentMinimalGlsl, VK_SHADER_STAGE_FRAGMENT_BIT);
+
+    VkPipelineCreateFlags2CreateInfoKHR pipeline_create_flags_2_create_info = vku::InitStructHelper();
+    pipeline_create_flags_2_create_info.flags = VK_PIPELINE_CREATE_2_DESCRIPTOR_HEAP_BIT_EXT;
+
+    VkPipelineShaderStageCreateInfo stages[2] = {vs_module.GetStageCreateInfo(), fs_module.GetStageCreateInfo()};
+    stages[0].pNext = &mapping_info;
+    stages[1].pNext = &mapping_info;
+
+    CreatePipelineHelper pipe(*this, &pipeline_create_flags_2_create_info);
+    pipe.gp_ci_.layout = VK_NULL_HANDLE;
+    pipe.gp_ci_.stageCount = 2;
+    pipe.gp_ci_.pStages = stages;
+    pipe.CreateGraphicsPipeline(false);
+
+    VkBindHeapInfoEXT bind_resource_info = vku::InitStructHelper();
+    bind_resource_info.heapRange.address = descriptor_heap.Address();
+    bind_resource_info.heapRange.size = resource_heap_size_driver;
+    bind_resource_info.reservedRangeOffset = resource_heap_size_app;
+    bind_resource_info.reservedRangeSize = heap_props.minResourceHeapReservedRange;
+
+    VkBufferCopy copy_region;
+    copy_region.srcOffset = 0u;
+    copy_region.dstOffset = 0u;
+    copy_region.size = resource_heap_size_app;
+
+    VkMemoryBarrier2 memory_barrier = vku::InitStructHelper();
+    memory_barrier.srcStageMask = VK_PIPELINE_STAGE_2_TRANSFER_BIT;
+    memory_barrier.srcAccessMask = VK_ACCESS_2_TRANSFER_WRITE_BIT;
+    memory_barrier.dstStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+    memory_barrier.dstAccessMask = VK_ACCESS_2_RESOURCE_HEAP_READ_BIT_EXT | VK_ACCESS_2_SAMPLER_HEAP_READ_BIT_EXT;
+
+    VkDependencyInfo dependency_info = vku::InitStructHelper();
+    dependency_info.memoryBarrierCount = 1u;
+    dependency_info.pMemoryBarriers = &memory_barrier;
+
+    m_command_buffer.Begin();
+    vk::CmdCopyBuffer(m_command_buffer, copy_src, descriptor_heap, 1u, &copy_region);
+    vk::CmdPipelineBarrier2(m_command_buffer, &dependency_info);
+    vk::CmdBindResourceHeapEXT(m_command_buffer, &bind_resource_info);
+    m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
+    vk::CmdDraw(m_command_buffer, 3u, 1u, 0u, 0u);
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+
+    m_errorMonitor->SetDesiredInfo("c == 20");
+    m_default_queue->SubmitAndWait(m_command_buffer);
+    m_errorMonitor->VerifyFound();
+}


### PR DESCRIPTION
- No need to modify reserved range anymore
- Writing the descriptors in `PreCallSetupShaderInstrumentationResourcesDescriptorHeap` is a lot more simple
- No more issues with non host visible heap
- No more issues with copies during a render pass