### PR TITLE
sync: Add more information to attachment error message

### DIFF
--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -482,7 +482,7 @@ void CommandBufferAccessContext::RecordEndRendering(const RecordObject &record_o
         return;
     }
 
-    auto store_tag = NextCommandTag(record_obj.location.function, ResourceUsageRecord::SubcommandType::kStoreOp);
+    auto store_tag = NextCommandTag(record_obj.location.function, SubCommandType::kStoreOp);
     AccessContext &access_context = *GetCurrentAccessContext();
 
     for (const auto &attachment : dynamic_rendering_info_->attachments) {
@@ -1226,9 +1226,9 @@ ResourceUsageTag CommandBufferAccessContext::RecordBeginRenderPass(vvl::Func com
                                                                    const VkRect2D &render_area,
                                                                    const std::vector<const vvl::ImageView *> &attachment_views) {
     // Create an access context the current renderpass.
-    const auto barrier_tag = NextCommandTag(command, ResourceUsageRecord::SubcommandType::kSubpassTransition);
+    const auto barrier_tag = NextCommandTag(command, SubCommandType::kSubpassTransition, 0);
     AddCommandHandle(barrier_tag, rp_state.Handle());
-    const auto load_tag = NextSubcommandTag(command, ResourceUsageRecord::SubcommandType::kLoadOp);
+    const auto load_tag = NextSubCommandTag(command, SubCommandType::kLoadOp, 0);
     render_pass_contexts_.emplace_back(std::make_unique<RenderPassAccessContext>(
         rp_state, render_area, GetQueueFlags(), attachment_views, cb_access_context_, current_render_pass_instance_id_));
     current_renderpass_context_ = render_pass_contexts_.back().get();
@@ -1241,11 +1241,15 @@ ResourceUsageTag CommandBufferAccessContext::RecordNextSubpass(vvl::Func command
     assert(current_renderpass_context_);
     if (!current_renderpass_context_) return NextCommandTag(command);
 
-    auto store_tag = NextCommandTag(command, ResourceUsageRecord::SubcommandType::kStoreOp);
+    // At this point current subpass value has not updated yet to the index of "next subpass"
+    const uint32_t previous_subpass = current_renderpass_context_->GetCurrentSubpass();
+    const uint32_t this_subpass = previous_subpass + 1;
+
+    auto store_tag = NextCommandTag(command, SubCommandType::kStoreOp, previous_subpass);
     AddCommandHandle(store_tag, current_renderpass_context_->GetRenderPassState()->Handle());
 
-    auto barrier_tag = NextSubcommandTag(command, ResourceUsageRecord::SubcommandType::kSubpassTransition);
-    auto load_tag = NextSubcommandTag(command, ResourceUsageRecord::SubcommandType::kLoadOp);
+    auto barrier_tag = NextSubCommandTag(command, SubCommandType::kSubpassTransition, this_subpass);
+    auto load_tag = NextSubCommandTag(command, SubCommandType::kLoadOp, this_subpass);
 
     current_renderpass_context_->RecordNextSubpass(store_tag, barrier_tag, load_tag);
     current_context_ = &current_renderpass_context_->CurrentContext();
@@ -1256,10 +1260,12 @@ ResourceUsageTag CommandBufferAccessContext::RecordEndRenderPass(vvl::Func comma
     assert(current_renderpass_context_);
     if (!current_renderpass_context_) return NextCommandTag(command);
 
-    auto store_tag = NextCommandTag(command, ResourceUsageRecord::SubcommandType::kStoreOp);
+    const uint32_t current_subpass = current_renderpass_context_->GetCurrentSubpass();
+
+    auto store_tag = NextCommandTag(command, SubCommandType::kStoreOp, current_subpass);
     AddCommandHandle(store_tag, current_renderpass_context_->GetRenderPassState()->Handle());
 
-    auto barrier_tag = NextSubcommandTag(command, ResourceUsageRecord::SubcommandType::kSubpassTransition);
+    auto barrier_tag = NextSubCommandTag(command, SubCommandType::kSubpassTransition);
 
     current_renderpass_context_->RecordEndRenderPass(&cb_access_context_, store_tag, barrier_tag);
     current_context_ = &cb_access_context_;
@@ -1310,11 +1316,11 @@ void CommandBufferAccessContext::ImportRecordedAccessLog(const CommandBufferAcce
     }
 }
 
-ResourceUsageTag CommandBufferAccessContext::NextCommandTag(vvl::Func command, ResourceUsageRecord::SubcommandType subcommand) {
+ResourceUsageTag CommandBufferAccessContext::NextCommandTag(vvl::Func command, SubCommandType subcommand, uint32_t subpass) {
     command_number_++;
     current_command_tag_ = access_log_->size();
 
-    ResourceUsageRecord &record = access_log_->emplace_back(command, command_number_, subcommand, cb_state_, reset_count_);
+    ResourceUsageRecord &record = access_log_->emplace_back(command, command_number_, subcommand, cb_state_, reset_count_, subpass);
 
     if (!cb_state_->GetLabelCommands().empty()) {
         record.label_command_index = static_cast<uint32_t>(cb_state_->GetLabelCommands().size() - 1);
@@ -1323,9 +1329,9 @@ ResourceUsageTag CommandBufferAccessContext::NextCommandTag(vvl::Func command, R
     return current_command_tag_;
 }
 
-ResourceUsageTag CommandBufferAccessContext::NextSubcommandTag(vvl::Func command, ResourceUsageRecord::SubcommandType subcommand) {
+ResourceUsageTag CommandBufferAccessContext::NextSubCommandTag(vvl::Func command, SubCommandType subcommand, uint32_t subpass) {
     const ResourceUsageTag tag = access_log_->size();
-    ResourceUsageRecord &record = access_log_->emplace_back(command, command_number_, subcommand, cb_state_, reset_count_);
+    ResourceUsageRecord &record = access_log_->emplace_back(command, command_number_, subcommand, cb_state_, reset_count_, subpass);
 
     // By default copy handle range from the main command, but can be overwritten with AddSubcommandHandle.
     const auto &main_command_record = (*access_log_)[current_command_tag_];
@@ -1915,12 +1921,11 @@ void CommandBufferSubState::RecordEndRenderPass(const VkSubpassEndInfo *subpass_
 
 void CommandBufferSubState::RecordExecuteCommand(vvl::CommandBuffer &secondary_command_buffer, uint32_t cmd_index,
                                                  const Location &loc) {
-    const auto subcommand = ResourceUsageRecord::SubcommandType::kIndex;
     if (cmd_index == 0) {
-        ResourceUsageTag cb_tag = access_context.NextCommandTag(loc.function, subcommand);
+        ResourceUsageTag cb_tag = access_context.NextCommandTag(loc.function, SubCommandType::kIndex);
         access_context.AddCommandHandleIndexed(cb_tag, secondary_command_buffer.Handle(), cmd_index);
     } else {
-        ResourceUsageTag cb_tag = access_context.NextSubcommandTag(loc.function, subcommand);
+        ResourceUsageTag cb_tag = access_context.NextSubCommandTag(loc.function, SubCommandType::kIndex);
         access_context.AddSubcommandHandleIndexed(cb_tag, secondary_command_buffer.Handle(), cmd_index);
     }
     access_context.RecordExecutedCommandBuffer(*GetAccessContext(secondary_command_buffer));

--- a/layers/sync/sync_commandbuffer.h
+++ b/layers/sync/sync_commandbuffer.h
@@ -84,15 +84,21 @@ struct HandleRecord {
     }
 };
 
+enum class SubCommandType { kNone, kSubpassTransition, kLoadOp, kStoreOp, kResolveOp, kIndex };
+
 // ResourceUsageRecord encodes information about the command that performed the access.
 // It's important to limit the size of this structure. Separate record is stored per access command.
 struct ResourceUsageRecord {
     static constexpr auto kMaxIndex = std::numeric_limits<ResourceUsageTag>::max();
-    enum class SubcommandType { kNone, kSubpassTransition, kLoadOp, kStoreOp, kResolveOp, kIndex };
 
-    ResourceUsageRecord(vvl::Func command, uint32_t seq_num, SubcommandType sub_type, const vvl::CommandBuffer *cb_state,
-                        uint32_t reset_count)
-        : command(command), seq_num(seq_num), sub_command_type(sub_type), cb_state(cb_state), reset_count(reset_count) {}
+    ResourceUsageRecord(vvl::Func command, uint32_t seq_num, SubCommandType sub_type, const vvl::CommandBuffer *cb_state,
+                        uint32_t reset_count, uint32_t subpass = vvl::kNoIndex32)
+        : command(command),
+          seq_num(seq_num),
+          sub_command_type(sub_type),
+          subpass(subpass),
+          cb_state(cb_state),
+          reset_count(reset_count) {}
     ResourceUsageRecord(const AlternateResourceUsage &other) : alt_usage(other) {}
 
     vvl::Func command = vvl::Func::Empty;
@@ -101,7 +107,9 @@ struct ResourceUsageRecord {
     // Currently this indexes only the commands that initiate memory accesses (so are of interest to syncval).
     uint32_t seq_num = 0;
 
-    SubcommandType sub_command_type = SubcommandType::kNone;
+    SubCommandType sub_command_type = SubCommandType::kNone;
+
+    uint32_t subpass = vvl::kNoIndex32;
 
     // This is somewhat repetitive, but it prevents the need for Exec/Submit time touchup, after which usage records can be
     // from different command buffers and resets.
@@ -121,6 +129,8 @@ struct ResourceUsageRecord {
 struct ResourceUsageInfo {
     vvl::Func command = vvl::Func::Empty;
     uint32_t command_seq = vvl::kNoIndex32;
+    SubCommandType sub_command_type = SubCommandType::kNone;
+    uint32_t subpass = vvl::kNoIndex32;
 
     VulkanTypedHandle resource_handle;
     std::string debug_region_name;
@@ -257,9 +267,9 @@ class CommandBufferAccessContext : public CommandExecutionContext, DebugNameProv
         return VulkanTypedHandle(static_cast<VkCommandBuffer>(VK_NULL_HANDLE), kVulkanObjectTypeCommandBuffer);
     }
 
-    ResourceUsageTag NextCommandTag(vvl::Func command,
-                                    ResourceUsageRecord::SubcommandType subcommand = ResourceUsageRecord::SubcommandType::kNone);
-    ResourceUsageTag NextSubcommandTag(vvl::Func command, ResourceUsageRecord::SubcommandType subcommand);
+    ResourceUsageTag NextCommandTag(vvl::Func command, SubCommandType subcommand = SubCommandType::kNone,
+                                    uint32_t subpass = vvl::kNoIndex32);
+    ResourceUsageTag NextSubCommandTag(vvl::Func command, SubCommandType subcommand, uint32_t subpass = vvl::kNoIndex32);
 
     ResourceUsageTagEx AddCommandHandle(ResourceUsageTag tag, const VulkanTypedHandle &typed_handle);
     ResourceUsageTagEx AddCommandHandleIndexed(ResourceUsageTag tag, const VulkanTypedHandle &typed_handle, uint32_t index);

--- a/layers/sync/sync_reporting.cpp
+++ b/layers/sync/sync_reporting.cpp
@@ -436,31 +436,51 @@ std::string FormatErrorMessage(const HazardResult &hazard, const CommandExecutio
     }
     ss << " " << resouce_description << ", which was previously ";
     if (prior_access.access_index == SYNC_PRESENT_ENGINE_SYNCVAL_PRESENT_ACQUIRE_READ_SYNCVAL) {
-        ss << "accessed by ";
+        ss << "accessed ";
     } else if (hazard_info.IsPriorWrite()) {
         if (prior_access.access_index == SYNC_IMAGE_LAYOUT_TRANSITION) {
-            ss << "written during an image layout transition initiated by ";
+            ss << "written during an image layout transition initiated ";
         } else {
-            ss << "written by ";
+            ss << "written ";
         }
     } else {
-        ss << "read by ";
+        ss << "read ";
     }
     if (hazard.Tag() == kInvalidTag) {
         // Invalid tag for prior access means the same command performed ILT before loadOp,
         // resolve before ILT or ILT after storeOp.
-        ss << "the same command";
+        ss << "by the same command";
     } else {
         const ResourceUsageInfo prior_usage_info = context.GetResourceUsageInfo(hazard.TagEx());
-        if (prior_usage_info.command == command) {
-            ss << "another ";
-        }
-        ss << vvl::String(prior_usage_info.command);
-        if (!prior_usage_info.debug_region_name.empty()) {
-            ss << "[" << prior_usage_info.debug_region_name << "]";
-        }
-        if (prior_usage_info.command == command) {
-            ss << " command";
+        const vvl::Func prior_command = prior_usage_info.command;
+        if (prior_usage_info.sub_command_type == SubCommandType::kLoadOp) {
+            if (prior_usage_info.subpass != vvl::kNoIndex32) {
+                ss << "at the beginning of subpass " << prior_usage_info.subpass << " ";
+            } else {
+                ss << "at the beginning of the render pass instance ";
+            }
+            ss << "(" << vvl::String(prior_command) << ") ";
+            ss << "by the attachment loadOp";
+        } else if (prior_usage_info.sub_command_type == SubCommandType::kStoreOp) {
+            if (prior_usage_info.subpass != vvl::kNoIndex32) {
+                ss << "at the end of subpass " << prior_usage_info.subpass << " ";
+            } else {
+                ss << "at the end of the render pass instance ";
+            }
+            ss << "(" << vvl::String(prior_command) << ") ";
+            ss << "by the attachment storeOp";
+        } else {
+            ss << "by ";
+            if (prior_usage_info.command == command) {
+                ss << "another ";
+            }
+            ss << vvl::String(prior_usage_info.command);
+            if (!prior_usage_info.debug_region_name.empty()) {
+                ss << "[" << prior_usage_info.debug_region_name << "]";
+            }
+            if (prior_usage_info.command == command) {
+                ss << " command";
+            }
         }
     }
     if (!additional_info.brief_description_end_text.empty()) {
@@ -618,6 +638,8 @@ static ResourceUsageInfo GetResourceUsageInfoFromRecord(ResourceUsageTagEx tag_e
     } else {
         info.command = record.command;
         info.command_seq = record.seq_num;
+        info.sub_command_type = record.sub_command_type;
+        info.subpass = record.subpass;
         info.command_buffer_reset_count = record.reset_count;
 
         // Associated resource

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -2309,9 +2309,9 @@ bool SyncValidator::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuf
     // Make working copies of the access and events contexts
     for (uint32_t cb_index = 0; cb_index < commandBufferCount; ++cb_index) {
         if (cb_index == 0) {
-            proxy_cb_context.NextCommandTag(error_obj.location.function, ResourceUsageRecord::SubcommandType::kIndex);
+            proxy_cb_context.NextCommandTag(error_obj.location.function, SubCommandType::kIndex);
         } else {
-            proxy_cb_context.NextSubcommandTag(error_obj.location.function, ResourceUsageRecord::SubcommandType::kIndex);
+            proxy_cb_context.NextSubCommandTag(error_obj.location.function, SubCommandType::kIndex);
         }
 
         const auto recorded_cb = Get<vvl::CommandBuffer>(pCommandBuffers[cb_index]);


### PR DESCRIPTION
Add subpass index and whether it's loadOp or storeOp.

> vkCmdCopyImage(): WRITE_AFTER_WRITE hazard detected. vkCmdCopyImage writes to VkImage 0x40000000004, which was previously written at the end of subpass 0 (vkCmdEndRenderPass) by the attachment storeOp. 
No sufficient synchronization is present to ensure that a write (VK_ACCESS_2_TRANSFER_WRITE_BIT) at VK_PIPELINE_STAGE_2_COPY_BIT does not conflict with a prior write (VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT) at VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT.