### PR TITLE
gpuav: Unify DebugPrintf and GPU-AV error record

### DIFF
--- a/layers/gpuav/debug_printf/debug_printf.cpp
+++ b/layers/gpuav/debug_printf/debug_printf.cpp
@@ -168,18 +168,20 @@ static std::vector<Substring> ParseFormatString(const std::string &format_string
 #endif
 
 // The contents each "printf" is writting to the output buffer streams
+//
+// We make sure the first few bytes match the header of the shader instrumentation
+// (this allows it easier to parse the shader debug info the same)
 struct OutputRecord {
-    uint32_t size;
-    uint32_t shader_id;
-    uint32_t instruction_position_offset;
+    uint32_t size;                  // kHeader_ErrorRecordSizeOffset
+    uint32_t shader_id;             // kHeader_ShaderIdErrorOffset
+    uint32_t stage_instruction_id;  // kHeader_StageInstructionIdOffset
+    uint32_t stage_info_0;  // kHeader_StageInfoOffset_0
+    uint32_t stage_info_1;  // kHeader_StageInfoOffset_1
+    uint32_t stage_info_2;  // kHeader_StageInfoOffset_2
     uint32_t format_string_id;
     uint32_t double_bitmask;     // used to distinguish if float is 1 or 2 dwords
     uint32_t signed_8_bitmask;   // used to distinguish if signed int is a int8_t
     uint32_t signed_16_bitmask;  // used to distinguish if signed int is a int16_t
-    uint32_t stage_id;
-    uint32_t stage_info_0;
-    uint32_t stage_info_1;
-    uint32_t stage_info_2;
     uint32_t values;  // place holder to be casted to get rest of items in record
 };
 
@@ -204,8 +206,8 @@ struct DebugPrintfCbState {
     std::vector<DebugPrintfBufferInfo> buffer_infos;
 };
 
-void AnalyzeAndGenerateMessage(Validator &gpuav, VkCommandBuffer command_buffer, DebugPrintfBufferInfo &buffer_info,
-                               uint32_t *const debug_output_buffer, const Location &loc) {
+void AnalyzeAndGenerateMessage(Validator& gpuav, VkCommandBuffer command_buffer, DebugPrintfBufferInfo& buffer_info,
+                               const uint32_t* debug_output_buffer, const Location& loc) {
     uint32_t output_buffer_dwords_counts = debug_output_buffer[gpuav::kDebugPrintf_OutputBuffer_DWordsCount];
     if (!output_buffer_dwords_counts) return;
 
@@ -213,7 +215,7 @@ void AnalyzeAndGenerateMessage(Validator &gpuav, VkCommandBuffer command_buffer,
     while (debug_output_buffer[output_record_i]) {
         std::ostringstream shader_message;
 
-        OutputRecord *debug_record = reinterpret_cast<OutputRecord *>(&debug_output_buffer[output_record_i]);
+        const OutputRecord* debug_record = reinterpret_cast<const OutputRecord*>(&debug_output_buffer[output_record_i]);
         // Lookup the VkShaderModule handle and SPIR-V code used to create the shader, using the unique shader ID value returned
         // by the instrumented shader.
         const gpuav::InstrumentedShader *instrumented_shader = nullptr;
@@ -246,7 +248,7 @@ void AnalyzeAndGenerateMessage(Validator &gpuav, VkCommandBuffer command_buffer,
 
         // Break the format string into strings with 1 or 0 value
         auto format_substrings = ParseFormatString(format_string);
-        void *current_value = static_cast<void *>(&debug_record->values);
+        const void* current_value = static_cast<const void*>(&debug_record->values);
         // Sprintf each format substring into a temporary string then add that to the message
         for (size_t substring_i = 0; substring_i < format_substrings.size(); substring_i++) {
             auto &substring = format_substrings[substring_i];
@@ -268,7 +270,7 @@ void AnalyzeAndGenerateMessage(Validator &gpuav, VkCommandBuffer command_buffer,
                             break;
                         }
 
-                        const uint64_t value = *static_cast<uint64_t *>(current_value);
+                        const uint64_t value = *static_cast<const uint64_t*>(current_value);
                         // +1 for null terminator
                         needed = std::snprintf(nullptr, 0, substring.string.c_str(), value) + 1;
                         temp_string.resize(needed);
@@ -282,7 +284,7 @@ void AnalyzeAndGenerateMessage(Validator &gpuav, VkCommandBuffer command_buffer,
                                                   "Trying to DebugPrintf a 64-bit signed int but not using \"%%ld\" to print it.");
                         }
 
-                        const uint32_t *current_ptr = static_cast<uint32_t *>(current_value);
+                        const uint32_t* current_ptr = static_cast<const uint32_t*>(current_value);
                         const uint64_t value_unsigned = glsl::GetUint64(current_ptr);
                         const int64_t value = static_cast<int64_t>(value_unsigned);
 
@@ -295,7 +297,7 @@ void AnalyzeAndGenerateMessage(Validator &gpuav, VkCommandBuffer command_buffer,
                 } else {
                     if (substring.type == NumericTypeUint) {
                         // +1 for null terminator
-                        const uint32_t value = *static_cast<uint32_t *>(current_value);
+                        const uint32_t value = *static_cast<const uint32_t*>(current_value);
                         needed = std::snprintf(nullptr, 0, substring.string.c_str(), value) + 1;
                         temp_string.resize(needed);
                         std::snprintf(&temp_string[0], needed, substring.string.c_str(), value);
@@ -303,17 +305,17 @@ void AnalyzeAndGenerateMessage(Validator &gpuav, VkCommandBuffer command_buffer,
                     } else if (substring.type == NumericTypeSint) {
                         // When dealing with signed int, we need to know which size the int was to print the correct value
                         if (debug_record->signed_8_bitmask & (1 << substring_i)) {
-                            const int8_t value = *static_cast<int8_t *>(current_value);
+                            const int8_t value = *static_cast<const int8_t*>(current_value);
                             needed = std::snprintf(nullptr, 0, substring.string.c_str(), value) + 1;
                             temp_string.resize(needed);
                             std::snprintf(&temp_string[0], needed, substring.string.c_str(), value);
                         } else if (debug_record->signed_16_bitmask & (1 << substring_i)) {
-                            const int16_t value = *static_cast<int16_t *>(current_value);
+                            const int16_t value = *static_cast<const int16_t*>(current_value);
                             needed = std::snprintf(nullptr, 0, substring.string.c_str(), value) + 1;
                             temp_string.resize(needed);
                             std::snprintf(&temp_string[0], needed, substring.string.c_str(), value);
                         } else {
-                            const int32_t value = *static_cast<int32_t *>(current_value);
+                            const int32_t value = *static_cast<const int32_t*>(current_value);
                             needed = std::snprintf(nullptr, 0, substring.string.c_str(), value) + 1;
                             temp_string.resize(needed);
                             std::snprintf(&temp_string[0], needed, substring.string.c_str(), value);
@@ -326,12 +328,12 @@ void AnalyzeAndGenerateMessage(Validator &gpuav, VkCommandBuffer command_buffer,
                         // This is much simpler than enforcing a %lf which doesn't line up with how the CPU side works
                         if (debug_record->double_bitmask & (1 << substring_i)) {
                             substring.is_64_bit = true;
-                            const double value = *static_cast<double *>(current_value);
+                            const double value = *static_cast<const double*>(current_value);
                             needed = std::snprintf(nullptr, 0, substring.string.c_str(), value) + 1;
                             temp_string.resize(needed);
                             std::snprintf(&temp_string[0], needed, substring.string.c_str(), value);
                         } else {
-                            const float value = *static_cast<float *>(current_value);
+                            const float value = *static_cast<const float*>(current_value);
                             needed = std::snprintf(nullptr, 0, substring.string.c_str(), value) + 1;
                             temp_string.resize(needed);
                             std::snprintf(&temp_string[0], needed, substring.string.c_str(), value);
@@ -340,7 +342,7 @@ void AnalyzeAndGenerateMessage(Validator &gpuav, VkCommandBuffer command_buffer,
                 }
 
                 const uint32_t offset = substring.is_64_bit ? 2 : 1;
-                current_value = static_cast<uint32_t *>(current_value) + offset;
+                current_value = static_cast<const uint32_t*>(current_value) + offset;
 
             } else {
                 // incase where someone just printing a string with no arguments to it
@@ -354,16 +356,9 @@ void AnalyzeAndGenerateMessage(Validator &gpuav, VkCommandBuffer command_buffer,
 
         const bool use_stdout = gpuav.gpuav_settings.debug_printf_to_stdout;
         if (gpuav.gpuav_settings.debug_printf_verbose) {
-            GpuShaderInstrumentor::ShaderMessageInfo shader_info{debug_record->stage_id,
-                                                                 debug_record->stage_info_0,
-                                                                 debug_record->stage_info_1,
-                                                                 debug_record->stage_info_2,
-                                                                 debug_record->instruction_position_offset,
-                                                                 debug_record->shader_id};
-
             std::string debug_info_message =
-                gpuav.GenerateDebugInfoMessage(command_buffer, shader_info, instrumented_shader, buffer_info.pipeline_bind_point,
-                                               buffer_info.action_command_index);
+                gpuav.GenerateDebugInfoMessage(command_buffer, (uint32_t*)debug_record, instrumented_shader,
+                                               buffer_info.pipeline_bind_point, buffer_info.action_command_index);
             if (use_stdout) {
                 std::cout << "VVL-DEBUG-PRINTF " << shader_message.str() << '\n' << debug_info_message;
             } else {
@@ -401,7 +396,7 @@ void AnalyzeAndGenerateMessage(Validator &gpuav, VkCommandBuffer command_buffer,
     uint32_t clear_size = sizeof(uint32_t) * (debug_output_buffer[gpuav::kDebugPrintf_OutputBuffer_DWordsCount] +
                                               gpuav::kDebugPrintf_OutputBuffer_Data);
     clear_size = std::min(gpuav.gpuav_settings.debug_printf_buffer_size, clear_size);
-    memset(debug_output_buffer, 0, clear_size);
+    memset((void*)debug_output_buffer, 0, clear_size);
 }
 
 #if defined(__GNUC__)

--- a/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
@@ -320,10 +320,10 @@ static bool WasInstrumented(const LastBound &last_bound) {
 // sure it is available when the pipeline is submitted.  (The ShaderModule tracking object also
 // keeps a copy, but it can be destroyed after the pipeline is created and before it is submitted.)
 //
-bool LogInstrumentationError(Validator &gpuav, const CommandBufferSubState &cb_state, const LogObjectList &objlist,
-                             const CommonInstrumentationErrorInfo &error_info, const uint32_t *error_record,
-                             const Location &loc_with_debug_region,
-                             const std::vector<CommandBufferSubState::InstrumentationErrorLogger> &error_loggers) {
+bool LogInstrumentationError(Validator& gpuav, const VkCommandBuffer cb_handle, const LogObjectList& objlist,
+                             const CommonInstrumentationErrorInfo& error_info, const uint32_t* error_record,
+                             const Location& loc_with_debug_region,
+                             const std::vector<CommandBufferSubState::InstrumentationErrorLogger>& error_loggers) {
     // The second word in the debug output buffer is the number of words that would have
     // been written by the shader instrumentation, if there was enough room in the buffer we provided.
     // The number of words actually written by the shaders is determined by the size of the buffer
@@ -345,6 +345,9 @@ bool LogInstrumentationError(Validator &gpuav, const CommandBufferSubState &cb_s
         }
     }
 
+    // We should find an error, otherwise this means we are not registering a check somewhere
+    assert(error_found);
+
     if (error_found) {
         // Lookup the VkShaderModule handle and SPIR-V code used to create the shader, using the unique shader ID value returned
         // by the instrumented shader.
@@ -355,17 +358,8 @@ bool LogInstrumentationError(Validator &gpuav, const CommandBufferSubState &cb_s
             instrumented_shader = &it->second;
         }
 
-        const uint32_t stage_id = error_record[glsl::kHeader_StageInstructionIdOffset] >> glsl::kStageId_Shift;
-        const uint32_t instruction_position_offset =
-            error_record[glsl::kHeader_StageInstructionIdOffset] & glsl::kInstructionId_Mask;
-        GpuShaderInstrumentor::ShaderMessageInfo shader_info{stage_id,
-                                                             error_record[glsl::kHeader_StageInfoOffset_0],
-                                                             error_record[glsl::kHeader_StageInfoOffset_1],
-                                                             error_record[glsl::kHeader_StageInfoOffset_2],
-                                                             instruction_position_offset,
-                                                             unique_shader_id};
         std::string debug_info_message = gpuav.GenerateDebugInfoMessage(
-            cb_state.VkHandle(), shader_info, instrumented_shader, error_info.pipeline_bind_point, error_info.action_command_index);
+            cb_handle, error_record, instrumented_shader, error_info.pipeline_bind_point, error_info.action_command_index);
 
         gpuav.LogError(vuid_msg.c_str(), objlist, loc_with_debug_region, "%s\n%s", error_msg.c_str(), debug_info_message.c_str());
     }
@@ -376,10 +370,11 @@ bool LogInstrumentationError(Validator &gpuav, const CommandBufferSubState &cb_s
 void PreCallSetupShaderInstrumentationResourcesClassic(Validator &gpuav, CommandBufferSubState &cb_state,
                                                        const LastBound &last_bound,
                                                        const InstBindingPipeLayout &inst_binding_pipe_layout, const Location &loc) {
+    const VkCommandBuffer cb_handle = cb_state.VkHandle();
     VkDescriptorSet instrumentation_desc_set =
         cb_state.gpu_resources_manager.GetManagedDescriptorSet(cb_state.GetInstrumentationDescriptorSetLayout());
     if (!instrumentation_desc_set) {
-        gpuav.InternalError(cb_state.VkHandle(), loc, "Unable to allocate instrumentation descriptor sets.");
+        gpuav.InternalError(cb_handle, loc, "Unable to allocate instrumentation descriptor sets.");
         return;
     }
 
@@ -402,7 +397,7 @@ void PreCallSetupShaderInstrumentationResourcesClassic(Validator &gpuav, Command
     if (inst_binding_pipe_layout.handle != VK_NULL_HANDLE) {
         if (inst_binding_pipe_layout.state &&
             (uint32_t)inst_binding_pipe_layout.state->set_layouts.list.size() > gpuav.instrumentation_desc_set_bind_index_) {
-            gpuav.InternalWarning(cb_state.Handle(), loc,
+            gpuav.InternalWarning(cb_handle, loc,
                                   "Unable to bind instrumentation descriptor set, it would override application's bound set");
             return;
         }
@@ -413,7 +408,7 @@ void PreCallSetupShaderInstrumentationResourcesClassic(Validator &gpuav, Command
                 assert(false);
                 break;
             case PipelineLayoutSource::LastBoundPipeline:
-                DispatchCmdBindDescriptorSets(cb_state.VkHandle(), last_bound.bind_point, inst_binding_pipe_layout.handle,
+                DispatchCmdBindDescriptorSets(cb_handle, last_bound.bind_point, inst_binding_pipe_layout.handle,
                                               gpuav.instrumentation_desc_set_bind_index_, 1, &instrumentation_desc_set,
                                               static_cast<uint32_t>(dynamic_offsets.size()), dynamic_offsets.data());
                 break;
@@ -442,7 +437,7 @@ void PreCallSetupShaderInstrumentationResourcesClassic(Validator &gpuav, Command
                         gpuav.instrumentation_desc_set_bind_index_);
 
                     if (instrumentation_pipe_layout != VK_NULL_HANDLE) {
-                        DispatchCmdBindDescriptorSets(cb_state.VkHandle(), last_bound.bind_point, instrumentation_pipe_layout,
+                        DispatchCmdBindDescriptorSets(cb_handle, last_bound.bind_point, instrumentation_pipe_layout,
                                                       gpuav.instrumentation_desc_set_bind_index_, 1, &instrumentation_desc_set,
                                                       static_cast<uint32_t>(dynamic_offsets.size()), dynamic_offsets.data());
                         DispatchDestroyPipelineLayout(gpuav.device, instrumentation_pipe_layout, nullptr);
@@ -452,8 +447,7 @@ void PreCallSetupShaderInstrumentationResourcesClassic(Validator &gpuav, Command
                     }
                 } else {
                     // No incompatibility detected, safe to use pipeline layout for last bound descriptor set/push constants.
-                    DispatchCmdBindDescriptorSets(cb_state.VkHandle(), last_bound.bind_point,
-                                                  inst_binding_pipe_layout.state->VkHandle(),
+                    DispatchCmdBindDescriptorSets(cb_handle, last_bound.bind_point, inst_binding_pipe_layout.state->VkHandle(),
                                                   gpuav.instrumentation_desc_set_bind_index_, 1, &instrumentation_desc_set,
                                                   static_cast<uint32_t>(dynamic_offsets.size()), dynamic_offsets.data());
                 }
@@ -463,7 +457,7 @@ void PreCallSetupShaderInstrumentationResourcesClassic(Validator &gpuav, Command
     } else {
         // If no pipeline layout was bound when using shader objects that don't use any descriptor set, and no push constants, bind
         // the instrumentation pipeline layout
-        DispatchCmdBindDescriptorSets(cb_state.VkHandle(), last_bound.bind_point,
+        DispatchCmdBindDescriptorSets(cb_handle, last_bound.bind_point,
                                       gpuav.GetInstrumentationPipelineLayout(vvl::DescriptorModeClassic),
                                       gpuav.instrumentation_desc_set_bind_index_, 1, &instrumentation_desc_set,
                                       static_cast<uint32_t>(dynamic_offsets.size()), dynamic_offsets.data());
@@ -474,13 +468,14 @@ void PreCallSetupShaderInstrumentationResourcesClassic(Validator &gpuav, Command
         error_loggers.emplace_back(func(gpuav, cb_state, last_bound));
     }
 
-    CommandBufferSubState::ErrorLoggerFunc error_logger = [&gpuav, &cb_state, error_info, error_loggers = std::move(error_loggers)](
-                                                              const uint32_t *error_record, const Location &loc_with_debug_region,
-                                                              const LogObjectList &objlist) {
-        bool skip = false;
-        skip |= LogInstrumentationError(gpuav, cb_state, objlist, error_info, error_record, loc_with_debug_region, error_loggers);
-        return skip;
-    };
+    CommandBufferSubState::ErrorLoggerFunc error_logger =
+        [&gpuav, &cb_handle, error_info, error_loggers = std::move(error_loggers)](
+            const uint32_t* error_record, const Location& loc_with_debug_region, const LogObjectList& objlist) {
+            bool skip = false;
+            skip |=
+                LogInstrumentationError(gpuav, cb_handle, objlist, error_info, error_record, loc_with_debug_region, error_loggers);
+            return skip;
+        };
 
     cb_state.AddCommandErrorLogger(loc, &last_bound, std::move(error_logger));
 }

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.cpp
@@ -1809,80 +1809,81 @@ static std::string LookupDebugUtilsNameNoLock(const DebugReport *debug_report, c
 }
 
 // Generate the stage-specific part of the message.
-static void GenerateStageMessage(std::ostringstream &ss, const GpuShaderInstrumentor::ShaderMessageInfo &shader_info,
-                                 const std::vector<uint32_t> &instructions) {
-    switch (shader_info.stage_id) {
+static void GenerateStageMessage(std::ostringstream& ss, const uint32_t* error_record, const std::vector<uint32_t>& instructions) {
+    const uint32_t stage_id = error_record[glsl::kHeader_StageInstructionIdOffset] >> glsl::kStageId_Shift;
+    const uint32_t stage_info_0 = error_record[glsl::kHeader_StageInfoOffset_0];
+    const uint32_t stage_info_1 = error_record[glsl::kHeader_StageInfoOffset_1];
+    const uint32_t stage_info_2 = error_record[glsl::kHeader_StageInfoOffset_2];
+
+    switch (stage_id) {
         case glsl::kExecutionModel_Vertex: {
-            ss << "Stage = Vertex. Vertex Index = " << shader_info.stage_info_0 << " Instance Index = " << shader_info.stage_info_1
-               << ". ";
+            ss << "Stage = Vertex. Vertex Index = " << stage_info_0 << " Instance Index = " << stage_info_1 << ". ";
         } break;
         case glsl::kExecutionModel_TessellationControl: {
-            ss << "Stage = Tessellation Control.  Invocation ID = " << shader_info.stage_info_0
-               << ", Primitive ID = " << shader_info.stage_info_1;
+            ss << "Stage = Tessellation Control.  Invocation ID = " << stage_info_0 << ", Primitive ID = " << stage_info_1;
         } break;
         case glsl::kExecutionModel_TessellationEvaluation: {
-            ss << "Stage = Tessellation Eval.  Primitive ID = " << shader_info.stage_info_0 << ", TessCoord (u, v) = ("
-               << shader_info.stage_info_1 << ", " << shader_info.stage_info_2 << "). ";
+            ss << "Stage = Tessellation Eval.  Primitive ID = " << stage_info_0 << ", TessCoord (u, v) = (" << stage_info_1 << ", "
+               << stage_info_2 << "). ";
         } break;
         case glsl::kExecutionModel_Geometry: {
-            ss << "Stage = Geometry.  Primitive ID = " << shader_info.stage_info_0
-               << " Invocation ID = " << shader_info.stage_info_1 << ". ";
+            ss << "Stage = Geometry.  Primitive ID = " << stage_info_0 << " Invocation ID = " << stage_info_1 << ". ";
         } break;
         case glsl::kExecutionModel_Fragment: {
             // Should use std::bit_cast but requires c++20
             // need memcpy or -Wstrict-aliasing will yell
             float x_coord;
             float y_coord;
-            std::memcpy(&x_coord, &shader_info.stage_info_0, sizeof(float));
-            std::memcpy(&y_coord, &shader_info.stage_info_1, sizeof(float));
+            std::memcpy(&x_coord, &stage_info_0, sizeof(float));
+            std::memcpy(&y_coord, &stage_info_1, sizeof(float));
             ss << "Stage = Fragment.  Fragment coord (x,y) = (" << x_coord << ", " << y_coord << "). ";
         } break;
         case glsl::kExecutionModel_GLCompute: {
-            ss << "Stage = Compute.  Global invocation ID (x, y, z) = (" << shader_info.stage_info_0 << ", "
-               << shader_info.stage_info_1 << ", " << shader_info.stage_info_2 << ")";
+            ss << "Stage = Compute.  Global invocation ID (x, y, z) = (" << stage_info_0 << ", " << stage_info_1 << ", "
+               << stage_info_2 << ")";
         } break;
         case glsl::kExecutionModel_RayGenerationKHR: {
-            ss << "Stage = Ray Generation.  Global Launch ID (x,y,z) = (" << shader_info.stage_info_0 << ", "
-               << shader_info.stage_info_1 << ", " << shader_info.stage_info_2 << "). ";
+            ss << "Stage = Ray Generation.  Global Launch ID (x,y,z) = (" << stage_info_0 << ", " << stage_info_1 << ", "
+               << stage_info_2 << "). ";
         } break;
         case glsl::kExecutionModel_IntersectionKHR: {
-            ss << "Stage = Intersection.  Global Launch ID (x,y,z) = (" << shader_info.stage_info_0 << ", "
-               << shader_info.stage_info_1 << ", " << shader_info.stage_info_2 << "). ";
+            ss << "Stage = Intersection.  Global Launch ID (x,y,z) = (" << stage_info_0 << ", " << stage_info_1 << ", "
+               << stage_info_2 << "). ";
         } break;
         case glsl::kExecutionModel_AnyHitKHR: {
-            ss << "Stage = Any Hit.  Global Launch ID (x,y,z) = (" << shader_info.stage_info_0 << ", " << shader_info.stage_info_1
-               << ", " << shader_info.stage_info_2 << "). ";
+            ss << "Stage = Any Hit.  Global Launch ID (x,y,z) = (" << stage_info_0 << ", " << stage_info_1 << ", " << stage_info_2
+               << "). ";
         } break;
         case glsl::kExecutionModel_ClosestHitKHR: {
-            ss << "Stage = Closest Hit.  Global Launch ID (x,y,z) = (" << shader_info.stage_info_0 << ", "
-               << shader_info.stage_info_1 << ", " << shader_info.stage_info_2 << "). ";
+            ss << "Stage = Closest Hit.  Global Launch ID (x,y,z) = (" << stage_info_0 << ", " << stage_info_1 << ", "
+               << stage_info_2 << "). ";
         } break;
         case glsl::kExecutionModel_MissKHR: {
-            ss << "Stage = Miss.  Global Launch ID (x,y,z) = (" << shader_info.stage_info_0 << ", " << shader_info.stage_info_1
-               << ", " << shader_info.stage_info_2 << "). ";
+            ss << "Stage = Miss.  Global Launch ID (x,y,z) = (" << stage_info_0 << ", " << stage_info_1 << ", " << stage_info_2
+               << "). ";
         } break;
         case glsl::kExecutionModel_CallableKHR: {
-            ss << "Stage = Callable.  Global Launch ID (x,y,z) = (" << shader_info.stage_info_0 << ", " << shader_info.stage_info_1
-               << ", " << shader_info.stage_info_2 << "). ";
+            ss << "Stage = Callable.  Global Launch ID (x,y,z) = (" << stage_info_0 << ", " << stage_info_1 << ", " << stage_info_2
+               << "). ";
         } break;
         case glsl::kExecutionModel_TaskEXT: {
-            ss << "Stage = TaskEXT. Global invocation ID (x, y, z) = (" << shader_info.stage_info_0 << ", "
-               << shader_info.stage_info_1 << ", " << shader_info.stage_info_2 << ")";
+            ss << "Stage = TaskEXT. Global invocation ID (x, y, z) = (" << stage_info_0 << ", " << stage_info_1 << ", "
+               << stage_info_2 << ")";
         } break;
         case glsl::kExecutionModel_MeshEXT: {
-            ss << "Stage = MeshEXT. Global invocation ID (x, y, z) = (" << shader_info.stage_info_0 << ", "
-               << shader_info.stage_info_1 << ", " << shader_info.stage_info_2 << ")";
+            ss << "Stage = MeshEXT. Global invocation ID (x, y, z) = (" << stage_info_0 << ", " << stage_info_1 << ", "
+               << stage_info_2 << ")";
         } break;
         case glsl::kExecutionModel_TaskNV: {
-            ss << "Stage = TaskNV. Global invocation ID (x, y, z) = (" << shader_info.stage_info_0 << ", "
-               << shader_info.stage_info_1 << ", " << shader_info.stage_info_2 << ")";
+            ss << "Stage = TaskNV. Global invocation ID (x, y, z) = (" << stage_info_0 << ", " << stage_info_1 << ", "
+               << stage_info_2 << ")";
         } break;
         case glsl::kExecutionModel_MeshNV: {
-            ss << "Stage = MeshNV. Global invocation ID (x, y, z) = (" << shader_info.stage_info_0 << ", "
-               << shader_info.stage_info_1 << ", " << shader_info.stage_info_2 << ")";
+            ss << "Stage = MeshNV. Global invocation ID (x, y, z) = (" << stage_info_0 << ", " << stage_info_1 << ", "
+               << stage_info_2 << ")";
         } break;
         default: {
-            ss << "Internal Error (unexpected stage = " << shader_info.stage_id << "). ";
+            ss << "Internal Error (unexpected stage = " << stage_id << "). ";
             assert(false);
         } break;
     }
@@ -1890,8 +1891,8 @@ static void GenerateStageMessage(std::ostringstream &ss, const GpuShaderInstrume
 }
 
 // Where we build up the error message with all the useful debug information about where the error occured
-std::string GpuShaderInstrumentor::GenerateDebugInfoMessage(VkCommandBuffer commandBuffer, const ShaderMessageInfo &shader_info,
-                                                            const InstrumentedShader *instrumented_shader,
+std::string GpuShaderInstrumentor::GenerateDebugInfoMessage(VkCommandBuffer commandBuffer, const uint32_t* error_record,
+                                                            const InstrumentedShader* instrumented_shader,
                                                             VkPipelineBindPoint pipeline_bind_point,
                                                             uint32_t action_command_index) const {
     std::ostringstream ss;
@@ -1900,7 +1901,7 @@ std::string GpuShaderInstrumentor::GenerateDebugInfoMessage(VkCommandBuffer comm
         return ss.str();
     }
 
-    GenerateStageMessage(ss, shader_info, instrumented_shader->original_spirv);
+    GenerateStageMessage(ss, error_record, instrumented_shader->original_spirv);
 
     ss << std::hex << std::showbase;
     if (instrumented_shader->shader_module == VK_NULL_HANDLE && instrumented_shader->shader_object == VK_NULL_HANDLE) {
@@ -1934,25 +1935,27 @@ std::string GpuShaderInstrumentor::GenerateDebugInfoMessage(VkCommandBuffer comm
         }
         ss << std::hex << std::noshowbase;
 
+        const uint32_t unique_shader_id = error_record[glsl::kHeader_ShaderIdErrorOffset] & glsl::kShaderIdMask;
         if (instrumented_shader->shader_module == VK_NULL_HANDLE) {
             ss << "Shader Object " << LookupDebugUtilsNameNoLock(debug_report, HandleToUint64(instrumented_shader->shader_object))
-               << "(0x" << HandleToUint64(instrumented_shader->shader_object) << ") (internal ID " << std::dec
-               << shader_info.shader_id << ")\n";
+               << "(0x" << HandleToUint64(instrumented_shader->shader_object) << ") (internal ID " << std::dec << unique_shader_id
+               << ")\n";
         } else {
             if (instrumented_shader->shader_module == kPipelineStageInfoHandle) {
                 ss << "Shader Module was passed in via VkPipelineShaderStageCreateInfo::pNext (internal ID " << std::dec
-                   << shader_info.shader_id << ")\n";
+                   << unique_shader_id << ")\n";
             } else {
                 ss << "Shader Module "
                    << LookupDebugUtilsNameNoLock(debug_report, HandleToUint64(instrumented_shader->shader_module)) << "(0x"
-                   << HandleToUint64(instrumented_shader->shader_module) << ") (internal ID " << std::dec << shader_info.shader_id
+                   << HandleToUint64(instrumented_shader->shader_module) << ") (internal ID " << std::dec << unique_shader_id
                    << ")\n";
             }
         }
     }
     ss << std::dec << std::noshowbase;
 
-    ::spirv::FindShaderSource(ss, instrumented_shader->original_spirv, shader_info.instruction_position_offset,
+    const uint32_t instruction_position_offset = error_record[glsl::kHeader_StageInstructionIdOffset] & glsl::kInstructionId_Mask;
+    ::spirv::FindShaderSource(ss, instrumented_shader->original_spirv, instruction_position_offset,
                               gpuav_settings.debug_printf_only);
 
     return ss.str();

--- a/layers/gpuav/instrumentation/gpuav_shader_instrumentor.h
+++ b/layers/gpuav/instrumentation/gpuav_shader_instrumentor.h
@@ -165,16 +165,8 @@ class GpuShaderInstrumentor : public vvl::DeviceProxy {
 
     bool IsSelectiveInstrumentationEnabled(const void *pNext);
 
-    struct ShaderMessageInfo {
-        uint32_t stage_id;
-        uint32_t stage_info_0;
-        uint32_t stage_info_1;
-        uint32_t stage_info_2;
-        uint32_t instruction_position_offset;
-        uint32_t shader_id;
-    };
-    std::string GenerateDebugInfoMessage(VkCommandBuffer commandBuffer, const ShaderMessageInfo &shader_info,
-                                         const InstrumentedShader *instrumented_shader, VkPipelineBindPoint pipeline_bind_point,
+    std::string GenerateDebugInfoMessage(VkCommandBuffer commandBuffer, const uint32_t* error_record,
+                                         const InstrumentedShader* instrumented_shader, VkPipelineBindPoint pipeline_bind_point,
                                          uint32_t operation_index) const;
 
   protected:

--- a/layers/gpuav/instrumentation/shared_memory_data_race.cpp
+++ b/layers/gpuav/instrumentation/shared_memory_data_race.cpp
@@ -17,7 +17,6 @@
 #include "gpuav/resources/gpuav_state_trackers.h"
 #include "gpuav/shaders/gpuav_error_codes.h"
 #include "gpuav/shaders/gpuav_error_header.h"
-#include "state_tracker/shader_module.h"
 #include "error_message/spirv_logging.h"
 
 namespace gpuav {

--- a/layers/gpuav/spirv/debug_printf_pass.cpp
+++ b/layers/gpuav/spirv/debug_printf_pass.cpp
@@ -239,21 +239,23 @@ void DebugPrintfPass::CreateFunctionCall(BasicBlock& block, InstructionIt* inst_
     // We know the first part, then build up the rest from the printf arguments
     // except a few slots, we place hold it with zero until we build up the params
     const size_t function_def_slot = 2;
-    const size_t double_bitmask_slot = 5;
-    const size_t signed_8_bitmask_slot = 6;
-    const size_t signed_16_bitmask_slot = 7;
-    std::vector<uint32_t> function_call_params = {void_type,
-                                                  function_result,
-                                                  0,  // function_def_slot
-                                                  inst_position_constant.Id(),
-                                                  string_id_constant.Id(),
-                                                  0,  // double_bitmask_slot,
-                                                  0,  // signed_8_bitmask_slot,
-                                                  0,  // signed_16_bitmask_slot,
-                                                  block_func.stage_info_x_id_,
-                                                  block_func.stage_info_y_id_,
-                                                  block_func.stage_info_z_id_,
-                                                  block_func.stage_info_w_id_};
+    const size_t double_bitmask_slot = 9;
+    const size_t signed_8_bitmask_slot = 10;
+    const size_t signed_16_bitmask_slot = 11;
+    std::vector<uint32_t> function_call_params = {
+        void_type,
+        function_result,
+        0,  // function_def_slot
+        inst_position_constant.Id(),
+        block_func.stage_info_x_id_,  // shader stage
+        block_func.stage_info_y_id_,
+        block_func.stage_info_z_id_,
+        block_func.stage_info_w_id_,
+        string_id_constant.Id(),
+        0,  // double_bitmask_slot,
+        0,  // signed_8_bitmask_slot,
+        0,  // signed_16_bitmask_slot,
+    };
 
     ParamMeta param_meta;
     // where we find the first arugment in OpExtInst instruction
@@ -353,9 +355,10 @@ void DebugPrintfPass::CreateBufferWriteFunction(uint32_t argument_count, uint32_
     //     }
     // }
 
-    // Need 1 byte to write the "how many bytes will there be"
-    // Need 1 byte for the shader stage (which we don't pass in as we know already)
-    const uint32_t byte_written = argument_count + 2;
+    // + 1 byte to write the "how many bytes will there be"
+    // + 1 byte for the shader stage (which we don't pass in as we know already)
+    // - 1 byte as we combine the instruction offset and stage type
+    const uint32_t byte_written = argument_count + 1;
 
     // Debug name is matching number of bytes written into the buffer
     std::string function_name = "inst_debug_printf_" + std::to_string(byte_written);
@@ -460,11 +463,38 @@ void DebugPrintfPass::CreateBufferWriteFunction(uint32_t argument_count, uint32_
         store_block.CreateInstruction(spv::OpStore, {access_chain_id, shader_id});
     }
 
-    // Write a 32-bit word to the output buffer for each argument
-    const uint32_t argument_id_offset = 2;
-    for (uint32_t i = 0; i < argument_count; i++) {
+    // Store Instruction Position Offset + Stage Type
+    {
+        const uint32_t two_id = type_manager_.GetConstantUInt32(2).Id();
         const uint32_t int_add_id = module_.TakeNextId();
-        const uint32_t offset_id = type_manager_.GetConstantUInt32(i + argument_id_offset).Id();
+        store_block.CreateInstruction(spv::OpIAdd, {uint32_type_id, int_add_id, atomic_add_id, two_id});
+
+        const uint32_t access_chain_id = module_.TakeNextId();
+        store_block.CreateInstruction(spv::OpAccessChain,
+                                      {pointer_type_id, access_chain_id, output_buffer_variable_id, one_id, int_add_id});
+
+        // Matches the code
+        //    error_payload.inst_offset | (stage_info.x << kStageId_Shift);
+        // found in log_error.comp
+        const uint32_t shift_id = type_manager_.GetConstantUInt32(glsl::kStageId_Shift).Id();
+        const uint32_t shift_left_id = module_.TakeNextId();
+        const uint32_t stage_info_x = function_param_ids[1];
+        store_block.CreateInstruction(spv::OpShiftLeftLogical, {uint32_type_id, shift_left_id, stage_info_x, shift_id});
+
+        const uint32_t bitwise_or_id = module_.TakeNextId();
+        const uint32_t instruction_position_offset = function_param_ids[0];
+        store_block.CreateInstruction(spv::OpBitwiseOr,
+                                      {uint32_type_id, bitwise_or_id, instruction_position_offset, shift_left_id});
+
+        store_block.CreateInstruction(spv::OpStore, {access_chain_id, bitwise_or_id});
+    }
+
+    // Write a 32-bit word to the output buffer for each argument.
+    // Skip [0] and [1] as they set above already
+    for (uint32_t i = 2; i < argument_count; i++) {
+        const uint32_t int_add_id = module_.TakeNextId();
+        // Offset by 1 such that the first in this loop is at [offset + 3]
+        const uint32_t offset_id = type_manager_.GetConstantUInt32(i + 1).Id();
         store_block.CreateInstruction(spv::OpIAdd, {uint32_type_id, int_add_id, atomic_add_id, offset_id});
 
         const uint32_t access_chain_id = module_.TakeNextId();

--- a/tests/unit/debug_printf.cpp
+++ b/tests/unit/debug_printf.cpp
@@ -3134,7 +3134,7 @@ TEST_F(NegativeDebugPrintf, ShaderObjectUnusedBoundDescriptor) {
 
 TEST_F(NegativeDebugPrintf, OverflowBuffer) {
     TEST_DESCRIPTION("go over the VK_LAYER_PRINTF_BUFFER_SIZE limit");
-    uint32_t value = 128;
+    uint32_t value = 100;
     const VkLayerSettingEXT settings = {OBJECT_LAYER_NAME, "printf_buffer_size", VK_LAYER_SETTING_TYPE_UINT32_EXT, 1, &value};
     VkLayerSettingsCreateInfoEXT layer_settings_create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1,
                                                                &settings};
@@ -3167,7 +3167,7 @@ TEST_F(NegativeDebugPrintf, OverflowBuffer) {
 
 TEST_F(NegativeDebugPrintf, OverflowBufferLoop) {
     TEST_DESCRIPTION("go over the VK_LAYER_PRINTF_BUFFER_SIZE limit... by a LOT");
-    uint32_t value = 128;
+    uint32_t value = 100;
     const VkLayerSettingEXT settings = {OBJECT_LAYER_NAME, "printf_buffer_size", VK_LAYER_SETTING_TYPE_UINT32_EXT, 1, &value};
     VkLayerSettingsCreateInfoEXT layer_settings_create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1,
                                                                &settings};


### PR DESCRIPTION
We had this clunky `GpuShaderInstrumentor::ShaderMessageInfo` that we passed into `GenerateDebugInfoMessage` from both the normal GPU-AV code and DebugPrintf

By just moving around the error log that DebugPrintf has to match GPU-AV, we can now just keep everything in the same `const uint32_t* error_record` as they now share the same first 5 `uint32_t` to get the basic meta data out for the error messages