### PR TITLE
layers: Add missing check for remapping struct

### DIFF
--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -80,17 +80,22 @@ bool CoreChecks::ValidateShaderInputAttachment(const spirv::Module &module_state
 
     // VUID 06061 requires dynamicRenderingLocalRead and if they have, we can just check the colorAttachmentCount
     if (rp_state->UsesDynamicRendering()) {
-        const uint32_t color_count = rp_state->dynamic_pipeline_rendering_create_info.colorAttachmentCount;
-        for (const auto i : variable.input_attachment_index_read) {
-            // offsets by the InputAttachmentIndex decoration
-            const uint32_t input_attachment_index = variable.decorations.input_attachment_index_start + i;
-            if (input_attachment_index >= color_count) {
-                const LogObjectList objlist(module_state.handle(), pipeline.Handle(), rp_state->Handle());
-                skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-renderPass-09652", objlist, loc,
+        const bool has_input_attachment_remapping_info =
+            vku::FindStructInPNextChain<VkRenderingInputAttachmentIndexInfo>(pipeline.GetCreateInfoPNext());
+        if (!has_input_attachment_remapping_info) {
+            const uint32_t color_count = rp_state->dynamic_pipeline_rendering_create_info.colorAttachmentCount;
+            for (const auto i : variable.input_attachment_index_read) {
+                // offsets by the InputAttachmentIndex decoration
+                const uint32_t input_attachment_index = variable.decorations.input_attachment_index_start + i;
+                if (input_attachment_index >= color_count) {
+                    const LogObjectList objlist(module_state.handle(), pipeline.Handle(), rp_state->Handle());
+                    skip |=
+                        LogError("VUID-VkGraphicsPipelineCreateInfo-renderPass-09652", objlist, loc,
                                  "%s which is not less than VkPipelineRenderingCreateInfo::colorAttachmentCount (%" PRIu32
                                  ")\nIf VkRenderingInputAttachmentIndexInfo is provided, the index can be set, but without it, it "
                                  "uses the default index values.",
                                  print_index(input_attachment_index).c_str(), color_count);
+                }
             }
         }
     } else {

--- a/tests/unit/dynamic_rendering_local_read_positive.cpp
+++ b/tests/unit/dynamic_rendering_local_read_positive.cpp
@@ -601,3 +601,27 @@ TEST_F(PositiveDynamicRenderingLocalRead, InputAttachmentIndexArray2) {
     pipe.gp_ci_.pColorBlendState = &cbi;
     pipe.CreateGraphicsPipeline();
 }
+
+TEST_F(PositiveDynamicRenderingLocalRead, InputAttachmentIndexDepth) {
+    TEST_DESCRIPTION("Use depth attachment as input attachment");
+    RETURN_IF_SKIP(InitBasicDynamicRenderingLocalRead());
+
+    const VkFormat depth_format = FindSupportedDepthOnlyFormat(Gpu());
+
+    // Use depth attachment as input attachment 0
+    uint32_t zero = 0;
+    VkRenderingInputAttachmentIndexInfo input_attachment_info = vku::InitStructHelper();
+    input_attachment_info.pDepthInputAttachmentIndex = &zero;
+
+    VkPipelineRenderingCreateInfo pipeline_rendering_info_read = vku::InitStructHelper(&input_attachment_info);
+    pipeline_rendering_info_read.depthAttachmentFormat = depth_format;
+
+    VkShaderObj vs(*m_device, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
+    VkShaderObj fs(*m_device, kFragmentSubpassLoadGlsl, VK_SHADER_STAGE_FRAGMENT_BIT);
+
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info_read);
+    pipe.ds_ci_ = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
+    pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
+    pipe.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 1, VK_SHADER_STAGE_FRAGMENT_BIT};
+    pipe.CreateGraphicsPipeline();
+}


### PR DESCRIPTION
`VUID-VkGraphicsPipelineCreateInfo-renderPass-09652` validates only use case when no remapping is specified.
Found this when tried to use depth attachment as input attachment in syncval. This requires remapping to assign index to depth attachment.
