### PR TITLE
gpuav: Print the OpTypeStruct for a BDA struct copy

### DIFF
--- a/layers/error_message/spirv_logging.cpp
+++ b/layers/error_message/spirv_logging.cpp
@@ -489,7 +489,7 @@ void FindShaderSource(std::ostringstream &ss, const std::vector<uint32_t> &instr
     }
 }
 
-void FindOpVariableName(std::ostringstream& ss, const std::vector<uint32_t>& instructions, uint32_t variable_id) {
+void FindGlobalName(std::ostringstream& ss, const std::vector<uint32_t>& instructions, uint32_t find_opcode, uint32_t find_id) {
     uint32_t shader_debug_info_set_id = 0;
     uint32_t offset = kModuleStartingOffset;
     while (offset < instructions.size()) {
@@ -504,7 +504,7 @@ void FindOpVariableName(std::ostringstream& ss, const std::vector<uint32_t>& ins
             break;
         }
 
-        if (opcode == spv::OpName && instructions[offset + 1] == variable_id) {
+        if (opcode == spv::OpName && instructions[offset + 1] == find_id) {
             const char* str = reinterpret_cast<const char*>(&instructions[offset + 2]);
             ss << str;
             return;
@@ -517,9 +517,10 @@ void FindOpVariableName(std::ostringstream& ss, const std::vector<uint32_t>& ins
             }
         }
 
+        // TODO - Currently to find OpTypeStruct (or things like it, we need to actually fully parse the ShaderDebugInfo)
         if (opcode == spv::OpExtInst && instructions[offset + 3] == shader_debug_info_set_id &&
-            instructions[offset + 4] == NonSemanticShaderDebugInfo100DebugGlobalVariable &&
-            instructions[offset + 12] == variable_id) {
+            instructions[offset + 4] == NonSemanticShaderDebugInfo100DebugGlobalVariable && instructions[offset + 12] == find_id &&
+            find_opcode == spv::OpVariable) {
             ss << spirv::GetOpString(instructions, instructions[offset + 5]);
             return;
         }
@@ -527,7 +528,74 @@ void FindOpVariableName(std::ostringstream& ss, const std::vector<uint32_t>& ins
         offset += length;
     }
 
-    ss << "[No OpName found, ID " << variable_id << "]";
+    ss << "[No OpName found, ID " << find_id << "]";
+}
+
+// Tries to the same logic as BufferDeviceAddressPass::RequiresInstrumentation
+// This is heavily favored for GLSL where this problem occurs
+void FindOpStructFromBDA(std::ostringstream& ss, const std::vector<uint32_t>& instructions, uint32_t instruction_position_offset) {
+    uint32_t last_seen_function_offset = 0;
+
+    uint32_t offset = kModuleStartingOffset;
+    while (offset < instructions.size()) {
+        const uint32_t instruction = instructions[offset];
+        const uint32_t length = Length(instruction);
+        const uint32_t opcode = Opcode(instruction);
+
+        if (opcode == spv::OpFunction) {
+            last_seen_function_offset = offset + length;
+        }
+
+        offset += length;
+
+        if (offset >= instruction_position_offset) {
+            break;
+        }
+    }
+    Instruction access_inst(instructions.data() + offset);
+
+    const uint32_t access_chain_id = access_inst.Operand(0);
+    uint32_t pointer_id = 0;
+    offset = last_seen_function_offset;
+    while (offset < instructions.size()) {
+        const uint32_t instruction = instructions[offset];
+        const uint32_t length = Length(instruction);
+        const uint32_t opcode = Opcode(instruction);
+
+        if (opcode == spv::OpFunction) {
+            break;
+        } else if (opcode == spv::OpAccessChain && instructions[offset + 2] == access_chain_id) {
+            pointer_id = instructions[offset + 1];
+            break;
+        }
+        offset += length;
+    }
+    if (pointer_id == 0) {
+        return;
+    }
+
+    // Find the OpTypePointer
+    uint32_t struct_id = 0;
+    offset = kModuleStartingOffset;
+    while (offset < instructions.size()) {
+        const uint32_t instruction = instructions[offset];
+        const uint32_t length = Length(instruction);
+        const uint32_t opcode = Opcode(instruction);
+
+        if (opcode == spv::OpFunction) {
+            break;
+        } else if (opcode == spv::OpTypePointer && instructions[offset + 1] == pointer_id) {
+            struct_id = instructions[offset + 3];
+            break;
+        }
+        offset += length;
+    }
+
+    if (struct_id != 0) {
+        ss << " (struct \"";
+        FindGlobalName(ss, instructions, (uint32_t)spv::OpTypeStruct, struct_id);
+        ss << "\")";
+    }
 }
 
 }  // namespace spirv

--- a/layers/error_message/spirv_logging.h
+++ b/layers/error_message/spirv_logging.h
@@ -34,9 +34,13 @@ void GetShaderSourceInfo(std::ostringstream &ss, const std::vector<uint32_t> &in
 void FindShaderSource(std::ostringstream& ss, const std::vector<uint32_t>& instructions, uint32_t instruction_position_offset,
                       bool debug_printf_only);
 
-// Will inject the name found from OpName (or DebugGlobalVariable in ShaderDebugInfo if no OpName is present)
-// (Assumes a global variable, not a function variable)
-void FindOpVariableName(std::ostringstream& ss, const std::vector<uint32_t>& instructions, uint32_t variable_id);
+// Will inject the name found from OpName (or OpString in ShaderDebugInfo if no OpName is present)
+// Will find anything prior to the Function block (OpVariable, OpTypeStruct, etc)
+// (For variables, assumes a global variable, not a function variable)
+void FindGlobalName(std::ostringstream& ss, const std::vector<uint32_t>& instructions, uint32_t find_opcode, uint32_t find_id);
+
+// Will try to get the OpStruct from a BDA access
+void FindOpStructFromBDA(std::ostringstream& ss, const std::vector<uint32_t>& instructions, uint32_t instruction_position_offset);
 
 // These are used where we can't use normal spirv::Instructions.
 // The main spot is post-processisng error message in GPU-AV, the time it takes to interchange back from a vector<uint32_t> to a

--- a/layers/gpuav/instrumentation/buffer_device_address.cpp
+++ b/layers/gpuav/instrumentation/buffer_device_address.cpp
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+#include "error_message/spirv_logging.h"
 #include "gpuav/core/gpuav.h"
 #include "gpuav/resources/gpuav_state_trackers.h"
 #include "gpuav/resources/gpuav_vulkan_objects.h"
@@ -39,7 +40,7 @@ void RegisterBufferDeviceAddressValidation(Validator& gpuav, CommandBufferSubSta
                                                                           const LastBound& last_bound) {
         CommandBufferSubState::InstrumentationErrorLogger inst_error_logger = [](Validator& gpuav, const Location&,
                                                                                  const uint32_t* error_record,
-                                                                                 const InstrumentedShader*,
+                                                                                 const InstrumentedShader* instrumented_shader,
                                                                                  std::string& out_error_msg,
                                                                                  std::string& out_vuid_msg) {
             using namespace glsl;
@@ -66,8 +67,11 @@ void RegisterBufferDeviceAddressValidation(Validator& gpuav, CommandBufferSubSta
                          << std::hex << address << '.';
                     if (is_struct) {
                         // Added because glslang currently has no way to seperate out the struct (Slang does as of 2025.6.2)
-                        strm << " This " << (is_write ? "write" : "read")
-                             << " corresponds to a full OpTypeStruct load. While not all members of the struct might be accessed, "
+                        strm << " This " << (is_write ? "write" : "read") << " corresponds to a full OpTypeStruct load";
+                        const uint32_t instruction_position_offset =
+                            error_record[kHeader_StageInstructionIdOffset] & kInstructionId_Mask;
+                        ::spirv::FindOpStructFromBDA(strm, instrumented_shader->original_spirv, instruction_position_offset);
+                        strm << ". While not all members of the struct might be accessed, "
                                 "it is up "
                                 "to the source language or tooling to detect that and reflect it in the SPIR-V.";
                     }

--- a/layers/gpuav/instrumentation/shared_memory_data_race.cpp
+++ b/layers/gpuav/instrumentation/shared_memory_data_race.cpp
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+#include <spirv/unified1/spirv.hpp>
 #include "gpuav/core/gpuav.h"
 #include "gpuav/resources/gpuav_state_trackers.h"
 #include "gpuav/shaders/gpuav_error_codes.h"
@@ -46,7 +47,7 @@ void RegisterSharedMemoryDataRaceValidation(Validator &gpuav, CommandBufferSubSt
                     std::ostringstream strm;
                     strm << "A data race was detected on the shared memory variable \"";
                     if (instrumented_shader) {
-                        ::spirv::FindOpVariableName(strm, instrumented_shader->original_spirv, variable_id);
+                        ::spirv::FindGlobalName(strm, instrumented_shader->original_spirv, (uint32_t)spv::OpVariable, variable_id);
                     } else {
                         strm << "[error, original SPIR-V not found]";
                     }

--- a/tests/unit/gpu_av_buffer_device_address.cpp
+++ b/tests/unit/gpu_av_buffer_device_address.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2020-2025 The Khronos Group Inc.
- * Copyright (c) 2020-2025 Valve Corporation
- * Copyright (c) 2020-2025 LunarG, Inc.
- * Copyright (c) 2020-2025 Google, Inc.
+ * Copyright (c) 2020-2026 The Khronos Group Inc.
+ * Copyright (c) 2020-2026 Valve Corporation
+ * Copyright (c) 2020-2026 LunarG, Inc.
+ * Copyright (c) 2020-2026 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1208,7 +1208,8 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ProxyStructLoad2) {
 
     // VUID-RuntimeSpirv-PhysicalStorageBuffer64-11819
     m_errorMonitor->SetDesiredError(
-        "This read corresponds to a full OpTypeStruct load. While not all members of the struct might be accessed, it is up to the "
+        "This read corresponds to a full OpTypeStruct load (struct \"RealCamera\"). While not all members of the struct might be "
+        "accessed, it is up to the "
         "source language or tooling to detect that and reflect it in the SPIR-V");
     m_default_queue->SubmitAndWait(m_command_buffer);
     m_errorMonitor->VerifyFound();

--- a/tests/unit/shader_debug_info.cpp
+++ b/tests/unit/shader_debug_info.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2025 The Khronos Group Inc.
- * Copyright (c) 2025 Valve Corporation
- * Copyright (c) 2025 LunarG, Inc.
+ * Copyright (c) 2025-2026 The Khronos Group Inc.
+ * Copyright (c) 2025-2026 Valve Corporation
+ * Copyright (c) 2025-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -651,7 +651,7 @@ void main(){
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeShaderDebugInfo, DebugGloablVariableName) {
+TEST_F(NegativeShaderDebugInfo, DebugGlobalVariableName) {
     TEST_DESCRIPTION("Get the name of the OpVariable from OpString, not OpName");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);


### PR DESCRIPTION
The old message

> vkCmdDrawIndexedIndirect(): Out of bounds access: 152 bytes read at buffer device address 0x4dd0460. This read corresponds to a full OpTypeStruct load. While not all members of the struct might be accessed, it is up to the source language or tooling to detect that and reflect it in the SPIR-V.

we hard if you didn't know the `OpTypeStruct`

This adds logic so it prints the struct name (this is mainly an issue with GLSL I have found)