### PR TITLE
layers: Cleanup SubpassDependencyInfo

### DIFF
--- a/layers/state_tracker/render_pass_state.cpp
+++ b/layers/state_tracker/render_pass_state.cpp
@@ -22,48 +22,43 @@
 #include "state_tracker/image_state.h"
 #include "containers/span.h"
 
+// Defined according to spec (check VkSubpassDependency documentation)
 static VkSubpassDependency2 ImplicitDependencyFromExternal(uint32_t subpass) {
-    VkSubpassDependency2 from_external = {VK_STRUCTURE_TYPE_SUBPASS_DEPENDENCY_2,
-                                          nullptr,
-                                          VK_SUBPASS_EXTERNAL,
-                                          subpass,
-                                          VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
-                                          VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-                                          0,
-                                          VK_ACCESS_INPUT_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
-                                              VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT |
-                                              VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT,
-                                          0,
-                                          0};
+    VkSubpassDependency2 from_external = vku::InitStructHelper();
+    from_external.srcSubpass = VK_SUBPASS_EXTERNAL;
+    from_external.dstSubpass = subpass;
+    from_external.srcStageMask = VK_PIPELINE_STAGE_NONE;
+    from_external.dstStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+    from_external.srcAccessMask = 0;
+    from_external.dstAccessMask = VK_ACCESS_INPUT_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
+                                  VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT |
+                                  VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
     return from_external;
 }
 
+// Defined according to spec (check VkSubpassDependency documentation)
 static VkSubpassDependency2 ImplicitDependencyToExternal(uint32_t subpass) {
-    VkSubpassDependency2 to_external = {VK_STRUCTURE_TYPE_SUBPASS_DEPENDENCY_2,
-                                        nullptr,
-                                        subpass,
-                                        VK_SUBPASS_EXTERNAL,
-                                        VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-                                        VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
-                                        VK_ACCESS_INPUT_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
-                                            VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT |
-                                            VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT,
-                                        0,
-                                        0,
-                                        0};
+    VkSubpassDependency2 to_external = vku::InitStructHelper();
+    to_external.srcSubpass = subpass;
+    to_external.dstSubpass = VK_SUBPASS_EXTERNAL;
+    to_external.srcStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+    to_external.dstStageMask = VK_PIPELINE_STAGE_NONE;
+    to_external.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+    to_external.dstAccessMask = 0;
     return to_external;
 }
+
 // NOTE: The functions below are only called from the vvl::RenderPass constructor, and use const_cast<> to set up
 // members that never change after construction is finished.
 static void RecordRenderPassDAG(const VkRenderPassCreateInfo2 *pCreateInfo, vvl::RenderPass &render_pass) {
     auto &self_dependencies = const_cast<std::vector<std::vector<uint32_t>> &>(render_pass.self_dependencies);
     self_dependencies.resize(pCreateInfo->subpassCount);
-    auto &subpass_dependencies = const_cast<std::vector<SubpassDependencyInfo> &>(render_pass.subpass_dependency_infos);
-    subpass_dependencies.resize(pCreateInfo->subpassCount);
+    auto &subpass_dependency_infos = const_cast<std::vector<SubpassDependencyInfo> &>(render_pass.subpass_dependency_infos);
+    subpass_dependency_infos.resize(pCreateInfo->subpassCount);
 
     for (uint32_t i = 0; i < pCreateInfo->subpassCount; ++i) {
         self_dependencies[i].clear();
-        subpass_dependencies[i].subpass = i;
+        subpass_dependency_infos[i].subpass = i;
     }
     for (uint32_t i = 0; i < pCreateInfo->dependencyCount; ++i) {
         const VkSubpassDependency2 &dependency = pCreateInfo->pDependencies[i];
@@ -74,34 +69,28 @@ static void RecordRenderPassDAG(const VkRenderPassCreateInfo2 *pCreateInfo, vvl:
             // Invalid per VUID-VkSubpassDependency-srcSubpass-00865
             continue;
         }
-
         if (src_subpass == dst_subpass) {
             self_dependencies[dependency.srcSubpass].push_back(i);
         } else if (src_subpass == VK_SUBPASS_EXTERNAL) {
-            subpass_dependencies[dst_subpass].barrier_from_external.emplace_back(&dependency);
+            subpass_dependency_infos[dst_subpass].barrier_from_external.emplace_back(&dependency);
         } else if (dst_subpass == VK_SUBPASS_EXTERNAL) {
-            subpass_dependencies[src_subpass].barrier_to_external.emplace_back(&dependency);
+            subpass_dependency_infos[src_subpass].barrier_to_external.emplace_back(&dependency);
         } else {
-            // ignore self dependencies in prev and next
-            subpass_dependencies[src_subpass].next[&subpass_dependencies[dst_subpass]].emplace_back(&dependency);
-            subpass_dependencies[dst_subpass].prev[&subpass_dependencies[src_subpass]].emplace_back(&dependency);
+            subpass_dependency_infos[dst_subpass].dependencies[src_subpass].emplace_back(&dependency);
         }
     }
 
     // If no barriers to external are provided for a given subpass, add them.
-    for (auto &subpass_dep : subpass_dependencies) {
-        const uint32_t subpass = subpass_dep.subpass;
-        if (subpass_dep.barrier_from_external.empty()) {
-            // Add implicit from barrier if they're aren't any
-            subpass_dep.implicit_barrier_from_external =
-                std::make_unique<VkSubpassDependency2>(ImplicitDependencyFromExternal(subpass));
-            subpass_dep.barrier_from_external.emplace_back(subpass_dep.implicit_barrier_from_external.get());
+    // This is used for initialLayout/finalLayout transitions when corresponding
+    // subpass is the first/last subpass that uses the attachment.
+    for (SubpassDependencyInfo &info : subpass_dependency_infos) {
+        if (info.barrier_from_external.empty()) {
+            info.implicit_barrier_from_external = ImplicitDependencyFromExternal(info.subpass);
+            info.barrier_from_external.emplace_back(&info.implicit_barrier_from_external);
         }
-        if (subpass_dep.barrier_to_external.empty()) {
-            // Add implicit to barrier  if they're aren't any
-            subpass_dep.implicit_barrier_to_external =
-                std::make_unique<VkSubpassDependency2>(ImplicitDependencyToExternal(subpass));
-            subpass_dep.barrier_to_external.emplace_back(subpass_dep.implicit_barrier_to_external.get());
+        if (info.barrier_to_external.empty()) {
+            info.implicit_barrier_to_external = ImplicitDependencyToExternal(info.subpass);
+            info.barrier_to_external.emplace_back(&info.implicit_barrier_to_external);
         }
     }
 
@@ -114,18 +103,17 @@ static void RecordRenderPassDAG(const VkRenderPassCreateInfo2 *pCreateInfo, vvl:
     for (uint32_t i = 1; i < pCreateInfo->subpassCount; ++i) {
         auto &depends = pass_depends[i];
         depends.resize(i);
-        auto &subpass_dep = subpass_dependencies[i];
-        for (const auto &prev : subpass_dep.prev) {
-            const auto prev_subpass = prev.first->subpass;
-            const auto &prev_depends = pass_depends[prev_subpass];
-            for (uint32_t j = 0; j < prev_subpass; j++) {
-                depends[j] = depends[j] || prev_depends[j];
+        SubpassDependencyInfo &info = subpass_dependency_infos[i];
+        for (const auto &[src_subpass, _] : info.dependencies) {
+            const auto &src_depends = pass_depends[src_subpass];
+            for (uint32_t j = 0; j < src_subpass; j++) {
+                depends[j] = depends[j] || src_depends[j];
             }
-            depends[prev_subpass] = true;
+            depends[src_subpass] = true;
         }
-        for (uint32_t subpass = 0; subpass < subpass_dep.subpass; subpass++) {
+        for (uint32_t subpass = 0; subpass < info.subpass; subpass++) {
             if (!depends[subpass]) {
-                subpass_dep.async.push_back(subpass);
+                info.async.push_back(subpass);
             }
         }
     }
@@ -168,9 +156,8 @@ struct AttachmentTracker {  // This is really only of local interest, but a bit 
 
         // max_prev is invariant across attachments
         uint32_t max_prev = VK_SUBPASS_EXTERNAL;
-        for (const auto &prev : rp.subpass_dependency_infos[subpass].prev) {
-            const auto prev_subpass = prev.first->subpass;
-            max_prev = (max_prev == VK_SUBPASS_EXTERNAL) ? prev_subpass : std::max(prev_subpass, max_prev);
+        for (const auto &[src_subpass, _] : rp.subpass_dependency_infos[subpass].dependencies) {
+            max_prev = (max_prev == VK_SUBPASS_EXTERNAL) ? src_subpass : std::max(src_subpass, max_prev);
         }
 
         for (const auto attachment : vvl::make_span(preserved, count)) {
@@ -200,16 +187,15 @@ struct AttachmentTracker {  // This is really only of local interest, but a bit 
                 }
                 last[attachment] = subpass;
 
-                for (const auto &prev : rp.subpass_dependency_infos[subpass].prev) {
-                    const auto prev_pass = prev.first->subpass;
-                    const auto prev_layout = subpass_attachment_layout[prev_pass][attachment];
+                for (const auto &[src_subpass, _] : rp.subpass_dependency_infos[subpass].dependencies) {
+                    const auto prev_layout = subpass_attachment_layout[src_subpass][attachment];
                     if ((prev_layout != kInvalidLayout) && (prev_layout != layout)) {
                         subpass_transitions[subpass].emplace_back(
-                            vvl::RenderPass::AttachmentTransition{prev_pass, attachment, prev_layout, layout});
+                            vvl::RenderPass::AttachmentTransition{src_subpass, attachment, prev_layout, layout});
                     }
                 }
 
-                if (no_external_transition && (rp.subpass_dependency_infos[subpass].prev.empty())) {
+                if (no_external_transition && (rp.subpass_dependency_infos[subpass].dependencies.empty())) {
                     // This will insert a layout transition when dependencies are missing between first and subsequent use
                     // but is consistent with the idea of an implicit external dependency
                     if (initial_layout != layout) {

--- a/layers/state_tracker/render_pass_state.h
+++ b/layers/state_tracker/render_pass_state.h
@@ -36,16 +36,29 @@ static inline uint32_t GetSubpassDepthStencilAttachmentIndex(const vku::safe_VkP
 }
 
 struct SubpassDependencyInfo {
+    // For dependencies between subpasses this is a dstSubpass.
+    // For external dependencies this can be either srcSubpass or dstSubpass
     uint32_t subpass;
 
-    std::map<const SubpassDependencyInfo *, std::vector<const VkSubpassDependency2 *>> prev;
-    std::map<const SubpassDependencyInfo *, std::vector<const VkSubpassDependency2 *>> next;
-    std::vector<uint32_t> async;  // asynchronous subpasses with a lower subpass index
+    // Map's key is a srcSubpass in subpass dependency.
+    // this->subpass is a dstSubpass in subpass dependency.
+    // Map's value is a list of dependencies defined for a given (srcSubpass, dstSubpass) pair.
+    std::map<uint32_t, std::vector<const VkSubpassDependency2 *>> dependencies;
 
+    // Asynchronous subpasses with a lower subpass index
+    std::vector<uint32_t> async;
+
+    // Subpass dependencies with srcSubpass = VK_SUBPASS_EXTERNAL
     std::vector<const VkSubpassDependency2 *> barrier_from_external;
+
+    // Subpass dependencies with dstSubpass = VK_SUBPASS_EXTERNAL
     std::vector<const VkSubpassDependency2 *> barrier_to_external;
-    std::unique_ptr<VkSubpassDependency2> implicit_barrier_from_external;
-    std::unique_ptr<VkSubpassDependency2> implicit_barrier_to_external;
+
+    // Implicit external barriers are defined only if subpass dependencies do not specify them.
+    // Given how SubpassDependencyInfo objects are stored, it is safe to keep references to
+    // these barriers in the barrier_from_external and barrier_to_external vectors.
+    VkSubpassDependency2 implicit_barrier_from_external;
+    VkSubpassDependency2 implicit_barrier_to_external;
 };
 
 struct SubpassLayout {
@@ -78,7 +91,7 @@ class RenderPass : public StateObject {
     // For each subpass, indices into pDependencies for that subpass's self-dependencies
     const std::vector<std::vector<uint32_t>> self_dependencies;  // [subpassCount]
 
-    // For each subpass, all dependencies where it appears as srcSubpass or dstSubpass
+    // Dependency information for each subpass
     const std::vector<SubpassDependencyInfo> subpass_dependency_infos;  // [subpassCount]
 
     // For each attachment, the index of the first subpass that uses it.

--- a/layers/sync/sync_access_context.cpp
+++ b/layers/sync/sync_access_context.cpp
@@ -28,33 +28,32 @@ namespace syncval {
 bool SimpleBinding(const vvl::Bindable &bindable) { return !bindable.sparse && bindable.Binding(); }
 VkDeviceSize ResourceBaseAddress(const vvl::Buffer &buffer) { return buffer.GetFakeBaseAddress(); }
 
-void AccessContext::InitFrom(uint32_t subpass, VkQueueFlags queue_flags, const std::vector<SubpassDependencyInfo> &dependencies,
-                             const AccessContext *contexts, const AccessContext *external_context) {
-    const auto &subpass_dep = dependencies[subpass];
-    const bool has_barrier_from_external = subpass_dep.barrier_from_external.size() > 0U;
-    prev_.reserve(subpass_dep.prev.size() + (has_barrier_from_external ? 1U : 0U));
+void AccessContext::InitFrom(uint32_t subpass, VkQueueFlags queue_flags,
+                             const std::vector<SubpassDependencyInfo> &subpass_dependency_infos, const AccessContext *contexts,
+                             const AccessContext *external_context) {
+    const SubpassDependencyInfo &info = subpass_dependency_infos[subpass];
+    const bool has_barrier_from_external = !info.barrier_from_external.empty();
+
+    prev_.reserve(info.dependencies.size() + (has_barrier_from_external ? 1 : 0));
     prev_by_subpass_.resize(subpass, nullptr);  // Can't be more prevs than the subpass we're on
-    for (const auto &prev_dep : subpass_dep.prev) {
-        const auto prev_subpass = prev_dep.first->subpass;
-        const auto &prev_barriers = prev_dep.second;
-        assert(prev_dep.second.size());
-        prev_.emplace_back(&contexts[prev_subpass], queue_flags, prev_barriers);
-        prev_by_subpass_[prev_subpass] = &prev_.back();
+    for (const auto &[src_subpass, subpass_dependencies] : info.dependencies) {
+        prev_.emplace_back(&contexts[src_subpass], queue_flags, subpass_dependencies);
+        prev_by_subpass_[src_subpass] = &prev_.back();
     }
 
-    async_.reserve(subpass_dep.async.size());
-    for (const auto async_subpass : subpass_dep.async) {
+    async_.reserve(info.async.size());
+    for (const auto async_subpass : info.async) {
         // Start tags are not known at creation time (as it's done at BeginRenderpass)
         async_.emplace_back(contexts[async_subpass], kInvalidTag, kQueueIdInvalid);
     }
 
     if (has_barrier_from_external) {
         // Store the barrier from external with the reat, but save pointer for "by subpass" lookups.
-        prev_.emplace_back(external_context, queue_flags, subpass_dep.barrier_from_external);
+        prev_.emplace_back(external_context, queue_flags, info.barrier_from_external);
         src_external_ = &prev_.back();
     }
-    if (subpass_dep.barrier_to_external.size()) {
-        dst_external_ = SubpassBarrierTrackback(this, queue_flags, subpass_dep.barrier_to_external);
+    if (info.barrier_to_external.size()) {
+        dst_external_ = SubpassBarrierTrackback(this, queue_flags, info.barrier_to_external);
     }
 }
 

--- a/layers/sync/sync_access_context.h
+++ b/layers/sync/sync_access_context.h
@@ -299,7 +299,7 @@ class AccessContext {
     AccessContext(const AccessContext &other) = delete;
     AccessContext &operator=(const AccessContext &) = delete;
 
-    void InitFrom(uint32_t subpass, VkQueueFlags queue_flags, const std::vector<SubpassDependencyInfo> &dependencies,
+    void InitFrom(uint32_t subpass, VkQueueFlags queue_flags, const std::vector<SubpassDependencyInfo> &subpass_dependency_infos,
                   const AccessContext *contexts, const AccessContext *external_context);
     void InitFrom(const AccessContext &other);
     void Reset();


### PR DESCRIPTION
Follow up to https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/11737 (using this to clarify one validation related to layout transition in syncval)

* Remove unused `next` field
* Update naming, especially using `prev` everywhere was a bit confusing
* Update definitions of implicit external barriers to match the spec
* Comments
