### PR TITLE
gpuav: Add small meta data to Type struct

### DIFF
--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -1363,21 +1363,19 @@ bool CoreChecks::ValidateVectorTypes(const spirv::Module& module_state, const sp
                                      const Location& loc) const {
     bool skip = false;
 
-    const bool valid_long_vector = enabled_features.longVector == VK_TRUE;
+    if (!enabled_features.longVector) {
+        return skip;
+    }
 
-    if (valid_long_vector) {
-        const uint32_t maxVectorComponents = phys_dev_ext_props.shader_long_vector_props.maxVectorComponents;
-
-        for (const spirv::Instruction *vec_type_inst : module_state.static_data_.vector_type_inst) {
-            const spirv::Instruction &insn = *vec_type_inst;
-
-            uint32_t components = module_state.GetNumComponentsInBaseType(&insn);
-            if (components > maxVectorComponents) {
-                skip |= LogError(
-                    "VUID-RuntimeSpirv-longVector-12296", module_state.handle(), loc,
-                    "shader %s vector type component count (%" PRIu32 ") exceeds maxVectorComponents (%" PRIu32 ").\n%s\n",
-                    entrypoint.Describe().c_str(), components, maxVectorComponents, module_state.DescribeInstruction(insn).c_str());
-            }
+    const uint32_t max_vector_components = phys_dev_ext_props.shader_long_vector_props.maxVectorComponents;
+    for (const spirv::Instruction* insn : module_state.static_data_.vector_type_inst) {
+        const uint32_t components = module_state.GetNumComponentsInBaseType(insn);
+        if (components > max_vector_components) {
+            skip |= LogError("VUID-RuntimeSpirv-longVector-12296", module_state.handle(), loc,
+                             "shader %s has a %s with a Component Count (%" PRIu32 ") which exceeds maxVectorComponents (%" PRIu32
+                             ").\n%s\n",
+                             entrypoint.Describe().c_str(), string_SpvOpcode(insn->Opcode()), components, max_vector_components,
+                             module_state.DescribeInstruction(*insn).c_str());
         }
     }
     return skip;

--- a/layers/gpuav/spirv/CMakeLists.txt
+++ b/layers/gpuav/spirv/CMakeLists.txt
@@ -93,6 +93,11 @@ elseif(MSVC)
     )
 endif()
 
+# No matter what I do, MinGW is unaware how small_vector works
+if(MINGW)
+    target_compile_options(gpu_av_spirv PRIVATE -Wno-maybe-uninitialized)
+endif()
+
 # Auto generate Shaders' SPIR-V code upon GLSL changes
 set(GPUAV_SHADERS_DIR "${VVL_SOURCE_DIR}/layers/gpuav/shaders")
 file(GLOB_RECURSE GPUAV_SHADERS CONFIGURE_DEPENDS

--- a/layers/gpuav/spirv/debug_printf_pass.cpp
+++ b/layers/gpuav/spirv/debug_printf_pass.cpp
@@ -58,7 +58,7 @@ void DebugPrintfPass::CreateFunctionParams(uint32_t argument_id, const Type& arg
 
     switch (argument_type.spv_type_) {
         case SpvType::kVector: {
-            const uint32_t component_count = argument_type.inst_.Word(3);
+            const uint32_t component_count = argument_type.meta_.vector.component_count;
             const uint32_t component_type_id = argument_type.inst_.Word(2);
             const Type* component_type = type_manager_.FindTypeById(component_type_id);
             assert(component_type);
@@ -71,10 +71,10 @@ void DebugPrintfPass::CreateFunctionParams(uint32_t argument_id, const Type& arg
         }
 
         case SpvType::kInt: {
-            const uint32_t width = argument_type.inst_.Word(2);
+            const uint32_t width = argument_type.meta_.scalar.bit_width;
 
             // first thing is to get any signed to unsigned via bitcast
-            const bool is_signed = argument_type.inst_.Word(3) != 0;
+            const bool is_signed = argument_type.meta_.scalar.is_signed;
             uint32_t incoming_id = argument_id;
             if (is_signed) {
                 const uint32_t bitcast_id = module_.TakeNextId();
@@ -131,7 +131,7 @@ void DebugPrintfPass::CreateFunctionParams(uint32_t argument_id, const Type& arg
         }
 
         case SpvType::kFloat: {
-            const uint32_t width = argument_type.inst_.Word(2);
+            const uint32_t width = argument_type.meta_.scalar.bit_width;
             if (width == 16) {
                 const uint32_t float32_type_id = type_manager_.GetTypeFloat(32).Id();
                 const uint32_t fconvert_id = module_.TakeNextId();

--- a/layers/gpuav/spirv/module.cpp
+++ b/layers/gpuav/spirv/module.cpp
@@ -736,9 +736,9 @@ void Module::LinkFunctions(const LinkInfo& info) {
             // (we want lenght of 4 as that means it is 32-bit)
             if (opcode == spv::OpConstant && new_inst->Length() == 4) {
                 const uint32_t constant_value = new_inst->Word(3);
-                if (type.inst_.Opcode() == spv::OpTypeInt && type.inst_.Word(2) == 32) {
+                if (type.spv_type_ == SpvType::kInt && type.meta_.scalar.bit_width == 32) {
                     constant = type_manager_.FindConstantInt32(type.Id(), constant_value);
-                } else if (type.inst_.Opcode() == spv::OpTypeFloat && type.inst_.Word(2) == 32) {
+                } else if (type.spv_type_ == SpvType::kFloat && type.meta_.scalar.bit_width == 32) {
                     constant = type_manager_.FindConstantFloat32(type.Id(), constant_value);
                 }
             }

--- a/layers/gpuav/spirv/pass.cpp
+++ b/layers/gpuav/spirv/pass.cpp
@@ -259,20 +259,20 @@ uint32_t Pass::FindTypeByteSize(uint32_t type_id, uint32_t matrix_stride, bool c
                 module_.InternalError("FindTypeByteSize", "missing matrix stride");
             }
             if (col_major) {
-                return type.inst_.Word(3) * matrix_stride;
+                return type.meta_.matrix.component_count * matrix_stride;
             } else {
                 const Type* vector_type = type_manager_.FindTypeById(type.inst_.Word(2));
-                return vector_type->inst_.Word(3) * matrix_stride;
+                return vector_type->meta_.vector.component_count * matrix_stride;
             }
         }
         case SpvType::kVector: {
-            uint32_t size = type.inst_.Word(3);
+            uint32_t size = type.meta_.vector.component_count;
             const Type* component_type = type_manager_.FindTypeById(type.inst_.Word(2));
             // if vector in row major matrix, the vector is strided so return the number of bytes spanned by the vector
             if (in_matrix && !col_major && matrix_stride > 0) {
                 return (size - 1) * matrix_stride + FindTypeByteSize(component_type->Id());
             } else if (component_type->spv_type_ == SpvType::kFloat || component_type->spv_type_ == SpvType::kInt) {
-                const uint32_t width = component_type->inst_.Word(2);
+                const uint32_t width = component_type->meta_.scalar.bit_width;
                 size *= width;
             } else {
                 module_.InternalError("FindTypeByteSize", "unexpected vector type");
@@ -281,15 +281,11 @@ uint32_t Pass::FindTypeByteSize(uint32_t type_id, uint32_t matrix_stride, bool c
         }
         case SpvType::kFloat:
         case SpvType::kInt: {
-            const uint32_t width = type.inst_.Word(2);
-            return width / 8;
+            return type.meta_.scalar.bit_width / 8u;
         }
         case SpvType::kArray: {
             const uint32_t array_stride = GetDecoration(type_id, spv::DecorationArrayStride)->Word(3);
-            const Constant* count = type_manager_.FindConstantById(type.inst_.Operand(1));
-            assert(count && !count->is_spec_constant_);
-            const uint32_t array_length = (count && !count->is_spec_constant_) ? count->inst_.Operand(0) : 1;
-            return array_length * array_stride;
+            return type.meta_.array.length * array_stride;
         }
         case SpvType::kStruct: {
             const uint32_t struct_length = type.inst_.Length() - 2;
@@ -889,15 +885,16 @@ InjectConditionalData Pass::InjectFunctionPre(Function& function, const BasicBlo
             invalid_block.CreateInstruction(spv::OpConvertUToPtr, {phi_type.Id(), null_id, null_constant.Id()});
             module_.AddCapability(spv::CapabilityInt64);
         } else {
-            if ((phi_type.spv_type_ == SpvType::kInt || phi_type.spv_type_ == SpvType::kFloat) && phi_type.inst_.Word(2) < 32) {
+            if ((phi_type.spv_type_ == SpvType::kInt || phi_type.spv_type_ == SpvType::kFloat) &&
+                phi_type.meta_.scalar.bit_width < 32) {
                 // You can't make a constant of a 8-int, 16-int, 16-float without having the capability
                 // The only way this situation occurs if they use something like
                 //     OpCapability StorageBuffer8BitAccess
                 // but there is not explicit Int8
                 // It should be more than safe to inject it for them
-                spv::Capability capability = (phi_type.spv_type_ == SpvType::kFloat) ? spv::CapabilityFloat16
-                                             : (phi_type.inst_.Word(2) == 16)        ? spv::CapabilityInt16
-                                                                                     : spv::CapabilityInt8;
+                spv::Capability capability = (phi_type.spv_type_ == SpvType::kFloat)   ? spv::CapabilityFloat16
+                                             : (phi_type.meta_.scalar.bit_width == 16) ? spv::CapabilityInt16
+                                                                                       : spv::CapabilityInt8;
                 module_.AddCapability(capability);
             }
 

--- a/layers/gpuav/spirv/spec_constant.cpp
+++ b/layers/gpuav/spirv/spec_constant.cpp
@@ -248,6 +248,7 @@ bool Module::ConstantFoldVectorShuffle(Instruction* inst, const Type& result_typ
         return false;
     }
 
+    // LongVectors should not be possible as it would require the user to know the number of literal operands to use
     const uint32_t vec1_length = type_manager_.FindTypeById(vec1->inst_.TypeId())->VectorSize();
 
     std::vector<uint32_t> words = {result_type.Id(), inst->ResultId()};
@@ -365,7 +366,6 @@ bool Module::ConstantFold(Instruction* inst, const Type& result_type) {
     spv::Op target_opcode = (spv::Op)inst->Word(3);
 
     // OpSpecConstantOp has a limited set of instructions it can be, these are not handled the special
-    // TODO - Need to test these with LongVector
     if (target_opcode == spv::OpVectorShuffle) {
         return ConstantFoldVectorShuffle(inst, result_type);
     } else if (target_opcode == spv::OpCompositeExtract) {
@@ -432,7 +432,7 @@ bool Module::ConstantFold(Instruction* inst, const Type& result_type) {
         }
 
         uint64_t lane_result = 0;
-        const uint32_t result_bit_width = scalar_type.inst_.GetBitWidth();
+        const uint32_t result_bit_width = scalar_type.meta_.scalar.bit_width;
         if (target_opcode == spv::OpSConvert || target_opcode == spv::OpUConvert) {
             uint64_t mask = (result_bit_width == 64) ? ~0ULL : (1ULL << result_bit_width) - 1;
             lane_result = args[0] & mask;

--- a/layers/gpuav/spirv/type_manager.cpp
+++ b/layers/gpuav/spirv/type_manager.cpp
@@ -49,7 +49,7 @@ const Type* Variable::PointerType(TypeManager& type_manager_) const {
 const Type& TypeManager::AddType(std::unique_ptr<Instruction> new_inst, SpvType spv_type) {
     const auto& inst = module_.types_values_constants_.emplace_back(std::move(new_inst));
 
-    id_to_type_[inst->ResultId()] = std::make_unique<Type>(spv_type, *inst);
+    id_to_type_[inst->ResultId()] = std::make_unique<Type>(spv_type, *inst, *this);
     const Type* new_type = id_to_type_[inst->ResultId()].get();
 
     switch (spv_type) {
@@ -259,8 +259,7 @@ const Type& TypeManager::GetTypeAccelerationStructure() {
 
 const Type& TypeManager::GetTypeInt(uint32_t bit_width, bool is_signed) {
     for (const auto type : int_types_) {
-        const bool int_is_signed = type->inst_.Word(3) != 0;
-        if (type->inst_.Word(2) == bit_width && int_is_signed == is_signed) {
+        if (type->meta_.scalar.bit_width == bit_width && type->meta_.scalar.is_signed == is_signed) {
             return *type;
         }
     }
@@ -274,7 +273,7 @@ const Type& TypeManager::GetTypeInt(uint32_t bit_width, bool is_signed) {
 
 const Type& TypeManager::GetTypeFloat(uint32_t bit_width) {
     for (const auto type : float_types_) {
-        if (type->inst_.Word(2) == bit_width) {
+        if (type->meta_.scalar.bit_width == bit_width) {
             return *type;
         }
     }
@@ -321,7 +320,7 @@ const Type& TypeManager::GetTypeRuntimeArray(const Type& element_type, bool get_
 
 const Type& TypeManager::GetTypeVector(const Type& component_type, uint32_t component_count) {
     for (const auto type : vector_types_) {
-        if (type->inst_.Word(3) != component_count) {
+        if (type->meta_.vector.component_count != component_count) {
             continue;
         }
 
@@ -339,7 +338,7 @@ const Type& TypeManager::GetTypeVector(const Type& component_type, uint32_t comp
 
 const Type& TypeManager::GetTypeMatrix(const Type& column_type, uint32_t column_count) {
     for (const auto type : matrix_types_) {
-        if (type->inst_.Word(3) != column_count) {
+        if (type->meta_.matrix.component_count != column_count) {
             continue;
         }
 
@@ -431,28 +430,28 @@ const Type& TypeManager::GetTypePointerBuiltInInput(spv::BuiltIn built_in) {
 }
 
 uint32_t TypeManager::TypeLength(const Type& type) {
-    switch (type.inst_.Opcode()) {
-        case spv::OpTypeFloat:
-        case spv::OpTypeInt:
-            return type.inst_.Operand(0) / 8u;
-        case spv::OpTypeVector:
-        case spv::OpTypeMatrix: {
-            const Type* count = FindTypeById(type.inst_.Operand(0));
-            return type.inst_.Operand(1) * TypeLength(*count);
+    switch (type.spv_type_) {
+        case SpvType::kFloat:
+        case SpvType::kInt:
+            return type.meta_.scalar.bit_width / 8u;
+        case SpvType::kVector:
+        case SpvType::kVectorIdEXT: {
+            const Type* count_type = FindTypeById(type.inst_.Operand(0));
+            return type.meta_.vector.component_count * TypeLength(*count_type);
         }
-        case spv::OpTypePointer:
+        case SpvType::kMatrix: {
+            const Type* column_type = FindTypeById(type.inst_.Operand(0));
+            return type.meta_.matrix.component_count * TypeLength(*column_type);
+        }
+        case SpvType::kPointer:
             assert(type.inst_.Operand(0) == spv::StorageClassPhysicalStorageBuffer && "unexpected pointer type");
             // always will be PhysicalStorageBuffer64 addressing model
             return 8u;
-        case spv::OpTypeArray: {
+        case SpvType::kArray: {
             const Type* element_type = FindTypeById(type.inst_.Operand(0));
-            const Constant* count = FindConstantById(type.inst_.Operand(1));
-            // TODO - Need to handle spec constant here, for now return zero to have things not blowup
-            assert(count && !count->is_spec_constant_);
-            const uint32_t array_length = (count && !count->is_spec_constant_) ? count->inst_.Operand(0) : 0;
-            return array_length * TypeLength(*element_type);
+            return type.meta_.array.length * TypeLength(*element_type);
         }
-        case spv::OpTypeStruct: {
+        case SpvType::kStruct: {
             // Get the offset of the last member and then figure out it's size
             // Note: the largest offset doesn't have to be the last element index of the struct
             uint32_t last_offset = 0;
@@ -485,7 +484,7 @@ uint32_t TypeManager::TypeLength(const Type& type) {
             struct_size_map_[struct_id] = struct_size;
             return struct_size;
         }
-        case spv::OpTypeRuntimeArray:
+        case SpvType::kRuntimeArray:
             assert(false && "unsupported type");
             break;
         default:
@@ -502,12 +501,12 @@ const Constant& TypeManager::AddConstant(std::unique_ptr<Instruction> new_inst, 
     const Constant* new_constant = id_to_constant_[inst->ResultId()].get();
 
     if (inst->Opcode() == spv::OpConstant) {
-        if (type.inst_.Opcode() == spv::OpTypeInt && type.inst_.Word(2) == 32) {
+        if (type.spv_type_ == SpvType::kInt && type.meta_.scalar.bit_width == 32) {
             int_32bit_constants_.emplace_back(new_constant);
-        } else if (type.inst_.Opcode() == spv::OpTypeFloat) {
-            if (type.inst_.Word(2) == 16) {
+        } else if (type.spv_type_ == SpvType::kFloat) {
+            if (type.meta_.scalar.bit_width == 16) {
                 float_16bit_constants_.emplace_back(new_constant);
-            } else if (type.inst_.Word(2) == 32) {
+            } else if (type.meta_.scalar.bit_width == 32) {
                 float_32bit_constants_.emplace_back(new_constant);
             }
         }
@@ -740,9 +739,38 @@ const Variable* TypeManager::FindVariableById(uint32_t id) const {
 
 const Variable* TypeManager::FindPushConstantVariable() const { return push_constant_variable_; }
 
+Type::Meta Type::SetMeta(SpvType spv_type, const Instruction& inst, const TypeManager& type_manager) {
+    Meta m{};  // Zero-initialize (unions don't zero-init automatically)
+    if (spv_type == SpvType::kVector) {
+        m.vector.component_count = inst.Word(3);
+    } else if (spv_type == SpvType::kVectorIdEXT) {
+        const Constant* count = type_manager.FindConstantById(inst.Word(3));
+        assert(count && !count->is_spec_constant_);
+        m.vector.component_count = count->GetValueUint32();
+    } else if (spv_type == SpvType::kMatrix) {
+        m.matrix.component_count = inst.Word(3);
+    } else if (spv_type == SpvType::kArray) {
+        const Constant* count = type_manager.FindConstantById(inst.Word(3));
+        assert(count && !count->is_spec_constant_);
+        m.array.length = count->GetValueUint32();
+    } else if (spv_type == SpvType::kFloat) {
+        m.scalar.bit_width = inst.Word(2);
+    } else if (spv_type == SpvType::kInt) {
+        m.scalar.bit_width = inst.Word(2);
+        m.scalar.is_signed = inst.Word(3) == 1;
+    } else if (spv_type == SpvType::kBool) {
+        // "Boolean values considered as 32-bit integer values for the purpose of this calculation"
+        m.scalar.bit_width = 32;
+    }
+    return m;
+}
+
+Type::Type(SpvType spv_type, const Instruction& inst, const TypeManager& type_manager)
+    : spv_type_(spv_type), inst_(inst), meta_(SetMeta(spv_type, inst, type_manager)) {}
+
 bool Type::IsArray() const { return spv_type_ == SpvType::kArray || spv_type_ == SpvType::kRuntimeArray; }
 
-bool Type::IsSignedInt() const { return spv_type_ == SpvType::kInt && inst_.Word(3) == 1; }
+bool Type::IsSignedInt() const { return spv_type_ == SpvType::kInt && meta_.scalar.is_signed; }
 
 bool Type::IsIVec3(const TypeManager& type_manager) const {
     if (spv_type_ == SpvType::kVector) {
@@ -755,15 +783,12 @@ bool Type::IsIVec3(const TypeManager& type_manager) const {
 }
 
 uint32_t Type::VectorSize() const {
-    if (spv_type_ == SpvType::kVector) {
-        return inst_.Word(3);
-    }
-    return 0;
+    return (spv_type_ == SpvType::kVector || spv_type_ == SpvType::kVectorIdEXT) ? meta_.vector.component_count : 0;
 }
 
 bool Type::Is64Bit() const {
     if (spv_type_ == SpvType::kFloat || spv_type_ == SpvType::kInt) {
-        return inst_.Word(2) == 64;
+        return meta_.scalar.bit_width == 64;
     }
     return false;
 }
@@ -772,18 +797,15 @@ uint32_t TypeManager::GetNumScalarElements(const Type& type) const {
     switch (type.spv_type_) {
         case SpvType::kStruct:
             return GetNumScalarElementsBeforeCompositeMember(type, type.inst_.Length() - 2);
-        case SpvType::kVectorIdEXT:
         case SpvType::kArray: {
-            const Constant* count = FindConstantById(type.inst_.Word(3));
-            assert(count && !count->is_spec_constant_);
-            const uint32_t array_length = count->GetValueUint32();
             const Type* element_type = FindTypeById(type.inst_.Word(2));
-            return array_length * GetNumScalarElements(*element_type);
+            return type.meta_.array.length * GetNumScalarElements(*element_type);
         }
+        case SpvType::kVectorIdEXT:
         case SpvType::kVector:
-            return type.inst_.Word(3);
+            return type.meta_.vector.component_count;
         case SpvType::kMatrix:
-            return type.inst_.Word(3) * GetNumScalarElements(*FindTypeById(type.inst_.Word(2)));
+            return type.meta_.matrix.component_count * GetNumScalarElements(*FindTypeById(type.inst_.Word(2)));
         case SpvType::kInt:
         case SpvType::kFloat:
         case SpvType::kBool:
@@ -800,7 +822,7 @@ uint32_t Constant::GetValueUint32() const {
 }
 
 uint64_t Constant::GetValueUint64(bool is_signed) const {
-    const uint32_t bit_width = type_.inst_.Word(2);
+    const uint32_t bit_width = type_.meta_.scalar.bit_width;
 
     uint64_t value = inst_.Word(3);
     if (bit_width == 64) {

--- a/layers/gpuav/spirv/type_manager.h
+++ b/layers/gpuav/spirv/type_manager.h
@@ -53,7 +53,7 @@ static constexpr bool ConstantOperation(uint32_t opcode) {
 // trade-off to doing complex logic to resolve more complex types). The class also takes advantage that while Instrumenting we are
 // always aware of our types we are adding or just explictly found.
 struct Type {
-    Type(SpvType spv_type, const Instruction& inst) : spv_type_(spv_type), inst_(inst) {}
+    Type(SpvType spv_type, const Instruction& inst, const TypeManager& type_manager);
 
     bool operator==(Type const& other) const;
     uint32_t Id() const { return inst_.ResultId(); }
@@ -69,6 +69,31 @@ struct Type {
 
     const SpvType spv_type_;
     const Instruction& inst_;
+
+    // Some metadata depending on the type. Some things can't be detected without full view of the module, instead of passing in
+    // TypeManager as an argument to helper functions, it can just get the information once at construction time Want to keep this
+    // *simple* and at most 8 bytes (since Type is aligned up to 24 bytes currently)
+    struct VectorMeta {
+        uint32_t component_count;
+    };
+    struct MatrixMeta {
+        uint32_t component_count;
+    };
+    struct ArrayMeta {
+        uint32_t length;
+    };
+    struct ScalarMeta {
+        uint32_t bit_width;
+        bool is_signed;
+    };
+    union Meta {
+        VectorMeta vector;
+        MatrixMeta matrix;
+        ArrayMeta array;
+        ScalarMeta scalar;
+    };
+    const Meta meta_;
+    static Meta SetMeta(SpvType spv_type, const Instruction& inst, const TypeManager& type_manager);
 };
 
 static bool IsSpecConstant(uint32_t opcode) {


### PR DESCRIPTION
Instead of having to keep doing `.Word(2)` or for `OpTypeArray`, first get the `OpConstant`, we now just embed some basic information into the `Type` struct

The goal is to still keep `Type` **simple**, but also provide better naming and usage for the struct in the GPU-AV instrumentation passes