### PR TITLE
tests: Add CreateAccelerationStructure2KHR support

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -45,6 +45,7 @@ target_sources(VkLayer_utils PRIVATE
     ${API_TYPE}/generated/error_location_helper.h
     ${API_TYPE}/generated/feature_requirements_helper.cpp
     ${API_TYPE}/generated/feature_requirements_helper.h
+    ${API_TYPE}/generated/test_icd_helper.h
     ${API_TYPE}/generated/pnext_chain_extraction.cpp
     ${API_TYPE}/generated/pnext_chain_extraction.h
     ${API_TYPE}/generated/vk_function_pointers.cpp

--- a/tests/framework/ray_tracing_objects.cpp
+++ b/tests/framework/ray_tracing_objects.cpp
@@ -491,6 +491,22 @@ VkAccelerationStructureBuildRangeInfoKHR GeometryKHR::GetFullBuildRange() const 
 AccelerationStructureKHR::AccelerationStructureKHR(const vkt::Device *device)
     : device_(device), vk_info_(vku::InitStructHelper()), device_buffer_() {}
 
+AccelerationStructureKHR &AccelerationStructureKHR::SetCreateWithVersion2(bool create_with_version_2, bool auto_set_address_range) {
+    create_with_version_2_ = create_with_version_2;
+    auto_set_address_range_ = auto_set_address_range;
+    return *this;
+}
+
+AccelerationStructureKHR &AccelerationStructureKHR::SetAddressRange(VkDeviceAddressRangeKHR address_range) {
+    vk_info_2_.addressRange = address_range;
+    return *this;
+}
+
+AccelerationStructureKHR &AccelerationStructureKHR::SetAddressFlags(VkAddressCommandFlagsKHR address_flags) {
+    vk_info_2_.addressFlags = address_flags;
+    return *this;
+}
+
 AccelerationStructureKHR &AccelerationStructureKHR::SetSize(VkDeviceSize size) {
     vk_info_.size = size;
     return *this;
@@ -503,11 +519,13 @@ AccelerationStructureKHR &AccelerationStructureKHR::SetOffset(VkDeviceSize offse
 
 AccelerationStructureKHR &AccelerationStructureKHR::SetType(VkAccelerationStructureTypeKHR type) {
     vk_info_.type = type;
+    vk_info_2_.type = type;
     return *this;
 }
 
 AccelerationStructureKHR &AccelerationStructureKHR::SetFlags(VkAccelerationStructureCreateFlagsKHR flags) {
     vk_info_.createFlags = flags;
+    vk_info_2_.createFlags = flags;
     return *this;
 }
 
@@ -561,6 +579,10 @@ void AccelerationStructureKHR::Create() {
         alloc_flags.flags = buffer_memory_allocate_flags_;
         VkBufferCreateInfo ci = vku::InitStructHelper();
         ci.size = vk_info_.offset + vk_info_.size;
+        if (create_with_version_2_ && auto_set_address_range_) {
+            // To have room to align buffer address to 256
+            ci.size += 256;
+        }
         ci.usage = buffer_usage_flags_;
         if (buffer_init_no_mem_) {
             device_buffer_.InitNoMemory(*device_, ci);
@@ -571,11 +593,23 @@ void AccelerationStructureKHR::Create() {
     vk_info_.buffer = device_buffer_;
 
     // Create acceleration structure
-    VkAccelerationStructureKHR handle;
-    const VkResult result = vk::CreateAccelerationStructureKHR(device_->handle(), &vk_info_, nullptr, &handle);
-    assert(result == VK_SUCCESS);
-    if (result == VK_SUCCESS) {
-        init(device_->handle(), handle);
+    VkAccelerationStructureKHR handle = VK_NULL_HANDLE;
+    if (create_with_version_2_) {
+        if (auto_set_address_range_) {
+            vk_info_2_.addressRange.address = Align<VkDeviceAddress>(device_buffer_.Address(), 256);
+            vk_info_2_.addressRange.size = vk_info_.size;
+        }
+        const VkResult result = vk::CreateAccelerationStructure2KHR(device_->handle(), &vk_info_2_, nullptr, &handle);
+        assert(result == VK_SUCCESS);
+        if (result == VK_SUCCESS) {
+            init(device_->handle(), handle);
+        }
+    } else {
+        const VkResult result = vk::CreateAccelerationStructureKHR(device_->handle(), &vk_info_, nullptr, &handle);
+        assert(result == VK_SUCCESS);
+        if (result == VK_SUCCESS) {
+            init(device_->handle(), handle);
+        }
     }
 }
 

--- a/tests/framework/ray_tracing_objects.h
+++ b/tests/framework/ray_tracing_objects.h
@@ -181,10 +181,19 @@ class AccelerationStructureKHR : public vkt::internal::NonDispHandle<VkAccelerat
     AccelerationStructureKHR& operator=(AccelerationStructureKHR&&) = default;
     AccelerationStructureKHR& operator=(const AccelerationStructureKHR&) = delete;
 
+    // Common to both create info 1 and 2
     AccelerationStructureKHR& SetSize(VkDeviceSize size);
-    AccelerationStructureKHR& SetOffset(VkDeviceSize offset);
     AccelerationStructureKHR& SetType(VkAccelerationStructureTypeKHR type);
     AccelerationStructureKHR& SetFlags(VkAccelerationStructureCreateFlagsKHR flags);
+
+    // For create info 1
+    AccelerationStructureKHR& SetOffset(VkDeviceSize offset);
+
+    // For create info 2
+    AccelerationStructureKHR& SetCreateWithVersion2(bool create_with_version_2, bool auto_set_address_range);
+    AccelerationStructureKHR& SetAddressRange(VkDeviceAddressRangeKHR address_range);
+    AccelerationStructureKHR& SetAddressFlags(VkAddressCommandFlagsKHR address_flags);
+
     AccelerationStructureKHR& SetDeviceBuffer(vkt::Buffer&& buffer);
     AccelerationStructureKHR& SetDeviceBufferMemoryAllocateFlags(VkMemoryAllocateFlags memory_allocate_flags);
     AccelerationStructureKHR& SetDeviceBufferMemoryPropertyFlags(VkMemoryPropertyFlags memory_property_flags);
@@ -202,12 +211,15 @@ class AccelerationStructureKHR : public vkt::internal::NonDispHandle<VkAccelerat
     bool IsBuilt() const { return initialized(); }
     void Destroy();
 
-    auto& GetBuffer() { return device_buffer_; }
+    vkt::Buffer& GetBuffer() { return device_buffer_; }
 
   private:
+    bool create_with_version_2_ = false;
+    bool auto_set_address_range_ = false;
     const vkt::Device* device_;
     bool is_null_ = false;
-    VkAccelerationStructureCreateInfoKHR vk_info_;
+    VkAccelerationStructureCreateInfoKHR vk_info_ = vku::InitStructHelper();
+    VkAccelerationStructureCreateInfo2KHR vk_info_2_ = vku::InitStructHelper();
     vkt::Buffer device_buffer_;
     VkMemoryAllocateFlags buffer_memory_allocate_flags_{};
     VkMemoryPropertyFlags buffer_memory_property_flags_{};
@@ -264,11 +276,11 @@ class BuildGeometryInfoKHR {
     void VkCmdBuildAccelerationStructuresIndirectKHR(VkCommandBuffer cmd_buffer);
     void VkBuildAccelerationStructuresKHR();
 
-    auto& GetInfo() { return vk_info_; }
-    auto& GetGeometries() { return geometries_; }
-    auto& GetSrcAS() { return src_as_; }
-    auto& GetDstAS() { return dst_as_; }
-    const auto& GetScratchBuffer() const { return device_scratch_; }
+    VkAccelerationStructureBuildGeometryInfoKHR& GetInfo() { return vk_info_; }
+    std::vector<GeometryKHR>& GetGeometries() { return geometries_; }
+    std::shared_ptr<AccelerationStructureKHR>& GetSrcAS() { return src_as_; }
+    std::shared_ptr<AccelerationStructureKHR>& GetDstAS() { return dst_as_; }
+    const std::shared_ptr<vkt::Buffer>& GetScratchBuffer() const { return device_scratch_; }
     VkAccelerationStructureBuildSizesInfoKHR GetSizeInfo(bool use_ppGeometries = true);
     std::vector<VkAccelerationStructureBuildRangeInfoKHR> GetBuildRangeInfosFromGeometries();
 
@@ -285,7 +297,8 @@ class BuildGeometryInfoKHR {
     VkAccelerationStructureBuildGeometryInfoKHR vk_info_;
     VkAccelerationStructureBuildTypeKHR build_type_;
     std::vector<GeometryKHR> geometries_;
-    std::shared_ptr<AccelerationStructureKHR> src_as_, dst_as_;
+    std::shared_ptr<AccelerationStructureKHR> src_as_;
+    std::shared_ptr<AccelerationStructureKHR> dst_as_;
     bool build_scratch_ = true;
     VkDeviceAddress device_scratch_offset_ = 0;
     VkBufferUsageFlags device_scratch_additional_flags_ = 0;

--- a/tests/unit/ray_tracing_positive.cpp
+++ b/tests/unit/ray_tracing_positive.cpp
@@ -2270,3 +2270,49 @@ TEST_F(PositiveRayTracing, DescriptorHeap) {
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 }
+
+TEST_F(PositiveRayTracing, CreateAccelerationStructure2KHR) {
+    TEST_DESCRIPTION(
+        "Build a list of destination acceleration structures, built with vkCreateAccelerationStructure2KHR, then do an update "
+        "build on that same list");
+
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_DEVICE_ADDRESS_COMMANDS_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::deviceAddressCommands);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::rayQuery);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    RETURN_IF_SKIP(InitState());
+
+    constexpr size_t blas_count = 10;
+
+    std::vector<vkt::as::BuildGeometryInfoKHR> blas_vec;
+    for (size_t i = 0; i < blas_count; ++i) {
+        auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
+        // use vkCreateAccelerationStructure2KHR
+        blas.GetDstAS()->SetCreateWithVersion2(true, true);
+        blas.GetDstAS()->SetAddressFlags(VK_ADDRESS_COMMAND_STORAGE_BUFFER_USAGE_BIT_KHR);
+        blas.AddFlags(VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR);
+        blas_vec.emplace_back(std::move(blas));
+    }
+
+    m_command_buffer.Begin();
+    vkt::as::BuildAccelerationStructuresKHR(m_command_buffer, blas_vec);
+
+    m_command_buffer.End();
+    m_default_queue->Submit(m_command_buffer);
+    m_device->Wait();
+
+    for (auto& blas : blas_vec) {
+        blas.SetSrcAS(blas.GetDstAS());
+        blas.SetMode(VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR);
+        blas.SetDstAS(vkt::as::blueprint::AccelStructSimpleOnDeviceBottomLevel(*m_device, 4096));
+    }
+
+    m_command_buffer.Begin();
+    vkt::as::BuildAccelerationStructuresKHR(m_command_buffer, blas_vec);
+    m_command_buffer.End();
+    m_default_queue->Submit(m_command_buffer);
+    m_device->Wait();
+}


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/11881

Does the job for now,
design decisions around how I updated the RT test API to account for vkCreateAccelerationStructure2KHR will likely evolve based on usage