### PR TITLE
sync: Add multiview support for dynamic rendering

### DIFF
--- a/layers/state_tracker/subresource_adapter.cpp
+++ b/layers/state_tracker/subresource_adapter.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2019-2025 The Khronos Group Inc.
- * Copyright (c) 2019-2025 Valve Corporation
- * Copyright (c) 2019-2025 LunarG, Inc.
+/* Copyright (c) 2019-2026 The Khronos Group Inc.
+ * Copyright (c) 2019-2026 Valve Corporation
+ * Copyright (c) 2019-2026 LunarG, Inc.
  * Copyright (C) 2019-2025 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,6 +26,7 @@
 #include "state_tracker/image_state.h"
 #include "generated/dispatch_functions.h"
 #include "utils/image_utils.h"
+#include "utils/math_utils.h"
 
 namespace subresource_adapter {
 Subresource::Subresource(const RangeEncoder& encoder, const VkImageSubresource& subres)
@@ -537,6 +538,17 @@ void ImageRangeGenerator::SetInitialPosSomeLayers(uint32_t layer, uint32_t aspec
     incr_state_.Set(1, 1, base, span, span, z_step);
 }
 
+void ImageRangeGenerator::SetInitialPosMultiviewLayers(uint32_t layer, uint32_t aspect_index) {
+    assert(!encoder_->Is3D() && (offset_.x == 0) && (offset_.y == 0) && (offset_.z == 0));
+    const auto& subres_layout = subres_info_->layout;
+    const IndexType base = base_address_ + subres_layout.offset + (subres_range_.baseArrayLayer + layer) * subres_layout.arrayPitch;
+    const IndexType span = subres_layout.arrayPitch * 1;
+    const IndexType z_step = subres_layout.arrayPitch * 1;
+    incr_state_.Set(1, subres_range_.layerCount, base, span, span, z_step);
+    incr_state_.layer_z_index = layer;
+    incr_state_.view_mask_ = view_mask_;
+}
+
 void ImageRangeGenerator::SetInitialPosAllLayers(uint32_t layer, uint32_t aspect_index) {
     assert(!encoder_->Is3D() && (offset_.x == 0) && (offset_.y == 0) && (offset_.z == 0) && (layer == 0));
     const auto& subres_layout = subres_info_->layout;
@@ -618,6 +630,37 @@ ImageRangeGenerator::ImageRangeGenerator(const ImageRangeEncoder& encoder, const
 }
 
 ImageRangeGenerator::ImageRangeGenerator(const ImageRangeEncoder& encoder, const VkImageSubresourceRange& subres_range,
+                                         VkDeviceSize base_address, bool is_depth_sliced, uint32_t view_mask)
+    : encoder_(&encoder),
+      subres_range_(GetRemaining(encoder.FullRange(), subres_range)),
+      offset_(),
+      extent_(),
+      base_address_(base_address),
+      view_mask_(view_mask),
+      is_depth_sliced_(is_depth_sliced) {
+    assert(IsValid(*encoder_, subres_range_));
+    if (SubresourceRangeIsEmpty(subres_range)) {
+        // Not robust to empty ranges, so for to "at end" condition.
+        pos_ = {0, 0};
+        return;
+    }
+    SetUpSubresInfo();
+    extent_ = subres_info_->extent;
+    const bool converted = Convert2DCompatibleTo3D();
+    SetUpIncrementerDefaults();
+    if (converted && (extent_.depth != subres_info_->extent.depth)) {
+        SetUpIncrementer(true, true, false);
+    } else {
+        SetUpSubresIncrementer();
+    }
+
+    // baseArrayLayer is taken into account inside SetInitialPosMultiviewLayers
+    uint32_t relative_base_layer = view_mask ? (uint32_t)LeastSignificantBit(view_mask) : 0;
+    SetInitialPos(relative_base_layer, aspect_index_);
+    pos_ = incr_state_.y_base;
+}
+
+ImageRangeGenerator::ImageRangeGenerator(const ImageRangeEncoder& encoder, const VkImageSubresourceRange& subres_range,
                                          const VkOffset3D& offset, const VkExtent3D& extent, VkDeviceSize base_address,
                                          bool is_depth_sliced)
     : encoder_(&encoder),
@@ -687,6 +730,9 @@ void ImageRangeGenerator::SetUpSubresIncrementer() {
         } else {
             set_initial_pos_fn_ = &ImageRangeGenerator::SetInitialPosFullHeight;
         }
+    } else if (!is_3d && view_mask_ != 0) {
+        // TODO: handle 3d case too
+        set_initial_pos_fn_ = &ImageRangeGenerator::SetInitialPosMultiviewLayers;
     } else if (is_3d || CoversAllLayers(full_range, subres_range_)) {
         if (!linear_image) {
             // Linear images are defined by the implementation and so we can't assume the ordering we use here
@@ -735,9 +781,11 @@ ImageRangeGenerator& ImageRangeGenerator::operator++() {
         incr_state_.y_base += incr_state_.incr_y;
         pos_ = incr_state_.y_base;
     } else {
-        incr_state_.layer_z_index += incr_state_.layer_z_step;
+        uint32_t old_z_index = incr_state_.layer_z_index;
+        incr_state_.layer_z_index = incr_state_.GetNextLayerZIndex();
         if (incr_state_.layer_z_index < incr_state_.layer_z_count) {
-            incr_state_.layer_z_base += incr_state_.incr_layer_z;
+            uint32_t z_count = incr_state_.layer_z_index - old_z_index;
+            incr_state_.layer_z_base += z_count * incr_state_.incr_layer_z;
             incr_state_.y_base = incr_state_.layer_z_base;
             pos_ = incr_state_.y_base;
         } else {
@@ -905,6 +953,21 @@ void ImageRangeGenerator::IncrementerState::Set(uint32_t y_count_, uint32_t laye
     layer_z_base = y_base;
     incr_y = y_step;
     incr_layer_z = z_step;
+}
+
+uint32_t ImageRangeGenerator::IncrementerState::GetNextLayerZIndex() const {
+    if (view_mask_ == 0) {
+        return layer_z_index + layer_z_step;
+    } else {
+        uint32_t next_z = layer_z_index + 1;
+        while (next_z < layer_z_count) {
+            if ((1 << next_z) & view_mask_) {
+                break;
+            }
+            next_z++;
+        }
+        return next_z;
+    }
 }
 
 }  // namespace subresource_adapter

--- a/layers/state_tracker/subresource_adapter.h
+++ b/layers/state_tracker/subresource_adapter.h
@@ -387,9 +387,6 @@ class ImageRangeEncoder : public RangeEncoder {
     bool is_compressed_;
 };
 
-// TODO: add support for view mask. If specified, the ragne generator iterates only over
-// the view layers. Currently we have to organize an external loop to go over view layers
-// and we create range generator for each view.
 class ImageRangeGenerator {
   public:
     using RangeType = IndexRange;
@@ -397,19 +394,13 @@ class ImageRangeGenerator {
     ImageRangeGenerator() : encoder_(nullptr), subres_range_(), offset_(), extent_(), base_address_(), pos_() {}
     ImageRangeGenerator(const ImageRangeEncoder& encoder, const VkImageSubresourceRange& subres_range, const VkOffset3D& offset,
                         const VkExtent3D& extent, VkDeviceSize base_address, bool is_depth_sliced);
-    void SetInitialPosFullOffset(uint32_t layer, uint32_t aspect_index);
-    void SetInitialPosFullWidth(uint32_t layer, uint32_t aspect_index);
-    void SetInitialPosFullHeight(uint32_t layer, uint32_t aspect_index);
-    void SetInitialPosSomeDepth(uint32_t layer, uint32_t aspect_index);
-    void SetInitialPosFullDepth(uint32_t layer, uint32_t aspect_index);
-    void SetInitialPosAllLayers(uint32_t layer, uint32_t aspect_index);
-    void SetInitialPosOneAspect(uint32_t layer, uint32_t aspect_index);
-    void SetInitialPosAllSubres(uint32_t layer, uint32_t aspect_index);
-    void SetInitialPosSomeLayers(uint32_t layer, uint32_t aspect_index);
     ImageRangeGenerator(const ImageRangeEncoder& encoder, const VkImageSubresourceRange& subres_range, VkDeviceSize base_address,
                         bool is_depth_sliced);
-    inline const IndexRange& operator*() const { return pos_; }
-    inline const IndexRange* operator->() const { return &pos_; }
+    ImageRangeGenerator(const ImageRangeEncoder& encoder, const VkImageSubresourceRange& subres_range, VkDeviceSize base_address,
+                        bool is_depth_sliced, uint32_t view_mask);
+
+    const IndexRange& operator*() const { return pos_; }
+    const IndexRange* operator->() const { return &pos_; }
     ImageRangeGenerator& operator++();
     ImageRangeGenerator& operator=(const ImageRangeGenerator&) = default;
 
@@ -419,17 +410,31 @@ class ImageRangeGenerator {
     void SetUpIncrementerDefaults();
     void SetUpSubresIncrementer();
     void SetUpIncrementer(bool all_width, bool all_height, bool all_depth);
-    typedef void (ImageRangeGenerator::*SetInitialPosFn)(uint32_t, uint32_t);
-    inline void SetInitialPos(uint32_t layer, uint32_t aspect_index) { (this->*(set_initial_pos_fn_))(layer, aspect_index); }
+
+    using SetInitialPosFn = void (ImageRangeGenerator::*)(uint32_t, uint32_t);
+    void SetInitialPos(uint32_t layer, uint32_t aspect_index) { (this->*(set_initial_pos_fn_))(layer, aspect_index); }
+
+    void SetInitialPosFullOffset(uint32_t layer, uint32_t aspect_index);
+    void SetInitialPosFullWidth(uint32_t layer, uint32_t aspect_index);
+    void SetInitialPosFullHeight(uint32_t layer, uint32_t aspect_index);
+    void SetInitialPosSomeDepth(uint32_t layer, uint32_t aspect_index);
+    void SetInitialPosFullDepth(uint32_t layer, uint32_t aspect_index);
+    void SetInitialPosAllLayers(uint32_t layer, uint32_t aspect_index);
+    void SetInitialPosOneAspect(uint32_t layer, uint32_t aspect_index);
+    void SetInitialPosAllSubres(uint32_t layer, uint32_t aspect_index);
+    void SetInitialPosSomeLayers(uint32_t layer, uint32_t aspect_index);
+    void SetInitialPosMultiviewLayers(uint32_t layer, uint32_t aspect_index);
 
     VkOffset3D GetOffset(uint32_t aspect_index) const;
     VkExtent3D GetExtent(uint32_t aspect_index) const;
 
+  private:
     const ImageRangeEncoder* encoder_;
     VkImageSubresourceRange subres_range_;
     VkOffset3D offset_;
     VkExtent3D extent_;
     VkDeviceSize base_address_;
+    uint32_t view_mask_ = 0;
 
     uint32_t mip_index_ = 0U;
     uint32_t incr_mip_ = 0U;
@@ -438,6 +443,7 @@ class ImageRangeGenerator {
     const ImageRangeEncoder::SubresInfo* subres_info_ = nullptr;
 
     SetInitialPosFn set_initial_pos_fn_ = nullptr;
+
     IndexRange pos_;
 
     struct IncrementerState {
@@ -454,7 +460,17 @@ class ImageRangeGenerator {
         IndexRange layer_z_base = {0U, 0U};
         IndexType incr_y = 0U;
         IndexType incr_layer_z = 0U;
+
+        uint32_t view_mask_ = 0;
+
         void Set(uint32_t y_count_, uint32_t layer_z_count_, IndexType base, IndexType span, IndexType y_step, IndexType z_step);
+
+        // When multiview is disabled returns:
+        //      layer_z_index + incr_state_.layer_z_step
+        // When multiview is enabled returns:
+        //      the next value after layer_z_index that corresponds to the next set bit in view mask.
+        //      When all view bits are iterated or layer_z_count is reach then returns layer_z_count.
+        uint32_t GetNextLayerZIndex() const;
     };
     IncrementerState incr_state_;
     bool single_full_size_range_ = true;

--- a/layers/sync/sync_access_context.h
+++ b/layers/sync/sync_access_context.h
@@ -364,7 +364,7 @@ class AccessContext {
                                         const AttachmentAccess &attachment_access) const;
     HazardResult DetectAttachmentHazard(const AttachmentViewGen &view_gen, AttachmentViewGen::Gen gen_type,
                                         SyncAccessIndex current_usage, const AttachmentAccess &attachment_access,
-                                        uint32_t view_mask = 0) const;
+                                        uint32_t view_mask) const;
     HazardResult DetectAttachmentHazard(const vvl::Image &image, const VkImageSubresourceRange &subresource_range,
                                         bool is_depth_sliced, SyncAccessIndex current_usage,
                                         const AttachmentAccess &attachment_access) const;

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -344,7 +344,7 @@ bool CommandBufferAccessContext::ValidateBeginRendering(const ErrorObject &error
         }
 
         const AttachmentAccess attachment_access = GetAttachmentAccess(attachment.GetOrdering(), AttachmentAccessType::LoadOp);
-        ImageRangeGen range_gen = attachment.view_gen;
+        ImageRangeGen range_gen = attachment.GetRangeGen(info.info.viewMask);
         const HazardResult hazard = GetCurrentAccessContext()->DetectAttachmentHazard(range_gen, load_index, attachment_access);
         if (hazard.IsHazard()) {
             LogObjectList objlist(cb_state_->Handle(), attachment.view->Handle());
@@ -378,7 +378,7 @@ void CommandBufferAccessContext::RecordBeginRendering(BeginRenderingCmdState &cm
             if (load_index == SYNC_ACCESS_INDEX_NONE) {
                 continue;
             }
-            ImageRangeGen range_gen = attachment.view_gen;
+            ImageRangeGen range_gen = attachment.GetRangeGen(info.info.viewMask);
             const AttachmentAccess attachment_access = GetAttachmentAccess(attachment.GetOrdering(), AttachmentAccessType::LoadOp);
             GetCurrentAccessContext()->UpdateAttachmentAccessState(range_gen, load_index, attachment_access,
                                                                    ResourceUsageTagEx{tag});
@@ -410,7 +410,7 @@ bool CommandBufferAccessContext::ValidateEndRendering(const ErrorObject &error_o
             const SyncOrdering kResolveOrder = is_color ? kColorResolveOrder : kDepthStencilResolveOrder;
 
             const AttachmentAccess resolve_read_access = GetAttachmentAccess(kResolveOrder, AttachmentAccessType::ResolveRead);
-            ImageRangeGen view_gen = attachment.view_gen;
+            ImageRangeGen view_gen = attachment.GetRangeGen(dynamic_rendering_info_->info.viewMask);
             HazardResult hazard = current_context_->DetectAttachmentHazard(view_gen, kResolveRead, resolve_read_access);
             if (hazard.IsHazard()) {
                 LogObjectList objlist(cb_state_->Handle(), attachment.view->Handle());
@@ -451,7 +451,7 @@ bool CommandBufferAccessContext::ValidateEndRendering(const ErrorObject &error_o
         const SyncAccessIndex store_access = attachment.GetStoreUsage();
         if (store_access != SYNC_ACCESS_INDEX_NONE) {
             const AttachmentAccess attachment_access = GetAttachmentAccess(kStoreOrder, AttachmentAccessType::StoreOp);
-            ImageRangeGen view_gen = attachment.view_gen;
+            ImageRangeGen view_gen = attachment.GetRangeGen(dynamic_rendering_info_->info.viewMask);
 
             HazardResult hazard = current_context_->DetectAttachmentHazard(view_gen, store_access, attachment_access);
             if (hazard.IsHazard()) {
@@ -492,7 +492,7 @@ void CommandBufferAccessContext::RecordEndRendering(const RecordObject &record_o
             const SyncOrdering kResolveOrder = is_color ? kColorResolveOrder : kDepthStencilResolveOrder;
 
             const AttachmentAccess resolve_read_access = GetAttachmentAccess(kResolveOrder, AttachmentAccessType::ResolveRead);
-            ImageRangeGen view_gen = attachment.view_gen;
+            ImageRangeGen view_gen = attachment.GetRangeGen(dynamic_rendering_info_->info.viewMask);
             access_context.UpdateAttachmentAccessState(view_gen, kResolveRead, resolve_read_access, ResourceUsageTagEx{store_tag});
 
             const AttachmentAccess resolve_write_access = GetAttachmentAccess(kResolveOrder, AttachmentAccessType::ResolveWrite);
@@ -504,7 +504,7 @@ void CommandBufferAccessContext::RecordEndRendering(const RecordObject &record_o
         const SyncAccessIndex store_index = attachment.GetStoreUsage();
         if (store_index != SYNC_ACCESS_INDEX_NONE) {
             const AttachmentAccess attachment_access = GetAttachmentAccess(kStoreOrder, AttachmentAccessType::StoreOp);
-            ImageRangeGen view_gen = attachment.view_gen;
+            ImageRangeGen view_gen = attachment.GetRangeGen(dynamic_rendering_info_->info.viewMask);
             access_context.UpdateAttachmentAccessState(view_gen, store_index, attachment_access, ResourceUsageTagEx{store_tag});
         }
     }
@@ -954,7 +954,7 @@ bool CommandBufferAccessContext::ValidateDrawDynamicRenderingAttachment(const Lo
             continue;
         }
         const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kColorAttachment);
-        ImageRangeGen view_gen = attachment.view_gen;
+        ImageRangeGen view_gen = attachment.GetRangeGen(info.info.viewMask);
         HazardResult hazard =
             access_context.DetectAttachmentHazard(view_gen, SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, attachment_access);
 
@@ -977,7 +977,7 @@ bool CommandBufferAccessContext::ValidateDrawDynamicRenderingAttachment(const Lo
 
         if (writeable) {
             const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kDepthStencilAttachment);
-            ImageRangeGen view_gen = attachment.view_gen;
+            ImageRangeGen view_gen = attachment.GetRangeGen(info.info.viewMask);
             HazardResult hazard = access_context.DetectAttachmentHazard(
                 view_gen, SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, attachment_access);
 
@@ -1021,7 +1021,7 @@ void CommandBufferAccessContext::RecordDrawDynamicRenderingAttachment(ResourceUs
             continue;
         }
         const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kColorAttachment);
-        ImageRangeGen view_gen = attachment.view_gen;
+        ImageRangeGen view_gen = attachment.GetRangeGen(info.info.viewMask);
         access_context.UpdateAttachmentAccessState(view_gen, SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, attachment_access,
                                                    ResourceUsageTagEx{tag});
     }
@@ -1038,7 +1038,7 @@ void CommandBufferAccessContext::RecordDrawDynamicRenderingAttachment(ResourceUs
 
         if (writeable) {
             const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kDepthStencilAttachment);
-            ImageRangeGen view_gen = attachment.view_gen;
+            ImageRangeGen view_gen = attachment.GetRangeGen(info.info.viewMask);
             access_context.UpdateAttachmentAccessState(view_gen, SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE,
                                                        attachment_access, ResourceUsageTagEx{tag});
         }

--- a/layers/sync/sync_image.cpp
+++ b/layers/sync/sync_image.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2019-2025 Valve Corporation
- * Copyright (c) 2019-2025 LunarG, Inc.
+ * Copyright (c) 2019-2026 Valve Corporation
+ * Copyright (c) 2019-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,6 +73,16 @@ ImageRangeGen ImageSubState::MakeImageRangeGen(const VkImageSubresourceRange &su
     return range_gen;
 }
 
+ImageRangeGen ImageSubState::MakeImageRangeGen(const VkImageSubresourceRange &subresource_range, bool is_depth_sliced,
+                                               uint32_t view_mask) const {
+    if (!IsSimplyBound()) {
+        return {};
+    }
+    const VkDeviceSize base_address = GetResourceBaseAddress();
+    ImageRangeGen range_gen(fragment_encoder, subresource_range, base_address, is_depth_sliced, view_mask);
+    return range_gen;
+}
+
 ImageRangeGen ImageSubState::MakeImageRangeGen(const VkImageSubresourceRange &subresource_range,
                                                               const VkOffset3D &offset, const VkExtent3D &extent,
                                                               bool is_depth_sliced) const {
@@ -91,12 +101,22 @@ ImageRangeGen MakeImageRangeGen(const vvl::ImageView &view) {
     return sub_state.MakeImageRangeGen(view.normalized_subresource_range, view.is_depth_sliced);
 }
 
+ImageRangeGen MakeImageRangeGen(const vvl::ImageView &view, uint32_t view_mask,
+                                VkImageAspectFlags override_depth_stencil_aspect_mask) {
+    VkImageSubresourceRange subresource_range = view.normalized_subresource_range;
+    if (override_depth_stencil_aspect_mask != 0) {
+        assert((override_depth_stencil_aspect_mask & kDepthStencilAspects) == override_depth_stencil_aspect_mask);
+        subresource_range.aspectMask = override_depth_stencil_aspect_mask;
+    }
+    const auto &sub_state = SubState(*view.image_state);
+    return sub_state.MakeImageRangeGen(subresource_range, view.is_depth_sliced, view_mask);
+}
+
 ImageRangeGen MakeImageRangeGen(const vvl::ImageView &view, const VkOffset3D &offset, const VkExtent3D &extent,
                                 VkImageAspectFlags override_depth_stencil_aspect_mask) {
     if (view.Invalid()) ImageRangeGen();
 
     VkImageSubresourceRange subresource_range = view.normalized_subresource_range;
-
     if (override_depth_stencil_aspect_mask != 0) {
         assert((override_depth_stencil_aspect_mask & kDepthStencilAspects) == override_depth_stencil_aspect_mask);
         subresource_range.aspectMask = override_depth_stencil_aspect_mask;

--- a/layers/sync/sync_image.h
+++ b/layers/sync/sync_image.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2019-2025 Valve Corporation
- * Copyright (c) 2019-2025 LunarG, Inc.
+ * Copyright (c) 2019-2026 Valve Corporation
+ * Copyright (c) 2019-2026 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,8 @@ class ImageSubState : public vvl::ImageSubState {
 
     VkDeviceSize GetResourceBaseAddress() const;
     ImageRangeGen MakeImageRangeGen(const VkImageSubresourceRange &subresource_range, bool is_depth_sliced) const;
+    ImageRangeGen MakeImageRangeGen(const VkImageSubresourceRange &subresource_range, bool is_depth_sliced,
+                                    uint32_t view_mask) const;
     ImageRangeGen MakeImageRangeGen(const VkImageSubresourceRange &subresource_range, const VkOffset3D &offset,
                                     const VkExtent3D &extent, bool is_depth_sliced) const;
 
@@ -53,6 +55,8 @@ static inline const ImageSubState &SubState(const vvl::Image &img) {
 }
 
 ImageRangeGen MakeImageRangeGen(const vvl::ImageView &view);
+ImageRangeGen MakeImageRangeGen(const vvl::ImageView &view, uint32_t view_mask,
+                                VkImageAspectFlags override_depth_stencil_aspect_mask = 0);
 ImageRangeGen MakeImageRangeGen(const vvl::ImageView &view, const VkOffset3D &offset, const VkExtent3D &extent,
                                 VkImageAspectFlags override_depth_stencil_aspect_mask = 0);
 

--- a/layers/sync/sync_renderpass.cpp
+++ b/layers/sync/sync_renderpass.cpp
@@ -637,9 +637,9 @@ bool RenderPassAccessContext::ValidateDrawSubpassAttachment(const CommandBufferA
 
         if (depth_write) {
             const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kDepthStencilAttachment);
-            ImageRangeGen attachment_range_gen = view_gen.GetRangeGen(AttachmentViewGen::Gen::kDepthOnlyRenderArea);
-            HazardResult hazard = current_context.DetectAttachmentHazard(
-                attachment_range_gen, SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, attachment_access);
+            HazardResult hazard = current_context.DetectAttachmentHazard(view_gen, AttachmentViewGen::Gen::kDepthOnlyRenderArea,
+                                                                         SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE,
+                                                                         attachment_access, subpass.viewMask);
             if (hazard.IsHazard()) {
                 std::ostringstream ss;
                 ss << "depth aspect of depth-stencil attachment  in subpass " << cmd_buffer.GetActiveSubpass();
@@ -649,9 +649,9 @@ bool RenderPassAccessContext::ValidateDrawSubpassAttachment(const CommandBufferA
         }
         if (stencil_write) {
             const AttachmentAccess attachment_access = GetAttachmentAccess(SyncOrdering::kDepthStencilAttachment);
-            ImageRangeGen attachment_range_gen = view_gen.GetRangeGen(AttachmentViewGen::Gen::kStencilOnlyRenderArea);
-            HazardResult hazard = current_context.DetectAttachmentHazard(
-                attachment_range_gen, SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, attachment_access);
+            HazardResult hazard = current_context.DetectAttachmentHazard(view_gen, AttachmentViewGen::Gen::kStencilOnlyRenderArea,
+                                                                         SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE,
+                                                                         attachment_access, subpass.viewMask);
             if (hazard.IsHazard()) {
                 std::ostringstream ss;
                 ss << "stencil aspect of depth-stencil attachment  in subpass " << cmd_buffer.GetActiveSubpass();
@@ -702,7 +702,7 @@ void RenderPassAccessContext::RecordDrawSubpassAttachment(const vvl::CommandBuff
             const auto ds_gentype = view_gen.GetDepthStencilRenderAreaGenType(depth_write, stencil_write);
             current_context.UpdateAttachmentAccessState(view_gen, ds_gentype,
                                                         SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, attachment_access,
-                                                        ResourceUsageTagEx{tag});
+                                                        ResourceUsageTagEx{tag}, subpass.viewMask);
         }
     }
 }
@@ -1071,6 +1071,20 @@ DynamicRenderingInfo::Attachment::Attachment(const SyncValidator &state, const v
                     resolve_gen.emplace(MakeImageRangeGen(*resolve_view, offset, extent, VK_IMAGE_ASPECT_STENCIL_BIT));
                 }
             }
+        }
+    }
+}
+
+ImageRangeGen DynamicRenderingInfo::Attachment::GetRangeGen(uint32_t view_mask) const {
+    if (view_mask == 0) {
+        return view_gen;  // precomputed range gen when multivie is disabled
+    } else {
+        if (type == AttachmentType::kColor) {
+            return MakeImageRangeGen(*view, view_mask);
+        } else if (type == AttachmentType::kDepth) {
+            return MakeImageRangeGen(*view, view_mask, VK_IMAGE_ASPECT_DEPTH_BIT);
+        } else {
+            return MakeImageRangeGen(*view, view_mask, VK_IMAGE_ASPECT_STENCIL_BIT);
         }
     }
 }

--- a/layers/sync/sync_renderpass.h
+++ b/layers/sync/sync_renderpass.h
@@ -46,6 +46,8 @@ struct DynamicRenderingInfo {
         Attachment(const SyncValidator &state, const vku::safe_VkRenderingAttachmentInfo &info, const AttachmentType type_,
                    const VkOffset3D &offset, const VkExtent3D &extent);
 
+        ImageRangeGen GetRangeGen(uint32_t view_mask = 0) const;
+
         SyncAccessIndex GetLoadUsage() const;
         SyncAccessIndex GetStoreUsage() const;
         SyncOrdering GetOrdering() const;

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -4404,3 +4404,82 @@ TEST_F(PositiveSyncVal, StencilNotWritable4) {
     m_command_buffer.EndRendering();
     m_command_buffer.End();
 }
+
+TEST_F(PositiveSyncVal, Multiview) {
+    TEST_DESCRIPTION("Two rendering instances render to its own view");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    AddRequiredFeature(vkt::Feature::multiview);
+    RETURN_IF_SKIP(InitSyncVal());
+
+    const VkImageCreateInfo image_ci =
+        vkt::Image::ImageCreateInfo2D(128, 128, 1, 2 /*layers*/, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    vkt::Image image(*m_device, image_ci);
+    vkt::ImageView image_view = image.CreateView(VK_IMAGE_VIEW_TYPE_2D_ARRAY, 0, 1, 0, 2 /*layers*/);
+
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
+    color_attachment.imageView = image_view;
+    color_attachment.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+    color_attachment.loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+    color_attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+
+    VkRenderingInfo rendering_info_view0 = vku::InitStructHelper();
+    rendering_info_view0.renderArea.extent = {128, 128};
+    rendering_info_view0.layerCount = 1;
+    rendering_info_view0.viewMask = 0x1;
+    rendering_info_view0.colorAttachmentCount = 1;
+    rendering_info_view0.pColorAttachments = &color_attachment;
+
+    VkRenderingInfo rendering_info_view1 = rendering_info_view0;
+    rendering_info_view1.viewMask = 0x2;
+
+    // No hazard: each rendering instance renders to a separate layer (view) of the same image
+    m_command_buffer.Begin();
+
+    m_command_buffer.BeginRendering(rendering_info_view0);
+    m_command_buffer.EndRendering();
+
+    m_command_buffer.BeginRendering(rendering_info_view1);
+    m_command_buffer.EndRendering();
+
+    m_command_buffer.End();
+}
+
+TEST_F(PositiveSyncVal, Multiview2) {
+    TEST_DESCRIPTION("Multiview and copy modify different layers");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    AddRequiredFeature(vkt::Feature::multiview);
+    RETURN_IF_SKIP(InitSyncVal());
+
+    const VkImageCreateInfo image_ci = vkt::Image::ImageCreateInfo2D(
+        128, 128, 1, 3, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::Image image(*m_device, image_ci);
+    vkt::ImageView image_view = image.CreateView(VK_IMAGE_VIEW_TYPE_2D_ARRAY, 0, 1, 0, 3);
+
+    vkt::Buffer buffer(*m_device, 128 * 128 * 4, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
+
+    VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
+    color_attachment.imageView = image_view;
+    color_attachment.imageLayout = VK_IMAGE_LAYOUT_GENERAL;
+    color_attachment.loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+    color_attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+
+    VkRenderingInfo rendering_info = vku::InitStructHelper();
+    rendering_info.renderArea.extent = {128, 128};
+    rendering_info.layerCount = 1;
+    rendering_info.viewMask = 0x5;  // view 0 + view 2
+    rendering_info.colorAttachmentCount = 1;
+    rendering_info.pColorAttachments = &color_attachment;
+
+    VkBufferImageCopy region{};
+    region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 1};  // layer 1
+    region.imageExtent = {128, 128, 1};
+
+    // No hazard: copy writes to layer 1 and rendering works with layer 0 and layer 2
+    m_command_buffer.Begin();
+    vk::CmdCopyBufferToImage(m_command_buffer, buffer, image, VK_IMAGE_LAYOUT_GENERAL, 1, &region);
+    m_command_buffer.BeginRendering(rendering_info);
+    m_command_buffer.EndRendering();
+    m_command_buffer.End();
+}


### PR DESCRIPTION
Multiview for dynamic rendering works almost automatically by replacing 

` ImageRangeGen range_gen = attachment.view_gen;`
with 
`ImageRangeGen range_gen = attachment.GetRangeGen(dynamic_rendering_info_->info.viewMask);`

For this to work I had to add support of view masks to ImageRangeGenerator. The original plan was to refactor and cleanup ImageRangeGenerator at first. Due to lack of time this was not done and view mask functionality was just somehow added. So this is far from ideal and probably will need some iterations but it's good to have something as the first step.