### PR TITLE
layers: Remove <algorithm> from logging.h

### DIFF
--- a/layers/error_message/logging.h
+++ b/layers/error_message/logging.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2025 The Khronos Group Inc.
- * Copyright (c) 2015-2025 Valve Corporation
- * Copyright (c) 2015-2025 LunarG, Inc.
+/* Copyright (c) 2015-2026 The Khronos Group Inc.
+ * Copyright (c) 2015-2026 Valve Corporation
+ * Copyright (c) 2015-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -168,11 +168,11 @@ struct LoggingLabelState {
             exported_labels.emplace_back(insert_label.Export());
         }
 
-        std::for_each(labels.rbegin(), labels.rend(), [&exported_labels](const LoggingLabel &label) {
-            if (!label.Empty()) {
-                exported_labels.emplace_back(label.Export());
+        for (auto label_it = labels.rbegin(); label_it != labels.rend(); ++label_it) {
+            if (!label_it->Empty()) {
+                exported_labels.emplace_back(label_it->Export());
             }
-        });
+        }
     }
 };
 


### PR DESCRIPTION
https://github.com/KhronosGroup/Vulkan-ValidationLayers/commit/e2007bfa4d3d7adbc2961c4bc425b763b0ce46d0 broke internal Google CI... simple fix should be removing the `std::for_each` from `logging.h`