### PR TITLE
layers:fix buffer intersection check for ClusterAccelerationStructure

### DIFF
--- a/layers/core_checks/cc_ray_tracing_nv.cpp
+++ b/layers/core_checks/cc_ray_tracing_nv.cpp
@@ -694,9 +694,10 @@ bool CoreChecks::PreCallValidateCmdBuildClusterAccelerationStructureIndirectNV(
                              .c_str());
     }
 
+    VkAccelerationStructureBuildSizesInfoKHR accelerationStructure_size = vku::InitStructHelper();
+    DispatchGetClusterAccelerationStructureBuildSizesNV(device, &(pCommandInfos->input), &accelerationStructure_size);
+
     {
-        VkAccelerationStructureBuildSizesInfoKHR accelerationStructure_size = vku::InitStructHelper();
-        DispatchGetClusterAccelerationStructureBuildSizesNV(device, &(pCommandInfos->input), &accelerationStructure_size);
         BufferAddressValidation<2> scratch_buffer_validator = {{{
             {"VUID-vkCmdBuildClusterAccelerationStructureIndirectNV-scratchData-12300",
              [&accelerationStructure_size](const vvl::Buffer& buffer_state) {
@@ -791,51 +792,30 @@ bool CoreChecks::PreCallValidateCmdBuildClusterAccelerationStructureIndirectNV(
     }
 
     if (pCommandInfos->scratchData && pCommandInfos->dstImplicitData) {
-        const auto scratch_buffer_states = GetBuffersByAddress(pCommandInfos->scratchData);
-        const auto dst_implicit_buffer_states = GetBuffersByAddress(pCommandInfos->dstImplicitData);
-        for (const auto& scratch_buffer_state : scratch_buffer_states) {
-            vvl::range<VkDeviceAddress> scratch_address_range = scratch_buffer_state->DeviceAddressRange();
-
-            if (!scratch_address_range.empty()) {
-                for (const auto& dst_implicit_buffer_state : dst_implicit_buffer_states) {
-                    const vvl::range<VkDeviceAddress> dst_implicit_address_range = dst_implicit_buffer_state->DeviceAddressRange();
-                    if (dst_implicit_address_range.intersects(scratch_address_range)) {
-                        const LogObjectList objlist_implicit(commandBuffer, dst_implicit_buffer_state->Handle(),
-                                                             scratch_buffer_state->Handle());
-                        skip |= LogError("VUID-vkCmdBuildClusterAccelerationStructureIndirectNV-dstImplicitData-12303",
-                                         objlist_implicit, command_infos_loc.dot(Field::dstImplicitData),
-                                         "%s address range %s intersects with scratchData address range %s",
-                                         FormatHandle(dst_implicit_buffer_state->Handle()).c_str(),
-                                         string_range_hex(dst_implicit_address_range).c_str(),
-                                         string_range_hex(scratch_address_range).c_str());
-                    }
-                }
-            }
+        const vvl::range<VkDeviceAddress> scratch_range = {
+            pCommandInfos->scratchData, pCommandInfos->scratchData + accelerationStructure_size.buildScratchSize};
+        const vvl::range<VkDeviceAddress> dst_implicit_range = {
+            pCommandInfos->dstImplicitData, pCommandInfos->dstImplicitData + accelerationStructure_size.accelerationStructureSize};
+        if (scratch_range.intersects(dst_implicit_range)) {
+            skip |= LogError("VUID-vkCmdBuildClusterAccelerationStructureIndirectNV-dstImplicitData-12303", objlist,
+                             command_infos_loc.dot(Field::dstImplicitData),
+                             "dstImplicitData address range %s intersects with scratchData address range %s",
+                             string_range_hex(dst_implicit_range).c_str(), string_range_hex(scratch_range).c_str());
         }
     }
 
     if (pCommandInfos->scratchData && pCommandInfos->dstAddressesArray.deviceAddress) {
-        const auto scratch_buffer_states = GetBuffersByAddress(pCommandInfos->scratchData);
-        const auto dst_addresses_buffer_states = GetBuffersByAddress(pCommandInfos->dstAddressesArray.deviceAddress);
-        for (const auto& scratch_buffer_state : scratch_buffer_states) {
-            vvl::range<VkDeviceAddress> scratch_address_range = scratch_buffer_state->DeviceAddressRange();
-
-            if (!scratch_address_range.empty()) {
-                for (const auto& dst_addresses_buffer_state : dst_addresses_buffer_states) {
-                    const vvl::range<VkDeviceAddress> dst_addresses_address_range =
-                        dst_addresses_buffer_state->DeviceAddressRange();
-                    if (dst_addresses_address_range.intersects(scratch_address_range)) {
-                        const LogObjectList objlist_addresses(commandBuffer, dst_addresses_buffer_state->Handle(),
-                                                              scratch_buffer_state->Handle());
-                        skip |= LogError("VUID-vkCmdBuildClusterAccelerationStructureIndirectNV-dstAddressesArray-12302",
-                                         objlist_addresses, command_infos_loc.dot(Field::dstAddressesArray),
-                                         "%s address range %s intersects with scratchData address range %s",
-                                         FormatHandle(dst_addresses_buffer_state->Handle()).c_str(),
-                                         string_range_hex(dst_addresses_address_range).c_str(),
-                                         string_range_hex(scratch_address_range).c_str());
-                    }
-                }
-            }
+        const vvl::range<VkDeviceAddress> scratch_range = {
+            pCommandInfos->scratchData, pCommandInfos->scratchData + accelerationStructure_size.buildScratchSize};
+        const VkDeviceSize dst_addresses_size =
+            pCommandInfos->dstAddressesArray.stride * pCommandInfos->input.maxAccelerationStructureCount;
+        const vvl::range<VkDeviceAddress> dst_addresses_range = {
+            pCommandInfos->dstAddressesArray.deviceAddress, pCommandInfos->dstAddressesArray.deviceAddress + dst_addresses_size};
+        if (scratch_range.intersects(dst_addresses_range)) {
+            skip |= LogError("VUID-vkCmdBuildClusterAccelerationStructureIndirectNV-dstAddressesArray-12302", objlist,
+                             command_infos_loc.dot(Field::dstAddressesArray),
+                             "dstAddressesArray address range %s intersects with scratchData address range %s",
+                             string_range_hex(dst_addresses_range).c_str(), string_range_hex(scratch_range).c_str());
         }
     }
 

--- a/tests/unit/ray_tracing_positive.cpp
+++ b/tests/unit/ray_tracing_positive.cpp
@@ -2279,6 +2279,93 @@ TEST_F(PositiveRayTracing, CmdBuildClusterAccelerationStructureIndirect) {
     ASSERT_TRUE(has_data);
 }
 
+TEST_F(PositiveRayTracing, CmdBuildClusterAccelerationStructureIndirectSameBufferNonOverlapping) {
+    TEST_DESCRIPTION(
+        "Validate vkCmdBuildClusterAccelerationStructureIndirectNV does not report overlap errors when "
+        "dstImplicitData and scratchData use the same buffer at non-overlapping offsets");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_NV_CLUSTER_ACCELERATION_STRUCTURE_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::rayTracingPipeline);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::rayQuery);
+    AddRequiredFeature(vkt::Feature::clusterAccelerationStructure);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    RETURN_IF_SKIP(InitState());
+
+    uint32_t total_triangles = 1;
+    uint32_t total_vertices = 3 * total_triangles;
+
+    VkClusterAccelerationStructureTriangleClusterInputNV tri_cluster = vku::InitStructHelper();
+    tri_cluster.vertexFormat = VK_FORMAT_R32G32B32_SFLOAT;
+    tri_cluster.maxGeometryIndexValue = total_triangles - 1;
+    tri_cluster.maxClusterUniqueGeometryCount = 0;
+    tri_cluster.maxClusterTriangleCount = 1;
+    tri_cluster.maxClusterVertexCount = 3;
+    tri_cluster.maxTotalTriangleCount = total_triangles;
+    tri_cluster.maxTotalVertexCount = total_vertices;
+    tri_cluster.minPositionTruncateBitCount = 0;
+
+    VkClusterAccelerationStructureOpInputNV input = {};
+    input.pTriangleClusters = &tri_cluster;
+    VkClusterAccelerationStructureInputInfoNV input_info = vku::InitStructHelper();
+    input_info.maxAccelerationStructureCount = 1;
+    input_info.flags = VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR;
+    input_info.opType = VK_CLUSTER_ACCELERATION_STRUCTURE_OP_TYPE_BUILD_TRIANGLE_CLUSTER_TEMPLATE_NV;
+    input_info.opInput = input;
+
+    VkAccelerationStructureBuildSizesInfoKHR clas_size_info = vku::InitStructHelper();
+    vk::GetClusterAccelerationStructureBuildSizesNV(*m_device, &input_info, &clas_size_info);
+
+    VkPhysicalDeviceClusterAccelerationStructurePropertiesNV accel_struct_props = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(accel_struct_props);
+    const VkDeviceSize scratch_alignment = accel_struct_props.clusterScratchByteAlignment;
+
+    const VkDeviceSize implicit_size = clas_size_info.accelerationStructureSize;
+    const VkDeviceSize combined_size = implicit_size + scratch_alignment + clas_size_info.buildScratchSize;
+
+    vkt::Buffer combined_buffer(*m_device, combined_size,
+                                VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT |
+                                    VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR,
+                                vkt::device_address);
+
+    const VkDeviceAddress base_addr = combined_buffer.Address();
+    const VkDeviceAddress scratch_addr =
+        (base_addr + implicit_size + scratch_alignment - 1) / scratch_alignment * scratch_alignment;
+
+    vkt::Buffer src_info_buffer(
+        *m_device, sizeof(VkClusterAccelerationStructureBuildTriangleClusterTemplateInfoNV),
+        VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
+        vkt::device_address);
+
+    vkt::Buffer count_buffer(
+        *m_device, sizeof(uint32_t),
+        VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
+        vkt::device_address);
+    uint32_t input_count = 1;
+    auto* count_data = static_cast<uint32_t*>(count_buffer.Memory().Map());
+    memcpy(count_data, &input_count, sizeof(input_count));
+
+    vkt::Buffer dst_addresses_buffer(
+        *m_device, sizeof(VkDeviceAddress),
+        VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR, vkt::device_address);
+
+    VkClusterAccelerationStructureCommandsInfoNV command_info = vku::InitStructHelper();
+    command_info.input = input_info;
+    command_info.input.opMode = VK_CLUSTER_ACCELERATION_STRUCTURE_OP_MODE_IMPLICIT_DESTINATIONS_NV;
+    command_info.dstImplicitData = base_addr;
+    command_info.scratchData = scratch_addr;
+    command_info.dstAddressesArray.deviceAddress = dst_addresses_buffer.Address();
+    command_info.dstAddressesArray.stride = sizeof(VkDeviceAddress);
+    command_info.srcInfosArray.deviceAddress = src_info_buffer.Address();
+    command_info.srcInfosArray.stride = sizeof(VkClusterAccelerationStructureBuildTriangleClusterTemplateInfoNV);
+    command_info.srcInfosCount = count_buffer.Address();
+
+    m_command_buffer.Begin();
+    vk::CmdBuildClusterAccelerationStructureIndirectNV(m_command_buffer.handle(), &command_info);
+    m_command_buffer.End();
+}
+
 TEST_F(PositiveRayTracing, GetClusterAccelerationStructureBuildSizes) {
     TEST_DESCRIPTION(
         "Test vKGetClusterAccelerationStructureBuildSizes can retrieve the buffer allocation requirements for cluster geometry "


### PR DESCRIPTION
Fix Issue:https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11804

change how we check buffer intersection and add tests for the buffer-overlap-but-range-not-intersect case.