### PR TITLE
gpuav: Pass in original shaders to error message

### DIFF
--- a/layers/gpuav/instrumentation/buffer_device_address.cpp
+++ b/layers/gpuav/instrumentation/buffer_device_address.cpp
@@ -39,6 +39,7 @@ void RegisterBufferDeviceAddressValidation(Validator& gpuav, CommandBufferSubSta
                                                                           const LastBound& last_bound) {
         CommandBufferSubState::InstrumentationErrorLogger inst_error_logger = [](Validator& gpuav, const Location&,
                                                                                  const uint32_t* error_record,
+                                                                                 const InstrumentedShader*,
                                                                                  std::string& out_error_msg,
                                                                                  std::string& out_vuid_msg) {
             using namespace glsl;

--- a/layers/gpuav/instrumentation/descriptor_checks.cpp
+++ b/layers/gpuav/instrumentation/descriptor_checks.cpp
@@ -131,6 +131,7 @@ void RegisterDescriptorChecksValidation(Validator& gpuav, CommandBufferSubState&
         CommandBufferSubState::InstrumentationErrorLogger inst_error_logger = [&cb, descriptor_binding_index](
                                                                                   Validator& gpuav, const Location& loc,
                                                                                   const uint32_t* error_record,
+                                                                                  const InstrumentedShader*,
                                                                                   std::string& out_error_msg,
                                                                                   std::string& out_vuid_msg) {
             using namespace glsl;
@@ -230,6 +231,7 @@ void RegisterDescriptorChecksValidation(Validator& gpuav, CommandBufferSubState&
         CommandBufferSubState::InstrumentationErrorLogger inst_error_logger = [&cb, descriptor_binding_index, uses_shader_object](
                                                                                   Validator& gpuav, const Location& loc,
                                                                                   const uint32_t* error_record,
+                                                                                  const InstrumentedShader*,
                                                                                   std::string& out_error_msg,
                                                                                   std::string& out_vuid_msg) {
             using namespace glsl;

--- a/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpuav/instrumentation/gpuav_instrumentation.cpp
@@ -338,8 +338,17 @@ bool LogInstrumentationError(Validator& gpuav, const VkCommandBuffer cb_handle, 
     std::string vuid_msg;
     bool error_found = false;
 
+    // Lookup the VkShaderModule handle and SPIR-V code used to create the shader, using the unique shader ID value returned
+    // by the instrumented shader.
+    const InstrumentedShader* instrumented_shader = nullptr;
+    const uint32_t unique_shader_id = error_record[glsl::kHeader_ShaderIdErrorOffset] & glsl::kShaderIdMask;
+    auto it = gpuav.instrumented_shaders_map_.find(unique_shader_id);
+    if (it != gpuav.instrumented_shaders_map_.end()) {
+        instrumented_shader = &it->second;
+    }
+
     for (const CommandBufferSubState::InstrumentationErrorLogger &error_logger : error_loggers) {
-        error_found = error_logger(gpuav, loc_with_debug_region, error_record, error_msg, vuid_msg);
+        error_found = error_logger(gpuav, loc_with_debug_region, error_record, instrumented_shader, error_msg, vuid_msg);
         if (error_found) {
             break;
         }
@@ -347,17 +356,7 @@ bool LogInstrumentationError(Validator& gpuav, const VkCommandBuffer cb_handle, 
 
     // We should find an error, otherwise this means we are not registering a check somewhere
     assert(error_found);
-
     if (error_found) {
-        // Lookup the VkShaderModule handle and SPIR-V code used to create the shader, using the unique shader ID value returned
-        // by the instrumented shader.
-        const InstrumentedShader *instrumented_shader = nullptr;
-        const uint32_t unique_shader_id = error_record[glsl::kHeader_ShaderIdErrorOffset] & glsl::kShaderIdMask;
-        auto it = gpuav.instrumented_shaders_map_.find(unique_shader_id);
-        if (it != gpuav.instrumented_shaders_map_.end()) {
-            instrumented_shader = &it->second;
-        }
-
         std::string debug_info_message = gpuav.GenerateDebugInfoMessage(
             cb_handle, error_record, instrumented_shader, error_info.pipeline_bind_point, error_info.action_command_index);
 

--- a/layers/gpuav/instrumentation/mesh_shading.cpp
+++ b/layers/gpuav/instrumentation/mesh_shading.cpp
@@ -26,10 +26,10 @@ void RegisterMeshShadingValidation(Validator &gpuav, CommandBufferSubState &cb) 
     }
 
     cb.on_instrumentation_error_logger_register_functions.emplace_back(
-        [](Validator &gpuav, CommandBufferSubState &cb, const LastBound &last_bound) {
+        [](Validator& gpuav, CommandBufferSubState& cb, const LastBound& last_bound) {
             CommandBufferSubState::InstrumentationErrorLogger inst_error_logger =
-                [](Validator &gpuav, const Location &loc, const uint32_t *error_record, std::string &out_error_msg,
-                   std::string &out_vuid_msg) {
+                [](Validator& gpuav, const Location& loc, const uint32_t* error_record, const InstrumentedShader*,
+                   std::string& out_error_msg, std::string& out_vuid_msg) {
                     using namespace glsl;
                     bool error_found = false;
                     if (GetErrorGroup(error_record) != kErrorGroup_InstMeshShading) {

--- a/layers/gpuav/instrumentation/ray_hit_object.cpp
+++ b/layers/gpuav/instrumentation/ray_hit_object.cpp
@@ -26,12 +26,13 @@ void RegisterRayHitObjectValidation(Validator &gpuav, CommandBufferSubState &cb)
         return;
     }
 
-    cb.on_instrumentation_error_logger_register_functions.emplace_back([](Validator &gpuav, CommandBufferSubState &cb,
-                                                                          const LastBound &last_bound) {
-        CommandBufferSubState::InstrumentationErrorLogger inst_error_logger = [](Validator &gpuav, const Location &loc,
-                                                                                 const uint32_t *error_record,
-                                                                                 std::string &out_error_msg,
-                                                                                 std::string &out_vuid_msg) {
+    cb.on_instrumentation_error_logger_register_functions.emplace_back([](Validator& gpuav, CommandBufferSubState& cb,
+                                                                          const LastBound& last_bound) {
+        CommandBufferSubState::InstrumentationErrorLogger inst_error_logger = [](Validator& gpuav, const Location& loc,
+                                                                                 const uint32_t* error_record,
+                                                                                 const InstrumentedShader*,
+                                                                                 std::string& out_error_msg,
+                                                                                 std::string& out_vuid_msg) {
             using namespace glsl;
             bool error_found = false;
             if (GetErrorGroup(error_record) != kErrorGroup_InstRayHitObject) {

--- a/layers/gpuav/instrumentation/ray_query.cpp
+++ b/layers/gpuav/instrumentation/ray_query.cpp
@@ -25,90 +25,90 @@ void RegisterRayQueryValidation(Validator &gpuav, CommandBufferSubState &cb) {
         return;
     }
 
-    cb.on_instrumentation_error_logger_register_functions.emplace_back([](Validator &gpuav, CommandBufferSubState &cb,
-                                                                          const LastBound &last_bound) {
-        CommandBufferSubState::InstrumentationErrorLogger inst_error_logger = [](Validator &gpuav, const Location &loc,
-                                                                                 const uint32_t *error_record,
-                                                                                 std::string &out_error_msg,
-                                                                                 std::string &out_vuid_msg) {
-            using namespace glsl;
-            bool error_found = false;
-            if (GetErrorGroup(error_record) != kErrorGroup_InstRayQuery) {
-                return error_found;
-            }
-            error_found = true;
+    cb.on_instrumentation_error_logger_register_functions.emplace_back(
+        [](Validator& gpuav, CommandBufferSubState& cb, const LastBound& last_bound) {
+            CommandBufferSubState::InstrumentationErrorLogger inst_error_logger =
+                [](Validator& gpuav, const Location& loc, const uint32_t* error_record, const InstrumentedShader*,
+                   std::string& out_error_msg, std::string& out_vuid_msg) {
+                    using namespace glsl;
+                    bool error_found = false;
+                    if (GetErrorGroup(error_record) != kErrorGroup_InstRayQuery) {
+                        return error_found;
+                    }
+                    error_found = true;
 
-            std::ostringstream strm;
+                    std::ostringstream strm;
 
-            const uint32_t error_sub_code = GetSubError(error_record);
+                    const uint32_t error_sub_code = GetSubError(error_record);
 
-            switch (error_sub_code) {
-                case kErrorSubCode_RayQuery_NegativeMin: {
-                    // Should use std::bit_cast but requires c++20
-                    const float tmin = *(float*)(error_record + kInst_LogError_ParameterOffset_0);
-                    strm << "OpRayQueryInitializeKHR operand Ray Tmin value (" << tmin << ") is negative. ";
-                    out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06349";
-                } break;
-                case kErrorSubCode_RayQuery_NegativeMax: {
-                    const float tmax = *(float*)(error_record + kInst_LogError_ParameterOffset_0);
-                    strm << "OpRayQueryInitializeKHR operand Ray Tmax value (" << tmax << ") is negative. ";
-                    out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06349";
-                } break;
-                case kErrorSubCode_RayQuery_MinMax: {
-                    const float tmin = *(float*)(error_record + kInst_LogError_ParameterOffset_0);
-                    const float tmax = *(float*)(error_record + kInst_LogError_ParameterOffset_1);
-                    strm << "OpRayQueryInitializeKHR operand Ray Tmax (" << tmax << ") is less than Ray Tmin (" << tmin << "). ";
-                    out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06350";
-                } break;
-                case kErrorSubCode_RayQuery_MinNaN: {
-                    strm << "OpRayQueryInitializeKHR operand Ray Tmin is NaN. ";
-                    out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06351";
-                } break;
-                case kErrorSubCode_RayQuery_MaxNaN: {
-                    strm << "OpRayQueryInitializeKHR operand Ray Tmax is NaN. ";
-                    out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06351";
-                } break;
-                case kErrorSubCode_RayQuery_OriginNaN: {
-                    strm << "OpRayQueryInitializeKHR operand Ray Origin contains a NaN. ";
-                    out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06351";
-                } break;
-                case kErrorSubCode_RayQuery_DirectionNaN: {
-                    strm << "OpRayQueryInitializeKHR operand Ray Direction contains a NaN. ";
-                    out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06351";
-                } break;
-                case kErrorSubCode_RayQuery_OriginFinite: {
-                    strm << "OpRayQueryInitializeKHR operand Ray Origin contains a non-finite value. ";
-                    out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06348";
-                } break;
-                case kErrorSubCode_RayQuery_DirectionFinite: {
-                    strm << "OpRayQueryInitializeKHR operand Ray Direction contains a non-finite value. ";
-                    out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06348";
-                } break;
-                case kErrorSubCode_RayQuery_BothSkip: {
-                    const uint32_t value = error_record[kInst_LogError_ParameterOffset_0];
-                    strm << "OpRayQueryInitializeKHR operand Ray Flags is 0x" << std::hex << value << ". ";
-                    out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06889";
-                } break;
-                case kErrorSubCode_RayQuery_SkipCull: {
-                    const uint32_t value = error_record[kInst_LogError_ParameterOffset_0];
-                    strm << "OpRayQueryInitializeKHR operand Ray Flags is 0x" << std::hex << value << ". ";
-                    out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06890";
-                } break;
-                case kErrorSubCode_RayQuery_Opaque: {
-                    const uint32_t value = error_record[kInst_LogError_ParameterOffset_0];
-                    strm << "OpRayQueryInitializeKHR operand Ray Flags is 0x" << std::hex << value << ". ";
-                    out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06891";
-                } break;
-                default:
-                    error_found = false;
-                    break;
-            }
-            out_error_msg += strm.str();
-            return error_found;
-        };
+                    switch (error_sub_code) {
+                        case kErrorSubCode_RayQuery_NegativeMin: {
+                            // Should use std::bit_cast but requires c++20
+                            const float tmin = *(float*)(error_record + kInst_LogError_ParameterOffset_0);
+                            strm << "OpRayQueryInitializeKHR operand Ray Tmin value (" << tmin << ") is negative. ";
+                            out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06349";
+                        } break;
+                        case kErrorSubCode_RayQuery_NegativeMax: {
+                            const float tmax = *(float*)(error_record + kInst_LogError_ParameterOffset_0);
+                            strm << "OpRayQueryInitializeKHR operand Ray Tmax value (" << tmax << ") is negative. ";
+                            out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06349";
+                        } break;
+                        case kErrorSubCode_RayQuery_MinMax: {
+                            const float tmin = *(float*)(error_record + kInst_LogError_ParameterOffset_0);
+                            const float tmax = *(float*)(error_record + kInst_LogError_ParameterOffset_1);
+                            strm << "OpRayQueryInitializeKHR operand Ray Tmax (" << tmax << ") is less than Ray Tmin (" << tmin
+                                 << "). ";
+                            out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06350";
+                        } break;
+                        case kErrorSubCode_RayQuery_MinNaN: {
+                            strm << "OpRayQueryInitializeKHR operand Ray Tmin is NaN. ";
+                            out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06351";
+                        } break;
+                        case kErrorSubCode_RayQuery_MaxNaN: {
+                            strm << "OpRayQueryInitializeKHR operand Ray Tmax is NaN. ";
+                            out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06351";
+                        } break;
+                        case kErrorSubCode_RayQuery_OriginNaN: {
+                            strm << "OpRayQueryInitializeKHR operand Ray Origin contains a NaN. ";
+                            out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06351";
+                        } break;
+                        case kErrorSubCode_RayQuery_DirectionNaN: {
+                            strm << "OpRayQueryInitializeKHR operand Ray Direction contains a NaN. ";
+                            out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06351";
+                        } break;
+                        case kErrorSubCode_RayQuery_OriginFinite: {
+                            strm << "OpRayQueryInitializeKHR operand Ray Origin contains a non-finite value. ";
+                            out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06348";
+                        } break;
+                        case kErrorSubCode_RayQuery_DirectionFinite: {
+                            strm << "OpRayQueryInitializeKHR operand Ray Direction contains a non-finite value. ";
+                            out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06348";
+                        } break;
+                        case kErrorSubCode_RayQuery_BothSkip: {
+                            const uint32_t value = error_record[kInst_LogError_ParameterOffset_0];
+                            strm << "OpRayQueryInitializeKHR operand Ray Flags is 0x" << std::hex << value << ". ";
+                            out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06889";
+                        } break;
+                        case kErrorSubCode_RayQuery_SkipCull: {
+                            const uint32_t value = error_record[kInst_LogError_ParameterOffset_0];
+                            strm << "OpRayQueryInitializeKHR operand Ray Flags is 0x" << std::hex << value << ". ";
+                            out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06890";
+                        } break;
+                        case kErrorSubCode_RayQuery_Opaque: {
+                            const uint32_t value = error_record[kInst_LogError_ParameterOffset_0];
+                            strm << "OpRayQueryInitializeKHR operand Ray Flags is 0x" << std::hex << value << ". ";
+                            out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06891";
+                        } break;
+                        default:
+                            error_found = false;
+                            break;
+                    }
+                    out_error_msg += strm.str();
+                    return error_found;
+                };
 
-        return inst_error_logger;
-    });
+            return inst_error_logger;
+        });
 }
 
 }  // namespace gpuav

--- a/layers/gpuav/instrumentation/sanitizer.cpp
+++ b/layers/gpuav/instrumentation/sanitizer.cpp
@@ -34,12 +34,13 @@ void RegisterSanitizer(Validator &gpuav, CommandBufferSubState &cb) {
         return;
     }
 
-    cb.on_instrumentation_error_logger_register_functions.emplace_back([](Validator &gpuav, CommandBufferSubState &cb,
-                                                                          const LastBound &last_bound) {
-        CommandBufferSubState::InstrumentationErrorLogger inst_error_logger = [](Validator &gpuav, const Location &loc,
-                                                                                 const uint32_t *error_record,
-                                                                                 std::string &out_error_msg,
-                                                                                 std::string &out_vuid_msg) {
+    cb.on_instrumentation_error_logger_register_functions.emplace_back([](Validator& gpuav, CommandBufferSubState& cb,
+                                                                          const LastBound& last_bound) {
+        CommandBufferSubState::InstrumentationErrorLogger inst_error_logger = [](Validator& gpuav, const Location& loc,
+                                                                                 const uint32_t* error_record,
+                                                                                 const InstrumentedShader*,
+                                                                                 std::string& out_error_msg,
+                                                                                 std::string& out_vuid_msg) {
             using namespace glsl;
             bool error_found = false;
             if (GetErrorGroup(error_record) != kErrorGroup_InstSanitizer) {

--- a/layers/gpuav/instrumentation/shared_memory_data_race.cpp
+++ b/layers/gpuav/instrumentation/shared_memory_data_race.cpp
@@ -27,24 +27,16 @@ void RegisterSharedMemoryDataRaceValidation(Validator &gpuav, CommandBufferSubSt
     }
 
     cb.on_instrumentation_error_logger_register_functions.emplace_back(
-        [](Validator &gpuav, CommandBufferSubState &cb, const LastBound &last_bound) {
+        [](Validator& gpuav, CommandBufferSubState& cb, const LastBound& last_bound) {
             CommandBufferSubState::InstrumentationErrorLogger inst_error_logger =
-                [](Validator &gpuav, const Location &loc, const uint32_t *error_record, std::string &out_error_msg,
-                   std::string &out_vuid_msg) {
+                [](Validator& gpuav, const Location& loc, const uint32_t* error_record,
+                   const InstrumentedShader* instrumented_shader, std::string& out_error_msg, std::string& out_vuid_msg) {
                     using namespace glsl;
                     bool error_found = false;
                     if (GetErrorGroup(error_record) != kErrorGroup_SharedMemoryDataRace) {
                         return error_found;
                     }
                     error_found = true;
-
-                    // TODO - We shouldn't need to grab the core Module object here...
-                    const InstrumentedShader *instrumented_shader = nullptr;
-                    const uint32_t unique_shader_id = error_record[glsl::kHeader_ShaderIdErrorOffset] & glsl::kShaderIdMask;
-                    auto it = gpuav.instrumented_shaders_map_.find(unique_shader_id);
-                    if (it != gpuav.instrumented_shaders_map_.end()) {
-                        instrumented_shader = &it->second;
-                    }
 
                     const uint32_t thread_id = error_record[kInst_LogError_ParameterOffset_0];
                     const uint32_t collide_id = error_record[kInst_LogError_ParameterOffset_1] & 0xFFFF;
@@ -53,7 +45,11 @@ void RegisterSharedMemoryDataRaceValidation(Validator &gpuav, CommandBufferSubSt
                     const uint32_t error_sub_code = GetSubError(error_record);
                     std::ostringstream strm;
                     strm << "A data race was detected on the shared memory variable \"";
-                    ::spirv::FindOpVariableName(strm, instrumented_shader->original_spirv, variable_id);
+                    if (instrumented_shader) {
+                        ::spirv::FindOpVariableName(strm, instrumented_shader->original_spirv, variable_id);
+                    } else {
+                        strm << "[error, original SPIR-V not found]";
+                    }
                     strm << "\" in local invocation index " << thread_id << " while performing a ";
                     switch (error_sub_code) {
                         case kErrorSubCode_SharedMemoryDataRace_RaceOnStore: {

--- a/layers/gpuav/instrumentation/vertex_attribute_fetch_oob.cpp
+++ b/layers/gpuav/instrumentation/vertex_attribute_fetch_oob.cpp
@@ -167,6 +167,7 @@ void RegisterVertexAttributeFetchOobValidation(Validator &gpuav, CommandBufferSu
         CommandBufferSubState::InstrumentationErrorLogger inst_error_logger = [local_error_info = std::move(local_error_info)](
                                                                                   Validator& gpuav, const Location& loc,
                                                                                   const uint32_t* error_record,
+                                                                                  const InstrumentedShader*,
                                                                                   std::string& out_error_msg,
                                                                                   std::string& out_vuid_msg) {
             if (GetErrorGroup(error_record) != glsl::kErrorGroup_InstIndexedDraw) {

--- a/layers/gpuav/resources/gpuav_state_trackers.h
+++ b/layers/gpuav/resources/gpuav_state_trackers.h
@@ -43,6 +43,7 @@ namespace gpuav {
 
 class Validator;
 class QueueSubState;
+struct InstrumentedShader;
 
 class CommandBufferSubState : public vvl::CommandBufferSubState {
   public:
@@ -50,9 +51,9 @@ class CommandBufferSubState : public vvl::CommandBufferSubState {
         const std::vector<std::string> &initial_label_stack;
     };
 
-    using InstrumentationErrorLogger =
-        stdext::inplace_function<bool(Validator &gpuav, const Location &loc, const uint32_t *error_record,
-                                      std::string &out_error_msg, std::string &out_vuid_msg)>;
+    using InstrumentationErrorLogger = stdext::inplace_function<bool(
+        Validator& gpuav, const Location& loc, const uint32_t* error_record, const InstrumentedShader* instrumented_shader,
+        std::string& out_error_msg, std::string& out_vuid_msg)>;
     using OnInstrumentationErrorLoggerRegister = stdext::inplace_function<InstrumentationErrorLogger(
         Validator &gpuav, CommandBufferSubState &cb, const LastBound &last_bound)>;
     using OnInstrumentationDescSetUpdate =


### PR DESCRIPTION
Currently only the `SharedMemoryDataRace` pass takes advantage of this, but after this PR, I want to start adding more logic in to produce better error messages around the "variable name" or "struct name" that causes errors in GPU-AV by using the original shader source