### PR TITLE
gpuav: Fix debugprintf in callback functions

### DIFF
--- a/layers/gpuav/spirv/module.cpp
+++ b/layers/gpuav/spirv/module.cpp
@@ -249,35 +249,9 @@ Module::Module(vvl::span<const uint32_t> words, DebugReport* debug_report, const
             current_function->inst_map_[result_id] = new_inst.get();
         }
 
-        if (opcode == spv::OpFunctionCall) {
-            function_call_map[current_function->id_].insert(new_inst->Word(3));
-        }
-
-        // Coopmat2 callback functions are not called via OpFunctionCall, but are still reachable
-        if (opcode == spv::OpCooperativeMatrixPerElementOpNV) {
-            // Word(4) = Func
-            function_call_map[current_function->id_].insert(new_inst->Word(4));
-        } else if (opcode == spv::OpCooperativeMatrixReduceNV) {
-            // Word(5) = CombineFunc (after Matrix=Word(3), Reduce literal=Word(4))
-            function_call_map[current_function->id_].insert(new_inst->Word(5));
-        } else if (opcode == spv::OpCooperativeMatrixLoadTensorNV) {
-            // DecodeFunc is optional, gated by TensorAddressingOperands bitmask.
-            // Layout: ResultType(1), Result(2), Pointer(3), Object(4), TensorLayout(5),
-            //         MemoryOperand literal(6), [extra memory operand words...],
-            //         TensorAddressingOperands literal, [TensorView ID], [DecodeFunc ID]
-            uint32_t idx = 7;  // first word after MemoryOperand literal
-            const uint32_t mem_operand = new_inst->Word(6);
-            if (mem_operand & spv::MemoryAccessAlignedMask) idx++;
-            if (mem_operand & spv::MemoryAccessMakePointerAvailableMask) idx++;
-            if (mem_operand & spv::MemoryAccessMakePointerVisibleMask) idx++;
-            if (idx < new_inst->Length()) {
-                const uint32_t tensor_operand = new_inst->Word(idx);
-                idx++;
-                if (tensor_operand & spv::TensorAddressingOperandsTensorViewMask) idx++;
-                if ((tensor_operand & spv::TensorAddressingOperandsDecodeFuncMask) && idx < new_inst->Length()) {
-                    function_call_map[current_function->id_].insert(new_inst->Word(idx));
-                }
-            }
+        const uint32_t called_function_id = new_inst->GetCalledFunctionId();
+        if (called_function_id != 0) {
+            function_call_map[current_function->id_].insert(called_function_id);
         }
 
         if (opcode == spv::OpFunctionEnd) {

--- a/layers/state_tracker/shader_instruction.cpp
+++ b/layers/state_tracker/shader_instruction.cpp
@@ -618,4 +618,30 @@ ImageInstruction::ImageInstruction(const uint32_t* words) {
     }
 }
 
+uint32_t Instruction::GetCalledFunctionId() const {
+    const uint32_t opcode = Opcode();
+    if (opcode == spv::OpFunctionCall) {
+        return Word(3);
+    } else if (opcode == spv::OpCooperativeMatrixPerElementOpNV) {
+        return Word(4);
+    } else if (opcode == spv::OpCooperativeMatrixReduceNV) {
+        return Word(5);
+    } else if (opcode == spv::OpCooperativeMatrixLoadTensorNV) {
+        uint32_t idx = 7;
+        const uint32_t mem_operand = Word(6);
+        if (mem_operand & spv::MemoryAccessAlignedMask) idx++;
+        if (mem_operand & spv::MemoryAccessMakePointerAvailableMask) idx++;
+        if (mem_operand & spv::MemoryAccessMakePointerVisibleMask) idx++;
+        if (idx < Length()) {
+            const uint32_t tensor_operand = Word(idx);
+            idx++;
+            if (tensor_operand & spv::TensorAddressingOperandsTensorViewMask) idx++;
+            if ((tensor_operand & spv::TensorAddressingOperandsDecodeFuncMask) && idx < Length()) {
+                return Word(idx);
+            }
+        }
+    }
+    return 0;
+}
+
 }  // namespace spirv

--- a/layers/state_tracker/shader_instruction.h
+++ b/layers/state_tracker/shader_instruction.h
@@ -86,6 +86,8 @@ class Instruction {
     bool IsTensor() const;
     bool IsConstant() const;
     bool IsSpecConstant() const;
+    // Returns the function ID referenced by this instruction (OpFunctionCall, or coopmat2 callback operands), or 0 if none.
+    uint32_t GetCalledFunctionId() const;
 
     // Auto-generated helper functions
     spv::StorageClass StorageClass() const;

--- a/tests/unit/debug_printf.cpp
+++ b/tests/unit/debug_printf.cpp
@@ -44,7 +44,7 @@ class NegativeDebugPrintf : public DebugPrintfTests {
   public:
     void BasicComputeTest(const char *shader, const char *message);
     void BasicFormattingTest(const char *shader, bool warning = false);
-    void CoopMat2CallbackTest(const char *shader_source, const char *message, bool needs_buffer);
+    void CoopMat2CallbackTest(const char *shader_source, const char *message);
 };
 
 void NegativeDebugPrintf::BasicComputeTest(const char *shader, const char *message) {
@@ -6561,50 +6561,36 @@ TEST_F(NegativeDebugPrintf, DeviceLocalHeapGraphics) {
     m_errorMonitor->VerifyFound();
 }
 
-// Helper for coopmat2 debugPrintfEXT callback tests.
-// Caller adds test-specific features/extensions before calling this.
-void NegativeDebugPrintf::CoopMat2CallbackTest(const char *shader_source, const char *message, bool needs_buffer) {
+void NegativeDebugPrintf::CoopMat2CallbackTest(const char *shader_source, const char *message) {
     AddRequiredExtensions(VK_KHR_COOPERATIVE_MATRIX_EXTENSION_NAME);
     AddRequiredExtensions(VK_NV_COOPERATIVE_MATRIX_2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::cooperativeMatrix);
     AddRequiredFeature(vkt::Feature::shaderFloat16);
     AddRequiredFeature(vkt::Feature::vulkanMemoryModel);
-    if (needs_buffer) {
-        AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
-        AddRequiredFeature(vkt::Feature::cooperativeMatrixTensorAddressing);
-        AddRequiredFeature(vkt::Feature::cooperativeMatrixBlockLoads);
-        AddRequiredFeature(vkt::Feature::storageBuffer16BitAccess);
-        AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
-    }
+    AddRequiredFeature(vkt::Feature::storageBuffer16BitAccess);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
     SetTargetApiVersion(VK_API_VERSION_1_3);
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
 
     CreateComputePipelineHelper pipe(*this);
-    if (needs_buffer) {
-        pipe.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr};
-    }
+    pipe.dsl_bindings_[0] = {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr};
     pipe.cs_ = VkShaderObj(*m_device, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_3);
     pipe.CreateComputePipeline();
 
     vkt::Buffer buffer(*m_device, 256 * 256 * 2, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, kHostVisibleMemProps);
-    if (needs_buffer) {
-        pipe.descriptor_set_.WriteDescriptorBufferInfo(0, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
-        pipe.descriptor_set_.UpdateDescriptorSets();
-    }
+    pipe.descriptor_set_.WriteDescriptorBufferInfo(0, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    pipe.descriptor_set_.UpdateDescriptorSets();
 
     m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
-    if (needs_buffer) {
-        vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_, 0, 1,
-                                  &pipe.descriptor_set_.set_, 0, nullptr);
-    }
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_, 0, 1,
+                              &pipe.descriptor_set_.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
     m_command_buffer.End();
 
     m_errorMonitor->SetDesiredInfo(message);
-    m_errorMonitor->SetAllowedFailureMsg(message);
-    m_errorMonitor->SetAllowedFailureMsg("Debug Printf message was truncated");
     m_default_queue->SubmitAndWait(m_command_buffer);
     m_errorMonitor->VerifyFound();
 }
@@ -6620,7 +6606,10 @@ TEST_F(NegativeDebugPrintf, CoopMat2PerElementOp) {
         #extension GL_KHR_cooperative_matrix : enable
         #extension GL_EXT_shader_explicit_arithmetic_types : enable
         #extension GL_NV_cooperative_matrix2 : enable
+        #extension GL_EXT_buffer_reference : enable
         layout(local_size_x = 32) in;
+        layout(set = 0, binding = 0) buffer BufType { float16_t x[]; } buf;
+        layout(buffer_reference, std430, buffer_reference_align = 2) buffer fp16Buf { float16_t f; };
         float16_t myFunc(const in uint32_t row, const in uint32_t col, const in float16_t x) {
             if (row == 0 && col == 0) {
                 debugPrintfEXT("perelemop callback");
@@ -6633,7 +6622,7 @@ TEST_F(NegativeDebugPrintf, CoopMat2PerElementOp) {
         }
     )glsl";
 
-    CoopMat2CallbackTest(shader_source, "perelemop callback", false);
+    CoopMat2CallbackTest(shader_source, "perelemop callback");
 }
 
 TEST_F(NegativeDebugPrintf, CoopMat2Reduce) {
@@ -6647,22 +6636,32 @@ TEST_F(NegativeDebugPrintf, CoopMat2Reduce) {
         #extension GL_KHR_cooperative_matrix : enable
         #extension GL_EXT_shader_explicit_arithmetic_types : enable
         #extension GL_NV_cooperative_matrix2 : enable
+        #extension GL_EXT_buffer_reference : enable
         layout(local_size_x = 32) in;
+        layout(set = 0, binding = 0) buffer BufType { float16_t x[]; } buf;
+        layout(buffer_reference, std430, buffer_reference_align = 2) buffer fp16Buf { float16_t f; };
+        shared uint printed;
         float16_t combineFunc(const in float16_t a, const in float16_t b) {
-            debugPrintfEXT("reduce callback");
+            if (atomicExchange(printed, 1u) == 0u) {
+                debugPrintfEXT("reduce callback");
+            }
             return a + b;
         }
         void main() {
+            if (gl_LocalInvocationIndex == 0u) printed = 0u;
+            barrier();
             coopmat<float16_t, gl_ScopeSubgroup, 16, 16, gl_MatrixUseAccumulator> m = coopmat<float16_t, gl_ScopeSubgroup, 16, 16, gl_MatrixUseAccumulator>(float16_t(0));
             coopMatReduceNV(m, m, gl_CooperativeMatrixReduceRowNV, combineFunc);
         }
     )glsl";
 
-    CoopMat2CallbackTest(shader_source, "reduce callback", false);
+    CoopMat2CallbackTest(shader_source, "reduce callback");
 }
 
 TEST_F(NegativeDebugPrintf, CoopMat2LoadTensorDecode) {
     TEST_DESCRIPTION("debugPrintfEXT inside a coopMatLoadTensorNV decode callback function");
+    AddRequiredFeature(vkt::Feature::cooperativeMatrixTensorAddressing);
+    AddRequiredFeature(vkt::Feature::cooperativeMatrixBlockLoads);
 
     const char *shader_source = R"glsl(
         #version 450
@@ -6673,17 +6672,18 @@ TEST_F(NegativeDebugPrintf, CoopMat2LoadTensorDecode) {
         #extension GL_NV_cooperative_matrix2 : enable
         #extension GL_EXT_buffer_reference : enable
         layout(local_size_x = 32) in;
-        layout(set = 0, binding = 0) buffer BufType {
-            float16_t x[];
-        } buf;
-        layout(buffer_reference, std430, buffer_reference_align = 2) buffer fp16Buf {
-            float16_t f;
-        };
+        layout(set = 0, binding = 0) buffer BufType { float16_t x[]; } buf;
+        layout(buffer_reference, std430, buffer_reference_align = 2) buffer fp16Buf { float16_t f; };
+        shared uint printed;
         float16_t decodeFunc(const in fp16Buf b, const in uint32_t blockCoords[2], const in uint32_t coordInBlock[2]) {
-            debugPrintfEXT("decode callback");
+            if (atomicExchange(printed, 1u) == 0u) {
+                debugPrintfEXT("decode callback");
+            }
             return b.f;
         }
         void main() {
+            if (gl_LocalInvocationIndex == 0u) printed = 0u;
+            barrier();
             coopmat<float16_t, gl_ScopeSubgroup, 16, 16, gl_MatrixUseA> A;
             tensorLayoutNV<2> t = createTensorLayoutNV(2);
             t = setTensorLayoutDimensionNV(t, 256, 256);
@@ -6692,11 +6692,13 @@ TEST_F(NegativeDebugPrintf, CoopMat2LoadTensorDecode) {
         }
     )glsl";
 
-    CoopMat2CallbackTest(shader_source, "decode callback", true);
+    CoopMat2CallbackTest(shader_source, "decode callback");
 }
 
 TEST_F(NegativeDebugPrintf, CoopMat2LoadTensorDecodeWithView) {
     TEST_DESCRIPTION("debugPrintfEXT inside a coopMatLoadTensorNV decode callback with both TensorView and DecodeFunc");
+    AddRequiredFeature(vkt::Feature::cooperativeMatrixTensorAddressing);
+    AddRequiredFeature(vkt::Feature::cooperativeMatrixBlockLoads);
 
     const char *shader_source = R"glsl(
         #version 450
@@ -6707,17 +6709,18 @@ TEST_F(NegativeDebugPrintf, CoopMat2LoadTensorDecodeWithView) {
         #extension GL_NV_cooperative_matrix2 : enable
         #extension GL_EXT_buffer_reference : enable
         layout(local_size_x = 32) in;
-        layout(set = 0, binding = 0) buffer BufType {
-            float16_t x[];
-        } buf;
-        layout(buffer_reference, std430, buffer_reference_align = 2) buffer fp16Buf {
-            float16_t f;
-        };
+        layout(set = 0, binding = 0) buffer BufType { float16_t x[]; } buf;
+        layout(buffer_reference, std430, buffer_reference_align = 2) buffer fp16Buf { float16_t f; };
+        shared uint printed;
         float16_t decodeFunc(const in fp16Buf b, const in uint32_t blockCoords[2], const in uint32_t coordInBlock[2]) {
-            debugPrintfEXT("decode with view callback");
+            if (atomicExchange(printed, 1u) == 0u) {
+                debugPrintfEXT("decode with view callback");
+            }
             return b.f;
         }
         void main() {
+            if (gl_LocalInvocationIndex == 0u) printed = 0u;
+            barrier();
             coopmat<float16_t, gl_ScopeSubgroup, 16, 16, gl_MatrixUseA> A;
             tensorLayoutNV<2> t = createTensorLayoutNV(2);
             t = setTensorLayoutDimensionNV(t, 256, 256);
@@ -6728,5 +6731,5 @@ TEST_F(NegativeDebugPrintf, CoopMat2LoadTensorDecodeWithView) {
         }
     )glsl";
 
-    CoopMat2CallbackTest(shader_source, "decode with view callback", true);
+    CoopMat2CallbackTest(shader_source, "decode with view callback");
 }


### PR DESCRIPTION
I noticed debugprintf wasn't working from coopmat2 callback functions, because they weren't being considered reachable. I generated this change using AI, but I've reviewed it.