### PR TITLE
gpuav: Handle explicit layouts when linking

### DIFF
--- a/layers/gpuav/spirv/module.cpp
+++ b/layers/gpuav/spirv/module.cpp
@@ -610,12 +610,12 @@ void Module::LinkFunctions(const LinkInfo& info) {
                 case SpvType::kArray: {
                     const Type* element_type = type_manager_.FindTypeById(id_swap_map[new_inst->Word(2)]);
                     const Constant* element_length = type_manager_.FindConstantById(id_swap_map[new_inst->Word(3)]);
-                    type_id = type_manager_.GetTypeArray(*element_type, *element_length).Id();
+                    type_id = type_manager_.GetTypeArray(*element_type, *element_length, false).Id();
                     break;
                 }
                 case SpvType::kRuntimeArray: {
                     const Type* element_type = type_manager_.FindTypeById(id_swap_map[new_inst->Word(2)]);
-                    type_id = type_manager_.GetTypeRuntimeArray(*element_type).Id();
+                    type_id = type_manager_.GetTypeRuntimeArray(*element_type, false).Id();
                     break;
                 }
                 case SpvType::kVector: {
@@ -646,7 +646,7 @@ void Module::LinkFunctions(const LinkInfo& info) {
                     } else {
                         spv::StorageClass storage_class = spv::StorageClass(new_inst->Word(2));
                         const Type* pointer_type = type_manager_.FindTypeById(id_swap_map[new_inst->Word(3)]);
-                        type_id = type_manager_.GetTypePointer(storage_class, *pointer_type).Id();
+                        type_id = type_manager_.GetTypePointer(storage_class, *pointer_type, false).Id();
                     }
                     break;
                 }

--- a/layers/gpuav/spirv/type_manager.cpp
+++ b/layers/gpuav/spirv/type_manager.cpp
@@ -129,6 +129,7 @@ const Type& TypeManager::AddType(std::unique_ptr<Instruction> new_inst, SpvType 
 // We don't want to waste time trying to look up potential recursive struct type
 // This is added for those we want to spend time to not duplicate and link with.
 // We also will hit spirv-val errors if using 2 OpTypeStruct, even if same internals
+// (https://gitlab.khronos.org/spirv/SPIR-V/-/issues/918)
 void TypeManager::AddStructTypeForLinking(const Type* new_type) {
     assert(new_type && new_type->spv_type_ == SpvType::kStruct);
     linking_struct_types_.push_back(new_type);
@@ -284,12 +285,14 @@ const Type& TypeManager::GetTypeFloat(uint32_t bit_width) {
     return AddType(std::move(new_inst), SpvType::kFloat);
 }
 
-const Type& TypeManager::GetTypeArray(const Type& element_type, const Constant& length) {
-    for (const auto type : array_types_) {
-        const Type* this_element_type = FindTypeById(type->inst_.Word(2));
-        if (this_element_type && (*this_element_type == element_type)) {
-            if (type->inst_.Word(3) == length.Id()) {
-                return *type;
+const Type& TypeManager::GetTypeArray(const Type& element_type, const Constant& length, bool get_explicit_layout) {
+    if (get_explicit_layout || !IsExplicitLayoutType(element_type)) {
+        for (const auto type : array_types_) {
+            const Type* this_element_type = FindTypeById(type->inst_.Word(2));
+            if (this_element_type && (*this_element_type == element_type)) {
+                if (type->inst_.Word(3) == length.Id()) {
+                    return *type;
+                }
             }
         }
     }
@@ -300,11 +303,13 @@ const Type& TypeManager::GetTypeArray(const Type& element_type, const Constant& 
     return AddType(std::move(new_inst), SpvType::kArray);
 }
 
-const Type& TypeManager::GetTypeRuntimeArray(const Type& element_type) {
-    for (const auto type : runtime_array_types_) {
-        const Type* this_element_type = FindTypeById(type->inst_.Word(2));
-        if (this_element_type && (*this_element_type == element_type)) {
-            return *type;
+const Type& TypeManager::GetTypeRuntimeArray(const Type& element_type, bool get_explicit_layout) {
+    if (get_explicit_layout || !IsExplicitLayoutType(element_type)) {
+        for (const auto type : runtime_array_types_) {
+            const Type* this_element_type = FindTypeById(type->inst_.Word(2));
+            if (this_element_type && (*this_element_type == element_type)) {
+                return *type;
+            }
         }
     }
 
@@ -364,15 +369,17 @@ const Type& TypeManager::GetTypeSampledImage(const Type& image_type) {
     return AddType(std::move(new_inst), SpvType::kSampledImage);
 }
 
-const Type& TypeManager::GetTypePointer(spv::StorageClass storage_class, const Type& pointer_type) {
-    for (const auto type : pointer_types_) {
-        if (type->inst_.Word(2) != storage_class) {
-            continue;
-        }
+const Type& TypeManager::GetTypePointer(spv::StorageClass storage_class, const Type& pointer_type, bool get_explicit_layout) {
+    if (get_explicit_layout || !IsExplicitLayoutType(pointer_type)) {
+        for (const auto type : pointer_types_) {
+            if (type->inst_.Word(2) != storage_class) {
+                continue;
+            }
 
-        const Type* this_pointer_type = FindTypeById(type->inst_.Word(3));
-        if (this_pointer_type && (*this_pointer_type == pointer_type)) {
-            return *type;
+            const Type* this_pointer_type = FindTypeById(type->inst_.Word(3));
+            if (this_pointer_type && (*this_pointer_type == pointer_type)) {
+                return *type;
+            }
         }
     }
 
@@ -848,6 +855,11 @@ uint32_t TypeManager::GetNumScalarElementsBeforeCompositeMember(const Type& type
     }
     return count;
 }
+
+// This stems from the fact even if you have two OpTypeStruct that are the EXACT SAME, it is not valid to mix and match them
+// (https://gitlab.khronos.org/spirv/SPIR-V/-/issues/918) The idea is when linking, to ignore anything that has any reference to an
+// explicit layout types (like structs) that might collide with our incoming GLSL code
+bool TypeManager::IsExplicitLayoutType(const Type& type) const { return type.spv_type_ == SpvType::kStruct; }
 
 }  // namespace spirv
 }  // namespace gpuav

--- a/layers/gpuav/spirv/type_manager.h
+++ b/layers/gpuav/spirv/type_manager.h
@@ -131,12 +131,12 @@ class TypeManager {
     const Type& GetTypeAccelerationStructure();
     const Type& GetTypeInt(uint32_t bit_width, bool is_signed);
     const Type& GetTypeFloat(uint32_t bit_width);
-    const Type& GetTypeArray(const Type& element_type, const Constant& length);
-    const Type& GetTypeRuntimeArray(const Type& element_type);
+    const Type& GetTypeArray(const Type& element_type, const Constant& length, bool get_explicit_layout = true);
+    const Type& GetTypeRuntimeArray(const Type& element_type, bool get_explicit_layout = true);
     const Type& GetTypeVector(const Type& component_type, uint32_t component_count);
     const Type& GetTypeMatrix(const Type& column_type, uint32_t column_count);
     const Type& GetTypeSampledImage(const Type& image_type);
-    const Type& GetTypePointer(spv::StorageClass storage_class, const Type& pointer_type);
+    const Type& GetTypePointer(spv::StorageClass storage_class, const Type& pointer_type, bool get_explicit_layout = true);
     const Type& GetTypePointerBuiltInInput(spv::BuiltIn built_in);
     uint32_t TypeLength(const Type& type);
 
@@ -230,6 +230,8 @@ class TypeManager {
 
     // The use of OpUndef is sometime misused, we store all OpUndef here as way to check if we have it one by accident
     vvl::unordered_set<uint32_t> undef_ids_;
+
+    bool IsExplicitLayoutType(const Type& type) const;
 };
 
 }  // namespace spirv

--- a/tests/unit/gpu_av_buffer_device_address_positive.cpp
+++ b/tests/unit/gpu_av_buffer_device_address_positive.cpp
@@ -2644,3 +2644,40 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, DualShaderLibraryDestroyModule) {
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     ASSERT_TRUE(exe_pipe.initialized());
 }
+
+TEST_F(PositiveGpuAVBufferDeviceAddress, LinkingSameStruct) {
+    TEST_DESCRIPTION("https://gitlab.khronos.org/spirv/SPIR-V/-/issues/918");
+    RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
+
+    const char* shader_source = R"glsl(
+        #version 450
+        #extension GL_EXT_buffer_reference : require
+        #extension GL_EXT_scalar_block_layout : require
+        #extension GL_ARB_gpu_shader_int64 : require
+
+        // Matches that foudn in inst_buffer_device_address_range()
+        // to ensure the linking of structs work
+        struct Range {
+            uint64_t a;
+            uint64_t b;
+        };
+
+        layout(buffer_reference, buffer_reference_align = 8, scalar) buffer BufferDeviceAddressRanges {
+            Range bda_ranges;
+        };
+
+        layout(set = 0, binding = 0, scalar) buffer BuffAddrInputBuffer {
+            BufferDeviceAddressRanges bda_ranges_ptr;
+        };
+
+        void main() {
+            Range cache_range = bda_ranges_ptr.bda_ranges;
+            cache_range.a = 0;
+        }
+    )glsl";
+
+    CreateComputePipelineHelper pipe(*this);
+    pipe.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr};
+    pipe.cs_ = VkShaderObj(*m_device, shader_source, VK_SHADER_STAGE_COMPUTE_BIT);
+    pipe.CreateComputePipeline();
+}


### PR DESCRIPTION
fixes an annoying issue around explicit layout, basically (for anyone who cares) when we link, we need to be careful that anything referencing a struct (such as a OpTypePointer or OpTypeArray) creates its own copy, or else we run into the situation where we fail `spirv-val` 