### PR TITLE
layers: Improve Shader Interface error messages

### DIFF
--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -924,25 +924,25 @@ bool CoreChecks::ValidateDrawDynamicStateVertex(const LastBound& last_bound_stat
                     if (!enabled_features.legacyVertexAttributes || shader64) {
                         skip |= LogError(vuid.vertex_input_08734, vert_spirv_state->handle(), vuid.loc(),
                                          "vkCmdSetVertexInputEXT set pVertexAttributeDescriptions[%" PRIu32 "] (binding %" PRIu32
-                                         ", location %" PRIu32 ") with format %s but the vertex shader input is numeric type %s",
+                                         ", location %" PRIu32 ") with format %s but the vertex shader %s is numeric type %s",
                                          attrib->index, attrib->desc.binding, attrib->desc.location,
-                                         string_VkFormat(attrib->desc.format),
+                                         string_VkFormat(attrib->desc.format), variable_ptr->Describe().c_str(),
                                          vert_spirv_state->DescribeType(var_base_type_id).c_str());
                     }
                 } else if (attribute64 && !shader64) {
-                    skip |= LogError(
-                        vuid.vertex_input_format_08936, vert_spirv_state->handle(), vuid.loc(),
-                        "vkCmdSetVertexInputEXT set pVertexAttributeDescriptions[%" PRIu32 "] (binding %" PRIu32
-                        ", location %" PRIu32 ") with a 64-bit format (%s) but the vertex shader input is 32-bit type (%s)",
-                        attrib->index, attrib->desc.binding, attrib->desc.location, string_VkFormat(attrib->desc.format),
-                        vert_spirv_state->DescribeType(var_base_type_id).c_str());
+                    skip |=
+                        LogError(vuid.vertex_input_format_08936, vert_spirv_state->handle(), vuid.loc(),
+                                 "vkCmdSetVertexInputEXT set pVertexAttributeDescriptions[%" PRIu32 "] (binding %" PRIu32
+                                 ", location %" PRIu32 ") with a 64-bit format (%s) but the vertex shader %s is a 32-bit type (%s)",
+                                 attrib->index, attrib->desc.binding, attrib->desc.location, string_VkFormat(attrib->desc.format),
+                                 variable_ptr->Describe().c_str(), vert_spirv_state->DescribeType(var_base_type_id).c_str());
                 } else if (!attribute64 && shader64) {
-                    skip |= LogError(
-                        vuid.vertex_input_format_08937, vert_spirv_state->handle(), vuid.loc(),
-                        "vkCmdSetVertexInputEXT set pVertexAttributeDescriptions[%" PRIu32 "] (binding %" PRIu32
-                        ", location %" PRIu32 ") with a 32-bit format (%s) but the vertex shader input is 64-bit type (%s)",
-                        attrib->index, attrib->desc.binding, attrib->desc.location, string_VkFormat(attrib->desc.format),
-                        vert_spirv_state->DescribeType(var_base_type_id).c_str());
+                    skip |=
+                        LogError(vuid.vertex_input_format_08937, vert_spirv_state->handle(), vuid.loc(),
+                                 "vkCmdSetVertexInputEXT set pVertexAttributeDescriptions[%" PRIu32 "] (binding %" PRIu32
+                                 ", location %" PRIu32 ") with a 32-bit format (%s) but the vertex shader %s is a 64-bit type (%s)",
+                                 attrib->index, attrib->desc.binding, attrib->desc.location, string_VkFormat(attrib->desc.format),
+                                 variable_ptr->Describe().c_str(), vert_spirv_state->DescribeType(var_base_type_id).c_str());
                 } else if (attribute64 && shader64) {
                     const uint32_t attribute_components = vkuFormatComponentCount(attrib->desc.format);
                     const uint32_t input_components = vert_spirv_state->GetNumComponentsInBaseType(&variable_ptr->base_type);
@@ -950,20 +950,20 @@ bool CoreChecks::ValidateDrawDynamicStateVertex(const LastBound& last_bound_stat
                         skip |= LogError(vuid.vertex_input_format_09203, vert_spirv_state->handle(), vuid.loc(),
                                          "vkCmdSetVertexInputEXT set pVertexAttributeDescriptions[%" PRIu32 "] (binding %" PRIu32
                                          ", location %" PRIu32 ") with a %" PRIu32
-                                         "-wide 64-bit format (%s) but the vertex shader input is %" PRIu32
+                                         "-wide 64-bit format (%s) but the vertex shader %s is %" PRIu32
                                          "-wide. (64-bit vertex input don't have default values and require "
                                          "components to match what is used in the shader)",
                                          attrib->index, attrib->desc.binding, attrib->desc.location, attribute_components,
-                                         string_VkFormat(attrib->desc.format), input_components);
+                                         string_VkFormat(attrib->desc.format), variable_ptr->Describe().c_str(), input_components);
                     }
                 }
             }
             if (!location_provided && !enabled_features.vertexAttributeRobustness && !enabled_features.maintenance9) {
                 skip |= LogError(vuid.vertex_input_format_07939, vert_spirv_state->handle(), vuid.loc(),
-                                 "Vertex shader uses input at location %" PRIu32
+                                 "Vertex shader %s is using Location %" PRIu32
                                  ", but it was not provided with vkCmdSetVertexInputEXT(). (This can be valid if "
                                  "either the vertexAttributeRobustness or maintenance9 feature is enabled)",
-                                 variable_ptr->decorations.location);
+                                 variable_ptr->Describe().c_str(), variable_ptr->decorations.location);
             }
         }
     }

--- a/layers/core_checks/cc_device_generated_commands.cpp
+++ b/layers/core_checks/cc_device_generated_commands.cpp
@@ -19,6 +19,8 @@
 #include <vulkan/vk_enum_string_helper.h>
 #include <vulkan/vulkan_core.h>
 #include <spirv/unified1/spirv.hpp>
+#include <sstream>
+#include <string>
 #include "core_validation.h"
 #include "drawdispatch/drawdispatch_vuids.h"
 #include "error_message/error_strings.h"
@@ -924,13 +926,31 @@ bool CoreChecks::PreCallValidateUpdateIndirectExecutionSetPipelineEXT(
                              DynamicStatesToString(update_pipeline->dynamic_state).c_str());
             }
 
-            if (initial_pipeline->fragmentShader_writable_output_location_list !=
-                update_pipeline->fragmentShader_writable_output_location_list) {
+            if (initial_pipeline->fs_writable_output_location_list != update_pipeline->fs_writable_output_location_list) {
                 LogObjectList objlist(initial_pipeline->Handle(), update_pipeline->Handle());
+                std::stringstream ss;
+                ss << "was created with a fragment shader output interface using Locations [";
+                bool first = true;
+                for (const uint32_t& locations : initial_pipeline->fs_writable_output_location_list) {
+                    if (!first) {
+                        ss << ", ";
+                    }
+                    ss << locations;
+                    first = false;
+                }
+                ss << "], but it doesn't match the initial Fragment shader in initialPipeline which statically wrote to output "
+                      "Locations [";
+                first = true;
+                for (const uint32_t& locations : update_pipeline->fs_writable_output_location_list) {
+                    if (!first) {
+                        ss << ", ";
+                    }
+                    ss << locations;
+                    first = false;
+                }
+                ss << ']';
                 skip |= LogError("VUID-vkUpdateIndirectExecutionSetPipelineEXT-initialPipeline-11147", objlist,
-                                 set_write_loc.dot(Field::pipeline),
-                                 "was created with a fragment shader interface different from the one specified in "
-                                 "initialPipeline. The fragment shaders statically write to different locations.");
+                                 set_write_loc.dot(Field::pipeline), "%s", ss.str().c_str());
             }
 
             // Default to false incase there is not fragment shader
@@ -1084,8 +1104,9 @@ bool CoreChecks::PreCallValidateUpdateIndirectExecutionSetShaderEXT(VkDevice dev
         const auto initial_fragment_shader_object = indirect_execution_set->initial_fragment_shader_object;
         if (initial_fragment_shader_object && update_shader_object->create_info.stage == VK_SHADER_STAGE_FRAGMENT_BIT) {
             if (update_shader_object->entrypoint && initial_fragment_shader_object->entrypoint) {
-                vvl::unordered_set<uint32_t> update_shader_output_locations;
-                vvl::unordered_set<uint32_t> initial_shader_output_locations;
+                // Ordered to provide a faster comparison and better error message, these should be small sets.
+                std::set<uint32_t> update_shader_output_locations;
+                std::set<uint32_t> initial_shader_output_locations;
 
                 // From GetFSOutputLocations()
                 for (const auto* variable : update_shader_object->entrypoint->user_defined_interface_variables) {
@@ -1103,10 +1124,28 @@ bool CoreChecks::PreCallValidateUpdateIndirectExecutionSetShaderEXT(VkDevice dev
 
                 if (update_shader_output_locations != initial_shader_output_locations) {
                     LogObjectList objlist(initial_fragment_shader_object->Handle(), update_shader_object->Handle());
-                    skip |=
-                        LogError("VUID-vkUpdateIndirectExecutionSetShaderEXT-None-11148", objlist, set_write_loc.dot(Field::shader),
-                                 "was created with a fragment shader interface different from the initial Fragment VkShaderEXT. "
-                                 "The fragment shaders statically write to different locations.");
+                    std::stringstream ss;
+                    ss << "was created with a fragment shader output interface using Locations [";
+                    bool first = true;
+                    for (const uint32_t& locations : update_shader_output_locations) {
+                        if (!first) {
+                            ss << ", ";
+                        }
+                        ss << locations;
+                        first = false;
+                    }
+                    ss << "], but it doesn't match the initial Fragment VkShaderEXT statically wrote to output Locations [";
+                    first = true;
+                    for (const uint32_t& locations : initial_shader_output_locations) {
+                        if (!first) {
+                            ss << ", ";
+                        }
+                        ss << locations;
+                        first = false;
+                    }
+                    ss << ']';
+                    skip |= LogError("VUID-vkUpdateIndirectExecutionSetShaderEXT-None-11148", objlist,
+                                     set_write_loc.dot(Field::shader), "%s", ss.str().c_str());
                 }
 
                 const bool initial_shader_frag_depth =

--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -2136,6 +2136,8 @@ bool CoreChecks::ValidateDrawAttachmentColorBlend(const LastBound &last_bound_st
     const bool dynamic_write_mask = last_bound_state.IsDynamic(CB_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT);
     const bool dynamic_blend_constants = last_bound_state.IsDynamic(CB_DYNAMIC_STATE_BLEND_CONSTANTS);
 
+    const spirv::EntryPoint* fragment_entry_point = last_bound_state.GetFragmentEntryPoint();
+
     for (uint32_t i = 0; i < cb_state.active_attachments.size(); ++i) {
         const auto &attachment_info = cb_state.active_attachments[i];
         const auto *attachment = attachment_info.image_view;
@@ -2260,28 +2262,25 @@ bool CoreChecks::ValidateDrawAttachmentColorBlend(const LastBound &last_bound_st
 
         // Validation needing access to spir-v information
         // ---
-        const spirv::EntryPoint *fragment_entry_point = last_bound_state.GetFragmentEntryPoint();
         if (fragment_entry_point && last_bound_state.IsDualBlending(color_index)) {
-            const auto get_max_fragment_location = [fragment_entry_point]() {
-                uint32_t max_fragment_location = 0;
-                for (const auto *variable : fragment_entry_point->user_defined_interface_variables) {
-                    if (variable->storage_class != spv::StorageClassOutput) {
-                        continue;
-                    }
-                    if (variable->decorations.location != spirv::kInvalidValue) {
-                        max_fragment_location = std::max(max_fragment_location, variable->decorations.location);
+            // Can start at zero, Location zero can't be higher than maxFragmentDualSrcAttachments
+            uint32_t max_fragment_location = 0;
+            const spirv::StageInterfaceVariable* max_output_variable = nullptr;
+            for (const auto* variable : fragment_entry_point->user_defined_interface_variables) {
+                if (variable->storage_class == spv::StorageClassOutput && variable->decorations.location != spirv::kInvalidValue) {
+                    if (variable->decorations.location > max_fragment_location) {
+                        max_fragment_location = variable->decorations.location;
+                        max_output_variable = variable;
                     }
                 }
-                return max_fragment_location;
-            };
+            }
 
-            const uint32_t max_fragment_location = get_max_fragment_location();
             if (max_fragment_location >= phys_dev_props.limits.maxFragmentDualSrcAttachments) {
                 std::ostringstream ss;
                 ss << "color attachment index " << color_index << " (" << attachment_info.Describe(cb_state, i)
-                   << ") is using Dual-Source Blending, but the largest output fragment Location (" << max_fragment_location
-                   << ") is not less than maxFragmentDualSrcAttachments (" << phys_dev_props.limits.maxFragmentDualSrcAttachments
-                   << ").\n";
+                   << ") is using Dual-Source Blending, but the Fragment shader " << max_output_variable->Describe()
+                   << " Location must be less than maxFragmentDualSrcAttachments ("
+                   << phys_dev_props.limits.maxFragmentDualSrcAttachments << ").\n";
                 if (max_fragment_location == 1 && phys_dev_props.limits.maxFragmentDualSrcAttachments == 1) {
                     // maxFragmentDualSrcAttachments is basically 1 for everyone and common case of trying to use dual-blending
                     // incorrectly

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -3731,8 +3731,8 @@ bool CoreChecks::ValidateDrawPipelineDynamicRenderpassFragmentFormat(const LastB
                                      ? rp_state.dynamic_rendering_begin_rendering_info.colorAttachmentCount
                                      : rp_state.inheritance_rendering_info.colorAttachmentCount;
     for (uint32_t i = 0; i < color_count; ++i) {
-        const bool statically_writes_to_color_attachment = pipeline.fragmentShader_writable_output_location_list.find(i) !=
-                                                           pipeline.fragmentShader_writable_output_location_list.end();
+        const bool statically_writes_to_color_attachment =
+            pipeline.fs_writable_output_location_list.find(i) != pipeline.fs_writable_output_location_list.end();
         const bool mask_and_write_enabled = last_bound_state.GetColorWriteMask(i) != 0 && last_bound_state.IsColorWriteEnabled(i);
         if (!statically_writes_to_color_attachment || !mask_and_write_enabled) {
             continue;

--- a/layers/core_checks/cc_shader_interface.cpp
+++ b/layers/core_checks/cc_shader_interface.cpp
@@ -49,6 +49,7 @@ bool CoreChecks::ValidateInterfaceVertexInput(const vvl::Pipeline &pipeline, con
     struct AttribInputPair {
         const VkFormat *attribute_input = nullptr;
         const spirv::Instruction *shader_input = nullptr;
+        const spirv::StageInterfaceVariable* variable_ptr = nullptr;
         uint32_t attribute_index = 0;
     };
     // For vertex input, we only need to care about Location.
@@ -85,7 +86,9 @@ bool CoreChecks::ValidateInterfaceVertexInput(const vvl::Pipeline &pipeline, con
         // If the interface variable doesn't have the Locations, find them inside the struct members
         if (!variable.type_struct_info) {
             for (const auto &slot : variable.interface_slots) {
-                location_map[slot.Location()].shader_input = &variable.base_type;
+                const uint32_t location = slot.Location();
+                location_map[location].shader_input = &variable.base_type;
+                location_map[location].variable_ptr = variable_ptr;
             }
         } else if (variable.decorations.location != spirv::kInvalidValue) {
             // Variable is decorated with Location
@@ -97,13 +100,16 @@ bool CoreChecks::ValidateInterfaceVertexInput(const vvl::Pipeline &pipeline, con
                 const uint32_t num_locations = module_state.GetLocationsConsumedByType(member_type);
                 for (uint32_t j = 0; j < num_locations; ++j) {
                     location_map[location + j].shader_input = member.insn;
+                    location_map[location + j].variable_ptr = variable_ptr;
                 }
                 location += num_locations;
             }
         } else {
             // Can't be nested so only need to look at first level of members
             for (const auto &member : variable.type_struct_info->members) {
-                location_map[member.decorations->location].shader_input = member.insn;
+                const uint32_t location = member.decorations->location;
+                location_map[location].shader_input = member.insn;
+                location_map[location].variable_ptr = variable_ptr;
             }
         }
     }
@@ -120,9 +126,9 @@ bool CoreChecks::ValidateInterfaceVertexInput(const vvl::Pipeline &pipeline, con
                 skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-Input-07904", module_state.handle(),
                                  vi_loc.dot(Field::pVertexAttributeDescriptions),
                                  "does not have a Location %" PRIu32
-                                 " but vertex shader has an input variable at that Location. (This can be valid if "
+                                 ", but vertex shader has %s at that Location. (This can be valid if "
                                  "either the vertexAttributeRobustness or maintenance9 feature is enabled)",
-                                 location);
+                                 location, attribute_info.variable_ptr->Describe().c_str());
             }
         } else if (attribute_input && shader_input) {
             const VkFormat attribute_format = *attribute_input;
@@ -138,20 +144,21 @@ bool CoreChecks::ValidateInterfaceVertexInput(const vvl::Pipeline &pipeline, con
             if ((attribute_type & var_numeric_type) == 0) {
                 skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-Input-08733", module_state.handle(),
                                  vi_loc.dot(Field::pVertexAttributeDescriptions, attribute_info.attribute_index).dot(Field::format),
-                                 "(%s) at Location %" PRIu32 " does not match vertex shader input type (%s).",
-                                 string_VkFormat(attribute_format), location, module_state.DescribeType(var_base_type_id).c_str());
+                                 "(%s) at Location %" PRIu32 " does not match vertex shader %s type (%s).",
+                                 string_VkFormat(attribute_format), location, attribute_info.variable_ptr->Describe().c_str(),
+                                 module_state.DescribeType(var_base_type_id).c_str());
             } else if (attribute64 && !shader64) {
-                skip |=
-                    LogError("VUID-VkGraphicsPipelineCreateInfo-pVertexInputState-08929", module_state.handle(),
-                             vi_loc.dot(Field::pVertexAttributeDescriptions, attribute_info.attribute_index).dot(Field::format),
-                             "(%s) is a 64-bit format, but at Location %" PRIu32 " the vertex shader input is 32-bit type (%s).",
-                             string_VkFormat(attribute_format), location, module_state.DescribeType(var_base_type_id).c_str());
+                skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-pVertexInputState-08929", module_state.handle(),
+                                 vi_loc.dot(Field::pVertexAttributeDescriptions, attribute_info.attribute_index).dot(Field::format),
+                                 "(%s) is a 64-bit format, but the vertex shader %s at Location %" PRIu32 " is 32-bit type (%s).",
+                                 string_VkFormat(attribute_format), attribute_info.variable_ptr->Describe().c_str(), location,
+                                 module_state.DescribeType(var_base_type_id).c_str());
             } else if (!attribute64 && shader64) {
-                skip |=
-                    LogError("VUID-VkGraphicsPipelineCreateInfo-pVertexInputState-08930", module_state.handle(),
-                             vi_loc.dot(Field::pVertexAttributeDescriptions, attribute_info.attribute_index).dot(Field::format),
-                             "(%s) is a 64-bit format, but at Location %" PRIu32 " the vertex shader input is 64-bit type (%s).",
-                             string_VkFormat(attribute_format), location, module_state.DescribeType(var_base_type_id).c_str());
+                skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-pVertexInputState-08930", module_state.handle(),
+                                 vi_loc.dot(Field::pVertexAttributeDescriptions, attribute_info.attribute_index).dot(Field::format),
+                                 "(%s) is a 64-bit format, but the vertex shader %s at Location %" PRIu32 " is 64-bit type (%s).",
+                                 string_VkFormat(attribute_format), attribute_info.variable_ptr->Describe().c_str(), location,
+                                 module_state.DescribeType(var_base_type_id).c_str());
             } else if (attribute64 && shader64) {
                 const uint32_t attribute_components = vkuFormatComponentCount(attribute_format);
                 const uint32_t input_components = module_state.GetNumComponentsInBaseType(shader_input);
@@ -159,11 +166,11 @@ bool CoreChecks::ValidateInterfaceVertexInput(const vvl::Pipeline &pipeline, con
                     skip |= LogError(
                         "VUID-VkGraphicsPipelineCreateInfo-pVertexInputState-09198", module_state.handle(),
                         vi_loc.dot(Field::pVertexAttributeDescriptions, attribute_info.attribute_index).dot(Field::format),
-                        "(%s) is a %" PRIu32 "-wide 64-bit format, but at location %" PRIu32 " the vertex shader input is %" PRIu32
+                        "(%s) is a %" PRIu32 "-wide 64-bit format, but the vertex shader %s at Location %" PRIu32 " is %" PRIu32
                         "-wide 64-bit type (%s). (64-bit vertex input don't have default values and require "
                         "components to match what is used in the shader)",
-                        string_VkFormat(attribute_format), attribute_components, location, input_components,
-                        module_state.DescribeType(var_base_type_id).c_str());
+                        string_VkFormat(attribute_format), attribute_components, attribute_info.variable_ptr->Describe().c_str(),
+                        location, input_components, module_state.DescribeType(var_base_type_id).c_str());
                 }
             }
         } else {            // !attrib && !input
@@ -205,11 +212,14 @@ bool CoreChecks::ValidateBuiltInLimits(const spirv::Module &module_state, const 
             variable->array_size > phys_dev_props.limits.maxSampleMaskWords) {
             const char *vuid = pipeline ? "VUID-VkPipelineShaderStageCreateInfo-maxSampleMaskWords-00711"
                                         : "VUID-VkShaderCreateInfoEXT-pCode-08451";
+            const bool glsl_name = module_state.static_data_.source_language != spv::SourceLanguageHLSL &&
+                                   module_state.static_data_.source_language != spv::SourceLanguageSlang;
             skip |= LogError(vuid, module_state.handle(), loc,
-                             "The BuiltIns SampleMask array sizes is %" PRIu32
+                             "The SampleMask BuiltIn (%s) array sizes is %" PRIu32
                              " which exceeds "
                              "maxSampleMaskWords of %" PRIu32 ".",
-                             variable->array_size, phys_dev_props.limits.maxSampleMaskWords);
+                             glsl_name ? "gl_SampleMask[]" : "SV_SampleMask", variable->array_size,
+                             phys_dev_props.limits.maxSampleMaskWords);
             break;
         }
     }
@@ -553,26 +563,28 @@ bool CoreChecks::ValidateFsOutputsAgainstRenderPass(const spirv::Module &module_
         } else if (!attachment && output) {
             // With alphaToCoverage, the write is not "discarded" as the alpha mask is still updated
             if (!alpha_to_coverage_enabled || location != 0) {
-                skip |= LogUndefinedValue("Undefined-Value-ShaderOutputNotConsumed", module_state.handle(), create_info_loc,
-                                          "Inside the fragment shader, it writes to output Location %" PRIu32
-                                          " but there is no VkSubpassDescription::pColorAttachments[%" PRIu32
-                                          "] and this write is unused.\nSpec information at "
-                                          "https://docs.vulkan.org/spec/latest/chapters/interfaces.html#interfaces-fragmentoutput",
-                                          location, location);
+                skip |= LogUndefinedValue(
+                    "Undefined-Value-ShaderOutputNotConsumed", module_state.handle(), create_info_loc,
+                    "Inside the fragment shader, it writes to %s, but there is no VkSubpassDescription::pColorAttachments[%" PRIu32
+                    "] and this write is unused.\nSpec information at "
+                    "https://docs.vulkan.org/spec/latest/chapters/interfaces.html#interfaces-fragmentoutput",
+                    output->Describe().c_str(), location);
             }
         } else if (attachment && output) {
             if (!output->IsWrittenTo()) {
                 const auto& attachment_states = pipeline.AttachmentStates();
                 if (location < attachment_states.size() && attachment_states[location].colorWriteMask != 0) {
-                    skip |= LogUndefinedValue(
-                        "Undefined-Value-OutputNotWritten", module_state.handle(), create_info_loc,
-                        "Inside the fragment shader, the output Location %" PRIu32
-                        " was never written to. This means anything future VkSubpassDescription::pColorAttachments[%" PRIu32
-                        "] will have undefined values written to it.\nThe pipeline was created with "
-                        "pColorBlendState->pAttachments[%" PRIu32 "].colorWriteMask set to 0x%" PRIx32
-                        " so setting it to zero is one way to prevent undefined values overriding your color attachment.\nIf you have the output variable, but are not using it on purpose, removing it from being declared in the shader will remove the "
-                        "undefined value warning.",
-                        location, location, location, attachment_states[location].colorWriteMask);
+                    skip |= LogUndefinedValue("Undefined-Value-OutputNotWritten", module_state.handle(), create_info_loc,
+                                              "Inside the fragment shader, %s was never written to. This means anything future "
+                                              "VkSubpassDescription::pColorAttachments[%" PRIu32
+                                              "] will have undefined values written to it.\nThe pipeline was created with "
+                                              "pColorBlendState->pAttachments[%" PRIu32 "].colorWriteMask set to 0x%" PRIx32
+                                              " so setting it to zero is one way to prevent undefined values overriding your color "
+                                              "attachment.\nIf you have the output variable, but are not using it on purpose, "
+                                              "removing it from being declared in the shader will remove the "
+                                              "undefined value warning.",
+                                              output->Describe().c_str(), location, location,
+                                              attachment_states[location].colorWriteMask);
                 }
             } else {
                 const uint32_t attachment_type = spirv::GetFormatType(attachment->format);
@@ -580,16 +592,16 @@ bool CoreChecks::ValidateFsOutputsAgainstRenderPass(const spirv::Module &module_
 
                 // Type checking
                 if ((output_type & attachment_type) == 0) {
-                    skip |=
-                        LogUndefinedValue("Undefined-Value-ShaderFragmentOutputMismatch", module_state.handle(), create_info_loc,
-                                          "Inside the fragment shader, it writes to output Location %" PRIu32
-                                          " with a numeric type of %s but VkSubpassDescription::pColorAttachments[%" PRIu32
-                                          "] pointing at VkRenderPassCreateInfo::pAttachments[%" PRIu32
-                                          "] is created with %s (numeric type of %s) which does not match and the resulting values "
-                                          "written will be undefined.\nSpec information at "
-                                          "https://docs.vulkan.org/spec/latest/chapters/interfaces.html#interfaces-fragmentoutput",
-                                          location, spirv::string_NumericType(output_type), location, reference->attachment,
-                                          string_VkFormat(attachment->format), spirv::string_NumericType(attachment_type));
+                    skip |= LogUndefinedValue(
+                        "Undefined-Value-ShaderFragmentOutputMismatch", module_state.handle(), create_info_loc,
+                        "Inside the fragment shader, it writes to %s with a numeric type of %s but "
+                        "VkSubpassDescription::pColorAttachments[%" PRIu32
+                        "] pointing at VkRenderPassCreateInfo::pAttachments[%" PRIu32
+                        "] is created with %s (numeric type of %s) which does not match and the resulting values "
+                        "written will be undefined.\nSpec information at "
+                        "https://docs.vulkan.org/spec/latest/chapters/interfaces.html#interfaces-fragmentoutput",
+                        output->Describe().c_str(), spirv::string_NumericType(output_type), location, reference->attachment,
+                        string_VkFormat(attachment->format), spirv::string_NumericType(attachment_type));
                 }
             }
         } else {            // !attachment && !output
@@ -598,16 +610,6 @@ bool CoreChecks::ValidateFsOutputsAgainstRenderPass(const spirv::Module &module_
     }
 
     return skip;
-}
-
-static std::string DescribeMappedLocation(uint32_t shader, uint32_t rendering_info) {
-    std::ostringstream msg;
-    if (shader == rendering_info) {
-        msg << shader;
-    } else {
-        msg << shader << " (which was remapped to attachment " << rendering_info << ")";
-    }
-    return msg.str();
 }
 
 // This is validated at draw time unlike the VkRenderPass version
@@ -678,27 +680,32 @@ bool CoreChecks::ValidateDrawDynamicRenderingFsOutputs(const LastBound &last_bou
                 const bool null_image_view = attachment_info.rendering_attachment_info &&
                                              attachment_info.rendering_attachment_info->imageView == VK_NULL_HANDLE;
                 const LogObjectList objlist = last_bound_state.cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS);
-                std::ostringstream reason;
+                std::ostringstream ss;
+                ss << "Inside the fragment shader, it writes to " << output->Describe();
+                if (location != mapped_loc) {
+                    ss << " (which was remapped to Location/attachment " << mapped_loc << ")";
+                }
+                ss << " but ";
                 if (null_image_view || location >= cb_state.rendering_attachments.color_locations.size()) {
-                    reason << "there is no VkRenderingInfo::pColorAttachments[" << mapped_loc << "]";
+                    ss << "there is no VkRenderingInfo::pColorAttachments[" << mapped_loc << "]";
                     if (null_image_view) {
-                        reason << " (imageView is VK_NULL_HANDLE)";
+                        ss << " (imageView is VK_NULL_HANDLE)";
                     }
                 } else {
-                    reason << "none of the attachments were mapped to that location (mapping was [";
+                    ss << "none of the attachments were mapped to that location (mapping was [";
                     for (const uint32_t &mapping : cb_state.rendering_attachments.color_locations) {
                         if (&mapping != &cb_state.rendering_attachments.color_locations[0]) {
-                            reason << ", ";
+                            ss << ", ";
                         }
-                        reason << string_Attachment(mapping);
+                        ss << string_Attachment(mapping);
                     }
-                    reason << "])";
+                    ss << "])";
                 }
-                skip |= LogUndefinedValue(
-                    "Undefined-Value-ShaderOutputNotConsumed-DynamicRendering", objlist, loc,
-                    "Inside the fragment shader, it writes to output Location %s but %s and this write is unused.\n"
-                    "Spec information at https://docs.vulkan.org/spec/latest/chapters/interfaces.html#interfaces-fragmentoutput",
-                    DescribeMappedLocation(location, mapped_loc).c_str(), reason.str().c_str());
+                ss << " and this write is unused.\nSpec information at "
+                      "https://docs.vulkan.org/spec/latest/chapters/interfaces.html#interfaces-fragmentoutput";
+
+                skip |= LogUndefinedValue("Undefined-Value-ShaderOutputNotConsumed-DynamicRendering", objlist, loc, "%s",
+                                          ss.str().c_str());
             }
         } else if (has_attachment && output) {
             const auto image_view_state = Get<vvl::ImageView>(attachment_info.rendering_attachment_info->imageView);
@@ -720,8 +727,11 @@ bool CoreChecks::ValidateDrawDynamicRenderingFsOutputs(const LastBound &last_bou
                 const VkColorComponentFlags color_write_mask = last_bound_state.GetColorWriteMask(location);
                 if (color_write_mask != 0) {
                     std::ostringstream msg;
-                    msg << "Inside the fragment shader, the output Location " << location
-                        << " was never written to. This means the bound VkRenderingInfo::pColorAttachments[" << location
+                    msg << "Inside the fragment shader, " << output->Describe();
+                    if (location != mapped_loc) {
+                        msg << " (which was remapped to Location/attachment " << mapped_loc << ")";
+                    }
+                    msg << " was never written to. This means the bound VkRenderingInfo::pColorAttachments[" << location
                         << "].imageView (" << FormatHandle(attachment_info.rendering_attachment_info->imageView)
                         << ") will have undefined values written to it.\n";
                     if (last_bound_state.pipeline_state) {
@@ -751,16 +761,20 @@ bool CoreChecks::ValidateDrawDynamicRenderingFsOutputs(const LastBound &last_bou
                 // Type checking
                 if ((output_type & attachment_type) == 0) {
                     const LogObjectList objlist = last_bound_state.cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS);
-                    skip |= LogUndefinedValue(
-                        "Undefined-Value-ShaderFragmentOutputMismatch-DynamicRendering", objlist, loc,
-                        "Inside the fragment shader, it writes to output Location %s with a numeric type of %s but "
-                        "VkRenderingInfo::pColorAttachments[%" PRIu32
-                        "].imageView is created with %s (numeric type of %s) which does not match and the "
-                        "resulting values written will be undefined.\n"
-                        "Spec information at "
-                        "https://docs.vulkan.org/spec/latest/chapters/interfaces.html#interfaces-fragmentoutput",
-                        DescribeMappedLocation(location, mapped_loc).c_str(), spirv::string_NumericType(output_type), mapped_loc,
-                        string_VkFormat(image_view_state->create_info.format), spirv::string_NumericType(attachment_type));
+                    std::stringstream ss;
+                    ss << "Inside the fragment shader, " << output->Describe();
+                    if (location != mapped_loc) {
+                        ss << " (which was remapped to Location/attachment " << mapped_loc << ")";
+                    }
+                    ss << " with a numeric type of " << spirv::string_NumericType(output_type)
+                       << " but VkRenderingInfo::pColorAttachments[" << mapped_loc << "].imageView is created with "
+                       << string_VkFormat(image_view_state->create_info.format) << " (numeric type of "
+                       << spirv::string_NumericType(attachment_type)
+                       << ") which does not match and the resulting values written will be undefined.\n"
+                          "Spec information at "
+                          "https://docs.vulkan.org/spec/latest/chapters/interfaces.html#interfaces-fragmentoutput";
+                    skip |= LogUndefinedValue("Undefined-Value-ShaderFragmentOutputMismatch-DynamicRendering", objlist, loc, "%s",
+                                              ss.str().c_str());
                 }
             }
         } else {  // !attachment && !output

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -913,7 +913,7 @@ Pipeline::Pipeline(const DeviceState& state_data, const VkGraphicsPipelineCreate
       create_info_shaders(GetCreateInfoShaders(*this)),
       linking_shaders(GetLinkingShaders(library_create_info, state_data)),
       active_shaders(create_info_shaders | linking_shaders),
-      fragmentShader_writable_output_location_list(GetFSOutputLocations(stage_states)),
+      fs_writable_output_location_list(GetFSOutputLocations(stage_states)),
       active_slots(GetActiveSlots(stage_states)),
       max_active_slot(GetMaxActiveSlot(active_slots)),
       dynamic_state(GetGraphicsDynamicState(*this)),

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -125,7 +125,7 @@ class Pipeline : public StateObject, public SubStateManager<PipelineSubState> {
     // create_info_shaders + linking_shaders
     const VkShaderStageFlags active_shaders = 0;
 
-    const vvl::unordered_set<uint32_t> fragmentShader_writable_output_location_list;
+    const vvl::unordered_set<uint32_t> fs_writable_output_location_list;
 
     // NOTE: this map is used in performance critical code paths.
     // The values of existing entries in the samplers_used_by_image map

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -1964,6 +1964,34 @@ std::string ResourceInterfaceVariable::DescribeDescriptor() const {
     return ss.str();
 }
 
+std::string StageInterfaceVariable::Describe() const {
+    assert(!is_built_in);
+    std::ostringstream ss;
+    ss << "[" << string_SpvStorageClass(storage_class) << " variable";
+
+    if (type_struct_info) {
+        // is a struct where each field has it's own location
+        if (!debug_name.empty()) {
+            ss << " \"" << debug_name << "\"";
+        }
+        // TODO - We don't track details about the member variables here (Location, Name)
+        // GLSL/HLSL/Slang seem to all generate non-structs anyway in practice
+        // If we decide to add, various test targeting VU 08733 can be used
+        ss << " is a struct with " << type_struct_info->members.size() << " members";
+    } else if (decorations.location != spirv::kInvalidValue) {
+        ss << ", Location " << decorations.location;
+        if (!debug_name.empty()) {
+            ss << ", \"" << debug_name << "\"";
+        }
+    } else {
+        assert(false);
+        ss << "INVALID, no location or struct";
+    }
+
+    ss << "]";
+    return ss.str();
+}
+
 bool StageInterfaceVariable::IsPerTaskNV(const StageInterfaceVariable& variable) {
     // will always be in a struct member
     if (variable.type_struct_info &&

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -403,6 +403,8 @@ struct StageInterfaceVariable : public VariableBase {
     const std::vector<spv::BuiltIn> built_in_block;
     uint32_t total_built_in_components = 0;
 
+    std::string Describe() const;
+
     StageInterfaceVariable(const Module &module_state, const Instruction &insn, VkShaderStageFlagBits stage,
                            const ParsedInfo &parsed);
 

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -935,7 +935,7 @@ bool CommandBufferAccessContext::ValidateDrawDynamicRenderingAttachment(const Lo
     const auto *pipe = last_bound_state.pipeline_state;
     if (!pipe || pipe->RasterizationDisabled()) return skip;
 
-    const auto &list = pipe->fragmentShader_writable_output_location_list;
+    const auto& list = pipe->fs_writable_output_location_list;
     const auto &access_context = *GetCurrentAccessContext();
 
     const DynamicRenderingInfo &info = *dynamic_rendering_info_;
@@ -1004,7 +1004,7 @@ void CommandBufferAccessContext::RecordDrawDynamicRenderingAttachment(ResourceUs
     const auto *pipe = last_bound_state.pipeline_state;
     if (!pipe || pipe->RasterizationDisabled()) return;
 
-    const auto &list = pipe->fragmentShader_writable_output_location_list;
+    const auto& list = pipe->fs_writable_output_location_list;
     auto &access_context = *GetCurrentAccessContext();
 
     const DynamicRenderingInfo &info = *dynamic_rendering_info_;

--- a/layers/sync/sync_renderpass.cpp
+++ b/layers/sync/sync_renderpass.cpp
@@ -549,7 +549,7 @@ bool RenderPassAccessContext::ValidateDrawSubpassAttachment(const CommandBufferA
         return skip;
     }
 
-    const auto &list = pipe->fragmentShader_writable_output_location_list;
+    const auto& list = pipe->fs_writable_output_location_list;
     const auto &subpass = rp_state_->create_info.pSubpasses[current_subpass_];
     const auto &current_context = CurrentContext();
     const SyncValidator &sync_state = cb_context.GetSyncState();
@@ -644,7 +644,7 @@ void RenderPassAccessContext::RecordDrawSubpassAttachment(const vvl::CommandBuff
     const auto *pipe = last_bound_state.pipeline_state;
     if (!pipe || pipe->RasterizationDisabled()) return;
 
-    const auto &list = pipe->fragmentShader_writable_output_location_list;
+    const auto& list = pipe->fs_writable_output_location_list;
     const auto &subpass = rp_state_->create_info.pSubpasses[current_subpass_];
 
     auto &current_context = CurrentContext();

--- a/tests/unit/vertex_input.cpp
+++ b/tests/unit/vertex_input.cpp
@@ -1308,14 +1308,14 @@ TEST_F(NegativeVertexInput, AttributeNotProvided) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const char *vsSource = R"glsl(
+    const char* vs_source = R"glsl(
         #version 450
         layout(location=0) in vec4 x; /* not provided */
         void main(){
            gl_Position = x;
         }
     )glsl";
-    VkShaderObj vs(*m_device, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
+    VkShaderObj vs(*m_device, vs_source, VK_SHADER_STAGE_VERTEX_BIT);
 
     const auto set_info = [&](CreatePipelineHelper &helper) {
         helper.shader_stages_ = {vs.GetStageCreateInfo(), helper.fs_->GetStageCreateInfo()};
@@ -1374,10 +1374,11 @@ TEST_F(NegativeVertexInput, AttributeStructTypeFirstLocation) {
     //         layout(location = 4) vec4 x;
     //         layout(location = 6) uvec4 y;
     //     } x_struct;
-    const char *vsSource = R"(
+    const char* vsSource = R"(
                OpCapability Shader
                OpMemoryModel Logical Simple
                OpEntryPoint Vertex %1 "main" %2
+               OpName %_struct_3 "x_struct"
                OpMemberDecorate %_struct_3 0 Location 4
                OpMemberDecorate %_struct_3 1 Location 6
                OpDecorate %_struct_3 Block


### PR DESCRIPTION
Adds a `StageInterfaceVariable::Describe` to help provide better error messages, mainly print the variable name, which is very nice