### PR TITLE
gpuav: Use Instruction::GetBitWidth

### DIFF
--- a/layers/gpuav/spirv/spec_constant.cpp
+++ b/layers/gpuav/spirv/spec_constant.cpp
@@ -301,7 +301,7 @@ bool Module::ConstantFold(Instruction* inst, const Type& result_type) {
         }
 
         uint64_t lane_result = 0;
-        const uint32_t result_bit_width = scalar_type.ScalarBitWidth();
+        const uint32_t result_bit_width = scalar_type.inst_.GetBitWidth();
         if (target_opcode == spv::OpSConvert || target_opcode == spv::OpUConvert) {
             uint64_t mask = (result_bit_width == 64) ? ~0ULL : (1ULL << result_bit_width) - 1;
             lane_result = args[0] & mask;

--- a/layers/gpuav/spirv/type_manager.cpp
+++ b/layers/gpuav/spirv/type_manager.cpp
@@ -750,16 +750,6 @@ bool Type::Is64Bit() const {
     return false;
 }
 
-uint32_t Type::ScalarBitWidth() const {
-    if (spv_type_ == SpvType::kFloat || spv_type_ == SpvType::kInt) {
-        return inst_.Word(2);
-    } else if (spv_type_ == SpvType::kBool) {
-        return 1;
-    }
-    assert(false);
-    return 0;
-}
-
 uint32_t Constant::GetValueUint32() const {
     assert(inst_.Opcode() == spv::OpConstant || inst_.Opcode() == spv::OpConstantNull);
     return inst_.Opcode() == spv::OpConstantNull ? 0 : inst_.Word(3);

--- a/layers/gpuav/spirv/type_manager.h
+++ b/layers/gpuav/spirv/type_manager.h
@@ -66,7 +66,6 @@ struct Type {
     uint32_t VectorSize() const;
     // 64-bit floats/int take up 2 dwords
     bool Is64Bit() const;
-    uint32_t ScalarBitWidth() const;
 
     const SpvType spv_type_;
     const Instruction& inst_;


### PR DESCRIPTION
I created `ScalarBitWidth` and now realize we had it already in `Instruction` class