### PR TITLE
gpuav: Add full native Spec Constant support

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -264,6 +264,7 @@ vvl_sources = [
   "layers/gpuav/spirv/debug_printf_pass.h",
   "layers/gpuav/spirv/type_manager.cpp",
   "layers/gpuav/spirv/type_manager.h",
+  "layers/gpuav/spirv/spec_constant.cpp",
   "layers/layer_options.cpp",
   "layers/layer_options.h",
   "layers/layer_options_validation.h",

--- a/layers/containers/limits.h
+++ b/layers/containers/limits.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,8 @@ constexpr auto kU64Max = std::numeric_limits<uint64_t>::max();
 constexpr auto kI32Max = std::numeric_limits<int32_t>::max();
 // Typesafe INT64_MAX
 constexpr auto kI64Max = std::numeric_limits<int64_t>::max();
+// Typesafe INT64_MIN
+constexpr auto kI64Min = std::numeric_limits<int64_t>::min();
 
 // Descriptive names to indicate uninitialized/invalid unsigned index values
 constexpr auto kNoIndex32 = kU32Max;

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
@@ -474,6 +474,7 @@ bool GpuShaderInstrumentor::PreCallRecordShaderObjectInstrumentation(
     interface.unique_shader_id = unique_shader_id;
     interface.entry_point_name = modified_create_info.pName;
     interface.entry_point_stage = modified_create_info.stage;
+    interface.specialization_info = modified_create_info.pSpecializationInfo->ptr();
     BuildDescriptorSetLayoutInfo(modified_create_info, interface.instrumentation_dsl);
 
     const bool is_shader_instrumented = InstrumentShader(
@@ -1251,6 +1252,7 @@ bool GpuShaderInstrumentor::PreCallRecordPipelineCreationShaderInstrumentation(
         interface.unique_shader_id = unique_shader_id;
         interface.entry_point_name = stage_state.GetPName();
         interface.entry_point_stage = stage_state.GetStage();
+        interface.specialization_info = stage_state.GetSpecializationInfo()->ptr();
         const bool is_shader_instrumented = InstrumentShader(modified_module_state->spirv->words_, interface, instrumented_spirv);
         if (is_shader_instrumented) {
             instrumentation_metadata.unique_shader_id = unique_shader_id;
@@ -1447,6 +1449,7 @@ bool GpuShaderInstrumentor::PreCallRecordPipelineCreationShaderInstrumentationGP
             interface.unique_shader_id = unique_shader_id;
             interface.entry_point_name = modified_stage_state.GetPName();
             interface.entry_point_stage = modified_stage_state.GetStage();
+            interface.specialization_info = modified_stage_state.GetSpecializationInfo()->ptr();
             const bool is_shader_instrumented =
                 InstrumentShader(modified_module_state->spirv->words_, interface, instrumented_spirv);
 

--- a/layers/gpuav/spirv/CMakeLists.txt
+++ b/layers/gpuav/spirv/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ~~~
-# Copyright (c) 2024-2025 LunarG, Inc.
+# Copyright (c) 2024-2026 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -54,6 +54,7 @@ target_sources(gpu_av_spirv PRIVATE
     type_manager.cpp
     pass.h
     pass.cpp
+    spec_constant.cpp
     ${VVL_SOURCE_DIR}/layers/${API_TYPE}/generated/spirv_grammar_helper.cpp
 
     ${VVL_SOURCE_DIR}/layers/${API_TYPE}/generated/gpuav_offline_spirv.h

--- a/layers/gpuav/spirv/interface.h
+++ b/layers/gpuav/spirv/interface.h
@@ -79,6 +79,7 @@ struct InstrumentationInterface {
     VkShaderStageFlagBits entry_point_stage = VK_SHADER_STAGE_FLAG_BITS_MAX_ENUM;
 
     InstrumentationDescriptorSetLayouts instrumentation_dsl;
+    const VkSpecializationInfo* specialization_info;
 
     const Location& loc;
 

--- a/layers/gpuav/spirv/module.cpp
+++ b/layers/gpuav/spirv/module.cpp
@@ -17,12 +17,12 @@
 #include <cassert>
 #include <spirv/unified1/spirv.hpp>
 #include "containers/custom_containers.h"
+#include "containers/limits.h"
 #include "function_basic_block.h"
 #include "generated/spirv_grammar_helper.h"
 #include "gpuav/shaders/gpuav_shaders_constants.h"
 #include "error_message/logging.h"
 #include "error_message/log_message_type.h"
-#include "error_message/error_location.h"
 #include "utils/shader_utils.h"
 
 #include <iostream>
@@ -50,6 +50,14 @@ Module::Module(vvl::span<const uint32_t> words, DebugReport* debug_report, const
     header_.generator = *it++;
     header_.bound = *it++;
     header_.schema = *it++;
+
+    // We do the equivalent of SetSpecConstantDefaultValuePass and FreezeSpecConstantValuePass spirv-opt pass here. These are simple
+    // and we don't need spirv-opt overhead to do it. Unfortunately this is a bit duplicated from Core Validation, but that code
+    // needs to validate the VkSpecializationInfo struct.
+    //
+    // [OpSpecConstant Result ID -> OpDecorate SpecID value] mapping
+    vvl::unordered_map<uint32_t, uint32_t> id_to_spec_id;
+
     // Parse everything up until the first function and sort into seperate lists
     while (it != words.end()) {
         const uint32_t opcode = *it & 0x0ffffu;
@@ -105,7 +113,6 @@ Module::Module(vvl::span<const uint32_t> words, DebugReport* debug_report, const
                 // https://github.com/KhronosGroup/SPIRV-Tools/issues/5513
                 types_values_constants_.emplace_back(std::move(new_inst));
                 break;
-            case spv::OpDecorate:
             case spv::OpMemberDecorate:
             case spv::OpDecorationGroup:
             case spv::OpGroupDecorate:
@@ -116,6 +123,18 @@ Module::Module(vvl::span<const uint32_t> words, DebugReport* debug_report, const
                 annotations_.emplace_back(std::move(new_inst));
                 break;
 
+            case spv::OpDecorate: {
+                if (new_inst->Word(2) == spv::DecorationSpecId) {
+                    const uint32_t target_id = new_inst->Word(1);
+                    // This will get filled before seeing any spec constant
+                    id_to_spec_id[target_id] = new_inst->Word(3);
+                    // We don't add because after we set/freeze the SpecConstant these can be removed
+                } else {
+                    annotations_.emplace_back(std::move(new_inst));
+                }
+                break;
+            }
+
             case spv::OpUndef:
                 type_manager_.AddUndef(std::move(new_inst));
                 break;
@@ -125,14 +144,21 @@ Module::Module(vvl::span<const uint32_t> words, DebugReport* debug_report, const
             case spv::OpConstantTrue:
             case spv::OpConstantFalse: {
                 const Type& type = type_manager_.GetTypeBool();
+                if (opcode == spv::OpSpecConstantTrue || opcode == spv::OpSpecConstantFalse) {
+                    SetSpecConstantValue(new_inst.get(), type, id_to_spec_id);
+                }
                 type_manager_.AddConstant(std::move(new_inst), type);
                 break;
             }
             case spv::OpSpecConstant:
+            case spv::OpSpecConstantComposite:
             case spv::OpConstant:
             case spv::OpConstantNull:
             case spv::OpConstantComposite: {
                 const Type* type = type_manager_.FindTypeById(new_inst->TypeId());
+                if (opcode == spv::OpSpecConstant || opcode == spv::OpSpecConstantComposite) {
+                    SetSpecConstantValue(new_inst.get(), *type, id_to_spec_id);
+                }
                 type_manager_.AddConstant(std::move(new_inst), *type);
                 break;
             }
@@ -156,13 +182,23 @@ Module::Module(vvl::span<const uint32_t> words, DebugReport* debug_report, const
 
                 break;
             }
+            case spv::OpSpecConstantOp: {
+                const Type* type = type_manager_.FindTypeById(new_inst->TypeId());
+                // If folded, we drop the |new_inst| as we will add it inside the function
+                const bool folded = ConstantFold(new_inst.get(), *type);
+                if (!folded) {
+                    assert(false);
+                    // Even if we can't fold, we need to keep the instruction in the constant section to maintain being valid
+                    types_values_constants_.emplace_back(std::move(new_inst));
+                }
+                break;
+            }
             default: {
                 SpvType spv_type = GetSpvType(new_inst->Opcode());
                 if (spv_type != SpvType::Empty) {
                     type_manager_.AddType(std::move(new_inst), spv_type);
                 } else {
                     // unknown instruction, try and just keep in last section to not just crash
-                    // example: OpSpecConstant
                     types_values_constants_.emplace_back(std::move(new_inst));
                 }
                 break;

--- a/layers/gpuav/spirv/module.h
+++ b/layers/gpuav/spirv/module.h
@@ -123,6 +123,14 @@ class Module {
     // Used when UseErrorPayloadVariable is set. Needs to be same for all passes.
     // Will be set in the LogErrorPass
     uint32_t error_payload_variable_id_ = 0;
+
+  private:
+    // This is here to emulate the
+    //  spirv-opt --set-spec-const-default-value <values> --freeze-spec-const --fold-spec-const-op-composite
+    // Normally done, but by doing it internally, we can both be faster (not re-prasing the SPIR-V) and most importantly, preserve
+    // the |position_offset| value to know the index of the instructions from the original operation
+    void SetSpecConstantValue(Instruction* inst, const Type& type, vvl::unordered_map<uint32_t, uint32_t>& id_to_spec_id);
+    bool ConstantFold(Instruction* inst, const Type& type);
 };
 
 }  // namespace spirv

--- a/layers/gpuav/spirv/pass.cpp
+++ b/layers/gpuav/spirv/pass.cpp
@@ -287,7 +287,6 @@ uint32_t Pass::FindTypeByteSize(uint32_t type_id, uint32_t matrix_stride, bool c
         case SpvType::kArray: {
             const uint32_t array_stride = GetDecoration(type_id, spv::DecorationArrayStride)->Word(3);
             const Constant* count = type_manager_.FindConstantById(type.inst_.Operand(1));
-            // TODO - Need to handle spec constant here, for now return one to have things not blowup
             assert(count && !count->is_spec_constant_);
             const uint32_t array_length = (count && !count->is_spec_constant_) ? count->inst_.Operand(0) : 1;
             return array_length * array_stride;
@@ -717,7 +716,6 @@ CooperativeMatrixAccess Pass::GetCooperativeMatrixAccess(const Instruction& inst
 
     const Constant* rows_const = type_manager_.FindConstantById(info.type->inst_.Word(4));
     const Constant* columns_const = type_manager_.FindConstantById(info.type->inst_.Word(5));
-    // TODO - Need to handle spec constant here, for now return zero to have things not blowup
     assert(rows_const && !rows_const->is_spec_constant_ && columns_const && !columns_const->is_spec_constant_);
     info.rows = rows_const->inst_.Operand(0);
     info.columns = columns_const->inst_.Operand(0);

--- a/layers/gpuav/spirv/sanitizer_pass.cpp
+++ b/layers/gpuav/spirv/sanitizer_pass.cpp
@@ -269,7 +269,7 @@ uint32_t SanitizerPass::CreateFunctionCall(BasicBlock& block, InstructionIt* ins
 
 bool SanitizerPass::IsConstantZero(const Constant& constant) const {
     if (constant.is_spec_constant_) {
-        // TODO - We have the spec constants information, we just need to pipe it into the passes
+        assert(false);
         return false;
     }
     const spv::Op opcode = (spv::Op)constant.inst_.Opcode();
@@ -321,8 +321,8 @@ bool SanitizerPass::RequiresInstrumentation(const Instruction& inst, Instruction
         // 04664 requires this to be a constant
         if (const Constant* constant = type_manager_.FindConstantById(inst.Word(5))) {
             const uint32_t constant_value = constant->GetValueUint32();
-            // TODO - Support spec constants
-            if (!constant->is_spec_constant_ && constant_value > 3) {
+            assert(!constant->is_spec_constant_);
+            if (constant_value > 3) {
                 meta.sub_code = glsl::kErrorSubCode_Sanitizer_ImageGather;
                 meta.skip_safe_mode = true;
                 meta.constant_value = constant_value;

--- a/layers/gpuav/spirv/spec_constant.cpp
+++ b/layers/gpuav/spirv/spec_constant.cpp
@@ -1,0 +1,348 @@
+/* Copyright (c) 2024-2026 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "containers/limits.h"
+#include "containers/small_vector.h"
+#include "generated/spirv_grammar_helper.h"
+#include "module.h"
+#include <cassert>
+#include <cstdint>
+#include <cstring>
+#include <spirv/unified1/spirv.hpp>
+#include "containers/custom_containers.h"
+#include "function_basic_block.h"
+
+namespace gpuav {
+namespace spirv {
+
+void Module::SetSpecConstantValue(Instruction* inst, const Type& type, vvl::unordered_map<uint32_t, uint32_t>& id_to_spec_id) {
+    const uint32_t opcode = inst->Opcode();
+
+    if (opcode == spv::OpSpecConstantComposite) {
+        return inst->FreezeSpecConstant();
+    }
+
+    const bool has_spec_info = interface_.specialization_info && interface_.specialization_info->mapEntryCount > 0;
+    if (!has_spec_info) {
+        return inst->FreezeSpecConstant();
+    }
+
+    const uint32_t result_id = inst->ResultId();
+    const auto it = id_to_spec_id.find(result_id);
+    if (it == id_to_spec_id.end()) {
+        // OpDecorate SpecId was not set, so using default
+        return inst->FreezeSpecConstant();
+    }
+    const uint32_t spec_id = it->second;
+
+    VkSpecializationMapEntry map_entry = {0, 0, 0};
+    bool found = false;
+    for (uint32_t i = 0; i < interface_.specialization_info->mapEntryCount; i++) {
+        if (interface_.specialization_info->pMapEntries[i].constantID == spec_id) {
+            map_entry = interface_.specialization_info->pMapEntries[i];
+            found = true;
+            break;
+        }
+    }
+
+    if (!found) {
+        return inst->FreezeSpecConstant();
+    }
+
+    if ((map_entry.offset + map_entry.size) <= interface_.specialization_info->dataSize) {
+        // Spec constants at most can be a int64/float64
+        assert(map_entry.size <= 8);
+        const uint8_t* out_p = static_cast<const uint8_t*>(interface_.specialization_info->pData);
+        const uint8_t* target_addr = out_p + map_entry.offset;
+
+        if (opcode == spv::OpSpecConstantTrue || opcode == spv::OpSpecConstantFalse) {
+            // For Boolean, just swap from True <-> False spec constant, then will be frozen
+            VkBool32 raw_value = 0;
+            std::memcpy(&raw_value, target_addr, std::min(map_entry.size, sizeof(VkBool32)));
+            inst->SetNewOpcode(raw_value ? spv::OpSpecConstantTrue : spv::OpSpecConstantFalse);
+        } else {
+            assert(opcode == spv::OpSpecConstant);
+            const bool is_signed = type.IsSignedInt();
+
+            uint64_t raw_value = 0;
+            std::memcpy(&raw_value, target_addr, map_entry.size);
+
+            // Sign-extend 8-bit and 16-bit negative numbers up to 32 bits
+            if (is_signed && map_entry.size < 4) {
+                const uint32_t bit_width = static_cast<uint32_t>(map_entry.size * 8);
+                const uint64_t sign_bit = 1ULL << (bit_width - 1);
+
+                // If the sign bit is 1, fill the upper bits with 1s
+                if (raw_value & sign_bit) {
+                    uint64_t mask = ~0ULL << bit_width;
+                    raw_value |= mask;
+                }
+            }
+
+            const uint32_t word_0 = static_cast<uint32_t>(raw_value & 0xFFFFFFFF);
+            inst->UpdateWord(3, word_0);
+            if (map_entry.size == 8) {
+                const uint32_t word_1 = static_cast<uint32_t>(raw_value >> 32);
+                inst->UpdateWord(4, word_1);
+            }
+        }
+    }
+
+    return inst->FreezeSpecConstant();
+}
+
+static uint64_t EvaluateArithmetic(spv::Op opcode, uint64_t arg0, uint64_t arg1, uint32_t bit_width) {
+    uint64_t mask = (bit_width == 64) ? ~0ULL : (1ULL << bit_width) - 1;
+
+    uint64_t u_a = arg0;
+    uint64_t u_b = arg1;
+    int64_t s_a = static_cast<int64_t>(arg0);
+    int64_t s_b = static_cast<int64_t>(arg1);
+
+    uint64_t res = 0;
+
+    switch (opcode) {
+        case spv::OpSNegate:
+            res = static_cast<uint64_t>(-s_a);
+            break;
+        case spv::OpSDiv:
+            if (s_b != 0) {
+                if (bit_width == 64 && s_a == vvl::kI64Min && s_b == -1) {
+                    res = static_cast<uint64_t>(vvl::kI64Min);
+                } else {
+                    res = static_cast<uint64_t>(s_a / s_b);
+                }
+            }
+            break;
+        case spv::OpSRem:
+            if (s_b != 0) {
+                if (bit_width == 64 && s_a == vvl::kI64Min && s_b == -1) {
+                    res = 0;
+                } else {
+                    res = static_cast<uint64_t>(s_a % s_b);
+                }
+            }
+            break;
+        case spv::OpSMod:
+            if (s_b != 0) {
+                if (bit_width == 64 && s_a == vvl::kI64Min && s_b == -1) {
+                    res = 0;
+                } else {
+                    res = static_cast<uint64_t>(s_a % s_b);
+                    if ((res > 0 && s_b < 0) || s_b > 0) {
+                        res += u_b;
+                    }
+                }
+            }
+            break;
+        case spv::OpShiftRightArithmetic:
+            if (u_b >= 64) {
+                res = (s_a < 0) ? -1 : 0;
+            } else {
+                res = static_cast<uint64_t>(s_a >> u_b);
+            }
+            break;
+        case spv::OpSLessThan:
+            res = (s_a < s_b) ? 1 : 0;
+            break;
+        case spv::OpSGreaterThan:
+            res = (s_a > s_b) ? 1 : 0;
+            break;
+        case spv::OpSLessThanEqual:
+            res = (s_a <= s_b) ? 1 : 0;
+            break;
+        case spv::OpSGreaterThanEqual:
+            res = (s_a >= s_b) ? 1 : 0;
+            break;
+
+        case spv::OpIAdd:
+            res = u_a + u_b;
+            break;
+        case spv::OpISub:
+            res = u_a - u_b;
+            break;
+        case spv::OpIMul:
+            res = u_a * u_b;
+            break;
+        case spv::OpUDiv:
+            if (u_b != 0) res = u_a / u_b;
+            break;
+        case spv::OpUMod:
+            if (u_b != 0) res = u_a % u_b;
+            break;
+        case spv::OpShiftRightLogical:
+            res = (u_b >= 64) ? 0 : (u_a >> u_b);
+            break;
+        case spv::OpShiftLeftLogical:
+            res = (u_b >= 64) ? 0 : (u_a << u_b);
+            break;
+        case spv::OpBitwiseOr:
+            res = u_a | u_b;
+            break;
+        case spv::OpBitwiseXor:
+            res = u_a ^ u_b;
+            break;
+        case spv::OpBitwiseAnd:
+            res = u_a & u_b;
+            break;
+        case spv::OpNot:
+            res = ~u_a;
+            break;
+
+        case spv::OpLogicalOr:
+            res = (u_a || u_b) ? 1 : 0;
+            break;
+        case spv::OpLogicalAnd:
+            res = (u_a && u_b) ? 1 : 0;
+            break;
+        case spv::OpLogicalNot:
+            res = (!u_a) ? 1 : 0;
+            break;
+        case spv::OpLogicalEqual:
+        case spv::OpIEqual:
+            res = (u_a == u_b) ? 1 : 0;
+            break;
+        case spv::OpLogicalNotEqual:
+        case spv::OpINotEqual:
+            res = (u_a != u_b) ? 1 : 0;
+            break;
+        case spv::OpULessThan:
+            res = (u_a < u_b) ? 1 : 0;
+            break;
+        case spv::OpUGreaterThan:
+            res = (u_a > u_b) ? 1 : 0;
+            break;
+        case spv::OpULessThanEqual:
+            res = (u_a <= u_b) ? 1 : 0;
+            break;
+        case spv::OpUGreaterThanEqual:
+            res = (u_a >= u_b) ? 1 : 0;
+            break;
+        default:
+            assert(false);  // Only a limited set of instructions allowed
+            return 0;
+    }
+
+    return res & mask;
+}
+
+bool Module::ConstantFold(Instruction* inst, const Type& result_type) {
+    assert(inst->Opcode() == spv::OpSpecConstantOp);
+    if (result_type.spv_type_ == SpvType::kStruct) {
+        return false;  // TODO - Add support
+    }
+
+    spv::Op target_opcode = (spv::Op)inst->Word(3);
+
+    const bool is_vector = result_type.spv_type_ == SpvType::kVector;
+    uint32_t vector_length = is_vector ? result_type.inst_.Word(3) : 1;
+    const Type& scalar_type = is_vector ? *type_manager_.FindTypeById(result_type.inst_.Word(2)) : result_type;
+
+    small_vector<uint32_t, 4> new_composite_components;
+
+    // Scalar will have a single lane
+    for (uint32_t lane = 0; lane < vector_length; lane++) {
+        // might be up to 3 for OpSelect
+        small_vector<uint64_t, 3> args;
+
+        for (uint32_t i = 4; i < inst->Length(); i++) {
+            const uint32_t operand_id = inst->Word(i);
+            const Constant* constant = type_manager_.FindConstantById(operand_id);
+            if (!constant) {
+                assert(false);  // TODO
+                return false;
+            }
+
+            const Constant* lane_constant = constant;
+            if (is_vector && constant->inst_.Opcode() == spv::OpConstantComposite) {
+                uint32_t comp_id = constant->inst_.Word(3 + lane);
+                lane_constant = type_manager_.FindConstantById(comp_id);
+                if (!lane_constant) {
+                    assert(false);
+                    return false;
+                }
+            }
+
+            if (lane_constant->inst_.Opcode() == spv::OpConstantNull) {
+                args.emplace_back(0ul);
+            } else if (lane_constant->type_.spv_type_ == SpvType::kBool) {
+                if (lane_constant->inst_.Opcode() == spv::OpConstantTrue) {
+                    args.emplace_back(1ul);
+                } else {
+                    assert(lane_constant->inst_.Opcode() == spv::OpConstantFalse);
+                    args.emplace_back(0ul);
+                }
+            } else {
+                bool op_is_signed = lane_constant->type_.inst_.Word(3) != 0;
+
+                if (target_opcode == spv::OpSConvert) {
+                    // OpSConvert implies the source is treated as signed and must sign-extend
+                    op_is_signed = true;
+                } else if (target_opcode == spv::OpUConvert) {
+                    // OpUConvert implies the source is treated as unsigned (zero-extends)
+                    op_is_signed = false;
+                }
+
+                const uint64_t value64 = lane_constant->GetValueUint64(op_is_signed);
+                args.emplace_back(value64);
+            }
+        }
+
+        uint64_t lane_result = 0;
+        const uint32_t result_bit_width = scalar_type.ScalarBitWidth();
+        if (target_opcode == spv::OpSConvert || target_opcode == spv::OpUConvert) {
+            uint64_t mask = (result_bit_width == 64) ? ~0ULL : (1ULL << result_bit_width) - 1;
+            lane_result = args[0] & mask;
+        } else if (target_opcode == spv::OpSelect) {
+            lane_result = (args[0] != 0) ? args[1] : args[2];
+        } else {
+            const uint64_t arg1 = args.size() > 1 ? args[1] : 0;
+            lane_result = EvaluateArithmetic(target_opcode, args[0], arg1, result_bit_width);
+        }
+
+        if (is_vector) {
+            // If we have
+            //   %12 = OpSpecConstantComposite %v2short %short_4 %short_4
+            //   %13 = OpSpecConstantOp %v2short IMul %12 %12
+            // we will want
+            //   %12 = OpConstantComposite %v2short %short_4 %short_4
+            //   %short_16 = OpConstant %short 16
+            //   %13 = OpConstantComposite %v2short %short_16 %short_16
+            // Which means we need to need to "create" the new OpConstant here
+            uint32_t scalar_id = type_manager_.CreateConstantScalar(lane_result, scalar_type).Id();
+            new_composite_components.emplace_back(scalar_id);
+        } else if (scalar_type.spv_type_ == SpvType::kBool) {
+            const spv::Op new_opcode = (lane_result == 0) ? spv::OpConstantFalse : spv::OpConstantTrue;
+            auto new_inst = std::make_unique<Instruction>(3, new_opcode);
+            new_inst->Fill({scalar_type.Id(), inst->ResultId()});
+            type_manager_.AddConstant(std::move(new_inst), scalar_type);
+            return true;
+        } else {
+            type_manager_.CreateConstantScalar(lane_result, scalar_type, inst->ResultId());
+            return true;
+        }
+    }
+
+    assert(is_vector);
+    auto new_inst = std::make_unique<Instruction>(3 + new_composite_components.size(), spv::OpConstantComposite);
+    std::vector<uint32_t> words = {result_type.Id(), inst->ResultId()};
+    words.insert(words.end(), new_composite_components.begin(), new_composite_components.end());
+    new_inst->Fill(words);
+    type_manager_.AddConstant(std::move(new_inst), result_type);
+    return true;
+}
+
+}  // namespace spirv
+}  // namespace gpuav

--- a/layers/gpuav/spirv/type_manager.cpp
+++ b/layers/gpuav/spirv/type_manager.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "type_manager.h"
+#include <cstdint>
 #include <spirv/unified1/spirv.hpp>
 #include "generated/spirv_grammar_helper.h"
 #include "module.h"
@@ -549,6 +550,25 @@ const Constant& TypeManager::CreateConstantUInt32(uint32_t value) {
     return AddConstant(std::move(new_inst), type);
 }
 
+// Used when not sure if 8-bit float, 64-bit int, or something inbetween
+const Constant& TypeManager::CreateConstantScalar(uint64_t value, const Type& type, uint32_t result_id) {
+    const bool is_64bit = type.Is64Bit();
+
+    auto new_inst = std::make_unique<Instruction>(is_64bit ? 5 : 4, spv::OpConstant);
+
+    if (result_id == 0) {
+        result_id = module_.TakeNextId();
+    }
+
+    std::vector<uint32_t> words = {type.Id(), result_id, static_cast<uint32_t>(value & 0xFFFFFFFF)};
+    if (is_64bit) {
+        words.emplace_back(static_cast<uint32_t>(value >> 32));
+    }
+    new_inst->Fill(words);
+
+    return AddConstant(std::move(new_inst), type);
+}
+
 const Constant& TypeManager::GetConstantUInt32(uint32_t value) {
     if (value == 0) {
         return GetConstantZeroUint32();
@@ -730,9 +750,38 @@ bool Type::Is64Bit() const {
     return false;
 }
 
+uint32_t Type::ScalarBitWidth() const {
+    if (spv_type_ == SpvType::kFloat || spv_type_ == SpvType::kInt) {
+        return inst_.Word(2);
+    } else if (spv_type_ == SpvType::kBool) {
+        return 1;
+    }
+    assert(false);
+    return 0;
+}
+
 uint32_t Constant::GetValueUint32() const {
     assert(inst_.Opcode() == spv::OpConstant || inst_.Opcode() == spv::OpConstantNull);
     return inst_.Opcode() == spv::OpConstantNull ? 0 : inst_.Word(3);
+}
+
+uint64_t Constant::GetValueUint64(bool is_signed) const {
+    const uint32_t bit_width = type_.inst_.Word(2);
+
+    uint64_t value = inst_.Word(3);
+    if (bit_width == 64) {
+        value |= (static_cast<uint64_t>(inst_.Word(4)) << 32);
+    }
+
+    // Sign-extend if necessary (8, 16, 32 bit negative numbers)
+    if (is_signed && bit_width < 64) {
+        uint64_t sign_bit = 1ULL << (bit_width - 1);
+        if (value & sign_bit) {
+            uint64_t mask = ~0ULL << bit_width;
+            value |= mask;
+        }
+    }
+    return value;
 }
 
 void TypeManager::AddUndef(std::unique_ptr<Instruction> new_inst) {

--- a/layers/gpuav/spirv/type_manager.h
+++ b/layers/gpuav/spirv/type_manager.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2024-2025 LunarG, Inc.
+/* Copyright (c) 2024-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,6 +66,7 @@ struct Type {
     uint32_t VectorSize() const;
     // 64-bit floats/int take up 2 dwords
     bool Is64Bit() const;
+    uint32_t ScalarBitWidth() const;
 
     const SpvType spv_type_;
     const Instruction& inst_;
@@ -77,7 +78,7 @@ static bool IsSpecConstant(uint32_t opcode) {
 }
 
 // Represents a OpConstant* or OpSpecConstant*
-// (Currently doesn't handle OpSpecConstantComposite or OpSpecConstantOp)
+// (Currently doesn't handle OpSpecConstantOp)
 struct Constant {
     Constant(const Type& type, const Instruction& inst)
         : type_(type), inst_(inst), is_spec_constant_(IsSpecConstant(inst.Opcode())) {}
@@ -86,11 +87,12 @@ struct Constant {
 
     // Only for cases where we know the constant value
     uint32_t GetValueUint32() const;
+    uint64_t GetValueUint64(bool is_signed) const;
 
     const Type& type_;
     const Instruction& inst_;
-    // Most times we just need Constant to get type or id, so being a spec const doesn't matter.
-    // This boolean is here incase we do care about the value of the constant.
+    // We currently freeze spec constants and do our own constant folding, but we have this here as a way to catch any edge cases we
+    // have missed in constant folding
     const bool is_spec_constant_;
 };
 
@@ -150,6 +152,7 @@ class TypeManager {
     const Constant* FindConstantFloat32(uint32_t type_id, uint32_t value) const;
     // most constants are uint
     const Constant& CreateConstantUInt32(uint32_t value);
+    const Constant& CreateConstantScalar(uint64_t value, const Type& type, uint32_t result_id = 0);
     const Constant& GetConstantUInt32(uint32_t value);
     const Constant& GetConstantZeroUint32();
     const Constant& GetConstantOneUint32();

--- a/layers/state_tracker/shader_instruction.cpp
+++ b/layers/state_tracker/shader_instruction.cpp
@@ -503,6 +503,24 @@ void Instruction::ReplaceLinkedId(vvl::unordered_map<uint32_t, uint32_t>& id_swa
     UpdateDebugInfo();
 }
 
+void Instruction::FreezeSpecConstant() {
+    const uint32_t opcode = Opcode();
+    if (opcode == spv::OpSpecConstant) {
+        SetNewOpcode(spv::OpConstant);
+    } else if (opcode == spv::OpSpecConstantTrue) {
+        SetNewOpcode(spv::OpConstantTrue);
+    } else if (opcode == spv::OpSpecConstantFalse) {
+        SetNewOpcode(spv::OpConstantFalse);
+    } else if (opcode == spv::OpSpecConstantComposite) {
+        SetNewOpcode(spv::OpConstantComposite);
+    }
+}
+
+void Instruction::SetNewOpcode(uint32_t opcode) {
+    words_[0] = (words_[0] & 0xffff0000u) | (opcode & 0x0ffffu);
+    UpdateDebugInfo();
+}
+
 static inline bool IsImageOperandsBiasOffset(uint32_t type) {
     return (type & (spv::ImageOperandsBiasMask | spv::ImageOperandsConstOffsetMask | spv::ImageOperandsOffsetMask |
                     spv::ImageOperandsConstOffsetsMask)) != 0;

--- a/layers/state_tracker/shader_instruction.h
+++ b/layers/state_tracker/shader_instruction.h
@@ -108,6 +108,10 @@ class Instruction {
     void ReplaceOperandId(uint32_t old_word, uint32_t new_word);
     void ReplaceLinkedId(vvl::unordered_map<uint32_t, uint32_t>& id_swap_map);
 
+    // Used to freeze OpSpecConstant into a OpConstant
+    void FreezeSpecConstant();
+    void SetNewOpcode(uint32_t opcode);
+
     // This is only used for very specific spots that explain why where used.
     // There really should be no need to access the raw bytes
     const uint32_t* GetRawBytes() const { return words_.data(); }
@@ -130,6 +134,7 @@ class Instruction {
     uint32_t operand_index_ = 1;
 
     // used to find original position of instruction in shader, pre-instrumented
+    // Even if we constant fold, this will be preserved when compared to the original SPIR-V
     const uint32_t position_offset_;
     const OperandInfo& operand_info_;
 

--- a/tests/unit/gpu_av_descriptor_class_general_buffer.cpp
+++ b/tests/unit/gpu_av_descriptor_class_general_buffer.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2020-2025 The Khronos Group Inc.
- * Copyright (c) 2020-2025 Valve Corporation
- * Copyright (c) 2020-2025 LunarG, Inc.
- * Copyright (c) 2020-2025 Google, Inc.
+ * Copyright (c) 2020-2026 The Khronos Group Inc.
+ * Copyright (c) 2020-2026 Valve Corporation
+ * Copyright (c) 2020-2026 LunarG, Inc.
+ * Copyright (c) 2020-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1745,31 +1745,28 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, SpecConstant) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    const char *cs_source = R"glsl(
+    const char* cs_source = R"glsl(
         #version 450
-        layout(constant_id = 0) const uint index = 2;
-
+        layout(constant_id = 0) const int INDEX = 2;
         layout(set = 0, binding = 0) buffer foo {
-            uint a;
-            uint b[4];
+            uint a[8]; // 32 bytes
         };
-
         void main() {
-            a = b[index];
+            a[INDEX] = 44;
         }
     )glsl";
 
-    const uint32_t value = 25;
+    uint32_t data = 7;
     VkSpecializationMapEntry entry = {0, 0, sizeof(uint32_t)};
-    VkSpecializationInfo spec_info = {1, &entry, sizeof(uint32_t), &value};
+    VkSpecializationInfo specialization_info = {1, &entry, sizeof(uint32_t), &data};
 
     CreateComputePipelineHelper pipe(*this);
     pipe.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr};
-    pipe.cs_ = VkShaderObj(*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_GLSL, &spec_info);
+    pipe.cs_ =
+        VkShaderObj(*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_GLSL, &specialization_info);
     pipe.CreateComputePipeline();
 
-    vkt::Buffer in_buffer(*m_device, 20, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-
+    vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
     pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_.UpdateDescriptorSets();
 

--- a/tests/unit/gpu_av_descriptor_class_general_buffer_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_class_general_buffer_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2020-2025 The Khronos Group Inc.
- * Copyright (c) 2020-2025 Valve Corporation
- * Copyright (c) 2020-2025 LunarG, Inc.
- * Copyright (c) 2020-2025 Google, Inc.
+ * Copyright (c) 2020-2026 The Khronos Group Inc.
+ * Copyright (c) 2020-2026 Valve Corporation
+ * Copyright (c) 2020-2026 LunarG, Inc.
+ * Copyright (c) 2020-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1581,6 +1581,142 @@ TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, InternalPipelineLayoutSelectio
                               nullptr);
     vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+
+    m_default_queue->SubmitAndWait(m_command_buffer);
+}
+
+TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, SpecConstant) {
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    RETURN_IF_SKIP(InitGpuAvFramework());
+    RETURN_IF_SKIP(InitState());
+
+    const char* cs_source = R"glsl(
+        #version 450
+        layout(constant_id = 0) const int INDEX = 7;
+        layout(set = 0, binding = 0) buffer foo {
+            uint a[8]; // 32 bytes
+        };
+        void main() {
+            a[INDEX] = 44;
+        }
+    )glsl";
+
+    uint32_t data = 2;
+    VkSpecializationMapEntry entry = {0, 0, sizeof(uint32_t)};
+    VkSpecializationInfo specialization_info = {1, &entry, sizeof(uint32_t), &data};
+
+    CreateComputePipelineHelper pipe(*this);
+    pipe.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr};
+    pipe.cs_ =
+        VkShaderObj(*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_GLSL, &specialization_info);
+    pipe.CreateComputePipeline();
+
+    vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
+    pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    pipe.descriptor_set_.UpdateDescriptorSets();
+
+    m_command_buffer.Begin();
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_, 0, 1,
+                              &pipe.descriptor_set_.set_, 0, nullptr);
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_command_buffer.End();
+
+    m_default_queue->SubmitAndWait(m_command_buffer);
+}
+
+TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, SpecConstantOp) {
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredFeature(vkt::Feature::shaderInt64);
+    RETURN_IF_SKIP(InitGpuAvFramework());
+    RETURN_IF_SKIP(InitState());
+
+    const char* cs_source = R"glsl(
+        #version 450
+        #extension GL_EXT_shader_explicit_arithmetic_types_int64 : enable
+        layout(constant_id = 0) const uint64_t X = 1;
+        layout(constant_id = 1) const bool Y = false;
+        layout(constant_id = 2) const uint BAD = 16;
+        #define Z (X == 1 || X == 2 || X == 3)
+
+        layout(set = 0, binding = 0) buffer foo {
+            uint a[8]; // 32 bytes
+        };
+        void main() {
+            const uint i = Z ? BAD : 1;
+            const uint k = Y ? 1 : BAD;
+            a[i] = 1;
+            a[k] = 2;
+        }
+    )glsl";
+
+    uint64_t data[2] = {/*X*/ 4, /*Y*/ 1};
+    VkSpecializationMapEntry entries[2] = {{0, 0, sizeof(uint64_t)}, {1, sizeof(uint64_t), sizeof(VkBool32)}};
+    VkSpecializationInfo specialization_info = {2, entries, sizeof(uint64_t) * 2, &data};
+
+    CreateComputePipelineHelper pipe(*this);
+    pipe.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr};
+    pipe.cs_ =
+        VkShaderObj(*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_GLSL, &specialization_info);
+    pipe.CreateComputePipeline();
+
+    vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
+    pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    pipe.descriptor_set_.UpdateDescriptorSets();
+
+    m_command_buffer.Begin();
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_, 0, 1,
+                              &pipe.descriptor_set_.set_, 0, nullptr);
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
+    m_command_buffer.End();
+
+    m_default_queue->SubmitAndWait(m_command_buffer);
+}
+
+TEST_F(PositiveGpuAVDescriptorClassGeneralBuffer, SpecConstantOpVector) {
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredFeature(vkt::Feature::shaderInt16);
+    RETURN_IF_SKIP(InitGpuAvFramework());
+    RETURN_IF_SKIP(InitState());
+
+    const char* cs_source = R"glsl(
+        #version 450
+        #extension GL_EXT_shader_explicit_arithmetic_types_int16 : enable
+
+        layout(constant_id = 0) const int16_t val = 4s;
+        const i16vec2 x = i16vec2(val, val);
+        const i16vec2 y = x * x;
+
+        layout(set = 0, binding = 0) buffer foo {
+            uint a[8]; // 32 bytes
+        };
+        void main() {
+            int16_t b = y[0];
+            a[b] = 1;
+        }
+    )glsl";
+
+    uint16_t data = 1;
+    VkSpecializationMapEntry entry = {0, 0, sizeof(uint16_t)};
+    VkSpecializationInfo specialization_info = {1, &entry, sizeof(uint16_t), &data};
+
+    CreateComputePipelineHelper pipe(*this);
+    pipe.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr};
+    pipe.cs_ =
+        VkShaderObj(*m_device, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_GLSL, &specialization_info);
+    pipe.CreateComputePipeline();
+
+    vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
+    pipe.descriptor_set_.WriteDescriptorBufferInfo(0, in_buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    pipe.descriptor_set_.UpdateDescriptorSets();
+
+    m_command_buffer.Begin();
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_, 0, 1,
+                              &pipe.descriptor_set_.set_, 0, nullptr);
+    vk::CmdDispatch(m_command_buffer, 1, 1, 1);
     m_command_buffer.End();
 
     m_default_queue->SubmitAndWait(m_command_buffer);


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11747 (in prep for replacing in https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/11717)

Adds (for GPU-AV only currently) our own way to do `spirv-opt`'s constant folding

The main 2 reasons for all this works

1. Will be faster than transferring between spirv-opt and back (pipeline compilation time is already an issue for GPU-AV)
2. We can do constant folding and preserve the "index" into the SPIR-V such that we provide a correct error message when printing the error source