### PR TITLE
layers: Check for vkFreeCommandBuffers double free

### DIFF
--- a/layers/stateless/sl_cmd_buffer.cpp
+++ b/layers/stateless/sl_cmd_buffer.cpp
@@ -16,7 +16,11 @@
  * limitations under the License.
  */
 
+#include <vulkan/vulkan_core.h>
 #include <cmath>
+#include <cstdint>
+#include "containers/custom_containers.h"
+#include "error_message/logging.h"
 #include "stateless/stateless_validation.h"
 #include "generated/enum_flag_bits.h"
 #include "containers/range.h"
@@ -1147,6 +1151,28 @@ bool Device::manual_PreCallValidateFreeCommandBuffers(VkDevice device, VkCommand
     skip |= context.ValidateArray(error_obj.location.dot(Field::commandBufferCount), error_obj.location.dot(Field::pCommandBuffers),
                                   commandBufferCount, &pCommandBuffers, true, true, kVUIDUndefined,
                                   "VUID-vkFreeCommandBuffers-pCommandBuffers-00048");
+
+    if (pCommandBuffers && commandBufferCount > 1) {
+        vvl::unordered_map<VkCommandBuffer, uint32_t> seen_cb;
+        for (uint32_t i = 0; i < commandBufferCount; i++) {
+            const VkCommandBuffer next_cb = pCommandBuffers[i];
+            if (next_cb == VK_NULL_HANDLE) {
+                continue;
+            }
+            auto it = seen_cb.find(next_cb);
+            if (it != seen_cb.end()) {
+                const LogObjectList objlist(commandPool, next_cb);
+                skip |= LogError("VUID-vkFreeCommandBuffers-pCommandBuffers-00048", objlist,
+                                 context.error_obj.location.dot(Field::pCommandBuffers, i),
+                                 "(%s) was already freed in pCommandBuffers[%" PRIu32
+                                 "] and this is trying to do an invalid double free.",
+                                 FormatHandle(next_cb).c_str(), it->second);
+                break;
+            }
+            seen_cb[next_cb] = i;
+        }
+    }
+
     return skip;
 }
 

--- a/tests/unit/object_lifetime.cpp
+++ b/tests/unit/object_lifetime.cpp
@@ -1156,6 +1156,24 @@ TEST_F(NegativeObjectLifetime, FreeCommandBuffersNull) {
     m_errorMonitor->VerifyFound();
 }
 
+TEST_F(NegativeObjectLifetime, FreeSameCommandBuffer) {
+    RETURN_IF_SKIP(Init());
+
+    vkt::CommandPool command_pool(*m_device, m_device->graphics_queue_node_index_);
+
+    VkCommandBuffer command_buffers[2];
+    VkCommandBufferAllocateInfo alloc_info = vku::InitStructHelper();
+    alloc_info.commandPool = command_pool;
+    alloc_info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    alloc_info.commandBufferCount = 2;
+    vk::AllocateCommandBuffers(device(), &alloc_info, command_buffers);
+
+    VkCommandBuffer new_cb[2] = {command_buffers[0], command_buffers[0]};
+    m_errorMonitor->SetDesiredError("VUID-vkFreeCommandBuffers-pCommandBuffers-00048");
+    vk::FreeCommandBuffers(device(), command_pool, 2, new_cb);
+    m_errorMonitor->VerifyFound();
+}
+
 TEST_F(NegativeObjectLifetime, FreeDescriptorSetsNull) {
     TEST_DESCRIPTION("Can pass NULL for vkFreeDescriptorSets");
     RETURN_IF_SKIP(Init());


### PR DESCRIPTION
before we just asserted and gave a bad error message, now we print

```
Validation Error: [ VUID-vkFreeCommandBuffers-pCommandBuffers-00048 ] | MessageID = 0x1eb50db9
vkFreeCommandBuffers(): pCommandBuffers[1] (VkCommandBuffer 0x59a3f1891d00) was already freed in pCommandBuffers[0] and this is trying to do an invalid double free.
```