### PR TITLE
sync: Detect loadOp and storeOp subpass per view

### DIFF
--- a/layers/containers/small_vector.h
+++ b/layers/containers/small_vector.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,7 +64,8 @@ class small_vector {
         other.clear();
     }
 
-    small_vector(size_type size, const value_type &value = value_type()) : size_(0), capacity_(N), working_store_(GetSmallStore()) {
+    explicit small_vector(size_type size, const value_type &value = value_type())
+        : size_(0), capacity_(N), working_store_(GetSmallStore()) {
         if (size > 0) {
             reserve(size);
             auto dest = GetWorkingStore();

--- a/layers/state_tracker/render_pass_state.cpp
+++ b/layers/state_tracker/render_pass_state.cpp
@@ -18,9 +18,10 @@
  */
 
 #include "state_tracker/render_pass_state.h"
-#include "utils/convert_utils.h"
 #include "state_tracker/image_state.h"
 #include "containers/span.h"
+#include "utils/convert_utils.h"
+#include "utils/math_utils.h"
 
 // Defined according to spec (check VkSubpassDependency documentation)
 static VkSubpassDependency2 ImplicitDependencyFromExternal(uint32_t subpass) {
@@ -125,30 +126,39 @@ static void RecordRenderPassDAG(const VkRenderPassCreateInfo2 *pCreateInfo, vvl:
 
 struct AttachmentTracker {  // This is really only of local interest, but a bit big for a lambda
     vvl::RenderPass &rp;
-    std::vector<uint32_t> &first;
-    std::vector<uint32_t> &last;
+    std::vector<vvl::RenderPass::SubpassPerView> &first;
+    std::vector<vvl::RenderPass::SubpassPerView> &last;
     std::vector<std::vector<vvl::RenderPass::AttachmentTransition>> &subpass_transitions;
-    const uint32_t attachment_count;
     std::vector<VkImageLayout> attachment_layout;
     std::vector<std::vector<VkImageLayout>> subpass_attachment_layout;
-    explicit AttachmentTracker(vvl::RenderPass &render_pass)
+
+    explicit AttachmentTracker(vvl::RenderPass &render_pass, int32_t max_view_index)
         : rp(render_pass),
-          first(const_cast<std::vector<uint32_t> &>(rp.attachment_first_subpass)),
-          last(const_cast<std::vector<uint32_t> &>(rp.attachment_last_subpass)),
+          first(const_cast<std::vector<vvl::RenderPass::SubpassPerView> &>(rp.attachment_first_subpass)),
+          last(const_cast<std::vector<vvl::RenderPass::SubpassPerView> &>(rp.attachment_last_subpass)),
           subpass_transitions(
-              const_cast<std::vector<std::vector<vvl::RenderPass::AttachmentTransition>> &>(rp.subpass_transitions)),
-          attachment_count(rp.create_info.attachmentCount),
-          attachment_layout(),
-          subpass_attachment_layout() {
-        first.resize(attachment_count, VK_SUBPASS_EXTERNAL);
-        last.resize(attachment_count, VK_SUBPASS_EXTERNAL);
-        subpass_transitions.resize(rp.create_info.subpassCount + 1);  // Add an extra for EndRenderPass
-        attachment_layout.reserve(attachment_count);
+              const_cast<std::vector<std::vector<vvl::RenderPass::AttachmentTransition>> &>(rp.subpass_transitions)) {
+        const uint32_t attachment_count = rp.create_info.attachmentCount;
+
+        first.resize(attachment_count);
+        for (auto &subpass_per_view : first) {
+            subpass_per_view.resize(max_view_index + 1, VK_SUBPASS_EXTERNAL);
+        }
+
+        last.resize(attachment_count);
+        for (auto &subpass_per_view : last) {
+            subpass_per_view.resize(max_view_index + 1, VK_SUBPASS_EXTERNAL);
+        }
+
+        // Add an extra for final transition
+        subpass_transitions.resize(rp.create_info.subpassCount + 1);
+
         subpass_attachment_layout.resize(rp.create_info.subpassCount);
         for (auto &subpass_layouts : subpass_attachment_layout) {
             subpass_layouts.resize(attachment_count, kInvalidLayout);
         }
 
+        attachment_layout.reserve(attachment_count);
         for (uint32_t j = 0; j < attachment_count; j++) {
             attachment_layout.push_back(rp.create_info.pAttachments[j].initialLayout);
         }
@@ -173,24 +183,40 @@ struct AttachmentTracker {  // This is really only of local interest, but a bit 
         }
     }
 
-    void Update(uint32_t subpass, const VkAttachmentReference2 *attach_ref, uint32_t count, bool is_read) {
-        if (nullptr == attach_ref) return;
-        for (uint32_t j = 0; j < count; ++j) {
+    void Update(uint32_t subpass, uint32_t view_mask, const VkAttachmentReference2 *attach_ref, uint32_t count) {
+        if (!attach_ref) {
+            return;
+        }
+        // Disabled multiview is equivalent to a single view in the context of this function.
+        // This allows unified code without branching on whether a view mask is specified
+        if (view_mask == 0) {
+            view_mask = 1;
+        }
+        const auto view_indices = GetSetBitIndices(view_mask);
+
+        for (uint32_t j = 0; j < count; j++) {
             const auto attachment = attach_ref[j].attachment;
             if (attachment != VK_ATTACHMENT_UNUSED) {
                 const auto layout = attach_ref[j].layout;
                 const auto initial_layout = rp.create_info.pAttachments[attachment].initialLayout;
                 bool no_external_transition = true;
-                if (first[attachment] == VK_SUBPASS_EXTERNAL) {
-                    first[attachment] = subpass;
-                    if (initial_layout != layout) {
-                        subpass_transitions[subpass].emplace_back(
-                            vvl::RenderPass::AttachmentTransition{VK_SUBPASS_EXTERNAL, attachment, initial_layout, layout});
-                        no_external_transition = false;
+
+                // Initial transition
+                bool first_transition = true;
+                for (uint32_t subpass_per_view : first[attachment]) {
+                    // Check if earlier or this subpass already registered transition
+                    if (subpass_per_view != VK_SUBPASS_EXTERNAL) {
+                        assert(subpass_per_view <= subpass);
+                        first_transition = false;
+                        break;
                     }
                 }
-                last[attachment] = subpass;
-
+                if (first_transition && initial_layout != layout) {
+                    subpass_transitions[subpass].emplace_back(
+                        vvl::RenderPass::AttachmentTransition{VK_SUBPASS_EXTERNAL, attachment, initial_layout, layout});
+                    no_external_transition = false;
+                }
+                // Transition between subpasses
                 for (const auto &[src_subpass, _] : rp.subpass_dependency_infos[subpass].dependencies) {
                     const auto prev_layout = subpass_attachment_layout[src_subpass][attachment];
                     if ((prev_layout != kInvalidLayout) && (prev_layout != layout)) {
@@ -198,10 +224,10 @@ struct AttachmentTracker {  // This is really only of local interest, but a bit 
                             vvl::RenderPass::AttachmentTransition{src_subpass, attachment, prev_layout, layout});
                     }
                 }
-
-                if (no_external_transition && (rp.subpass_dependency_infos[subpass].dependencies.empty())) {
-                    // This will insert a layout transition when dependencies are missing between first and subsequent use
-                    // but is consistent with the idea of an implicit external dependency
+                // This will insert a layout transition when dependencies are missing between first and subsequent use
+                // but is consistent with the idea of an implicit external dependency
+                // TODO: why do we check that dependencies is empty?
+                if (no_external_transition && rp.subpass_dependency_infos[subpass].dependencies.empty()) {
                     if (initial_layout != layout) {
                         subpass_transitions[subpass].emplace_back(
                             vvl::RenderPass::AttachmentTransition{VK_SUBPASS_EXTERNAL, attachment, initial_layout, layout});
@@ -210,17 +236,43 @@ struct AttachmentTracker {  // This is really only of local interest, but a bit 
 
                 attachment_layout[attachment] = layout;
                 subpass_attachment_layout[subpass][attachment] = layout;
+
+                // Update the first/last subpass that attachment was used in
+                for (uint32_t view_index : view_indices) {
+                    if (first[attachment][view_index] == VK_SUBPASS_EXTERNAL) {
+                        first[attachment][view_index] = subpass;
+                    }
+                }
+                for (uint32_t view_index : view_indices) {
+                    last[attachment][view_index] = subpass;
+                }
             }
         }
     }
-    void FinalTransitions() {
-        auto &final_transitions = subpass_transitions[rp.create_info.subpassCount];
 
+    void FinalTransitions() {
+        // The last subpass that used the attachment is the maximum SubpassPerView value
+        // that is not VK_SUBPASS_EXTERNAL.
+        auto get_last_subpass = [](const vvl::RenderPass::SubpassPerView &subpass_per_view) {
+            uint32_t max_subpass = VK_SUBPASS_EXTERNAL;
+            for (uint32_t subpass : subpass_per_view) {
+                if (max_subpass == VK_SUBPASS_EXTERNAL) {
+                    max_subpass = subpass;
+                } else if (subpass != VK_SUBPASS_EXTERNAL) {
+                    // It's safe to use max function here, because both arguments are not VK_SUBPASS_EXTERNAL
+                    max_subpass = std::max(max_subpass, subpass);
+                }
+            }
+            return max_subpass;
+        };
+        // Final transitions
+        const uint32_t attachment_count = rp.create_info.attachmentCount;
         for (uint32_t attachment = 0; attachment < attachment_count; ++attachment) {
             const auto final_layout = rp.create_info.pAttachments[attachment].finalLayout;
-            // Add final transitions for attachments that were used and change layout.
-            if ((last[attachment] != VK_SUBPASS_EXTERNAL) && final_layout != attachment_layout[attachment]) {
-                final_transitions.emplace_back(vvl::RenderPass::AttachmentTransition{last[attachment], attachment,
+            const uint32_t last_transition_subpass = get_last_subpass(last[attachment]);
+            if (last_transition_subpass != VK_SUBPASS_EXTERNAL && final_layout != attachment_layout[attachment]) {
+                auto &final_transitions = subpass_transitions[rp.create_info.subpassCount];
+                final_transitions.emplace_back(vvl::RenderPass::AttachmentTransition{last_transition_subpass, attachment,
                                                                                      attachment_layout[attachment], final_layout});
             }
         }
@@ -244,14 +296,20 @@ static void InitRenderPassState(vvl::RenderPass &render_pass) {
 
     RecordRenderPassDAG(create_info, render_pass);
 
-    AttachmentTracker attachment_tracker(render_pass);
+    uint32_t all_view_mask = 0;
+    for (const auto &subpass : vvl::make_span(create_info->pSubpasses, create_info->subpassCount)) {
+        all_view_mask |= subpass.viewMask;
+    }
+    const uint32_t max_view_index = all_view_mask ? MostSignificantBit(all_view_mask) : 0;
+
+    AttachmentTracker attachment_tracker(render_pass, max_view_index);
 
     for (uint32_t subpass_index = 0; subpass_index < create_info->subpassCount; ++subpass_index) {
         const VkSubpassDescription2 &subpass = create_info->pSubpasses[subpass_index];
-        attachment_tracker.Update(subpass_index, subpass.pColorAttachments, subpass.colorAttachmentCount, false);
-        attachment_tracker.Update(subpass_index, subpass.pResolveAttachments, subpass.colorAttachmentCount, false);
-        attachment_tracker.Update(subpass_index, subpass.pDepthStencilAttachment, 1, false);
-        attachment_tracker.Update(subpass_index, subpass.pInputAttachments, subpass.inputAttachmentCount, true);
+        attachment_tracker.Update(subpass_index, subpass.viewMask, subpass.pColorAttachments, subpass.colorAttachmentCount);
+        attachment_tracker.Update(subpass_index, subpass.viewMask, subpass.pResolveAttachments, subpass.colorAttachmentCount);
+        attachment_tracker.Update(subpass_index, subpass.viewMask, subpass.pDepthStencilAttachment, 1);
+        attachment_tracker.Update(subpass_index, subpass.viewMask, subpass.pInputAttachments, subpass.inputAttachmentCount);
         attachment_tracker.Update(subpass_index, subpass.pPreserveAttachments, subpass.preserveAttachmentCount);
     }
     attachment_tracker.FinalTransitions();

--- a/layers/state_tracker/render_pass_state.h
+++ b/layers/state_tracker/render_pass_state.h
@@ -94,13 +94,19 @@ class RenderPass : public StateObject {
     // Dependency information for each subpass
     const std::vector<SubpassDependencyInfo> subpass_dependency_infos;  // [subpassCount]
 
-    // For each attachment, the index of the first subpass that uses it.
-    // VK_SUBPASS_EXTERNAL if the attachment is unused.
-    const std::vector<uint32_t> attachment_first_subpass;  // [attachmentCount]
+    // Maps view index to subpass index: subpass = SubpassPerView[view_index].
+    // If multiview is not used then this stores a single subpass index as the first element
+    using SubpassPerView = small_vector<uint32_t, 2>;
 
-    // For each attachment, the index of the last subpass that uses it.
+    // For each attachment, the first subpass that uses it.
     // VK_SUBPASS_EXTERNAL if the attachment is unused.
-    const std::vector<uint32_t> attachment_last_subpass;  // [attachmentCount]
+    // If multiview is enabled, the subpass is tracked per view
+    const std::vector<SubpassPerView> attachment_first_subpass;  // [attachmentCount]
+
+    // For each attachment, the last subpass that uses it.
+    // VK_SUBPASS_EXTERNAL if the attachment is unused.
+    // If multiview is enabled the subpass is defined per view
+    const std::vector<SubpassPerView> attachment_last_subpass;  // [attachmentCount]
 
     struct AttachmentTransition {
         // Subpass index or VK_SUBPASS_EXTERNAL for transitions from initialLayout.

--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -1223,6 +1223,7 @@ bool SyncOpBeginRenderPass::Validate(const CommandBufferAccessContext &cb_contex
     auto &rp_state = *rp_state_.get();
 
     const uint32_t subpass = 0;
+    const uint32_t view_mask = rp_state_->create_info.pSubpasses[0].viewMask;
 
     // Construct the state to validate against (since validation is const and RecordCmdBeginRenderPass hasn't happened yet).
     // TODO: investigate if using nullptr in InitFrom is safe (this just follows the initial implementation - it assumes
@@ -1243,13 +1244,13 @@ bool SyncOpBeginRenderPass::Validate(const CommandBufferAccessContext &cb_contex
     // operations (though it's currently a messy approach)
     const AttachmentViewGenVector view_gens = RenderPassAccessContext::CreateAttachmentViewGen(render_area, attachments_);
     skip |= RenderPassAccessContext::ValidateLayoutTransitions(cb_context, temp_context, rp_state, render_area,
-                                                               render_pass_instance_id, subpass, view_gens, command_);
+                                                               render_pass_instance_id, subpass, view_mask, view_gens, command_);
 
     // Validate load operations if there were no layout transition hazards
     if (!skip) {
         RenderPassAccessContext::RecordLayoutTransitions(rp_state, subpass, view_gens, kInvalidTag, temp_context);
         skip |= RenderPassAccessContext::ValidateLoadOperation(cb_context, temp_context, rp_state, render_area,
-                                                               render_pass_instance_id, subpass, view_gens, command_);
+                                                               render_pass_instance_id, subpass, view_mask, view_gens, command_);
     }
 
     return skip;

--- a/layers/sync/sync_renderpass.cpp
+++ b/layers/sync/sync_renderpass.cpp
@@ -22,6 +22,7 @@
 #include "sync/sync_image.h"
 #include "state_tracker/render_pass_state.h"
 #include "state_tracker/pipeline_state.h"
+#include "utils/math_utils.h"
 
 namespace syncval {
 
@@ -127,16 +128,29 @@ static SyncAccessIndex DepthStencilLoadUsage(VkAttachmentLoadOp load_op) {
     return GetLoadOpUsageIndex(load_op, AttachmentType::kDepth);
 }
 
+static bool IsSubpassIncluded(uint32_t subpass, const vvl::RenderPass::SubpassPerView &subpass_per_view, uint32_t view_mask) {
+    if (view_mask == 0) {
+        return subpass_per_view[0] == subpass;
+    }
+    const auto view_indices = GetSetBitIndices(view_mask);
+    for (uint8_t view_index : view_indices) {
+        if (subpass_per_view[view_index] == subpass) {
+            return true;
+        }
+    }
+    return false;
+}
+
 // Caller must manage returned pointer
 static AccessContext *CreateStoreResolveProxyContext(const AccessContext &context, const vvl::RenderPass &rp_state,
-                                                     uint32_t render_pass_instance_id, uint32_t subpass,
+                                                     uint32_t render_pass_instance_id, uint32_t subpass, uint32_t view_mask,
                                                      const AttachmentViewGenVector &attachment_views) {
     auto *proxy = new AccessContext(*context.validator);
     proxy->InitFrom(context);
     RenderPassAccessContext::UpdateAttachmentResolveAccess(rp_state, attachment_views, render_pass_instance_id, subpass,
                                                            kInvalidTag, *proxy);
-    RenderPassAccessContext::UpdateAttachmentStoreAccess(rp_state, attachment_views, render_pass_instance_id, subpass, kInvalidTag,
-                                                         *proxy);
+    RenderPassAccessContext::UpdateAttachmentStoreAccess(rp_state, attachment_views, render_pass_instance_id, subpass, view_mask,
+                                                         kInvalidTag, *proxy);
     return proxy;
 }
 
@@ -144,8 +158,8 @@ static AccessContext *CreateStoreResolveProxyContext(const AccessContext &contex
 bool RenderPassAccessContext::ValidateLayoutTransitions(const CommandBufferAccessContext &cb_context,
                                                         const AccessContext &access_context, const vvl::RenderPass &rp_state,
                                                         const VkRect2D &render_area, uint32_t render_pass_instance_id,
-                                                        uint32_t subpass, const AttachmentViewGenVector &attachment_views,
-                                                        vvl::Func command) {
+                                                        uint32_t subpass, uint32_t view_mask,
+                                                        const AttachmentViewGenVector &attachment_views, vvl::Func command) {
     bool skip = false;
     // As validation methods are const and precede the record/update phase, for any tranistions from the immediately
     // previous subpass, we have to validate them against a copy of the AccessContext, with resolve operations applied, as
@@ -170,7 +184,7 @@ bool RenderPassAccessContext::ValidateLayoutTransitions(const CommandBufferAcces
                 // Proxy depends on current iteration (transition.src_subpass), so it should be recreated
                 // each time when needed. Write a test that exposes this and make a fix.
                 src_context_proxy.reset(CreateStoreResolveProxyContext(*subpass_barrier.src_subpass_context, rp_state,
-                                                                       render_pass_instance_id, transition.src_subpass,
+                                                                       render_pass_instance_id, transition.src_subpass, view_mask,
                                                                        attachment_views));
                 proxy_subpass_barrier = subpass_barrier;
                 proxy_subpass_barrier.src_subpass_context = src_context_proxy.get();
@@ -211,7 +225,8 @@ bool RenderPassAccessContext::ValidateLayoutTransitions(const CommandBufferAcces
 bool RenderPassAccessContext::ValidateLoadOperation(const CommandBufferAccessContext &cb_context,
                                                     const AccessContext &access_context, const vvl::RenderPass &rp_state,
                                                     const VkRect2D &render_area, uint32_t render_pass_instance_id, uint32_t subpass,
-                                                    const AttachmentViewGenVector &attachment_views, vvl::Func command) {
+                                                    uint32_t view_mask, const AttachmentViewGenVector &attachment_views,
+                                                    vvl::Func command) {
     bool skip = false;
 
     AttachmentAccess attachment_access;
@@ -220,7 +235,7 @@ bool RenderPassAccessContext::ValidateLoadOperation(const CommandBufferAccessCon
     attachment_access.subpass = subpass;
 
     for (uint32_t i = 0; i < rp_state.create_info.attachmentCount; i++) {
-        if (subpass == rp_state.attachment_first_subpass[i]) {
+        if (IsSubpassIncluded(subpass, rp_state.attachment_first_subpass[i], view_mask)) {
             const auto &view_gen = attachment_views[i];
             const auto &ci = rp_state.create_info.pAttachments[i];
 
@@ -242,9 +257,9 @@ bool RenderPassAccessContext::ValidateLoadOperation(const CommandBufferAccessCon
 
             bool checked_stencil = false;
             if (is_color && (load_index != SYNC_ACCESS_INDEX_NONE)) {
-                ImageRangeGen attachment_range_gen = view_gen.GetRangeGen(AttachmentViewGen::Gen::kRenderArea);
                 attachment_access.ordering = SyncOrdering::kColorAttachment;
-                hazard = access_context.DetectAttachmentHazard(attachment_range_gen, load_index, attachment_access);
+                hazard = access_context.DetectAttachmentHazard(view_gen, AttachmentViewGen::Gen::kRenderArea, load_index,
+                                                               attachment_access, view_mask);
                 aspect = "color";
             } else {
                 if (has_depth && (load_index != SYNC_ACCESS_INDEX_NONE)) {
@@ -298,9 +313,10 @@ bool RenderPassAccessContext::ValidateStoreOperation(const CommandBufferAccessCo
     bool skip = false;
 
     const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kRaster, AttachmentAccessType::StoreOp);
+    const uint32_t view_mask = rp_state_->create_info.pSubpasses[current_subpass_].viewMask;
 
     for (uint32_t i = 0; i < rp_state_->create_info.attachmentCount; i++) {
-        if (current_subpass_ == rp_state_->attachment_last_subpass[i]) {
+        if (IsSubpassIncluded(current_subpass_, rp_state_->attachment_last_subpass[i], view_mask)) {
             const AttachmentViewGen &view_gen = attachment_views_[i];
             const auto &ci = rp_state_->create_info.pAttachments[i];
 
@@ -317,7 +333,6 @@ bool RenderPassAccessContext::ValidateStoreOperation(const CommandBufferAccessCo
             const char *aspect = nullptr;
             bool checked_stencil = false;
             if (is_color) {
-                uint32_t view_mask = rp_state_->create_info.pSubpasses[current_subpass_].viewMask;
                 hazard = CurrentContext().DetectAttachmentHazard(view_gen, AttachmentViewGen::Gen::kRenderArea,
                                                                  SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE,
                                                                  attachment_access, view_mask);
@@ -488,7 +503,7 @@ void RenderPassAccessContext::UpdateAttachmentResolveAccess(const vvl::RenderPas
 
 void RenderPassAccessContext::UpdateAttachmentStoreAccess(const vvl::RenderPass &rp_state,
                                                           const AttachmentViewGenVector &attachment_views,
-                                                          uint32_t render_pass_instance_id, uint32_t subpass,
+                                                          uint32_t render_pass_instance_id, uint32_t subpass, uint32_t view_mask,
                                                           const ResourceUsageTag tag, AccessContext &access_context) {
     AttachmentAccess attachment_access;
     attachment_access.type = AttachmentAccessType::StoreOp;
@@ -497,7 +512,7 @@ void RenderPassAccessContext::UpdateAttachmentStoreAccess(const vvl::RenderPass 
     attachment_access.subpass = subpass;
 
     for (uint32_t i = 0; i < rp_state.create_info.attachmentCount; i++) {
-        if (rp_state.attachment_last_subpass[i] == subpass) {
+        if (IsSubpassIncluded(subpass, rp_state.attachment_last_subpass[i], view_mask)) {
             const auto &view_gen = attachment_views[i];
 
             const auto &ci = rp_state.create_info.pAttachments[i];
@@ -509,7 +524,7 @@ void RenderPassAccessContext::UpdateAttachmentStoreAccess(const vvl::RenderPass 
             if (is_color && store_op_stores) {
                 access_context.UpdateAttachmentAccessState(view_gen, AttachmentViewGen::Gen::kRenderArea,
                                                            SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, attachment_access,
-                                                           ResourceUsageTagEx{tag});
+                                                           ResourceUsageTagEx{tag}, view_mask);
             } else {
                 if (has_depth && store_op_stores) {
                     access_context.UpdateAttachmentAccessState(view_gen, AttachmentViewGen::Gen::kDepthOnlyRenderArea,
@@ -709,9 +724,10 @@ bool RenderPassAccessContext::ValidateNextSubpass(const CommandBufferAccessConte
     if (next_subpass >= rp_state_->create_info.subpassCount) {
         return skip;
     }
+    const uint32_t next_subpass_view_mask = rp_state_->create_info.pSubpasses[next_subpass].viewMask;
     const auto &next_context = subpass_contexts_[next_subpass];
     skip |= ValidateLayoutTransitions(cb_context, next_context, *rp_state_, render_area_, render_pass_instance_id_, next_subpass,
-                                      attachment_views_, command);
+                                      next_subpass_view_mask, attachment_views_, command);
     if (!skip) {
         // To avoid complex (and buggy) duplication of the affect of layout transitions on load operations, we'll record them
         // on a copy of the (empty) next context.
@@ -720,7 +736,7 @@ bool RenderPassAccessContext::ValidateNextSubpass(const CommandBufferAccessConte
         temp_context.InitFrom(next_context);
         RecordLayoutTransitions(*rp_state_, next_subpass, attachment_views_, kInvalidTag, temp_context);
         skip |= ValidateLoadOperation(cb_context, temp_context, *rp_state_, render_area_, render_pass_instance_id_, next_subpass,
-                                      attachment_views_, command);
+                                      next_subpass_view_mask, attachment_views_, command);
     }
     return skip;
 }
@@ -735,7 +751,7 @@ bool RenderPassAccessContext::ValidateEndRenderPass(const CommandBufferAccessCon
 
 AccessContext *RenderPassAccessContext::CreateStoreResolveProxy() const {
     return CreateStoreResolveProxyContext(CurrentContext(), *rp_state_, render_pass_instance_id_, current_subpass_,
-                                          attachment_views_);
+                                          rp_state_->create_info.pSubpasses[current_subpass_].viewMask, attachment_views_);
 }
 
 bool RenderPassAccessContext::ValidateFinalSubpassLayoutTransitions(const CommandBufferAccessContext &cb_context,
@@ -803,9 +819,10 @@ void RenderPassAccessContext::RecordLayoutTransitions(const ResourceUsageTag tag
 void RenderPassAccessContext::RecordLoadOperations(const ResourceUsageTag tag) {
     const auto *attachment_ci = rp_state_->create_info.pAttachments;
     auto &subpass_context = CurrentContext();
+    const uint32_t view_mask = rp_state_->create_info.pSubpasses[current_subpass_].viewMask;
 
     for (uint32_t i = 0; i < rp_state_->create_info.attachmentCount; i++) {
-        if (rp_state_->attachment_first_subpass[i] == current_subpass_) {
+        if (IsSubpassIncluded(current_subpass_, rp_state_->attachment_first_subpass[i], view_mask)) {
             const AttachmentViewGen &view_gen = attachment_views_[i];
 
             const VkAttachmentDescription2 &ci = *attachment_ci[i].ptr();
@@ -818,7 +835,6 @@ void RenderPassAccessContext::RecordLoadOperations(const ResourceUsageTag tag) {
                 // The exception is when a feedback loop is enabled for the attachment, then only the render area is accessed.
                 const SyncAccessIndex load_op_access = ColorLoadUsage(ci.loadOp);
                 if (load_op_access != SYNC_ACCESS_INDEX_NONE) {
-                    uint32_t view_mask = rp_state_->create_info.pSubpasses[current_subpass_].viewMask;
                     const AttachmentAccess attachment_access =
                         GetAttachmentAccess(SyncOrdering::kColorAttachment, AttachmentAccessType::LoadOp);
                     subpass_context.UpdateAttachmentAccessState(view_gen, AttachmentViewGen::Gen::kRenderArea, load_op_access,
@@ -884,10 +900,12 @@ void RenderPassAccessContext::RecordBeginRenderPass(const ResourceUsageTag barri
 
 void RenderPassAccessContext::RecordNextSubpass(const ResourceUsageTag store_tag, const ResourceUsageTag barrier_tag,
                                                 const ResourceUsageTag load_tag) {
+    const uint32_t view_mask = rp_state_->create_info.pSubpasses[current_subpass_].viewMask;
+
     // Resolves are against *prior* subpass context and thus *before* the subpass increment
     UpdateAttachmentResolveAccess(*rp_state_, attachment_views_, render_pass_instance_id_, current_subpass_, store_tag,
                                   CurrentContext());
-    UpdateAttachmentStoreAccess(*rp_state_, attachment_views_, render_pass_instance_id_, current_subpass_, store_tag,
+    UpdateAttachmentStoreAccess(*rp_state_, attachment_views_, render_pass_instance_id_, current_subpass_, view_mask, store_tag,
                                 CurrentContext());
 
     if (current_subpass_ + 1 >= rp_state_->create_info.subpassCount) {
@@ -905,10 +923,12 @@ void RenderPassAccessContext::RecordNextSubpass(const ResourceUsageTag store_tag
 
 void RenderPassAccessContext::RecordEndRenderPass(AccessContext *external_context, const ResourceUsageTag store_tag,
                                                   const ResourceUsageTag barrier_tag) {
+    const uint32_t view_mask = rp_state_->create_info.pSubpasses[current_subpass_].viewMask;
+
     // Add the resolve and store accesses
     UpdateAttachmentResolveAccess(*rp_state_, attachment_views_, render_pass_instance_id_, current_subpass_, store_tag,
                                   CurrentContext());
-    UpdateAttachmentStoreAccess(*rp_state_, attachment_views_, render_pass_instance_id_, current_subpass_, store_tag,
+    UpdateAttachmentStoreAccess(*rp_state_, attachment_views_, render_pass_instance_id_, current_subpass_, view_mask, store_tag,
                                 CurrentContext());
 
     // Export the accesses from the renderpass...

--- a/layers/sync/sync_renderpass.h
+++ b/layers/sync/sync_renderpass.h
@@ -93,12 +93,12 @@ class RenderPassAccessContext {
 
     static bool ValidateLayoutTransitions(const CommandBufferAccessContext &cb_context, const AccessContext &access_context,
                                           const vvl::RenderPass &rp_state, const VkRect2D &render_area,
-                                          uint32_t render_pass_instance_id, uint32_t subpass,
+                                          uint32_t render_pass_instance_id, uint32_t subpass, uint32_t view_mask,
                                           const AttachmentViewGenVector &attachment_views, vvl::Func command);
 
     static bool ValidateLoadOperation(const CommandBufferAccessContext &cb_context, const AccessContext &access_context,
                                       const vvl::RenderPass &rp_state, const VkRect2D &render_area,
-                                      uint32_t render_pass_instance_id, uint32_t subpass,
+                                      uint32_t render_pass_instance_id, uint32_t subpass, uint32_t view_mask,
                                       const AttachmentViewGenVector &attachment_views, vvl::Func command);
 
     bool ValidateStoreOperation(const CommandBufferAccessContext &cb_context, vvl::Func command) const;
@@ -109,8 +109,8 @@ class RenderPassAccessContext {
                                               AccessContext &access_context);
 
     static void UpdateAttachmentStoreAccess(const vvl::RenderPass &rp_state, const AttachmentViewGenVector &attachment_views,
-                                            uint32_t render_pass_instance_id, uint32_t subpass, const ResourceUsageTag tag,
-                                            AccessContext &access_context);
+                                            uint32_t render_pass_instance_id, uint32_t subpass, uint32_t view_mask,
+                                            const ResourceUsageTag tag, AccessContext &access_context);
 
     static void RecordLayoutTransitions(const vvl::RenderPass &rp_state, uint32_t subpass,
                                         const AttachmentViewGenVector &attachment_views, const ResourceUsageTag tag,

--- a/layers/utils/math_utils.h
+++ b/layers/utils/math_utils.h
@@ -33,6 +33,8 @@
 
 #include <vulkan/vulkan_core.h>
 
+#include "containers/small_vector.h"
+
 template <typename T>
 constexpr bool IsPowerOfTwo(T x) {
     static_assert(std::is_integral_v<T> && std::is_unsigned_v<T>, "Unsigned integer required");
@@ -50,6 +52,22 @@ template <typename T>
 constexpr bool IsSingleBitSet(T flags) {
     static_assert(std::is_integral_v<T> && std::is_unsigned_v<T>, "Unsigned integer required");
     return IsPowerOfTwo(flags);
+}
+
+// Return index of each set bit in a 32-bit value (the maximum size of returned vector is 32).
+// Use a practical small vector capacity (usually we have values with only a few flags set).
+static inline small_vector<uint8_t, 8> GetSetBitIndices(uint32_t value) {
+    small_vector<uint8_t, 8> indices;
+    indices.reserve(GetBitSetCount(value));
+    uint8_t index = 0;
+    while (value) {
+        if (value & 1) {
+            indices.emplace_back(index);
+        }
+        value >>= 1;
+        index++;
+    }
+    return indices;
 }
 
 // Returns the 0-based index of the MSB, like the x86 bit scan reverse (bsr) instruction
@@ -180,3 +198,4 @@ static inline uint32_t GetSmallestGreaterOrEquallPowerOfTwo(uint32_t v) {
     v++;
     return v;
 }
+

--- a/tests/unit/sync_val_render_pass.cpp
+++ b/tests/unit/sync_val_render_pass.cpp
@@ -683,7 +683,7 @@ TEST_F(NegativeSyncValRenderPass, FinalLayoutTransitionHazard) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeSyncValRenderPass, MultiviewSameViewLayer) {
+TEST_F(NegativeSyncValRenderPass, MultiviewSameView) {
     TEST_DESCRIPTION("Two async subpasses render to the same view");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredFeature(vkt::Feature::multiview);
@@ -733,8 +733,8 @@ TEST_F(NegativeSyncValRenderPass, MultiviewSameViewLayer) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeSyncValRenderPass, MultiviewSharedViewLayer) {
-    TEST_DESCRIPTION("Two async subpasses render to the same view");
+TEST_F(NegativeSyncValRenderPass, MultiviewSharedView) {
+    TEST_DESCRIPTION("Two async subpasses have a shared view");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredFeature(vkt::Feature::multiview);
     RETURN_IF_SKIP(InitSyncVal());
@@ -781,6 +781,155 @@ TEST_F(NegativeSyncValRenderPass, MultiviewSharedViewLayer) {
     m_command_buffer.BeginRenderPass(render_pass, framebuffer, 128, 128, 1, &clear_value);
     m_errorMonitor->SetDesiredError("SYNC-HAZARD-WRITE-RACING-WRITE");
     m_command_buffer.NextSubpass();
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeSyncValRenderPass, MultiviewMultipleStoreOps) {
+    TEST_DESCRIPTION("Multiview broadcasts storeOp to different subpasses");
+    SetTargetApiVersion(VK_API_VERSION_1_4);
+    AddRequiredFeature(vkt::Feature::multiview);
+    RETURN_IF_SKIP(InitSyncVal());
+
+    const VkImageCreateInfo image_ci = vkt::Image::ImageCreateInfo2D(
+        128, 128, 1, 2, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::Image image(*m_device, image_ci);
+    vkt::ImageView image_view = image.CreateView(VK_IMAGE_VIEW_TYPE_2D_ARRAY, 0, 1, 0, 2);
+
+    vkt::Buffer buffer(*m_device, 128 * 128 * 4 * 2, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
+
+    VkAttachmentDescription attachment{};
+    attachment.format = VK_FORMAT_R8G8B8A8_UNORM;
+    attachment.samples = VK_SAMPLE_COUNT_1_BIT;
+    attachment.loadOp = VK_ATTACHMENT_LOAD_OP_NONE;
+    attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    attachment.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
+    attachment.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+    const VkAttachmentReference color_ref = {0, VK_IMAGE_LAYOUT_GENERAL};
+
+    VkSubpassDescription subpasses[2] = {};
+    subpasses[0].pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    subpasses[0].colorAttachmentCount = 1;
+    subpasses[0].pColorAttachments = &color_ref;
+
+    subpasses[1] = subpasses[0];
+
+    // Define dependency with external copy for the second subpass but not for the first one
+    VkSubpassDependency subpass_dependency{};
+    subpass_dependency.srcSubpass = 1;
+    subpass_dependency.dstSubpass = VK_SUBPASS_EXTERNAL;
+    subpass_dependency.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    subpass_dependency.dstStageMask = VK_PIPELINE_STAGE_TRANSFER_BIT;
+    subpass_dependency.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+    subpass_dependency.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+
+    const uint32_t view_masks[2] = {1, 2};
+    VkRenderPassMultiviewCreateInfo multiview_ci = vku::InitStructHelper();
+    multiview_ci.subpassCount = 2;
+    multiview_ci.pViewMasks = view_masks;
+
+    VkRenderPassCreateInfo render_pass_ci = vku::InitStructHelper(&multiview_ci);
+    render_pass_ci.attachmentCount = 1;
+    render_pass_ci.pAttachments = &attachment;
+    render_pass_ci.subpassCount = 2;
+    render_pass_ci.pSubpasses = subpasses;
+    render_pass_ci.dependencyCount = 1;
+    render_pass_ci.pDependencies = &subpass_dependency;
+
+    vkt::RenderPass render_pass(*m_device, render_pass_ci);
+    vkt::Framebuffer framebuffer(*m_device, render_pass, 1, &image_view.handle(), 128, 128);
+
+    VkBufferImageCopy region{};
+    region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 2};
+    region.imageExtent = {128, 128, 1};
+
+    m_command_buffer.Begin();
+
+    m_command_buffer.BeginRenderPass(render_pass, framebuffer, 128, 128);
+    // storeOp for view 0 happens at the end of this subpass (0).
+    // This storeOp is not synchronized by external subpass dependency
+
+    m_command_buffer.NextSubpass();
+    // storeOp for view 1 happens at the end of this subpass (1)
+
     m_command_buffer.EndRenderPass();
+
+    m_errorMonitor->SetDesiredError("SYNC-HAZARD-WRITE-AFTER-WRITE");
+    vk::CmdCopyBufferToImage(m_command_buffer, buffer, image, VK_IMAGE_LAYOUT_GENERAL, 1, &region);
+    m_errorMonitor->VerifyFound();
+    m_command_buffer.End();
+}
+
+TEST_F(NegativeSyncValRenderPass, MultiviewMultipleLoadOps) {
+    TEST_DESCRIPTION("Multiview broadcasts loadOp to different subpasses");
+    SetTargetApiVersion(VK_API_VERSION_1_4);
+    AddRequiredFeature(vkt::Feature::multiview);
+    RETURN_IF_SKIP(InitSyncVal());
+
+    const VkImageCreateInfo image_ci = vkt::Image::ImageCreateInfo2D(
+        128, 128, 1, 2, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::Image image(*m_device, image_ci);
+    vkt::ImageView image_view = image.CreateView(VK_IMAGE_VIEW_TYPE_2D_ARRAY, 0, 1, 0, 2);
+
+    vkt::Buffer buffer(*m_device, 128 * 128 * 4 * 2, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
+
+    VkAttachmentDescription attachment{};
+    attachment.format = VK_FORMAT_R8G8B8A8_UNORM;
+    attachment.samples = VK_SAMPLE_COUNT_1_BIT;
+    attachment.loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+    attachment.storeOp = VK_ATTACHMENT_STORE_OP_NONE;
+    attachment.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
+    attachment.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+    const VkAttachmentReference color_ref = {0, VK_IMAGE_LAYOUT_GENERAL};
+
+    VkSubpassDescription subpasses[2] = {};
+    subpasses[0].pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    subpasses[0].colorAttachmentCount = 1;
+    subpasses[0].pColorAttachments = &color_ref;
+
+    subpasses[1] = subpasses[0];
+
+    // Define dependency with external copy for the first subpass but not for the second one
+    VkSubpassDependency subpass_dependency{};
+    subpass_dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
+    subpass_dependency.dstSubpass = 0;
+    subpass_dependency.srcStageMask = VK_PIPELINE_STAGE_TRANSFER_BIT;
+    subpass_dependency.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    subpass_dependency.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+    subpass_dependency.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;
+
+    const uint32_t view_masks[2] = {1, 2};
+    VkRenderPassMultiviewCreateInfo multiview_ci = vku::InitStructHelper();
+    multiview_ci.subpassCount = 2;
+    multiview_ci.pViewMasks = view_masks;
+
+    VkRenderPassCreateInfo render_pass_ci = vku::InitStructHelper(&multiview_ci);
+    render_pass_ci.attachmentCount = 1;
+    render_pass_ci.pAttachments = &attachment;
+    render_pass_ci.subpassCount = 2;
+    render_pass_ci.pSubpasses = subpasses;
+    render_pass_ci.dependencyCount = 1;
+    render_pass_ci.pDependencies = &subpass_dependency;
+
+    vkt::RenderPass render_pass(*m_device, render_pass_ci);
+    vkt::Framebuffer framebuffer(*m_device, render_pass, 1, &image_view.handle(), 128, 128);
+
+    VkBufferImageCopy region{};
+    region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 2};
+    region.imageExtent = {128, 128, 1};
+
+    m_command_buffer.Begin();
+
+    vk::CmdCopyBufferToImage(m_command_buffer, buffer, image, VK_IMAGE_LAYOUT_GENERAL, 1, &region);
+
+    m_command_buffer.BeginRenderPass(render_pass, framebuffer, 128, 128);
+    // loadOp for view 0 happens at the beginning of this subpass (0).
+
+    m_errorMonitor->SetDesiredError("SYNC-HAZARD-READ-AFTER-WRITE");
+    m_command_buffer.NextSubpass();
+    // loadOp for view 1 happens at the beginning of this subpass (1).
+    // This load is not synchronized by external subpass dependency
+
     m_errorMonitor->VerifyFound();
 }

--- a/tests/unit/sync_val_render_pass_positive.cpp
+++ b/tests/unit/sync_val_render_pass_positive.cpp
@@ -558,6 +558,191 @@ TEST_F(PositiveSyncValRenderPass, MultiviewAsyncSubpasses3) {
     m_command_buffer.End();
 }
 
+TEST_F(PositiveSyncValRenderPass, MultiviewMultipleStoreOps) {
+    TEST_DESCRIPTION("Multiview broadcasts storeOp to different subpasses that write to different views");
+    SetTargetApiVersion(VK_API_VERSION_1_4);
+    AddRequiredFeature(vkt::Feature::multiview);
+    RETURN_IF_SKIP(InitSyncVal());
+
+    const VkImageCreateInfo image_ci =
+        vkt::Image::ImageCreateInfo2D(128, 128, 1, 2, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    vkt::Image image(*m_device, image_ci);
+    vkt::ImageView image_view = image.CreateView(VK_IMAGE_VIEW_TYPE_2D_ARRAY, 0, 1, 0, 2);
+
+    VkAttachmentDescription attachment{};
+    attachment.format = VK_FORMAT_R8G8B8A8_UNORM;
+    attachment.samples = VK_SAMPLE_COUNT_1_BIT;
+    attachment.loadOp = VK_ATTACHMENT_LOAD_OP_NONE;
+    attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    attachment.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
+    attachment.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+    const VkAttachmentReference color_ref = {0, VK_IMAGE_LAYOUT_GENERAL};
+
+    VkSubpassDescription subpasses[2] = {};
+    subpasses[0].pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    subpasses[0].colorAttachmentCount = 1;
+    subpasses[0].pColorAttachments = &color_ref;
+
+    subpasses[1] = subpasses[0];
+
+    const uint32_t view_masks[2] = {1, 2};
+    VkRenderPassMultiviewCreateInfo multiview_ci = vku::InitStructHelper();
+    multiview_ci.subpassCount = 2;
+    multiview_ci.pViewMasks = view_masks;
+
+    VkRenderPassCreateInfo render_pass_ci = vku::InitStructHelper(&multiview_ci);
+    render_pass_ci.attachmentCount = 1;
+    render_pass_ci.pAttachments = &attachment;
+    render_pass_ci.subpassCount = 2;
+    render_pass_ci.pSubpasses = subpasses;
+
+    vkt::RenderPass render_pass(*m_device, render_pass_ci);
+    vkt::Framebuffer framebuffer(*m_device, render_pass, 1, &image_view.handle(), 128, 128);
+
+    // Each subpass executes storeOp for a separate view
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(render_pass, framebuffer, 128, 128);
+    m_command_buffer.NextSubpass();
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}
+
+TEST_F(PositiveSyncValRenderPass, MultiviewMultipleLoadOps) {
+    TEST_DESCRIPTION("Multiview broadcasts loadOp to different subpasses that synchronize with external copy");
+    SetTargetApiVersion(VK_API_VERSION_1_4);
+    AddRequiredFeature(vkt::Feature::multiview);
+    RETURN_IF_SKIP(InitSyncVal());
+
+    const VkImageCreateInfo image_ci = vkt::Image::ImageCreateInfo2D(
+        128, 128, 1, 2, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::Image image(*m_device, image_ci);
+    vkt::ImageView image_view = image.CreateView(VK_IMAGE_VIEW_TYPE_2D_ARRAY, 0, 1, 0, 2);
+
+    vkt::Buffer buffer(*m_device, 128 * 128 * 4 * 2, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
+
+    VkAttachmentDescription attachment{};
+    attachment.format = VK_FORMAT_R8G8B8A8_UNORM;
+    attachment.samples = VK_SAMPLE_COUNT_1_BIT;
+    attachment.loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+    attachment.storeOp = VK_ATTACHMENT_STORE_OP_NONE;
+    attachment.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
+    attachment.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+    const VkAttachmentReference color_ref = {0, VK_IMAGE_LAYOUT_GENERAL};
+
+    VkSubpassDescription subpasses[2] = {};
+    subpasses[0].pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    subpasses[0].colorAttachmentCount = 1;
+    subpasses[0].pColorAttachments = &color_ref;
+
+    subpasses[1] = subpasses[0];
+
+    VkSubpassDependency subpass_dependencies[2] = {};
+    subpass_dependencies[0].srcSubpass = VK_SUBPASS_EXTERNAL;
+    subpass_dependencies[0].dstSubpass = 0;
+    subpass_dependencies[0].srcStageMask = VK_PIPELINE_STAGE_TRANSFER_BIT;
+    subpass_dependencies[0].dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    subpass_dependencies[0].srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+    subpass_dependencies[0].dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;
+
+    subpass_dependencies[1] = subpass_dependencies[0];
+    subpass_dependencies[1].dstSubpass = 1;
+
+    const uint32_t view_masks[2] = {1, 2};
+    VkRenderPassMultiviewCreateInfo multiview_ci = vku::InitStructHelper();
+    multiview_ci.subpassCount = 2;
+    multiview_ci.pViewMasks = view_masks;
+
+    VkRenderPassCreateInfo render_pass_ci = vku::InitStructHelper(&multiview_ci);
+    render_pass_ci.attachmentCount = 1;
+    render_pass_ci.pAttachments = &attachment;
+    render_pass_ci.subpassCount = 2;
+    render_pass_ci.pSubpasses = subpasses;
+    render_pass_ci.dependencyCount = 2;
+    render_pass_ci.pDependencies = subpass_dependencies;
+
+    vkt::RenderPass render_pass(*m_device, render_pass_ci);
+    vkt::Framebuffer framebuffer(*m_device, render_pass, 1, &image_view.handle(), 128, 128);
+
+    VkBufferImageCopy region{};
+    region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 2};
+    region.imageExtent = {128, 128, 1};
+
+    m_command_buffer.Begin();
+
+    vk::CmdCopyBufferToImage(m_command_buffer, buffer, image, VK_IMAGE_LAYOUT_GENERAL, 1, &region);
+
+    m_command_buffer.BeginRenderPass(render_pass, framebuffer, 128, 128);
+    // loadOp for view 0 happens at the beginning of this subpass (0).
+    // Subpass dependency 0 synchronizes it with copy
+
+    m_command_buffer.NextSubpass();
+    // loadOp for view 1 happens at the beginning of this subpass (1).
+    // Subpass dependency 1 synchronizes it with copy
+
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}
+
+TEST_F(PositiveSyncValRenderPass, MultiviewAsyncSubpasses3DImage) {
+    TEST_DESCRIPTION("Use slices of 3D image for multiview views");
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredFeature(vkt::Feature::multiview);
+    RETURN_IF_SKIP(InitSyncVal());
+
+    VkImageCreateInfo image_ci = vku::InitStructHelper();
+    image_ci.flags = VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT;
+    image_ci.imageType = VK_IMAGE_TYPE_3D;
+    image_ci.format = VK_FORMAT_R8G8B8A8_UNORM;
+    image_ci.extent = {128,128, 2};
+    image_ci.mipLevels = 1;
+    image_ci.arrayLayers = 1;
+    image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
+    image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
+    image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    vkt::Image image_3d(*m_device, image_ci);
+
+    vkt::ImageView image_view = image_3d.CreateView(VK_IMAGE_VIEW_TYPE_2D_ARRAY, 0, 1, 0, 2 /*slices*/);
+
+    VkAttachmentDescription attachment{};
+    attachment.format = VK_FORMAT_R8G8B8A8_UNORM;
+    attachment.samples = VK_SAMPLE_COUNT_1_BIT;
+    attachment.loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+    attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    attachment.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
+    attachment.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+    const VkAttachmentReference color_ref = {0, VK_IMAGE_LAYOUT_GENERAL};
+
+    VkSubpassDescription subpasses[2] = {};
+    subpasses[0].pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    subpasses[0].colorAttachmentCount = 1;
+    subpasses[0].pColorAttachments = &color_ref;
+
+    subpasses[1] = subpasses[0];
+
+    const uint32_t view_masks[2] = {1, 2};
+    VkRenderPassMultiviewCreateInfo multiview_ci = vku::InitStructHelper();
+    multiview_ci.subpassCount = 2;
+    multiview_ci.pViewMasks = view_masks;
+
+    VkRenderPassCreateInfo render_pass_ci = vku::InitStructHelper(&multiview_ci);
+    render_pass_ci.attachmentCount = 1;
+    render_pass_ci.pAttachments = &attachment;
+    render_pass_ci.subpassCount = 2;
+    render_pass_ci.pSubpasses = subpasses;
+    vkt::RenderPass render_pass(*m_device, render_pass_ci);
+
+    vkt::Framebuffer framebuffer(*m_device, render_pass, 1, &image_view.handle(), 128, 128);
+
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(render_pass, framebuffer, 128, 128);
+    m_command_buffer.NextSubpass();
+    m_command_buffer.EndRenderPass();
+    m_command_buffer.End();
+}
+
 TEST_F(PositiveSyncValRenderPass, MultiviewSubpassDependency) {
     TEST_DESCRIPTION("Use subpass dependency to sync multiview subpasses that have a shared view");
     SetTargetApiVersion(VK_API_VERSION_1_1);


### PR DESCRIPTION
Follow up to https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/11786.

LoadOp/StoreOp happen in the first/last subpass that uses the attachment, but with multiview the first/last usage is defined per view (so subpass loads/stores only its own views)

