### PR TITLE
sync: Identify resolve operation in the error message

### DIFF
--- a/layers/sync/sync_access_state.cpp
+++ b/layers/sync/sync_access_state.cpp
@@ -532,7 +532,7 @@ void AccessState::Update(const SyncAccessInfo &usage_info, const AttachmentAcces
             const auto not_usage_stage = ~usage_stage;
             for (auto &read_access : GetReads()) {
                 if (read_access.stage == usage_stage) {
-                    read_access.Set(usage_stage, usage_info.access_index, tag_ex);
+                    read_access.Set(usage_stage, usage_info.access_index, attachment_access, tag_ex);
                 } else if (read_access.barriers & usage_stage) {
                     // If the current access is barriered to this stage, mark it as "known to happen after"
                     read_access.sync_stages |= usage_stage;
@@ -550,7 +550,7 @@ void AccessState::Update(const SyncAccessInfo &usage_info, const AttachmentAcces
                 }
             }
             ReadState new_read_state;
-            new_read_state.Set(usage_stage, usage_info.access_index, tag_ex);
+            new_read_state.Set(usage_stage, usage_info.access_index, attachment_access, tag_ex);
             AddRead(new_read_state);
             last_read_stages |= usage_stage;
         }
@@ -1097,10 +1097,12 @@ void AccessState::TouchupFirstForLayoutTransition(ResourceUsageTag tag, const Or
     }
 }
 
-void ReadState::Set(VkPipelineStageFlagBits2 stage, SyncAccessIndex access_index, ResourceUsageTagEx tag_ex) {
+void ReadState::Set(VkPipelineStageFlagBits2 stage, SyncAccessIndex access_index, const AttachmentAccess &attachment_access,
+                    ResourceUsageTagEx tag_ex) {
     assert(access_index != SYNC_ACCESS_INDEX_NONE);
     this->stage = stage;
     this->access_index = access_index;
+    this->attachment_access = attachment_access;
     barriers = VK_PIPELINE_STAGE_2_NONE;
     sync_stages = VK_PIPELINE_STAGE_2_NONE;
     tag = tag_ex.tag;

--- a/layers/sync/sync_access_state.h
+++ b/layers/sync/sync_access_state.h
@@ -205,15 +205,17 @@ using ResourceUsageTagSet = CachedInsertSet<ResourceUsageTag, 4>;
 // but only up to one per pipeline stage (as another read from the *same* stage become more recent,
 // and applicable one for hazard detection
 struct ReadState {
-    VkPipelineStageFlagBits2 stage;     // The stage of this read
-    SyncAccessIndex access_index;       // TODO: Revisit whether this needs to support multiple reads per stage
+    VkPipelineStageFlagBits2 stage;  // The stage of this read
+    SyncAccessIndex access_index;    // TODO: Revisit whether this needs to support multiple reads per stage
+    AttachmentAccess attachment_access;
     VkPipelineStageFlags2 barriers;     // all applicable barriered stages
     VkPipelineStageFlags2 sync_stages;  // reads known to have happened after this
     ResourceUsageTag tag;
     uint32_t handle_index;
     QueueId queue;
 
-    void Set(VkPipelineStageFlagBits2 stage, SyncAccessIndex access_index, ResourceUsageTagEx tag_ex);
+    void Set(VkPipelineStageFlagBits2 stage, SyncAccessIndex access_index, const AttachmentAccess &attachment_access,
+             ResourceUsageTagEx tag_ex);
 
     ResourceUsageTagEx TagEx() const { return {tag, handle_index}; }
     bool operator==(const ReadState &rhs) const {

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -1315,15 +1315,15 @@ ResourceUsageTag CommandBufferAccessContext::RecordNextSubpass(vvl::Func command
     const uint32_t previous_subpass = current_renderpass_context_->GetCurrentSubpass();
     const uint32_t this_subpass = previous_subpass + 1;
 
-    auto store_tag = NextCommandTag(command, SubCommandType::kStoreOp, previous_subpass);
-    AddCommandHandle(store_tag, current_renderpass_context_->GetRenderPassState()->Handle());
-
-    auto barrier_tag = NextSubCommandTag(command, SubCommandType::kSubpassTransition, this_subpass);
+    auto resolve_tag = NextCommandTag(command, SubCommandType::kResolveOp, previous_subpass);
+    AddCommandHandle(resolve_tag, current_renderpass_context_->GetRenderPassState()->Handle());
+    auto store_tag = NextSubCommandTag(command, SubCommandType::kStoreOp, previous_subpass);
+    auto transition_tag = NextSubCommandTag(command, SubCommandType::kSubpassTransition, this_subpass);
     auto load_tag = NextSubCommandTag(command, SubCommandType::kLoadOp, this_subpass);
 
-    current_renderpass_context_->RecordNextSubpass(store_tag, barrier_tag, load_tag);
+    current_renderpass_context_->RecordNextSubpass(resolve_tag, store_tag, transition_tag, load_tag);
     current_context_ = &current_renderpass_context_->CurrentContext();
-    return barrier_tag;
+    return transition_tag;
 }
 
 ResourceUsageTag CommandBufferAccessContext::RecordEndRenderPass(vvl::Func command) {

--- a/layers/sync/sync_renderpass.cpp
+++ b/layers/sync/sync_renderpass.cpp
@@ -898,12 +898,12 @@ void RenderPassAccessContext::RecordBeginRenderPass(const ResourceUsageTag barri
     RecordLoadOperations(load_tag);
 }
 
-void RenderPassAccessContext::RecordNextSubpass(const ResourceUsageTag store_tag, const ResourceUsageTag barrier_tag,
-                                                const ResourceUsageTag load_tag) {
+void RenderPassAccessContext::RecordNextSubpass(ResourceUsageTag resolve_tag, const ResourceUsageTag store_tag,
+                                                const ResourceUsageTag transition_tag, const ResourceUsageTag load_tag) {
     const uint32_t view_mask = rp_state_->create_info.pSubpasses[current_subpass_].viewMask;
 
     // Resolves are against *prior* subpass context and thus *before* the subpass increment
-    UpdateAttachmentResolveAccess(*rp_state_, attachment_views_, render_pass_instance_id_, current_subpass_, store_tag,
+    UpdateAttachmentResolveAccess(*rp_state_, attachment_views_, render_pass_instance_id_, current_subpass_, resolve_tag,
                                   CurrentContext());
     UpdateAttachmentStoreAccess(*rp_state_, attachment_views_, render_pass_instance_id_, current_subpass_, view_mask, store_tag,
                                 CurrentContext());
@@ -915,14 +915,14 @@ void RenderPassAccessContext::RecordNextSubpass(const ResourceUsageTag store_tag
     // subpass, so their tag needs to be different from the layout and load operations below.
     current_subpass_++;
     AccessContext &current_context = CurrentContext();
-    current_context.SetStartTag(barrier_tag);
+    current_context.SetStartTag(transition_tag);
 
-    RecordLayoutTransitions(barrier_tag);
+    RecordLayoutTransitions(transition_tag);
     RecordLoadOperations(load_tag);
 }
 
 void RenderPassAccessContext::RecordEndRenderPass(AccessContext *external_context, const ResourceUsageTag store_tag,
-                                                  const ResourceUsageTag barrier_tag) {
+                                                  const ResourceUsageTag transition_tag) {
     const uint32_t view_mask = rp_state_->create_info.pSubpasses[current_subpass_].viewMask;
 
     // Add the resolve and store accesses
@@ -958,7 +958,7 @@ void RenderPassAccessContext::RecordEndRenderPass(AccessContext *external_contex
                                                     pending_barriers);
             external_context->UpdateMemoryAccessState(collect_barriers, range_gen);
         }
-        pending_barriers.Apply(barrier_tag);
+        pending_barriers.Apply(transition_tag);
     }
 }
 

--- a/layers/sync/sync_renderpass.h
+++ b/layers/sync/sync_renderpass.h
@@ -128,8 +128,9 @@ class RenderPassAccessContext {
     void RecordLayoutTransitions(ResourceUsageTag tag);
     void RecordLoadOperations(ResourceUsageTag tag);
     void RecordBeginRenderPass(ResourceUsageTag tag, ResourceUsageTag load_tag);
-    void RecordNextSubpass(ResourceUsageTag store_tag, ResourceUsageTag barrier_tag, ResourceUsageTag load_tag);
-    void RecordEndRenderPass(AccessContext *external_context, ResourceUsageTag store_tag, ResourceUsageTag barrier_tag);
+    void RecordNextSubpass(ResourceUsageTag resolve_tag, ResourceUsageTag store_tag, ResourceUsageTag transition_tag,
+                           ResourceUsageTag load_tag);
+    void RecordEndRenderPass(AccessContext *external_context, ResourceUsageTag store_tag, ResourceUsageTag transition_tag);
 
     uint32_t GetCurrentSubpass() const { return current_subpass_; }
     AccessContext &CurrentContext();

--- a/layers/sync/sync_reporting.cpp
+++ b/layers/sync/sync_reporting.cpp
@@ -463,14 +463,20 @@ std::string FormatErrorMessage(const HazardResult &hazard, const CommandExecutio
             }
             ss << "(" << vvl::String(prior_command) << ") ";
             ss << "by the attachment loadOp";
-        } else if (prior_usage_info.sub_command_type == SubCommandType::kStoreOp) {
+        } else if (prior_usage_info.sub_command_type == SubCommandType::kStoreOp ||
+                   prior_usage_info.sub_command_type == SubCommandType::kResolveOp) {
             if (prior_usage_info.subpass != vvl::kNoIndex32) {
                 ss << "at the end of subpass " << prior_usage_info.subpass << " ";
             } else {
                 ss << "at the end of the render pass instance ";
             }
             ss << "(" << vvl::String(prior_command) << ") ";
-            ss << "by the attachment storeOp";
+            if (prior_usage_info.sub_command_type == SubCommandType::kStoreOp) {
+                ss << "by the attachment storeOp";
+            } else {
+                assert(prior_usage_info.sub_command_type == SubCommandType::kResolveOp);
+                ss << "during resolve operation";
+            }
         } else {
             ss << "by ";
             if (prior_usage_info.command == command) {


### PR DESCRIPTION
Previously resolve was reported as storeOp if resolve was a previous access.

Reproducible by:
NegativeSyncValRenderPass.InputAttachmentReadAndResolveWrite