### PR TITLE
gpuav: Add other atomics to GeneralBufferPass

### DIFF
--- a/layers/gpuav/spirv/descriptor_class_general_buffer_pass.cpp
+++ b/layers/gpuav/spirv/descriptor_class_general_buffer_pass.cpp
@@ -84,8 +84,9 @@ bool DescriptorClassGeneralBufferPass::RequiresInstrumentation(const Function& f
                                                                InstructionMeta& meta) {
     const uint32_t opcode = inst.Opcode();
 
-    if (!IsValueIn(spv::Op(opcode), {spv::OpLoad, spv::OpStore, spv::OpAtomicStore, spv::OpAtomicLoad, spv::OpAtomicExchange,
-                                     spv::OpCooperativeMatrixLoadKHR, spv::OpCooperativeMatrixStoreKHR})) {
+    if (!IsValueIn(spv::Op(opcode),
+                   {spv::OpLoad, spv::OpStore, spv::OpCooperativeMatrixLoadKHR, spv::OpCooperativeMatrixStoreKHR}) &&
+        !AtomicOperation(opcode)) {
         return false;
     }
 

--- a/tests/unit/gpu_av_descriptor_class_general_buffer.cpp
+++ b/tests/unit/gpu_av_descriptor_class_general_buffer.cpp
@@ -2163,6 +2163,22 @@ TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, AtomicExchange) {
     ComputeStorageBufferTest(cs_source, SPV_SOURCE_GLSL, 16, "VUID-vkCmdDispatch-storageBuffers-06936");
 }
 
+TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, AtomicAdd) {
+    const char* cs_source = R"glsl(
+        #version 450
+        #extension GL_KHR_memory_scope_semantics : enable
+        layout(set = 0, binding = 0, std430) buffer foo {
+            uvec4 a;
+            uint b;
+        };
+
+        void main() {
+            atomicAdd(b, 1u);
+        }
+    )glsl";
+    ComputeStorageBufferTest(cs_source, SPV_SOURCE_GLSL, 16, "VUID-vkCmdDispatch-storageBuffers-06936");
+}
+
 TEST_F(NegativeGpuAVDescriptorClassGeneralBuffer, AtomicsDescriptorIndex) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitGpuAvFramework());


### PR DESCRIPTION
the reason is was "store/load/exchange" only is because those are the only 3 allowed for image atomics and this code was originally part of single "descriptor indexing" check long ago