### PR TITLE
tests: Add <cmath> in RT test files

### DIFF
--- a/tests/unit/gpu_av_ray_tracing.cpp
+++ b/tests/unit/gpu_av_ray_tracing.cpp
@@ -11,6 +11,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#include <cmath>
 #include <vulkan/utility/vk_format_utils.h>
 #include "../framework/layer_validation_tests.h"
 #include "../framework/descriptor_helper.h"

--- a/tests/unit/gpu_av_ray_tracing_positive.cpp
+++ b/tests/unit/gpu_av_ray_tracing_positive.cpp
@@ -11,6 +11,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#include <cmath>
 #include "../framework/layer_validation_tests.h"
 #include "../framework/ray_tracing_objects.h"
 #include "../framework/descriptor_helper.h"


### PR DESCRIPTION
- on some systems the missing header was causing a build error:
error: 'NAN' was not declared in this scope