### PR TITLE
sync: Cleanup subpass barriers

### DIFF
--- a/layers/state_tracker/render_pass_state.cpp
+++ b/layers/state_tracker/render_pass_state.cpp
@@ -69,6 +69,10 @@ static void RecordRenderPassDAG(const VkRenderPassCreateInfo2 *pCreateInfo, vvl:
             // Invalid per VUID-VkSubpassDependency-srcSubpass-00865
             continue;
         }
+        if (src_subpass != VK_SUBPASS_EXTERNAL && dst_subpass != VK_SUBPASS_EXTERNAL && src_subpass > dst_subpass) {
+            // Invalid per VUID-VkSubpassDependency-srcSubpass-00864
+            continue;
+        }
         if (src_subpass == dst_subpass) {
             self_dependencies[dependency.srcSubpass].push_back(i);
         } else if (src_subpass == VK_SUBPASS_EXTERNAL) {

--- a/layers/state_tracker/render_pass_state.h
+++ b/layers/state_tracker/render_pass_state.h
@@ -105,7 +105,7 @@ class RenderPass : public StateObject {
     struct AttachmentTransition {
         // Subpass index or VK_SUBPASS_EXTERNAL for transitions from initialLayout.
         // For transitions into finalLayout this is the last subpass that used the attachment.
-        uint32_t prev_subpass;
+        uint32_t src_subpass;
 
         uint32_t attachment;
         VkImageLayout old_layout;

--- a/layers/sync/sync_access_context.cpp
+++ b/layers/sync/sync_access_context.cpp
@@ -30,31 +30,25 @@ VkDeviceSize ResourceBaseAddress(const vvl::Buffer &buffer) { return buffer.GetF
 
 void AccessContext::InitFrom(uint32_t subpass, VkQueueFlags queue_flags,
                              const std::vector<SubpassDependencyInfo> &subpass_dependency_infos, const AccessContext *contexts,
-                             const AccessContext *external_context) {
+                             const AccessContext &external_context) {
     const SubpassDependencyInfo &info = subpass_dependency_infos[subpass];
-    const bool has_barrier_from_external = !info.barrier_from_external.empty();
-
-    prev_.reserve(info.dependencies.size() + (has_barrier_from_external ? 1 : 0));
-    prev_by_subpass_.resize(subpass, nullptr);  // Can't be more prevs than the subpass we're on
-    for (const auto &[src_subpass, subpass_dependencies] : info.dependencies) {
-        prev_.emplace_back(&contexts[src_subpass], queue_flags, subpass_dependencies);
-        prev_by_subpass_[src_subpass] = &prev_.back();
-    }
-
     async_.reserve(info.async.size());
-    for (const auto async_subpass : info.async) {
+    for (const uint32_t async_subpass : info.async) {
         // Start tags are not known at creation time (as it's done at BeginRenderpass)
         async_.emplace_back(contexts[async_subpass], kInvalidTag, kQueueIdInvalid);
     }
 
-    if (has_barrier_from_external) {
-        // Store the barrier from external with the reat, but save pointer for "by subpass" lookups.
-        prev_.emplace_back(external_context, queue_flags, info.barrier_from_external);
-        src_external_ = &prev_.back();
+    // Initialize barriers for the preceding subpasses and the external src barrier.
+    // To resolve contexts, we usually need regular subpass contexts and the external
+    // src context, so the corresponding barriers are stored together.
+    subpass_barriers_.resize(subpass + 1);
+    for (const auto &[src_subpass, subpass_dependencies] : info.dependencies) {
+        subpass_barriers_[src_subpass] = SubpassBarrier(contexts[src_subpass], queue_flags, subpass_dependencies);
     }
-    if (info.barrier_to_external.size()) {
-        dst_external_ = SubpassBarrierTrackback(this, queue_flags, info.barrier_to_external);
-    }
+    subpass_barriers_[subpass] = SubpassBarrier(external_context, queue_flags, info.barrier_from_external);
+
+    // External dst barrier
+    dst_external_ = SubpassBarrier(*this, queue_flags, info.barrier_to_external);
 }
 
 ApplySingleBufferBarrierFunctor::ApplySingleBufferBarrierFunctor(const AccessContext &access_context,
@@ -119,11 +113,8 @@ void CollectBarriersFunctor::operator()(const Iterator &pos) const {
 
 void AccessContext::InitFrom(const AccessContext &other) {
     access_state_map_.Assign(other.access_state_map_);
-    prev_ = other.prev_;
-    prev_by_subpass_ = other.prev_by_subpass_;
+
     async_ = other.async_;
-    src_external_ = other.src_external_;
-    dst_external_ = other.dst_external_;
     start_tag_ = other.start_tag_;
 
     global_barriers_queue_ = other.global_barriers_queue_;
@@ -138,19 +129,22 @@ void AccessContext::InitFrom(const AccessContext &other) {
     finalized_ = false;
 
     sorted_first_accesses_.Clear();
+
+    // TODO: the following assignments look incorrect: the copies will reference the old context.
+    // Find a scenario when this does not work, write a test and make a fix.
+    subpass_barriers_ = other.subpass_barriers_;
+    dst_external_ = other.dst_external_;
 }
 
 void AccessContext::Reset() {
     access_state_map_.Clear();
-    prev_.clear();
-    prev_by_subpass_.clear();
     async_.clear();
-    src_external_ = nullptr;
-    dst_external_ = {};
     start_tag_ = {};
     ResetGlobalBarriers();
     finalized_ = false;
     sorted_first_accesses_.Clear();
+    subpass_barriers_.clear();
+    dst_external_ = {};
 }
 
 void AccessContext::Finalize() {
@@ -269,28 +263,42 @@ void AccessContext::AddReferencedTags(ResourceUsageTagSet &used) const {
     }
 }
 
+const SubpassBarrier &AccessContext::GetSubpassBarrier(uint32_t src_subpass) const {
+    if (src_subpass == VK_SUBPASS_EXTERNAL) {
+        return subpass_barriers_.back();
+    } else {
+        assert(subpass_barriers_[src_subpass].src_subpass_context != nullptr);
+        return subpass_barriers_[src_subpass];
+    }
+}
+
 void AccessContext::ResolveFromContext(const AccessContext &from) {
     assert(!finalized_);
     auto noop_action = [](AccessState *access) {};
     from.ResolveAccessRangeRecursePrev(kFullRange, noop_action, *this, false);
 }
 
-void AccessContext::ResolvePreviousAccesses() {
-    assert(!finalized_);
-    if (!prev_.empty()) {
-        for (const auto &prev_dep : prev_) {
-            const ApplyTrackbackStackAction barrier_action(prev_dep.barriers, nullptr);
-            prev_dep.source_subpass->ResolveAccessRangeRecursePrev(kFullRange, barrier_action, *this, true);
-        }
-    }
-}
-
-void AccessContext::ResolveFromSubpassContext(const ApplySubpassTransitionBarriersAction &subpass_transition_action,
+void AccessContext::ResolveFromSubpassContext(const ApplySubpassTransitionBarrierAction &subpass_transition_action,
                                               const AccessContext &from_context,
                                               subresource_adapter::ImageRangeGenerator attachment_range_gen) {
     assert(!finalized_);
     for (; attachment_range_gen->non_empty(); ++attachment_range_gen) {
         from_context.ResolveAccessRangeRecursePrev(*attachment_range_gen, subpass_transition_action, *this, true);
+    }
+}
+
+void AccessContext::ResolveAllSubpassDependencies() {
+    assert(!finalized_);
+    ResolveSubpassDependencies(kFullRange, *this, true);
+}
+
+void AccessContext::ResolveSubpassDependencies(const AccessRange &range, AccessContext &resolve_context, bool infill,
+                                               const AccessStateFunction *previous_barrier_action) const {
+    for (const SubpassBarrier &subpass_barrier : subpass_barriers_) {
+        if (subpass_barrier.src_subpass_context) {
+            const ApplySubpassBarrierAction barrier_action(subpass_barrier, previous_barrier_action);
+            subpass_barrier.src_subpass_context->ResolveAccessRangeRecursePrev(range, barrier_action, resolve_context, infill);
+        }
     }
 }
 
@@ -408,45 +416,35 @@ void AccessContext::ResolveAccessRangeRecursePrev(const AccessRange &range, cons
 void AccessContext::ResolveGapsRecursePrev(const AccessRange &range, AccessContext &descent_context, bool infill,
                                            const AccessStateFunction &previous_barrier_action) const {
     assert(range.non_empty());
-    AccessMap &descent_map = descent_context.access_state_map_;
-    if (prev_.empty()) {
-        if (infill) {
-            AccessState access_state = AccessState::DefaultAccessState();
+    if (!subpass_barriers_.empty()) {
+        ResolveSubpassDependencies(range, descent_context, infill, &previous_barrier_action);
+        return;
+    }
+    if (infill) {
+        AccessState access_state = AccessState::DefaultAccessState();
+        // The following is not needed for correctness but is rather an optimization. We are going to fill
+        // the gaps and the application of the global barriers to an empty state is noop (nothing is in the
+        // barrier's source scope). Update the index to skip application of the registered global barriers.
+        access_state.next_global_barrier_index = descent_context.GetGlobalBarrierCount();
 
-            // The following is not needed for correctness but is rather an optimization. We are going to fill
-            // the gaps and the application of the global barriers to an empty state is noop (nothing is in the
-            // barrier's source scope). Update the index to skip application of the registered global barriers.
-            access_state.next_global_barrier_index = descent_context.GetGlobalBarrierCount();
-
-            previous_barrier_action(&access_state);
-            descent_map.InfillGaps(range, access_state);
-        }
-    } else {
-        for (const auto &prev_dep : prev_) {
-            const ApplyTrackbackStackAction barrier_action(prev_dep.barriers, &previous_barrier_action);
-            prev_dep.source_subpass->ResolveAccessRangeRecursePrev(range, barrier_action, descent_context, infill);
-        }
+        previous_barrier_action(&access_state);
+        descent_context.access_state_map_.InfillGaps(range, access_state);
     }
 }
 
 AccessMap::iterator AccessContext::ResolveGapRecursePrev(const AccessRange &gap_range, AccessMap::iterator pos_hint) {
     assert(gap_range.non_empty());
-    if (prev_.empty()) {
-        AccessState access_state = AccessState::DefaultAccessState();
-
-        // The following is not needed for correctness but is rather an optimization. We are going to fill
-        // the gaps and the application of the global barriers to an empty state is noop (nothing is in the
-        // barrier's source scope). Update the index to skip application of the registered global barriers.
-        access_state.next_global_barrier_index = GetGlobalBarrierCount();
-
-        return access_state_map_.InfillGap(pos_hint, gap_range, access_state);
-    } else {
-        for (const auto &prev_dep : prev_) {
-            const ApplyTrackbackStackAction barrier_action(prev_dep.barriers, nullptr);
-            prev_dep.source_subpass->ResolveAccessRangeRecursePrev(gap_range, barrier_action, *this, true);
-        }
+    if (!subpass_barriers_.empty()) {
+        ResolveSubpassDependencies(gap_range, *this, true);
         return access_state_map_.LowerBound(gap_range.begin);
     }
+    AccessState access_state = AccessState::DefaultAccessState();
+    // The next line is not needed for correctness but is rather an optimization. We are going to fill
+    // the gaps and the application of the global barriers to an empty state is noop (nothing is in the
+    // barrier's source scope). Update the index to skip application of the registered global barriers.
+    access_state.next_global_barrier_index = GetGlobalBarrierCount();
+
+    return access_state_map_.InfillGap(pos_hint, gap_range, access_state);
 }
 
 // Update memory access state over the given range.
@@ -580,7 +578,7 @@ void AccessContext::ResolveChildContexts(vvl::span<AccessContext> subpass_contex
     assert(!finalized_);
 
     for (AccessContext &context : subpass_contexts) {
-        ApplyTrackbackStackAction barrier_action(context.GetDstExternalTrackBack().barriers);
+        ApplySubpassBarrierAction barrier_action(context.GetDstExternalSubpassBarrier());
         context.ResolveAccessRange(kFullRange, barrier_action, *this);
     }
 }
@@ -708,6 +706,15 @@ AttachmentViewGen::Gen AttachmentViewGen::GetDepthStencilRenderAreaGenType(bool 
     }
     assert(depth_op || stencil_op);
     return kRenderArea;
+}
+
+SubpassBarrier::SubpassBarrier(const AccessContext &src_subpass_context, VkQueueFlags queue_flags,
+                               const std::vector<const VkSubpassDependency2 *> &subpass_dependencies)
+    : src_subpass_context(&src_subpass_context) {
+    barriers.reserve(subpass_dependencies.size());
+    for (const VkSubpassDependency2 *dependency : subpass_dependencies) {
+        barriers.emplace_back(queue_flags, *dependency);
+    }
 }
 
 }  // namespace syncval

--- a/layers/sync/sync_access_context.h
+++ b/layers/sync/sync_access_context.h
@@ -147,46 +147,38 @@ struct QueueTagOffsetBarrierAction {
     ResourceUsageTag tag_offset;
 };
 
-struct ApplyTrackbackStackAction {
-    explicit ApplyTrackbackStackAction(const std::vector<SyncBarrier> &barriers_,
-                                       const AccessStateFunction *previous_barrier_ = nullptr)
-        : barriers(barriers_), previous_barrier(previous_barrier_) {}
-    void operator()(AccessState *access) const {
-        assert(access);
-        ApplyBarriers(*access, barriers);
-        if (previous_barrier) {
-            assert(bool(*previous_barrier));
-            (*previous_barrier)(access);
-        }
-    }
-    const std::vector<SyncBarrier> &barriers;
-    const AccessStateFunction *previous_barrier;
-};
+struct SubpassBarrier {
+    const AccessContext *src_subpass_context = nullptr;
 
-struct ApplySubpassTransitionBarriersAction {
-    explicit ApplySubpassTransitionBarriersAction(const std::vector<SyncBarrier> &barriers, ResourceUsageTag layout_transition_tag)
-        : barriers(barriers), layout_transition_tag(layout_transition_tag) {}
-    void operator()(AccessState *access) const {
-        assert(access);
-        ApplyBarriers(*access, barriers, true, layout_transition_tag);
-    }
-    const std::vector<SyncBarrier> &barriers;
-    const ResourceUsageTag layout_transition_tag;
-};
-
-struct SubpassBarrierTrackback {
+    // Multiple subpass dependencies may be defined for the same (src_subpass, dst_subpass) pair.
+    // Each subpass dependency adds a separate barrier.
     std::vector<SyncBarrier> barriers;
-    const AccessContext *source_subpass = nullptr;
-    SubpassBarrierTrackback() = default;
-    SubpassBarrierTrackback(const AccessContext *source_subpass, VkQueueFlags queue_flags,
-                            const std::vector<const VkSubpassDependency2 *> &subpass_dependencies)
-        : source_subpass(source_subpass) {
-        barriers.reserve(subpass_dependencies.size());
-        for (const VkSubpassDependency2 *dependency : subpass_dependencies) {
-            assert(dependency);
-            barriers.emplace_back(queue_flags, *dependency);
+
+    SubpassBarrier() = default;
+    SubpassBarrier(const AccessContext &src_subpass_context, VkQueueFlags queue_flags,
+                   const std::vector<const VkSubpassDependency2 *> &subpass_dependencies);
+};
+
+struct ApplySubpassBarrierAction {
+    explicit ApplySubpassBarrierAction(const SubpassBarrier &subpass_barrier,
+                                       const AccessStateFunction *previous_barrier_action = nullptr)
+        : subpass_barrier(subpass_barrier), previous_barrier_action(previous_barrier_action) {}
+    void operator()(AccessState *access) const {
+        ApplyBarriers(*access, subpass_barrier.barriers);
+        if (previous_barrier_action) {
+            (*previous_barrier_action)(access);
         }
     }
+    const SubpassBarrier &subpass_barrier;
+    const AccessStateFunction *previous_barrier_action;
+};
+
+struct ApplySubpassTransitionBarrierAction {
+    ApplySubpassTransitionBarrierAction(const SubpassBarrier &subpass_barrier, ResourceUsageTag layout_transition_tag)
+        : subpass_barrier(subpass_barrier), layout_transition_tag(layout_transition_tag) {}
+    void operator()(AccessState *access) const { ApplyBarriers(*access, subpass_barrier.barriers, true, layout_transition_tag); }
+    const SubpassBarrier &subpass_barrier;
+    const ResourceUsageTag layout_transition_tag;
 };
 
 class AttachmentViewGen {
@@ -260,17 +252,15 @@ class AccessContext {
         kDetectAll = (kDetectPrevious | kDetectAsync)
     };
 
-    const SubpassBarrierTrackback &GetDstExternalTrackBack() const { return dst_external_; }
-
     void ResolveFromContext(const AccessContext &from);
 
-    // Non-lazy import of all accesses. WaitEvents needs this.
-    void ResolvePreviousAccesses();
-
     // Resolves this subpass context from the subpass context defined by the layout transition dependency
-    void ResolveFromSubpassContext(const ApplySubpassTransitionBarriersAction &subpass_transition_action,
+    void ResolveFromSubpassContext(const ApplySubpassTransitionBarrierAction &subpass_transition_action,
                                    const AccessContext &from_context,
                                    subresource_adapter::ImageRangeGenerator attachment_range_gen);
+
+    // Import accesses from all subpass dependencies (including src external dependency)
+    void ResolveAllSubpassDependencies();
 
     template <typename ResolveOp>
     void ResolveFromContext(ResolveOp &&resolve_op, const AccessContext &from_context);
@@ -300,7 +290,7 @@ class AccessContext {
     AccessContext &operator=(const AccessContext &) = delete;
 
     void InitFrom(uint32_t subpass, VkQueueFlags queue_flags, const std::vector<SubpassDependencyInfo> &subpass_dependency_infos,
-                  const AccessContext *contexts, const AccessContext *external_context);
+                  const AccessContext *contexts, const AccessContext &external_context);
     void InitFrom(const AccessContext &other);
     void Reset();
 
@@ -308,14 +298,8 @@ class AccessContext {
     void AddReferencedTags(ResourceUsageTagSet &referenced) const;
 
     const AccessMap &GetAccessMap() const { return access_state_map_; }
-    const SubpassBarrierTrackback *GetTrackBackFromSubpass(uint32_t subpass) const {
-        if (subpass == VK_SUBPASS_EXTERNAL) {
-            return src_external_;
-        } else {
-            assert(subpass < prev_by_subpass_.size());
-            return prev_by_subpass_[subpass];
-        }
-    }
+    const SubpassBarrier &GetSubpassBarrier(uint32_t src_subpass) const;
+    const SubpassBarrier &GetDstExternalSubpassBarrier() const { return dst_external_; }
 
     void SetStartTag(ResourceUsageTag tag) { start_tag_ = tag; }
     ResourceUsageTag StartTag() const { return start_tag_; }
@@ -391,8 +375,7 @@ class AccessContext {
     HazardResult DetectImageBarrierHazard(const AttachmentViewGen &attachment_view, const SyncBarrier &barrier,
                                           DetectOptions options) const;
 
-    HazardResult DetectSubpassTransitionHazard(const SubpassBarrierTrackback &track_back,
-                                               const AttachmentViewGen &attach_view) const;
+    HazardResult DetectSubpassTransitionHazard(const SubpassBarrier &subpass_barrier, const AttachmentViewGen &attach_view) const;
 
     HazardResult DetectFirstUseHazard(QueueId queue_id, const ResourceUsageRange &tag_range,
                                       const AccessContext &access_context) const;
@@ -403,6 +386,10 @@ class AccessContext {
 
   private:
     void ResetGlobalBarriers();
+
+    // Resolve accesses from src contexts from all subpass dependencies including src external dependency
+    void ResolveSubpassDependencies(const AccessRange &range, AccessContext &resolve_context, bool infill,
+                                    const AccessStateFunction *previous_barrier_action = nullptr) const;
 
     // Resolve resolve_context from the current context.
     // Do not infill gaps that are also empty in the current context
@@ -456,14 +443,9 @@ class AccessContext {
   private:
     AccessMap access_state_map_;
 
-    std::vector<SubpassBarrierTrackback> prev_;
-    std::vector<SubpassBarrierTrackback *> prev_by_subpass_;
-
     // These contexts *must* have the same lifespan as this context, or be cleared, before the referenced contexts can expire
     std::vector<AsyncReference> async_;
 
-    SubpassBarrierTrackback *src_external_ = nullptr;
-    SubpassBarrierTrackback dst_external_;
     ResourceUsageTag start_tag_ = 0;
 
     // Global barriers are registered at the AccessContext level and applied to access states
@@ -483,13 +465,26 @@ class AccessContext {
     std::vector<uint32_t> global_barriers_;
 
     // True if access map won't be modified anymore.
-    // NOTE: In the current implementation we mark only command buffer contexts as finalized.
-    // TODO: mark other contexts as finalized too if needed.
+    // NOTE: In the current implementation we mark only command buffer contexts as finalized,
+    // but if necessary this can be done for other contexts too.
     bool finalized_ = false;
 
     // Provides ordering of the context's first accesses based on tag values.
     // Only available for finalized contexts.
     SortedFirstAccesses sorted_first_accesses_;
+
+    // Barriers between preceding subpasses and the current subpass
+    // (only for subpass contexts).
+    //
+    // SubpassBarrier::src_subpass_context is null if no dependency exists between
+    // that preceding subpass and the current subpass.
+    //
+    // The dependency from VK_SUBPASS_EXTERNAL (src) to the current subpass is stored
+    // as the last element.
+    std::vector<SubpassBarrier> subpass_barriers_;  // [currentSubpassIndex + 1]
+
+    // The dependency from the current subpass to VK_SUBPASS_EXTERNAL (dst)
+    SubpassBarrier dst_external_;
 };
 
 // The semantics of the InfillUpdateOps of InfillUpdateRange are slightly different than for the

--- a/layers/sync/sync_commandbuffer.h
+++ b/layers/sync/sync_commandbuffer.h
@@ -208,7 +208,13 @@ class CommandBufferAccessContext : public CommandExecutionContext, DebugNameProv
     ResourceUsageInfo GetResourceUsageInfo(ResourceUsageTagEx tag_ex) const override;
     AccessContext *GetCurrentAccessContext() override { return current_context_; }
     SyncEventsContext *GetCurrentEventsContext() override { return &events_context_; }
-    const AccessContext *GetCurrentAccessContext() const override { return current_context_; }
+
+    const AccessContext *GetCurrentAccessContext() const override {
+        // TODO: return a reference (update a lot of places!)
+        assert(current_context_ != nullptr);
+        return current_context_;
+    }
+
     const SyncEventsContext *GetCurrentEventsContext() const override { return &events_context_; }
     QueueId GetQueueId() const override;
 

--- a/layers/sync/sync_hazard_detection.cpp
+++ b/layers/sync/sync_hazard_detection.cpp
@@ -398,15 +398,13 @@ HazardResult AccessContext::DetectImageBarrierHazard(const AttachmentViewGen &vi
     return DetectHazardGeneratedRangeGen(detector, range_gen, options);
 }
 
-HazardResult AccessContext::DetectSubpassTransitionHazard(const SubpassBarrierTrackback &track_back,
+HazardResult AccessContext::DetectSubpassTransitionHazard(const SubpassBarrier &subpass_barrier,
                                                           const AttachmentViewGen &attach_view) const {
-    // We should never ask for a transition from a context we don't have
-    assert(track_back.source_subpass);
-
     // Do the detection against the specific prior context independent of other contexts.  (Synchronous only)
     // Hazard detection for the transition can be against the merged of the barriers (it only uses src_...)
-    const SyncBarrier merged_barrier(track_back.barriers);
-    HazardResult hazard = track_back.source_subpass->DetectImageBarrierHazard(attach_view, merged_barrier, kDetectPrevious);
+    const SyncBarrier merged_barrier(subpass_barrier.barriers);
+    const AccessContext &src_subpass_context = *subpass_barrier.src_subpass_context;
+    HazardResult hazard = src_subpass_context.DetectImageBarrierHazard(attach_view, merged_barrier, kDetectPrevious);
     if (!hazard.IsHazard()) {
         // The Async hazard check is against the current context's async set.
         SyncBarrier null_barrier = {};
@@ -612,14 +610,12 @@ HazardResult AccessContext::DetectHazardOneRange(Detector &detector, bool detect
 
 template <typename Detector>
 HazardResult AccessContext::DetectPreviousHazard(Detector &detector, const AccessRange &range) const {
-    if (prev_.empty()) {
+    if (subpass_barriers_.empty()) {
         return {};
     }
     AccessContext descent_context;
-    for (const auto &prev_dep : prev_) {
-        const ApplyTrackbackStackAction barrier_action(prev_dep.barriers, nullptr);
-        prev_dep.source_subpass->ResolveAccessRangeRecursePrev(range, barrier_action, descent_context, false);
-    }
+    ResolveSubpassDependencies(range, descent_context, false);
+
     AccessMap &descent_map = descent_context.access_state_map_;
     for (auto prev = descent_map.begin(); prev != descent_map.end(); ++prev) {
         HazardResult hazard = detector.Detect(prev);

--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -817,7 +817,7 @@ void SyncOpWaitEvents::ReplayRecord(CommandExecutionContext &exec_context, Resou
     SyncEventsContext *events_context = exec_context.GetCurrentEventsContext();
     const QueueId queue_id = exec_context.GetQueueId();
 
-    access_context->ResolvePreviousAccesses();
+    access_context->ResolveAllSubpassDependencies();
 
     assert(barrier_sets_.size() == 1 || (barrier_sets_.size() == events_.size()));
 
@@ -1230,7 +1230,7 @@ bool SyncOpBeginRenderPass::Validate(const CommandBufferAccessContext &cb_contex
     AccessContext temp_context(cb_context.GetSyncState());
 
     temp_context.InitFrom(subpass, cb_context.GetQueueFlags(), rp_state.subpass_dependency_infos, nullptr,
-                          cb_context.GetCurrentAccessContext());
+                          *cb_context.GetCurrentAccessContext());
 
     // Validate attachment operations
     if (attachments_.empty()) return skip;

--- a/layers/sync/sync_renderpass.cpp
+++ b/layers/sync/sync_renderpass.cpp
@@ -99,7 +99,7 @@ std::unique_ptr<AccessContext[]> InitSubpassContexts(VkQueueFlags queue_flags, c
     for (uint32_t pass = 0; pass < subpass_count; pass++) {
         subpass_contexts[pass].validator = external_context.validator;
         subpass_contexts[pass].InitFrom(pass, queue_flags, rp_state.subpass_dependency_infos, subpass_contexts.get(),
-                                        &external_context);
+                                        external_context);
     }
     return subpass_contexts;
 }
@@ -163,25 +163,31 @@ bool RenderPassAccessContext::ValidateLayoutTransitions(const CommandBufferAcces
     //
     // Note: we could be more efficient by tracking whether or not we actually *have* any changes (e.g. attachment resolve)
     // to apply and only copy then, if this proves a hot spot.
-    std::unique_ptr<AccessContext> proxy_for_prev;
-    SubpassBarrierTrackback proxy_track_back;
+    std::unique_ptr<AccessContext> src_context_proxy;
+    SubpassBarrier proxy_subpass_barrier;
 
     const auto &transitions = rp_state.subpass_transitions[subpass];
     for (const auto &transition : transitions) {
-        const bool prev_needs_proxy = transition.prev_subpass != VK_SUBPASS_EXTERNAL && (transition.prev_subpass + 1 == subpass);
+        const SubpassBarrier &subpass_barrier = access_context.GetSubpassBarrier(transition.src_subpass);
+        const SubpassBarrier *p_subpass_barrier = &subpass_barrier;
 
-        const auto *track_back = access_context.GetTrackBackFromSubpass(transition.prev_subpass);
-        assert(track_back);
-        if (prev_needs_proxy) {
-            if (!proxy_for_prev) {
-                proxy_for_prev.reset(CreateStoreResolveProxyContext(*track_back->source_subpass, rp_state, render_pass_instance_id,
-                                                                    transition.prev_subpass, attachment_views));
-                proxy_track_back = *track_back;
-                proxy_track_back.source_subpass = proxy_for_prev.get();
+        const bool src_context_needs_proxy =
+            transition.src_subpass != VK_SUBPASS_EXTERNAL && (transition.src_subpass + 1 == subpass);
+
+        if (src_context_needs_proxy) {
+            if (!src_context_proxy) {
+                // TODO: this looks wrong to create proxy once for all iterations.
+                // Proxy depends on current iteration (transition.src_subpass), so it should be recreated
+                // each time when needed. Write a test that exposes this and make a fix.
+                src_context_proxy.reset(CreateStoreResolveProxyContext(*subpass_barrier.src_subpass_context, rp_state,
+                                                                       render_pass_instance_id, transition.src_subpass,
+                                                                       attachment_views));
+                proxy_subpass_barrier = subpass_barrier;
+                proxy_subpass_barrier.src_subpass_context = src_context_proxy.get();
             }
-            track_back = &proxy_track_back;
+            p_subpass_barrier = &proxy_subpass_barrier;
         }
-        auto hazard = access_context.DetectSubpassTransitionHazard(*track_back, attachment_views[transition.attachment]);
+        auto hazard = access_context.DetectSubpassTransitionHazard(*p_subpass_barrier, attachment_views[transition.attachment]);
         if (hazard.IsHazard()) {
             const SyncValidator &sync_state = cb_context.GetSyncState();
             const Location loc(command);
@@ -200,7 +206,7 @@ bool RenderPassAccessContext::ValidateLayoutTransitions(const CommandBufferAcces
             if (hazard.Tag() == kInvalidTag) {
                 const auto error = sync_state.error_messages_.RenderPassLayoutTransitionVsResolveError(
                     hazard, cb_context, command, resource_description, transition.old_layout, transition.new_layout,
-                    transition.prev_subpass);
+                    transition.src_subpass);
                 skip |= sync_state.SyncError(hazard.Hazard(), rp_state.Handle(), loc, error);
             } else {
                 const auto error = sync_state.error_messages_.RenderPassLayoutTransitionError(
@@ -532,18 +538,14 @@ void RenderPassAccessContext::RecordLayoutTransitions(const vvl::RenderPass &rp_
                                                       AccessContext &access_context) {
     const auto &transitions = rp_state.subpass_transitions[subpass];
     for (const auto &transition : transitions) {
-        const auto prev_subpass = transition.prev_subpass;
         const auto &view_gen = attachment_views[transition.attachment];
-
-        const auto *trackback = access_context.GetTrackBackFromSubpass(prev_subpass);
-        assert(trackback);
+        const SubpassBarrier &subpass_barrier = access_context.GetSubpassBarrier(transition.src_subpass);
+        const AccessContext &src_subpass_context = *subpass_barrier.src_subpass_context;
 
         // Import the attachments into the current context
-        const auto *prev_context = trackback->source_subpass;
-        assert(prev_context);
-        ApplySubpassTransitionBarriersAction barrier_action(trackback->barriers, tag);
+        ApplySubpassTransitionBarrierAction barrier_action(subpass_barrier, tag);
         const std::optional<ImageRangeGen> &attachment_gen = view_gen.GetRangeGen(AttachmentViewGen::Gen::kViewSubresource);
-        access_context.ResolveFromSubpassContext(barrier_action, *prev_context, *attachment_gen);
+        access_context.ResolveFromSubpassContext(barrier_action, src_subpass_context, *attachment_gen);
     }
 }
 
@@ -755,11 +757,10 @@ bool RenderPassAccessContext::ValidateFinalSubpassLayoutTransitions(const Comman
     const auto &final_transitions = rp_state_->subpass_transitions.back();
     for (const auto &transition : final_transitions) {
         const auto &view_gen = attachment_views_[transition.attachment];
-        const auto &trackback = subpass_contexts_[transition.prev_subpass].GetDstExternalTrackBack();
-        assert(trackback.source_subpass);  // Transitions are given implicit transitions if the StateTracker is working correctly
-        auto *context = trackback.source_subpass;
+        const SubpassBarrier &subpass_barrier = subpass_contexts_[transition.src_subpass].GetDstExternalSubpassBarrier();
+        const AccessContext *context = subpass_barrier.src_subpass_context;
 
-        if (transition.prev_subpass == current_subpass_) {
+        if (transition.src_subpass == current_subpass_) {
             if (!proxy_for_current) {
                 // We haven't recorded resolve ofor the current_subpass, so we need to copy current and update it *as if*
                 proxy_for_current.reset(CreateStoreResolveProxy());
@@ -768,7 +769,7 @@ bool RenderPassAccessContext::ValidateFinalSubpassLayoutTransitions(const Comman
         }
 
         // Use the merged barrier for the hazard check (safe since it just considers the src (first) scope.
-        const SyncBarrier merged_barrier(trackback.barriers);
+        const SyncBarrier merged_barrier(subpass_barrier.barriers);
         auto hazard = context->DetectImageBarrierHazard(view_gen, merged_barrier, AccessContext::DetectOptions::kDetectPrevious);
         if (hazard.IsHazard()) {
             const SyncValidator &sync_state = cb_context.GetSyncState();
@@ -786,7 +787,7 @@ bool RenderPassAccessContext::ValidateFinalSubpassLayoutTransitions(const Comman
             if (hazard.Tag() == kInvalidTag) {  // Hazard vs. store/resolve
                 const std::string error = sync_state.error_messages_.RenderPassFinalLayoutTransitionVsStoreOrResolveError(
                     hazard, cb_context, command, resource_description, transition.old_layout, transition.new_layout,
-                    transition.prev_subpass);
+                    transition.src_subpass);
                 skip |= sync_state.SyncError(hazard.Hazard(), rp_state_->Handle(), loc, error);
             } else {
                 const std::string error = sync_state.error_messages_.RenderPassFinalLayoutTransitionError(
@@ -918,8 +919,8 @@ void RenderPassAccessContext::RecordEndRenderPass(AccessContext *external_contex
     const auto &final_transitions = rp_state_->subpass_transitions.back();
     for (const auto &transition : final_transitions) {
         const AttachmentViewGen &view_gen = attachment_views_[transition.attachment];
-        const auto &last_trackback = subpass_contexts_[transition.prev_subpass].GetDstExternalTrackBack();
-        assert(&subpass_contexts_[transition.prev_subpass] == last_trackback.source_subpass);
+        const SubpassBarrier &dst_external_barrier = subpass_contexts_[transition.src_subpass].GetDstExternalSubpassBarrier();
+        assert(&subpass_contexts_[transition.src_subpass] == dst_external_barrier.src_subpass_context);
 
         const std::optional<ImageRangeGen> &ref_range_gen = view_gen.GetRangeGen(AttachmentViewGen::Gen::kViewSubresource);
         ImageRangeGen markup_range_gen(*ref_range_gen);
@@ -928,7 +929,7 @@ void RenderPassAccessContext::RecordEndRenderPass(AccessContext *external_contex
 
         ImageRangeGen range_gen(*ref_range_gen);
         PendingBarriers pending_barriers;
-        for (const auto &barrier : last_trackback.barriers) {
+        for (const auto &barrier : dst_external_barrier.barriers) {
             const BarrierScope barrier_scope(barrier);
             CollectBarriersFunctor collect_barriers(*external_context, barrier_scope, barrier, true, vvl::kNoIndex32,
                                                     pending_barriers);


### PR DESCRIPTION
General cleanup of subpass dependencies and renames. 

Introduce a simple `SubpassBarrier` concept (based on VkSubpassDependency). It existed previously as `SubpassBarrierTrackback`. This and other Trackback-related names were quite intimidated, and this improves by making this code not scary at all 

Another rename is related to `AccessContext::prev_` field and related Prev names. `prev_` sounds quite general but all `prev_` functionality is only about subpass dependencies, so `prev_` was renamed to `subpass_barriers_`.