### PR TITLE
layers: Remove AS build status validation

### DIFF
--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -824,13 +824,6 @@ bool CoreChecks::ValidateAccelerationStructureBuildGeometryInfoUpdate(const vvl:
                                                                       const VulkanTypedHandle& handle) const {
     bool skip = false;
 
-    if (!src_as_state.is_built) {
-        const LogObjectList objlist(handle, info.srcAccelerationStructure);
-        skip |= LogError(
-            GetBuildASVUID(info_loc, vvl::BuildASError::IsBuilt_03667), objlist, info_loc.dot(Field::mode),
-            "is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR, but srcAccelerationStructure must have been previously built");
-        return skip;
-    }
     if (!src_as_state.build_info_khr.has_value()) {
         return skip;
     }
@@ -1280,10 +1273,7 @@ bool CoreChecks::PreCallValidateWriteAccelerationStructuresPropertiesKHR(VkDevic
         skip |= ValidateAccelStructBufferMemoryIsNotMultiInstance(*as_state, as_loc,
                                                                   "VUID-vkWriteAccelerationStructuresPropertiesKHR-buffer-03784");
 
-        if (!as_state->is_built) {
-            skip |= LogError("VUID-vkWriteAccelerationStructuresPropertiesKHR-pAccelerationStructures-04964", device, as_loc,
-                             "has not been built.");
-        } else if (as_state->build_info_khr.has_value()) {
+        if (as_state->build_info_khr.has_value()) {
             if (queryType == VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR) {
                 if (!(as_state->build_info_khr->flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR)) {
                     const LogObjectList objlist(device, pAccelerationStructures[i]);
@@ -1329,10 +1319,6 @@ bool CoreChecks::PreCallValidateCmdWriteAccelerationStructuresPropertiesKHR(
         skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *as_state->buffer_state, as_loc.dot(Field::buffer),
                                               "VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-buffer-03736");
 
-        if (!as_state->is_built) {
-            skip |= LogError("VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-pAccelerationStructures-04964", commandBuffer,
-                             as_loc, "has not been built.");
-        } else {
             if (queryType == VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR && as_state->build_info_khr.has_value()) {
                 if (!(as_state->build_info_khr->flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR)) {
                     skip |= LogError("VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-accelerationStructures-03431",
@@ -1341,7 +1327,6 @@ bool CoreChecks::PreCallValidateCmdWriteAccelerationStructuresPropertiesKHR(
                                      string_VkBuildAccelerationStructureFlagsKHR(as_state->build_info_khr->flags).c_str());
                 }
             }
-        }
     }
     return skip;
 }
@@ -1352,11 +1337,6 @@ bool CoreChecks::ValidateCopyAccelerationStructureInfoKHR(const VkCopyAccelerati
 
     auto src_as_state = Get<vvl::AccelerationStructureKHR>(as_info.src);
     if (src_as_state) {
-        if (!src_as_state->is_built) {
-            skip |= LogError("VUID-VkCopyAccelerationStructureInfoKHR-src-04963", device, info_loc.dot(Field::src),
-                             "has not been built.");
-        }
-
         if (auto buffer_state = Get<vvl::Buffer>(src_as_state->GetBuffer())) {
             skip |= ValidateMemoryIsBoundToBuffer(device, *buffer_state, info_loc.dot(Field::src),
                                                   "VUID-VkCopyAccelerationStructureInfoKHR-buffer-03718");
@@ -1446,18 +1426,6 @@ bool CoreChecks::PreCallValidateCopyAccelerationStructureKHR(VkDevice device, Vk
     return skip;
 }
 
-bool CoreChecks::ValidateVkCopyAccelerationStructureToMemoryInfoKHR(const vvl::AccelerationStructureKHR &src_accel_struct,
-                                                                    LogObjectList objlist, const Location &loc) const {
-    bool skip = false;
-    if (!src_accel_struct.is_built) {
-        objlist.add(src_accel_struct.Handle());
-        skip |= LogError("VUID-VkCopyAccelerationStructureToMemoryInfoKHR-src-04959", objlist, loc.dot(Field::src),
-                         "has not been built.");
-    }
-
-    return skip;
-}
-
 bool CoreChecks::PreCallValidateCopyAccelerationStructureToMemoryKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                                      const VkCopyAccelerationStructureToMemoryInfoKHR *pInfo,
                                                                      const ErrorObject &error_obj) const {
@@ -1467,8 +1435,6 @@ bool CoreChecks::PreCallValidateCopyAccelerationStructureToMemoryKHR(VkDevice de
 
     if (const auto src_accel_struct = Get<vvl::AccelerationStructureKHR>(pInfo->src)) {
         const Location info_loc = error_obj.location.dot(Field::pInfo);
-        skip |= ValidateVkCopyAccelerationStructureToMemoryInfoKHR(*src_accel_struct, LogObjectList(device), info_loc);
-
         if (auto buffer_state = Get<vvl::Buffer>(src_accel_struct->GetBuffer())) {
             skip |= ValidateAccelStructBufferMemoryIsHostVisible(*src_accel_struct, info_loc.dot(Field::src),
                                                                  "VUID-vkCopyAccelerationStructureToMemoryKHR-buffer-03731");
@@ -1490,8 +1456,6 @@ bool CoreChecks::PreCallValidateCmdCopyAccelerationStructureToMemoryKHR(VkComman
     const Location info_loc = error_obj.location.dot(Field::pInfo);
 
     if (auto src_accel_struct = Get<vvl::AccelerationStructureKHR>(pInfo->src)) {
-        skip |= ValidateVkCopyAccelerationStructureToMemoryInfoKHR(*src_accel_struct, LogObjectList(commandBuffer), info_loc);
-
         if (auto buffer_state = Get<vvl::Buffer>(src_accel_struct->GetBuffer())) {
             skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *buffer_state, info_loc.dot(Field::src),
                                                   "VUID-vkCmdCopyAccelerationStructureToMemoryKHR-None-03559");

--- a/layers/core_checks/cc_ray_tracing_nv.cpp
+++ b/layers/core_checks/cc_ray_tracing_nv.cpp
@@ -291,10 +291,6 @@ bool CoreChecks::PreCallValidateCmdCopyAccelerationStructureNV(VkCommandBuffer c
         skip |= VerifyBoundMemoryIsDeviceVisible(src_as_state->MemoryState(), objlist, src_as_state->Handle(),
                                                  error_obj.location.dot(Field::src),
                                                  "VUID-vkCmdCopyAccelerationStructureNV-buffer-03718");
-        if (!src_as_state->built) {
-            skip |= LogError("VUID-vkCmdCopyAccelerationStructureNV-src-04963", commandBuffer, error_obj.location,
-                             "The source acceleration structure src has not yet been built.");
-        }
     }
 
     if (mode == VK_COPY_ACCELERATION_STRUCTURE_MODE_COMPACT_NV) {

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -2455,8 +2455,6 @@ class CoreChecks : public vvl::DeviceProxy {
     bool PreCallValidateCopyAccelerationStructureKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                      const VkCopyAccelerationStructureInfoKHR* pInfo,
                                                      const ErrorObject& error_obj) const override;
-    bool ValidateVkCopyAccelerationStructureToMemoryInfoKHR(const vvl::AccelerationStructureKHR& src_accel_struct,
-                                                            LogObjectList objlist, const Location& loc) const;
     bool PreCallValidateCopyAccelerationStructureToMemoryKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                              const VkCopyAccelerationStructureToMemoryInfoKHR* pInfo,
                                                              const ErrorObject& error_obj) const override;

--- a/layers/state_tracker/ray_tracing_state.h
+++ b/layers/state_tracker/ray_tracing_state.h
@@ -137,7 +137,6 @@ class AccelerationStructureKHR : public StateObject, public SubStateManager<Acce
 
     void Build(const VkAccelerationStructureBuildGeometryInfoKHR *pInfo, const bool is_host,
                const VkAccelerationStructureBuildRangeInfoKHR *build_range_info) {
-        is_built = true;
         if (!build_info_khr.has_value()) {
             build_info_khr = vku::safe_VkAccelerationStructureBuildGeometryInfoKHR();
         }
@@ -164,9 +163,6 @@ class AccelerationStructureKHR : public StateObject, public SubStateManager<Acce
     VkDeviceAddress acceleration_structure_address = 0;
     std::optional<vku::safe_VkAccelerationStructureBuildGeometryInfoKHR> build_info_khr{};
     std::vector<VkAccelerationStructureBuildRangeInfoKHR> build_range_infos{};
-    // You can't have is_built == false and a build_info_khr, but you can have is_built == true and no build_info_khr,
-    // if the acceleration structure was filled by a call to vkCmdCopyMemoryToAccelerationStructure
-    bool is_built = false;
 
   private:
     const VkAccelerationStructureCreateFlagsKHR create_flags = 0;

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -5558,8 +5558,6 @@ void DeviceState::PostCallRecordCopyAccelerationStructureKHR(VkDevice device, Vk
     auto src_as_state = Get<AccelerationStructureKHR>(pInfo->src);
     auto dst_as_state = Get<AccelerationStructureKHR>(pInfo->dst);
     if (dst_as_state && src_as_state) {
-        dst_as_state->is_built = true;
-
         dst_as_state->build_info_khr = src_as_state->build_info_khr;
     }
 }
@@ -5573,7 +5571,6 @@ void DeviceState::PostCallRecordCmdCopyAccelerationStructureKHR(VkCommandBuffer 
     auto src_as_state = Get<AccelerationStructureKHR>(pInfo->src);
     auto dst_as_state = Get<AccelerationStructureKHR>(pInfo->dst);
     if (dst_as_state && src_as_state) {
-        dst_as_state->is_built = true;
         dst_as_state->build_info_khr = src_as_state->build_info_khr;
         if (!disabled[command_buffer_state]) {
             cb_state->AddChild(dst_as_state);
@@ -5607,7 +5604,6 @@ void DeviceState::PostCallRecordCmdCopyMemoryToAccelerationStructureKHR(VkComman
         auto dst_as_state = Get<AccelerationStructureKHR>(pInfo->dst);
         ASSERT_AND_RETURN(dst_as_state);
         cb_state->AddChild(dst_as_state);
-        dst_as_state->is_built = true;
 
         // Issue https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6461
         // showed that it is incorrect to try to add buffers obtained through a call to GetBuffersByAddress as children to a

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -575,7 +575,6 @@ TEST_F(NegativeRayTracing, CopyUnboundAccelerationStructure) {
 
     m_command_buffer.Begin();
 
-    m_errorMonitor->SetDesiredError("VUID-VkCopyAccelerationStructureInfoKHR-src-04963");
     m_errorMonitor->SetDesiredError("VUID-VkCopyAccelerationStructureInfoKHR-buffer-03718");
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyAccelerationStructureKHR-buffer-03737");
     vk::CmdCopyAccelerationStructureKHR(m_command_buffer, &copy_info);
@@ -583,7 +582,6 @@ TEST_F(NegativeRayTracing, CopyUnboundAccelerationStructure) {
 
     copy_info.src = valid_blas->handle();
     copy_info.dst = blas_no_mem->handle();
-    m_errorMonitor->SetDesiredError("VUID-VkCopyAccelerationStructureInfoKHR-src-04963");
     m_errorMonitor->SetDesiredError("VUID-VkCopyAccelerationStructureInfoKHR-buffer-03719");
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyAccelerationStructureKHR-buffer-03738");
     vk::CmdCopyAccelerationStructureKHR(m_command_buffer, &copy_info);
@@ -695,7 +693,6 @@ TEST_F(NegativeRayTracing, CmdCopyUnboundAccelerationStructure) {
     m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkCopyAccelerationStructureInfoKHR-buffer-03718");
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyAccelerationStructureKHR-buffer-03737");
-    m_errorMonitor->SetDesiredError("VUID-VkCopyAccelerationStructureInfoKHR-src-04963");
     vk::CmdCopyAccelerationStructureKHR(m_command_buffer, &copy_info);
     m_errorMonitor->VerifyFound();
     m_command_buffer.End();
@@ -706,7 +703,6 @@ TEST_F(NegativeRayTracing, CmdCopyUnboundAccelerationStructure) {
     m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkCopyAccelerationStructureInfoKHR-buffer-03719");
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyAccelerationStructureKHR-buffer-03738");
-    m_errorMonitor->SetDesiredError("VUID-VkCopyAccelerationStructureInfoKHR-src-04963");
     vk::CmdCopyAccelerationStructureKHR(m_command_buffer, &copy_info);
     m_errorMonitor->VerifyFound();
     m_command_buffer.End();
@@ -750,7 +746,6 @@ TEST_F(NegativeRayTracing, CopyAccelerationStructureNoHostMem) {
     copy_info.dst = blas->handle();
 
     m_errorMonitor->SetDesiredError("VUID-vkCopyAccelerationStructureKHR-buffer-03727");
-    m_errorMonitor->SetDesiredError("VUID-VkCopyAccelerationStructureInfoKHR-src-04963");
     vk::CopyAccelerationStructureKHR(device(), VK_NULL_HANDLE, &copy_info);
     m_errorMonitor->VerifyFound();
 
@@ -758,7 +753,6 @@ TEST_F(NegativeRayTracing, CopyAccelerationStructureNoHostMem) {
     copy_info.dst = blas_no_host_mem->handle();
 
     m_errorMonitor->SetDesiredError("VUID-vkCopyAccelerationStructureKHR-buffer-03728");
-    m_errorMonitor->SetDesiredError("VUID-VkCopyAccelerationStructureInfoKHR-src-04963");
     vk::CopyAccelerationStructureKHR(device(), VK_NULL_HANDLE, &copy_info);
     m_errorMonitor->VerifyFound();
 }
@@ -841,7 +835,8 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructureKHR) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeRayTracing, BuildAccelerationStructureModeUpdate) {
+// github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11839
+TEST_F(NegativeRayTracing, DISABLED_BuildAccelerationStructureModeUpdate) {
     TEST_DESCRIPTION("In an acceleration structure update, source acceleration structure was not built");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -2192,7 +2187,6 @@ TEST_F(NegativeRayTracing, CmdCopyAccelerationStructureToMemoryKHR) {
 
     m_errorMonitor->SetDesiredError("VUID-VkDeviceAddress-size-11364");
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyAccelerationStructureToMemoryKHR-None-03559");
-    m_errorMonitor->SetDesiredError("VUID-VkCopyAccelerationStructureToMemoryInfoKHR-src-04959");
     vk::CmdCopyAccelerationStructureToMemoryKHR(m_command_buffer, &copy_info);
     m_errorMonitor->VerifyFound();
 
@@ -2238,7 +2232,6 @@ TEST_F(NegativeRayTracing, CopyAccelerationStructureToMemoryKHR) {
     m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-vkCopyAccelerationStructureToMemoryKHR-buffer-03731");
-    m_errorMonitor->SetDesiredError("VUID-VkCopyAccelerationStructureToMemoryInfoKHR-src-04959");
     vk::CopyAccelerationStructureToMemoryKHR(*m_device, VK_NULL_HANDLE, &copy_info);
     m_errorMonitor->VerifyFound();
 
@@ -2500,7 +2493,8 @@ TEST_F(NegativeRayTracing, WriteAccelerationStructuresPropertiesAccelStructDestr
     m_command_buffer.End();
 }
 
-TEST_F(NegativeRayTracing, WriteAccelerationStructuresPropertiesDeviceBlasNotBuilt) {
+// github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11839
+TEST_F(NegativeRayTracing, DISABLED_WriteAccelerationStructuresPropertiesDeviceBlasNotBuilt) {
     TEST_DESCRIPTION("vkCmdWriteAccelerationStructuresPropertiesKHR with unbuilt blas");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -2691,12 +2685,6 @@ TEST_F(NegativeRayTracing, WriteAccelerationStructuresPropertiesDataSizeTooSmall
     constexpr size_t stride = 1;
     constexpr size_t data_size = sizeof(VkDeviceSize) * stride;
     uint8_t data[data_size];
-
-    m_errorMonitor->SetDesiredError("VUID-vkWriteAccelerationStructuresPropertiesKHR-pAccelerationStructures-04964");
-    vk::WriteAccelerationStructuresPropertiesKHR(*m_device, 1, &blas.GetDstAS()->handle(),
-                                                 VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR, data_size, data,
-                                                 sizeof(VkDeviceSize));
-    m_errorMonitor->VerifyFound();
 
     blas.BuildHost();
 

--- a/tests/unit/ray_tracing_nv.cpp
+++ b/tests/unit/ray_tracing_nv.cpp
@@ -1779,10 +1779,6 @@ TEST_F(NegativeRayTracingNV, ValidateCmdCopyAccelerationStructure) {
 
     m_command_buffer.Begin();
 
-    m_errorMonitor->SetDesiredError("VUID-vkCmdCopyAccelerationStructureNV-src-04963");
-    vk::CmdCopyAccelerationStructureNV(m_command_buffer, dst_as, src_as, VK_COPY_ACCELERATION_STRUCTURE_MODE_CLONE_NV);
-    m_errorMonitor->VerifyFound();
-
     vk::CmdBuildAccelerationStructureNV(m_command_buffer, &bot_level_as_create_info.info, VK_NULL_HANDLE, 0, VK_FALSE, src_as,
                                         VK_NULL_HANDLE, bot_level_as_scratch, 0);
     m_command_buffer.End();


### PR DESCRIPTION
Anything related to AS build status is not properly validated as of now, because build status is not tracked properly
Linked to github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11839