### PR TITLE
scripts: Fix ObjectTracking VUID churn

### DIFF
--- a/layers/vulkan/generated/object_tracker.cpp
+++ b/layers/vulkan/generated/object_tracker.cpp
@@ -6214,8 +6214,8 @@ bool Device::PreCallValidateReleaseFullScreenExclusiveModeEXT(VkDevice device, V
     bool skip = false;
     // Checked by chassis: device: "VUID-vkReleaseFullScreenExclusiveModeEXT-device-parameter"
     skip |= ValidateObject(swapchain, kVulkanObjectTypeSwapchainKHR, false,
-                           "VUID-vkReleaseFullScreenExclusiveModeEXT-swapchain-parameter", kVUIDUndefined,
-                           error_obj.location.dot(Field::swapchain));
+                           "VUID-vkReleaseFullScreenExclusiveModeEXT-swapchain-parameter",
+                           "VUID-vkReleaseFullScreenExclusiveModeEXT-swapchain-parent", error_obj.location.dot(Field::swapchain));
 
     return skip;
 }
@@ -8038,11 +8038,12 @@ bool Device::PreCallValidateCreateDataGraphPipelinesARM(VkDevice device, VkDefer
     bool skip = false;
     // Checked by chassis: device: "VUID-vkCreateDataGraphPipelinesARM-device-parameter"
     skip |= ValidateObject(deferredOperation, kVulkanObjectTypeDeferredOperationKHR, true,
-                           "VUID-vkCreateDataGraphPipelinesARM-deferredOperation-parameter", kVUIDUndefined,
+                           "VUID-vkCreateDataGraphPipelinesARM-deferredOperation-parameter",
+                           "VUID-vkCreateDataGraphPipelinesARM-deferredOperation-parent",
                            error_obj.location.dot(Field::deferredOperation));
     skip |= ValidateObject(pipelineCache, kVulkanObjectTypePipelineCache, true,
-                           "VUID-vkCreateDataGraphPipelinesARM-pipelineCache-parameter", kVUIDUndefined,
-                           error_obj.location.dot(Field::pipelineCache));
+                           "VUID-vkCreateDataGraphPipelinesARM-pipelineCache-parameter",
+                           "VUID-vkCreateDataGraphPipelinesARM-pipelineCache-parent", error_obj.location.dot(Field::pipelineCache));
     if (pCreateInfos) {
         for (uint32_t index0 = 0; index0 < createInfoCount; ++index0) {
             [[maybe_unused]] const Location index0_loc = error_obj.location.dot(Field::pCreateInfos, index0);

--- a/scripts/generators/object_tracker_generator.py
+++ b/scripts/generators/object_tracker_generator.py
@@ -253,6 +253,7 @@ class ObjectTrackerOutputGenerator(BaseGenerator):
             'vkMergePipelineCaches',
             'vkCreateGraphicsPipelines',
             'vkCreateComputePipelines',
+            'vkCreateDataGraphPipelinesARM',
             'vkUpdateDescriptorSetWithTemplate',
             'vkUpdateDescriptorSetWithTemplateKHR',
             'vkAcquireNextImageKHR',
@@ -575,12 +576,6 @@ bool Device::ReportUndestroyedObjects(const Location& loc) const {
         params = self.vk.commands[commandName].params
         only_dispatchable_parameter = len([x for x in params if x.type in self.vk.handles and (not x.pointer or x.const)]) == 1
         if only_dispatchable_parameter:
-            return False
-
-        # Special case: vkReleaseFullScreenExclusiveModeEXT.
-        # The specification does not define a parent VUID for the swapchain parameter.
-        # It mentions in a free form that device should be associated with a swapchain.
-        if commandName == 'vkReleaseFullScreenExclusiveModeEXT' or commandName == 'vkCreateDataGraphPipelinesARM':
             return False
 
         # Not a vulkan handle. Parent VUIDs are only for vulkan handles


### PR DESCRIPTION
adds `VUID-vkReleaseFullScreenExclusiveModeEXT-swapchain-parent` as it somehow got into the spec where it was missing prior