### PR TITLE
layers: Fix initializing depth stencil state

### DIFF
--- a/layers/chassis/dispatch_object_manual.cpp
+++ b/layers/chassis/dispatch_object_manual.cpp
@@ -1082,7 +1082,10 @@ VkResult Device::CreateGraphicsPipelines(VkDevice device, VkPipelineCache pipeli
             }
 
             const VkFormat *original_color_attachment_formats = nullptr;
-            auto dynamic_rendering = vku::FindStructInPNextChain<VkPipelineRenderingCreateInfo>(pCreateInfos[idx0].pNext);
+            const VkPipelineRenderingCreateInfo *dynamic_rendering = nullptr;
+            if (pCreateInfos[idx0].renderPass == VK_NULL_HANDLE) {
+                dynamic_rendering = vku::FindStructInPNextChain<VkPipelineRenderingCreateInfo>(pCreateInfos[idx0].pNext);
+            }
             if (dynamic_rendering) {
                 if (has_fragment_output_state) {
                     uses_color_attachment = (dynamic_rendering->colorAttachmentCount > 0);


### PR DESCRIPTION
Only initialize `VkGraphicsPipelineCreateInfo::pDepthStencilState` from VkPipelineRenderingCreateInfo if renderPass is NULL.

This fixes a bug where depth and stencil state would not work correctly, when a pipeline is created with a valid renderPass handle and a `VkPipelineRenderingCreateInfo`  in the pNext chain