### PR TITLE
layers: Allow Present Timing Calibration to request multiple present stages

### DIFF
--- a/layers/core_checks/cc_device.cpp
+++ b/layers/core_checks/cc_device.cpp
@@ -232,7 +232,8 @@ bool core::Instance::ValidateDeviceQueueCreateInfos(const vvl::PhysicalDevice &p
         const VkQueueFamilyProperties requested_queue_family_props = pd_state.queue_family_properties[requested_queue_family];
 
         // if using protected flag, make sure queue supports it
-        if ((flags & VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT) && ((requested_queue_family_props.queueFlags & VK_QUEUE_PROTECTED_BIT) == 0)) {
+        if ((flags & VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT) &&
+            ((requested_queue_family_props.queueFlags & VK_QUEUE_PROTECTED_BIT) == 0)) {
             skip |= LogError("VUID-VkDeviceQueueCreateInfo-flags-06449", pd_state.Handle(), info_loc.dot(Field::queueFamilyIndex),
                              "(%" PRIu32 ") does not have VK_QUEUE_PROTECTED_BIT supported, but pQueueCreateInfos[%" PRIu32
                              "].flags has VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT.",
@@ -697,11 +698,19 @@ bool CoreChecks::PreCallValidateGetCalibratedTimestampsKHR(VkDevice device, uint
     std::vector<VkTimeDomainKHR> valid_time_domains(count);
     query_function(physical_device, &count, valid_time_domains.data());
 
-    vvl::unordered_map<VkTimeDomainKHR, uint32_t> time_domain_map;
+    vvl::unordered_map<VkTimeDomainKHR, VkPresentStageFlagsEXT> time_domain_map;
     for (uint32_t i = 0; i < timestampCount; i++) {
         const VkTimeDomainKHR time_domain = pTimestampInfos[i].timeDomain;
+
+        // The VK_TIME_DOMAIN_PRESENT_STAGE_LOCAL_EXT domain can be duplicated if the present stage is different
+        const auto *present_stage_info =
+            vku::FindStructInPNextChain<VkSwapchainCalibratedTimestampInfoEXT>(pTimestampInfos[i].pNext);
+        const VkPresentStageFlagsEXT present_stage = (time_domain == VK_TIME_DOMAIN_PRESENT_STAGE_LOCAL_EXT && present_stage_info)
+                                                         ? present_stage_info->presentStage
+                                                         : vvl::kU32Max;
+
         auto it = time_domain_map.find(time_domain);
-        if (it != time_domain_map.end()) {
+        if (it != time_domain_map.end() && (it->second & present_stage) != 0) {
             skip |= LogError("VUID-vkGetCalibratedTimestampsKHR-timeDomain-09246", device,
                              error_obj.location.dot(Field::pTimestampInfos, i).dot(Field::timeDomain),
                              "and pTimestampInfos[%" PRIu32 "].timeDomain are both %s.", it->second,
@@ -712,7 +721,7 @@ bool CoreChecks::PreCallValidateGetCalibratedTimestampsKHR(VkDevice device, uint
                              error_obj.location.dot(Field::pTimestampInfos, i).dot(Field::timeDomain), "is %s.",
                              string_VkTimeDomainKHR(time_domain));
         }
-        time_domain_map[time_domain] = i;
+        time_domain_map[time_domain] |= present_stage;
     }
     return skip;
 }
@@ -814,7 +823,6 @@ bool CoreChecks::PreCallValidateCreatePipelineBinariesKHR(VkDevice device, const
                                                           const VkAllocationCallbacks *pAllocator,
                                                           VkPipelineBinaryHandlesInfoKHR *pBinaries,
                                                           const ErrorObject &error_obj) const {
-
     bool skip = false;
 
     uint32_t pointerCount = 0;

--- a/tests/unit/wsi.cpp
+++ b/tests/unit/wsi.cpp
@@ -5725,7 +5725,8 @@ TEST_F(NegativeWsi, PresentTimingsCalibrateableTimeDomains2) {
 
     VkSwapchainCalibratedTimestampInfoEXT swapchain_timestamp_info = vku::InitStructHelper();
     swapchain_timestamp_info.swapchain = swapchain;
-    swapchain_timestamp_info.presentStage = VK_PRESENT_STAGE_QUEUE_OPERATIONS_END_BIT_EXT | VK_PRESENT_STAGE_REQUEST_DEQUEUED_BIT_EXT;
+    swapchain_timestamp_info.presentStage =
+        VK_PRESENT_STAGE_QUEUE_OPERATIONS_END_BIT_EXT | VK_PRESENT_STAGE_REQUEST_DEQUEUED_BIT_EXT;
 
     VkCalibratedTimestampInfoKHR timestamp_info = vku::InitStructHelper(&swapchain_timestamp_info);
     timestamp_info.timeDomain = VK_TIME_DOMAIN_PRESENT_STAGE_LOCAL_EXT;
@@ -5733,6 +5734,71 @@ TEST_F(NegativeWsi, PresentTimingsCalibrateableTimeDomains2) {
     uint64_t max_deviation;
     m_errorMonitor->SetDesiredError("VUID-VkSwapchainCalibratedTimestampInfoEXT-timeDomain-12228");
     vk::GetCalibratedTimestampsKHR(device(), 1u, &timestamp_info, &timestamp, &max_deviation);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeWsi, PresentTimingsCalibrateableTimeDomains3) {
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddSurfaceExtension();
+    AddRequiredExtensions(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_CALIBRATED_TIMESTAMPS_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_PRESENT_TIMING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::presentTiming);
+    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitSurface());
+    InitSwapchainInfo();
+
+    VkSwapchainCreateInfoKHR swapchain_ci = vku::InitStructHelper();
+    swapchain_ci.flags = VK_SWAPCHAIN_CREATE_PRESENT_TIMING_BIT_EXT;
+    swapchain_ci.surface = m_surface;
+    swapchain_ci.minImageCount = m_surface_capabilities.minImageCount;
+    swapchain_ci.imageFormat = m_surface_formats[0].format;
+    swapchain_ci.imageColorSpace = m_surface_formats[0].colorSpace;
+    swapchain_ci.imageExtent = m_surface_capabilities.minImageExtent;
+    swapchain_ci.imageArrayLayers = 1;
+    swapchain_ci.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    swapchain_ci.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    swapchain_ci.preTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
+    swapchain_ci.compositeAlpha = m_surface_composite_alpha;
+    swapchain_ci.presentMode = m_surface_non_shared_present_mode;
+    swapchain_ci.clipped = VK_FALSE;
+    swapchain_ci.oldSwapchain = 0;
+    vkt::Swapchain swapchain(*m_device, swapchain_ci);
+
+    uint32_t time_domain_count = 0u;
+    vk::GetPhysicalDeviceCalibrateableTimeDomainsKHR(gpu_, &time_domain_count, nullptr);
+    std::vector<VkTimeDomainKHR> time_domains(time_domain_count);
+    vk::GetPhysicalDeviceCalibrateableTimeDomainsKHR(Gpu(), &time_domain_count, time_domains.data());
+
+    bool found = false;
+    for (uint32_t i = 0; i < time_domain_count; ++i) {
+        if (time_domains[i] == VK_TIME_DOMAIN_PRESENT_STAGE_LOCAL_EXT) {
+            found = true;
+            break;
+        }
+    }
+    if (!found) {
+        GTEST_SKIP() << "VK_TIME_DOMAIN_PRESENT_STAGE_LOCAL_EXT not supported";
+    }
+
+    std::array<VkPresentStageFlagBitsEXT, 3> present_stages_to_test{VK_PRESENT_STAGE_QUEUE_OPERATIONS_END_BIT_EXT,
+                                                                    VK_PRESENT_STAGE_REQUEST_DEQUEUED_BIT_EXT,
+                                                                    VK_PRESENT_STAGE_QUEUE_OPERATIONS_END_BIT_EXT};
+    std::vector<VkSwapchainCalibratedTimestampInfoEXT> swapchain_timestamp_infos(present_stages_to_test.size());
+    std::vector<VkCalibratedTimestampInfoKHR> timestamp_infos(swapchain_timestamp_infos.size());
+    for (size_t i = 0; i < swapchain_timestamp_infos.size(); i++) {
+        swapchain_timestamp_infos[i] = vku::InitStructHelper();
+        swapchain_timestamp_infos[i].swapchain = swapchain;
+        swapchain_timestamp_infos[i].presentStage = present_stages_to_test[i];
+
+        timestamp_infos[i] = vku::InitStructHelper(&swapchain_timestamp_infos[i]);
+        timestamp_infos[i].timeDomain = VK_TIME_DOMAIN_PRESENT_STAGE_LOCAL_EXT;
+    }
+
+    std::vector<uint64_t> timestamps(timestamp_infos.size());
+    uint64_t max_deviation;
+    m_errorMonitor->SetDesiredError("VUID-vkGetCalibratedTimestampsKHR-timeDomain-09246");
+    vk::GetCalibratedTimestampsKHR(device(), timestamp_infos.size(), timestamp_infos.data(), timestamps.data(), &max_deviation);
     m_errorMonitor->VerifyFound();
 }
 

--- a/tests/unit/wsi_positive.cpp
+++ b/tests/unit/wsi_positive.cpp
@@ -3038,6 +3038,102 @@ TEST_F(PositiveWsi, PresentTimings) {
     }
 }
 
+TEST_F(PositiveWsi, PresentTimingsCalibrateableTimeDomains) {
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddSurfaceExtension();
+    AddRequiredExtensions(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_CALIBRATED_TIMESTAMPS_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_PRESENT_TIMING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::presentTiming);
+    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitSurface());
+    InitSwapchainInfo();
+
+    if (IsPlatformMockICD()) {
+        GTEST_SKIP() << "Skipping on mock icd because time domains cannot be queried.";
+    }
+
+    VkSurfaceCapabilities2KHR capabilities2 = vku::InitStructHelper();
+    VkPhysicalDeviceSurfaceInfo2KHR surface_info = vku::InitStructHelper();
+    surface_info.surface = m_surface;
+    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu_, &surface_info, &capabilities2);
+
+    VkPresentTimingSurfaceCapabilitiesEXT present_timing_surface_capabilities = vku::InitStructHelper();
+    VkSurfaceCapabilities2KHR surface_capabilities = vku::InitStructHelper(&present_timing_surface_capabilities);
+    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu_, &surface_info, &surface_capabilities);
+
+    uint32_t present_mode_count = 0;
+    vk::GetPhysicalDeviceSurfacePresentModesKHR(gpu_, m_surface, &present_mode_count, nullptr);
+    if (present_mode_count == 0) {
+        GTEST_SKIP() << "No present modes supported";
+    }
+
+    std::vector<VkPresentModeKHR> present_modes(present_mode_count);
+    vk::GetPhysicalDeviceSurfacePresentModesKHR(gpu_, m_surface, &present_mode_count, present_modes.data());
+
+    VkSwapchainCreateInfoKHR swapchain_ci = vku::InitStructHelper();
+    swapchain_ci.flags = VK_SWAPCHAIN_CREATE_PRESENT_TIMING_BIT_EXT | VK_SWAPCHAIN_CREATE_PRESENT_ID_2_BIT_KHR;
+    swapchain_ci.surface = m_surface;
+    swapchain_ci.minImageCount = m_surface_capabilities.minImageCount;
+    swapchain_ci.imageFormat = m_surface_formats[0].format;
+    swapchain_ci.imageColorSpace = m_surface_formats[0].colorSpace;
+    swapchain_ci.imageExtent = m_surface_capabilities.minImageExtent;
+    swapchain_ci.imageArrayLayers = 1;
+    swapchain_ci.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    swapchain_ci.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    swapchain_ci.preTransform = VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR;
+    swapchain_ci.compositeAlpha = m_surface_composite_alpha;
+    swapchain_ci.presentMode = present_modes[0];
+    swapchain_ci.clipped = VK_FALSE;
+    swapchain_ci.oldSwapchain = 0;
+    vkt::Swapchain swapchain(*m_device, swapchain_ci);
+
+    uint32_t time_domain_count = 0u;
+    vk::GetPhysicalDeviceCalibrateableTimeDomainsKHR(gpu_, &time_domain_count, nullptr);
+    std::vector<VkTimeDomainKHR> time_domains(time_domain_count);
+    vk::GetPhysicalDeviceCalibrateableTimeDomainsKHR(Gpu(), &time_domain_count, time_domains.data());
+
+    VkTimeDomainKHR non_present_stage_time_domain = VK_TIME_DOMAIN_MAX_ENUM_KHR;
+    bool found = false;
+    for (uint32_t i = 0; i < time_domain_count; ++i) {
+        if (time_domains[i] == VK_TIME_DOMAIN_PRESENT_STAGE_LOCAL_EXT) {
+            found = true;
+            break;
+        } else {
+            non_present_stage_time_domain = time_domains[i];
+        }
+    }
+    if (!found) {
+        GTEST_SKIP() << "VK_TIME_DOMAIN_PRESENT_STAGE_LOCAL_EXT not supported";
+    }
+
+    std::vector<VkPresentStageFlagsEXT> present_stages_to_test{VK_PRESENT_STAGE_QUEUE_OPERATIONS_END_BIT_EXT,
+                                                               VK_PRESENT_STAGE_REQUEST_DEQUEUED_BIT_EXT};
+    if (non_present_stage_time_domain != VK_TIME_DOMAIN_MAX_ENUM_KHR) {
+        present_stages_to_test.push_back(0);
+    }
+
+    std::vector<VkSwapchainCalibratedTimestampInfoEXT> swapchain_timestamp_infos(present_stages_to_test.size());
+    std::vector<VkCalibratedTimestampInfoKHR> timestamp_infos(present_stages_to_test.size());
+    for (size_t i = 0; i < present_stages_to_test.size(); i++) {
+        swapchain_timestamp_infos[i] = vku::InitStructHelper();
+        swapchain_timestamp_infos[i].swapchain = swapchain;
+        swapchain_timestamp_infos[i].presentStage = present_stages_to_test[i];
+
+        timestamp_infos[i] = vku::InitStructHelper(&swapchain_timestamp_infos[i]);
+        timestamp_infos[i].timeDomain =
+            present_stages_to_test[i] ? VK_TIME_DOMAIN_PRESENT_STAGE_LOCAL_EXT : non_present_stage_time_domain;
+    }
+
+    // Disable this error for now; the spec incorrectly labelled this VUIDs as implicit, when in-fact it
+    // only applies when VkSwapchainCalibratedTimestampInfoEXT::presentStage is VK_TIME_DOMAIN_PRESENT_STAGE_LOCAL_EXT
+    m_errorMonitor->SetAllowedFailureMsg("VUID-VkSwapchainCalibratedTimestampInfoEXT-presentStage-requiredbitmask");
+
+    std::vector<uint64_t> timestamps(present_stages_to_test.size());
+    uint64_t max_deviation{};
+    vk::GetCalibratedTimestampsKHR(device(), timestamp_infos.size(), timestamp_infos.data(), timestamps.data(), &max_deviation);
+}
+
 TEST_F(PositiveWsi, PresentTimingsFull) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddSurfaceExtension();


### PR DESCRIPTION
- This updates VVL to accommodate the spec update in https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/8059, where `vkGetCalibratedTimestampsKHR()` can be called with multiple `VK_TIME_DOMAIN_PRESENT_STAGE_LOCAL_EXT`, provided each `VkPresentStageFlagsEXT` is unique
- This change also adds a positive and negative unit-test to validate VVL when requesting calibrated timestamps