### PR TITLE
tests: Update CreateAccelerationStructure2KHR API

### DIFF
--- a/tests/framework/ray_tracing_objects.cpp
+++ b/tests/framework/ray_tracing_objects.cpp
@@ -491,14 +491,13 @@ VkAccelerationStructureBuildRangeInfoKHR GeometryKHR::GetFullBuildRange() const 
 AccelerationStructureKHR::AccelerationStructureKHR(const vkt::Device *device)
     : device_(device), vk_info_(vku::InitStructHelper()), device_buffer_() {}
 
-AccelerationStructureKHR &AccelerationStructureKHR::SetCreateWithVersion2(bool create_with_version_2, bool auto_set_address_range) {
+AccelerationStructureKHR &AccelerationStructureKHR::SetCreateWithVersion2(bool create_with_version_2) {
     create_with_version_2_ = create_with_version_2;
-    auto_set_address_range_ = auto_set_address_range;
     return *this;
 }
 
-AccelerationStructureKHR &AccelerationStructureKHR::SetAddressRange(VkDeviceAddressRangeKHR address_range) {
-    vk_info_2_.addressRange = address_range;
+AccelerationStructureKHR &AccelerationStructureKHR::SetAddressRange(std::optional<VkDeviceAddressRangeKHR> address_range) {
+    address_range_ = address_range;
     return *this;
 }
 
@@ -579,7 +578,7 @@ void AccelerationStructureKHR::Create() {
         alloc_flags.flags = buffer_memory_allocate_flags_;
         VkBufferCreateInfo ci = vku::InitStructHelper();
         ci.size = vk_info_.offset + vk_info_.size;
-        if (create_with_version_2_ && auto_set_address_range_) {
+        if (create_with_version_2_ && !address_range_.has_value()) {
             // To have room to align buffer address to 256
             ci.size += 256;
         }
@@ -595,7 +594,9 @@ void AccelerationStructureKHR::Create() {
     // Create acceleration structure
     VkAccelerationStructureKHR handle = VK_NULL_HANDLE;
     if (create_with_version_2_) {
-        if (auto_set_address_range_) {
+        if (address_range_.has_value()) {
+            vk_info_2_.addressRange = *address_range_;
+        } else {
             vk_info_2_.addressRange.address = Align<VkDeviceAddress>(device_buffer_.Address(), 256);
             vk_info_2_.addressRange.size = vk_info_.size;
         }

--- a/tests/framework/ray_tracing_objects.h
+++ b/tests/framework/ray_tracing_objects.h
@@ -190,8 +190,10 @@ class AccelerationStructureKHR : public vkt::internal::NonDispHandle<VkAccelerat
     AccelerationStructureKHR& SetOffset(VkDeviceSize offset);
 
     // For create info 2
-    AccelerationStructureKHR& SetCreateWithVersion2(bool create_with_version_2, bool auto_set_address_range);
-    AccelerationStructureKHR& SetAddressRange(VkDeviceAddressRangeKHR address_range);
+    AccelerationStructureKHR& SetCreateWithVersion2(bool create_with_version_2);
+    // If no address range is explicitly supplied, it will be computed automatically
+    // at Create() time based on AS's buffer.
+    AccelerationStructureKHR& SetAddressRange(std::optional<VkDeviceAddressRangeKHR> address_range);
     AccelerationStructureKHR& SetAddressFlags(VkAddressCommandFlagsKHR address_flags);
 
     AccelerationStructureKHR& SetDeviceBuffer(vkt::Buffer&& buffer);
@@ -215,16 +217,16 @@ class AccelerationStructureKHR : public vkt::internal::NonDispHandle<VkAccelerat
 
   private:
     bool create_with_version_2_ = false;
-    bool auto_set_address_range_ = false;
     const vkt::Device* device_;
     bool is_null_ = false;
     VkAccelerationStructureCreateInfoKHR vk_info_ = vku::InitStructHelper();
-    VkAccelerationStructureCreateInfo2KHR vk_info_2_ = vku::InitStructHelper();
     vkt::Buffer device_buffer_;
     VkMemoryAllocateFlags buffer_memory_allocate_flags_{};
     VkMemoryPropertyFlags buffer_memory_property_flags_{};
     VkBufferUsageFlags buffer_usage_flags_{};
     bool buffer_init_no_mem_ = false;
+    VkAccelerationStructureCreateInfo2KHR vk_info_2_ = vku::InitStructHelper();
+    std::optional<VkDeviceAddressRangeKHR> address_range_ = std::nullopt;
 };
 
 class BuildGeometryInfoKHR {

--- a/tests/unit/ray_tracing_positive.cpp
+++ b/tests/unit/ray_tracing_positive.cpp
@@ -2291,7 +2291,7 @@ TEST_F(PositiveRayTracing, CreateAccelerationStructure2KHR) {
     for (size_t i = 0; i < blas_count; ++i) {
         auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
         // use vkCreateAccelerationStructure2KHR
-        blas.GetDstAS()->SetCreateWithVersion2(true, true);
+        blas.GetDstAS()->SetCreateWithVersion2(true);
         blas.GetDstAS()->SetAddressFlags(VK_ADDRESS_COMMAND_STORAGE_BUFFER_USAGE_BIT_KHR);
         blas.AddFlags(VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR);
         blas_vec.emplace_back(std::move(blas));


### PR DESCRIPTION
follow up to https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/11908

Having an RT test API that offers easy ways to create valid objects, but also easy ways to modify their internal to make them invalid has been my main struggle. 
Using `std::optional` for object attributes more could be a solution: when an optional attribute is supplied, it would be used, otherwise a valid attribute would be computed.
Try to start that with `vkCreateAccelerationStructure2KHR`