### PR TITLE
gpuav: Add spirv::Module from Core

### DIFF
--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
@@ -460,9 +460,10 @@ void GpuShaderInstrumentor::PreCallRecordGetShaderBinaryDataEXT(VkDevice device,
     chassis_state.modified_shader_handle = sub_state.original_handle;
 }
 
-bool GpuShaderInstrumentor::PreCallRecordShaderObjectInstrumentation(
-    vku::safe_VkShaderCreateInfoEXT &modified_create_info, const Location &create_info_loc,
-    chassis::ShaderObjectInstrumentationData &instrumentation_data) {
+bool GpuShaderInstrumentor::PreCallRecordShaderObjectInstrumentation(vku::safe_VkShaderCreateInfoEXT& modified_create_info,
+                                                                     const Location& create_info_loc,
+                                                                     chassis::ShaderObjectInstrumentationData& instrumentation_data,
+                                                                     ::spirv::Module* module_state) {
     if (gpuav_settings.select_instrumented_shaders && !IsSelectiveInstrumentationEnabled(modified_create_info.pNext)) {
         return false;
     }
@@ -475,6 +476,7 @@ bool GpuShaderInstrumentor::PreCallRecordShaderObjectInstrumentation(
     interface.entry_point_name = modified_create_info.pName;
     interface.entry_point_stage = modified_create_info.stage;
     interface.specialization_info = modified_create_info.pSpecializationInfo->ptr();
+    interface.core_module = module_state;
     BuildDescriptorSetLayoutInfo(modified_create_info, interface.instrumentation_dsl);
 
     const bool is_shader_instrumented = InstrumentShader(
@@ -504,12 +506,14 @@ void GpuShaderInstrumentor::PreCallRecordCreateShadersEXT(VkDevice device, uint3
         vku::safe_VkShaderCreateInfoEXT &new_create_info = chassis_state.modified_create_infos[i];
         new_create_info.initialize(&pCreateInfos[i]);
 
-        const Location &create_info_loc = record_obj.location.dot(vvl::Field::pCreateInfos, i);
-        auto &instrumentation_data = chassis_state.instrumentations_data[i];
-
         if (new_create_info.codeType != VK_SHADER_CODE_TYPE_SPIRV_EXT) {
             continue;
+        } else if (!chassis_state.module_states[i]) {
+            continue;
         }
+
+        const Location& create_info_loc = record_obj.location.dot(vvl::Field::pCreateInfos, i);
+        auto& instrumentation_data = chassis_state.instrumentations_data[i];
 
         // See pipeline version for explanation
         if (new_create_info.flags & VK_SHADER_CREATE_INDIRECT_BINDABLE_BIT_EXT) {
@@ -543,8 +547,8 @@ void GpuShaderInstrumentor::PreCallRecordCreateShadersEXT(VkDevice device, uint3
                     continue;
                 }
                 AddDescriptorHeapMappings(reinterpret_cast<VkBaseOutStructure *>(&new_create_info));
-                chassis_state.is_modified |=
-                    PreCallRecordShaderObjectInstrumentation(new_create_info, create_info_loc, instrumentation_data);
+                chassis_state.is_modified |= PreCallRecordShaderObjectInstrumentation(
+                    new_create_info, create_info_loc, instrumentation_data, chassis_state.module_states[i].get());
             } else {
                 // We need to remove the old layouts we copied in safe_VkShaderCreateInfoEXT::initialize
                 if (new_create_info.pSetLayouts) {
@@ -561,8 +565,8 @@ void GpuShaderInstrumentor::PreCallRecordCreateShadersEXT(VkDevice device, uint3
                 }
                 new_create_info.pSetLayouts[instrumentation_desc_set_bind_index_] = instrumentation_desc_layout_[mode];
 
-                chassis_state.is_modified |=
-                    PreCallRecordShaderObjectInstrumentation(new_create_info, create_info_loc, instrumentation_data);
+                chassis_state.is_modified |= PreCallRecordShaderObjectInstrumentation(
+                    new_create_info, create_info_loc, instrumentation_data, chassis_state.module_states[i].get());
             }
         }
     }
@@ -1253,6 +1257,7 @@ bool GpuShaderInstrumentor::PreCallRecordPipelineCreationShaderInstrumentation(
         interface.entry_point_name = stage_state.GetPName();
         interface.entry_point_stage = stage_state.GetStage();
         interface.specialization_info = stage_state.GetSpecializationInfo()->ptr();
+        interface.core_module = stage_state.spirv_state.get();
         const bool is_shader_instrumented = InstrumentShader(modified_module_state->spirv->words_, interface, instrumented_spirv);
         if (is_shader_instrumented) {
             instrumentation_metadata.unique_shader_id = unique_shader_id;
@@ -1450,6 +1455,7 @@ bool GpuShaderInstrumentor::PreCallRecordPipelineCreationShaderInstrumentationGP
             interface.entry_point_name = modified_stage_state.GetPName();
             interface.entry_point_stage = modified_stage_state.GetStage();
             interface.specialization_info = modified_stage_state.GetSpecializationInfo()->ptr();
+            interface.core_module = modified_stage_state.spirv_state.get();
             const bool is_shader_instrumented =
                 InstrumentShader(modified_module_state->spirv->words_, interface, instrumented_spirv);
 

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.h
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.h
@@ -39,6 +39,10 @@ struct ShaderInstrumentationMetadata;
 struct ShaderObjectInstrumentationData;
 }  // namespace chassis
 
+namespace spirv {
+struct Module;
+}
+
 namespace gpuav {
 class Validator;
 
@@ -106,9 +110,10 @@ class GpuShaderInstrumentor : public vvl::DeviceProxy {
                                           const RecordObject &record_obj, chassis::CreateShaderModule &chassis_state) override;
     void PreCallRecordGetShaderBinaryDataEXT(VkDevice device, VkShaderEXT shader, size_t *pDataSize, void *pData,
                                              const RecordObject &record_obj, chassis::ShaderBinaryData &chassis_state) override;
-    bool PreCallRecordShaderObjectInstrumentation(vku::safe_VkShaderCreateInfoEXT &modified_create_info,
-                                                  const Location &create_info_loc,
-                                                  chassis::ShaderObjectInstrumentationData &shader_instrumentation_data);
+    bool PreCallRecordShaderObjectInstrumentation(vku::safe_VkShaderCreateInfoEXT& modified_create_info,
+                                                  const Location& create_info_loc,
+                                                  chassis::ShaderObjectInstrumentationData& shader_instrumentation_data,
+                                                  ::spirv::Module* module_state);
     void PreCallRecordCreateShadersEXT(VkDevice device, uint32_t createInfoCount, const VkShaderCreateInfoEXT *pCreateInfos,
                                        const VkAllocationCallbacks *pAllocator, VkShaderEXT *pShaders,
                                        const RecordObject &record_obj, chassis::ShaderObject &chassis_state) override;

--- a/layers/gpuav/spirv/interface.h
+++ b/layers/gpuav/spirv/interface.h
@@ -24,6 +24,10 @@
 
 struct Location;
 
+namespace spirv {
+struct Module;
+}
+
 namespace gpuav {
 namespace spirv {
 
@@ -80,6 +84,14 @@ struct InstrumentationInterface {
 
     InstrumentationDescriptorSetLayouts instrumentation_dsl;
     const VkSpecializationInfo* specialization_info;
+
+    // There are TWO spirv::Module !??
+    // Yes, it was a very conscious decision to have a "read-only" version in Core Validation be different than the
+    // "read-than-write" framework in GPU-AV as they require drastically different things.
+    //
+    // The GPU-AV version is much lighter, but sometimes there is a real need to make use of the utils found in the Core Validation
+    // version, so when needed, this can be used in instrumentation passes
+    const ::spirv::Module* core_module = nullptr;
 
     const Location& loc;
 

--- a/layers/gpuav/spirv/module.cpp
+++ b/layers/gpuav/spirv/module.cpp
@@ -44,6 +44,8 @@ Module::Module(vvl::span<const uint32_t> words, DebugReport* debug_report, const
       enabled_features_(enabled_features),
       has_bindless_descriptors_(interface.instrumentation_dsl.has_bindless_descriptors),
       debug_report_(debug_report) {
+    assert(interface.core_module);
+
     spirv_iterator it = words.begin();
     header_.magic_number = *it++;
     header_.version = *it++;

--- a/tests/unit/gpu_av_positive.cpp
+++ b/tests/unit/gpu_av_positive.cpp
@@ -2573,3 +2573,33 @@ TEST_F(PositiveGpuAV, SafeBuffers) {
         ASSERT_TRUE(buffer_ci.size == 63);
     }
 }
+
+TEST_F(PositiveGpuAV, ShaderModuleIdentifier) {
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_EXT_SHADER_MODULE_IDENTIFIER_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::pipelineCreationCacheControl);
+    AddRequiredFeature(vkt::Feature::shaderModuleIdentifier);
+    RETURN_IF_SKIP(InitGpuAvFramework());
+    RETURN_IF_SKIP(InitState());
+
+    InitRenderTarget();
+    VkPipelineShaderStageModuleIdentifierCreateInfoEXT sm_id_create_info = vku::InitStructHelper();
+    VkShaderObj vs(*m_device, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
+
+    VkShaderModuleIdentifierEXT get_identifier = vku::InitStructHelper();
+    vk::GetShaderModuleIdentifierEXT(device(), vs, &get_identifier);
+    sm_id_create_info.identifierSize = get_identifier.identifierSize;
+    sm_id_create_info.pIdentifier = get_identifier.identifier;
+
+    VkPipelineShaderStageCreateInfo stage_ci = vku::InitStructHelper(&sm_id_create_info);
+    stage_ci.stage = VK_SHADER_STAGE_VERTEX_BIT;
+    stage_ci.module = VK_NULL_HANDLE;
+    stage_ci.pName = "main";
+
+    CreatePipelineHelper pipe(*this);
+    pipe.gp_ci_.stageCount = 1;
+    pipe.gp_ci_.pStages = &stage_ci;
+    pipe.gp_ci_.flags = VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
+    pipe.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
+    pipe.CreateGraphicsPipeline();
+}


### PR DESCRIPTION
needed for both https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/11717 and my upcoming Mesh GPU-AV PR

... basically my way to solve the fact there are two `spirv::Module`, which I still will stand behind was the right choice long term