### PR TITLE
layers: Use duplicate_message_limit to adjust batching size

### DIFF
--- a/layers/object_tracker/object_lifetime_validation.cpp
+++ b/layers/object_tracker/object_lifetime_validation.cpp
@@ -636,11 +636,17 @@ void Instance::FindLeakedObjects(VulkanObjectType object_type, std::vector<Vulka
 bool Instance::ReportLeakedObjects(std::vector<VulkanTypedHandle>& leaked_list, const Location& loc) const {
     std::stringstream ss;
     ss << FormatHandle(instance) << " has " << leaked_list.size() << " leaked objects that have not been destroyed.\n";
+    const uint32_t limit = debug_report->duplicate_message_limit;
+    if (leaked_list.size() > limit) {
+        // Feels like spam after this, user should have zero anyway
+        ss << "(Only printing the first " << limit
+           << " objects, but can be increased by raising the VK_LAYER_DUPLICATE_MESSAGE_LIMIT/'duplicate_message_limit' setting "
+              "value)\n";
+    }
+
     uint32_t count = 0;
     for (const auto& object : leaked_list) {
-        if (count >= 64) {
-            // Feels like spam after this, user should have zero anyway
-            ss << "\n(Only printing the first 64 objects)";
+        if (count >= limit) {
             break;
         }
         if (count != 0) {
@@ -663,11 +669,17 @@ void Device::FindLeakedObjects(VulkanObjectType object_type, std::vector<VulkanT
 bool Device::ReportLeakedObjects(std::vector<VulkanTypedHandle>& leaked_list, const Location& loc) const {
     std::stringstream ss;
     ss << FormatHandle(device) << " has " << leaked_list.size() << " leaked objects that have not been destroyed.\n";
+    const uint32_t limit = debug_report->duplicate_message_limit;
+    if (leaked_list.size() > limit) {
+        // Feels like spam after this, user should have zero anyway
+        ss << "(Only printing the first " << limit
+           << " objects, but can be increased by raising the VK_LAYER_DUPLICATE_MESSAGE_LIMIT/'duplicate_message_limit' setting "
+              "value)\n";
+    }
+
     uint32_t count = 0;
     for (const auto& object : leaked_list) {
-        if (count >= 64) {
-            // Feels like spam after this, user should have zero anyway
-            ss << "\n(Only printing the first 64 objects)";
+        if (count >= limit) {
             break;
         }
         if (count != 0) {


### PR DESCRIPTION
From https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/11682#discussion_r2820698141

Now will print

```
Validation Error: [ VUID-vkDestroyDevice-device-05137 ] | MessageID = 0x4872eaa0
vkDestroyDevice(): VkDevice 0x7bd9d26a5b30 has 12186 leaked objects that have not been destroyed.
(Only printing the first 20 objects, but can be increased by raising the VK_LAYER_DUPLICATE_MESSAGE_LIMIT/'duplicate_message_limit' setting value)
VkBuffer 0x410000000041, VkBuffer 0x1860000000186, VkBuffer 0x6cd40000006cd4, VkBuffer 0x6c460000006c46, VkBuffer 0x6b360000006b36, VkBuffer 0x5cc80000005cc8, VkBuffer 0x64640000006464, VkBuffer 0x76e000000076e, VkBuffer 0x50000000005, VkBuffer 0x18f000000018f, VkBuffer 0x6a1e0000006a1e, VkBuffer 0x6bbe0000006bbe, VkBuffer 0x6b3c0000006b3c, VkBuffer 0x688e000000688e, VkBuffer 0x70000000007, VkBuffer 0x6a2c0000006a2c, VkBuffer 0x18b000000018b, VkBuffer 0x6a1a0000006a1a, VkBuffer 0x18c000000018c, VkBuffer 0x69100000006910
```